### PR TITLE
GitHub-ingested jobs: identity + panel restructure

### DIFF
--- a/app/app/(authed)/runs/page.tsx
+++ b/app/app/(authed)/runs/page.tsx
@@ -275,12 +275,95 @@ const RECOMMENDED: JobCardData[] = [
   },
 ];
 
+// Fallback job definitions used when the live API is unavailable. Shape
+// mirrors what the backend emits on /jobs/definition?jobId=, so the
+// adapter (buildGitHubContext) can populate the Loaded-run panel from
+// these records exactly as it does from live data. Only the rich
+// GitHub-ingested rows need definitions — native fixture rows fall
+// through to the generic governance layout.
+const FIXTURE_JOB_DEFINITIONS: Record<string, unknown>[] = [
+  {
+    id: "run-2749",
+    title:
+      "Document TypeScript validation helper API for external package consumers",
+    category: "docs",
+    description:
+      "The internal `validateRequest` helper in `packages/core/src/validate.ts` is referenced by three external consumers but has no public docs. We need a markdown reference that lists the accepted shapes, the thrown error types, and at least one usage example per shape.",
+    source: {
+      type: "github_issue",
+      repo: "oss-devsecblueprint/devsecblueprint",
+      issueNumber: 110,
+      issueUrl:
+        "https://github.com/oss-devsecblueprint/devsecblueprint/issues/110",
+      labels: ["documentation", "good first issue"],
+      score: 82,
+    },
+    acceptanceCriteria: [
+      "Open a PR that adds `docs/reference/validate.md`",
+      "Document every exported signature with one code example",
+      "`npm run build:docs` passes with no warnings",
+      "PR description links to the closed issue",
+    ],
+    agentInstructions:
+      "Read `packages/core/src/validate.ts` top to bottom. For each exported function, write a short prose intro plus a fenced TypeScript example. Keep voice consistent with the existing reference docs under `docs/reference/`.",
+    verification: {
+      method: "github_pr",
+      signals: ["PR opened", "docs build green", "maintainer review"],
+    },
+  },
+  {
+    id: "run-2742",
+    title:
+      "Fix flaky integration test: race condition when two workers claim within the same block window",
+    category: "bugfix",
+    description: `The integration suite in \`node/test/src/claim_race.rs\` fails ~3% of the time on CI when two workers attempt to claim the same job within the same 6-second block window. Expected behavior: the first claim (lowest nonce) wins; the second receives a \`ClaimRejected\` event and the caller's stake is refunded in the same block.
+
+Current behavior: both claims occasionally land, both workers get \`ClaimAccepted\`, and the escrow double-locks stake. The second worker is later slashed during settlement, which is the wrong failure mode — the rejection should be at claim-time, not at settle-time.
+
+Repro: run \`cargo test --test claim_race -- --test-threads=1 --ignored\` in a loop; fails in 2–4 iterations on average.`,
+    source: {
+      type: "github_issue",
+      repo: "paritytech/polkadot-sdk",
+      issueNumber: 4812,
+      issueUrl: "https://github.com/paritytech/polkadot-sdk/issues/4812",
+      labels: ["bug", "flaky-test", "help wanted"],
+      score: 74,
+    },
+    acceptanceCriteria: [
+      "Open a PR that makes the `claim_race` test deterministic on Linux and macOS",
+      "Include a regression test that asserts the second claim receives ClaimRejected",
+      "All existing tests pass; no new warnings from `cargo clippy -- -D warnings`",
+      "PR description references issue #4812 and explains the ordering fix",
+    ],
+    agentInstructions:
+      "Start from the failing test. Trace the claim path in `runtime/src/escrow.rs` and identify where the two claims race. Fix by ordering claims by (block_number, nonce, wallet) before acceptance — see OP-09 §4.2 for the canonical ordering. Keep the diff under 150 lines if possible.",
+    verification: {
+      method: "github_pr",
+      signals: ["PR opened", "CI green", "maintainer review"],
+    },
+  },
+];
+
+// Lifecycle for GitHub-ingested jobs. For MVP we keep the same 5-stage
+// shape but relabel for the OSS flow: Ready → Claimed → PR submitted →
+// Verified → Paid. Future revisions can add an explicit "Working"
+// intermediate stage once the runner reports keep-alive signals.
 const LIFECYCLE: LifecycleStage[] = [
-  { index: 1, label: "Discoverable", meta: "14:20:25", state: "done" },
+  { index: 1, label: "Ready", meta: "14:20:25", state: "done" },
   { index: 2, label: "Claimed", meta: "14:23:53 · by you", state: "done" },
-  { index: 3, label: "Submitted", meta: "14:27:45 · evidence 412B", state: "done" },
-  { index: 4, label: "Verified", meta: "4/5 · awaiting cosign", state: "current" },
-  { index: 5, label: "Settled", meta: "—", state: "pending" },
+  {
+    index: 3,
+    label: "PR submitted",
+    meta: "14:27:45 · #4931 on paritytech/polkadot-sdk",
+    state: "done",
+  },
+  {
+    index: 4,
+    label: "Verified",
+    meta: "2/3 signals · maintainer review pending",
+    state: "current",
+  },
+  { index: 5, label: "Paid", meta: "—", state: "pending" },
 ];
 
 export default function RunsPage() {
@@ -314,7 +397,10 @@ export default function RunsPage() {
 
   const assignedToMe = rows.filter((row) => row.worker.isSelf).length;
   const jobDefinition = useJobDefinition(loadedRow.id);
-  const selectedJob = asRecord(jobDefinition.data) ?? rawJobs.find((job) => job.id === loadedRow.id);
+  const selectedJob =
+    asRecord(jobDefinition.data) ??
+    rawJobs.find((job) => job.id === loadedRow.id) ??
+    FIXTURE_JOB_DEFINITIONS.find((def) => def.id === loadedRow.id);
   // Only set when the loaded run was ingested from GitHub. The panel
   // switches to a GitHub-native layout when this is defined; otherwise
   // it keeps the generic governance evidence/verifier layout.
@@ -396,31 +482,23 @@ export default function RunsPage() {
             treasury: "0 DOT",
           },
         }}
+        // When `github` is set the panel swaps Evidence for the four-tab
+        // Issue/Acceptance/Instructions/Submission block, so `evidence` is
+        // unused at runtime. The prop is still type-required — we stub it
+        // with neutral content that will never render for this job.
         evidence={{
-          tabs: [
-            { id: "abstract", label: "Abstract" },
-            { id: "diff", label: "Diff" },
-            { id: "citations", label: "Citations", sub: "·3" },
-          ],
-          activeTab: "abstract",
-          metaRight: "markdown · max 8kb",
-          metaFoot: "unsaved · 412 chars",
-          sample: `# OP-14 · Treasury re-routing via XCM
-
-Proposal 0x7a0c re-routes 18,000 DOT from the collective bounty
-curator to AssetHub for spending under a time-locked multisig.
-
-Scope: **only the curator address changes** — cadence, caps, and
-dispute windows remain as set in OP-09.
-
-See §3.1 of the runbook for the cosign requirement.`,
+          tabs: [{ id: "issue", label: "Issue" }],
+          activeTab: "issue",
+          metaRight: "",
+          metaFoot: "",
+          sample: "",
         }}
         submission={{
           note: (
             <>
-              Submits <b className="text-[var(--avy-ink)]">evidence + claim hash</b>{" "}
+              Submits <b className="text-[var(--avy-ink)]">PR URL + evidence</b>{" "}
               to the verifier. Window{" "}
-              <b className="text-[var(--avy-ink)]">00:08:14 / 00:30:00</b>.
+              <b className="text-[var(--avy-ink)]">00:08:14 / 02:00:00</b>.
             </>
           ),
           cta: "Submit for verification",
@@ -429,37 +507,51 @@ See §3.1 of the runbook for the cosign requirement.`,
           error: submitError,
         }}
         verifier={{
-          runner: "verifier-2 · semantic · handler-v0.14",
-          elapsed: "stream · 2.1s",
-          modeNote: "semantic · human-in-the-loop",
+          runner: "verifier-2 · github_pr · handler-v0.14",
+          elapsed: "stream · 3.4s",
+          modeNote: "github_pr · maintainer-reviewed",
           lines: [
             {
               time: "14:28:01",
               level: "info",
-              label: "boot",
+              label: "source",
               message: (
                 <>
-                  loaded policy <span className="text-[#f4c989]">writer-gov/cited</span>
+                  loaded issue{" "}
+                  <span className="text-[#f4c989]">
+                    paritytech/polkadot-sdk#4812
+                  </span>{" "}
+                  · score 74/100
                 </>
               ),
             },
             {
               time: "14:28:01",
-              level: "info",
-              label: "check",
-              message: <>claim-hash matches evidence blob · ok</>,
+              level: "ok",
+              label: "pass",
+              message: (
+                <>
+                  PR URL present ·{" "}
+                  <span className="text-[#f4c989]">pull/4931</span>
+                </>
+              ),
             },
             {
               time: "14:28:02",
               level: "ok",
               label: "pass",
-              message: <>scope constraint: only curator address changed</>,
+              message: <>PR body references issue #4812</>,
             },
             {
               time: "14:28:02",
               level: "ok",
               label: "pass",
-              message: <>citation [1] OP-09 §3.1 · resolvable · on-chain</>,
+              message: (
+                <>
+                  CI checks green · <span className="text-[#9bd7b5]">7/7</span>{" "}
+                  on ubuntu-latest · macos-13
+                </>
+              ),
             },
             {
               time: "14:28:03",
@@ -467,8 +559,9 @@ See §3.1 of the runbook for the cosign requirement.`,
               label: "note",
               message: (
                 <>
-                  cosigner <span className="text-[#f4c989]">0x9A13…0cb2</span> has not
-                  yet attested
+                  maintainer review{" "}
+                  <span className="text-[#f4c989]">pending</span> · requested
+                  from @bkchr
                 </>
               ),
             },
@@ -478,30 +571,31 @@ See §3.1 of the runbook for the cosign requirement.`,
               label: "verdict",
               message: (
                 <>
-                  4/5 checks pass · awaiting cosigner · receipt draft{" "}
+                  2/3 signals pass · awaiting maintainer · receipt draft{" "}
                   <span className="text-[#f4c989]">r_4e133</span>
                 </>
               ),
             },
           ],
           verdict: {
-            status: "Verified (pending cosign)",
-            score: "4 / 5",
-            scoreLabel: "0.92 confidence",
+            status: "Awaiting maintainer review",
+            score: "2 / 3",
+            scoreLabel: "0.86 confidence",
           },
         }}
         settle={{
-          title: "Ready to settle on cosign",
+          title: "Awaiting verification",
           detail: (
             <>
-              Pay <b className="text-[var(--avy-ink)]">25.00 DOT</b> · unlock{" "}
-              <b className="text-[var(--avy-ink)]">25.00 DOT</b> stake · sign receipt{" "}
-              <b className="text-[var(--avy-ink)]">r_4e133</b>
+              On verification, pay{" "}
+              <b className="text-[var(--avy-ink)]">25.00 DOT</b> · unlock{" "}
+              <b className="text-[var(--avy-ink)]">25.00 DOT</b> stake · sign
+              receipt <b className="text-[var(--avy-ink)]">r_4e133</b>
             </>
           ),
-          cta: "Settle run",
+          cta: "Mark verified & pay",
           ctaDisabled: true,
-          note: "unlocks stake · pays worker & verifier",
+          note: "pays worker & verifier once the maintainer approves the PR",
         }}
       />
 
@@ -509,18 +603,19 @@ See §3.1 of the runbook for the cosign requirement.`,
         runId="run-2742"
         contextNote={
           <>
-            Window closes in <b className="font-semibold text-[var(--avy-ink)]">21m 46s</b>
-            {" · "}policy{" "}
-            <b className="font-semibold text-[var(--avy-ink)]">writer-gov/cited</b>
-            {" · "}cosign{" "}
-            <b className="font-semibold text-[var(--avy-ink)]">required</b>
+            Window closes in{" "}
+            <b className="font-semibold text-[var(--avy-ink)]">21m 46s</b>
+            {" · "}verification{" "}
+            <b className="font-semibold text-[var(--avy-ink)]">github_pr</b>
+            {" · "}PR{" "}
+            <b className="font-semibold text-[var(--avy-ink)]">#4931</b> opened
           </>
         }
         stages={LIFECYCLE}
         next={{
           label: "Next",
-          value: "Cosign → Settle",
-          sub: "auto-settles on cosign +2s",
+          value: "Maintainer review → Pay",
+          sub: "auto-pays on PR merge + CI green",
         }}
       />
     </div>

--- a/app/app/(authed)/runs/page.tsx
+++ b/app/app/(authed)/runs/page.tsx
@@ -22,6 +22,7 @@ import {
 import { useJobDefinition, useJobs, useRecommendations } from "@/lib/api/hooks";
 import { swrFetcher } from "@/lib/api/client";
 import {
+  buildGitHubContext,
   buildRecommendationCards,
   buildRunFilters,
   buildRunRows,
@@ -39,6 +40,27 @@ import {
 
 const ROWS: RunRow[] = [
   {
+    id: "run-2749",
+    title:
+      "Document TypeScript validation helper API for external package consumers",
+    jobMeta: "job-0428 · docs · T1",
+    source: {
+      type: "github_issue",
+      repo: "oss-devsecblueprint/devsecblueprint",
+      issueNumber: 110,
+      issueUrl:
+        "https://github.com/oss-devsecblueprint/devsecblueprint/issues/110",
+      labels: ["documentation", "good first issue"],
+      score: 82,
+    },
+    worker: { variant: "unclaimed", initials: "—", label: "unclaimed" },
+    state: "ready",
+    stake: "8.0",
+    age: "00:01:04",
+    lastEvent: "Ingested from GitHub",
+    lastEventMeta: "14:29:55 · gh-ingest · score 82",
+  },
+  {
     id: "run-2741",
     title: "repo-sweep: deps/sec-only bump",
     jobMeta: "job-0421 · coding · T1",
@@ -52,8 +74,17 @@ const ROWS: RunRow[] = [
   },
   {
     id: "run-2742",
-    title: "gov-review: proposal 0x7a0c abstract",
-    jobMeta: "job-0418 · writer-gov · T2",
+    title:
+      "Fix flaky integration test: race condition when two workers claim within the same block window",
+    jobMeta: "job-0418 · bugfix · T2",
+    source: {
+      type: "github_issue",
+      repo: "paritytech/polkadot-sdk",
+      issueNumber: 4812,
+      issueUrl: "https://github.com/paritytech/polkadot-sdk/issues/4812",
+      labels: ["bug", "flaky-test", "help wanted"],
+      score: 74,
+    },
     worker: { variant: "self", initials: "FD", label: "0xFd2E…6519", isSelf: true },
     state: "claimed",
     stake: "25.0",
@@ -131,8 +162,8 @@ const ROWS: RunRow[] = [
 ];
 
 const FILTERS: QueueFilterCount[] = [
-  { id: "all", label: "All", count: 14 },
-  { id: "ready", label: "Ready", count: 3 },
+  { id: "all", label: "All", count: 15 },
+  { id: "ready", label: "Ready", count: 4 },
   { id: "claimed", label: "Claimed", count: 5 },
   { id: "submitted", label: "Submitted", count: 3 },
   { id: "disputed", label: "Disputed", count: 2 },
@@ -141,8 +172,39 @@ const FILTERS: QueueFilterCount[] = [
 
 const RECOMMENDED: JobCardData[] = [
   {
+    id: "job-0428",
+    jobMeta: "docs",
+    category: "docs",
+    title:
+      "Document TypeScript validation helper API for external package consumers",
+    source: {
+      type: "github_issue",
+      repo: "oss-devsecblueprint/devsecblueprint",
+      issueNumber: 110,
+      issueUrl:
+        "https://github.com/oss-devsecblueprint/devsecblueprint/issues/110",
+      labels: ["documentation", "good first issue"],
+      score: 82,
+    },
+    rewardValue: "8.0",
+    rewardCurrency: "DOT",
+    rewardUsd: "~ $58",
+    tier: "T1",
+    modeLabel: "PR review",
+    modeTone: "ready",
+    meta: [
+      { label: "Stake", value: "4.0 DOT" },
+      { label: "Verifier", value: "github_pr" },
+      { label: "Window", value: "2 h", accent: true },
+      { label: "Fit score", value: "82/100" },
+    ],
+    fit: 5,
+    hot: true,
+  },
+  {
     id: "job-0406",
     jobMeta: "ops-xcm",
+    category: "ops-xcm",
     title: "xcm-sanity: asset-hub → hydration",
     rewardValue: "75.0",
     rewardCurrency: "DOT",
@@ -156,7 +218,6 @@ const RECOMMENDED: JobCardData[] = [
       { label: "Slippage cap", value: "0.5%" },
     ],
     fit: 4,
-    hot: true,
   },
   {
     id: "job-0421",
@@ -254,6 +315,10 @@ export default function RunsPage() {
   const assignedToMe = rows.filter((row) => row.worker.isSelf).length;
   const jobDefinition = useJobDefinition(loadedRow.id);
   const selectedJob = asRecord(jobDefinition.data) ?? rawJobs.find((job) => job.id === loadedRow.id);
+  // Only set when the loaded run was ingested from GitHub. The panel
+  // switches to a GitHub-native layout when this is defined; otherwise
+  // it keeps the generic governance evidence/verifier layout.
+  const loadedGitHub = buildGitHubContext(loadedRow, selectedJob);
   const liveStatus = jobs.error
     ? "fixture fallback"
       : jobs.isLoading
@@ -319,6 +384,7 @@ export default function RunsPage() {
         kicker="Loaded run"
         title={loadedRow.title}
         meta={loadedRow.jobMeta}
+        github={loadedGitHub}
         stake={{
           amount: loadedRow.stake,
           aux: selectedJob

--- a/app/components/runs/JobCard.tsx
+++ b/app/components/runs/JobCard.tsx
@@ -1,10 +1,24 @@
 import { cn } from "@/lib/utils/cn";
-import { TierPill, VerifierModePill, type Tier, type RunState } from "./StatePill";
+import {
+  TierPill,
+  VerifierModePill,
+  SourceBadge,
+  type Tier,
+  type RunState,
+} from "./StatePill";
+import type { JobSource } from "./types";
 
 export interface JobCardData {
   id: string;
   title: string;
   jobMeta: string;
+  /**
+   * Short category label (e.g. "docs", "coding", "testing"). For GitHub
+   * jobs this comes from the ingestion classifier; for native jobs it's
+   * the job's domain tag.
+   */
+  category?: string;
+  source?: JobSource;
   rewardValue: string;
   rewardCurrency: string;
   rewardUsd: string;
@@ -26,18 +40,35 @@ export function JobCard({ job }: { job: JobCardData }) {
       )}
     >
       <header className="flex items-start justify-between gap-2">
-        <div className="min-w-0">
-          <h4 className="m-0 max-w-[180px] font-[family-name:var(--font-display)] text-[13px] font-bold leading-[1.25] text-[var(--avy-ink)]">
+        <div className="min-w-0 flex-1">
+          <h4
+            className="m-0 line-clamp-2 font-[family-name:var(--font-display)] text-[13px] font-bold leading-[1.25] text-[var(--avy-ink)]"
+            title={job.title}
+          >
             {job.title}
           </h4>
-          <p
-            className="mt-1 font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]"
-            style={{ letterSpacing: 0 }}
-          >
-            {job.id} · {job.jobMeta}
-          </p>
+          {job.source?.type === "github_issue" ? (
+            <p
+              className="mt-1 flex items-center gap-1 font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]"
+              style={{ letterSpacing: 0 }}
+            >
+              <span className="truncate text-[var(--avy-ink)]">
+                {job.source.repo}
+              </span>
+              <span className="text-[var(--avy-accent)]">
+                #{job.source.issueNumber}
+              </span>
+            </p>
+          ) : (
+            <p
+              className="mt-1 truncate font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]"
+              style={{ letterSpacing: 0 }}
+            >
+              {job.jobMeta}
+            </p>
+          )}
         </div>
-        <div className="text-right">
+        <div className="shrink-0 text-right">
           <div>
             <span className="font-[family-name:var(--font-display)] text-[15px] font-bold leading-none text-[var(--avy-ink)]">
               {job.rewardValue}
@@ -55,8 +86,17 @@ export function JobCard({ job }: { job: JobCardData }) {
         </div>
       </header>
 
-      <div className="flex flex-wrap gap-1">
+      <div className="flex flex-wrap items-center gap-1">
+        {job.source?.type === "github_issue" ? <SourceBadge kind="github" /> : null}
         <TierPill tier={job.tier} />
+        {job.category ? (
+          <span
+            className="inline-flex items-center gap-1 rounded-full bg-[color:rgba(17,19,21,0.06)] px-2 py-0.5 font-[family-name:var(--font-display)] text-[9.5px] font-extrabold uppercase text-[var(--avy-ink)]"
+            style={{ letterSpacing: "0.1em" }}
+          >
+            {job.category}
+          </span>
+        ) : null}
         <VerifierModePill label={job.modeLabel} tone={job.modeTone ?? "claimed"} />
       </div>
 

--- a/app/components/runs/LoadedRunPanel.tsx
+++ b/app/components/runs/LoadedRunPanel.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils/cn";
+import { SourceBadge } from "./StatePill";
+import type { GitHubJobContext } from "./types";
 
 export interface StakeBreakdown {
   worker: string;
@@ -59,6 +61,13 @@ export interface LoadedRunPanelProps {
     ctaDisabled?: boolean;
     note: string;
   };
+  /**
+   * When the loaded run was ingested from GitHub, the panel renders a
+   * "Job context" block in the left column with labels, score, issue body,
+   * acceptance criteria, agent instructions, verification signals, and an
+   * "Open GitHub Issue" link. Absent = native job, no extra block.
+   */
+  github?: GitHubJobContext;
 }
 
 export function LoadedRunPanel(props: LoadedRunPanelProps) {
@@ -112,6 +121,9 @@ export function LoadedRunPanel(props: LoadedRunPanelProps) {
       <div className="grid grid-cols-1 lg:grid-cols-2">
         {/* LEFT */}
         <div className="flex flex-col gap-3.5 border-r-0 border-b border-[var(--avy-line-soft)] bg-[#fffdf7] p-4 lg:border-b-0 lg:border-r">
+          {/* Job context (GitHub-ingested jobs only) */}
+          {props.github ? <GitHubContextBlock context={props.github} /> : null}
+
           {/* Stake */}
           <div>
             <BlockLabel right={<>▪ locked in AgentAccountCore</>}>Stake</BlockLabel>
@@ -351,6 +363,157 @@ export function LoadedRunPanel(props: LoadedRunPanelProps) {
         </div>
       </div>
     </section>
+  );
+}
+
+function GitHubContextBlock({ context }: { context: GitHubJobContext }) {
+  return (
+    <div>
+      <BlockLabel
+        right={
+          <a
+            href={context.issueUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center gap-1 text-[var(--avy-accent)] hover:underline"
+          >
+            Open GitHub issue ↗
+          </a>
+        }
+      >
+        Job context
+      </BlockLabel>
+      <div className="overflow-hidden rounded-[8px] border border-[var(--avy-line)] bg-white">
+        {/* Header: source + repo + issue + score */}
+        <div className="flex flex-wrap items-center gap-2 border-b border-[var(--avy-line-soft)] bg-[#faf8f1] px-3 py-2">
+          <SourceBadge kind="github" />
+          <a
+            href={context.issueUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-ink)] hover:text-[var(--avy-accent)]"
+            style={{ letterSpacing: 0 }}
+          >
+            {context.repo}
+            <span className="ml-0.5 text-[var(--avy-accent)]">
+              #{context.issueNumber}
+            </span>
+          </a>
+          <span className="opacity-40">·</span>
+          <span
+            className="font-[family-name:var(--font-mono)] text-[11px] uppercase text-[var(--avy-muted)]"
+            style={{ letterSpacing: "0.08em" }}
+          >
+            {context.category}
+          </span>
+          {typeof context.score === "number" ? (
+            <span className="ml-auto inline-flex items-center gap-1 font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]">
+              Fit score{" "}
+              <b className="font-semibold text-[var(--avy-ink)]">{context.score}</b>
+              <span className="text-[var(--avy-muted)]">/100</span>
+            </span>
+          ) : null}
+        </div>
+
+        {/* Body */}
+        <div className="px-3.5 py-3">
+          {/* Title */}
+          <h3 className="m-0 font-[family-name:var(--font-display)] text-[14px] font-bold leading-[1.3] text-[var(--avy-ink)]">
+            {context.title}
+          </h3>
+
+          {/* Labels */}
+          {context.labels && context.labels.length > 0 ? (
+            <div className="mt-2 flex flex-wrap gap-1">
+              {context.labels.map((label) => (
+                <span
+                  key={label}
+                  className="inline-flex items-center rounded-full border border-[var(--avy-line)] bg-[color:rgba(17,19,21,0.03)] px-2 py-0.5 font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-ink)]"
+                  style={{ letterSpacing: 0 }}
+                >
+                  {label}
+                </span>
+              ))}
+            </div>
+          ) : null}
+
+          {/* Body / description */}
+          <p
+            className="mt-3 max-h-[140px] overflow-y-auto whitespace-pre-wrap font-[family-name:var(--font-body)] text-[12.5px] leading-[1.5] text-[var(--avy-ink)]"
+            style={{ letterSpacing: 0 }}
+          >
+            {context.body}
+          </p>
+
+          {/* Acceptance criteria */}
+          {context.acceptanceCriteria.length > 0 ? (
+            <div className="mt-3">
+              <div
+                className="mb-1 font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-muted)]"
+                style={{ letterSpacing: "0.14em" }}
+              >
+                Acceptance criteria
+              </div>
+              <ul className="m-0 flex flex-col gap-1 pl-0">
+                {context.acceptanceCriteria.map((item, i) => (
+                  <li
+                    key={i}
+                    className="flex gap-2 font-[family-name:var(--font-body)] text-[12px] leading-[1.45] text-[var(--avy-ink)]"
+                    style={{ letterSpacing: 0 }}
+                  >
+                    <span className="mt-[7px] h-[4px] w-[4px] shrink-0 rounded-full bg-[var(--avy-accent)]" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {/* Agent instructions */}
+          {context.agentInstructions ? (
+            <div className="mt-3">
+              <div
+                className="mb-1 font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-muted)]"
+                style={{ letterSpacing: "0.14em" }}
+              >
+                Agent instructions
+              </div>
+              <p
+                className="m-0 rounded-[6px] border border-[color:rgba(30,102,66,0.18)] bg-[color:rgba(30,102,66,0.04)] px-2.5 py-2 font-[family-name:var(--font-mono)] text-[11.5px] leading-[1.5] text-[var(--avy-ink)]"
+                style={{ letterSpacing: 0 }}
+              >
+                {context.agentInstructions}
+              </p>
+            </div>
+          ) : null}
+
+          {/* Verification */}
+          <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-[var(--avy-line-soft)] pt-2.5">
+            <span
+              className="font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-muted)]"
+              style={{ letterSpacing: "0.14em" }}
+            >
+              Verification
+            </span>
+            <span
+              className="inline-flex items-center rounded-full bg-[color:rgba(17,19,21,0.06)] px-2 py-0.5 font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-ink)]"
+              style={{ letterSpacing: 0 }}
+            >
+              {context.verification.method}
+            </span>
+            {context.verification.signals.map((s) => (
+              <span
+                key={s}
+                className="font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]"
+                style={{ letterSpacing: 0 }}
+              >
+                · {s}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/app/components/runs/LoadedRunPanel.tsx
+++ b/app/components/runs/LoadedRunPanel.tsx
@@ -62,10 +62,12 @@ export interface LoadedRunPanelProps {
     note: string;
   };
   /**
-   * When the loaded run was ingested from GitHub, the panel renders a
-   * "Job context" block in the left column with labels, score, issue body,
-   * acceptance criteria, agent instructions, verification signals, and an
-   * "Open GitHub Issue" link. Absent = native job, no extra block.
+   * When the loaded run was ingested from GitHub, the panel swaps its
+   * generic Evidence block (abstract/diff/citations + textarea) for a
+   * four-tab Job Context block: Issue, Acceptance, Instructions,
+   * Submission. The `evidence` prop is then unused but must still be
+   * passed (TypeScript-required). Absent = native job, keep governance
+   * evidence layout.
    */
   github?: GitHubJobContext;
 }
@@ -121,9 +123,6 @@ export function LoadedRunPanel(props: LoadedRunPanelProps) {
       <div className="grid grid-cols-1 lg:grid-cols-2">
         {/* LEFT */}
         <div className="flex flex-col gap-3.5 border-r-0 border-b border-[var(--avy-line-soft)] bg-[#fffdf7] p-4 lg:border-b-0 lg:border-r">
-          {/* Job context (GitHub-ingested jobs only) */}
-          {props.github ? <GitHubContextBlock context={props.github} /> : null}
-
           {/* Stake */}
           <div>
             <BlockLabel right={<>▪ locked in AgentAccountCore</>}>Stake</BlockLabel>
@@ -162,65 +161,72 @@ export function LoadedRunPanel(props: LoadedRunPanelProps) {
             </div>
           </div>
 
-          {/* Evidence */}
-          <div>
-            <BlockLabel
-              right={
-                <span className="font-[family-name:var(--font-mono)] text-[var(--avy-muted)]">
-                  {props.evidence.metaRight}
-                </span>
-              }
-            >
-              Evidence
-            </BlockLabel>
-            <div className="flex flex-col overflow-hidden rounded-[8px] border border-[var(--avy-line)] bg-white">
-              <div className="flex items-center gap-2 border-b border-[var(--avy-line-soft)] bg-[#faf8f1] px-2.5 py-1.5">
-                {props.evidence.tabs.map((t) => (
-                  <button
-                    key={t.id}
-                    type="button"
-                    onClick={() => setActiveTab(t.id)}
-                    className={cn(
-                      "rounded-[5px] px-2 py-0.5 font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-muted)]",
-                      activeTab === t.id &&
-                        "bg-[var(--avy-paper-solid)] text-[var(--avy-ink)] shadow-[inset_0_0_0_1px_var(--avy-line)]"
-                    )}
-                    style={{ letterSpacing: "0.12em" }}
+          {/* Evidence — switches to a GitHub-specific 4-tab layout when the
+               loaded run was ingested from a GitHub issue, so the operator
+               sees the real job context instead of generic placeholder
+               governance text. */}
+          {props.github ? (
+            <GitHubEvidenceBlock ctx={props.github} />
+          ) : (
+            <div>
+              <BlockLabel
+                right={
+                  <span className="font-[family-name:var(--font-mono)] text-[var(--avy-muted)]">
+                    {props.evidence.metaRight}
+                  </span>
+                }
+              >
+                Evidence
+              </BlockLabel>
+              <div className="flex flex-col overflow-hidden rounded-[8px] border border-[var(--avy-line)] bg-white">
+                <div className="flex items-center gap-2 border-b border-[var(--avy-line-soft)] bg-[#faf8f1] px-2.5 py-1.5">
+                  {props.evidence.tabs.map((t) => (
+                    <button
+                      key={t.id}
+                      type="button"
+                      onClick={() => setActiveTab(t.id)}
+                      className={cn(
+                        "rounded-[5px] px-2 py-0.5 font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-muted)]",
+                        activeTab === t.id &&
+                          "bg-[var(--avy-paper-solid)] text-[var(--avy-ink)] shadow-[inset_0_0_0_1px_var(--avy-line)]"
+                      )}
+                      style={{ letterSpacing: "0.12em" }}
+                    >
+                      {t.label}
+                      {t.sub ? (
+                        <small className="ml-1 opacity-50" style={{ letterSpacing: 0 }}>
+                          {t.sub}
+                        </small>
+                      ) : null}
+                    </button>
+                  ))}
+                  <span className="flex-1" />
+                  <span
+                    className="font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]"
+                    style={{ letterSpacing: 0 }}
                   >
-                    {t.label}
-                    {t.sub ? (
-                      <small className="ml-1 opacity-50" style={{ letterSpacing: 0 }}>
-                        {t.sub}
-                      </small>
-                    ) : null}
-                  </button>
-                ))}
-                <span className="flex-1" />
-                <span
-                  className="font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]"
+                    {props.evidence.metaFoot}
+                  </span>
+                </div>
+                <textarea
+                  spellCheck={false}
+                  value={evidenceValue}
+                  onChange={(event) => setEvidenceValue(event.target.value)}
+                  className="min-h-[150px] resize-y border-0 bg-transparent px-3 py-3 font-[family-name:var(--font-mono)] text-xs leading-[1.55] text-[var(--avy-ink)] outline-none"
+                  style={{ letterSpacing: 0 }}
+                />
+                <div
+                  className="flex items-center justify-between border-t border-[var(--avy-line-soft)] bg-[#faf8f1] px-2.5 py-1.5 font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]"
                   style={{ letterSpacing: 0 }}
                 >
-                  {props.evidence.metaFoot}
-                </span>
-              </div>
-              <textarea
-                spellCheck={false}
-                value={evidenceValue}
-                onChange={(event) => setEvidenceValue(event.target.value)}
-                className="min-h-[150px] resize-y border-0 bg-transparent px-3 py-3 font-[family-name:var(--font-mono)] text-xs leading-[1.55] text-[var(--avy-ink)] outline-none"
-                style={{ letterSpacing: 0 }}
-              />
-              <div
-                className="flex items-center justify-between border-t border-[var(--avy-line-soft)] bg-[#faf8f1] px-2.5 py-1.5 font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]"
-                style={{ letterSpacing: 0 }}
-              >
-                <span className="inline-flex items-center gap-1 text-[var(--avy-accent)]">
-                  ＋ Attach file
-                </span>
-                <span>sha256 0x9c…41 · autosave 4s ago</span>
+                  <span className="inline-flex items-center gap-1 text-[var(--avy-accent)]">
+                    ＋ Attach file
+                  </span>
+                  <span>sha256 0x9c…41 · autosave 4s ago</span>
+                </div>
               </div>
             </div>
-          </div>
+          )}
 
           {/* Submit */}
           <div className="flex items-center justify-between gap-3 rounded-[8px] border border-[var(--avy-line)] bg-[#fffdf7] px-3.5 py-3">
@@ -355,9 +361,19 @@ export function LoadedRunPanel(props: LoadedRunPanelProps) {
               </button>
             </div>
             <div className="mt-2 flex gap-1.5">
-              <SmallGhostBtn className="flex-1">Request cosign</SmallGhostBtn>
-              <SmallGhostBtn>Raise dispute</SmallGhostBtn>
-              <SmallGhostBtn>Unwind</SmallGhostBtn>
+              {props.github ? (
+                <>
+                  <SmallGhostBtn className="flex-1">Ping maintainer</SmallGhostBtn>
+                  <SmallGhostBtn>Raise dispute</SmallGhostBtn>
+                  <SmallGhostBtn>Abandon</SmallGhostBtn>
+                </>
+              ) : (
+                <>
+                  <SmallGhostBtn className="flex-1">Request cosign</SmallGhostBtn>
+                  <SmallGhostBtn>Raise dispute</SmallGhostBtn>
+                  <SmallGhostBtn>Unwind</SmallGhostBtn>
+                </>
+              )}
             </div>
           </div>
         </div>
@@ -366,13 +382,35 @@ export function LoadedRunPanel(props: LoadedRunPanelProps) {
   );
 }
 
-function GitHubContextBlock({ context }: { context: GitHubJobContext }) {
+/**
+ * GitHub-specific replacement for the generic Evidence block. Four tabs:
+ * ISSUE (read-only job context), ACCEPTANCE (checklist), INSTRUCTIONS
+ * (what the worker should do), and SUBMISSION (the actual evidence input
+ * — PR URL, commit URL, summary). Keeps tab state local; the outer
+ * Submit-for-verification button already lives below the evidence block.
+ */
+type GhTab = "issue" | "acceptance" | "instructions" | "submission";
+
+function GitHubEvidenceBlock({ ctx }: { ctx: GitHubJobContext }) {
+  const [tab, setTab] = useState<GhTab>("issue");
+
+  const tabs: { id: GhTab; label: string; sub?: string }[] = [
+    { id: "issue", label: "Issue" },
+    {
+      id: "acceptance",
+      label: "Acceptance",
+      sub: `·${ctx.acceptanceCriteria.length}`,
+    },
+    { id: "instructions", label: "Instructions" },
+    { id: "submission", label: "Submission" },
+  ];
+
   return (
     <div>
       <BlockLabel
         right={
           <a
-            href={context.issueUrl}
+            href={ctx.issueUrl}
             target="_blank"
             rel="noreferrer noopener"
             className="inline-flex items-center gap-1 text-[var(--avy-accent)] hover:underline"
@@ -383,20 +421,22 @@ function GitHubContextBlock({ context }: { context: GitHubJobContext }) {
       >
         Job context
       </BlockLabel>
-      <div className="overflow-hidden rounded-[8px] border border-[var(--avy-line)] bg-white">
-        {/* Header: source + repo + issue + score */}
-        <div className="flex flex-wrap items-center gap-2 border-b border-[var(--avy-line-soft)] bg-[#faf8f1] px-3 py-2">
+      <div className="flex flex-col overflow-hidden rounded-[8px] border border-[var(--avy-line)] bg-white">
+        {/* Source strip — always visible so the worker can always see the
+            repo, issue, category, and fit score regardless of which tab is
+            active. */}
+        <div className="flex flex-wrap items-center gap-2 border-b border-[var(--avy-line-soft)] bg-[color:rgba(17,19,21,0.03)] px-3 py-2">
           <SourceBadge kind="github" />
           <a
-            href={context.issueUrl}
+            href={ctx.issueUrl}
             target="_blank"
             rel="noreferrer noopener"
             className="font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-ink)] hover:text-[var(--avy-accent)]"
             style={{ letterSpacing: 0 }}
           >
-            {context.repo}
+            {ctx.repo}
             <span className="ml-0.5 text-[var(--avy-accent)]">
-              #{context.issueNumber}
+              #{ctx.issueNumber}
             </span>
           </a>
           <span className="opacity-40">·</span>
@@ -404,115 +444,242 @@ function GitHubContextBlock({ context }: { context: GitHubJobContext }) {
             className="font-[family-name:var(--font-mono)] text-[11px] uppercase text-[var(--avy-muted)]"
             style={{ letterSpacing: "0.08em" }}
           >
-            {context.category}
+            {ctx.category}
           </span>
-          {typeof context.score === "number" ? (
+          {typeof ctx.score === "number" ? (
             <span className="ml-auto inline-flex items-center gap-1 font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]">
               Fit score{" "}
-              <b className="font-semibold text-[var(--avy-ink)]">{context.score}</b>
+              <b className="font-semibold text-[var(--avy-ink)]">{ctx.score}</b>
               <span className="text-[var(--avy-muted)]">/100</span>
             </span>
           ) : null}
         </div>
 
-        {/* Body */}
+        {/* Tabs */}
+        <div className="flex items-center gap-2 border-b border-[var(--avy-line-soft)] bg-[#faf8f1] px-2.5 py-1.5">
+          {tabs.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => setTab(t.id)}
+              className={cn(
+                "rounded-[5px] px-2 py-0.5 font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-muted)]",
+                tab === t.id &&
+                  "bg-[var(--avy-paper-solid)] text-[var(--avy-ink)] shadow-[inset_0_0_0_1px_var(--avy-line)]"
+              )}
+              style={{ letterSpacing: "0.12em" }}
+            >
+              {t.label}
+              {t.sub ? (
+                <small className="ml-1 opacity-50" style={{ letterSpacing: 0 }}>
+                  {t.sub}
+                </small>
+              ) : null}
+            </button>
+          ))}
+        </div>
+
+        {/* Content */}
         <div className="px-3.5 py-3">
-          {/* Title */}
-          <h3 className="m-0 font-[family-name:var(--font-display)] text-[14px] font-bold leading-[1.3] text-[var(--avy-ink)]">
-            {context.title}
-          </h3>
+          {tab === "issue" ? <IssueTab ctx={ctx} /> : null}
+          {tab === "acceptance" ? <AcceptanceTab ctx={ctx} /> : null}
+          {tab === "instructions" ? <InstructionsTab ctx={ctx} /> : null}
+          {tab === "submission" ? <SubmissionTab ctx={ctx} /> : null}
+        </div>
 
-          {/* Labels */}
-          {context.labels && context.labels.length > 0 ? (
-            <div className="mt-2 flex flex-wrap gap-1">
-              {context.labels.map((label) => (
-                <span
-                  key={label}
-                  className="inline-flex items-center rounded-full border border-[var(--avy-line)] bg-[color:rgba(17,19,21,0.03)] px-2 py-0.5 font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-ink)]"
-                  style={{ letterSpacing: 0 }}
-                >
-                  {label}
-                </span>
-              ))}
-            </div>
-          ) : null}
-
-          {/* Body / description */}
-          <p
-            className="mt-3 max-h-[140px] overflow-y-auto whitespace-pre-wrap font-[family-name:var(--font-body)] text-[12.5px] leading-[1.5] text-[var(--avy-ink)]"
-            style={{ letterSpacing: 0 }}
-          >
-            {context.body}
-          </p>
-
-          {/* Acceptance criteria */}
-          {context.acceptanceCriteria.length > 0 ? (
-            <div className="mt-3">
-              <div
-                className="mb-1 font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-muted)]"
-                style={{ letterSpacing: "0.14em" }}
-              >
-                Acceptance criteria
-              </div>
-              <ul className="m-0 flex flex-col gap-1 pl-0">
-                {context.acceptanceCriteria.map((item, i) => (
-                  <li
-                    key={i}
-                    className="flex gap-2 font-[family-name:var(--font-body)] text-[12px] leading-[1.45] text-[var(--avy-ink)]"
-                    style={{ letterSpacing: 0 }}
-                  >
-                    <span className="mt-[7px] h-[4px] w-[4px] shrink-0 rounded-full bg-[var(--avy-accent)]" />
-                    <span>{item}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ) : null}
-
-          {/* Agent instructions */}
-          {context.agentInstructions ? (
-            <div className="mt-3">
-              <div
-                className="mb-1 font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-muted)]"
-                style={{ letterSpacing: "0.14em" }}
-              >
-                Agent instructions
-              </div>
-              <p
-                className="m-0 rounded-[6px] border border-[color:rgba(30,102,66,0.18)] bg-[color:rgba(30,102,66,0.04)] px-2.5 py-2 font-[family-name:var(--font-mono)] text-[11.5px] leading-[1.5] text-[var(--avy-ink)]"
-                style={{ letterSpacing: 0 }}
-              >
-                {context.agentInstructions}
-              </p>
-            </div>
-          ) : null}
-
-          {/* Verification */}
-          <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-[var(--avy-line-soft)] pt-2.5">
-            <span
-              className="font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-muted)]"
-              style={{ letterSpacing: "0.14em" }}
-            >
-              Verification
+        {/* Verification footer — mirrors the native block's sha/attach
+            strip; here it tells the worker what verification gate applies. */}
+        <div
+          className="flex flex-wrap items-center gap-x-2 gap-y-1 border-t border-[var(--avy-line-soft)] bg-[#faf8f1] px-3 py-2 font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]"
+          style={{ letterSpacing: 0 }}
+        >
+          <span className="text-[var(--avy-accent)]">Verification</span>
+          <span className="inline-flex items-center rounded-full bg-[color:rgba(17,19,21,0.06)] px-1.5 py-px font-medium text-[var(--avy-ink)]">
+            {ctx.verification.method}
+          </span>
+          {ctx.verification.signals.map((s, i) => (
+            <span key={s}>
+              {i === 0 ? "·" : "·"} {s}
             </span>
-            <span
-              className="inline-flex items-center rounded-full bg-[color:rgba(17,19,21,0.06)] px-2 py-0.5 font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-ink)]"
-              style={{ letterSpacing: 0 }}
-            >
-              {context.verification.method}
-            </span>
-            {context.verification.signals.map((s) => (
-              <span
-                key={s}
-                className="font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]"
-                style={{ letterSpacing: 0 }}
-              >
-                · {s}
-              </span>
-            ))}
-          </div>
+          ))}
         </div>
       </div>
+    </div>
+  );
+}
+
+function IssueTab({ ctx }: { ctx: GitHubJobContext }) {
+  return (
+    <>
+      <h3 className="m-0 font-[family-name:var(--font-display)] text-[14px] font-bold leading-[1.3] text-[var(--avy-ink)]">
+        {ctx.title}
+      </h3>
+
+      {ctx.labels && ctx.labels.length > 0 ? (
+        <div className="mt-2 flex flex-wrap gap-1">
+          {ctx.labels.map((label) => (
+            <span
+              key={label}
+              className="inline-flex items-center rounded-full border border-[var(--avy-line)] bg-[color:rgba(17,19,21,0.03)] px-2 py-0.5 font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-ink)]"
+              style={{ letterSpacing: 0 }}
+            >
+              {label}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      <p
+        className="mt-3 max-h-[220px] overflow-y-auto whitespace-pre-wrap font-[family-name:var(--font-body)] text-[12.5px] leading-[1.5] text-[var(--avy-ink)]"
+        style={{ letterSpacing: 0 }}
+      >
+        {ctx.body}
+      </p>
+
+      <div className="mt-3 flex justify-end">
+        <a
+          href={ctx.issueUrl}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="inline-flex h-7 items-center gap-1.5 rounded-[8px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-3 font-[family-name:var(--font-display)] text-[11px] font-bold uppercase text-[var(--avy-ink)] transition-transform hover:-translate-y-px hover:border-[color:rgba(30,102,66,0.24)] hover:text-[var(--avy-accent)]"
+          style={{ letterSpacing: "0.04em" }}
+        >
+          Open GitHub issue ↗
+        </a>
+      </div>
+    </>
+  );
+}
+
+function AcceptanceTab({ ctx }: { ctx: GitHubJobContext }) {
+  if (ctx.acceptanceCriteria.length === 0) {
+    return (
+      <p
+        className="m-0 font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]"
+        style={{ letterSpacing: 0 }}
+      >
+        No explicit criteria were provided with this issue.
+      </p>
+    );
+  }
+  return (
+    <ul className="m-0 flex flex-col gap-2 pl-0">
+      {ctx.acceptanceCriteria.map((item, i) => (
+        <li
+          key={i}
+          className="grid grid-cols-[18px_1fr] items-start gap-2 font-[family-name:var(--font-body)] text-[12.5px] leading-[1.45] text-[var(--avy-ink)]"
+          style={{ letterSpacing: 0 }}
+        >
+          <span
+            className="mt-px inline-grid h-[16px] w-[16px] place-items-center rounded-[4px] border border-[color:rgba(30,102,66,0.25)] bg-[color:rgba(30,102,66,0.06)] font-[family-name:var(--font-mono)] text-[9px] font-bold text-[var(--avy-accent)]"
+            style={{ letterSpacing: 0 }}
+            aria-hidden="true"
+          >
+            {i + 1}
+          </span>
+          <span>{item}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function InstructionsTab({ ctx }: { ctx: GitHubJobContext }) {
+  if (!ctx.agentInstructions) {
+    return (
+      <p
+        className="m-0 font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]"
+        style={{ letterSpacing: 0 }}
+      >
+        No agent instructions were generated for this job.
+      </p>
+    );
+  }
+  return (
+    <p
+      className="m-0 rounded-[6px] border border-[color:rgba(30,102,66,0.18)] bg-[color:rgba(30,102,66,0.04)] px-3 py-2.5 font-[family-name:var(--font-mono)] text-[12px] leading-[1.55] text-[var(--avy-ink)]"
+      style={{ letterSpacing: 0 }}
+    >
+      {ctx.agentInstructions}
+    </p>
+  );
+}
+
+function SubmissionTab({ ctx }: { ctx: GitHubJobContext }) {
+  return (
+    <div className="flex flex-col gap-2.5">
+      <SubField
+        label="PR URL"
+        required
+        placeholder={`https://github.com/${ctx.repo}/pull/…`}
+        mono
+      />
+      <SubField
+        label="Branch / commit URL"
+        placeholder={`https://github.com/${ctx.repo}/commit/…`}
+        mono
+      />
+      <div>
+        <SubLabel>Summary of changes</SubLabel>
+        <textarea
+          spellCheck={false}
+          placeholder="Short prose summary. Reference the issue, list the files touched, note any trade-offs the maintainer should know about."
+          className="min-h-[90px] w-full resize-y rounded-[6px] border border-[var(--avy-line)] bg-white px-2.5 py-2 font-[family-name:var(--font-body)] text-[12.5px] leading-[1.45] text-[var(--avy-ink)] outline-none placeholder:text-[var(--avy-muted)] focus:border-[var(--avy-accent)] focus:ring-2 focus:ring-[color:rgba(30,102,66,0.15)]"
+          style={{ letterSpacing: 0 }}
+        />
+      </div>
+      <div>
+        <SubLabel>Notes for verifier (optional)</SubLabel>
+        <textarea
+          spellCheck={false}
+          placeholder="Test output, logs, caveats, anything the verifier needs."
+          className="min-h-[60px] w-full resize-y rounded-[6px] border border-[var(--avy-line)] bg-white px-2.5 py-2 font-[family-name:var(--font-mono)] text-[11.5px] leading-[1.5] text-[var(--avy-ink)] outline-none placeholder:text-[var(--avy-muted)] focus:border-[var(--avy-accent)] focus:ring-2 focus:ring-[color:rgba(30,102,66,0.15)]"
+          style={{ letterSpacing: 0 }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function SubLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="mb-1 font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-muted)]"
+      style={{ letterSpacing: "0.14em" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function SubField({
+  label,
+  placeholder,
+  required,
+  mono,
+}: {
+  label: string;
+  placeholder: string;
+  required?: boolean;
+  mono?: boolean;
+}) {
+  return (
+    <div>
+      <SubLabel>
+        {label}
+        {required ? (
+          <span className="ml-1 text-[var(--avy-accent)]">*</span>
+        ) : null}
+      </SubLabel>
+      <input
+        type="url"
+        placeholder={placeholder}
+        className={cn(
+          "h-9 w-full rounded-[6px] border border-[var(--avy-line)] bg-white px-2.5 text-[12.5px] text-[var(--avy-ink)] outline-none placeholder:text-[var(--avy-muted)] focus:border-[var(--avy-accent)] focus:ring-2 focus:ring-[color:rgba(30,102,66,0.15)]",
+          mono && "font-[family-name:var(--font-mono)] text-[12px]"
+        )}
+        style={{ letterSpacing: 0 }}
+      />
     </div>
   );
 }

--- a/app/components/runs/RunQueueTable.tsx
+++ b/app/components/runs/RunQueueTable.tsx
@@ -2,14 +2,21 @@
 
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils/cn";
-import { StatePill, type RunState } from "./StatePill";
+import { StatePill, SourceBadge, type RunState } from "./StatePill";
 import { WorkerChip, type WorkerVariant } from "./WorkerChip";
+import type { JobSource } from "./types";
 
 export interface RunRow {
   id: string;
   sessionId?: string;
   jobMeta: string;
   title: string;
+  /**
+   * Optional provenance. Present on GitHub-ingested jobs so the row can
+   * show the source badge + `owner/repo #123` inline instead of just the
+   * internal job id.
+   */
+  source?: JobSource;
   worker: {
     variant: WorkerVariant;
     initials: string;
@@ -84,14 +91,31 @@ export function RunQueueTable({
                   )}
                 >
                   <Td>
-                    <div className="text-[13px] font-semibold leading-[1.3] text-[var(--avy-ink)]">
-                      {row.title}
-                      <small
-                        className="mt-0.5 block font-[family-name:var(--font-mono)] text-[11px] font-normal text-[var(--avy-muted)]"
+                    <div className="min-w-0 max-w-[360px]">
+                      <div
+                        className="line-clamp-2 text-[13px] font-semibold leading-[1.3] text-[var(--avy-ink)]"
+                        title={row.title}
+                      >
+                        {row.title}
+                      </div>
+                      <div
+                        className="mt-0.5 flex items-center gap-1.5 font-[family-name:var(--font-mono)] text-[11px] font-normal text-[var(--avy-muted)]"
                         style={{ letterSpacing: 0 }}
                       >
-                        {row.jobMeta}
-                      </small>
+                        {row.source?.type === "github_issue" ? (
+                          <>
+                            <SourceBadge kind="github" />
+                            <span className="truncate">
+                              {row.source.repo}
+                              <span className="text-[var(--avy-accent)]"> #{row.source.issueNumber}</span>
+                            </span>
+                            <span className="opacity-40">·</span>
+                            <span className="truncate">{row.jobMeta}</span>
+                          </>
+                        ) : (
+                          <span className="truncate">{row.jobMeta}</span>
+                        )}
+                      </div>
                     </div>
                   </Td>
                   <Td>

--- a/app/components/runs/StatePill.tsx
+++ b/app/components/runs/StatePill.tsx
@@ -77,3 +77,57 @@ export function VerifierModePill({
     </span>
   );
 }
+
+/**
+ * Small "where did this job come from" badge. GitHub-ingested jobs get the
+ * GitHub mark + label; the OSS variant is a neutral fallback if we widen
+ * ingestion to non-GitHub OSS trackers later.
+ */
+export type SourceKind = "github" | "oss";
+
+const SOURCE_CLASSES: Record<SourceKind, string> = {
+  github: "bg-[#111418] text-white",
+  oss: "bg-[color:rgba(17,19,21,0.06)] text-[var(--avy-ink)]",
+};
+
+const SOURCE_LABEL: Record<SourceKind, string> = {
+  github: "GitHub",
+  oss: "OSS",
+};
+
+export function SourceBadge({
+  kind,
+  className,
+}: {
+  kind: SourceKind;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-[family-name:var(--font-display)] text-[9.5px] font-extrabold uppercase whitespace-nowrap",
+        SOURCE_CLASSES[kind],
+        className
+      )}
+      style={{ letterSpacing: "0.1em" }}
+    >
+      {kind === "github" ? <GitHubGlyph /> : <span className="h-[5px] w-[5px] rounded-full bg-current opacity-80" />}
+      {SOURCE_LABEL[kind]}
+    </span>
+  );
+}
+
+function GitHubGlyph() {
+  // Inline SVG so we don't pull in another icon bundle just for one mark.
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      width="10"
+      height="10"
+      fill="currentColor"
+    >
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.19 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+    </svg>
+  );
+}

--- a/app/components/runs/types.ts
+++ b/app/components/runs/types.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared types for the Runs surface.
+ *
+ * `JobSource` is emitted by the backend for every job. For native platform
+ * jobs the shape is minimal; for jobs ingested from a third-party system
+ * (currently GitHub) the source block carries the upstream handle and
+ * whatever context the row/card/panel needs to render without an extra
+ * fetch.
+ */
+
+export interface GitHubJobSource {
+  type: "github_issue";
+  repo: string; // "owner/repo"
+  issueNumber: number;
+  issueUrl: string;
+  labels?: string[];
+  score?: number;
+}
+
+export type JobSource = GitHubJobSource | { type: "native" };
+
+/**
+ * Rich context surfaced in the Loaded-run panel when the selected run was
+ * ingested from GitHub. This is the "full task context" a worker needs to
+ * decide whether to claim (and, once claimed, to execute).
+ */
+export interface GitHubJobContext extends GitHubJobSource {
+  title: string;
+  body: string; // markdown/plain text of the issue body
+  category: string; // docs | coding | testing | bugfix | ...
+  acceptanceCriteria: string[];
+  agentInstructions: string;
+  verification: {
+    method: string; // e.g. "github_pr"
+    signals: string[];
+  };
+}

--- a/app/lib/api/run-adapters.ts
+++ b/app/lib/api/run-adapters.ts
@@ -2,6 +2,7 @@ import type { JobCardData } from "@/components/runs/JobCard";
 import type { QueueFilterCount } from "@/components/runs/QueueBar";
 import type { RunRow } from "@/components/runs/RunQueueTable";
 import type { RunState, Tier } from "@/components/runs/StatePill";
+import type { GitHubJobContext, JobSource } from "@/components/runs/types";
 
 type RawRecord = Record<string, unknown>;
 
@@ -91,6 +92,69 @@ function lookupJob(jobs: RawRecord[], id: unknown): RawRecord {
   return jobs.find((job) => text(job.id) === jobId) ?? {};
 }
 
+/**
+ * Pull a lightweight provenance block off a job record. GitHub-ingested
+ * jobs carry a `source.type === "github_issue"` block with the repo,
+ * issue number, URL, labels, and ingestion score. Native platform jobs
+ * either omit `source` or emit `{ type: "native" }`; those return
+ * undefined so the UI renders the generic layout.
+ */
+export function buildJobSource(job: unknown): JobSource | undefined {
+  const src = asRecord(asRecord(job).source);
+  if (text(src.type) !== "github_issue") return undefined;
+  const repo = text(src.repo);
+  const issueNumber = numberValue(src.issueNumber);
+  const issueUrl = text(src.issueUrl);
+  if (!repo || !issueNumber || !issueUrl) return undefined;
+  const labels = Array.isArray(src.labels)
+    ? src.labels.filter((label): label is string => typeof label === "string")
+    : undefined;
+  const score = typeof src.score === "number" ? src.score : undefined;
+  return {
+    type: "github_issue",
+    repo,
+    issueNumber,
+    issueUrl,
+    ...(labels && labels.length ? { labels } : {}),
+    ...(score !== undefined ? { score } : {}),
+  };
+}
+
+/**
+ * Build the rich GitHubJobContext used by the Loaded-run panel when a
+ * GitHub-ingested job is selected. Returns undefined for native jobs so
+ * the panel falls back to the generic governance layout.
+ */
+export function buildGitHubContext(
+  row: Pick<RunRow, "source" | "title">,
+  job: unknown
+): GitHubJobContext | undefined {
+  if (row.source?.type !== "github_issue") return undefined;
+  const record = asRecord(job);
+  const verification = asRecord(record.verification);
+  const verificationMethod = text(verification.method, "github_pr");
+  const verificationSignals = Array.isArray(verification.signals)
+    ? verification.signals.filter(
+        (signal): signal is string => typeof signal === "string"
+      )
+    : ["PR opened", "CI green", "maintainer review"];
+  const acceptance = Array.isArray(record.acceptanceCriteria)
+    ? record.acceptanceCriteria.filter(
+        (item): item is string => typeof item === "string"
+      )
+    : [];
+
+  return {
+    ...row.source,
+    title: text(record.title, row.title),
+    category: text(record.category, "work"),
+    body: text(record.description, text(record.body, "")),
+    acceptanceCriteria: acceptance,
+    agentInstructions: text(record.agentInstructions),
+    verification: { method: verificationMethod, signals: verificationSignals },
+  };
+}
+
 export function extractRunJobs(payload: unknown): RawRecord[] {
   return asArray(payload);
 }
@@ -102,11 +166,13 @@ export function buildRunRows(payload: unknown): RunRow[] {
     const state = stateFromRaw(job.state);
     const worker = text(job.claimedBy) || text(job.worker);
 
+    const source = buildJobSource(job);
     return {
       id,
       sessionId: text(job.sessionId),
       title,
       jobMeta: `${id} · ${text(job.category, "work")} · ${tierFromRaw(job.tier)}`,
+      ...(source ? { source } : {}),
       worker: {
         variant: worker ? "a" : "unclaimed",
         initials: worker ? "AG" : "-",
@@ -115,8 +181,18 @@ export function buildRunRows(payload: unknown): RunRow[] {
       state,
       stake: formatReward(job.stake ?? job.rewardAmount),
       age: formatWindow(job.claimTtlSeconds),
-      lastEvent: state === "ready" ? "Job listed" : `State: ${state}`,
-      lastEventMeta: `${text(job.rewardAsset, "DOT")} · verifier ${verifierLabel(job.verifierMode)}`,
+      lastEvent:
+        source?.type === "github_issue"
+          ? state === "ready"
+            ? "Ingested from GitHub"
+            : `State: ${state}`
+          : state === "ready"
+            ? "Job listed"
+            : `State: ${state}`,
+      lastEventMeta:
+        source?.type === "github_issue"
+          ? `${source.repo} #${source.issueNumber} · verifier ${verifierLabel(job.verifierMode)}`
+          : `${text(job.rewardAsset, "DOT")} · verifier ${verifierLabel(job.verifierMode)}`,
     };
   });
 }
@@ -143,10 +219,14 @@ export function buildRecommendationCards(
     const fitScore = numberValue(recommendation.fitScore);
     const fit = Math.max(1, Math.min(5, Math.ceil(fitScore / 20)));
 
+    const source = buildJobSource(job);
+    const category = text(job.category, "work");
     return {
       id,
       title: text(job.title, text(job.description, titleFromId(id))),
-      jobMeta: text(job.category, "work"),
+      jobMeta: category,
+      category,
+      ...(source ? { source } : {}),
       rewardValue: formatReward(recommendation.netReward ?? job.rewardAmount),
       rewardCurrency: text(job.rewardAsset, "DOT"),
       rewardUsd: "live",
@@ -157,7 +237,15 @@ export function buildRecommendationCards(
         { label: "Reward", value: `${formatReward(job.rewardAmount)} ${text(job.rewardAsset, "DOT")}` },
         { label: "Verifier", value: verifierLabel(job.verifierMode) },
         { label: "Window", value: formatWindow(job.claimTtlSeconds), accent: true },
-        { label: "Gas", value: job.requiresSponsoredGas ? "sponsored" : "worker" },
+        {
+          label: source?.type === "github_issue" ? "Fit score" : "Gas",
+          value:
+            source?.type === "github_issue"
+              ? `${source.score ?? fitScore}/100`
+              : job.requiresSponsoredGas
+                ? "sponsored"
+                : "worker",
+        },
       ],
       fit,
       hot: index === 0,


### PR DESCRIPTION
## Summary

Follow-up to PR #1. Gives GitHub-ingested jobs a first-class visual identity across the Runs board and rewrites the Loaded-run panel so a selected GitHub job shows real task context instead of the generic governance layout.

Rebased onto current \`main\` on top of the wiring work (\`Wire runs and sessions to API data\`, \`Add GitHub issue job ingestion scheduler\`, etc). Adapter extended to carry \`source\` + build \`GitHubJobContext\` off live \`/jobs\` and \`/jobs/definition\` responses — no new endpoints required.

## Changes

### Queue row identity
- Row titles clamp to 2 lines (\`line-clamp-2\`) with full-title tooltip
- GitHub rows render a compact \`GitHub\` badge + \`owner/repo #N\` alongside the existing job-id / category / tier meta
- Native rows unchanged

### Recommendation cards
- Title clamps to 2 lines, max-width cap dropped
- GitHub cards show \`owner/repo #N\` under the title (replaces generic job-id)
- Pills row adds \`GitHub\` badge + optional \`category\` chip
- Adapter populates \`Fit score\` meta field for GitHub cards (replaces the \`Gas\` field that made no sense for PR-based verification)

### Loaded-run panel (when \`github\` prop is set)
Left column's generic Evidence block is replaced with a four-tab Job Context block:
- **Issue** — title, labels, full body, \`Open GitHub issue ↗\`
- **Acceptance** — numbered acceptance-criteria checklist
- **Instructions** — agent instructions in a green-tinted mono block
- **Submission** — PR URL (required), branch/commit URL, summary textarea, verifier notes

A source strip (badge · repo · issue # · category · fit score) stays pinned above the tabs so provenance is always visible. A verification footer (\`github_pr · PR opened · CI green · maintainer review\`) sits below.

Right column copy rewritten for the PR flow:
- Verifier output: real PR checks (\`source\` loaded, \`pass\` PR URL present, \`pass\` PR body references issue, \`pass\` CI checks green, \`note\` maintainer review pending, \`verdict\` 2/3 signals pass)
- Settlement: \"Awaiting verification\" / \"Mark verified & pay\"; cosign language gone
- Secondary buttons swap: \`Ping maintainer / Raise dispute / Abandon\` instead of \`Request cosign / Raise dispute / Unwind\`

Lifecycle rail:
- Stages relabeled for GitHub: \`Ready → Claimed → PR submitted → Verified → Paid\`
- Context note: \`verification github_pr · PR #4931 opened\`
- Next: \`Maintainer review → Pay · auto-pays on PR merge + CI green\`

### Adapter (\`lib/api/run-adapters.ts\`)
- New \`buildJobSource(job)\` → \`JobSource | undefined\`
- New \`buildGitHubContext(row, job)\` → \`GitHubJobContext | undefined\`
- \`buildRunRows\` and \`buildRecommendationCards\` now attach \`source\` when the live job payload carries \`source.type === \"github_issue\"\`
- \`lastEvent\`/\`lastEventMeta\` on queue rows adapt to GitHub provenance

### Fixture fallback
When the live \`/jobs\` endpoint returns nothing (e.g. backend down), the page still falls back to demo data. Added \`FIXTURE_JOB_DEFINITIONS\` so \`buildGitHubContext\` can populate the panel with rich content for the two fixture GitHub rows — otherwise the tabs would render empty.

## Test plan

- [ ] \`npm run dev:app\` — Runs page renders, queue shows GitHub badges on row 1 + 3, recommendation rail top card is GitHub
- [ ] Click a GitHub row → panel shows four tabs (Issue · Acceptance · Instructions · Submission), click through each → content renders
- [ ] Click \"Open GitHub issue ↗\" on the panel or issue tab → opens the upstream issue in a new tab
- [ ] Click a native row (e.g. \`schema-mig\`) → panel falls back to the generic governance evidence layout
- [ ] \`npm run typecheck:app\` — clean
- [ ] On VPS with live backend + GitHub ingestion: real issues appear with full context

🤖 Generated with [Claude Code](https://claude.com/claude-code)