### PR TITLE
Stop gating CI on committed frontend artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,27 +82,6 @@ jobs:
       - name: Build static operator export
         run: npm run build:frontend
 
-      - name: Detect operator artifact changes
-        id: frontend-changes
-        shell: bash
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            git fetch --no-tags --prune --depth=1 origin "${{ github.base_ref }}"
-            changed_files="$(git diff --name-only FETCH_HEAD HEAD)"
-          else
-            changed_files="$(git diff --name-only HEAD^ HEAD || git ls-files)"
-          fi
-
-          if grep -Eq '^(app/|frontend/|scripts/sync-operator-frontend\.mjs|package(-lock)?\.json$)' <<<"$changed_files"; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Generated frontend is committed
-        if: steps.frontend-changes.outputs.changed == 'true'
-        run: git diff --exit-code -- frontend
-
   public-site:
     name: Public site — static export
     runs-on: ubuntu-latest
@@ -122,27 +101,6 @@ jobs:
 
       - name: Build public site
         run: npm run build:site
-
-      - name: Detect public site artifact changes
-        id: public-site-changes
-        shell: bash
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            git fetch --no-tags --prune --depth=1 origin "${{ github.base_ref }}"
-            changed_files="$(git diff --name-only FETCH_HEAD HEAD)"
-          else
-            changed_files="$(git diff --name-only HEAD^ HEAD || git ls-files)"
-          fi
-
-          if grep -Eq '^(marketing/|site/|scripts/sync-marketing-site\.mjs|package(-lock)?\.json$)' <<<"$changed_files"; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Generated public site is committed
-        if: steps.public-site-changes.outputs.changed == 'true'
-        run: git diff --exit-code -- site
 
   indexer:
     name: Indexer — typecheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,12 +16,12 @@ reviewable changes and keep production deploys serialized.
 
 - Source changes live in `app/`, `mcp-server/`, `indexer/`, `contracts/`,
   `marketing/`, `sdk/`, `docs/`, and `scripts/`.
-- For now, generated static outputs in `frontend/` and `site/` are still
-  committed. If you change the operator app, run `npm run build:frontend`. If
-  you change the public site, run `npm run build:site`.
+- Do not commit regenerated `frontend/` or `site/` output for normal app or
+  marketing changes. CI builds those exports from source, and production deploy
+  rebuilds them on the VPS before serving.
 - Do not manually edit generated `_next/static` or `_astro` files.
-- If CI says generated output is dirty, rebuild from source and commit the
-  generated diff.
+- Only touch generated static output when a task explicitly changes the static
+  deploy surface itself.
 
 ## Required Checks
 

--- a/VPS_RUNBOOK.md
+++ b/VPS_RUNBOOK.md
@@ -233,6 +233,10 @@ The script now:
 6. Polls `https://app.averray.com/` for the operator shell.
 7. Rolls back and rebuilds the previous frontend if the check fails.
 
+Normal PRs should commit operator source changes in `app/`, not regenerated
+`frontend/` artifacts. CI verifies the static export can be built, and the
+production deploy script builds the served files on the VPS.
+
 If the operator app is protected with browser basic auth, pass those
 credentials into the health gate:
 


### PR DESCRIPTION
## Summary
- keep operator and public-site CI builds, but remove byte-equality checks against committed frontend/site exports
- document that normal app and marketing PRs should not commit regenerated frontend/site output
- production deploy remains unchanged and rebuilds served static files on the VPS

## Checks
- git diff --check

## Notes
This unblocks multi-agent work where Next static chunk hashes differ across otherwise valid build environments.