### PR TITLE
Enable Wikipedia ingestion in production

### DIFF
--- a/docs/PUBLIC_JOB_SOURCES.md
+++ b/docs/PUBLIC_JOB_SOURCES.md
@@ -50,6 +50,12 @@ Wikipedia. If a proposal is later sent to Wikipedia, it must be attributed to
 Averray or an approved Averray editor/bot account and follow Wikipedia
 disclosure and bot rules.
 
+In production, this crawler is enabled by default and creates jobs
+autonomously with conservative caps: two jobs per run, twenty open Wikipedia
+jobs maximum, and a thirty-minute interval. Set
+`WIKIPEDIA_INGEST_ENABLED=false` to disable it, or
+`WIKIPEDIA_INGEST_DRY_RUN=true` to observe candidates without creating jobs.
+
 ### Initial job types
 
 1. **Wikipedia citation repair**

--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -114,14 +114,16 @@ AUTH_CHAIN_ID=420420417
 # GITHUB_INGEST_QUERIES_JSON=["is:issue is:open label:\"good first issue\" language:TypeScript","is:issue is:open label:\"help wanted\" label:tests"]
 
 # --- Wikipedia maintenance job ingestion -------------------------------------
-# Disabled by default. Uses stable per-project MediaWiki Action API endpoints
-# like https://en.wikipedia.org/w/api.php, not the old API Portal /
-# api.wikimedia.org Core routes. Jobs are proposal-only: agents submit
-# structured corrections back to Averray, and any later Wikipedia communication
-# must come from Averray or an approved Averray editor/bot account with the
-# required community disclosures.
-# WIKIPEDIA_INGEST_ENABLED=false
-# WIKIPEDIA_INGEST_DRY_RUN=true
+# Production defaults to enabled with dry-run disabled, capped at two jobs per
+# run and twenty open Wikipedia jobs. Non-production stays opt-in. Uses stable
+# per-project MediaWiki Action API endpoints like
+# https://en.wikipedia.org/w/api.php, not the old API Portal / api.wikimedia.org
+# Core routes. Jobs are proposal-only: agents submit structured corrections back
+# to Averray, and any later Wikipedia communication must come from Averray or an
+# approved Averray editor/bot account with the required community disclosures.
+# Set these explicitly to override the production defaults.
+# WIKIPEDIA_INGEST_ENABLED=true
+# WIKIPEDIA_INGEST_DRY_RUN=false
 # WIKIPEDIA_INGEST_INTERVAL_MS=1800000
 # WIKIPEDIA_INGEST_LANGUAGE=en
 # WIKIPEDIA_INGEST_MIN_SCORE=75

--- a/mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.js
+++ b/mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.js
@@ -172,9 +172,14 @@ export class WikipediaMaintenanceIngestionScheduler {
 }
 
 export function loadWikipediaMaintenanceIngestionConfig(env = process.env) {
+  const productionDefault = env.NODE_ENV === "production";
   return {
-    enabled: parseBooleanEnv(env.WIKIPEDIA_INGEST_ENABLED),
-    dryRun: env.WIKIPEDIA_INGEST_DRY_RUN === undefined ? true : parseBooleanEnv(env.WIKIPEDIA_INGEST_DRY_RUN),
+    enabled: env.WIKIPEDIA_INGEST_ENABLED === undefined
+      ? productionDefault
+      : parseBooleanEnv(env.WIKIPEDIA_INGEST_ENABLED),
+    dryRun: env.WIKIPEDIA_INGEST_DRY_RUN === undefined
+      ? !productionDefault
+      : parseBooleanEnv(env.WIKIPEDIA_INGEST_DRY_RUN),
     intervalMs: parsePositiveInt(env.WIKIPEDIA_INGEST_INTERVAL_MS, 30 * 60 * 1000),
     language: env.WIKIPEDIA_INGEST_LANGUAGE?.trim() || "en",
     categories: parseCategories(env.WIKIPEDIA_INGEST_CATEGORIES_JSON ?? env.WIKIPEDIA_INGEST_CATEGORIES),

--- a/mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.test.js
+++ b/mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.test.js
@@ -134,6 +134,28 @@ test("loadWikipediaMaintenanceIngestionConfig parses env knobs safely", () => {
   ]);
 });
 
+test("loadWikipediaMaintenanceIngestionConfig enables production ingestion by default", () => {
+  const config = loadWikipediaMaintenanceIngestionConfig({
+    NODE_ENV: "production"
+  });
+
+  assert.equal(config.enabled, true);
+  assert.equal(config.dryRun, false);
+  assert.equal(config.intervalMs, 30 * 60 * 1000);
+  assert.equal(config.language, "en");
+  assert.equal(config.maxJobsPerRun, 2);
+  assert.equal(config.maxOpenJobs, 20);
+});
+
+test("loadWikipediaMaintenanceIngestionConfig stays opt-in outside production", () => {
+  const config = loadWikipediaMaintenanceIngestionConfig({
+    NODE_ENV: "development"
+  });
+
+  assert.equal(config.enabled, false);
+  assert.equal(config.dryRun, true);
+});
+
 function jsonResponse(payload) {
   return {
     ok: true,


### PR DESCRIPTION
## Summary
- Enable Wikipedia maintenance ingestion by default in production.
- Keep non-production opt-in and allow env vars to disable or force dry-run.
- Document the production behavior and conservative caps.

## Production behavior
- `NODE_ENV=production` defaults to `enabled=true` and `dryRun=false`.
- Scheduler remains capped at 2 jobs per run, 20 open Wikipedia jobs max, 30 minute interval.
- Set `WIKIPEDIA_INGEST_ENABLED=false` to disable or `WIKIPEDIA_INGEST_DRY_RUN=true` to observe without creating jobs.

## Tests
- `node --test mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.test.js`
- `npm --workspace mcp-server test`