### PR TITLE
Add Wikipedia maintenance ingestion

### DIFF
--- a/docs/PUBLIC_JOB_SOURCES.md
+++ b/docs/PUBLIC_JOB_SOURCES.md
@@ -34,6 +34,22 @@ begin gradual deprecation from July 2026. Prefer:
 Track deprecations through mediawiki.org/Wikitech API notices before adding any
 long-running crawler.
 
+### Crawler workflow
+
+The v1 crawler mirrors the GitHub issue ingestor, but the unit of discovery is
+a Wikipedia article revision instead of an issue:
+
+1. read maintenance categories through `https://{lang}.wikipedia.org/w/api.php`
+2. fetch the page URL, latest revision id, timestamp, and maintenance templates
+3. score the article for starter-agent suitability
+4. create a `wikipedia-*` Averray job with source metadata and schema refs
+5. dedupe by `language:pageId:revisionId:taskType`
+
+Workers submit structured proposals back to Averray. They do not write to
+Wikipedia. If a proposal is later sent to Wikipedia, it must be attributed to
+Averray or an approved Averray editor/bot account and follow Wikipedia
+disclosure and bot rules.
+
 ### Initial job types
 
 1. **Wikipedia citation repair**

--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -113,6 +113,22 @@ AUTH_CHAIN_ID=420420417
 # GITHUB_INGEST_MAX_OPEN_JOBS=20
 # GITHUB_INGEST_QUERIES_JSON=["is:issue is:open label:\"good first issue\" language:TypeScript","is:issue is:open label:\"help wanted\" label:tests"]
 
+# --- Wikipedia maintenance job ingestion -------------------------------------
+# Disabled by default. Uses stable per-project MediaWiki Action API endpoints
+# like https://en.wikipedia.org/w/api.php, not the old API Portal /
+# api.wikimedia.org Core routes. Jobs are proposal-only: agents submit
+# structured corrections back to Averray, and any later Wikipedia communication
+# must come from Averray or an approved Averray editor/bot account with the
+# required community disclosures.
+# WIKIPEDIA_INGEST_ENABLED=false
+# WIKIPEDIA_INGEST_DRY_RUN=true
+# WIKIPEDIA_INGEST_INTERVAL_MS=1800000
+# WIKIPEDIA_INGEST_LANGUAGE=en
+# WIKIPEDIA_INGEST_MIN_SCORE=75
+# WIKIPEDIA_INGEST_MAX_JOBS_PER_RUN=2
+# WIKIPEDIA_INGEST_MAX_OPEN_JOBS=20
+# WIKIPEDIA_INGEST_CATEGORIES_JSON=[{"title":"Category:All articles with dead external links","taskType":"citation_repair"},{"title":"Category:Wikipedia articles in need of updating","taskType":"freshness_check"}]
+
 # --- Supported on-chain assets ------------------------------------------------
 # Legacy shorthand still works:
 # SUPPORTED_ASSETS=DOT:0x5555555555555555555555555555555555555555

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -10,7 +10,8 @@
     "demo:e2e": "node src/demo/e2e-local.js",
     "demo:e2e:remote": "node src/demo/e2e-remote.js",
     "check:redis": "node src/demo/redis-persistence-check.js",
-    "ingest:github-issues": "node src/jobs/ingest-github-issues.js"
+    "ingest:github-issues": "node src/jobs/ingest-github-issues.js",
+    "ingest:wikipedia": "node src/jobs/ingest-wikipedia-maintenance.js"
   },
   "dependencies": {
     "ethers": "^6.16.0",

--- a/mcp-server/src/core/discovery-manifest.js
+++ b/mcp-server/src/core/discovery-manifest.js
@@ -41,6 +41,7 @@ const DISCOVERY_AUTHENTICATED_ENDPOINTS = [
   { path: "/jobs/recommendations", description: "Tier-gated recommendation list with fit score + unlock hints." },
   { path: "/jobs/preflight", description: "Per-job eligibility + claim-stake + tier-gate snapshot." },
   { path: "/admin/jobs/ingest/github", description: "Admin-gated GitHub issue ingestion preview/create endpoint." },
+  { path: "/admin/jobs/ingest/wikipedia", description: "Admin-gated Wikipedia maintenance ingestion preview/create endpoint." },
   { path: "/disputes", description: "Operator dispute queue derived from sessions requiring human review." },
   { path: "/disputes/:id", description: "Detailed dispute evidence, timeline, verdict, and stake release state." },
   { path: "/session", description: "Fetch a single session by id (owner-scoped)." },

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -100,7 +100,7 @@ export class PlatformService {
   }
 
   async getAdminStatus({ auth = undefined } = {}) {
-    const [policy, recurring, scheduler, githubIngestion, recentSessions] = await Promise.all([
+    const [policy, recurring, scheduler, githubIngestion, wikipediaIngestion, recentSessions] = await Promise.all([
       this.blockchainGateway?.getTreasuryPolicyStatus?.() ?? {
         enabled: false,
         policyAddress: undefined,
@@ -117,6 +117,18 @@ export class PlatformService {
         dryRun: true,
         intervalMs: 0,
         queryCount: 0,
+        minScore: 0,
+        maxJobsPerRun: 0,
+        maxOpenJobs: 0,
+        lastRun: undefined
+      },
+      this.wikipediaMaintenanceIngestionScheduler?.getStatus?.() ?? {
+        enabled: false,
+        running: false,
+        dryRun: true,
+        intervalMs: 0,
+        language: "en",
+        categoryCount: 0,
         minScore: 0,
         maxJobsPerRun: 0,
         maxOpenJobs: 0,
@@ -212,6 +224,7 @@ export class PlatformService {
       recurring: recurring,
       scheduler,
       githubIngestion: githubIngestion,
+      wikipediaIngestion: wikipediaIngestion,
       xcmSettlementWatcher: await this.xcmSettlementWatcher?.getStatus?.() ?? {
         enabled: false,
         running: false,

--- a/mcp-server/src/jobs/ingest-wikipedia-maintenance.js
+++ b/mcp-server/src/jobs/ingest-wikipedia-maintenance.js
@@ -1,0 +1,402 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+
+export const DEFAULT_LANGUAGE = "en";
+export const DEFAULT_BASE_URL = "http://localhost:8787";
+export const DEFAULT_CATEGORIES = [
+  { title: "Category:All articles with dead external links", taskType: "citation_repair" },
+  { title: "Category:All articles with unsourced statements", taskType: "citation_repair" },
+  { title: "Category:Wikipedia articles in need of updating", taskType: "freshness_check" },
+  { title: "Category:Articles with infoboxes needing cleanup", taskType: "infobox_consistency" }
+];
+
+const TASK_CONFIG = {
+  citation_repair: {
+    titlePrefix: "Wikipedia citation repair",
+    outputSchemaRef: "schema://jobs/wikipedia-citation-repair-output",
+    verifierTerms: ["page_title", "revision_id", "citation_findings", "proposed_changes", "review_notes"],
+    rewardAmount: 4
+  },
+  freshness_check: {
+    titlePrefix: "Wikipedia freshness check",
+    outputSchemaRef: "schema://jobs/wikipedia-freshness-check-output",
+    verifierTerms: ["page_title", "revision_id", "freshness_findings", "recommended_editor_actions", "risk_level"],
+    rewardAmount: 4
+  },
+  infobox_consistency: {
+    titlePrefix: "Wikipedia infobox consistency",
+    outputSchemaRef: "schema://jobs/wikipedia-infobox-consistency-output",
+    verifierTerms: ["page_title", "revision_id", "checked_fields", "proposed_changes", "review_notes"],
+    rewardAmount: 4
+  }
+};
+
+const MAINTENANCE_TEMPLATE_HINTS = [
+  "Template:Dead link",
+  "Template:Citation needed",
+  "Template:Update",
+  "Template:Outdated",
+  "Template:Infobox"
+];
+
+export function parseArgs(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith("--")) continue;
+    const key = arg.slice(2);
+    if (key.includes("=")) {
+      const [name, ...rest] = key.split("=");
+      parsed[name] = rest.join("=");
+      continue;
+    }
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      parsed[key] = true;
+      continue;
+    }
+    parsed[key] = next;
+    index += 1;
+  }
+  return parsed;
+}
+
+export async function ingestWikipediaMaintenance({
+  language = DEFAULT_LANGUAGE,
+  categories = DEFAULT_CATEGORIES,
+  limit = 10,
+  minScore = 55,
+  fetchImpl = fetch
+} = {}) {
+  const normalizedLanguage = normalizeLanguage(language);
+  const normalizedCategories = parseCategories(categories);
+  const seen = new Set();
+  const candidates = [];
+  let discovered = 0;
+
+  for (const category of normalizedCategories) {
+    if (candidates.length >= limit * 3) break;
+    const members = await fetchCategoryMembers({
+      language: normalizedLanguage,
+      categoryTitle: category.title,
+      limit: Math.max(limit * 2, 10),
+      fetchImpl
+    });
+    discovered += members.length;
+    for (const member of members) {
+      const article = await fetchArticleDetails({
+        language: normalizedLanguage,
+        pageId: member.pageid,
+        category,
+        fetchImpl
+      });
+      if (!article) continue;
+      const key = wikipediaArticleKey(article);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const score = scoreArticle(article);
+      if (score >= minScore) {
+        candidates.push({ article, score });
+      }
+    }
+  }
+
+  const jobs = candidates
+    .sort((left, right) => right.score - left.score)
+    .slice(0, limit)
+    .map(({ article, score }) => toPlatformJob(article, score));
+
+  return {
+    language: normalizedLanguage,
+    categories: normalizedCategories.map((category) => category.title),
+    minScore,
+    count: jobs.length,
+    jobs,
+    skipped: Math.max(0, discovered - jobs.length)
+  };
+}
+
+export async function fetchCategoryMembers({ language, categoryTitle, limit, fetchImpl = fetch }) {
+  const url = mediaWikiActionUrl(language);
+  url.searchParams.set("action", "query");
+  url.searchParams.set("format", "json");
+  url.searchParams.set("list", "categorymembers");
+  url.searchParams.set("cmtitle", categoryTitle);
+  url.searchParams.set("cmnamespace", "0");
+  url.searchParams.set("cmlimit", String(Math.min(limit, 50)));
+  url.searchParams.set("origin", "*");
+
+  const response = await fetchImpl(url, { headers: requestHeaders() });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Wikipedia category query failed (${response.status}): ${body}`);
+  }
+  const payload = await response.json();
+  return payload?.query?.categorymembers ?? [];
+}
+
+export async function fetchArticleDetails({ language, pageId, category, fetchImpl = fetch }) {
+  const url = mediaWikiActionUrl(language);
+  url.searchParams.set("action", "query");
+  url.searchParams.set("format", "json");
+  url.searchParams.set("prop", "info|revisions|templates");
+  url.searchParams.set("inprop", "url");
+  url.searchParams.set("rvlimit", "1");
+  url.searchParams.set("rvprop", "ids|timestamp");
+  url.searchParams.set("tllimit", "50");
+  url.searchParams.set("pageids", String(pageId));
+  url.searchParams.set("origin", "*");
+
+  const response = await fetchImpl(url, { headers: requestHeaders() });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Wikipedia page query failed (${response.status}): ${body}`);
+  }
+  const payload = await response.json();
+  const page = Object.values(payload?.query?.pages ?? {})[0];
+  if (!page || page.missing) {
+    return undefined;
+  }
+  const revision = page.revisions?.[0] ?? {};
+  const taskType = normalizeTaskType(category.taskType ?? inferTaskType(category.title, page.templates));
+  return {
+    language,
+    pageId: Number(page.pageid ?? pageId),
+    title: String(page.title ?? ""),
+    pageUrl: String(page.fullurl ?? `https://${language}.wikipedia.org/wiki/${encodeURIComponent(String(page.title ?? ""))}`),
+    revisionId: String(revision.revid ?? ""),
+    revisionTimestamp: revision.timestamp,
+    categoryTitle: category.title,
+    taskType,
+    templates: (page.templates ?? []).map((template) => String(template.title ?? "")).filter(Boolean)
+  };
+}
+
+export function scoreArticle(article) {
+  let score = 25;
+  if (article.revisionId) score += 15;
+  if (article.pageId) score += 10;
+  if (article.taskType === "citation_repair") score += 20;
+  if (article.taskType === "freshness_check") score += 18;
+  if (article.taskType === "infobox_consistency") score += 16;
+  if (article.templates.some((template) => MAINTENANCE_TEMPLATE_HINTS.some((hint) => template.includes(hint)))) {
+    score += 15;
+  }
+  if (/\b(list of|timeline of|draft:|template:)\b/iu.test(article.title)) score -= 15;
+  return Math.max(0, score);
+}
+
+export function toPlatformJob(article, score = scoreArticle(article)) {
+  const task = TASK_CONFIG[article.taskType] ?? TASK_CONFIG.citation_repair;
+  const slug = slugify(article.title).slice(0, 48);
+  const id = `wiki-${article.language}-${article.pageId}-${article.taskType}-${slug}`.slice(0, 120);
+
+  return {
+    id,
+    title: `${task.titlePrefix}: ${article.title}`,
+    description:
+      `Review Wikipedia article "${article.title}" at revision ${article.revisionId} and return an Averray-attributed, editor-ready proposal.`,
+    jobType: "review",
+    requiredRole: "worker",
+    category: "wikipedia",
+    tier: "starter",
+    rewardAsset: "DOT",
+    rewardAmount: task.rewardAmount,
+    verifierMode: "benchmark",
+    verifierTerms: task.verifierTerms,
+    verifierMinimumMatches: 4,
+    inputSchemaRef: "schema://jobs/wikipedia-maintenance-input",
+    outputSchemaRef: task.outputSchemaRef,
+    claimTtlSeconds: 3600,
+    retryLimit: 1,
+    requiresSponsoredGas: true,
+    source: {
+      type: "wikipedia_article",
+      project: "wikipedia",
+      language: article.language,
+      pageId: article.pageId,
+      pageTitle: article.title,
+      pageUrl: article.pageUrl,
+      revisionId: article.revisionId,
+      revisionTimestamp: article.revisionTimestamp,
+      categoryTitle: article.categoryTitle,
+      taskType: article.taskType,
+      templates: article.templates,
+      score,
+      discoveryApi: `https://${article.language}.wikipedia.org/w/api.php`,
+      writePolicy: "averray_company_reviewed_proposal_only",
+      attribution: {
+        proposer: "Averray",
+        directEdit: false,
+        note:
+          "Worker output is submitted to Averray. Any later communication or edit to Wikipedia must be attributed to Averray and comply with Wikipedia disclosure and bot/editor rules."
+      }
+    },
+    acceptanceCriteria: [
+      "Names the exact Wikipedia page title and revision id reviewed.",
+      "Uses public Wikipedia revision data and reliable external source URLs.",
+      "Returns a structured proposal that can be reviewed by a human editor.",
+      "Does not claim the live Wikipedia article was edited.",
+      "Keeps Averray attribution intact for any downstream submission."
+    ],
+    estimatedDifficulty: estimateDifficulty(score),
+    agentInstructions: [
+      `Review the fixed revision at ${article.pageUrl}.`,
+      "Do not edit Wikipedia directly from the agent account.",
+      "Submit the correction or review notes back to Averray as structured evidence.",
+      "Any later public Wikipedia communication must come from Averray or an approved Averray editor/bot account, with required disclosures.",
+      "Include source URLs and enough context for a human editor to verify the proposal."
+    ],
+    verification: {
+      method: "reviewable_wikipedia_proposal",
+      evidenceSchemaRef: task.outputSchemaRef,
+      signals: ["page_revision_cited", "source_urls_present", "proposal_only", "averray_attribution", "human_review_ready"]
+    }
+  };
+}
+
+export async function postJobs({ baseUrl, adminToken, jobs, fetchImpl = fetch }) {
+  const results = [];
+  for (const job of jobs) {
+    results.push(await createJob({ baseUrl, adminToken, job, fetchImpl }));
+  }
+  return results;
+}
+
+export async function createJob({ baseUrl, adminToken, job, fetchImpl = fetch }) {
+  const response = await fetchImpl(`${trimTrailingSlash(baseUrl)}/admin/jobs`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${adminToken}`,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify(job)
+  });
+  const body = await response.text();
+  let payload;
+  try {
+    payload = body ? JSON.parse(body) : {};
+  } catch {
+    payload = { raw: body };
+  }
+  return { id: job.id, status: response.status, ok: response.ok, payload };
+}
+
+export function parseCategories(raw) {
+  if (!raw) return DEFAULT_CATEGORIES;
+  if (Array.isArray(raw)) {
+    return raw.map(normalizeCategory).filter(Boolean);
+  }
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) return parsed.map(normalizeCategory).filter(Boolean);
+    } catch {
+      // Fall through to comma/newline parsing.
+    }
+    return raw
+      .split(/\n|,/u)
+      .map((title) => normalizeCategory(title))
+      .filter(Boolean);
+  }
+  return DEFAULT_CATEGORIES;
+}
+
+export function wikipediaArticleKey(article) {
+  return `${article.language}:${article.pageId}:${article.revisionId}:${article.taskType}`;
+}
+
+function normalizeCategory(raw) {
+  if (typeof raw === "string") {
+    const title = raw.trim();
+    return title ? { title, taskType: inferTaskType(title) } : undefined;
+  }
+  const title = String(raw?.title ?? "").trim();
+  if (!title) return undefined;
+  return { title, taskType: normalizeTaskType(raw?.taskType ?? inferTaskType(title)) };
+}
+
+function inferTaskType(title, templates = []) {
+  const haystack = `${title} ${templates.map((template) => template.title ?? template).join(" ")}`.toLowerCase();
+  if (/\b(update|outdated|current|freshness)\b/u.test(haystack)) return "freshness_check";
+  if (/\binfobox\b/u.test(haystack)) return "infobox_consistency";
+  return "citation_repair";
+}
+
+function normalizeTaskType(value) {
+  const taskType = String(value ?? "").trim();
+  return TASK_CONFIG[taskType] ? taskType : "citation_repair";
+}
+
+function normalizeLanguage(value) {
+  const language = String(value ?? DEFAULT_LANGUAGE).trim().toLowerCase();
+  return /^[a-z][a-z0-9-]{1,15}$/u.test(language) ? language : DEFAULT_LANGUAGE;
+}
+
+function mediaWikiActionUrl(language) {
+  return new URL(`https://${normalizeLanguage(language)}.wikipedia.org/w/api.php`);
+}
+
+function requestHeaders() {
+  return {
+    accept: "application/json",
+    "user-agent": "AverrayWikipediaIngest/0.1 (https://averray.com; operator@averray.com)"
+  };
+}
+
+function estimateDifficulty(score) {
+  if (score >= 80) return "starter";
+  if (score >= 65) return "starter-plus";
+  return "review-needed";
+}
+
+function slugify(value) {
+  return String(value ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, "-")
+    .replace(/^-+|-+$/gu, "")
+    .replace(/-{2,}/gu, "-");
+}
+
+function parsePositiveInt(raw, fallback) {
+  const value = Number(raw);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function trimTrailingSlash(value) {
+  return String(value).replace(/\/+$/u, "");
+}
+
+async function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  const dryRun = Boolean(args["dry-run"]);
+  const language = String(args.language ?? process.env.WIKIPEDIA_INGEST_LANGUAGE ?? DEFAULT_LANGUAGE);
+  const categories = args.categories ?? process.env.WIKIPEDIA_INGEST_CATEGORIES_JSON ?? process.env.WIKIPEDIA_INGEST_CATEGORIES;
+  const limit = parsePositiveInt(args.limit, 10);
+  const minScore = parsePositiveInt(args["min-score"], 55);
+  const baseUrl = trimTrailingSlash(String(args.baseUrl ?? process.env.AGENT_API_BASE_URL ?? DEFAULT_BASE_URL));
+  const adminToken = process.env.AGENT_ADMIN_TOKEN?.trim();
+
+  if (!dryRun && !adminToken) {
+    fail("AGENT_ADMIN_TOKEN is required unless --dry-run is set.");
+  }
+
+  const dryRunPayload = await ingestWikipediaMaintenance({ language, categories, limit, minScore });
+  if (dryRun) {
+    console.log(JSON.stringify(dryRunPayload, null, 2));
+    return;
+  }
+
+  const results = await postJobs({ baseUrl, adminToken, jobs: dryRunPayload.jobs });
+  console.log(JSON.stringify({ ...dryRunPayload, results }, null, 2));
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await runCli();
+}

--- a/mcp-server/src/jobs/ingest-wikipedia-maintenance.test.js
+++ b/mcp-server/src/jobs/ingest-wikipedia-maintenance.test.js
@@ -1,0 +1,96 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ingestWikipediaMaintenance,
+  scoreArticle,
+  toPlatformJob
+} from "./ingest-wikipedia-maintenance.js";
+
+const ARTICLE = {
+  language: "en",
+  pageId: 123,
+  title: "Example article",
+  pageUrl: "https://en.wikipedia.org/wiki/Example_article",
+  revisionId: "987654321",
+  revisionTimestamp: "2026-04-25T10:00:00Z",
+  categoryTitle: "Category:All articles with dead external links",
+  taskType: "citation_repair",
+  templates: ["Template:Dead link"]
+};
+
+test("scoreArticle prefers fixed revisions with maintenance templates", () => {
+  assert.ok(scoreArticle(ARTICLE) >= 80);
+});
+
+test("toPlatformJob produces an Averray-attributed Wikipedia proposal job", () => {
+  const job = toPlatformJob(ARTICLE, 88);
+
+  assert.equal(job.id, "wiki-en-123-citation_repair-example-article");
+  assert.equal(job.category, "wikipedia");
+  assert.equal(job.jobType, "review");
+  assert.equal(job.source.type, "wikipedia_article");
+  assert.equal(job.source.writePolicy, "averray_company_reviewed_proposal_only");
+  assert.equal(job.source.attribution.proposer, "Averray");
+  assert.equal(job.source.attribution.directEdit, false);
+  assert.equal(job.inputSchemaRef, "schema://jobs/wikipedia-maintenance-input");
+  assert.equal(job.outputSchemaRef, "schema://jobs/wikipedia-citation-repair-output");
+  assert.ok(job.agentInstructions.some((entry) => entry.includes("Do not edit Wikipedia directly")));
+  assert.ok(job.agentInstructions.some((entry) => entry.includes("Averray")));
+  assert.deepEqual(job.verification.signals, [
+    "page_revision_cited",
+    "source_urls_present",
+    "proposal_only",
+    "averray_attribution",
+    "human_review_ready"
+  ]);
+});
+
+test("ingestWikipediaMaintenance turns category members into jobs", async () => {
+  const calls = [];
+  const payload = await ingestWikipediaMaintenance({
+    language: "en",
+    categories: [{ title: "Category:All articles with dead external links", taskType: "citation_repair" }],
+    limit: 2,
+    minScore: 55,
+    fetchImpl: async (url) => {
+      calls.push(String(url));
+      if (String(url).includes("list=categorymembers")) {
+        return jsonResponse({
+          query: {
+            categorymembers: [
+              { pageid: 123, ns: 0, title: "Example article" }
+            ]
+          }
+        });
+      }
+      return jsonResponse({
+        query: {
+          pages: {
+            123: {
+              pageid: 123,
+              title: "Example article",
+              fullurl: "https://en.wikipedia.org/wiki/Example_article",
+              revisions: [{ revid: 987654321, timestamp: "2026-04-25T10:00:00Z" }],
+              templates: [{ title: "Template:Dead link" }]
+            }
+          }
+        }
+      });
+    }
+  });
+
+  assert.equal(payload.count, 1);
+  assert.equal(payload.jobs[0].source.pageId, 123);
+  assert.equal(payload.jobs[0].source.revisionId, "987654321");
+  assert.ok(calls.every((url) => url.startsWith("https://en.wikipedia.org/w/api.php")));
+});
+
+function jsonResponse(payload) {
+  return {
+    ok: true,
+    async json() {
+      return payload;
+    }
+  };
+}

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -23,6 +23,7 @@ import {
   schemaRefToJobSchemaPath
 } from "../../core/job-schema-registry.js";
 import { ingestGithubIssues } from "../../jobs/ingest-github-issues.js";
+import { ingestWikipediaMaintenance, parseCategories } from "../../jobs/ingest-wikipedia-maintenance.js";
 
 const {
   platformService: service,
@@ -1092,6 +1093,8 @@ const server = createServer(async (request, response) => {
           "/verifier/handlers",
           "/verifier/replay",
           "/admin/jobs",
+          "/admin/jobs/ingest/github",
+          "/admin/jobs/ingest/wikipedia",
           "/admin/jobs/fire",
           "/admin/jobs/pause",
           "/admin/jobs/resume",
@@ -2124,6 +2127,74 @@ const server = createServer(async (request, response) => {
       const status = errors.length ? 207 : 201;
       return respond(response, status, {
         query: result.query,
+        minScore: result.minScore,
+        dryRun: false,
+        candidateCount: result.count,
+        created,
+        skipped: [
+          ...skipped,
+          ...(Number.isFinite(result.skipped) ? [{ reason: "below_min_score_or_over_limit", count: result.skipped }] : [])
+        ],
+        errors
+      });
+    }
+
+    if (request.method === "POST" && pathname === "/admin/jobs/ingest/wikipedia") {
+      const auth = await authMiddleware(request, url, { requireRole: "admin" });
+      await enforceLimit("admin_jobs", auth.wallet, rateLimitConfig.adminJobs);
+      const payload = await readJsonBody(request);
+      const language = typeof payload?.language === "string" && payload.language.trim()
+        ? payload.language.trim()
+        : undefined;
+      const categories = Array.isArray(payload?.categories) || typeof payload?.categories === "string"
+        ? parseCategories(payload.categories)
+        : undefined;
+      const limit = parsePositiveInteger(payload?.limit, 10, 50);
+      const minScore = parsePositiveInteger(payload?.minScore, 55, 100);
+      const dryRun = payload?.dryRun !== false;
+      const result = await ingestWikipediaMaintenance({
+        language,
+        categories,
+        limit,
+        minScore
+      });
+
+      if (dryRun) {
+        return respond(response, 200, {
+          ...result,
+          dryRun: true,
+          created: [],
+          skipped: [
+            ...(Array.isArray(result.skipped) ? result.skipped : []),
+            ...(Number.isFinite(result.skipped) ? [{ reason: "below_min_score_or_over_limit", count: result.skipped }] : [])
+          ]
+        });
+      }
+
+      const created = [];
+      const skipped = [];
+      const errors = [];
+      for (const job of result.jobs) {
+        try {
+          created.push(service.createJob(job));
+        } catch (error) {
+          const normalized = normalizeError(error);
+          if (normalized.code === "job_exists") {
+            skipped.push({ id: job.id, reason: "already_exists" });
+            continue;
+          }
+          errors.push({
+            id: job.id,
+            code: normalized.code,
+            message: normalized.message
+          });
+        }
+      }
+
+      const status = errors.length ? 207 : 201;
+      return respond(response, status, {
+        language: result.language,
+        categories: result.categories,
         minScore: result.minScore,
         dryRun: false,
         candidateCount: result.count,

--- a/mcp-server/src/services/bootstrap.js
+++ b/mcp-server/src/services/bootstrap.js
@@ -18,6 +18,10 @@ import {
   GithubIssueIngestionScheduler,
   loadGithubIssueIngestionConfig
 } from "./github-issue-ingestion-scheduler.js";
+import {
+  WikipediaMaintenanceIngestionScheduler,
+  loadWikipediaMaintenanceIngestionConfig
+} from "./wikipedia-maintenance-ingestion-scheduler.js";
 import { XcmSettlementWatcherService } from "./xcm-settlement-watcher.js";
 import { XcmObservationRelayService } from "./xcm-observation-relay.js";
 import { normaliseStrategyAssetConfig } from "./strategy-asset-config.js";
@@ -149,6 +153,12 @@ export async function createPlatformRuntime() {
       logger
     })
   );
+  const wikipediaMaintenanceIngestionScheduler = initStep("init-wikipedia-maintenance-ingestion-scheduler", logger, () =>
+    new WikipediaMaintenanceIngestionScheduler(platformService, eventBus, {
+      ...loadWikipediaMaintenanceIngestionConfig(process.env),
+      logger
+    })
+  );
   const xcmSettlementWatcher = initStep("init-xcm-settlement-watcher", logger, () =>
     new XcmSettlementWatcherService(platformService, stateStore, eventBus, {
       enabled: process.env.XCM_SETTLEMENT_WATCHER_ENABLED === undefined
@@ -172,10 +182,12 @@ export async function createPlatformRuntime() {
   );
   platformService.recurringScheduler = recurringScheduler;
   platformService.githubIssueIngestionScheduler = githubIssueIngestionScheduler;
+  platformService.wikipediaMaintenanceIngestionScheduler = wikipediaMaintenanceIngestionScheduler;
   platformService.xcmSettlementWatcher = xcmSettlementWatcher;
   platformService.xcmObservationRelay = xcmObservationRelay;
   recurringScheduler.start();
   githubIssueIngestionScheduler.start();
+  wikipediaMaintenanceIngestionScheduler.start();
   xcmSettlementWatcher.start();
   xcmObservationRelay.start();
 
@@ -201,6 +213,7 @@ export async function createPlatformRuntime() {
     eventListener,
     recurringScheduler,
     githubIssueIngestionScheduler,
+    wikipediaMaintenanceIngestionScheduler,
     xcmSettlementWatcher,
     xcmObservationRelay,
     authConfig,

--- a/mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.js
+++ b/mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.js
@@ -1,0 +1,216 @@
+import { ingestWikipediaMaintenance, parseCategories, wikipediaArticleKey } from "../jobs/ingest-wikipedia-maintenance.js";
+
+export class WikipediaMaintenanceIngestionScheduler {
+  constructor(platformService, eventBus = undefined, {
+    enabled = false,
+    dryRun = true,
+    intervalMs = 30 * 60 * 1000,
+    language = "en",
+    categories = [],
+    minScore = 75,
+    maxJobsPerRun = 2,
+    maxOpenJobs = 20,
+    fetchImpl = fetch,
+    logger = console
+  } = {}) {
+    this.platformService = platformService;
+    this.eventBus = eventBus;
+    this.enabled = enabled;
+    this.dryRun = dryRun;
+    this.intervalMs = intervalMs;
+    this.language = language;
+    this.categories = parseCategories(categories);
+    this.minScore = minScore;
+    this.maxJobsPerRun = maxJobsPerRun;
+    this.maxOpenJobs = maxOpenJobs;
+    this.fetchImpl = fetchImpl;
+    this.logger = logger;
+    this.timer = undefined;
+    this.running = false;
+    this.lastRun = undefined;
+  }
+
+  start() {
+    if (!this.enabled || this.running) {
+      return;
+    }
+    this.running = true;
+    void this.runOnceAndSchedule();
+  }
+
+  stop() {
+    this.running = false;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  async getStatus() {
+    return {
+      enabled: this.enabled,
+      running: this.running,
+      dryRun: this.dryRun,
+      intervalMs: this.intervalMs,
+      language: this.language,
+      categoryCount: this.categories.length,
+      minScore: this.minScore,
+      maxJobsPerRun: this.maxJobsPerRun,
+      maxOpenJobs: this.maxOpenJobs,
+      lastRun: this.lastRun
+    };
+  }
+
+  async runOnce(now = new Date()) {
+    const startedAt = now.toISOString();
+    const openWikipediaJobs = this.countOpenWikipediaJobs();
+    const summary = {
+      startedAt,
+      finishedAt: undefined,
+      dryRun: this.dryRun,
+      openWikipediaJobs,
+      candidateCount: 0,
+      createdCount: 0,
+      skipped: [],
+      errors: []
+    };
+
+    if (!this.enabled) {
+      summary.skipped.push({ reason: "disabled" });
+      return this.finishRun(summary);
+    }
+    if (openWikipediaJobs >= this.maxOpenJobs) {
+      summary.skipped.push({ reason: "max_open_jobs_reached", openWikipediaJobs, maxOpenJobs: this.maxOpenJobs });
+      return this.finishRun(summary);
+    }
+
+    const remaining = Math.max(0, Math.min(this.maxJobsPerRun, this.maxOpenJobs - openWikipediaJobs));
+    const seenSources = this.existingWikipediaArticleKeys();
+    try {
+      const result = await ingestWikipediaMaintenance({
+        language: this.language,
+        categories: this.categories,
+        limit: remaining,
+        minScore: this.minScore,
+        fetchImpl: this.fetchImpl
+      });
+      summary.candidateCount = result.count;
+      for (const job of result.jobs) {
+        const sourceKey = wikipediaJobKey(job);
+        if (sourceKey && seenSources.has(sourceKey)) {
+          summary.skipped.push({ id: job.id, reason: "source_already_ingested" });
+          continue;
+        }
+        if (this.platformService.getJobDefinition) {
+          try {
+            this.platformService.getJobDefinition(job.id);
+            summary.skipped.push({ id: job.id, reason: "job_already_exists" });
+            continue;
+          } catch {
+            // Missing jobs are expected and created below.
+          }
+        }
+        if (!this.dryRun) {
+          this.platformService.createJob(job);
+        }
+        seenSources.add(sourceKey);
+        summary.createdCount += 1;
+        this.eventBus?.publish?.({
+          id: `platform-wikipedia-ingest-${job.id}-${Date.now()}`,
+          topic: "jobs.ingest.wikipedia",
+          jobId: job.id,
+          timestamp: new Date().toISOString(),
+          data: {
+            dryRun: this.dryRun,
+            jobId: job.id,
+            source: job.source
+          }
+        });
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      summary.errors.push({ message });
+      this.logger.warn?.({ err: error }, "wikipedia_ingest.run_failed");
+    }
+
+    return this.finishRun(summary);
+  }
+
+  async runOnceAndSchedule() {
+    await this.runOnce(new Date());
+    if (!this.running) {
+      return;
+    }
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+    this.timer = setTimeout(() => {
+      void this.runOnceAndSchedule();
+    }, this.intervalMs);
+  }
+
+  finishRun(summary) {
+    summary.finishedAt = new Date().toISOString();
+    this.lastRun = summary;
+    return summary;
+  }
+
+  countOpenWikipediaJobs() {
+    return this.platformService.listJobs()
+      .filter((job) => job.source?.type === "wikipedia_article")
+      .filter((job) => !job.recurring)
+      .length;
+  }
+
+  existingWikipediaArticleKeys() {
+    return new Set(
+      this.platformService.listJobs()
+        .map((job) => wikipediaJobKey(job))
+        .filter(Boolean)
+    );
+  }
+}
+
+export function loadWikipediaMaintenanceIngestionConfig(env = process.env) {
+  return {
+    enabled: parseBooleanEnv(env.WIKIPEDIA_INGEST_ENABLED),
+    dryRun: env.WIKIPEDIA_INGEST_DRY_RUN === undefined ? true : parseBooleanEnv(env.WIKIPEDIA_INGEST_DRY_RUN),
+    intervalMs: parsePositiveInt(env.WIKIPEDIA_INGEST_INTERVAL_MS, 30 * 60 * 1000),
+    language: env.WIKIPEDIA_INGEST_LANGUAGE?.trim() || "en",
+    categories: parseCategories(env.WIKIPEDIA_INGEST_CATEGORIES_JSON ?? env.WIKIPEDIA_INGEST_CATEGORIES),
+    minScore: parsePositiveInt(env.WIKIPEDIA_INGEST_MIN_SCORE, 75),
+    maxJobsPerRun: parsePositiveInt(env.WIKIPEDIA_INGEST_MAX_JOBS_PER_RUN, 2),
+    maxOpenJobs: parsePositiveInt(env.WIKIPEDIA_INGEST_MAX_OPEN_JOBS, 20)
+  };
+}
+
+function wikipediaJobKey(job) {
+  const source = job?.source;
+  if (source?.type !== "wikipedia_article") {
+    return undefined;
+  }
+  return wikipediaArticleKey({
+    language: source.language,
+    pageId: source.pageId,
+    revisionId: source.revisionId,
+    taskType: source.taskType
+  });
+}
+
+function parsePositiveInt(raw, fallback) {
+  if (raw === undefined || raw === null || raw === "") {
+    return fallback;
+  }
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    return fallback;
+  }
+  return value;
+}
+
+function parseBooleanEnv(raw) {
+  if (raw === undefined || raw === null || raw === "") {
+    return false;
+  }
+  return ["1", "true", "yes", "on"].includes(String(raw).trim().toLowerCase());
+}

--- a/mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.test.js
+++ b/mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.test.js
@@ -1,0 +1,144 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  WikipediaMaintenanceIngestionScheduler,
+  loadWikipediaMaintenanceIngestionConfig
+} from "./wikipedia-maintenance-ingestion-scheduler.js";
+
+function makeFetch() {
+  return async (url) => {
+    if (String(url).includes("list=categorymembers")) {
+      return jsonResponse({
+        query: {
+          categorymembers: [{ pageid: 123, ns: 0, title: "Example article" }]
+        }
+      });
+    }
+    return jsonResponse({
+      query: {
+        pages: {
+          123: {
+            pageid: 123,
+            title: "Example article",
+            fullurl: "https://en.wikipedia.org/wiki/Example_article",
+            revisions: [{ revid: 987654321, timestamp: "2026-04-25T10:00:00Z" }],
+            templates: [{ title: "Template:Dead link" }]
+          }
+        }
+      }
+    });
+  };
+}
+
+function makePlatformService(initialJobs = []) {
+  const jobs = [...initialJobs];
+  return {
+    listJobs() {
+      return [...jobs];
+    },
+    createJob(job) {
+      jobs.unshift(job);
+      return job;
+    },
+    getJobDefinition(jobId) {
+      const job = jobs.find((candidate) => candidate.id === jobId);
+      if (!job) {
+        throw new Error("not found");
+      }
+      return job;
+    }
+  };
+}
+
+test("WikipediaMaintenanceIngestionScheduler dry-run does not create jobs", async () => {
+  const platform = makePlatformService();
+  const scheduler = new WikipediaMaintenanceIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: true,
+    categories: [{ title: "Category:All articles with dead external links", taskType: "citation_repair" }],
+    minScore: 55,
+    fetchImpl: makeFetch()
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-25T10:00:00.000Z"));
+  assert.equal(summary.createdCount, 1);
+  assert.equal(platform.listJobs().length, 0);
+  assert.equal((await scheduler.getStatus()).lastRun.dryRun, true);
+});
+
+test("WikipediaMaintenanceIngestionScheduler creates jobs when dryRun is false", async () => {
+  const platform = makePlatformService();
+  const scheduler = new WikipediaMaintenanceIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    categories: [{ title: "Category:All articles with dead external links", taskType: "citation_repair" }],
+    minScore: 55,
+    fetchImpl: makeFetch()
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-25T10:00:00.000Z"));
+  assert.equal(summary.createdCount, 1);
+  assert.equal(platform.listJobs().length, 1);
+  assert.equal(platform.listJobs()[0].source.type, "wikipedia_article");
+});
+
+test("WikipediaMaintenanceIngestionScheduler dedupes by article revision", async () => {
+  const platform = makePlatformService([
+    {
+      id: "existing",
+      source: {
+        type: "wikipedia_article",
+        language: "en",
+        pageId: 123,
+        revisionId: "987654321",
+        taskType: "citation_repair"
+      }
+    }
+  ]);
+  const scheduler = new WikipediaMaintenanceIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    categories: [{ title: "Category:All articles with dead external links", taskType: "citation_repair" }],
+    minScore: 55,
+    fetchImpl: makeFetch()
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-25T10:00:00.000Z"));
+  assert.equal(summary.createdCount, 0);
+  assert.equal(platform.listJobs().length, 1);
+  assert.equal(summary.skipped[0].reason, "source_already_ingested");
+});
+
+test("loadWikipediaMaintenanceIngestionConfig parses env knobs safely", () => {
+  const config = loadWikipediaMaintenanceIngestionConfig({
+    WIKIPEDIA_INGEST_ENABLED: "true",
+    WIKIPEDIA_INGEST_DRY_RUN: "false",
+    WIKIPEDIA_INGEST_INTERVAL_MS: "1800000",
+    WIKIPEDIA_INGEST_LANGUAGE: "de",
+    WIKIPEDIA_INGEST_MIN_SCORE: "80",
+    WIKIPEDIA_INGEST_MAX_JOBS_PER_RUN: "3",
+    WIKIPEDIA_INGEST_MAX_OPEN_JOBS: "12",
+    WIKIPEDIA_INGEST_CATEGORIES_JSON: '[{"title":"Category:Wikipedia articles in need of updating","taskType":"freshness_check"}]'
+  });
+
+  assert.equal(config.enabled, true);
+  assert.equal(config.dryRun, false);
+  assert.equal(config.intervalMs, 1800000);
+  assert.equal(config.language, "de");
+  assert.equal(config.minScore, 80);
+  assert.equal(config.maxJobsPerRun, 3);
+  assert.equal(config.maxOpenJobs, 12);
+  assert.deepEqual(config.categories, [
+    { title: "Category:Wikipedia articles in need of updating", taskType: "freshness_check" }
+  ]);
+});
+
+function jsonResponse(payload) {
+  return {
+    ok: true,
+    async json() {
+      return payload;
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- Add a Wikipedia maintenance ingestor that discovers public article maintenance work via per-project MediaWiki Action API endpoints.
- Generate Averray-attributed, proposal-only Wikipedia jobs for citation repair, freshness checks, and infobox consistency.
- Add optional background scheduler, admin status wiring, `/admin/jobs/ingest/wikipedia`, env knobs, CLI script, and tests.

## Notes
- Uses `https://{lang}.wikipedia.org/w/api.php`, not deprecated API Portal / `api.wikimedia.org` Core routes.
- Agent outputs are submitted back to Averray. Any later public Wikipedia communication must come from Averray or an approved Averray editor/bot account with required disclosures.

## Tests
- `npm --workspace mcp-server test`