### PR TITLE
operator-app: polish Runs detail panel for Wikipedia-vs-GitHub clarity

### DIFF
--- a/app/app/(authed)/runs/page.tsx
+++ b/app/app/(authed)/runs/page.tsx
@@ -80,6 +80,50 @@ function RunsPageInner() {
     return rows.filter((r) => r.state === activeFilter);
   }, [activeFilter, rows]);
 
+  // Lifecycle rail at the page level mirrors the loaded run, so its
+  // copy has to follow the selected row's source — otherwise selecting
+  // a Wikipedia maintenance run still shows "verification github_pr ·
+  // PR #4931 opened" and "Maintainer review → Pay", which is the wrong
+  // verification path and implies a direct GitHub flow that doesn't
+  // exist for that run.
+  const selectedRow = rows.find((row) => row.id === selectedId) ?? rows[0];
+  const selectedSourceType = selectedRow?.source?.type;
+  const lifecycleContextNote =
+    selectedSourceType === "wikipedia_article" ? (
+      <>
+        Window closes in{" "}
+        <b className="font-semibold text-[var(--avy-ink)]">21m 46s</b>
+        {" · "}verification{" "}
+        <b className="font-semibold text-[var(--avy-ink)]">
+          wikipedia_proposal_review
+        </b>
+        {" · "}proposal{" "}
+        <b className="font-semibold text-[var(--avy-ink)]">submitted</b> ·
+        pending Averray review
+      </>
+    ) : (
+      <>
+        Window closes in{" "}
+        <b className="font-semibold text-[var(--avy-ink)]">21m 46s</b>
+        {" · "}verification{" "}
+        <b className="font-semibold text-[var(--avy-ink)]">github_pr</b>
+        {" · "}PR{" "}
+        <b className="font-semibold text-[var(--avy-ink)]">#4931</b> opened
+      </>
+    );
+  const lifecycleNext =
+    selectedSourceType === "wikipedia_article"
+      ? {
+          label: "Next",
+          value: "Averray review → Pay",
+          sub: "auto-pays on Averray-approved review",
+        }
+      : {
+          label: "Next",
+          value: "Maintainer review → Pay",
+          sub: "auto-pays on PR merge + CI green",
+        };
+
   const assignedToMe = rows.filter((row) => row.worker.isSelf).length;
   const liveStatus = jobs.error
     ? "fixture fallback"
@@ -128,22 +172,9 @@ function RunsPageInner() {
 
       <LifecycleRail
         runId={selectedId}
-        contextNote={
-          <>
-            Window closes in{" "}
-            <b className="font-semibold text-[var(--avy-ink)]">21m 46s</b>
-            {" · "}verification{" "}
-            <b className="font-semibold text-[var(--avy-ink)]">github_pr</b>
-            {" · "}PR{" "}
-            <b className="font-semibold text-[var(--avy-ink)]">#4931</b> opened
-          </>
-        }
+        contextNote={lifecycleContextNote}
         stages={FIXTURE_LIFECYCLE}
-        next={{
-          label: "Next",
-          value: "Maintainer review → Pay",
-          sub: "auto-pays on PR merge + CI green",
-        }}
+        next={lifecycleNext}
       />
 
       <RecommendationRail

--- a/app/components/runs/LoadedRunPanel.tsx
+++ b/app/components/runs/LoadedRunPanel.tsx
@@ -549,14 +549,15 @@ function GitHubEvidenceBlock({ ctx }: { ctx: GitHubJobContext }) {
         {/* Source strip — always visible so the worker can always see the
             repo, issue, category, and fit score regardless of which tab is
             active. */}
-        <div className="flex flex-wrap items-center gap-2 border-b border-[var(--avy-line-soft)] bg-[color:rgba(17,19,21,0.03)] px-3 py-2">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-b border-[var(--avy-line-soft)] bg-[color:rgba(17,19,21,0.03)] px-3 py-2">
           <SourceBadge kind="github" />
           <a
             href={ctx.issueUrl}
             target="_blank"
             rel="noreferrer noopener"
-            className="font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-ink)] hover:text-[var(--avy-accent)]"
+            className="truncate whitespace-nowrap font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-ink)] hover:text-[var(--avy-accent)]"
             style={{ letterSpacing: 0 }}
+            title={`${ctx.repo} #${ctx.issueNumber}`}
           >
             {ctx.repo}
             <span className="ml-0.5 text-[var(--avy-accent)]">
@@ -565,13 +566,13 @@ function GitHubEvidenceBlock({ ctx }: { ctx: GitHubJobContext }) {
           </a>
           <span className="opacity-40">·</span>
           <span
-            className="font-[family-name:var(--font-mono)] text-[11px] uppercase text-[var(--avy-muted)]"
+            className="whitespace-nowrap font-[family-name:var(--font-mono)] text-[11px] uppercase text-[var(--avy-muted)]"
             style={{ letterSpacing: "0.08em" }}
           >
             {ctx.category}
           </span>
           {typeof ctx.score === "number" ? (
-            <span className="ml-auto inline-flex items-center gap-1 font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]">
+            <span className="ml-auto inline-flex items-center gap-1 whitespace-nowrap font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]">
               Fit score{" "}
               <b className="font-semibold text-[var(--avy-ink)]">{ctx.score}</b>
               <span className="text-[var(--avy-muted)]">/100</span>
@@ -618,7 +619,7 @@ function GitHubEvidenceBlock({ ctx }: { ctx: GitHubJobContext }) {
           style={{ letterSpacing: 0 }}
         >
           <span className="text-[var(--avy-accent)]">Verification</span>
-          <span className="inline-flex items-center rounded-full bg-[color:rgba(17,19,21,0.06)] px-1.5 py-px font-medium text-[var(--avy-ink)]">
+          <span className="inline-flex items-center whitespace-nowrap rounded-full bg-[color:rgba(17,19,21,0.06)] px-1.5 py-px font-medium text-[var(--avy-ink)]">
             {ctx.verification.method}
           </span>
           {ctx.verification.signals.map((s, i) => (
@@ -683,34 +684,35 @@ function WikipediaEvidenceBlock({ ctx }: { ctx: WikipediaJobContext }) {
       <div className="flex flex-col overflow-hidden rounded-[8px] border border-[var(--avy-line)] bg-white">
         {/* Source strip — pinned above the tabs so language, page, task
             type, and fit score stay readable on every tab. */}
-        <div className="flex flex-wrap items-center gap-2 border-b border-[var(--avy-line-soft)] bg-[color:rgba(17,19,21,0.03)] px-3 py-2">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-b border-[var(--avy-line-soft)] bg-[color:rgba(17,19,21,0.03)] px-3 py-2">
           <SourceBadge kind="wikipedia" />
           <a
             href={ctx.pageUrl}
             target="_blank"
             rel="noreferrer noopener"
-            className="font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-ink)] hover:text-[var(--avy-accent)]"
+            className="truncate whitespace-nowrap font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-ink)] hover:text-[var(--avy-accent)]"
             style={{ letterSpacing: 0 }}
+            title={`${ctx.language}.wikipedia / ${ctx.pageTitle}`}
           >
             <span className="text-[var(--avy-muted)]">{ctx.language}.wikipedia</span>
             <span className="text-[var(--avy-accent)]"> / {ctx.pageTitle}</span>
           </a>
           <span className="opacity-40">·</span>
           <span
-            className="font-[family-name:var(--font-mono)] text-[11px] uppercase text-[var(--avy-muted)]"
+            className="whitespace-nowrap font-[family-name:var(--font-mono)] text-[11px] uppercase text-[var(--avy-muted)]"
             style={{ letterSpacing: "0.08em" }}
           >
             {taskTypeLabel}
           </span>
           <span className="opacity-40">·</span>
           <span
-            className="font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
+            className="whitespace-nowrap font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
             style={{ letterSpacing: 0 }}
           >
             rev {ctx.revisionId}
           </span>
           {typeof ctx.score === "number" ? (
-            <span className="ml-auto inline-flex items-center gap-1 font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]">
+            <span className="ml-auto inline-flex items-center gap-1 whitespace-nowrap font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]">
               Fit score{" "}
               <b className="font-semibold text-[var(--avy-ink)]">{ctx.score}</b>
               <span className="text-[var(--avy-muted)]">/100</span>
@@ -732,8 +734,9 @@ function WikipediaEvidenceBlock({ ctx }: { ctx: WikipediaJobContext }) {
             Policy
           </span>
           <span>
-            Proposal-only. Agents submit evidence to Averray; Wikipedia edits
-            require approved Averray review.
+            Proposal-only · the agent never edits Wikipedia. Evidence + a
+            structured proposal go to Averray; any public edit is performed
+            downstream by an approved Averray editor.
           </span>
         </div>
 
@@ -776,7 +779,7 @@ function WikipediaEvidenceBlock({ ctx }: { ctx: WikipediaJobContext }) {
           style={{ letterSpacing: 0 }}
         >
           <span className="text-[var(--avy-accent)]">Verification</span>
-          <span className="inline-flex items-center rounded-full bg-[color:rgba(17,19,21,0.06)] px-1.5 py-px font-medium text-[var(--avy-ink)]">
+          <span className="inline-flex items-center whitespace-nowrap rounded-full bg-[color:rgba(17,19,21,0.06)] px-1.5 py-px font-medium text-[var(--avy-ink)]">
             {ctx.verification.method}
           </span>
           {ctx.verification.signals.map((s) => (

--- a/app/components/runs/LoadedRunView.tsx
+++ b/app/components/runs/LoadedRunView.tsx
@@ -109,10 +109,22 @@ export function LoadedRunView({
     }
   };
 
+  // Source-aware kicker so the very top of the panel reads as
+  // "what kind of work is this" before the worker scans the title.
+  // Avoids the marketing-flat "Loaded run" label on every run regardless
+  // of provenance, which previously left an operator to read the source
+  // strip lower down to figure out whether the page applied to a GitHub
+  // PR review or a Wikipedia proposal review.
+  const kicker = loadedWikipedia
+    ? "Loaded run · Wikipedia article"
+    : loadedGitHub
+      ? "Loaded run · GitHub issue"
+      : "Loaded run";
+
   return (
     <div className="flex flex-col gap-3.5">
       <LoadedRunPanel
-        kicker="Loaded run"
+        kicker={kicker}
         title={loadedRow.title}
         meta={loadedRow.jobMeta}
         state={loadedRow.state}
@@ -131,12 +143,14 @@ export function LoadedRunView({
             treasury: "0 DOT",
           },
         }}
-        // When `github` is set the panel swaps Evidence for the four-tab
-        // Issue/Acceptance/Instructions/Submission block. `evidence` is
-        // then unused at runtime but stays type-required.
+        // When `github` or `wikipedia` is set the panel swaps Evidence
+        // for the source-specific four-tab block. `evidence` is then
+        // unused at runtime but stays type-required, so we hand it a
+        // single neutral "Brief" tab — the previous "Issue" label
+        // leaked GitHub-domain language onto native runs.
         evidence={{
-          tabs: [{ id: "issue", label: "Issue" }],
-          activeTab: "issue",
+          tabs: [{ id: "brief", label: "Brief" }],
+          activeTab: "brief",
           metaRight: "",
           metaFoot: "",
           sample: "",
@@ -145,8 +159,8 @@ export function LoadedRunView({
           note: loadedWikipedia ? (
             <>
               Submits{" "}
-              <b className="text-[var(--avy-ink)]">proposal + evidence</b> to
-              Averray. Window{" "}
+              <b className="text-[var(--avy-ink)]">proposed change summary + citations</b>{" "}
+              to Averray. No direct Wikipedia edits. Window{" "}
               <b className="text-[var(--avy-ink)]">00:08:14 / 02:00:00</b>.
             </>
           ) : (

--- a/app/components/runs/ReceiptPreviewDrawer.tsx
+++ b/app/components/runs/ReceiptPreviewDrawer.tsx
@@ -123,14 +123,26 @@ export function ReceiptPreviewDrawer({
 
       {draft.wikipedia ? (
         <DrawerSection title="Source">
-          <div className="flex flex-wrap items-center gap-2 rounded-[8px] border border-[var(--avy-line)] bg-[color:rgba(17,19,21,0.02)] px-3 py-2">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 rounded-[8px] border border-[var(--avy-line)] bg-[color:rgba(17,19,21,0.02)] px-3 py-2">
             <SourceBadge kind="wikipedia" />
+            {/* Glanceable attribution pill so the reviewer sees the
+                proposal-only stance without having to read the warning
+                paragraph below. Uses the same warn token as the policy
+                banner on the loaded-run panel. */}
+            <span
+              className="inline-flex items-center whitespace-nowrap rounded-full bg-[var(--avy-warn)] px-1.5 py-0.5 font-[family-name:var(--font-display)] text-[9.5px] font-extrabold uppercase text-white"
+              style={{ letterSpacing: "0.1em" }}
+              title="Averray proposal only — no direct Wikipedia edit"
+            >
+              Proposal only
+            </span>
             <a
               href={draft.wikipedia.pageUrl}
               target="_blank"
               rel="noreferrer noopener"
-              className="font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-ink)] hover:text-[var(--avy-accent)]"
+              className="truncate whitespace-nowrap font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-ink)] hover:text-[var(--avy-accent)]"
               style={{ letterSpacing: 0 }}
+              title={`${draft.wikipedia.language}.wikipedia / ${draft.wikipedia.pageTitle}`}
             >
               <span className="text-[var(--avy-muted)]">
                 {draft.wikipedia.language}.wikipedia
@@ -141,7 +153,7 @@ export function ReceiptPreviewDrawer({
             </a>
             <span className="opacity-40">·</span>
             <span
-              className="font-[family-name:var(--font-mono)] text-[11.5px] uppercase text-[var(--avy-muted)]"
+              className="whitespace-nowrap font-[family-name:var(--font-mono)] text-[11.5px] uppercase text-[var(--avy-muted)]"
               style={{ letterSpacing: "0.08em" }}
             >
               {draft.wikipedia.taskType.replace(/_/g, " ")}

--- a/app/components/runs/fixtures.ts
+++ b/app/components/runs/fixtures.ts
@@ -24,7 +24,7 @@ export const FIXTURE_RUN_ROWS: RunRow[] = [
     id: "run-2749",
     title:
       "Document TypeScript validation helper API for external package consumers",
-    jobMeta: "job-0428 · docs · T1",
+    jobMeta: "docs · T1",
     source: {
       type: "github_issue",
       repo: "oss-devsecblueprint/devsecblueprint",
@@ -57,7 +57,7 @@ export const FIXTURE_RUN_ROWS: RunRow[] = [
     id: "run-2742",
     title:
       "Fix flaky integration test: race condition when two workers claim within the same block window",
-    jobMeta: "job-0418 · bugfix · T2",
+    jobMeta: "bugfix · T2",
     source: {
       type: "github_issue",
       repo: "paritytech/polkadot-sdk",
@@ -144,7 +144,7 @@ export const FIXTURE_RUN_ROWS: RunRow[] = [
     id: "run-2750",
     title:
       "Refresh outdated funding round figures and add 2025 audit citation",
-    jobMeta: "wikipedia · T1",
+    jobMeta: "freshness check · T1",
     source: {
       type: "wikipedia_article",
       pageTitle: "Polkadot (cryptocurrency)",

--- a/app/lib/api/run-adapters.ts
+++ b/app/lib/api/run-adapters.ts
@@ -262,14 +262,20 @@ export function buildRunRows(payload: unknown): RunRow[] {
     // For ingested-source jobs the row already shows the upstream
     // identity (owner/repo #N for GitHub, lang.wikipedia/page for
     // Wikipedia) via the SourceBadge, so drop the redundant job-id
-    // slug from jobMeta to keep the meta line scannable. Native jobs
+    // slug from jobMeta to keep the meta line scannable. Wikipedia
+    // rows additionally swap the job's own `category` (always
+    // "wikipedia", duplicating the SourceBadge) for the more specific
+    // task type so the meta line carries new signal. Native jobs
     // keep the full `id · category · tier` because there's no other
     // provenance signal.
-    const isIngested =
-      source?.type === "github_issue" || source?.type === "wikipedia_article";
-    const jobMeta = isIngested
-      ? `${text(job.category, "work")} · ${tierFromRaw(job.tier)}`
-      : `${id} · ${text(job.category, "work")} · ${tierFromRaw(job.tier)}`;
+    const tier = tierFromRaw(job.tier);
+    const category = text(job.category, "work");
+    const jobMeta =
+      source?.type === "wikipedia_article"
+        ? `${source.taskType.replace(/_/g, " ")} · ${tier}`
+        : source?.type === "github_issue"
+          ? `${category} · ${tier}`
+          : `${id} · ${category} · ${tier}`;
     return {
       id,
       sessionId: text(job.sessionId),


### PR DESCRIPTION
## Summary
Polish pass on the Runs **detail** panel so a Wikipedia maintenance run reads as a *proposal-only* task end to end, and a GitHub issue run reads as a PR-review task end to end — without either domain's language leaking into the other.

- **Source-aware kicker** on the loaded-run panel header — `Loaded run · Wikipedia article` / `Loaded run · GitHub issue` / `Loaded run` (native).
- **`jobMeta` carries new signal** for Wikipedia rows: drop the redundant `wikipedia` category, swap in the task type (e.g. `freshness check · T1`).
- **Native fallback evidence** tab renamed `Issue` → `Brief` so the GitHub-domain "Issue" label no longer shows on non-GitHub native runs.
- **Proposal-only stance hardened** on Wikipedia:
  - Policy banner now says explicitly that *the agent never edits Wikipedia* and the public edit happens downstream by an approved Averray editor.
  - Panel-level submission note: `Submits proposed change summary + citations to Averray. No direct Wikipedia edits.`
  - Receipt preview gets a small **`Proposal only`** warn-tinted pill next to the Wikipedia `SourceBadge` for at-a-glance attribution.
- **Wrap behaviour:** `whitespace-nowrap` on source links + chips (`repo #N`, `lang.wikipedia / pageTitle`, taskType, revision, fit score, verification method) so long page titles and repo names don't break mid-token in narrow split-pane widths.
- **Queue-page `LifecycleRail` now reads source from the selected row** — selecting a Wikipedia run no longer shows `verification github_pr · PR #4931 opened` or `Maintainer review → Pay`. (The rail inside `LoadedRunView` was already source-aware; this fixes the duplicate one rendered at page level.)

No backend, indexer, or contract changes. Generated `frontend/` not committed (rebuilt by CI per `AGENTS.md` guidance).

## Files
- `app/lib/api/run-adapters.ts` — `buildRunRows` jobMeta source-aware
- `app/components/runs/LoadedRunView.tsx` — source-aware kicker, neutral native tab, sharper submission note
- `app/components/runs/LoadedRunPanel.tsx` — policy banner copy, whitespace-nowrap on chips
- `app/components/runs/ReceiptPreviewDrawer.tsx` — `Proposal only` pill on Wikipedia source row
- `app/components/runs/fixtures.ts` — fixture jobMeta strings match the new convention
- `app/app/(authed)/runs/page.tsx` — queue-page LifecycleRail uses selected-row source

## Test plan
- [x] `npm run typecheck:app`
- [x] `npm run build:frontend` (15/15 pages, no warnings beyond pre-existing lockfile inference)
- [ ] Eyeball `/runs` with default selection (run-2742, GitHub) — kicker reads `Loaded run · GitHub issue`, lifecycle rail says `github_pr` / `Maintainer review → Pay`
- [ ] Select run-2750 (Wikipedia) — kicker reads `Loaded run · Wikipedia article`, jobMeta reads `freshness check · T1`, policy banner above tabs, submission note mentions `proposed change summary + citations`, lifecycle rail says `wikipedia_proposal_review` / `Averray review → Pay`
- [ ] Open Receipt preview on a Wikipedia run — `Proposal only` pill visible next to the Wikipedia SourceBadge
- [ ] `/runs/detail/?id=run-2750` — same panel rendering in fullscreen
- [ ] Narrow the panel column — source-strip chips truncate / wrap as units, never mid-token

🤖 Generated with [Claude Code](https://claude.com/claude-code)