### PR TITLE
Harden merge and deploy pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 # Cancel in-progress runs for the same ref when a new push lands — avoids
 # wasting CI minutes on commits that are already obsolete.
@@ -39,7 +40,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
 
       - name: Install workspace dependencies
@@ -111,7 +112,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
 
       - name: Install workspace dependencies

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -15,6 +15,7 @@ jobs:
   deploy:
     name: Deploy VPS production
     runs-on: ubuntu-latest
+    environment: production
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     env:
       VPS_HOST: ${{ secrets.VPS_HOST }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,17 @@ reviewable changes and keep production deploys serialized.
 ## Branching
 
 - Do not push directly to `main`.
-- Create one branch per task, for example `agent/github-pr-verifier` or
-  `agent/runs-ui-polish`.
+- Start each task from an up-to-date local `main` by running
+  `./scripts/ops/start-agent-branch.sh codex/<task-name>` from the repository
+  root. The helper fetches `origin/main`, fast-forwards local `main`, and then
+  creates the task branch.
+- Create one branch per task, for example `codex/github-pr-verifier` or
+  `codex/runs-ui-polish`.
 - Keep PRs narrow. Split unrelated backend, frontend, contract, and docs work.
 - Rebase or merge `origin/main` before marking a PR ready if other agents landed
   nearby changes.
+- After your PR merges, switch back to `main` and run
+  `git pull --ff-only origin main` before starting anything else.
 
 ## Generated Files
 


### PR DESCRIPTION
## Summary
- add `merge_group` to CI so merge queue refs can run the same required checks
- standardize backend and indexer CI jobs on Node 22
- attach the production deploy job to the GitHub `production` environment
- update `AGENTS.md` so agents always start from a freshly fast-forwarded local `main`

## Checks
- `git diff --check`
- YAML parse for `.github/workflows/ci.yml` and `.github/workflows/deploy-production.yml`

## Repo settings already applied
- `main` branch protection is enabled with PRs, required CI, linear history, no force pushes, no deletions, and resolved conversations
- GitHub `production` environment exists and is limited to protected branches

Merge queue should be enabled after this PR lands so CI can run on `merge_group` refs.
