### PR TITLE
Add agent worktree lifecycle helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ app/out/
 app/tsconfig.tsbuildinfo
 
 *.log
+
+.claude/
+.codex/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,17 +6,25 @@ reviewable changes and keep production deploys serialized.
 ## Branching
 
 - Do not push directly to `main`.
-- Start each task from an up-to-date local `main` by running
-  `./scripts/ops/start-agent-branch.sh codex/<task-name>` from the repository
-  root. The helper fetches `origin/main`, fast-forwards local `main`, and then
-  creates the task branch.
+- Start each task in its own worktree from fresh `origin/main` by running
+  `./scripts/ops/start-agent-worktree.sh codex/<task-name>` or
+  `./scripts/ops/start-agent-worktree.sh claude/<task-name>` from the repository
+  root. The helper fetches `origin/main`, creates the task branch, and prints
+  the worktree path to use.
 - Create one branch per task, for example `codex/github-pr-verifier` or
   `codex/runs-ui-polish`.
+- Keep the primary checkout on `main` for repo sync and branch creation. Agents
+  should do implementation work in task worktrees, not in the primary checkout.
 - Keep PRs narrow. Split unrelated backend, frontend, contract, and docs work.
 - Rebase or merge `origin/main` before marking a PR ready if other agents landed
   nearby changes.
-- After your PR merges, switch back to `main` and run
-  `git pull --ff-only origin main` before starting anything else.
+- After your PR merges, run
+  `./scripts/ops/finish-agent-worktree.sh <branch>` from the repository root to
+  remove the merged task worktree, delete the merged branch, and sync local
+  `main`.
+- To sync local `main` without changing task branches, run
+  `./scripts/ops/sync-local-main.sh`. GitHub cannot update local Macs after a
+  deployment, so this helper is the local follow-up step.
 
 ## Generated Files
 

--- a/scripts/ops/finish-agent-worktree.sh
+++ b/scripts/ops/finish-agent-worktree.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Remove a merged task worktree and delete its local/remote task branch. This
+# refuses to proceed if the branch is not merged into the remote base branch.
+
+REMOTE=${REMOTE:-origin}
+BASE_BRANCH=${BASE_BRANCH:-main}
+DELETE_REMOTE=${DELETE_REMOTE:-1}
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  ./scripts/ops/finish-agent-worktree.sh <branch>
+
+Example:
+  ./scripts/ops/finish-agent-worktree.sh claude/runs-detail-polish
+
+Environment:
+  REMOTE=origin        remote to fetch from
+  BASE_BRANCH=main     base branch that must contain the task branch
+  DELETE_REMOTE=1      delete the remote task branch when present
+USAGE
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 2
+fi
+
+branch="$1"
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+current_branch="$(git branch --show-current)"
+if [[ "$current_branch" == "$branch" ]]; then
+  echo "Refusing to remove the worktree currently running this script." >&2
+  echo "Run this from the primary checkout or another worktree instead." >&2
+  exit 1
+fi
+
+if [[ "$branch" == "$BASE_BRANCH" || "$branch" == "$REMOTE/$BASE_BRANCH" ]]; then
+  echo "Refusing to finish the base branch: $branch" >&2
+  exit 1
+fi
+
+echo "Refreshing $REMOTE/$BASE_BRANCH"
+git fetch "$REMOTE" "$BASE_BRANCH" --prune
+
+if ! git show-ref --verify --quiet "refs/heads/$branch"; then
+  echo "Local branch not found: $branch" >&2
+  exit 1
+fi
+
+if ! git merge-base --is-ancestor "$branch" "$REMOTE/$BASE_BRANCH"; then
+  echo "Refusing to delete $branch because it is not merged into $REMOTE/$BASE_BRANCH" >&2
+  exit 1
+fi
+
+worktree_path=""
+while IFS= read -r line; do
+  case "$line" in
+    worktree\ *)
+      current_path="${line#worktree }"
+      ;;
+    branch\ refs/heads/"$branch")
+      worktree_path="$current_path"
+      break
+      ;;
+  esac
+done < <(git worktree list --porcelain)
+
+if [[ -n "$worktree_path" ]]; then
+  echo "Removing worktree $worktree_path"
+  git worktree remove "$worktree_path"
+fi
+
+echo "Deleting local branch $branch"
+git branch -d "$branch"
+
+if [[ "$DELETE_REMOTE" == "1" ]] && git show-ref --verify --quiet "refs/remotes/$REMOTE/$branch"; then
+  echo "Deleting remote branch $REMOTE/$branch"
+  git push "$REMOTE" --delete "$branch"
+fi
+
+"$repo_root/scripts/ops/sync-local-main.sh"
+
+echo "Finished $branch"

--- a/scripts/ops/start-agent-branch.sh
+++ b/scripts/ops/start-agent-branch.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Start a new agent/task branch from the latest remote main.
-# This prevents agents from accidentally branching off a stale local checkout.
+# Start a new agent/task branch in the current worktree from the latest remote
+# main. Prefer start-agent-worktree.sh for multi-agent work.
 
 REMOTE=${REMOTE:-origin}
 BASE_BRANCH=${BASE_BRANCH:-main}
@@ -17,7 +17,7 @@ Example:
 
 Environment:
   REMOTE=origin       remote to fetch from
-  BASE_BRANCH=main    base branch to refresh before creating the new branch
+  BASE_BRANCH=main    remote base branch to create the new branch from
 USAGE
 }
 
@@ -51,11 +51,9 @@ if [[ -n "$tracked_changes" ]]; then
 fi
 
 echo "Refreshing $REMOTE/$BASE_BRANCH"
-git fetch "$REMOTE" --prune
-git switch "$BASE_BRANCH"
-git pull --ff-only "$REMOTE" "$BASE_BRANCH"
+git fetch "$REMOTE" "$BASE_BRANCH" --prune
 
-echo "Creating $new_branch from $(git rev-parse --short HEAD)"
-git switch -c "$new_branch"
+echo "Creating $new_branch from $(git rev-parse --short "$REMOTE/$BASE_BRANCH")"
+git switch -c "$new_branch" "$REMOTE/$BASE_BRANCH"
 
 echo "Ready on $new_branch"

--- a/scripts/ops/start-agent-worktree.sh
+++ b/scripts/ops/start-agent-worktree.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create a dedicated task worktree from the latest remote main. This keeps the
+# primary checkout free for syncing and prevents agents from branching off stale
+# local state.
+
+REMOTE=${REMOTE:-origin}
+BASE_BRANCH=${BASE_BRANCH:-main}
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  ./scripts/ops/start-agent-worktree.sh <new-branch> [worktree-path]
+
+Examples:
+  ./scripts/ops/start-agent-worktree.sh codex/github-pr-verifier
+  ./scripts/ops/start-agent-worktree.sh claude/runs-detail-polish
+
+Environment:
+  REMOTE=origin       remote to fetch from
+  BASE_BRANCH=main    base branch to create worktrees from
+USAGE
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage
+  exit 2
+fi
+
+new_branch="$1"
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if [[ "$new_branch" == "$BASE_BRANCH" || "$new_branch" == "$REMOTE/$BASE_BRANCH" ]]; then
+  echo "Refusing to create a task branch named like the base branch: $new_branch" >&2
+  exit 1
+fi
+
+if [[ "$new_branch" != */* ]]; then
+  echo "Use an owner prefix, for example codex/$new_branch or claude/$new_branch" >&2
+  exit 1
+fi
+
+if git show-ref --verify --quiet "refs/heads/$new_branch"; then
+  echo "Local branch already exists: $new_branch" >&2
+  exit 1
+fi
+
+if git show-ref --verify --quiet "refs/remotes/$REMOTE/$new_branch"; then
+  echo "Remote branch already exists: $REMOTE/$new_branch" >&2
+  exit 1
+fi
+
+owner="${new_branch%%/*}"
+slug="${new_branch#*/}"
+
+if [[ $# -eq 2 ]]; then
+  worktree_path="$2"
+else
+  case "$owner" in
+    claude)
+      worktree_path=".claude/worktrees/$slug"
+      ;;
+    codex)
+      worktree_path=".codex/worktrees/$slug"
+      ;;
+    *)
+      worktree_path=".agent-worktrees/$owner/$slug"
+      ;;
+  esac
+fi
+
+if [[ -e "$worktree_path" ]]; then
+  echo "Worktree path already exists: $worktree_path" >&2
+  exit 1
+fi
+
+echo "Refreshing $REMOTE/$BASE_BRANCH"
+git fetch "$REMOTE" "$BASE_BRANCH" --prune
+
+echo "Creating worktree $worktree_path from $REMOTE/$BASE_BRANCH"
+git worktree add -b "$new_branch" "$worktree_path" "$REMOTE/$BASE_BRANCH"
+
+echo
+echo "Ready:"
+echo "  branch:   $new_branch"
+echo "  worktree: $repo_root/$worktree_path"
+echo
+echo "Next:"
+echo "  cd $repo_root/$worktree_path"

--- a/scripts/ops/sync-local-main.sh
+++ b/scripts/ops/sync-local-main.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fast-forward the local base branch to the latest remote base branch without
+# requiring the caller to be on main. If main is checked out in another worktree,
+# the pull runs in that worktree.
+
+REMOTE=${REMOTE:-origin}
+BASE_BRANCH=${BASE_BRANCH:-main}
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+echo "Fetching $REMOTE/$BASE_BRANCH"
+git fetch "$REMOTE" "$BASE_BRANCH" --prune
+
+main_worktree=""
+while IFS= read -r line; do
+  case "$line" in
+    worktree\ *)
+      current_path="${line#worktree }"
+      ;;
+    branch\ refs/heads/"$BASE_BRANCH")
+      main_worktree="$current_path"
+      break
+      ;;
+  esac
+done < <(git worktree list --porcelain)
+
+if [[ -n "$main_worktree" ]]; then
+  tracked_changes="$(git -C "$main_worktree" status --porcelain --untracked-files=no)"
+  if [[ -n "$tracked_changes" ]]; then
+    echo "Refusing to sync $BASE_BRANCH because tracked changes exist in $main_worktree:" >&2
+    echo "$tracked_changes" >&2
+    exit 1
+  fi
+
+  echo "Fast-forwarding $BASE_BRANCH in $main_worktree"
+  git -C "$main_worktree" pull --ff-only "$REMOTE" "$BASE_BRANCH"
+else
+  if git show-ref --verify --quiet "refs/heads/$BASE_BRANCH"; then
+    echo "Fast-forwarding local $BASE_BRANCH without checking it out"
+    git fetch "$REMOTE" "$BASE_BRANCH:$BASE_BRANCH"
+  else
+    echo "Creating local $BASE_BRANCH from $REMOTE/$BASE_BRANCH"
+    git branch --track "$BASE_BRANCH" "$REMOTE/$BASE_BRANCH"
+  fi
+fi
+
+echo "$BASE_BRANCH is synced to $(git rev-parse --short "$REMOTE/$BASE_BRANCH")"


### PR DESCRIPTION
## Summary
- add helpers to start and finish per-agent task worktrees from fresh origin/main
- add a local main sync helper that works without leaving the current task branch
- update AGENTS.md to make worktree-based collaboration the default

## Checks
- bash -n scripts/ops/start-agent-branch.sh scripts/ops/sync-local-main.sh scripts/ops/start-agent-worktree.sh scripts/ops/finish-agent-worktree.sh
- smoke-tested start-agent-worktree.sh and finish-agent-worktree.sh with a temporary codex/smoke-agent-worktree-helper branch
- smoke-tested sync-local-main.sh

## Notes
- GitHub deploys cannot directly mutate local developer machines; scripts/ops/sync-local-main.sh is the local follow-up helper.
