### PR TITLE
Runs page: split-pane, markdown bodies, card rows + receipt preview

### DIFF
--- a/app/app/(authed)/runs/page.tsx
+++ b/app/app/(authed)/runs/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { mutate } from "swr";
 import { RunsTopbar } from "@/components/runs/RunsTopbar";
 import {
@@ -19,6 +20,10 @@ import {
   LifecycleRail,
   type LifecycleStage,
 } from "@/components/runs/LifecycleRail";
+import {
+  ReceiptPreviewDrawer,
+  type ReceiptPreviewDraft,
+} from "@/components/runs/ReceiptPreviewDrawer";
 import { useJobDefinition, useJobs, useRecommendations } from "@/lib/api/hooks";
 import { swrFetcher } from "@/lib/api/client";
 import {
@@ -366,13 +371,34 @@ const LIFECYCLE: LifecycleStage[] = [
   { index: 5, label: "Paid", meta: "—", state: "pending" },
 ];
 
+// `useSearchParams` requires a Suspense boundary under the App Router
+// static-export mode used on the VPS. Wrap the inner page component so
+// deep-links like `/runs/?run=run-2742` hydrate correctly without
+// breaking the static build.
 export default function RunsPage() {
+  return (
+    <Suspense fallback={null}>
+      <RunsPageInner />
+    </Suspense>
+  );
+}
+
+function RunsPageInner() {
+  const searchParams = useSearchParams();
+  const runParam = searchParams?.get("run") ?? null;
   const [activeFilter, setActiveFilter] = useState<QueueFilter>("all");
-  const [selectedId, setSelectedId] = useState<string>("run-2742");
+  const [selectedId, setSelectedId] = useState<string>(runParam ?? "run-2742");
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [receiptOpen, setReceiptOpen] = useState(false);
   const jobs = useJobs();
   const recommendations = useRecommendations();
+
+  // When someone opens the page with a ?run=<id> deep link, honour it on
+  // first hydration so the corresponding row is pre-selected.
+  useEffect(() => {
+    if (runParam) setSelectedId(runParam);
+  }, [runParam]);
 
   const liveRows = useMemo(() => buildRunRows(jobs.data), [jobs.data]);
   const rows = liveRows.length ? liveRows : ROWS;
@@ -477,9 +503,17 @@ export default function RunsPage() {
             handleSubmit={handleSubmit}
             submitting={submitting}
             submitError={submitError}
+            onReceiptPreview={() => setReceiptOpen(true)}
+            standaloneUrl={`/runs/?run=${encodeURIComponent(loadedRow.id)}`}
           />
         </div>
       </div>
+
+      <ReceiptPreviewDrawer
+        open={receiptOpen}
+        onClose={() => setReceiptOpen(false)}
+        draft={buildReceiptDraft(loadedRow, loadedGitHub)}
+      />
 
       <LifecycleRail
         runId="run-2742"
@@ -527,10 +561,12 @@ interface LoadedPanelProps {
   handleSubmit: (evidence: string) => Promise<void>;
   submitting: boolean;
   submitError: string | null;
+  onReceiptPreview?: () => void;
+  standaloneUrl?: string;
 }
 
 function LoadedRunPanelWrapper(props: LoadedPanelProps) {
-  const { loadedRow, selectedJob, loadedGitHub, handleSubmit, submitting, submitError } = props;
+  const { loadedRow, selectedJob, loadedGitHub, handleSubmit, submitting, submitError, onReceiptPreview, standaloneUrl } = props;
   return (
     <LoadedRunPanel
         kicker="Loaded run"
@@ -538,6 +574,8 @@ function LoadedRunPanelWrapper(props: LoadedPanelProps) {
         meta={loadedRow.jobMeta}
         state={loadedRow.state}
         github={loadedGitHub}
+        onReceiptPreview={onReceiptPreview}
+        standaloneUrl={standaloneUrl}
         stake={{
           amount: loadedRow.stake,
           aux: selectedJob
@@ -672,4 +710,56 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : null;
+}
+
+/**
+ * Assemble the unsigned receipt that the operator would commit if they
+ * clicked "Mark verified & pay" right now. Everything here is derived
+ * from data already on the Loaded-run panel; nothing is fetched. That's
+ * the whole point — the preview is a "before you sign" view, not a new
+ * round trip.
+ */
+function buildReceiptDraft(
+  row: RunRow,
+  github: ReturnType<typeof buildGitHubContext>
+): ReceiptPreviewDraft {
+  const workerSignerLabel = row.worker.isSelf
+    ? `Worker · ${row.worker.label} (you)`
+    : `Worker · ${row.worker.label}`;
+
+  return {
+    receiptRef: "r_4e133",
+    runId: row.id,
+    jobMeta: row.jobMeta,
+    state: row.state,
+    stake: {
+      amount: row.stake,
+      currency: "DOT",
+      breakdown: [
+        { label: "Worker payout", value: `${row.stake} DOT` },
+        { label: "Verifier fee", value: "0 DOT" },
+        { label: "Treasury reserve", value: "0 DOT" },
+      ],
+    },
+    verdict: {
+      status: github
+        ? "Awaiting maintainer review"
+        : "Verified (pending cosign)",
+      score: github ? "2 / 3" : "4 / 5",
+      confidence: github ? "0.86 confidence" : "0.92 confidence",
+    },
+    evidenceHash: github ? "sha256 0x9c…41" : "sha256 0x9c…41",
+    ...(github ? { github } : {}),
+    prUrl: github ? `https://github.com/${github.repo}/pull/4931` : undefined,
+    signers: [
+      { label: workerSignerLabel, status: "pending" },
+      {
+        label: github
+          ? "Maintainer · awaiting review"
+          : "Cosigner · 0x9A13…0cb2",
+        status: "pending",
+      },
+      { label: "Verifier · verifier-2", status: "signed" },
+    ],
+  };
 }

--- a/app/app/(authed)/runs/page.tsx
+++ b/app/app/(authed)/runs/page.tsx
@@ -443,11 +443,22 @@ export default function RunsPage() {
   };
 
   return (
-    <div className="flex w-full max-w-[1100px] flex-col gap-3.5">
+    <div className="flex w-full max-w-[1440px] flex-col gap-3.5">
       <RunsTopbar />
       <QueueBar filters={filters.length ? filters : FILTERS} active={activeFilter} onChange={setActiveFilter} />
 
-      <div className="grid grid-cols-1 items-start gap-3.5 xl:grid-cols-[minmax(0,1fr)_320px]">
+      {/*
+       * Email-client layout: queue on the left (compact, scannable) + loaded-
+       * run panel on the right, sticky so the details stay visible as the
+       * queue scrolls. Recommendation rail + lifecycle sit below the split
+       * pane so they don't steal horizontal room from the two primary panes.
+       *
+       * At xl: 45fr / 55fr split — the panel is wider because it hosts the
+       * two inner columns (stake + job context on the left, verifier +
+       * settlement on the right) and needs the headroom.
+       * Below xl: single column, panel stacks under the queue.
+       */}
+      <div className="grid grid-cols-1 items-start gap-3.5 xl:grid-cols-[minmax(480px,0.85fr)_minmax(0,1.15fr)]">
         <RunQueueTable
           rows={visibleRows}
           selectedId={selectedId}
@@ -458,18 +469,74 @@ export default function RunsPage() {
           assignedToMe={assignedToMe}
           liveStatus={liveStatus}
         />
-        <RecommendationRail
-          workerTier="live"
-          workerScore={recommendations.error ? 0 : recommendationCards.length}
-          jobs={recommendationCards}
-          totalMatches={recommendationCards.length}
-        />
+        <div className="xl:sticky xl:top-6 xl:max-h-[calc(100vh-3rem)] xl:overflow-y-auto">
+          <LoadedRunPanelWrapper
+            loadedRow={loadedRow}
+            selectedJob={selectedJob}
+            loadedGitHub={loadedGitHub}
+            handleSubmit={handleSubmit}
+            submitting={submitting}
+            submitError={submitError}
+          />
+        </div>
       </div>
 
-      <LoadedRunPanel
+      <LifecycleRail
+        runId="run-2742"
+        contextNote={
+          <>
+            Window closes in{" "}
+            <b className="font-semibold text-[var(--avy-ink)]">21m 46s</b>
+            {" · "}verification{" "}
+            <b className="font-semibold text-[var(--avy-ink)]">github_pr</b>
+            {" · "}PR{" "}
+            <b className="font-semibold text-[var(--avy-ink)]">#4931</b> opened
+          </>
+        }
+        stages={LIFECYCLE}
+        next={{
+          label: "Next",
+          value: "Maintainer review → Pay",
+          sub: "auto-pays on PR merge + CI green",
+        }}
+      />
+
+      <RecommendationRail
+        layout="horizontal"
+        workerTier="live"
+        workerScore={recommendations.error ? 0 : recommendationCards.length}
+        jobs={recommendationCards}
+        totalMatches={recommendationCards.length}
+      />
+    </div>
+  );
+}
+
+/**
+ * Thin wrapper around LoadedRunPanel so the gnarly fixture-shaped props
+ * (evidence stub, verifier fixture, settle fixture, submission handler)
+ * don't clutter the main page component. All live values continue to come
+ * from live data / the loaded row; the non-GitHub fixture verifier lines
+ * stay in place as a demo fallback while the backend isn't yet streaming
+ * real verifier output.
+ */
+interface LoadedPanelProps {
+  loadedRow: RunRow;
+  selectedJob: Record<string, unknown> | undefined;
+  loadedGitHub: ReturnType<typeof buildGitHubContext>;
+  handleSubmit: (evidence: string) => Promise<void>;
+  submitting: boolean;
+  submitError: string | null;
+}
+
+function LoadedRunPanelWrapper(props: LoadedPanelProps) {
+  const { loadedRow, selectedJob, loadedGitHub, handleSubmit, submitting, submitError } = props;
+  return (
+    <LoadedRunPanel
         kicker="Loaded run"
         title={loadedRow.title}
         meta={loadedRow.jobMeta}
+        state={loadedRow.state}
         github={loadedGitHub}
         stake={{
           amount: loadedRow.stake,
@@ -598,27 +665,6 @@ export default function RunsPage() {
           note: "pays worker & verifier once the maintainer approves the PR",
         }}
       />
-
-      <LifecycleRail
-        runId="run-2742"
-        contextNote={
-          <>
-            Window closes in{" "}
-            <b className="font-semibold text-[var(--avy-ink)]">21m 46s</b>
-            {" · "}verification{" "}
-            <b className="font-semibold text-[var(--avy-ink)]">github_pr</b>
-            {" · "}PR{" "}
-            <b className="font-semibold text-[var(--avy-ink)]">#4931</b> opened
-          </>
-        }
-        stages={LIFECYCLE}
-        next={{
-          label: "Next",
-          value: "Maintainer review → Pay",
-          sub: "auto-pays on PR merge + CI green",
-        }}
-      />
-    </div>
   );
 }
 

--- a/app/components/runs/IssueMarkdown.tsx
+++ b/app/components/runs/IssueMarkdown.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils/cn";
+
+/**
+ * Renders a GitHub issue body as markdown. Tailored to the noise we see
+ * in real issue bodies:
+ *   - shields.io / img.shields.io badges are dropped entirely (they're
+ *     decorative and render as 90px pills that blow out the layout)
+ *   - other inline images are replaced with a compact `[image: alt]`
+ *     token so we don't pull remote assets into the control room
+ *   - links open in a new tab with rel=noopener
+ *   - headings, blockquotes, lists, code fences and task lists are
+ *     typographically tamed so a 4-paragraph body doesn't overwhelm
+ *     the 420px-wide tab
+ *
+ * Kept small and dependency-surface-minimal: react-markdown + remark-gfm
+ * cover GitHub-flavoured markdown (tables, task lists, strikethrough,
+ * autolinks) without adding a full rehype/sanitize pipeline. We don't
+ * render raw HTML, so the default sanitisation is sufficient.
+ */
+export function IssueMarkdown({
+  children,
+  className,
+}: {
+  children: string;
+  className?: string;
+}) {
+  return (
+    <div className={cn("avy-md", className)}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          // Drop shields.io / img.shields.io badges — they're pure
+          // decoration and their fixed pixel widths blow out narrow
+          // columns. Surface other images as a compact placeholder so
+          // we don't fetch remote assets from inside the control room.
+          img: ({ src, alt }) => {
+            const href = typeof src === "string" ? src : "";
+            if (/(?:img\.)?shields\.io/i.test(href)) return null;
+            return (
+              <span
+                className="inline-block rounded border border-[var(--avy-line)] bg-[color:rgba(17,19,21,0.04)] px-1.5 py-0.5 font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]"
+                style={{ letterSpacing: 0 }}
+              >
+                [image{alt ? `: ${alt}` : ""}]
+              </span>
+            );
+          },
+          a: ({ href, children }) => (
+            <a
+              href={href}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="text-[var(--avy-accent)] underline decoration-[color:rgba(30,102,66,0.35)] underline-offset-2 hover:decoration-[var(--avy-accent)]"
+            >
+              {children}
+            </a>
+          ),
+          p: ({ children }) => (
+            <p className="mb-2.5 last:mb-0">{children}</p>
+          ),
+          h1: ({ children }) => (
+            <h3 className="mt-4 mb-1.5 font-[family-name:var(--font-display)] text-[13.5px] font-bold leading-[1.3] text-[var(--avy-ink)]">
+              {children}
+            </h3>
+          ),
+          h2: ({ children }) => (
+            <h4 className="mt-3.5 mb-1 font-[family-name:var(--font-display)] text-[12.5px] font-bold leading-[1.3] text-[var(--avy-ink)]">
+              {children}
+            </h4>
+          ),
+          h3: ({ children }) => (
+            <h5 className="mt-3 mb-1 font-[family-name:var(--font-display)] text-[12px] font-bold uppercase leading-[1.3] text-[var(--avy-muted)]"
+              style={{ letterSpacing: "0.08em" }}
+            >
+              {children}
+            </h5>
+          ),
+          ul: ({ children }) => (
+            <ul className="mb-2.5 ml-4 list-disc space-y-0.5 marker:text-[var(--avy-accent)]">
+              {children}
+            </ul>
+          ),
+          ol: ({ children }) => (
+            <ol className="mb-2.5 ml-4 list-decimal space-y-0.5">{children}</ol>
+          ),
+          li: ({ children }) => <li className="leading-[1.5]">{children}</li>,
+          blockquote: ({ children }) => (
+            <blockquote className="mb-2.5 border-l-[3px] border-[color:rgba(30,102,66,0.25)] bg-[color:rgba(30,102,66,0.04)] py-1 pl-3 pr-2 text-[var(--avy-muted)]">
+              {children}
+            </blockquote>
+          ),
+          code: ({ className, children }) => {
+            const inline = !className;
+            if (inline) {
+              return (
+                <code
+                  className="rounded bg-[color:rgba(17,19,21,0.06)] px-1 py-px font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-ink)]"
+                  style={{ letterSpacing: 0 }}
+                >
+                  {children}
+                </code>
+              );
+            }
+            return (
+              <code
+                className={cn(
+                  className,
+                  "font-[family-name:var(--font-mono)] text-[11.5px] leading-[1.55]"
+                )}
+                style={{ letterSpacing: 0 }}
+              >
+                {children}
+              </code>
+            );
+          },
+          pre: ({ children }) => (
+            <pre
+              className="mb-2.5 overflow-x-auto rounded-[6px] border border-[var(--avy-line)] bg-[#131715] px-3 py-2 text-[#e7ebe5]"
+              style={{ letterSpacing: 0 }}
+            >
+              {children}
+            </pre>
+          ),
+          hr: () => (
+            <hr className="my-3 border-0 border-t border-[var(--avy-line-soft)]" />
+          ),
+          strong: ({ children }) => (
+            <strong className="font-semibold text-[var(--avy-ink)]">
+              {children}
+            </strong>
+          ),
+          em: ({ children }) => (
+            <em className="italic text-[var(--avy-ink)]">{children}</em>
+          ),
+        }}
+      >
+        {children}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
+// Typed re-export so consumers don't need to know about the wrapper shape.
+export type IssueMarkdownProps = {
+  children: string;
+  className?: string;
+};
+
+// Utility for tests / debugging — strips the markdown of known-noisy
+// image refs without rendering. Not exported right now but useful for
+// future server-side summarisation.
+export function stripShieldsIoImages(markdown: string): string {
+  return markdown.replace(
+    /!\[[^\]]*\]\(https?:\/\/(?:img\.)?shields\.io[^)]*\)\s*/gi,
+    ""
+  );
+}
+
+// Back-compat helper for callers that want a plain ReactNode fallback
+// when the markdown is empty.
+export function renderIssueBody(body: string | undefined): ReactNode {
+  if (!body || !body.trim()) return null;
+  return <IssueMarkdown>{body}</IssueMarkdown>;
+}

--- a/app/components/runs/LoadedRunPanel.tsx
+++ b/app/components/runs/LoadedRunPanel.tsx
@@ -2,8 +2,60 @@
 
 import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils/cn";
-import { SourceBadge } from "./StatePill";
+import { SourceBadge, type RunState } from "./StatePill";
+import { IssueMarkdown } from "./IssueMarkdown";
 import type { GitHubJobContext } from "./types";
+
+/**
+ * Map the run's lifecycle state to the stake-block pill + copy. Keeps
+ * the "LOCKED in AgentAccountCore" language out of stages where the stake
+ * isn't actually locked (e.g. a ready run has escrow funded but no worker
+ * stake yet; a settled run has already released).
+ */
+type StakeDisplay = {
+  label: string;
+  pillTone: "locked" | "funded" | "held" | "released";
+  auxNote: string;
+};
+
+const STAKE_BY_STATE: Record<RunState, StakeDisplay> = {
+  ready: {
+    label: "Escrow funded · awaiting claim",
+    pillTone: "funded",
+    auxNote: "funded in AgentAccountCore",
+  },
+  claimed: {
+    label: "Locked · stake posted",
+    pillTone: "locked",
+    auxNote: "locked in AgentAccountCore",
+  },
+  submitted: {
+    label: "Locked · under verification",
+    pillTone: "locked",
+    auxNote: "locked in AgentAccountCore",
+  },
+  disputed: {
+    label: "Held · dispute open",
+    pillTone: "held",
+    auxNote: "held pending dispute resolution",
+  },
+  settled: {
+    label: "Released",
+    pillTone: "released",
+    auxNote: "released from AgentAccountCore",
+  },
+};
+
+const STAKE_PILL_TONE_CLASS: Record<StakeDisplay["pillTone"], string> = {
+  locked:
+    "bg-[var(--avy-accent-soft)] text-[var(--avy-accent)]",
+  funded:
+    "bg-[#e6ecf7] text-[#254e9a]",
+  held:
+    "bg-[#f4ddd5] text-[#a03a1a]",
+  released:
+    "bg-[color:rgba(17,19,21,0.06)] text-[var(--avy-ink)]",
+};
 
 export interface StakeBreakdown {
   worker: string;
@@ -70,6 +122,13 @@ export interface LoadedRunPanelProps {
    * evidence layout.
    */
   github?: GitHubJobContext;
+  /**
+   * Lifecycle state of the loaded run. Drives the stake block's pill +
+   * aux copy so the panel doesn't shout "LOCKED" on a run that hasn't
+   * been claimed yet (or a settled run whose stake is already released).
+   * Defaults to `"claimed"` to preserve the previous behaviour.
+   */
+  state?: RunState;
 }
 
 export function LoadedRunPanel(props: LoadedRunPanelProps) {
@@ -82,10 +141,17 @@ export function LoadedRunPanel(props: LoadedRunPanelProps) {
     setEvidenceValue(props.evidence.sample);
   }, [props.evidence.sample]);
 
+  const stakeDisplay = STAKE_BY_STATE[props.state ?? "claimed"];
+
   return (
     <section
       aria-label="Loaded run"
-      className="overflow-hidden rounded-[12px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] shadow-[var(--shadow-dense)]"
+      // `@container` establishes an inline-size container so the inner
+      // 2-col grid is driven by panel width, not viewport. That way the
+      // panel stacks cleanly when it's hosted in a narrow split-pane
+      // column and only goes side-by-side when there's real room (≥ ~1024px
+      // of panel width).
+      className="@container overflow-hidden rounded-[12px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] shadow-[var(--shadow-dense)]"
     >
       <header className="flex items-center justify-between gap-3.5 border-b border-[var(--avy-line-soft)] bg-gradient-to-b from-[#faf8f1] to-[#fffdf7] px-4.5 py-3.5">
         <div className="flex flex-wrap items-baseline gap-3">
@@ -107,25 +173,22 @@ export function LoadedRunPanel(props: LoadedRunPanelProps) {
             {props.meta}
           </span>
         </div>
-        <div className="flex items-center gap-1.5">
-          <SmallGhostBtn>⌕ Receipt preview</SmallGhostBtn>
-          <SmallGhostBtn>Open in new tab ↗</SmallGhostBtn>
-          <button
-            type="button"
-            title="Close"
-            className="grid h-7 w-7 cursor-pointer place-items-center rounded-[6px] border border-[var(--avy-line)] bg-transparent text-sm text-[var(--avy-muted)] hover:border-[var(--avy-ink)] hover:text-[var(--avy-ink)]"
-          >
-            ×
-          </button>
-        </div>
+        {/*
+         * Panel-header action slots intentionally left empty until the
+         * backend exposes a "preview receipt" and a deep-link endpoint.
+         * The old placeholder buttons (Receipt preview / Open in new tab
+         * / Close) are removed because in the split-pane layout a panel
+         * is always the right half of the page — there's nothing to
+         * close, and the placeholders read as bugs.
+         */}
       </header>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2">
+      <div className="grid grid-cols-1 @4xl:grid-cols-2">
         {/* LEFT */}
-        <div className="flex flex-col gap-3.5 border-r-0 border-b border-[var(--avy-line-soft)] bg-[#fffdf7] p-4 lg:border-b-0 lg:border-r">
+        <div className="flex flex-col gap-3.5 border-r-0 border-b border-[var(--avy-line-soft)] bg-[#fffdf7] p-4 @4xl:border-b-0 @4xl:border-r">
           {/* Stake */}
           <div>
-            <BlockLabel right={<>▪ locked in AgentAccountCore</>}>Stake</BlockLabel>
+            <BlockLabel right={<>▪ {stakeDisplay.auxNote}</>}>Stake</BlockLabel>
             <div className="grid grid-cols-[1fr_auto] items-center gap-x-4 gap-y-2.5 rounded-[8px] border border-[color:rgba(30,102,66,0.22)] bg-[color:rgba(30,102,66,0.04)] px-3.5 py-3">
               <div>
                 <div className="font-[family-name:var(--font-display)] text-[26px] font-bold leading-none text-[var(--avy-ink)]">
@@ -145,10 +208,13 @@ export function LoadedRunPanel(props: LoadedRunPanelProps) {
                 </p>
               </div>
               <span
-                className="inline-flex items-center gap-1.5 rounded-full bg-[var(--avy-accent-soft)] px-2.5 py-1 font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-accent)]"
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase whitespace-nowrap",
+                  STAKE_PILL_TONE_CLASS[stakeDisplay.pillTone]
+                )}
                 style={{ letterSpacing: "0.12em" }}
               >
-                ● Locked
+                ● {stakeDisplay.label}
               </span>
               <div
                 className="col-span-full grid grid-cols-3 gap-2 border-t border-[color:rgba(30,102,66,0.14)] pt-2.5 font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
@@ -529,12 +595,21 @@ function IssueTab({ ctx }: { ctx: GitHubJobContext }) {
         </div>
       ) : null}
 
-      <p
-        className="mt-3 max-h-[220px] overflow-y-auto whitespace-pre-wrap font-[family-name:var(--font-body)] text-[12.5px] leading-[1.5] text-[var(--avy-ink)]"
-        style={{ letterSpacing: 0 }}
-      >
-        {ctx.body}
-      </p>
+      {ctx.body ? (
+        <div
+          className="mt-3 max-h-[320px] overflow-y-auto font-[family-name:var(--font-body)] text-[12.5px] leading-[1.55] text-[var(--avy-ink)]"
+          style={{ letterSpacing: 0 }}
+        >
+          <IssueMarkdown>{ctx.body}</IssueMarkdown>
+        </div>
+      ) : (
+        <p
+          className="mt-3 font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]"
+          style={{ letterSpacing: 0 }}
+        >
+          No description on the upstream issue.
+        </p>
+      )}
 
       <div className="mt-3 flex justify-end">
         <a

--- a/app/components/runs/LoadedRunPanel.tsx
+++ b/app/components/runs/LoadedRunPanel.tsx
@@ -129,6 +129,19 @@ export interface LoadedRunPanelProps {
    * Defaults to `"claimed"` to preserve the previous behaviour.
    */
   state?: RunState;
+  /**
+   * Click handler for the "Receipt preview" action in the header. When
+   * provided, the button is rendered; when absent, the button is hidden
+   * so we don't ship a dead affordance.
+   */
+  onReceiptPreview?: () => void;
+  /**
+   * Full URL that opens the loaded run in a new tab. When provided, the
+   * header renders an "Open in new tab" anchor. Use the same origin +
+   * `/runs/?run=<id>` so the link is shareable / bookmarkable without
+   * requiring a bespoke fullscreen route.
+   */
+  standaloneUrl?: string;
 }
 
 export function LoadedRunPanel(props: LoadedRunPanelProps) {
@@ -173,14 +186,34 @@ export function LoadedRunPanel(props: LoadedRunPanelProps) {
             {props.meta}
           </span>
         </div>
-        {/*
-         * Panel-header action slots intentionally left empty until the
-         * backend exposes a "preview receipt" and a deep-link endpoint.
-         * The old placeholder buttons (Receipt preview / Open in new tab
-         * / Close) are removed because in the split-pane layout a panel
-         * is always the right half of the page — there's nothing to
-         * close, and the placeholders read as bugs.
-         */}
+        {/* Header actions. Each is conditional on its handler/URL so we
+            don't render a button that does nothing — avoids the "why is
+            this disabled" confusion a blanket placeholder causes. */}
+        {props.onReceiptPreview || props.standaloneUrl ? (
+          <div className="flex items-center gap-1.5">
+            {props.onReceiptPreview ? (
+              <button
+                type="button"
+                onClick={props.onReceiptPreview}
+                className="inline-flex h-7 items-center gap-1.5 rounded-[8px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-3 font-[family-name:var(--font-display)] text-[11px] font-bold uppercase text-[var(--avy-ink)] transition-transform hover:-translate-y-px hover:border-[color:rgba(30,102,66,0.24)] hover:text-[var(--avy-accent)]"
+                style={{ letterSpacing: "0.04em" }}
+              >
+                ⌕ Receipt preview
+              </button>
+            ) : null}
+            {props.standaloneUrl ? (
+              <a
+                href={props.standaloneUrl}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="inline-flex h-7 items-center gap-1.5 rounded-[8px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-3 font-[family-name:var(--font-display)] text-[11px] font-bold uppercase text-[var(--avy-ink)] transition-transform hover:-translate-y-px hover:border-[color:rgba(30,102,66,0.24)] hover:text-[var(--avy-accent)]"
+                style={{ letterSpacing: "0.04em" }}
+              >
+                Open in new tab ↗
+              </a>
+            ) : null}
+          </div>
+        ) : null}
       </header>
 
       <div className="grid grid-cols-1 @4xl:grid-cols-2">

--- a/app/components/runs/ReceiptPreviewDrawer.tsx
+++ b/app/components/runs/ReceiptPreviewDrawer.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { DetailDrawer, DrawerSection } from "@/components/shell/DetailDrawer";
+import { SourceBadge, StatePill, type RunState } from "./StatePill";
+import type { GitHubJobContext } from "./types";
+import { cn } from "@/lib/utils/cn";
+
+/**
+ * Draft ledger entry that the operator is about to sign when they hit
+ * "Mark verified & pay". Everything in this payload is assembled from
+ * data already visible in the Loaded-run panel — this drawer is a
+ * "print preview" before on-chain settlement, not a new data fetch.
+ *
+ * The explicit purpose: let the operator inspect the split, the
+ * verifier verdict, the PR reference, and the receipt ref BEFORE any
+ * DOT moves, so a wrong category / wrong split / wrong PR gets caught
+ * at the preview step instead of committed to the audit log.
+ */
+export interface ReceiptPreviewDraft {
+  receiptRef: string; // "r_4e133"
+  runId: string;
+  jobMeta: string;
+  state: RunState;
+  stake: {
+    amount: string;
+    currency: string;
+    breakdown: { label: string; value: string }[];
+  };
+  verdict: {
+    status: string;
+    score: string;
+    confidence: string;
+  };
+  evidenceHash?: string;
+  github?: GitHubJobContext;
+  prUrl?: string;
+  signers: { label: string; status: "pending" | "signed" }[];
+}
+
+export interface ReceiptPreviewDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  draft: ReceiptPreviewDraft;
+}
+
+export function ReceiptPreviewDrawer({
+  open,
+  onClose,
+  draft,
+}: ReceiptPreviewDrawerProps) {
+  return (
+    <DetailDrawer
+      open={open}
+      onClose={onClose}
+      width={560}
+      title={
+        <div>
+          <div
+            className="font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-accent)]"
+            style={{ letterSpacing: "0.14em" }}
+          >
+            Receipt preview · draft
+          </div>
+          <h2 className="m-0 mt-0.5 font-[family-name:var(--font-display)] text-[18px] font-bold leading-[1.2] text-[var(--avy-ink)]">
+            {draft.receiptRef}
+          </h2>
+        </div>
+      }
+      meta={
+        <div className="flex flex-wrap items-center gap-2 font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]" style={{ letterSpacing: 0 }}>
+          <StatePill state={draft.state} />
+          <span>{draft.runId}</span>
+          <span className="opacity-40">·</span>
+          <span>{draft.jobMeta}</span>
+        </div>
+      }
+    >
+      <DraftBanner />
+
+      {draft.github ? (
+        <DrawerSection title="Source">
+          <div className="flex flex-wrap items-center gap-2 rounded-[8px] border border-[var(--avy-line)] bg-[color:rgba(17,19,21,0.02)] px-3 py-2">
+            <SourceBadge kind="github" />
+            <a
+              href={draft.github.issueUrl}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-ink)] hover:text-[var(--avy-accent)]"
+              style={{ letterSpacing: 0 }}
+            >
+              {draft.github.repo}
+              <span className="ml-0.5 text-[var(--avy-accent)]">
+                #{draft.github.issueNumber}
+              </span>
+            </a>
+            <span className="opacity-40">·</span>
+            <span
+              className="font-[family-name:var(--font-mono)] text-[11.5px] uppercase text-[var(--avy-muted)]"
+              style={{ letterSpacing: "0.08em" }}
+            >
+              {draft.github.category}
+            </span>
+          </div>
+          {draft.prUrl ? (
+            <a
+              href={draft.prUrl}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="mt-2 inline-flex h-7 items-center gap-1.5 rounded-[8px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-3 font-[family-name:var(--font-display)] text-[11px] font-bold uppercase text-[var(--avy-ink)] transition-transform hover:-translate-y-px hover:border-[color:rgba(30,102,66,0.24)] hover:text-[var(--avy-accent)]"
+              style={{ letterSpacing: "0.04em" }}
+            >
+              View PR ↗
+            </a>
+          ) : null}
+        </DrawerSection>
+      ) : null}
+
+      <DrawerSection title="Payout split">
+        <div className="overflow-hidden rounded-[8px] border border-[color:rgba(30,102,66,0.22)] bg-[color:rgba(30,102,66,0.04)]">
+          <div className="flex items-baseline justify-between gap-3 border-b border-[color:rgba(30,102,66,0.14)] px-3.5 py-3">
+            <div>
+              <span className="font-[family-name:var(--font-display)] text-[24px] font-bold leading-none text-[var(--avy-ink)]">
+                {draft.stake.amount}
+              </span>
+              <span
+                className="ml-1 font-[family-name:var(--font-mono)] text-[11px] font-medium text-[var(--avy-muted)]"
+                style={{ letterSpacing: 0 }}
+              >
+                {draft.stake.currency}
+              </span>
+              <p
+                className="mt-1 font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
+                style={{ letterSpacing: 0 }}
+              >
+                total posted to pay at settlement
+              </p>
+            </div>
+          </div>
+          <ul className="divide-y divide-[color:rgba(30,102,66,0.12)]">
+            {draft.stake.breakdown.map((row) => (
+              <li
+                key={row.label}
+                className="flex items-center justify-between gap-3 px-3.5 py-2 font-[family-name:var(--font-mono)] text-[12px]"
+                style={{ letterSpacing: 0 }}
+              >
+                <span className="text-[var(--avy-muted)]">{row.label}</span>
+                <span className="font-semibold text-[var(--avy-ink)]">
+                  {row.value}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </DrawerSection>
+
+      <DrawerSection title="Verifier verdict">
+        <div className="flex items-center justify-between gap-3 rounded-[8px] border border-[var(--avy-line)] bg-white px-3.5 py-2.5">
+          <div>
+            <div className="font-[family-name:var(--font-display)] text-[12.5px] font-bold text-[var(--avy-ink)]">
+              {draft.verdict.status}
+            </div>
+            <div
+              className="mt-0.5 font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
+              style={{ letterSpacing: 0 }}
+            >
+              {draft.verdict.score} · {draft.verdict.confidence}
+            </div>
+          </div>
+          {draft.evidenceHash ? (
+            <div className="text-right">
+              <div
+                className="font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-muted)]"
+                style={{ letterSpacing: "0.1em" }}
+              >
+                Evidence
+              </div>
+              <div
+                className="font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-ink)]"
+                style={{ letterSpacing: 0 }}
+              >
+                {draft.evidenceHash}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </DrawerSection>
+
+      <DrawerSection title="Signers">
+        <ul className="flex flex-col gap-1.5">
+          {draft.signers.map((signer) => (
+            <li
+              key={signer.label}
+              className="flex items-center justify-between gap-2 rounded-[6px] border border-[var(--avy-line)] bg-white px-3 py-2 font-[family-name:var(--font-mono)] text-[11.5px]"
+              style={{ letterSpacing: 0 }}
+            >
+              <span className="truncate text-[var(--avy-ink)]">
+                {signer.label}
+              </span>
+              <span
+                className={cn(
+                  "inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase whitespace-nowrap",
+                  signer.status === "signed"
+                    ? "bg-[var(--avy-accent-soft)] text-[var(--avy-accent)]"
+                    : "bg-[color:rgba(17,19,21,0.06)] text-[var(--avy-muted)]"
+                )}
+                style={{ letterSpacing: "0.1em" }}
+              >
+                {signer.status === "signed" ? "✓ Signed" : "· Pending"}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </DrawerSection>
+
+      <DrawerSection title="On settlement">
+        <p
+          className="m-0 rounded-[6px] border border-[var(--avy-line)] bg-[color:rgba(17,19,21,0.02)] px-3 py-2 font-[family-name:var(--font-mono)] text-[11.5px] leading-[1.55] text-[var(--avy-muted)]"
+          style={{ letterSpacing: 0 }}
+        >
+          This draft becomes an append-only receipt at the moment{" "}
+          <b className="font-semibold text-[var(--avy-ink)]">Mark verified & pay</b>{" "}
+          is pressed. The payload — receipt ref, run id, stake split, verdict,
+          evidence hash, and signer addresses — is then hashed with sha256 and
+          co-signed into the audit log. Nothing on this page is written yet.
+        </p>
+      </DrawerSection>
+    </DetailDrawer>
+  );
+}
+
+function DraftBanner() {
+  return (
+    <div
+      className="flex items-center gap-2 rounded-[8px] border border-[var(--avy-warn)] bg-[color:rgba(211,145,27,0.08)] px-3 py-2 font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-ink)]"
+      style={{ letterSpacing: 0 }}
+    >
+      <span
+        className="inline-flex items-center rounded-full bg-[var(--avy-warn)] px-1.5 py-0.5 font-[family-name:var(--font-display)] text-[9.5px] font-extrabold uppercase text-white"
+        style={{ letterSpacing: "0.1em" }}
+      >
+        Draft
+      </span>
+      <span>
+        Unsigned preview. No DOT moves, no audit-log entry, no notifications
+        fire.
+      </span>
+    </div>
+  );
+}

--- a/app/components/runs/RecommendationRail.tsx
+++ b/app/components/runs/RecommendationRail.tsx
@@ -1,10 +1,19 @@
 import { JobCard, type JobCardData } from "./JobCard";
+import { cn } from "@/lib/utils/cn";
 
 export interface RecommendationRailProps {
   workerTier: string;
   workerScore: number;
   jobs: JobCardData[];
   totalMatches: number;
+  /**
+   * `"vertical"` stacks cards in a narrow sidebar (original shape, used when
+   * there's real estate to the right of the queue). `"horizontal"` lays the
+   * cards out left-to-right and scrolls on overflow — used when the rail sits
+   * below a split-pane queue+detail area so it doesn't fight for vertical
+   * space.
+   */
+  layout?: "vertical" | "horizontal";
 }
 
 export function RecommendationRail({
@@ -12,7 +21,9 @@ export function RecommendationRail({
   workerScore,
   jobs,
   totalMatches,
+  layout = "vertical",
 }: RecommendationRailProps) {
+  const isHorizontal = layout === "horizontal";
   return (
     <aside className="flex flex-col overflow-hidden rounded-[10px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)]">
       <header className="border-b border-[var(--avy-line-soft)] px-3.5 py-3 pb-2.5">
@@ -30,11 +41,35 @@ export function RecommendationRail({
         </p>
       </header>
 
-      <div className="flex flex-col gap-2 p-2.5">
-        {jobs.map((job) => (
-          <JobCard key={job.id} job={job} />
-        ))}
-      </div>
+      {isHorizontal ? (
+        <div className="relative">
+          <div
+            className="flex gap-2 overflow-x-auto p-2.5 [-webkit-overflow-scrolling:touch]"
+            // Tuck a little extra padding on the right so the last card
+            // doesn't butt up against the fade overlay.
+            style={{ paddingRight: "2.5rem" }}
+          >
+            {jobs.map((job) => (
+              <div key={job.id} className="w-[300px] shrink-0">
+                <JobCard job={job} />
+              </div>
+            ))}
+          </div>
+          {/* Right-edge fade: tells the user there's more content past the
+              visible edge without relying on a visible scrollbar. Pointer-
+              events-none so it doesn't block clicks on the card underneath. */}
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-[var(--avy-paper-solid)] to-transparent"
+          />
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2 p-2.5">
+          {jobs.map((job) => (
+            <JobCard key={job.id} job={job} />
+          ))}
+        </div>
+      )}
 
       <footer
         className="flex items-center justify-between border-t border-[var(--avy-line-soft)] bg-[#faf8f1] px-3.5 py-2.5 font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]"

--- a/app/components/runs/RunQueueTable.tsx
+++ b/app/components/runs/RunQueueTable.tsx
@@ -63,100 +63,34 @@ export function RunQueueTable({
         </span>
       </header>
 
-      <div className="overflow-x-auto">
-        <table className="w-full border-collapse font-[family-name:var(--font-body)] text-[13px]">
-          <thead>
-            <tr>
-              <Th width="34%">Run · Job</Th>
-              <Th>Worker</Th>
-              <Th>State</Th>
-              <Th align="right">Stake</Th>
-              <Th align="right" sortable>
-                Age <span className="ml-0.5 text-[9px] text-[var(--avy-accent)]">▼</span>
-              </Th>
-              <Th>Last event</Th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((row) => {
-              const isSelected = row.id === selectedId;
-              return (
-                <tr
-                  key={row.id}
-                  onClick={() => onSelect(row.id)}
-                  className={cn(
-                    "cursor-pointer transition-colors hover:bg-[color:rgba(17,19,21,0.025)]",
-                    isSelected &&
-                      "bg-[color:rgba(30,102,66,0.06)] [&>td:first-child]:[box-shadow:inset_2px_0_0_var(--avy-accent)]"
-                  )}
-                >
-                  <Td>
-                    <div className="min-w-0 max-w-[360px]">
-                      <div
-                        className="line-clamp-2 text-[13px] font-semibold leading-[1.3] text-[var(--avy-ink)]"
-                        title={row.title}
-                      >
-                        {row.title}
-                      </div>
-                      <div
-                        className="mt-0.5 flex items-center gap-1.5 font-[family-name:var(--font-mono)] text-[11px] font-normal text-[var(--avy-muted)]"
-                        style={{ letterSpacing: 0 }}
-                      >
-                        {row.source?.type === "github_issue" ? (
-                          <>
-                            <SourceBadge kind="github" />
-                            <span className="truncate">
-                              {row.source.repo}
-                              <span className="text-[var(--avy-accent)]"> #{row.source.issueNumber}</span>
-                            </span>
-                            <span className="opacity-40">·</span>
-                            <span className="truncate">{row.jobMeta}</span>
-                          </>
-                        ) : (
-                          <span className="truncate">{row.jobMeta}</span>
-                        )}
-                      </div>
-                    </div>
-                  </Td>
-                  <Td>
-                    <WorkerChip {...row.worker} />
-                  </Td>
-                  <Td>
-                    <StatePill state={row.state} />
-                  </Td>
-                  <Td align="right">
-                    <span className="font-[family-name:var(--font-mono)] text-[12.5px] text-[var(--avy-ink)]">
-                      {row.stake}
-                      <small className="font-normal text-[var(--avy-muted)]"> DOT</small>
-                    </span>
-                  </Td>
-                  <Td align="right">
-                    <span
-                      className={cn(
-                        "whitespace-nowrap font-[family-name:var(--font-mono)] text-xs",
-                        row.ageStale ? "text-[var(--avy-warn)]" : "text-[var(--avy-ink)]"
-                      )}
-                    >
-                      {row.age}
-                    </span>
-                  </Td>
-                  <Td>
-                    <div className="text-xs leading-[1.35] text-[var(--avy-ink)]">
-                      {row.lastEvent}
-                      <small
-                        className="mt-px block font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]"
-                        style={{ letterSpacing: 0 }}
-                      >
-                        {row.lastEventMeta}
-                      </small>
-                    </div>
-                  </Td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
+      {/*
+       * Card-row list instead of a 6-column table. A <table> forces every
+       * column to share a single horizontal lane, which either overflows
+       * or drops columns when the queue lives in a narrow split-pane.
+       * Structuring each row as a small 2-D card lets us surface all six
+       * pieces of info (title, source, state, stake, age, worker, last
+       * event) on every row at ~90px of height, without horizontal scroll.
+       */}
+      {rows.length === 0 ? (
+        <div
+          className="px-4 py-10 text-center font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-muted)]"
+          style={{ letterSpacing: 0 }}
+        >
+          No runs match this filter.{" "}
+          <span className="text-[var(--avy-accent)]">Try a different state.</span>
+        </div>
+      ) : (
+        <ul className="divide-y divide-[var(--avy-line-soft)]" role="list">
+          {rows.map((row) => (
+            <RunRowCard
+              key={row.id}
+              row={row}
+              selected={row.id === selectedId}
+              onSelect={() => onSelect(row.id)}
+            />
+          ))}
+        </ul>
+      )}
 
       <footer className="flex items-center justify-between border-t border-[var(--avy-line-soft)] bg-[#faf8f1] px-4 py-2.5 font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]">
         <span>
@@ -179,46 +113,103 @@ export function RunQueueTable({
   );
 }
 
-function Th({
-  children,
-  width,
-  align,
-  sortable,
+/**
+ * Compact card row for the run queue. Layout is a 3-line stack with the
+ * high-signal info on the left (title + source) and the terminal-style
+ * numbers on the right (state, stake, age) — plus a low-emphasis footer
+ * row with the worker and the last event so an operator can scan a run's
+ * status without ever leaving the queue.
+ */
+function RunRowCard({
+  row,
+  selected,
+  onSelect,
 }: {
-  children: ReactNode;
-  width?: string;
-  align?: "left" | "right";
-  sortable?: boolean;
+  row: RunRow;
+  selected: boolean;
+  onSelect: () => void;
 }) {
   return (
-    <th
-      className={cn(
-        "sticky top-0 z-[1] border-b border-[var(--avy-line-soft)] bg-[#faf8f1] px-3.5 py-2.5 font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-muted)] whitespace-nowrap",
-        align === "right" ? "text-right" : "text-left",
-        sortable && "cursor-pointer"
-      )}
-      style={{ letterSpacing: "0.14em", width }}
-    >
-      {children}
-    </th>
-  );
-}
+    <li>
+      <button
+        type="button"
+        onClick={onSelect}
+        className={cn(
+          // Default: soft background-tint hover + a 2px left accent hint
+          // on hover so the row reads as "clickable, will select". The
+          // selected state promotes that hint to a solid accent bar and
+          // a matching tint.
+          "group relative block w-full cursor-pointer px-4 py-3 text-left transition-all",
+          "hover:bg-[color:rgba(17,19,21,0.025)] hover:shadow-[inset_2px_0_0_rgba(30,102,66,0.35)]",
+          selected &&
+            "bg-[color:rgba(30,102,66,0.06)] shadow-[inset_2px_0_0_var(--avy-accent)] hover:bg-[color:rgba(30,102,66,0.08)] hover:shadow-[inset_2px_0_0_var(--avy-accent)]"
+        )}
+      >
+        {/* Row 1: title (left) + state/stake/age stack (right). */}
+        <div className="flex items-start gap-3">
+          <div className="min-w-0 flex-1">
+            <div
+              className="line-clamp-2 font-[family-name:var(--font-body)] text-[13px] font-semibold leading-[1.3] text-[var(--avy-ink)]"
+              title={row.title}
+            >
+              {row.title}
+            </div>
+            <div
+              className="mt-0.5 flex min-w-0 items-center gap-1.5 font-[family-name:var(--font-mono)] text-[11px] font-normal text-[var(--avy-muted)]"
+              style={{ letterSpacing: 0 }}
+            >
+              {row.source?.type === "github_issue" ? (
+                <>
+                  <SourceBadge kind="github" className="shrink-0" />
+                  <span className="truncate">
+                    {row.source.repo}
+                    <span className="text-[var(--avy-accent)]">
+                      {" "}#{row.source.issueNumber}
+                    </span>
+                  </span>
+                  <span className="shrink-0 opacity-40">·</span>
+                  <span className="shrink-0 whitespace-nowrap">
+                    {row.jobMeta}
+                  </span>
+                </>
+              ) : (
+                <span className="truncate">{row.jobMeta}</span>
+              )}
+            </div>
+          </div>
 
-function Td({
-  children,
-  align,
-}: {
-  children: ReactNode;
-  align?: "left" | "right";
-}) {
-  return (
-    <td
-      className={cn(
-        "border-b border-[var(--avy-line-soft)] px-3.5 py-2.5 align-middle last:border-b-0",
-        align === "right" && "text-right"
-      )}
-    >
-      {children}
-    </td>
+          <div className="flex shrink-0 flex-col items-end gap-0.5">
+            <StatePill state={row.state} />
+            <span className="font-[family-name:var(--font-mono)] text-[12.5px] leading-tight text-[var(--avy-ink)]">
+              {row.stake}
+              <small className="font-normal text-[var(--avy-muted)]"> DOT</small>
+            </span>
+            <span
+              className={cn(
+                "whitespace-nowrap font-[family-name:var(--font-mono)] text-[11.5px] leading-tight",
+                row.ageStale ? "text-[var(--avy-warn)]" : "text-[var(--avy-muted)]"
+              )}
+            >
+              {row.age}
+            </span>
+          </div>
+        </div>
+
+        {/* Row 2: worker (if any) + last event. Kept quiet so it doesn't
+            compete with the primary title/state row above. */}
+        <div className="mt-1.5 flex items-center gap-2 overflow-hidden font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]" style={{ letterSpacing: 0 }}>
+          <span className="shrink-0">
+            <WorkerChip {...row.worker} />
+          </span>
+          <span className="shrink-0 opacity-40">·</span>
+          <span className="min-w-0 flex-1 truncate text-[var(--avy-ink)]/80">
+            {row.lastEvent}
+          </span>
+          <span className="shrink-0 truncate text-[var(--avy-muted)]">
+            {row.lastEventMeta}
+          </span>
+        </div>
+      </button>
+    </li>
   );
 }

--- a/app/lib/api/run-adapters.ts
+++ b/app/lib/api/run-adapters.ts
@@ -167,11 +167,19 @@ export function buildRunRows(payload: unknown): RunRow[] {
     const worker = text(job.claimedBy) || text(job.worker);
 
     const source = buildJobSource(job);
+    // For GitHub-ingested jobs the row already shows `owner/repo #N` via
+    // the SourceBadge, so drop the redundant job-id slug from jobMeta to
+    // keep the meta line scannable. Native jobs keep the full
+    // `id · category · tier` because there's no other provenance signal.
+    const jobMeta =
+      source?.type === "github_issue"
+        ? `${text(job.category, "work")} · ${tierFromRaw(job.tier)}`
+        : `${id} · ${text(job.category, "work")} · ${tierFromRaw(job.tier)}`;
     return {
       id,
       sessionId: text(job.sessionId),
       title,
-      jobMeta: `${id} · ${text(job.category, "work")} · ${tierFromRaw(job.tier)}`,
+      jobMeta,
       ...(source ? { source } : {}),
       worker: {
         variant: worker ? "a" : "unclaimed",

--- a/app/package.json
+++ b/app/package.json
@@ -23,6 +23,8 @@
     "next": "15.5.15",
     "react": "19.0.0",
     "react-dom": "19.0.0",
+    "react-markdown": "^9.1.0",
+    "remark-gfm": "^4.0.1",
     "sonner": "1.7.1",
     "swr": "2.3.0",
     "tailwind-merge": "2.5.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,8 @@
         "next": "15.5.15",
         "react": "19.0.0",
         "react-dom": "19.0.0",
+        "react-markdown": "^9.1.0",
+        "remark-gfm": "^4.0.1",
         "sonner": "1.7.1",
         "swr": "2.3.0",
         "tailwind-merge": "2.5.5",
@@ -4071,6 +4073,15 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -4131,7 +4142,6 @@
       "version": "19.0.4",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.4.tgz",
       "integrity": "sha512-3O4QisJDYr1uTUMZHA2YswiQZRq+Pd8D+GdVFYikTutYsTz+QZgWkAPnP7rx9txoI6EXKcPiluMqWPFV3tT9Wg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -6047,6 +6057,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -6336,7 +6356,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -7666,6 +7685,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
@@ -8552,6 +8581,33 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-parse5": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
@@ -8631,6 +8687,16 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
       "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
       "license": "MIT"
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
@@ -8741,6 +8807,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -8763,6 +8835,30 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/brc-dd"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-array-buffer": {
@@ -8910,6 +9006,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-docker": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
@@ -8991,6 +9097,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-inside-container": {
@@ -9954,6 +10070,66 @@
       "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
       "license": "MIT",
       "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
         "devlop": "^1.0.0",
         "mdast-util-from-markdown": "^2.0.0",
@@ -11398,6 +11574,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/parse-latin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
@@ -11939,6 +12140,33 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-markdown": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.1.0.tgz",
+      "integrity": "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
@@ -13198,6 +13426,24 @@
       "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
       "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
       "license": "MIT"
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",


### PR DESCRIPTION
## Summary

Reshapes the Runs surface so details are always visible without scrolling, and kills the "governance placeholder" feel by rendering real GitHub issue content and wiring the panel-header actions.

## What changed

### Layout

- **Split-pane.** Queue on the left, Loaded-run panel on the right (sticky — stays in view as the queue scrolls). Click a row → details update instantly, no vertical scroll to reach them. Recommendation rail moves below as a horizontal card strip so it stops stealing vertical space. Page widened from `max-w-[1100px]` to `max-w-[1440px]`.
- **Panel uses `@container` queries** for its inner 2-col grid, so it stacks cleanly when hosted in the narrower split-pane column and only goes side-by-side when the panel itself is ≥ 896px wide.

### Queue card rows

- Replaces the 6-column table with a compact card-row list. Each row shows title + source + job meta on the left, state pill / stake / age stacked on the right, and worker + last-event on a third low-emphasis line. All six pieces of data at ~90px per row, no horizontal overflow.
- Empty state when a filter returns 0 rows.
- Hover and selected states distinguish clearly — hover gets a tinted left accent bar, selected promotes to the solid accent.

### GitHub issue markdown

- New `IssueMarkdown` component renders issue bodies via `react-markdown` + `remark-gfm` with tailored typography (inline code chips, dark-terminal code fences, blockquote styling). Drops `shields.io` badges entirely; replaces other images with `[image: alt]` placeholders so we don't pull remote assets into the app.
- Adapter (`buildRunRows`) drops the redundant job-id slug from `jobMeta` for GitHub rows (already carried by `owner/repo #N` via SourceBadge).

### Stake block reactive to state

- Stake pill + copy now reflect the run's lifecycle state: "Escrow funded · awaiting claim" / "Locked · stake posted" / "Locked · under verification" / "Held · dispute open" / "Released" with matching pill tones. No more "LOCKED" shouted at every stage.

### Receipt preview + deep links

- **Receipt preview button** opens a slide-in drawer with a draft of the ledger entry the operator would commit on "Mark verified & pay" — stake split, verifier verdict, PR reference, signer list, evidence hash. Explicit "Draft · Unsigned" banner. Assembled from data already on the panel; no backend fetch.
- **Open in new tab** uses `/runs/?run=<id>` query-param deep links (works with Next static export on the VPS, no dynamic-route dance needed). The page reads `?run=<id>` via `useSearchParams` (wrapped in Suspense) and preselects that row.
- Placeholder panel-header buttons removed; real ones wired conditionally on their handler/URL being provided.

### Recommendation rail

- Horizontal variant gets a right-edge gradient fade so operators can see there's more content past the visible edge.

## Test plan

- [ ] `npm run dev:app` — Runs page renders at 1440px: queue left, sticky panel right, lifecycle + recommendations below.
- [ ] Click any row → sticky panel updates instantly, no scroll.
- [ ] Click "⌕ Receipt preview" → drawer slides in with draft receipt. Close via × / Escape / backdrop click.
- [ ] Click "Open in new tab ↗" → opens `/runs/?run=run-2742` in a new tab, row pre-selected.
- [ ] Switch filter to a state with 0 rows → shows "No runs match this filter" empty state (if a filter bucket is ever empty).
- [ ] Check ISSUE tab renders markdown (inline code, headings, lists) and that shields.io badges are stripped.
- [ ] `npm run typecheck:app` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)