### PR TITLE
Fix CI artifact diff detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             git fetch --no-tags --prune --depth=1 origin "${{ github.base_ref }}"
-            changed_files="$(git diff --name-only FETCH_HEAD...HEAD)"
+            changed_files="$(git diff --name-only FETCH_HEAD HEAD)"
           else
             changed_files="$(git diff --name-only HEAD^ HEAD || git ls-files)"
           fi
@@ -125,7 +125,7 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             git fetch --no-tags --prune --depth=1 origin "${{ github.base_ref }}"
-            changed_files="$(git diff --name-only FETCH_HEAD...HEAD)"
+            changed_files="$(git diff --name-only FETCH_HEAD HEAD)"
           else
             changed_files="$(git diff --name-only HEAD^ HEAD || git ls-files)"
           fi


### PR DESCRIPTION
## Summary
- use direct tree diff for PR artifact-change detection
- avoids shallow checkout merge-base failures in frontend/public site CI jobs

## Tests
- not run locally; workflow-only change