### PR TITLE
Runs: /runs/detail/ fullscreen route + panel-header button polish

### DIFF
--- a/app/app/(authed)/runs/detail/page.tsx
+++ b/app/app/(authed)/runs/detail/page.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Suspense } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { LoadedRunView } from "@/components/runs/LoadedRunView";
+
+/**
+ * Standalone fullscreen view for a single run.
+ *
+ * Linked from the Loaded-run panel's "Full view ↗" button. Lives at
+ * `/runs/detail/?id=<runId>` (query param rather than a dynamic
+ * `/runs/[id]/` segment so it works cleanly with the Next static
+ * export on the VPS).
+ *
+ * What it's for: focused review of one run's evidence, PR, acceptance
+ * criteria — no queue on the left competing for attention, no
+ * recommendation strip below. Useful for disputes (reading a full
+ * issue body + PR diff + comments), for sharing a direct link to a
+ * co-signer, or for multi-tab triage ("I'll open these three claims
+ * and cross-check them").
+ */
+export default function RunDetailPage() {
+  return (
+    <Suspense fallback={null}>
+      <RunDetailInner />
+    </Suspense>
+  );
+}
+
+function RunDetailInner() {
+  const searchParams = useSearchParams();
+  const runId = searchParams?.get("id") ?? "run-2742";
+
+  return (
+    <div className="flex w-full max-w-[1100px] flex-col gap-4">
+      <div className="flex items-center justify-between gap-3">
+        <Link
+          href="/runs"
+          className="inline-flex h-8 items-center gap-1.5 rounded-[8px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-3 font-[family-name:var(--font-display)] text-[11px] font-bold uppercase text-[var(--avy-ink)] transition-transform hover:-translate-y-px hover:border-[color:rgba(30,102,66,0.24)] hover:text-[var(--avy-accent)]"
+          style={{ letterSpacing: "0.04em" }}
+        >
+          ← Back to queue
+        </Link>
+        <span
+          className="font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]"
+          style={{ letterSpacing: 0 }}
+        >
+          run <b className="text-[var(--avy-ink)]">{runId}</b> · fullscreen view
+        </span>
+      </div>
+
+      {/*
+       * `standaloneUrl` is intentionally omitted here — the "Full view"
+       * button doesn't need to link to the page you're already on.
+       * `showLifecycle` defaults to true so the single-run view is
+       * self-complete (panel + lifecycle, no other rails).
+       */}
+      <LoadedRunView runId={runId} />
+    </div>
+  );
+}

--- a/app/app/(authed)/runs/page.tsx
+++ b/app/app/(authed)/runs/page.tsx
@@ -2,379 +2,40 @@
 
 import { Suspense, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { mutate } from "swr";
 import { RunsTopbar } from "@/components/runs/RunsTopbar";
 import {
   QueueBar,
   type QueueFilter,
-  type QueueFilterCount,
 } from "@/components/runs/QueueBar";
-import {
-  RunQueueTable,
-  type RunRow,
-} from "@/components/runs/RunQueueTable";
+import { RunQueueTable } from "@/components/runs/RunQueueTable";
 import { RecommendationRail } from "@/components/runs/RecommendationRail";
-import type { JobCardData } from "@/components/runs/JobCard";
-import { LoadedRunPanel } from "@/components/runs/LoadedRunPanel";
+import { LoadedRunView } from "@/components/runs/LoadedRunView";
+import { LifecycleRail } from "@/components/runs/LifecycleRail";
 import {
-  LifecycleRail,
-  type LifecycleStage,
-} from "@/components/runs/LifecycleRail";
+  FIXTURE_FILTERS,
+  FIXTURE_LIFECYCLE,
+  FIXTURE_RECOMMENDATIONS,
+  FIXTURE_RUN_ROWS,
+} from "@/components/runs/fixtures";
+import { useJobs, useRecommendations } from "@/lib/api/hooks";
 import {
-  ReceiptPreviewDrawer,
-  type ReceiptPreviewDraft,
-} from "@/components/runs/ReceiptPreviewDrawer";
-import { useJobDefinition, useJobs, useRecommendations } from "@/lib/api/hooks";
-import { swrFetcher } from "@/lib/api/client";
-import {
-  buildGitHubContext,
   buildRecommendationCards,
   buildRunFilters,
   buildRunRows,
-  extractRunJobs,
   sumReadyStake,
 } from "@/lib/api/run-adapters";
 
-// TODO(data): replace each block's seed data with the matching SWR hook
-//   - Run queue: useSessions() filtered by state
-//   - Recommendation rail: useRecommendations()
-//   - Loaded run: useSession(sessionId) — selected from URL or state
-//   - Lifecycle: useSessionStateMachine() + the loaded session's history
-// Until those hook response shapes are stable, the page renders the same
-// fixture data Claude Design used so the layout reads correctly.
-
-const ROWS: RunRow[] = [
-  {
-    id: "run-2749",
-    title:
-      "Document TypeScript validation helper API for external package consumers",
-    jobMeta: "job-0428 · docs · T1",
-    source: {
-      type: "github_issue",
-      repo: "oss-devsecblueprint/devsecblueprint",
-      issueNumber: 110,
-      issueUrl:
-        "https://github.com/oss-devsecblueprint/devsecblueprint/issues/110",
-      labels: ["documentation", "good first issue"],
-      score: 82,
-    },
-    worker: { variant: "unclaimed", initials: "—", label: "unclaimed" },
-    state: "ready",
-    stake: "8.0",
-    age: "00:01:04",
-    lastEvent: "Ingested from GitHub",
-    lastEventMeta: "14:29:55 · gh-ingest · score 82",
-  },
-  {
-    id: "run-2741",
-    title: "repo-sweep: deps/sec-only bump",
-    jobMeta: "job-0421 · coding · T1",
-    worker: { variant: "unclaimed", initials: "—", label: "unclaimed" },
-    state: "ready",
-    stake: "12.0",
-    age: "00:11:42",
-    ageStale: true,
-    lastEvent: "Escrow funded",
-    lastEventMeta: "14:20:25 · by 0x9A13…0cb2",
-  },
-  {
-    id: "run-2742",
-    title:
-      "Fix flaky integration test: race condition when two workers claim within the same block window",
-    jobMeta: "job-0418 · bugfix · T2",
-    source: {
-      type: "github_issue",
-      repo: "paritytech/polkadot-sdk",
-      issueNumber: 4812,
-      issueUrl: "https://github.com/paritytech/polkadot-sdk/issues/4812",
-      labels: ["bug", "flaky-test", "help wanted"],
-      score: 74,
-    },
-    worker: { variant: "self", initials: "FD", label: "0xFd2E…6519", isSelf: true },
-    state: "claimed",
-    stake: "25.0",
-    age: "00:08:14",
-    lastEvent: "You claimed the run",
-    lastEventMeta: "14:23:53 · tx 0x3f…c1",
-  },
-  {
-    id: "run-2743",
-    title: "schema-mig: users → users_v2",
-    jobMeta: "job-0415 · ops · T3",
-    worker: { variant: "a", initials: "OM", label: "0xB1aa…3e41" },
-    state: "submitted",
-    stake: "50.0",
-    age: "00:06:02",
-    lastEvent: "Evidence submitted · 14 files",
-    lastEventMeta: "14:26:05 · hash 0x4e…b8",
-  },
-  {
-    id: "run-2744",
-    title: "handoff-sig verify: batch #214",
-    jobMeta: "job-0414 · coding-hand · T2",
-    worker: { variant: "b", initials: "CH", label: "0x2E94…7f02" },
-    state: "disputed",
-    stake: "40.0",
-    age: "00:34:18",
-    ageStale: true,
-    lastEvent: "Signature mismatch on payload",
-    lastEventMeta: "13:58:09 · by verifier-2",
-  },
-  {
-    id: "run-2745",
-    title: "docs-refresh: runbook v3.1",
-    jobMeta: "job-0411 · writer-gov · T1",
-    worker: { variant: "c", initials: "WG", label: "0xC7fE…9ab1" },
-    state: "submitted",
-    stake: "18.0",
-    age: "00:04:47",
-    lastEvent: "Verifier queued · semantic mode",
-    lastEventMeta: "14:27:19 · r_4e0f8",
-  },
-  {
-    id: "run-2746",
-    title: "lint-sweep: packages/*",
-    jobMeta: "job-0408 · coding · T1",
-    worker: { variant: "d", initials: "CH", label: "0x3A11…e7dd" },
-    state: "claimed",
-    stake: "8.0",
-    age: "00:03:21",
-    lastEvent: "Stake locked",
-    lastEventMeta: "14:28:42 · in AgentAccountCore",
-  },
-  {
-    id: "run-2747",
-    title: "xcm-sanity: asset-hub → hydration",
-    jobMeta: "job-0406 · ops-xcm · T3",
-    worker: { variant: "unclaimed", initials: "—", label: "unclaimed" },
-    state: "ready",
-    stake: "75.0",
-    age: "00:02:55",
-    lastEvent: "Escrow funded",
-    lastEventMeta: "14:29:09 · by treasury-1",
-  },
-  {
-    id: "run-2748",
-    title: "policy-audit: deps/sec-only",
-    jobMeta: "job-0405 · gov-review · T2",
-    worker: { variant: "a", initials: "GR", label: "0x88Ce…4422" },
-    state: "settled",
-    stake: "15.0",
-    age: "00:02:10",
-    lastEvent: "Receipt signed & co-signed",
-    lastEventMeta: "14:29:54 · r_4e12a",
-  },
-];
-
-const FILTERS: QueueFilterCount[] = [
-  { id: "all", label: "All", count: 15 },
-  { id: "ready", label: "Ready", count: 4 },
-  { id: "claimed", label: "Claimed", count: 5 },
-  { id: "submitted", label: "Submitted", count: 3 },
-  { id: "disputed", label: "Disputed", count: 2 },
-  { id: "settled", label: "Settled", count: 1 },
-];
-
-const RECOMMENDED: JobCardData[] = [
-  {
-    id: "job-0428",
-    jobMeta: "docs",
-    category: "docs",
-    title:
-      "Document TypeScript validation helper API for external package consumers",
-    source: {
-      type: "github_issue",
-      repo: "oss-devsecblueprint/devsecblueprint",
-      issueNumber: 110,
-      issueUrl:
-        "https://github.com/oss-devsecblueprint/devsecblueprint/issues/110",
-      labels: ["documentation", "good first issue"],
-      score: 82,
-    },
-    rewardValue: "8.0",
-    rewardCurrency: "DOT",
-    rewardUsd: "~ $58",
-    tier: "T1",
-    modeLabel: "PR review",
-    modeTone: "ready",
-    meta: [
-      { label: "Stake", value: "4.0 DOT" },
-      { label: "Verifier", value: "github_pr" },
-      { label: "Window", value: "2 h", accent: true },
-      { label: "Fit score", value: "82/100" },
-    ],
-    fit: 5,
-    hot: true,
-  },
-  {
-    id: "job-0406",
-    jobMeta: "ops-xcm",
-    category: "ops-xcm",
-    title: "xcm-sanity: asset-hub → hydration",
-    rewardValue: "75.0",
-    rewardCurrency: "DOT",
-    rewardUsd: "~ $540",
-    tier: "T3",
-    modeLabel: "Semantic",
-    meta: [
-      { label: "Stake", value: "40.0 DOT" },
-      { label: "Verifier", value: "paired-hash" },
-      { label: "Window", value: "12 min", accent: true },
-      { label: "Slippage cap", value: "0.5%" },
-    ],
-    fit: 4,
-  },
-  {
-    id: "job-0421",
-    jobMeta: "coding",
-    title: "repo-sweep: deps/sec-only bump",
-    rewardValue: "12.0",
-    rewardCurrency: "DOT",
-    rewardUsd: "~ $86",
-    tier: "T1",
-    modeLabel: "Diff-hash",
-    modeTone: "settled",
-    meta: [
-      { label: "Stake", value: "6.0 DOT" },
-      { label: "Verifier", value: "deterministic" },
-      { label: "Window", value: "45 min" },
-      { label: "Slippage cap", value: "—" },
-    ],
-    fit: 5,
-  },
-  {
-    id: "job-0420",
-    jobMeta: "writer-gov",
-    title: "writer-gov: OP-14 summary",
-    rewardValue: "22.0",
-    rewardCurrency: "DOT",
-    rewardUsd: "~ $158",
-    tier: "T2",
-    modeLabel: "Review",
-    modeTone: "ready",
-    meta: [
-      { label: "Stake", value: "11.0 DOT" },
-      { label: "Verifier", value: "human + LLM" },
-      { label: "Window", value: "30 min" },
-      { label: "Citations", value: "required" },
-    ],
-    fit: 3,
-  },
-  {
-    id: "job-0419",
-    jobMeta: "coding-hand",
-    title: "sig-verify: batch #215",
-    rewardValue: "40.0",
-    rewardCurrency: "DOT",
-    rewardUsd: "~ $288",
-    tier: "T2",
-    modeLabel: "Paired-hash",
-    modeTone: "submitted",
-    meta: [
-      { label: "Stake", value: "20.0 DOT" },
-      { label: "Verifier", value: "deterministic" },
-      { label: "Window", value: "20 min" },
-      { label: "Cosigner", value: "required" },
-    ],
-    fit: 4,
-  },
-];
-
-// Fallback job definitions used when the live API is unavailable. Shape
-// mirrors what the backend emits on /jobs/definition?jobId=, so the
-// adapter (buildGitHubContext) can populate the Loaded-run panel from
-// these records exactly as it does from live data. Only the rich
-// GitHub-ingested rows need definitions — native fixture rows fall
-// through to the generic governance layout.
-const FIXTURE_JOB_DEFINITIONS: Record<string, unknown>[] = [
-  {
-    id: "run-2749",
-    title:
-      "Document TypeScript validation helper API for external package consumers",
-    category: "docs",
-    description:
-      "The internal `validateRequest` helper in `packages/core/src/validate.ts` is referenced by three external consumers but has no public docs. We need a markdown reference that lists the accepted shapes, the thrown error types, and at least one usage example per shape.",
-    source: {
-      type: "github_issue",
-      repo: "oss-devsecblueprint/devsecblueprint",
-      issueNumber: 110,
-      issueUrl:
-        "https://github.com/oss-devsecblueprint/devsecblueprint/issues/110",
-      labels: ["documentation", "good first issue"],
-      score: 82,
-    },
-    acceptanceCriteria: [
-      "Open a PR that adds `docs/reference/validate.md`",
-      "Document every exported signature with one code example",
-      "`npm run build:docs` passes with no warnings",
-      "PR description links to the closed issue",
-    ],
-    agentInstructions:
-      "Read `packages/core/src/validate.ts` top to bottom. For each exported function, write a short prose intro plus a fenced TypeScript example. Keep voice consistent with the existing reference docs under `docs/reference/`.",
-    verification: {
-      method: "github_pr",
-      signals: ["PR opened", "docs build green", "maintainer review"],
-    },
-  },
-  {
-    id: "run-2742",
-    title:
-      "Fix flaky integration test: race condition when two workers claim within the same block window",
-    category: "bugfix",
-    description: `The integration suite in \`node/test/src/claim_race.rs\` fails ~3% of the time on CI when two workers attempt to claim the same job within the same 6-second block window. Expected behavior: the first claim (lowest nonce) wins; the second receives a \`ClaimRejected\` event and the caller's stake is refunded in the same block.
-
-Current behavior: both claims occasionally land, both workers get \`ClaimAccepted\`, and the escrow double-locks stake. The second worker is later slashed during settlement, which is the wrong failure mode — the rejection should be at claim-time, not at settle-time.
-
-Repro: run \`cargo test --test claim_race -- --test-threads=1 --ignored\` in a loop; fails in 2–4 iterations on average.`,
-    source: {
-      type: "github_issue",
-      repo: "paritytech/polkadot-sdk",
-      issueNumber: 4812,
-      issueUrl: "https://github.com/paritytech/polkadot-sdk/issues/4812",
-      labels: ["bug", "flaky-test", "help wanted"],
-      score: 74,
-    },
-    acceptanceCriteria: [
-      "Open a PR that makes the `claim_race` test deterministic on Linux and macOS",
-      "Include a regression test that asserts the second claim receives ClaimRejected",
-      "All existing tests pass; no new warnings from `cargo clippy -- -D warnings`",
-      "PR description references issue #4812 and explains the ordering fix",
-    ],
-    agentInstructions:
-      "Start from the failing test. Trace the claim path in `runtime/src/escrow.rs` and identify where the two claims race. Fix by ordering claims by (block_number, nonce, wallet) before acceptance — see OP-09 §4.2 for the canonical ordering. Keep the diff under 150 lines if possible.",
-    verification: {
-      method: "github_pr",
-      signals: ["PR opened", "CI green", "maintainer review"],
-    },
-  },
-];
-
-// Lifecycle for GitHub-ingested jobs. For MVP we keep the same 5-stage
-// shape but relabel for the OSS flow: Ready → Claimed → PR submitted →
-// Verified → Paid. Future revisions can add an explicit "Working"
-// intermediate stage once the runner reports keep-alive signals.
-const LIFECYCLE: LifecycleStage[] = [
-  { index: 1, label: "Ready", meta: "14:20:25", state: "done" },
-  { index: 2, label: "Claimed", meta: "14:23:53 · by you", state: "done" },
-  {
-    index: 3,
-    label: "PR submitted",
-    meta: "14:27:45 · #4931 on paritytech/polkadot-sdk",
-    state: "done",
-  },
-  {
-    index: 4,
-    label: "Verified",
-    meta: "2/3 signals · maintainer review pending",
-    state: "current",
-  },
-  { index: 5, label: "Paid", meta: "—", state: "pending" },
-];
-
-// `useSearchParams` requires a Suspense boundary under the App Router
-// static-export mode used on the VPS. Wrap the inner page component so
-// deep-links like `/runs/?run=run-2742` hydrate correctly without
-// breaking the static build.
+/**
+ * Runs — the operator's primary work surface.
+ *
+ * Layout: email-client split pane. Queue on the left (card-row list of
+ * all open runs), sticky detail pane on the right driven by LoadedRunView.
+ * Clicking a queue row just updates `selectedId`; LoadedRunView owns all
+ * the hooks, fixture fallback, and submit/drawer state for that run.
+ *
+ * Lifecycle rail + recommendation rail sit below the split pane so they
+ * don't steal horizontal room from the two primary panes.
+ */
 export default function RunsPage() {
   return (
     <Suspense fallback={null}>
@@ -388,28 +49,26 @@ function RunsPageInner() {
   const runParam = searchParams?.get("run") ?? null;
   const [activeFilter, setActiveFilter] = useState<QueueFilter>("all");
   const [selectedId, setSelectedId] = useState<string>(runParam ?? "run-2742");
-  const [submitting, setSubmitting] = useState(false);
-  const [submitError, setSubmitError] = useState<string | null>(null);
-  const [receiptOpen, setReceiptOpen] = useState(false);
+
   const jobs = useJobs();
   const recommendations = useRecommendations();
 
-  // When someone opens the page with a ?run=<id> deep link, honour it on
-  // first hydration so the corresponding row is pre-selected.
+  const liveRows = useMemo(() => buildRunRows(jobs.data), [jobs.data]);
+  const rows = liveRows.length ? liveRows : FIXTURE_RUN_ROWS;
+  const filters = useMemo(() => buildRunFilters(rows), [rows]);
+  const recommendationCards = useMemo(() => {
+    const liveCards = buildRecommendationCards(recommendations.data, jobs.data);
+    return liveCards.length ? liveCards : FIXTURE_RECOMMENDATIONS;
+  }, [jobs.data, recommendations.data]);
+
+  // Honour ?run=<id> deep links on first hydration so a linked run is
+  // pre-selected.
   useEffect(() => {
     if (runParam) setSelectedId(runParam);
   }, [runParam]);
 
-  const liveRows = useMemo(() => buildRunRows(jobs.data), [jobs.data]);
-  const rows = liveRows.length ? liveRows : ROWS;
-  const filters = useMemo(() => buildRunFilters(rows), [rows]);
-  const recommendationCards = useMemo(() => {
-    const liveCards = buildRecommendationCards(recommendations.data, jobs.data);
-    return liveCards.length ? liveCards : RECOMMENDED;
-  }, [jobs.data, recommendations.data]);
-  const rawJobs = useMemo(() => extractRunJobs(jobs.data), [jobs.data]);
-  const loadedRow = rows.find((row) => row.id === selectedId) ?? rows[0] ?? ROWS[0];
-
+  // Keep selectedId valid when the rows list changes (e.g. live data
+  // arrives and the previously-selected fixture id isn't in it).
   useEffect(() => {
     if (rows.length && !rows.some((row) => row.id === selectedId)) {
       setSelectedId(rows[0].id);
@@ -422,67 +81,26 @@ function RunsPageInner() {
   }, [activeFilter, rows]);
 
   const assignedToMe = rows.filter((row) => row.worker.isSelf).length;
-  const jobDefinition = useJobDefinition(loadedRow.id);
-  const selectedJob =
-    asRecord(jobDefinition.data) ??
-    rawJobs.find((job) => job.id === loadedRow.id) ??
-    FIXTURE_JOB_DEFINITIONS.find((def) => def.id === loadedRow.id);
-  // Only set when the loaded run was ingested from GitHub. The panel
-  // switches to a GitHub-native layout when this is defined; otherwise
-  // it keeps the generic governance evidence/verifier layout.
-  const loadedGitHub = buildGitHubContext(loadedRow, selectedJob);
   const liveStatus = jobs.error
     ? "fixture fallback"
-      : jobs.isLoading
-        ? "loading live jobs"
-        : "live API";
-  const handleSubmit = async (evidence: string) => {
-    setSubmitError(null);
-    if (!loadedRow.sessionId) {
-      setSubmitError("Claim this run before submitting evidence.");
-      return;
-    }
-    setSubmitting(true);
-    try {
-      await swrFetcher([
-        "/jobs/submit",
-        {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            sessionId: loadedRow.sessionId,
-            submission: {
-              evidence,
-              jobId: loadedRow.id,
-              submittedAt: new Date().toISOString(),
-            },
-          }),
-        },
-      ]);
-      mutate("/jobs");
-      mutate("/sessions");
-    } catch {
-      setSubmitError("Could not submit this run. Check session ownership and try again.");
-    } finally {
-      setSubmitting(false);
-    }
-  };
+    : jobs.isLoading
+      ? "loading live jobs"
+      : "live API";
 
   return (
     <div className="flex w-full max-w-[1440px] flex-col gap-3.5">
       <RunsTopbar />
-      <QueueBar filters={filters.length ? filters : FILTERS} active={activeFilter} onChange={setActiveFilter} />
+      <QueueBar
+        filters={filters.length ? filters : FIXTURE_FILTERS}
+        active={activeFilter}
+        onChange={setActiveFilter}
+      />
 
       {/*
-       * Email-client layout: queue on the left (compact, scannable) + loaded-
-       * run panel on the right, sticky so the details stay visible as the
-       * queue scrolls. Recommendation rail + lifecycle sit below the split
-       * pane so they don't steal horizontal room from the two primary panes.
-       *
-       * At xl: 45fr / 55fr split — the panel is wider because it hosts the
-       * two inner columns (stake + job context on the left, verifier +
-       * settlement on the right) and needs the headroom.
-       * Below xl: single column, panel stacks under the queue.
+       * Email-client layout: queue left, loaded-run detail right. The
+       * right pane is sticky so clicking a row instantly swaps detail
+       * without scrolling. Rails sit below so they don't compete with
+       * the two primary panes for horizontal real estate.
        */}
       <div className="grid grid-cols-1 items-start gap-3.5 xl:grid-cols-[minmax(480px,0.85fr)_minmax(0,1.15fr)]">
         <RunQueueTable
@@ -496,27 +114,20 @@ function RunsPageInner() {
           liveStatus={liveStatus}
         />
         <div className="xl:sticky xl:top-6 xl:max-h-[calc(100vh-3rem)] xl:overflow-y-auto">
-          <LoadedRunPanelWrapper
-            loadedRow={loadedRow}
-            selectedJob={selectedJob}
-            loadedGitHub={loadedGitHub}
-            handleSubmit={handleSubmit}
-            submitting={submitting}
-            submitError={submitError}
-            onReceiptPreview={() => setReceiptOpen(true)}
-            standaloneUrl={`/runs/?run=${encodeURIComponent(loadedRow.id)}`}
+          <LoadedRunView
+            runId={selectedId}
+            standaloneUrl={`/runs/detail/?id=${encodeURIComponent(selectedId)}`}
+            // The queue page renders the lifecycle rail below the split
+            // pane (full width) so it doesn't steal vertical room from
+            // the sticky panel column. The standalone detail page will
+            // render it inline instead.
+            showLifecycle={false}
           />
         </div>
       </div>
 
-      <ReceiptPreviewDrawer
-        open={receiptOpen}
-        onClose={() => setReceiptOpen(false)}
-        draft={buildReceiptDraft(loadedRow, loadedGitHub)}
-      />
-
       <LifecycleRail
-        runId="run-2742"
+        runId={selectedId}
         contextNote={
           <>
             Window closes in{" "}
@@ -527,7 +138,7 @@ function RunsPageInner() {
             <b className="font-semibold text-[var(--avy-ink)]">#4931</b> opened
           </>
         }
-        stages={LIFECYCLE}
+        stages={FIXTURE_LIFECYCLE}
         next={{
           label: "Next",
           value: "Maintainer review → Pay",
@@ -544,222 +155,4 @@ function RunsPageInner() {
       />
     </div>
   );
-}
-
-/**
- * Thin wrapper around LoadedRunPanel so the gnarly fixture-shaped props
- * (evidence stub, verifier fixture, settle fixture, submission handler)
- * don't clutter the main page component. All live values continue to come
- * from live data / the loaded row; the non-GitHub fixture verifier lines
- * stay in place as a demo fallback while the backend isn't yet streaming
- * real verifier output.
- */
-interface LoadedPanelProps {
-  loadedRow: RunRow;
-  selectedJob: Record<string, unknown> | undefined;
-  loadedGitHub: ReturnType<typeof buildGitHubContext>;
-  handleSubmit: (evidence: string) => Promise<void>;
-  submitting: boolean;
-  submitError: string | null;
-  onReceiptPreview?: () => void;
-  standaloneUrl?: string;
-}
-
-function LoadedRunPanelWrapper(props: LoadedPanelProps) {
-  const { loadedRow, selectedJob, loadedGitHub, handleSubmit, submitting, submitError, onReceiptPreview, standaloneUrl } = props;
-  return (
-    <LoadedRunPanel
-        kicker="Loaded run"
-        title={loadedRow.title}
-        meta={loadedRow.jobMeta}
-        state={loadedRow.state}
-        github={loadedGitHub}
-        onReceiptPreview={onReceiptPreview}
-        standaloneUrl={standaloneUrl}
-        stake={{
-          amount: loadedRow.stake,
-          aux: selectedJob
-            ? `${selectedJob.rewardAsset ?? "DOT"} reward · verifier ${selectedJob.verifierMode ?? "unknown"}`
-            : "fixture data · waiting for live selection",
-          breakdown: {
-            worker: `${loadedRow.stake} DOT`,
-            verifier: "0 DOT",
-            treasury: "0 DOT",
-          },
-        }}
-        // When `github` is set the panel swaps Evidence for the four-tab
-        // Issue/Acceptance/Instructions/Submission block, so `evidence` is
-        // unused at runtime. The prop is still type-required — we stub it
-        // with neutral content that will never render for this job.
-        evidence={{
-          tabs: [{ id: "issue", label: "Issue" }],
-          activeTab: "issue",
-          metaRight: "",
-          metaFoot: "",
-          sample: "",
-        }}
-        submission={{
-          note: (
-            <>
-              Submits <b className="text-[var(--avy-ink)]">PR URL + evidence</b>{" "}
-              to the verifier. Window{" "}
-              <b className="text-[var(--avy-ink)]">00:08:14 / 02:00:00</b>.
-            </>
-          ),
-          cta: "Submit for verification",
-          onSubmit: handleSubmit,
-          submitting,
-          error: submitError,
-        }}
-        verifier={{
-          runner: "verifier-2 · github_pr · handler-v0.14",
-          elapsed: "stream · 3.4s",
-          modeNote: "github_pr · maintainer-reviewed",
-          lines: [
-            {
-              time: "14:28:01",
-              level: "info",
-              label: "source",
-              message: (
-                <>
-                  loaded issue{" "}
-                  <span className="text-[#f4c989]">
-                    paritytech/polkadot-sdk#4812
-                  </span>{" "}
-                  · score 74/100
-                </>
-              ),
-            },
-            {
-              time: "14:28:01",
-              level: "ok",
-              label: "pass",
-              message: (
-                <>
-                  PR URL present ·{" "}
-                  <span className="text-[#f4c989]">pull/4931</span>
-                </>
-              ),
-            },
-            {
-              time: "14:28:02",
-              level: "ok",
-              label: "pass",
-              message: <>PR body references issue #4812</>,
-            },
-            {
-              time: "14:28:02",
-              level: "ok",
-              label: "pass",
-              message: (
-                <>
-                  CI checks green · <span className="text-[#9bd7b5]">7/7</span>{" "}
-                  on ubuntu-latest · macos-13
-                </>
-              ),
-            },
-            {
-              time: "14:28:03",
-              level: "warn",
-              label: "note",
-              message: (
-                <>
-                  maintainer review{" "}
-                  <span className="text-[#f4c989]">pending</span> · requested
-                  from @bkchr
-                </>
-              ),
-            },
-            {
-              time: "14:28:03",
-              level: "ok",
-              label: "verdict",
-              message: (
-                <>
-                  2/3 signals pass · awaiting maintainer · receipt draft{" "}
-                  <span className="text-[#f4c989]">r_4e133</span>
-                </>
-              ),
-            },
-          ],
-          verdict: {
-            status: "Awaiting maintainer review",
-            score: "2 / 3",
-            scoreLabel: "0.86 confidence",
-          },
-        }}
-        settle={{
-          title: "Awaiting verification",
-          detail: (
-            <>
-              On verification, pay{" "}
-              <b className="text-[var(--avy-ink)]">25.00 DOT</b> · unlock{" "}
-              <b className="text-[var(--avy-ink)]">25.00 DOT</b> stake · sign
-              receipt <b className="text-[var(--avy-ink)]">r_4e133</b>
-            </>
-          ),
-          cta: "Mark verified & pay",
-          ctaDisabled: true,
-          note: "pays worker & verifier once the maintainer approves the PR",
-        }}
-      />
-  );
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
-/**
- * Assemble the unsigned receipt that the operator would commit if they
- * clicked "Mark verified & pay" right now. Everything here is derived
- * from data already on the Loaded-run panel; nothing is fetched. That's
- * the whole point — the preview is a "before you sign" view, not a new
- * round trip.
- */
-function buildReceiptDraft(
-  row: RunRow,
-  github: ReturnType<typeof buildGitHubContext>
-): ReceiptPreviewDraft {
-  const workerSignerLabel = row.worker.isSelf
-    ? `Worker · ${row.worker.label} (you)`
-    : `Worker · ${row.worker.label}`;
-
-  return {
-    receiptRef: "r_4e133",
-    runId: row.id,
-    jobMeta: row.jobMeta,
-    state: row.state,
-    stake: {
-      amount: row.stake,
-      currency: "DOT",
-      breakdown: [
-        { label: "Worker payout", value: `${row.stake} DOT` },
-        { label: "Verifier fee", value: "0 DOT" },
-        { label: "Treasury reserve", value: "0 DOT" },
-      ],
-    },
-    verdict: {
-      status: github
-        ? "Awaiting maintainer review"
-        : "Verified (pending cosign)",
-      score: github ? "2 / 3" : "4 / 5",
-      confidence: github ? "0.86 confidence" : "0.92 confidence",
-    },
-    evidenceHash: github ? "sha256 0x9c…41" : "sha256 0x9c…41",
-    ...(github ? { github } : {}),
-    prUrl: github ? `https://github.com/${github.repo}/pull/4931` : undefined,
-    signers: [
-      { label: workerSignerLabel, status: "pending" },
-      {
-        label: github
-          ? "Maintainer · awaiting review"
-          : "Cosigner · 0x9A13…0cb2",
-        status: "pending",
-      },
-      { label: "Verifier · verifier-2", status: "signed" },
-    ],
-  };
 }

--- a/app/components/runs/LoadedRunPanel.tsx
+++ b/app/components/runs/LoadedRunPanel.tsx
@@ -166,39 +166,45 @@ export function LoadedRunPanel(props: LoadedRunPanelProps) {
       // of panel width).
       className="@container overflow-hidden rounded-[12px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] shadow-[var(--shadow-dense)]"
     >
-      <header className="flex items-center justify-between gap-3.5 border-b border-[var(--avy-line-soft)] bg-gradient-to-b from-[#faf8f1] to-[#fffdf7] px-4.5 py-3.5">
-        <div className="flex flex-wrap items-baseline gap-3">
-          <div>
-            <div
-              className="font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-accent)]"
-              style={{ letterSpacing: "0.14em" }}
-            >
-              {props.kicker}
-            </div>
-            <h2 className="m-0 font-[family-name:var(--font-display)] text-[18px] font-bold leading-[1.1]">
-              {props.title}
-            </h2>
+      <header className="flex items-start justify-between gap-3 border-b border-[var(--avy-line-soft)] bg-gradient-to-b from-[#faf8f1] to-[#fffdf7] px-4.5 py-3.5">
+        {/* min-w-0 on the title column lets the flex parent actually
+            shrink it so long file-path titles don't squash the action
+            buttons into a broken two-row text-wrap. */}
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <div
+            className="font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-accent)]"
+            style={{ letterSpacing: "0.14em" }}
+          >
+            {props.kicker}
           </div>
+          <h2
+            className="m-0 line-clamp-2 font-[family-name:var(--font-display)] text-[18px] font-bold leading-[1.2] text-[var(--avy-ink)]"
+            title={typeof props.title === "string" ? props.title : undefined}
+          >
+            {props.title}
+          </h2>
           <span
-            className="font-[family-name:var(--font-mono)] text-xs text-[var(--avy-muted)]"
+            className="mt-0.5 truncate font-[family-name:var(--font-mono)] text-xs text-[var(--avy-muted)]"
             style={{ letterSpacing: 0 }}
           >
             {props.meta}
           </span>
         </div>
         {/* Header actions. Each is conditional on its handler/URL so we
-            don't render a button that does nothing — avoids the "why is
-            this disabled" confusion a blanket placeholder causes. */}
+            don't render a button that does nothing. shrink-0 +
+            whitespace-nowrap keep them on one clean line when the title
+            column gets long. */}
         {props.onReceiptPreview || props.standaloneUrl ? (
-          <div className="flex items-center gap-1.5">
+          <div className="flex shrink-0 items-center gap-1.5 pt-0.5">
             {props.onReceiptPreview ? (
               <button
                 type="button"
                 onClick={props.onReceiptPreview}
-                className="inline-flex h-7 items-center gap-1.5 rounded-[8px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-3 font-[family-name:var(--font-display)] text-[11px] font-bold uppercase text-[var(--avy-ink)] transition-transform hover:-translate-y-px hover:border-[color:rgba(30,102,66,0.24)] hover:text-[var(--avy-accent)]"
+                title="Preview the signed receipt draft"
+                className="inline-flex h-7 items-center gap-1.5 whitespace-nowrap rounded-[8px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-3 font-[family-name:var(--font-display)] text-[11px] font-bold uppercase text-[var(--avy-ink)] transition-transform hover:-translate-y-px hover:border-[color:rgba(30,102,66,0.24)] hover:text-[var(--avy-accent)]"
                 style={{ letterSpacing: "0.04em" }}
               >
-                ⌕ Receipt preview
+                ⌕ Receipt
               </button>
             ) : null}
             {props.standaloneUrl ? (
@@ -206,10 +212,11 @@ export function LoadedRunPanel(props: LoadedRunPanelProps) {
                 href={props.standaloneUrl}
                 target="_blank"
                 rel="noreferrer noopener"
-                className="inline-flex h-7 items-center gap-1.5 rounded-[8px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-3 font-[family-name:var(--font-display)] text-[11px] font-bold uppercase text-[var(--avy-ink)] transition-transform hover:-translate-y-px hover:border-[color:rgba(30,102,66,0.24)] hover:text-[var(--avy-accent)]"
+                title="Open this run in a dedicated fullscreen view"
+                className="inline-flex h-7 items-center gap-1.5 whitespace-nowrap rounded-[8px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-3 font-[family-name:var(--font-display)] text-[11px] font-bold uppercase text-[var(--avy-ink)] transition-transform hover:-translate-y-px hover:border-[color:rgba(30,102,66,0.24)] hover:text-[var(--avy-accent)]"
                 style={{ letterSpacing: "0.04em" }}
               >
-                Open in new tab ↗
+                Full view ↗
               </a>
             ) : null}
           </div>

--- a/app/components/runs/LoadedRunView.tsx
+++ b/app/components/runs/LoadedRunView.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { mutate } from "swr";
+import { LoadedRunPanel } from "./LoadedRunPanel";
+import { LifecycleRail } from "./LifecycleRail";
+import {
+  ReceiptPreviewDrawer,
+  type ReceiptPreviewDraft,
+} from "./ReceiptPreviewDrawer";
+import {
+  FIXTURE_JOB_DEFINITIONS,
+  FIXTURE_LIFECYCLE,
+  FIXTURE_RUN_ROWS,
+} from "./fixtures";
+import type { RunRow } from "./RunQueueTable";
+import { swrFetcher } from "@/lib/api/client";
+import { useJobDefinition, useJobs } from "@/lib/api/hooks";
+import {
+  buildGitHubContext,
+  buildRunRows,
+  extractRunJobs,
+} from "@/lib/api/run-adapters";
+
+/**
+ * Self-contained detail view for a single run.
+ *
+ * Looks up the row (live or fixture), resolves the job definition,
+ * builds the GitHub job context, wires the submit handler, owns the
+ * receipt-preview drawer state, and renders LoadedRunPanel + LifecycleRail.
+ *
+ * Both consumers use it:
+ *   - `/runs/` — the split-pane queue page, in the sticky right column
+ *     (selectedRunId tracks the clicked row)
+ *   - `/runs/detail/?id=<id>` — the standalone fullscreen view
+ *
+ * Keeps the fixture-driven verifier / settlement / lifecycle copy inline
+ * because the backend doesn't yet stream real verifier output; swap
+ * these for live data once those endpoints land.
+ */
+export interface LoadedRunViewProps {
+  runId: string;
+  /**
+   * URL that opens this run in a dedicated fullscreen view. Omit on
+   * the standalone page itself (so the "Full view" button doesn't link
+   * to the page you're already on).
+   */
+  standaloneUrl?: string;
+  /** Hide the lifecycle rail when the host already renders one. */
+  showLifecycle?: boolean;
+}
+
+export function LoadedRunView({
+  runId,
+  standaloneUrl,
+  showLifecycle = true,
+}: LoadedRunViewProps) {
+  const jobs = useJobs();
+  const liveRows = useMemo(() => buildRunRows(jobs.data), [jobs.data]);
+  const rows = liveRows.length ? liveRows : FIXTURE_RUN_ROWS;
+  const rawJobs = useMemo(() => extractRunJobs(jobs.data), [jobs.data]);
+  const loadedRow =
+    rows.find((row) => row.id === runId) ?? rows[0] ?? FIXTURE_RUN_ROWS[0];
+
+  const jobDefinition = useJobDefinition(loadedRow.id);
+  const selectedJob =
+    asRecord(jobDefinition.data) ??
+    rawJobs.find((job) => job.id === loadedRow.id) ??
+    FIXTURE_JOB_DEFINITIONS.find((def) => def.id === loadedRow.id);
+  const loadedGitHub = buildGitHubContext(loadedRow, selectedJob);
+
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [receiptOpen, setReceiptOpen] = useState(false);
+
+  const handleSubmit = async (evidence: string) => {
+    setSubmitError(null);
+    if (!loadedRow.sessionId) {
+      setSubmitError("Claim this run before submitting evidence.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await swrFetcher([
+        "/jobs/submit",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            sessionId: loadedRow.sessionId,
+            submission: {
+              evidence,
+              jobId: loadedRow.id,
+              submittedAt: new Date().toISOString(),
+            },
+          }),
+        },
+      ]);
+      mutate("/jobs");
+      mutate("/sessions");
+    } catch {
+      setSubmitError(
+        "Could not submit this run. Check session ownership and try again."
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3.5">
+      <LoadedRunPanel
+        kicker="Loaded run"
+        title={loadedRow.title}
+        meta={loadedRow.jobMeta}
+        state={loadedRow.state}
+        github={loadedGitHub}
+        onReceiptPreview={() => setReceiptOpen(true)}
+        standaloneUrl={standaloneUrl}
+        stake={{
+          amount: loadedRow.stake,
+          aux: selectedJob
+            ? `${selectedJob.rewardAsset ?? "DOT"} reward · verifier ${selectedJob.verifierMode ?? "unknown"}`
+            : "fixture data · waiting for live selection",
+          breakdown: {
+            worker: `${loadedRow.stake} DOT`,
+            verifier: "0 DOT",
+            treasury: "0 DOT",
+          },
+        }}
+        // When `github` is set the panel swaps Evidence for the four-tab
+        // Issue/Acceptance/Instructions/Submission block. `evidence` is
+        // then unused at runtime but stays type-required.
+        evidence={{
+          tabs: [{ id: "issue", label: "Issue" }],
+          activeTab: "issue",
+          metaRight: "",
+          metaFoot: "",
+          sample: "",
+        }}
+        submission={{
+          note: (
+            <>
+              Submits <b className="text-[var(--avy-ink)]">PR URL + evidence</b>{" "}
+              to the verifier. Window{" "}
+              <b className="text-[var(--avy-ink)]">00:08:14 / 02:00:00</b>.
+            </>
+          ),
+          cta: "Submit for verification",
+          onSubmit: handleSubmit,
+          submitting,
+          error: submitError,
+        }}
+        verifier={{
+          runner: "verifier-2 · github_pr · handler-v0.14",
+          elapsed: "stream · 3.4s",
+          modeNote: "github_pr · maintainer-reviewed",
+          lines: [
+            {
+              time: "14:28:01",
+              level: "info",
+              label: "source",
+              message: (
+                <>
+                  loaded issue{" "}
+                  <span className="text-[#f4c989]">
+                    paritytech/polkadot-sdk#4812
+                  </span>{" "}
+                  · score 74/100
+                </>
+              ),
+            },
+            {
+              time: "14:28:01",
+              level: "ok",
+              label: "pass",
+              message: (
+                <>
+                  PR URL present ·{" "}
+                  <span className="text-[#f4c989]">pull/4931</span>
+                </>
+              ),
+            },
+            {
+              time: "14:28:02",
+              level: "ok",
+              label: "pass",
+              message: <>PR body references issue #4812</>,
+            },
+            {
+              time: "14:28:02",
+              level: "ok",
+              label: "pass",
+              message: (
+                <>
+                  CI checks green · <span className="text-[#9bd7b5]">7/7</span>{" "}
+                  on ubuntu-latest · macos-13
+                </>
+              ),
+            },
+            {
+              time: "14:28:03",
+              level: "warn",
+              label: "note",
+              message: (
+                <>
+                  maintainer review{" "}
+                  <span className="text-[#f4c989]">pending</span> · requested
+                  from @bkchr
+                </>
+              ),
+            },
+            {
+              time: "14:28:03",
+              level: "ok",
+              label: "verdict",
+              message: (
+                <>
+                  2/3 signals pass · awaiting maintainer · receipt draft{" "}
+                  <span className="text-[#f4c989]">r_4e133</span>
+                </>
+              ),
+            },
+          ],
+          verdict: {
+            status: "Awaiting maintainer review",
+            score: "2 / 3",
+            scoreLabel: "0.86 confidence",
+          },
+        }}
+        settle={{
+          title: "Awaiting verification",
+          detail: (
+            <>
+              On verification, pay{" "}
+              <b className="text-[var(--avy-ink)]">25.00 DOT</b> · unlock{" "}
+              <b className="text-[var(--avy-ink)]">25.00 DOT</b> stake · sign
+              receipt <b className="text-[var(--avy-ink)]">r_4e133</b>
+            </>
+          ),
+          cta: "Mark verified & pay",
+          ctaDisabled: true,
+          note: "pays worker & verifier once the maintainer approves the PR",
+        }}
+      />
+
+      {showLifecycle ? (
+        <LifecycleRail
+          runId={loadedRow.id}
+          contextNote={
+            <>
+              Window closes in{" "}
+              <b className="font-semibold text-[var(--avy-ink)]">21m 46s</b>
+              {" · "}verification{" "}
+              <b className="font-semibold text-[var(--avy-ink)]">github_pr</b>
+              {" · "}PR{" "}
+              <b className="font-semibold text-[var(--avy-ink)]">#4931</b> opened
+            </>
+          }
+          stages={FIXTURE_LIFECYCLE}
+          next={{
+            label: "Next",
+            value: "Maintainer review → Pay",
+            sub: "auto-pays on PR merge + CI green",
+          }}
+        />
+      ) : null}
+
+      <ReceiptPreviewDrawer
+        open={receiptOpen}
+        onClose={() => setReceiptOpen(false)}
+        draft={buildReceiptDraft(loadedRow, loadedGitHub)}
+      />
+    </div>
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/**
+ * Assemble the unsigned receipt that would be signed on "Mark verified
+ * & pay". Derived entirely from what the panel already shows — no
+ * extra fetch. For native (non-GitHub) runs the signer list flips from
+ * maintainer to cosigner and the source block is skipped.
+ */
+function buildReceiptDraft(
+  row: RunRow,
+  github: ReturnType<typeof buildGitHubContext>
+): ReceiptPreviewDraft {
+  const workerSignerLabel = row.worker.isSelf
+    ? `Worker · ${row.worker.label} (you)`
+    : `Worker · ${row.worker.label}`;
+
+  return {
+    receiptRef: "r_4e133",
+    runId: row.id,
+    jobMeta: row.jobMeta,
+    state: row.state,
+    stake: {
+      amount: row.stake,
+      currency: "DOT",
+      breakdown: [
+        { label: "Worker payout", value: `${row.stake} DOT` },
+        { label: "Verifier fee", value: "0 DOT" },
+        { label: "Treasury reserve", value: "0 DOT" },
+      ],
+    },
+    verdict: {
+      status: github
+        ? "Awaiting maintainer review"
+        : "Verified (pending cosign)",
+      score: github ? "2 / 3" : "4 / 5",
+      confidence: github ? "0.86 confidence" : "0.92 confidence",
+    },
+    evidenceHash: "sha256 0x9c…41",
+    ...(github ? { github } : {}),
+    prUrl: github ? `https://github.com/${github.repo}/pull/4931` : undefined,
+    signers: [
+      { label: workerSignerLabel, status: "pending" },
+      {
+        label: github
+          ? "Maintainer · awaiting review"
+          : "Cosigner · 0x9A13…0cb2",
+        status: "pending",
+      },
+      { label: "Verifier · verifier-2", status: "signed" },
+    ],
+  };
+}

--- a/app/components/runs/fixtures.ts
+++ b/app/components/runs/fixtures.ts
@@ -1,0 +1,351 @@
+/**
+ * Shared demo data for the Runs surface.
+ *
+ * These fixtures are used when the live `/jobs` endpoint hasn't returned
+ * yet (or returns an empty list) so the UI still reads correctly for
+ * design reviews + offline dev. Everything here is shaped to match what
+ * the backend adapters (`buildRunRows`, `buildGitHubContext`) emit for
+ * live jobs, which keeps the swap-in cost low once the API is wired
+ * everywhere.
+ *
+ * Kept in a separate module (rather than buried inside a page) so both
+ * the main queue page and the standalone `/runs/detail/` fullscreen view
+ * can fall back to the same content without duplicating ~300 lines of
+ * demo records.
+ */
+
+import type { JobCardData } from "./JobCard";
+import type { QueueFilterCount } from "./QueueBar";
+import type { LifecycleStage } from "./LifecycleRail";
+import type { RunRow } from "./RunQueueTable";
+
+export const FIXTURE_RUN_ROWS: RunRow[] = [
+  {
+    id: "run-2749",
+    title:
+      "Document TypeScript validation helper API for external package consumers",
+    jobMeta: "job-0428 · docs · T1",
+    source: {
+      type: "github_issue",
+      repo: "oss-devsecblueprint/devsecblueprint",
+      issueNumber: 110,
+      issueUrl:
+        "https://github.com/oss-devsecblueprint/devsecblueprint/issues/110",
+      labels: ["documentation", "good first issue"],
+      score: 82,
+    },
+    worker: { variant: "unclaimed", initials: "—", label: "unclaimed" },
+    state: "ready",
+    stake: "8.0",
+    age: "00:01:04",
+    lastEvent: "Ingested from GitHub",
+    lastEventMeta: "14:29:55 · gh-ingest · score 82",
+  },
+  {
+    id: "run-2741",
+    title: "repo-sweep: deps/sec-only bump",
+    jobMeta: "job-0421 · coding · T1",
+    worker: { variant: "unclaimed", initials: "—", label: "unclaimed" },
+    state: "ready",
+    stake: "12.0",
+    age: "00:11:42",
+    ageStale: true,
+    lastEvent: "Escrow funded",
+    lastEventMeta: "14:20:25 · by 0x9A13…0cb2",
+  },
+  {
+    id: "run-2742",
+    title:
+      "Fix flaky integration test: race condition when two workers claim within the same block window",
+    jobMeta: "job-0418 · bugfix · T2",
+    source: {
+      type: "github_issue",
+      repo: "paritytech/polkadot-sdk",
+      issueNumber: 4812,
+      issueUrl: "https://github.com/paritytech/polkadot-sdk/issues/4812",
+      labels: ["bug", "flaky-test", "help wanted"],
+      score: 74,
+    },
+    worker: { variant: "self", initials: "FD", label: "0xFd2E…6519", isSelf: true },
+    state: "claimed",
+    stake: "25.0",
+    age: "00:08:14",
+    lastEvent: "You claimed the run",
+    lastEventMeta: "14:23:53 · tx 0x3f…c1",
+  },
+  {
+    id: "run-2743",
+    title: "schema-mig: users → users_v2",
+    jobMeta: "job-0415 · ops · T3",
+    worker: { variant: "a", initials: "OM", label: "0xB1aa…3e41" },
+    state: "submitted",
+    stake: "50.0",
+    age: "00:06:02",
+    lastEvent: "Evidence submitted · 14 files",
+    lastEventMeta: "14:26:05 · hash 0x4e…b8",
+  },
+  {
+    id: "run-2744",
+    title: "handoff-sig verify: batch #214",
+    jobMeta: "job-0414 · coding-hand · T2",
+    worker: { variant: "b", initials: "CH", label: "0x2E94…7f02" },
+    state: "disputed",
+    stake: "40.0",
+    age: "00:34:18",
+    ageStale: true,
+    lastEvent: "Signature mismatch on payload",
+    lastEventMeta: "13:58:09 · by verifier-2",
+  },
+  {
+    id: "run-2745",
+    title: "docs-refresh: runbook v3.1",
+    jobMeta: "job-0411 · writer-gov · T1",
+    worker: { variant: "c", initials: "WG", label: "0xC7fE…9ab1" },
+    state: "submitted",
+    stake: "18.0",
+    age: "00:04:47",
+    lastEvent: "Verifier queued · semantic mode",
+    lastEventMeta: "14:27:19 · r_4e0f8",
+  },
+  {
+    id: "run-2746",
+    title: "lint-sweep: packages/*",
+    jobMeta: "job-0408 · coding · T1",
+    worker: { variant: "d", initials: "CH", label: "0x3A11…e7dd" },
+    state: "claimed",
+    stake: "8.0",
+    age: "00:03:21",
+    lastEvent: "Stake locked",
+    lastEventMeta: "14:28:42 · in AgentAccountCore",
+  },
+  {
+    id: "run-2747",
+    title: "xcm-sanity: asset-hub → hydration",
+    jobMeta: "job-0406 · ops-xcm · T3",
+    worker: { variant: "unclaimed", initials: "—", label: "unclaimed" },
+    state: "ready",
+    stake: "75.0",
+    age: "00:02:55",
+    lastEvent: "Escrow funded",
+    lastEventMeta: "14:29:09 · by treasury-1",
+  },
+  {
+    id: "run-2748",
+    title: "policy-audit: deps/sec-only",
+    jobMeta: "job-0405 · gov-review · T2",
+    worker: { variant: "a", initials: "GR", label: "0x88Ce…4422" },
+    state: "settled",
+    stake: "15.0",
+    age: "00:02:10",
+    lastEvent: "Receipt signed & co-signed",
+    lastEventMeta: "14:29:54 · r_4e12a",
+  },
+];
+
+// Counts are seeded higher than the row list because the fixture is a
+// slice of the "full queue" (matches the vibe of a paginated production
+// view). Real counts come from `buildRunFilters(rows)` once live data
+// lands.
+export const FIXTURE_FILTERS: QueueFilterCount[] = [
+  { id: "all", label: "All", count: 15 },
+  { id: "ready", label: "Ready", count: 4 },
+  { id: "claimed", label: "Claimed", count: 5 },
+  { id: "submitted", label: "Submitted", count: 3 },
+  { id: "disputed", label: "Disputed", count: 2 },
+  { id: "settled", label: "Settled", count: 1 },
+];
+
+export const FIXTURE_RECOMMENDATIONS: JobCardData[] = [
+  {
+    id: "job-0428",
+    jobMeta: "docs",
+    category: "docs",
+    title:
+      "Document TypeScript validation helper API for external package consumers",
+    source: {
+      type: "github_issue",
+      repo: "oss-devsecblueprint/devsecblueprint",
+      issueNumber: 110,
+      issueUrl:
+        "https://github.com/oss-devsecblueprint/devsecblueprint/issues/110",
+      labels: ["documentation", "good first issue"],
+      score: 82,
+    },
+    rewardValue: "8.0",
+    rewardCurrency: "DOT",
+    rewardUsd: "~ $58",
+    tier: "T1",
+    modeLabel: "PR review",
+    modeTone: "ready",
+    meta: [
+      { label: "Stake", value: "4.0 DOT" },
+      { label: "Verifier", value: "github_pr" },
+      { label: "Window", value: "2 h", accent: true },
+      { label: "Fit score", value: "82/100" },
+    ],
+    fit: 5,
+    hot: true,
+  },
+  {
+    id: "job-0406",
+    jobMeta: "ops-xcm",
+    category: "ops-xcm",
+    title: "xcm-sanity: asset-hub → hydration",
+    rewardValue: "75.0",
+    rewardCurrency: "DOT",
+    rewardUsd: "~ $540",
+    tier: "T3",
+    modeLabel: "Semantic",
+    meta: [
+      { label: "Stake", value: "40.0 DOT" },
+      { label: "Verifier", value: "paired-hash" },
+      { label: "Window", value: "12 min", accent: true },
+      { label: "Slippage cap", value: "0.5%" },
+    ],
+    fit: 4,
+  },
+  {
+    id: "job-0421",
+    jobMeta: "coding",
+    title: "repo-sweep: deps/sec-only bump",
+    rewardValue: "12.0",
+    rewardCurrency: "DOT",
+    rewardUsd: "~ $86",
+    tier: "T1",
+    modeLabel: "Diff-hash",
+    modeTone: "settled",
+    meta: [
+      { label: "Stake", value: "6.0 DOT" },
+      { label: "Verifier", value: "deterministic" },
+      { label: "Window", value: "45 min" },
+      { label: "Slippage cap", value: "—" },
+    ],
+    fit: 5,
+  },
+  {
+    id: "job-0420",
+    jobMeta: "writer-gov",
+    title: "writer-gov: OP-14 summary",
+    rewardValue: "22.0",
+    rewardCurrency: "DOT",
+    rewardUsd: "~ $158",
+    tier: "T2",
+    modeLabel: "Review",
+    modeTone: "ready",
+    meta: [
+      { label: "Stake", value: "11.0 DOT" },
+      { label: "Verifier", value: "human + LLM" },
+      { label: "Window", value: "30 min" },
+      { label: "Citations", value: "required" },
+    ],
+    fit: 3,
+  },
+  {
+    id: "job-0419",
+    jobMeta: "coding-hand",
+    title: "sig-verify: batch #215",
+    rewardValue: "40.0",
+    rewardCurrency: "DOT",
+    rewardUsd: "~ $288",
+    tier: "T2",
+    modeLabel: "Paired-hash",
+    modeTone: "submitted",
+    meta: [
+      { label: "Stake", value: "20.0 DOT" },
+      { label: "Verifier", value: "deterministic" },
+      { label: "Window", value: "20 min" },
+      { label: "Cosigner", value: "required" },
+    ],
+    fit: 4,
+  },
+];
+
+// Fallback job definitions keyed by run id. Shape mirrors what the
+// backend emits on /jobs/definition?jobId= so `buildGitHubContext` can
+// populate the Loaded-run panel from these records exactly as it does
+// from live data. Only the rich GitHub-ingested rows need definitions —
+// native fixture rows fall through to the generic governance layout.
+export const FIXTURE_JOB_DEFINITIONS: Record<string, unknown>[] = [
+  {
+    id: "run-2749",
+    title:
+      "Document TypeScript validation helper API for external package consumers",
+    category: "docs",
+    description:
+      "The internal `validateRequest` helper in `packages/core/src/validate.ts` is referenced by three external consumers but has no public docs. We need a markdown reference that lists the accepted shapes, the thrown error types, and at least one usage example per shape.",
+    source: {
+      type: "github_issue",
+      repo: "oss-devsecblueprint/devsecblueprint",
+      issueNumber: 110,
+      issueUrl:
+        "https://github.com/oss-devsecblueprint/devsecblueprint/issues/110",
+      labels: ["documentation", "good first issue"],
+      score: 82,
+    },
+    acceptanceCriteria: [
+      "Open a PR that adds `docs/reference/validate.md`",
+      "Document every exported signature with one code example",
+      "`npm run build:docs` passes with no warnings",
+      "PR description links to the closed issue",
+    ],
+    agentInstructions:
+      "Read `packages/core/src/validate.ts` top to bottom. For each exported function, write a short prose intro plus a fenced TypeScript example. Keep voice consistent with the existing reference docs under `docs/reference/`.",
+    verification: {
+      method: "github_pr",
+      signals: ["PR opened", "docs build green", "maintainer review"],
+    },
+  },
+  {
+    id: "run-2742",
+    title:
+      "Fix flaky integration test: race condition when two workers claim within the same block window",
+    category: "bugfix",
+    description: `The integration suite in \`node/test/src/claim_race.rs\` fails ~3% of the time on CI when two workers attempt to claim the same job within the same 6-second block window. Expected behavior: the first claim (lowest nonce) wins; the second receives a \`ClaimRejected\` event and the caller's stake is refunded in the same block.
+
+Current behavior: both claims occasionally land, both workers get \`ClaimAccepted\`, and the escrow double-locks stake. The second worker is later slashed during settlement, which is the wrong failure mode — the rejection should be at claim-time, not at settle-time.
+
+Repro: run \`cargo test --test claim_race -- --test-threads=1 --ignored\` in a loop; fails in 2–4 iterations on average.`,
+    source: {
+      type: "github_issue",
+      repo: "paritytech/polkadot-sdk",
+      issueNumber: 4812,
+      issueUrl: "https://github.com/paritytech/polkadot-sdk/issues/4812",
+      labels: ["bug", "flaky-test", "help wanted"],
+      score: 74,
+    },
+    acceptanceCriteria: [
+      "Open a PR that makes the `claim_race` test deterministic on Linux and macOS",
+      "Include a regression test that asserts the second claim receives ClaimRejected",
+      "All existing tests pass; no new warnings from `cargo clippy -- -D warnings`",
+      "PR description references issue #4812 and explains the ordering fix",
+    ],
+    agentInstructions:
+      "Start from the failing test. Trace the claim path in `runtime/src/escrow.rs` and identify where the two claims race. Fix by ordering claims by (block_number, nonce, wallet) before acceptance — see OP-09 §4.2 for the canonical ordering. Keep the diff under 150 lines if possible.",
+    verification: {
+      method: "github_pr",
+      signals: ["PR opened", "CI green", "maintainer review"],
+    },
+  },
+];
+
+// Lifecycle for GitHub-ingested jobs. For MVP we keep the same 5-stage
+// shape but relabel for the OSS flow: Ready → Claimed → PR submitted →
+// Verified → Paid. Future revisions can add an explicit "Working"
+// intermediate stage once the runner reports keep-alive signals.
+export const FIXTURE_LIFECYCLE: LifecycleStage[] = [
+  { index: 1, label: "Ready", meta: "14:20:25", state: "done" },
+  { index: 2, label: "Claimed", meta: "14:23:53 · by you", state: "done" },
+  {
+    index: 3,
+    label: "PR submitted",
+    meta: "14:27:45 · #4931 on paritytech/polkadot-sdk",
+    state: "done",
+  },
+  {
+    index: 4,
+    label: "Verified",
+    meta: "2/3 signals · maintainer review pending",
+    state: "current",
+  },
+  { index: 5, label: "Paid", meta: "—", state: "pending" },
+];


### PR DESCRIPTION
## Summary

Follow-up to PR #3. Adds the proper standalone fullscreen route behind the \"Full view ↗\" button and fixes the text-wrap bug that was making the two panel-header buttons collapse into ragged two-line chips on long titles.

## What changed

### Panel header
- Title column gets \`min-w-0 flex-1 line-clamp-2\` so long file-path titles stop squeezing the action buttons.
- Buttons get \`shrink-0 whitespace-nowrap\` so they stay on one clean line.
- Labels tightened: \"⌕ Receipt\" and \"Full view ↗\" with full-text \`title\` tooltips on hover.

### Standalone \`/runs/detail/\` route
- New page at \`/runs/detail/?id=<runId>\` with \"← Back to queue\" header and \"run <id> · fullscreen view\" label.
- Query param instead of a dynamic \`[id]\` segment — keeps the Next static export simple for the VPS build.
- At max-w-1100 the panel's \`@container\` query flips the inner grid to 2-col — stake + job context on the left, verifier + settlement on the right. Proper focused review view, no queue competing for attention.
- \"Full view ↗\" in the queue page's panel header links here (\`target=_blank\`). On the detail page itself the button is hidden so it doesn't link to the page you're already on.

### Shared infrastructure
- New \`components/runs/fixtures.ts\` centralises the demo records (\`FIXTURE_RUN_ROWS\`, \`FIXTURE_RECOMMENDATIONS\`, \`FIXTURE_FILTERS\`, \`FIXTURE_JOB_DEFINITIONS\`, \`FIXTURE_LIFECYCLE\`) — used by both the queue page and the detail page as fallback when the live API is empty.
- New \`components/runs/LoadedRunView.tsx\` — self-contained single-run view that owns live/fixture row lookup, job definition fetch, GitHub context build, submit handler, and receipt drawer state. Takes a \`runId\` prop, optional \`standaloneUrl\`, optional \`showLifecycle\`.
- \`runs/page.tsx\` shrinks from ~700 lines to ~120 — just queue + filter + recommendation wiring. Lifecycle rail + recommendation strip stay below the split pane as before.

## Test plan

- [ ] \`/runs\` — click any row → detail pane updates. Header shows \`⌕ RECEIPT\` + \`FULL VIEW ↗\` on one clean row.
- [ ] Click \`FULL VIEW ↗\` → opens \`/runs/detail/?id=<run-id>\` in new tab; shows full-width panel with 2-col internal layout, lifecycle below.
- [ ] Click \`← BACK TO QUEUE\` → lands back on \`/runs\`.
- [ ] On detail page, \`FULL VIEW ↗\` button is hidden (no self-link).
- [ ] \`npm run typecheck:app\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)