### PR TITLE
operator-app: roll out SourceBadge across Sessions/Agents/Receipts/Disputes

### DIFF
--- a/app/app/(authed)/agents/page.tsx
+++ b/app/app/(authed)/agents/page.tsx
@@ -39,7 +39,7 @@ const AGENTS: AgentRecord[] = [
     },
     specialty: "writer-gov",
     stake: { deposited: 1200, locked: 240, available: 960, slashed30: 0 },
-    activity: { msg: "Claimed run-2744", ref: "run-2744", when: "2m ago" },
+    activity: { msg: "Claimed run-2744", ref: "run-2744", when: "2m ago", source: "wikipedia" },
     state: "active",
     recentRuns: [
       { id: "run-2744", title: "docs refresh — v3.2", receipt: "r_4e14a", state: "Verified" },
@@ -69,7 +69,7 @@ const AGENTS: AgentRecord[] = [
     },
     specialty: "coding",
     stake: { deposited: 1500, locked: 420, available: 1080, slashed30: 0 },
-    activity: { msg: "Verified run-2735", ref: "run-2735", when: "14m ago" },
+    activity: { msg: "Verified run-2735", ref: "run-2735", when: "14m ago", source: "github" },
     state: "active",
     recentRuns: [
       { id: "run-2735", title: "lint & format sweep", receipt: "r_4e0c2", state: "Verified" },

--- a/app/app/(authed)/receipts/page.tsx
+++ b/app/app/(authed)/receipts/page.tsx
@@ -115,6 +115,7 @@ const ROWS: ReceiptRow[] = [
     kind: "run",
     subject: "run-2745",
     subjectSub: "coding-hand-3",
+    source: "github",
     signers: [
       { initials: "P", tone: "sage", role: "operator", address: "0xFd2EAE…6519" },
       { initials: "C", tone: "ink", role: "cosigner", address: "0x9A13BC…0cb2" },
@@ -142,6 +143,7 @@ const ROWS: ReceiptRow[] = [
     kind: "run",
     subject: "run-2744",
     subjectSub: "writer-gov-1",
+    source: "wikipedia",
     signers: [
       { initials: "P", tone: "sage", role: "operator", address: "0xFd2EAE…6519" },
       { initials: "C", tone: "ink", role: "cosigner", address: "0x9A13BC…0cb2" },

--- a/app/components/agents/AgentDirectoryTable.tsx
+++ b/app/components/agents/AgentDirectoryTable.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils/cn";
 import { Sparkline } from "@/components/overview/Sparkline";
 import { BadgeStrip } from "./BadgeStrip";
 import { TierChip } from "./TierChip";
+import { SourceBadge } from "@/components/runs/StatePill";
 import type { AgentRecord } from "./types";
 
 export interface AgentDirectoryTableProps {
@@ -124,20 +125,25 @@ export function AgentDirectoryTable({
                       </div>
                     </Td>
                     <Td>
-                      <div
-                        className="text-[13px] leading-[1.3] text-[var(--avy-ink)]"
-                        style={{ letterSpacing: 0 }}
-                      >
-                        {activityParts.map((chunk, i, arr) => (
-                          <span key={i}>
-                            {chunk}
-                            {i < arr.length - 1 ? (
-                              <span className="font-[family-name:var(--font-mono)] text-[var(--avy-accent)]">
-                                {a.activity.ref}
-                              </span>
-                            ) : null}
-                          </span>
-                        ))}
+                      <div className="flex items-center gap-2">
+                        {a.activity.source ? (
+                          <SourceBadge kind={a.activity.source} />
+                        ) : null}
+                        <span
+                          className="text-[13px] leading-[1.3] text-[var(--avy-ink)]"
+                          style={{ letterSpacing: 0 }}
+                        >
+                          {activityParts.map((chunk, i, arr) => (
+                            <span key={i}>
+                              {chunk}
+                              {i < arr.length - 1 ? (
+                                <span className="font-[family-name:var(--font-mono)] text-[var(--avy-accent)]">
+                                  {a.activity.ref}
+                                </span>
+                              ) : null}
+                            </span>
+                          ))}
+                        </span>
                       </div>
                       <div
                         className="mt-0.5 font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"

--- a/app/components/agents/types.ts
+++ b/app/components/agents/types.ts
@@ -1,3 +1,5 @@
+import type { SourceKind } from "@/components/runs/StatePill";
+
 export type AgentTier = "T1" | "T2" | "T3";
 export type AgentState = "active" | "idle" | "slashed";
 export type AgentSpecialty = "coding" | "writer-gov" | "ops" | "gov-review";
@@ -41,7 +43,13 @@ export interface AgentRecord {
   badgeDates: Record<string, string>;
   specialty: AgentSpecialty;
   stake: AgentStake;
-  activity: { msg: string; ref: string; when: string };
+  /**
+   * Last meaningful action by this agent. `source` is set when the
+   * activity is on an ingested-source run (GitHub PR / Wikipedia
+   * proposal) so the directory row can render a SourceBadge — receipts
+   * and policy refs leave it undefined.
+   */
+  activity: { msg: string; ref: string; when: string; source?: SourceKind };
   state: AgentState;
   recentRuns: AgentRecentRun[];
   slashes: AgentSlash[];

--- a/app/components/disputes/DisputesTable.tsx
+++ b/app/components/disputes/DisputesTable.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils/cn";
 import { DisputeStatePill, OriginPill } from "./pills";
 import { PartyChip } from "./PartyChip";
 import { WindowCountdown } from "./WindowCountdown";
+import { SourceBadge } from "@/components/runs/StatePill";
 import type { Dispute } from "./types";
 
 export interface DisputesTableProps {
@@ -79,12 +80,15 @@ export function DisputesTable({
                       </span>
                     </Td>
                     <Td>
-                      <span
-                        className="font-[family-name:var(--font-mono)] text-[12.5px] text-[var(--avy-ink)]"
-                        style={{ letterSpacing: 0 }}
-                      >
-                        {d.runRef}
-                      </span>
+                      <div className="flex items-center gap-1.5">
+                        {d.source ? <SourceBadge kind={d.source} /> : null}
+                        <span
+                          className="font-[family-name:var(--font-mono)] text-[12.5px] text-[var(--avy-ink)]"
+                          style={{ letterSpacing: 0 }}
+                        >
+                          {d.runRef}
+                        </span>
+                      </div>
                     </Td>
                     <Td>
                       <PartyChip party={d.opener} />

--- a/app/components/disputes/data.ts
+++ b/app/components/disputes/data.ts
@@ -9,6 +9,7 @@ export const DISPUTES: Dispute[] = [
   {
     id: "d_4e10c",
     runRef: "run-2739",
+    source: "github",
     openingReceipt: "r_4e10c",
     summary:
       "Signature on handoff payload did not verify against the claim-hash; stake frozen pending review.",
@@ -129,6 +130,7 @@ export const DISPUTES: Dispute[] = [
   {
     id: "d_4e04e",
     runRef: "run-2736",
+    source: "wikipedia",
     openingReceipt: "r_4e04e",
     summary:
       "Co-signer has not attested within the policy window; settlement blocked until second signature.",

--- a/app/components/disputes/types.ts
+++ b/app/components/disputes/types.ts
@@ -6,6 +6,8 @@
  * the reasons a verifier or co-signer would contest a claim.
  */
 
+import type { SourceKind } from "@/components/runs/StatePill";
+
 export type DisputeState =
   | "open"
   | "awaiting-evidence"
@@ -63,6 +65,14 @@ export interface DisputeTimelineEvent {
 export interface Dispute {
   id: string;
   runRef: string;
+  /**
+   * Provenance of the disputed run — orthogonal to `origin`, which is
+   * the *reason* a dispute was raised (signature, schema, …). When
+   * present, the table renders a SourceBadge alongside the run ref so
+   * the operator can see whether they're triaging a GitHub-PR vs.
+   * Wikipedia-proposal-review dispute without opening the drawer.
+   */
+  source?: SourceKind;
   openingReceipt: string;
   summary: string;
   origin: DisputeOrigin;

--- a/app/components/receipts/ReceiptsTable.tsx
+++ b/app/components/receipts/ReceiptsTable.tsx
@@ -3,12 +3,21 @@
 import { cn } from "@/lib/utils/cn";
 import { KindChip, type ReceiptKind } from "./KindChip";
 import { SignerAvatars, type Signer } from "./SignerAvatars";
+import { SourceBadge, type SourceKind } from "@/components/runs/StatePill";
 
 export interface ReceiptRow {
   id: string;
   kind: ReceiptKind;
   subject: string;
   subjectSub: string;
+  /**
+   * Provenance of the underlying run/job. Optional because non-run
+   * receipts (badge, policy, settle on a loan) usually don't carry a
+   * platform source. When present, the table renders a SourceBadge so
+   * an auditor can scan GitHub-PR vs. Wikipedia-proposal receipts at
+   * a glance instead of opening the drawer.
+   */
+  source?: SourceKind;
   signers: Signer[];
   policy: string;
   size: string;
@@ -89,11 +98,14 @@ export function ReceiptsTable({
                     <KindChip kind={row.kind} />
                   </Td>
                   <Td>
-                    <div
-                      className="font-[family-name:var(--font-mono)] text-[12.5px] text-[var(--avy-ink)]"
-                      style={{ letterSpacing: 0 }}
-                    >
-                      {row.subject}
+                    <div className="flex items-center gap-2">
+                      {row.source ? <SourceBadge kind={row.source} /> : null}
+                      <span
+                        className="font-[family-name:var(--font-mono)] text-[12.5px] text-[var(--avy-ink)]"
+                        style={{ letterSpacing: 0 }}
+                      >
+                        {row.subject}
+                      </span>
                     </div>
                     <div
                       className="font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]"

--- a/app/components/sessions/SessionsTable.tsx
+++ b/app/components/sessions/SessionsTable.tsx
@@ -3,6 +3,7 @@
 import { cn } from "@/lib/utils/cn";
 import { SessionStatePill, VerifierModeChip } from "./pills";
 import { WorkerChip } from "./WorkerChip";
+import { SourceBadge } from "@/components/runs/StatePill";
 import type { SessionDetail } from "./types";
 
 export interface SessionsTableProps {
@@ -84,8 +85,11 @@ export function SessionsTable({
                       </div>
                     </Td>
                     <Td>
-                      <div className="text-[13px] leading-tight text-[var(--avy-ink)]">
-                        {s.job.title}
+                      <div className="flex items-center gap-2">
+                        {s.source ? <SourceBadge kind={s.source} /> : null}
+                        <span className="text-[13px] leading-tight text-[var(--avy-ink)]">
+                          {s.job.title}
+                        </span>
                       </div>
                       <div
                         className="mt-0.5 font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"

--- a/app/components/sessions/data.ts
+++ b/app/components/sessions/data.ts
@@ -8,6 +8,7 @@ export const SESSIONS: SessionDetail[] = [
   {
     id: "sess_a91c…4412",
     runRef: "run-2742",
+    source: "github",
     job: { title: "gov-review: proposal 0x7a0c abstract", meta: "job-0418 · writer-gov · T2" },
     worker: { handle: "writer-gov-1", address: "0xFd2E…6519", initials: "FD", tone: "sage" },
     state: "approved",
@@ -85,6 +86,7 @@ export const SESSIONS: SessionDetail[] = [
   {
     id: "sess_a90b…31fa",
     runRef: "run-2738",
+    source: "wikipedia",
     job: { title: "docs refresh — v3.1", meta: "job-0411 · writer-gov · T1" },
     worker: { handle: "writer-gov-1", address: "0xFd2E…6519", initials: "FD", tone: "sage" },
     state: "settled",
@@ -228,6 +230,7 @@ export const SESSIONS: SessionDetail[] = [
   {
     id: "sess_a8e4…77b1",
     runRef: "run-2711",
+    source: "github",
     job: { title: "writer: OP-14 cited summary", meta: "job-0396 · writer-gov · T2" },
     worker: { handle: "writer-gov-2", address: "0x5C17F0…4a90", initials: "W2", tone: "clay" },
     state: "slashed",

--- a/app/components/sessions/types.ts
+++ b/app/components/sessions/types.ts
@@ -6,6 +6,8 @@
  * This page is the auditor's read-only log of every session across all runs.
  */
 
+import type { SourceKind } from "@/components/runs/StatePill";
+
 export type SessionState =
   | "active"
   | "submitted"
@@ -53,6 +55,13 @@ export interface PayoutEntry {
 export interface SessionRow {
   id: string;
   runRef: string;
+  /**
+   * Provenance of the run this session is keyed to. Optional because
+   * legacy/native runs predate ingested sources. When set, the row renders
+   * a small SourceBadge so an auditor can scan GitHub-PR vs. Wikipedia-
+   * proposal-review sessions without opening the drawer.
+   */
+  source?: SourceKind;
   job: { title: string; meta: string };
   worker: {
     handle: string;


### PR DESCRIPTION
## Summary
Second of three follow-up polish PRs after #14 / #18. Surfaces the existing `SourceBadge` (currently only used on the Runs surface) on the four other operator tables that show mixed-source data today without a provenance cue, so an auditor can scan GitHub-PR vs. Wikipedia-proposal rows at a glance.

**Type contract** (additive, optional)

Each affected row type gains an optional `source?: SourceKind`:
- `SessionRow`
- `ReceiptRow`
- `Dispute`
- `AgentRecord["activity"]`

Optional because (a) legacy/native rows have no ingested provenance and (b) the live API doesn't yet emit `source` on these surfaces. Tables render the badge only when the field is set, so this is safe against current data shapes.

**Per-table wiring**

- **Sessions**: `SourceBadge` in the Job cell next to the title.
- **Receipts**: `SourceBadge` in the Subject cell next to the run id.
- **Disputes**: `SourceBadge` in the Run cell next to the run ref. Kept alongside the existing `OriginPill` (which encodes the dispute *reason* — signature, schema, policy-violation — and is orthogonal to source).
- **Agents**: `SourceBadge` inline in the recent-activity cell when the activity points at an ingested-source run; left undefined for receipt / policy / co-sign refs where source doesn't apply.

**Fixtures**

Representative rows tagged so the demo shows a mix of `github` / `wikipedia` / native instead of all-or-nothing. No structural fixture change beyond setting the new optional field.

## Files
- `app/components/sessions/{types.ts, SessionsTable.tsx, data.ts}`
- `app/components/receipts/ReceiptsTable.tsx`, `app/app/(authed)/receipts/page.tsx`
- `app/components/disputes/{types.ts, DisputesTable.tsx, data.ts}`
- `app/components/agents/{types.ts, AgentDirectoryTable.tsx}`, `app/app/(authed)/agents/page.tsx`

## Test plan
- [x] \`npm run typecheck:app\`
- [x] \`npm run build:frontend\` (15/15 pages)
- [ ] /sessions — the writer-gov rows pointing at run-2742 (GitHub) and run-2738 (Wikipedia) show distinct SourceBadges
- [ ] /receipts — r_4e14c (run-2745) shows GitHub badge; r_4e14a (run-2744) shows Wikipedia badge; non-run receipts (settle, badge, policy) show no badge
- [ ] /disputes — d_4e10c (run-2739) shows GitHub badge alongside its existing signature OriginPill; d_4e04e shows Wikipedia
- [ ] /agents — writer-gov-1 row activity ("Claimed run-2744") shows Wikipedia badge; coding-hand-1 ("Verified run-2735") shows GitHub; gov-review-2 ("Co-signed r_4e12a") shows no badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)