### PR TITLE
Add macOS production sync watcher

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,10 @@ reviewable changes and keep production deploys serialized.
 - To sync local `main` without changing task branches, run
   `./scripts/ops/sync-local-main.sh`. GitHub cannot update local Macs after a
   deployment, so this helper is the local follow-up step.
+- On macOS, developers can install a login/background watcher with
+  `./scripts/ops/install-macos-production-sync-launchd.sh`. It polls the
+  production deploy workflow and runs `sync-local-main.sh` after successful
+  deploys, without touching active task branches.
 
 ## Generated Files
 

--- a/VPS_RUNBOOK.md
+++ b/VPS_RUNBOOK.md
@@ -211,6 +211,34 @@ these repository secrets for `.github/workflows/deploy-production.yml`:
 Keep branch protection enabled for `main`: require PRs, require CI, and use
 merge queue or auto-merge so multiple agents are serialized before deployment.
 
+### Local main sync after production deploys
+
+GitHub Actions cannot directly update a developer laptop after deployment. To
+keep a local macOS checkout's `main` branch current in the background, install
+the per-user launchd watcher from the repo root:
+
+```bash
+./scripts/ops/install-macos-production-sync-launchd.sh
+```
+
+The watcher polls the `Deploy Production` workflow on `main` and runs
+`./scripts/ops/sync-local-main.sh` after a new successful deploy. It does not
+switch away from active task branches.
+
+Useful commands:
+
+```bash
+# One-shot manual sync check
+./scripts/ops/watch-production-sync.sh --once
+
+# Watcher logs
+tail -f .codex/logs/production-sync.out.log
+tail -f .codex/logs/production-sync.err.log
+
+# Stop/remove the login watcher
+./scripts/ops/uninstall-macos-production-sync-launchd.sh
+```
+
 ### Frontend-only changes
 
 Use the scripted frontend deploy. The operator app is a static Next export

--- a/scripts/ops/install-macos-production-sync-launchd.sh
+++ b/scripts/ops/install-macos-production-sync-launchd.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install a per-user launchd agent that keeps local main synced after successful
+# production deploys. This is macOS-only and writes to ~/Library/LaunchAgents.
+
+LABEL=${LABEL:-com.averray.agent.production-sync}
+INTERVAL=${INTERVAL:-60}
+REMOTE=${REMOTE:-origin}
+BASE_BRANCH=${BASE_BRANCH:-main}
+WORKFLOW=${WORKFLOW:-deploy-production.yml}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+plist_escape() {
+  sed \
+    -e 's/&/\&amp;/g' \
+    -e 's/</\&lt;/g' \
+    -e 's/>/\&gt;/g' \
+    -e 's/"/\&quot;/g' \
+    -e "s/'/\&apos;/g"
+}
+
+require_command launchctl
+require_command git
+require_command gh
+
+repo_root="$(git rev-parse --show-toplevel)"
+script_path="$repo_root/scripts/ops/watch-production-sync.sh"
+
+if [[ ! -x "$script_path" ]]; then
+  echo "Missing executable watcher: $script_path" >&2
+  exit 1
+fi
+
+launch_agents_dir="$HOME/Library/LaunchAgents"
+log_dir="$repo_root/.codex/logs"
+state_dir="$repo_root/.codex/state"
+plist_path="$launch_agents_dir/$LABEL.plist"
+
+mkdir -p "$launch_agents_dir" "$log_dir" "$state_dir"
+
+repo_root_xml="$(printf '%s' "$repo_root" | plist_escape)"
+script_path_xml="$(printf '%s' "$script_path" | plist_escape)"
+path_xml="$(printf '%s' "$PATH" | plist_escape)"
+remote_xml="$(printf '%s' "$REMOTE" | plist_escape)"
+base_branch_xml="$(printf '%s' "$BASE_BRANCH" | plist_escape)"
+workflow_xml="$(printf '%s' "$WORKFLOW" | plist_escape)"
+interval_xml="$(printf '%s' "$INTERVAL" | plist_escape)"
+log_out_xml="$(printf '%s' "$log_dir/production-sync.out.log" | plist_escape)"
+log_err_xml="$(printf '%s' "$log_dir/production-sync.err.log" | plist_escape)"
+state_dir_xml="$(printf '%s' "$state_dir" | plist_escape)"
+
+cat > "$plist_path" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>$LABEL</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$script_path_xml</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>$repo_root_xml</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>$path_xml</string>
+    <key>REMOTE</key>
+    <string>$remote_xml</string>
+    <key>BASE_BRANCH</key>
+    <string>$base_branch_xml</string>
+    <key>WORKFLOW</key>
+    <string>$workflow_xml</string>
+    <key>INTERVAL</key>
+    <string>$interval_xml</string>
+    <key>STATE_DIR</key>
+    <string>$state_dir_xml</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>$log_out_xml</string>
+  <key>StandardErrorPath</key>
+  <string>$log_err_xml</string>
+</dict>
+</plist>
+PLIST
+
+launchctl bootout "gui/$(id -u)" "$plist_path" >/dev/null 2>&1 || true
+launchctl bootstrap "gui/$(id -u)" "$plist_path"
+launchctl enable "gui/$(id -u)/$LABEL"
+launchctl kickstart -k "gui/$(id -u)/$LABEL"
+
+echo "Installed launchd agent: $LABEL"
+echo "Plist: $plist_path"
+echo "Logs:"
+echo "  $log_dir/production-sync.out.log"
+echo "  $log_dir/production-sync.err.log"

--- a/scripts/ops/uninstall-macos-production-sync-launchd.sh
+++ b/scripts/ops/uninstall-macos-production-sync-launchd.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LABEL=${LABEL:-com.averray.agent.production-sync}
+plist_path="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+if command -v launchctl >/dev/null 2>&1; then
+  launchctl bootout "gui/$(id -u)" "$plist_path" >/dev/null 2>&1 || true
+fi
+
+rm -f "$plist_path"
+
+echo "Uninstalled launchd agent: $LABEL"

--- a/scripts/ops/watch-production-sync.sh
+++ b/scripts/ops/watch-production-sync.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Poll GitHub Actions for successful production deploys and fast-forward local
+# main after a new deploy succeeds. This never switches away from the caller's
+# current task branch; sync-local-main.sh handles the local main update.
+
+REMOTE=${REMOTE:-origin}
+BASE_BRANCH=${BASE_BRANCH:-main}
+WORKFLOW=${WORKFLOW:-deploy-production.yml}
+INTERVAL=${INTERVAL:-60}
+ONCE=${ONCE:-0}
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  ./scripts/ops/watch-production-sync.sh [--once]
+
+Environment:
+  REMOTE=origin                         git remote to sync from
+  BASE_BRANCH=main                      deployed branch to watch
+  WORKFLOW=deploy-production.yml         GitHub Actions workflow file/name
+  INTERVAL=60                           polling interval in seconds
+  GITHUB_REPOSITORY=owner/name           optional; inferred from origin
+  STATE_DIR=.codex/state                 local state directory
+  ONCE=1                                check once, then exit
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --once)
+      ONCE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+infer_repo() {
+  local remote_url repo
+  remote_url="$(git remote get-url "$REMOTE")"
+
+  case "$remote_url" in
+    https://github.com/*)
+      repo="${remote_url#https://github.com/}"
+      ;;
+    git@github.com:*)
+      repo="${remote_url#git@github.com:}"
+      ;;
+    *)
+      echo "Could not infer GitHub repository from $REMOTE URL: $remote_url" >&2
+      echo "Set GITHUB_REPOSITORY=owner/name and try again." >&2
+      exit 1
+      ;;
+  esac
+
+  repo="${repo%.git}"
+  echo "$repo"
+}
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+require_command gh
+require_command git
+
+GITHUB_REPOSITORY=${GITHUB_REPOSITORY:-$(infer_repo)}
+STATE_DIR=${STATE_DIR:-"$repo_root/.codex/state"}
+last_file="$STATE_DIR/last-production-sync"
+
+mkdir -p "$STATE_DIR"
+
+check_once() {
+  local line status conclusion head_sha run_id run_url previous_synced local_main
+
+  line="$(
+    gh run list \
+      --repo "$GITHUB_REPOSITORY" \
+      --workflow "$WORKFLOW" \
+      --branch "$BASE_BRANCH" \
+      --limit 1 \
+      --json databaseId,status,conclusion,headSha,url \
+      --jq 'if length == 0 then "" else .[0] | [.status, .conclusion, .headSha, (.databaseId | tostring), .url] | @tsv end'
+  )"
+
+  if [[ -z "$line" ]]; then
+    echo "No $WORKFLOW runs found for $GITHUB_REPOSITORY@$BASE_BRANCH"
+    return 0
+  fi
+
+  IFS=$'\t' read -r status conclusion head_sha run_id run_url <<<"$line"
+
+  if [[ "$status" != "completed" || "$conclusion" != "success" ]]; then
+    echo "Latest deploy is not successful yet: run=$run_id status=$status conclusion=${conclusion:-none}"
+    return 0
+  fi
+
+  previous_synced=""
+  if [[ -f "$last_file" ]]; then
+    previous_synced="$(<"$last_file")"
+  fi
+
+  local_main=""
+  if git show-ref --verify --quiet "refs/heads/$BASE_BRANCH"; then
+    local_main="$(git rev-parse "$BASE_BRANCH")"
+  fi
+
+  if [[ "$previous_synced" == "$head_sha" && "$local_main" == "$head_sha" ]]; then
+    echo "Already synced deployed $BASE_BRANCH at ${head_sha:0:7}"
+    return 0
+  fi
+
+  echo "Syncing local $BASE_BRANCH to successful deploy ${head_sha:0:7} from run $run_id"
+  "$repo_root/scripts/ops/sync-local-main.sh"
+
+  if git show-ref --verify --quiet "refs/heads/$BASE_BRANCH"; then
+    local_main="$(git rev-parse "$BASE_BRANCH")"
+  else
+    local_main=""
+  fi
+
+  if [[ "$local_main" != "$head_sha" ]]; then
+    echo "Warning: synced $BASE_BRANCH to ${local_main:0:7}, but latest deploy is ${head_sha:0:7}" >&2
+    echo "Deploy URL: $run_url" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$head_sha" > "$last_file"
+  echo "Synced local $BASE_BRANCH to deployed ${head_sha:0:7}"
+}
+
+if [[ "$ONCE" == "1" ]]; then
+  check_once
+  exit 0
+fi
+
+echo "Watching $GITHUB_REPOSITORY $WORKFLOW on $BASE_BRANCH every ${INTERVAL}s"
+echo "State: $last_file"
+
+while true; do
+  check_once || true
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
## Summary
- add a watcher that polls Deploy Production and syncs local main after successful deploys
- add macOS launchd install/uninstall helpers for a login/background watcher
- document the local production-sync flow for multi-agent work

## Checks
- bash -n scripts/ops/watch-production-sync.sh scripts/ops/install-macos-production-sync-launchd.sh scripts/ops/uninstall-macos-production-sync-launchd.sh
- git diff --check
- ./scripts/ops/watch-production-sync.sh --once

## Notes
- GitHub still cannot push into a developer laptop; this runs locally on macOS and pulls after deploy succeeds.
- The watcher does not switch away from active task branches.
