### PR TITLE
operator-app: empty states, dead-button hygiene, narrow audit timeline

### DIFF
--- a/app/app/(authed)/overview/page.tsx
+++ b/app/app/(authed)/overview/page.tsx
@@ -376,11 +376,15 @@ export default function OverviewPage() {
     <div className="flex w-full max-w-[1100px] flex-col gap-7">
       <OverviewTopbar />
       <MissionHero
-        openRuns={liveJobs.length || 14}
-        awaitingSignature={disputedSessions || 2}
+        // Use the explicit `hasLiveOverview` gate rather than `||`
+        // fallbacks — the previous form (`liveJobs.length || 14`) silently
+        // showed the fixture's `14` whenever live data legitimately
+        // returned zero rows, masking real "queue is empty" signals.
+        openRuns={hasLiveOverview ? liveJobs.length : 14}
+        awaitingSignature={hasLiveOverview ? disputedSessions : 2}
         lastReceiptTime={health.data ? "live" : "14:08 UTC"}
         treasuryPosture={liveVitals[3]?.value === "Amber" ? "Amber" : "Green"}
-        policiesAppliedToday={liveLanes.length || 22}
+        policiesAppliedToday={hasLiveOverview ? liveLanes.length : 22}
       />
       <RoomVitals vitals={vitals} comparedTo={hasLiveOverview ? "live API" : "14:08 UTC yesterday"} />
       <NeedsActionList alerts={alerts} meta={`${alerts.length} open`} />

--- a/app/components/agents/AgentDirectoryTable.tsx
+++ b/app/components/agents/AgentDirectoryTable.tsx
@@ -173,7 +173,9 @@ export function AgentDirectoryTable({
         </span>
         <button
           type="button"
-          className="inline-flex h-7 items-center gap-1.5 rounded-[8px] bg-[var(--avy-accent)] px-3 font-[family-name:var(--font-display)] text-[11px] font-bold uppercase text-[var(--fg-invert)] transition-transform hover:-translate-y-px hover:bg-[var(--avy-accent-2)]"
+          disabled
+          title="Agent invites are not yet wired to a live backend."
+          className="inline-flex h-7 cursor-not-allowed items-center gap-1.5 rounded-[8px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-3 font-[family-name:var(--font-display)] text-[11px] font-bold uppercase text-[var(--avy-muted)] opacity-60"
           style={{ letterSpacing: "0.04em" }}
         >
           ＋ Invite new agent

--- a/app/components/audit/AuditTimeline.tsx
+++ b/app/components/audit/AuditTimeline.tsx
@@ -77,8 +77,13 @@ export function AuditTimeline({ events }: { events: AuditEvent[] }) {
 function EventCard({ event }: { event: AuditEvent }) {
   return (
     <li
+      // Stack vertically at narrow widths so timestamp/source/body/actor/
+      // link don't get crushed into a fragile 5-column grid below ~900px.
+      // At md+ (≥768px) the original 5-column layout takes over via
+      // arbitrary-value grid-cols.
       className={cn(
-        "grid items-start gap-3 rounded-[10px] border border-[var(--avy-line)] bg-[var(--avy-paper)] px-4 py-3 shadow-[var(--shadow-card)] backdrop-blur-[8px] transition-colors hover:border-[color:rgba(30,102,66,0.28)]",
+        "flex flex-col gap-2 rounded-[10px] border border-[var(--avy-line)] bg-[var(--avy-paper)] px-4 py-3 shadow-[var(--shadow-card)] backdrop-blur-[8px] transition-colors hover:border-[color:rgba(30,102,66,0.28)]",
+        "md:grid md:grid-cols-[76px_110px_1fr_200px_auto] md:items-start md:gap-3",
         event.tone === "warn" &&
           "border-l-[3px] border-l-[var(--avy-warn)]",
         event.tone === "bad" &&
@@ -86,7 +91,6 @@ function EventCard({ event }: { event: AuditEvent }) {
         event.tone === "accent" &&
           "border-l-[3px] border-l-[var(--avy-accent)]"
       )}
-      style={{ gridTemplateColumns: "76px 110px 1fr 200px auto" }}
     >
       <div className="flex flex-col">
         <span

--- a/app/components/disputes/DisputesTable.tsx
+++ b/app/components/disputes/DisputesTable.tsx
@@ -131,12 +131,6 @@ export function DisputesTable({
           <b className="font-semibold text-[var(--avy-ink)]">{totalCount}</b> · queue empty
           when resolved
         </span>
-        <button
-          type="button"
-          className="cursor-pointer border-b border-dashed border-[color:rgba(30,102,66,0.4)] pb-px text-[var(--avy-accent)] hover:text-[var(--avy-accent-2)]"
-        >
-          What happens at window expiry? →
-        </button>
       </footer>
     </div>
   );

--- a/app/components/receipts/ReceiptsTable.tsx
+++ b/app/components/receipts/ReceiptsTable.tsx
@@ -55,7 +55,18 @@ export function ReceiptsTable({
             </tr>
           </thead>
           <tbody>
-            {rows.map((row) => {
+            {rows.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={7}
+                  className="p-8 text-center font-[family-name:var(--font-mono)] text-[13px] text-[var(--avy-muted)]"
+                  style={{ letterSpacing: 0 }}
+                >
+                  No receipts match these filters.
+                </td>
+              </tr>
+            ) : (
+              rows.map((row) => {
               const selected = row.id === selectedId;
               return (
                 <tr
@@ -120,27 +131,22 @@ export function ReceiptsTable({
                   </Td>
                 </tr>
               );
-            })}
+            })
+            )}
           </tbody>
         </table>
       </div>
 
       <footer className="flex items-center justify-between gap-3 border-t border-[var(--avy-line-soft)] bg-[rgba(250,248,241,0.5)] px-4 py-3 font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]">
-        <div className="flex items-center gap-3.5">
-          <span>
-            Showing <b className="font-semibold text-[var(--avy-ink)]">{shownCount}</b> of{" "}
-            <b className="font-semibold text-[var(--avy-ink)]">{totalCount.toLocaleString()}</b>
-          </span>
-          <button
-            type="button"
-            className="cursor-pointer border-b border-dashed border-[color:rgba(30,102,66,0.4)] pb-px text-[var(--avy-accent)] hover:text-[var(--avy-accent-2)]"
-          >
-            load more
-          </button>
-        </div>
+        <span>
+          Showing <b className="font-semibold text-[var(--avy-ink)]">{shownCount}</b> of{" "}
+          <b className="font-semibold text-[var(--avy-ink)]">{totalCount.toLocaleString()}</b>
+        </span>
         <button
           type="button"
-          className="cursor-pointer rounded-[6px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-3 py-1.5 font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase text-[var(--avy-ink)] hover:border-[color:rgba(30,102,66,0.3)] hover:text-[var(--avy-accent)]"
+          disabled
+          title="Manifest export is not yet wired to a live backend."
+          className="cursor-not-allowed rounded-[6px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-3 py-1.5 font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase text-[var(--avy-muted)] opacity-60"
           style={{ letterSpacing: "0.1em" }}
         >
           ⤓ Download signed manifest of this view

--- a/app/components/sessions/SessionsTable.tsx
+++ b/app/components/sessions/SessionsTable.tsx
@@ -36,7 +36,7 @@ export function SessionsTable({
         <table className="w-full border-collapse font-[family-name:var(--font-body)] text-[13px]">
           <thead>
             <tr>
-              <Th width={140}>Session · run</Th>
+              <Th width={140}>Session id · run</Th>
               <Th>Job</Th>
               <Th>Worker</Th>
               <Th align="right" width={110}>Escrow</Th>

--- a/app/components/treasury/CreditLinePanel.tsx
+++ b/app/components/treasury/CreditLinePanel.tsx
@@ -70,9 +70,16 @@ export function CreditLinePanel({
         </div>
 
         <div className="grid gap-2.5 border-t border-[var(--avy-line-soft)] pt-3">
-          {loans.map((loan) => (
-            <LoanRow key={loan.id} loan={loan} />
-          ))}
+          {loans.length === 0 ? (
+            <p
+              className="m-0 rounded-[8px] border border-dashed border-[var(--avy-line)] bg-[rgba(255,253,247,0.5)] px-3 py-3 text-center font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-muted)]"
+              style={{ letterSpacing: 0 }}
+            >
+              No active loans against this credit line.
+            </p>
+          ) : (
+            loans.map((loan) => <LoanRow key={loan.id} loan={loan} />)
+          )}
         </div>
       </div>
     </TreasuryPanel>
@@ -106,7 +113,9 @@ function LoanRow({ loan }: { loan: ActiveLoan }) {
       </div>
       <button
         type="button"
-        className="rounded-[6px] border border-[var(--avy-accent)] bg-[var(--avy-accent)] px-2.5 py-1 font-[family-name:var(--font-display)] text-[10.5px] font-bold uppercase text-[var(--fg-invert)] transition-transform hover:-translate-y-px"
+        disabled
+        title="Loan repayment is not yet wired to a live backend."
+        className="cursor-not-allowed rounded-[6px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-2.5 py-1 font-[family-name:var(--font-display)] text-[10.5px] font-bold uppercase text-[var(--avy-muted)] opacity-60"
         style={{ letterSpacing: "0.08em" }}
       >
         Repay

--- a/app/components/treasury/StrategyRoutingTable.tsx
+++ b/app/components/treasury/StrategyRoutingTable.tsx
@@ -75,10 +75,18 @@ export function StrategyRoutingTable({ lanes, sub }: StrategyRoutingTableProps) 
                 </Td>
                 <Td>
                   <div className="flex justify-end gap-1.5">
-                    <TinyBtn primary={lane.allocatePrimary} disabled={lane.allocateDisabled}>
+                    <TinyBtn
+                      disabled
+                      title="Strategy allocation is not yet wired to a live backend."
+                    >
                       Allocate
                     </TinyBtn>
-                    <TinyBtn>Deallocate</TinyBtn>
+                    <TinyBtn
+                      disabled
+                      title="Strategy allocation is not yet wired to a live backend."
+                    >
+                      Deallocate
+                    </TinyBtn>
                   </div>
                 </Td>
               </tr>
@@ -175,15 +183,18 @@ function TinyBtn({
   children,
   primary,
   disabled,
+  title,
 }: {
   children: React.ReactNode;
   primary?: boolean;
   disabled?: boolean;
+  title?: string;
 }) {
   return (
     <button
       type="button"
       disabled={disabled}
+      title={title}
       className={cn(
         "rounded-[6px] border px-2.5 py-1 font-[family-name:var(--font-display)] text-[10.5px] font-bold uppercase transition-colors",
         primary


### PR DESCRIPTION
## Summary
First of three follow-up polish PRs after the Runs detail pass (#14). Cross-page operator hygiene only — no backend/indexer/contract changes.

**Bugs fixed**

- `ReceiptsTable` rendered a header-only table when `rows.length === 0`. Now matches the empty-state treatment used by Sessions/Disputes.
- `CreditLinePanel` rendered a header followed by nothing when `loans.length === 0`. Now shows a dashed empty card.
- Overview's mission hero used `||` fallbacks (`liveJobs.length || 14`) so a legitimate "live API returned zero rows" silently displayed the fixture `14`. Switched to the explicit `hasLiveOverview` gate (same pattern already used for vitals/lanes a few lines down).
- Sessions table header `Session · run` implied a single entity, but the cell shows two stacked values. Renamed `Session id · run` to match the cell.

**Dead affordances**

Buttons without handlers were either disabled with an honest tooltip (preserves design intent) or removed when they were pure info-only:

- Disabled + `title="… not yet wired to a live backend"`: Receipts manifest export, Treasury Repay, Strategy Allocate/Deallocate, Agents "Invite new agent".
- Removed entirely: Receipts "load more", Disputes "What happens at window expiry?" (both were dashed underline links pointing nowhere).

**Polish**

`AuditTimeline` rows used a fixed 5-column grid via inline style (`76px 110px 1fr 200px auto`). The audit-log page is `max-w-[1100px]`, so narrow viewports were squeezing the actor + link columns into a fragile layout. Now stacks vertically at base and uses the 5-col grid at md+ (≥768px) via Tailwind arbitrary-value `grid-cols-[…]`.

## Files
- `app/app/(authed)/overview/page.tsx` — live-vs-fixture priority gate
- `app/components/receipts/ReceiptsTable.tsx` — empty state, dead buttons
- `app/components/disputes/DisputesTable.tsx` — drop dead info link
- `app/components/treasury/CreditLinePanel.tsx` — empty state, disabled Repay
- `app/components/treasury/StrategyRoutingTable.tsx` — disabled Allocate/Deallocate, threaded title prop
- `app/components/agents/AgentDirectoryTable.tsx` — disabled Invite
- `app/components/sessions/SessionsTable.tsx` — header copy
- `app/components/audit/AuditTimeline.tsx` — responsive grid

## Test plan
- [x] `npm run typecheck:app`
- [x] `npm run build:frontend` (15/15 pages, no warnings)
- [ ] Visit `/receipts` with the filter set to a state that returns no rows — empty-state row renders
- [ ] Visit `/treasury` — credit line empty card renders when no active loans; Repay/Allocate/Deallocate disabled with hover tooltip
- [ ] Visit `/agents` — Invite button disabled with tooltip
- [ ] Visit `/audit-log`, narrow the viewport to < 700px — rows stack cleanly instead of crushing into a broken 5-col grid
- [ ] Visit `/overview` against a live API that returns zero jobs — mission hero now reads `0` rather than the fixture `14`
- [ ] Visit `/sessions` — header reads `Session id · run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)