### PR TITLE
Allow staged indexer registry rollout

### DIFF
--- a/indexer/ponder.config.ts
+++ b/indexer/ponder.config.ts
@@ -41,20 +41,21 @@ const reputationSbtAddress = requireAddress(
   process.env.PONDER_REPUTATION_SBT_ADDRESS ?? process.env.REPUTATION_SBT_ADDRESS,
   "REPUTATION_SBT_ADDRESS"
 );
-const verifierRegistryAddress = requireAddress(
+const verifierRegistryAddress = optionalAddress(
   process.env.PONDER_VERIFIER_REGISTRY_ADDRESS ?? process.env.VERIFIER_REGISTRY_ADDRESS,
   "VERIFIER_REGISTRY_ADDRESS"
 );
-const discoveryRegistryAddress = requireAddress(
+const discoveryRegistryAddress = optionalAddress(
   process.env.PONDER_DISCOVERY_REGISTRY_ADDRESS ?? process.env.DISCOVERY_REGISTRY_ADDRESS,
   "DISCOVERY_REGISTRY_ADDRESS"
 );
-const disclosureLogAddress = requireAddress(
+const disclosureLogAddress = optionalAddress(
   process.env.PONDER_DISCLOSURE_LOG_ADDRESS ?? process.env.DISCLOSURE_LOG_ADDRESS,
   "DISCLOSURE_LOG_ADDRESS"
 );
 const xcmWrapperAddress = optionalAddress(
-  process.env.PONDER_XCM_WRAPPER_ADDRESS ?? process.env.XCM_WRAPPER_ADDRESS
+  process.env.PONDER_XCM_WRAPPER_ADDRESS ?? process.env.XCM_WRAPPER_ADDRESS,
+  "XCM_WRAPPER_ADDRESS"
 );
 
 const treasuryStartBlock = parseStartBlock(
@@ -103,24 +104,36 @@ const contracts = {
     address: reputationSbtAddress,
     startBlock: reputationStartBlock
   },
-  VerifierRegistry: {
-    chain: chainName,
-    abi: VerifierRegistryAbi,
-    address: verifierRegistryAddress,
-    startBlock: registryStartBlock
-  },
-  DiscoveryRegistry: {
-    chain: chainName,
-    abi: DiscoveryRegistryAbi,
-    address: discoveryRegistryAddress,
-    startBlock: registryStartBlock
-  },
-  DisclosureLog: {
-    chain: chainName,
-    abi: DisclosureLogAbi,
-    address: disclosureLogAddress,
-    startBlock: registryStartBlock
-  },
+  ...(verifierRegistryAddress
+    ? {
+        VerifierRegistry: {
+          chain: chainName,
+          abi: VerifierRegistryAbi,
+          address: verifierRegistryAddress,
+          startBlock: registryStartBlock
+        }
+      }
+    : {}),
+  ...(discoveryRegistryAddress
+    ? {
+        DiscoveryRegistry: {
+          chain: chainName,
+          abi: DiscoveryRegistryAbi,
+          address: discoveryRegistryAddress,
+          startBlock: registryStartBlock
+        }
+      }
+    : {}),
+  ...(disclosureLogAddress
+    ? {
+        DisclosureLog: {
+          chain: chainName,
+          abi: DisclosureLogAbi,
+          address: disclosureLogAddress,
+          startBlock: registryStartBlock
+        }
+      }
+    : {}),
   ...(xcmWrapperAddress
     ? {
         XcmWrapper: {
@@ -192,11 +205,11 @@ function requireAddress(raw: string | undefined, name: string): Address {
   return value as Address;
 }
 
-function optionalAddress(raw: string | undefined): Address | undefined {
+function optionalAddress(raw: string | undefined, name: string): Address | undefined {
   const value = raw?.trim();
   if (!value) return undefined;
   if (!/^0x[0-9a-fA-F]{40}$/u.test(value)) {
-    throw new Error(`Ponder: optional address ${value} is not a valid 20-byte EVM address.`);
+    throw new Error(`Ponder: ${name}=${value} is not a valid 20-byte EVM address.`);
   }
   return value as Address;
 }

--- a/indexer/src/index.ts
+++ b/indexer/src/index.ts
@@ -13,6 +13,15 @@ const zeroHash = `0x${"0".repeat(64)}` as `0x${string}`;
 const hasXcmWrapper = Boolean(
   process.env.PONDER_XCM_WRAPPER_ADDRESS?.trim() || process.env.XCM_WRAPPER_ADDRESS?.trim()
 );
+const hasVerifierRegistry = Boolean(
+  process.env.PONDER_VERIFIER_REGISTRY_ADDRESS?.trim() || process.env.VERIFIER_REGISTRY_ADDRESS?.trim()
+);
+const hasDiscoveryRegistry = Boolean(
+  process.env.PONDER_DISCOVERY_REGISTRY_ADDRESS?.trim() || process.env.DISCOVERY_REGISTRY_ADDRESS?.trim()
+);
+const hasDisclosureLog = Boolean(
+  process.env.PONDER_DISCLOSURE_LOG_ADDRESS?.trim() || process.env.DISCLOSURE_LOG_ADDRESS?.trim()
+);
 
 const decodeBytes32 = (value: string) => {
   try {
@@ -361,7 +370,8 @@ ponder.on("TreasuryPolicy:OutflowRecorded", async ({ event, context }) => {
   });
 });
 
-ponder.on("DiscoveryRegistry:ManifestPublished", async ({ event, context }) => {
+if (hasDiscoveryRegistry) {
+ponder.on("DiscoveryRegistry:ManifestPublished" as any, async ({ event, context }: any) => {
   await context.db.insert(schema.manifestPublication).values({
     id: toEventId(event.transaction.hash, event.log.logIndex),
     version: event.args.version,
@@ -372,8 +382,10 @@ ponder.on("DiscoveryRegistry:ManifestPublished", async ({ event, context }) => {
     timestamp: event.block.timestamp
   });
 });
+}
 
-ponder.on("VerifierRegistry:VerifierAdded", async ({ event, context }) => {
+if (hasVerifierRegistry) {
+ponder.on("VerifierRegistry:VerifierAdded" as any, async ({ event, context }: any) => {
   await context.db.insert(schema.verifierRegistryEvent).values({
     id: toEventId(event.transaction.hash, event.log.logIndex),
     kind: "VerifierAdded",
@@ -386,7 +398,7 @@ ponder.on("VerifierRegistry:VerifierAdded", async ({ event, context }) => {
   });
 });
 
-ponder.on("VerifierRegistry:VerifierRemoved", async ({ event, context }) => {
+ponder.on("VerifierRegistry:VerifierRemoved" as any, async ({ event, context }: any) => {
   await context.db.insert(schema.verifierRegistryEvent).values({
     id: toEventId(event.transaction.hash, event.log.logIndex),
     kind: "VerifierRemoved",
@@ -399,7 +411,7 @@ ponder.on("VerifierRegistry:VerifierRemoved", async ({ event, context }) => {
   });
 });
 
-ponder.on("VerifierRegistry:AdminTransferred", async ({ event, context }) => {
+ponder.on("VerifierRegistry:AdminTransferred" as any, async ({ event, context }: any) => {
   await context.db.insert(schema.verifierRegistryEvent).values({
     id: toEventId(event.transaction.hash, event.log.logIndex),
     kind: "AdminTransferred",
@@ -411,8 +423,10 @@ ponder.on("VerifierRegistry:AdminTransferred", async ({ event, context }) => {
     timestamp: event.block.timestamp
   });
 });
+}
 
-ponder.on("DisclosureLog:Disclosed", async ({ event, context }) => {
+if (hasDisclosureLog) {
+ponder.on("DisclosureLog:Disclosed" as any, async ({ event, context }: any) => {
   await context.db.insert(schema.disclosureEvent).values({
     id: toEventId(event.transaction.hash, event.log.logIndex),
     kind: "Disclosed",
@@ -424,7 +438,7 @@ ponder.on("DisclosureLog:Disclosed", async ({ event, context }) => {
   });
 });
 
-ponder.on("DisclosureLog:AutoDisclosed", async ({ event, context }) => {
+ponder.on("DisclosureLog:AutoDisclosed" as any, async ({ event, context }: any) => {
   await context.db.insert(schema.disclosureEvent).values({
     id: toEventId(event.transaction.hash, event.log.logIndex),
     kind: "AutoDisclosed",
@@ -435,6 +449,7 @@ ponder.on("DisclosureLog:AutoDisclosed", async ({ event, context }) => {
     timestamp: event.block.timestamp
   });
 });
+}
 
 ponder.on("AgentAccountCore:JobStakeLocked", async ({ event, context }) => {
   await context.db.insert(schema.jobStakeEvent).values({


### PR DESCRIPTION
## Summary
- make VerifierRegistry, DiscoveryRegistry, and DisclosureLog optional in the indexer config
- register registry/disclosure event handlers only when the corresponding contract address is configured
- keep existing core escrow, account, reputation, treasury, and optional XCM indexing behavior

## Verification
- npm --workspace indexer run typecheck
- git diff --check

This follows the same staged rollout intent as #19: production can boot before the new rc1 registry contracts are deployed and wired into env.