### PR TITLE
Add OSV npm advisory ingestion

### DIFF
--- a/docs/PUBLIC_JOB_SOURCES.md
+++ b/docs/PUBLIC_JOB_SOURCES.md
@@ -105,6 +105,10 @@ After Wikipedia, use the same pattern for:
 3. **OSV/NVD advisories**
    - package-to-CVE mapping, remediation summaries
    - structured impact notes
+   - v1 ingestion is allowlist-driven and npm-only:
+     `POST /admin/jobs/ingest/osv` accepts package/version/repo targets,
+     queries OSV, and emits dependency remediation PR jobs when a fixed version
+     exists. CVE aliases link to NVD for operator review.
 
 4. **Stack Exchange / Discourse**
    - unanswered-question triage, duplicate detection, answer summaries

--- a/docs/READY_TO_POST_JOBS.md
+++ b/docs/READY_TO_POST_JOBS.md
@@ -342,6 +342,37 @@ Analytics/Pageviews APIs, and dumps from `https://dumps.wikimedia.org/`.
 
 ---
 
+## OSV / NVD dependency jobs
+
+The first security-advisory provider is intentionally allowlist-driven. Operators
+provide npm package targets with the vulnerable version and intended repository,
+then OSV supplies advisory facts. CVE aliases link out to NVD, but OSV remains
+the ingestion API.
+
+Preview jobs through:
+
+```bash
+npm --workspace mcp-server run ingest:osv-advisories -- --dry-run \
+  --packages '[{"name":"minimist","version":"0.0.8","repo":"example/app","manifestPath":"package.json"}]'
+```
+
+Or through the admin API:
+
+```http
+POST /admin/jobs/ingest/osv
+```
+
+The generated jobs use:
+
+- `schema://jobs/dependency-remediation-input`
+- `schema://jobs/dependency-remediation-output`
+
+Only post jobs when OSV reports a fixed version. The worker should open a
+focused PR that bumps the dependency, updates lockfiles, references the
+OSV/GHSA/CVE identifiers, and includes test or install evidence.
+
+---
+
 ## Before posting
 
 Quick operator checklist:

--- a/docs/schemas/jobs/dependency-remediation-input.json
+++ b/docs/schemas/jobs/dependency-remediation-input.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "schema://jobs/dependency-remediation-input",
+  "type": "object",
+  "description": "Dependency vulnerability remediation input from public advisory sources such as OSV/NVD.",
+  "required": [
+    "ecosystem",
+    "packageName",
+    "vulnerableVersion",
+    "fixedVersion",
+    "advisoryIds",
+    "instructions"
+  ],
+  "properties": {
+    "ecosystem": {
+      "type": "string",
+      "enum": ["npm"]
+    },
+    "packageName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "vulnerableVersion": {
+      "type": "string",
+      "minLength": 1
+    },
+    "fixedVersion": {
+      "type": "string",
+      "minLength": 1
+    },
+    "repo": {
+      "type": "string"
+    },
+    "manifestPath": {
+      "type": "string"
+    },
+    "advisoryIds": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    },
+    "advisoryUrls": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "instructions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/docs/schemas/jobs/dependency-remediation-output.json
+++ b/docs/schemas/jobs/dependency-remediation-output.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "schema://jobs/dependency-remediation-output",
+  "type": "object",
+  "description": "Structured pull request evidence for a dependency vulnerability remediation.",
+  "required": [
+    "prUrl",
+    "packageName",
+    "vulnerableVersion",
+    "fixedVersion",
+    "advisoryIds",
+    "summary",
+    "tests"
+  ],
+  "properties": {
+    "prUrl": {
+      "type": "string",
+      "minLength": 1
+    },
+    "packageName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "vulnerableVersion": {
+      "type": "string",
+      "minLength": 1
+    },
+    "fixedVersion": {
+      "type": "string",
+      "minLength": 1
+    },
+    "advisoryIds": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tests": {
+      "type": "string",
+      "minLength": 1
+    },
+    "repo": {
+      "type": "string"
+    },
+    "manifestPath": {
+      "type": "string"
+    },
+    "lockfilesUpdated": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "filesChanged": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "ciStatus": {
+      "type": "string",
+      "enum": ["unknown", "pending", "passing", "failing"]
+    },
+    "checksPassing": {
+      "type": "boolean"
+    },
+    "notes": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": true
+}

--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -134,6 +134,15 @@ AUTH_CHAIN_ID=420420417
 # WIKIPEDIA_INGEST_MAX_OPEN_JOBS=20
 # WIKIPEDIA_INGEST_CATEGORIES_JSON=[{"title":"Category:All articles with dead external links","taskType":"citation_repair"},{"title":"Category:Wikipedia articles in need of updating","taskType":"freshness_check"}]
 
+# --- OSV / NVD dependency advisory job ingestion -----------------------------
+# v1 is allowlist-driven and npm-only: provide package/version/repo targets,
+# then the ingestor queries OSV and emits dependency remediation jobs only when
+# a fixed version is discoverable. CVE aliases link out to NVD.
+# CLI preview:
+# npm --workspace mcp-server run ingest:osv-advisories -- --dry-run --packages '[{"name":"minimist","version":"0.0.8","repo":"example/app","manifestPath":"package.json"}]'
+# Admin preview/create endpoint: POST /admin/jobs/ingest/osv
+# OSV_INGEST_PACKAGES_JSON=[{"name":"minimist","version":"0.0.8","repo":"example/app","manifestPath":"package.json"}]
+
 # --- Supported on-chain assets ------------------------------------------------
 # Legacy shorthand still works:
 # SUPPORTED_ASSETS=DOT:0x5555555555555555555555555555555555555555

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -11,7 +11,8 @@
     "demo:e2e:remote": "node src/demo/e2e-remote.js",
     "check:redis": "node src/demo/redis-persistence-check.js",
     "ingest:github-issues": "node src/jobs/ingest-github-issues.js",
-    "ingest:wikipedia": "node src/jobs/ingest-wikipedia-maintenance.js"
+    "ingest:wikipedia": "node src/jobs/ingest-wikipedia-maintenance.js",
+    "ingest:osv-advisories": "node src/jobs/ingest-osv-advisories.js"
   },
   "dependencies": {
     "ethers": "^6.16.0",

--- a/mcp-server/src/core/discovery-manifest.js
+++ b/mcp-server/src/core/discovery-manifest.js
@@ -41,6 +41,7 @@ const DISCOVERY_AUTHENTICATED_ENDPOINTS = [
   { path: "/jobs/recommendations", description: "Tier-gated recommendation list with fit score + unlock hints." },
   { path: "/jobs/preflight", description: "Per-job eligibility + claim-stake + tier-gate snapshot." },
   { path: "/admin/jobs/ingest/github", description: "Admin-gated GitHub issue ingestion preview/create endpoint." },
+  { path: "/admin/jobs/ingest/osv", description: "Admin-gated OSV npm advisory ingestion preview/create endpoint." },
   { path: "/admin/jobs/ingest/wikipedia", description: "Admin-gated Wikipedia maintenance ingestion preview/create endpoint." },
   { path: "/disputes", description: "Operator dispute queue derived from sessions requiring human review." },
   { path: "/disputes/:id", description: "Detailed dispute evidence, timeline, verdict, and stake release state." },

--- a/mcp-server/src/core/job-schema-registry.js
+++ b/mcp-server/src/core/job-schema-registry.js
@@ -176,6 +176,43 @@ const BUILTIN_JOB_SCHEMAS = new Map([
       fix_recommendation: stringSchema({ minLength: 1 })
     }
   })],
+  ["schema://jobs/dependency-remediation-input", objectSchema({
+    $id: "schema://jobs/dependency-remediation-input",
+    description: "Dependency vulnerability remediation input from public advisory sources such as OSV/NVD.",
+    required: ["ecosystem", "packageName", "vulnerableVersion", "fixedVersion", "advisoryIds", "instructions"],
+    properties: {
+      ecosystem: enumString(["npm"]),
+      packageName: stringSchema({ minLength: 1 }),
+      vulnerableVersion: stringSchema({ minLength: 1 }),
+      fixedVersion: stringSchema({ minLength: 1 }),
+      repo: stringSchema(),
+      manifestPath: stringSchema(),
+      advisoryIds: arrayOfStrings({ minItems: 1 }),
+      advisoryUrls: arrayOfStrings(),
+      instructions: arrayOfStrings({ minItems: 1 })
+    }
+  })],
+  ["schema://jobs/dependency-remediation-output", objectSchema({
+    $id: "schema://jobs/dependency-remediation-output",
+    description: "Structured pull request evidence for a dependency vulnerability remediation.",
+    required: ["prUrl", "packageName", "vulnerableVersion", "fixedVersion", "advisoryIds", "summary", "tests"],
+    properties: {
+      prUrl: stringSchema({ minLength: 1 }),
+      packageName: stringSchema({ minLength: 1 }),
+      vulnerableVersion: stringSchema({ minLength: 1 }),
+      fixedVersion: stringSchema({ minLength: 1 }),
+      advisoryIds: arrayOfStrings({ minItems: 1 }),
+      summary: stringSchema({ minLength: 1 }),
+      tests: stringSchema({ minLength: 1 }),
+      repo: stringSchema(),
+      manifestPath: stringSchema(),
+      lockfilesUpdated: arrayOfStrings(),
+      filesChanged: arrayOfStrings(),
+      ciStatus: enumString(["unknown", "pending", "passing", "failing"]),
+      checksPassing: booleanSchema(),
+      notes: stringSchema()
+    }
+  })],
   ["schema://jobs/wikipedia-maintenance-input", objectSchema({
     $id: "schema://jobs/wikipedia-maintenance-input",
     description: "Wikipedia public article maintenance job input.",

--- a/mcp-server/src/core/job-schema-registry.test.js
+++ b/mcp-server/src/core/job-schema-registry.test.js
@@ -81,6 +81,26 @@ test("validateStructuredSubmission accepts Wikipedia citation repair payload", (
   });
 });
 
+test("validateStructuredSubmission accepts dependency remediation evidence", () => {
+  const payload = {
+    prUrl: "https://github.com/example/app/pull/12",
+    packageName: "minimist",
+    vulnerableVersion: "0.0.8",
+    fixedVersion: "1.2.3",
+    advisoryIds: ["GHSA-vh95-rmgr-6w4m", "CVE-2020-7598"],
+    summary: "Updated minimist and regenerated the npm lockfile.",
+    tests: "npm test passed",
+    manifestPath: "package.json",
+    lockfilesUpdated: ["package-lock.json"],
+    checksPassing: true,
+    ciStatus: "passing"
+  };
+
+  assert.doesNotThrow(() => {
+    validateStructuredSubmission("schema://jobs/dependency-remediation-output", payload);
+  });
+});
+
 test("validateStructuredSubmission rejects missing required fields", () => {
   assert.throws(
     () => validateStructuredSubmission("schema://jobs/pr-review-findings-output", {

--- a/mcp-server/src/jobs/ingest-osv-advisories.js
+++ b/mcp-server/src/jobs/ingest-osv-advisories.js
@@ -1,0 +1,413 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+
+/**
+ * Ingest OSV package advisories into dependency remediation jobs.
+ *
+ * The v1 provider is intentionally allowlist-driven: operators provide npm
+ * package/version/repo targets, OSV supplies the advisory facts, and Averray
+ * emits PR-shaped remediation jobs only when a fixed version is discoverable.
+ *
+ * Example:
+ *   AGENT_ADMIN_TOKEN=... npm run ingest:osv-advisories -- \
+ *     --packages '[{"name":"minimist","version":"0.0.8","repo":"example/app"}]' \
+ *     --dry-run
+ */
+
+export const DEFAULT_BASE_URL = "http://localhost:8787";
+export const DEFAULT_ECOSYSTEM = "npm";
+export const OSV_QUERY_BATCH_URL = "https://api.osv.dev/v1/querybatch";
+
+const ECOSYSTEMS = new Set(["npm"]);
+
+export function parseArgs(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith("--")) continue;
+    const key = arg.slice(2);
+    if (key.includes("=")) {
+      const [name, ...rest] = key.split("=");
+      parsed[name] = rest.join("=");
+      continue;
+    }
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      parsed[key] = true;
+      continue;
+    }
+    parsed[key] = next;
+    index += 1;
+  }
+  return parsed;
+}
+
+export async function ingestOsvAdvisories({
+  packages = [],
+  limit = 10,
+  minScore = 55,
+  fetchImpl = fetch
+} = {}) {
+  const targets = parsePackages(packages);
+  if (!targets.length) {
+    return { ecosystem: DEFAULT_ECOSYSTEM, minScore, count: 0, jobs: [], skipped: [] };
+  }
+
+  const results = await queryOsvBatch({ packages: targets, fetchImpl });
+  const skipped = [];
+  const candidates = [];
+
+  targets.forEach((target, index) => {
+    const vulns = results[index]?.vulns ?? [];
+    if (!vulns.length) {
+      skipped.push({ package: target.name, version: target.version, reason: "no_vulnerabilities" });
+      return;
+    }
+    for (const advisory of vulns) {
+      const fixedVersion = findFixedVersion(advisory, target);
+      const score = scoreAdvisory(advisory, { fixedVersion });
+      if (!fixedVersion) {
+        skipped.push({ package: target.name, version: target.version, advisoryId: advisory.id, reason: "no_fixed_version" });
+        continue;
+      }
+      if (score < minScore) {
+        skipped.push({ package: target.name, version: target.version, advisoryId: advisory.id, reason: "below_min_score", score });
+        continue;
+      }
+      candidates.push({ target, advisory, fixedVersion, score });
+    }
+  });
+
+  const jobs = candidates
+    .sort((left, right) => right.score - left.score)
+    .slice(0, limit)
+    .map(({ target, advisory, fixedVersion, score }) => toPlatformJob({ target, advisory, fixedVersion, score }));
+
+  if (candidates.length > jobs.length) {
+    skipped.push({ reason: "over_limit", count: candidates.length - jobs.length });
+  }
+
+  return {
+    ecosystem: DEFAULT_ECOSYSTEM,
+    minScore,
+    count: jobs.length,
+    jobs,
+    skipped
+  };
+}
+
+export async function queryOsvBatch({ packages, fetchImpl = fetch }) {
+  const response = await fetchImpl(OSV_QUERY_BATCH_URL, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+      "user-agent": "AverrayOsvIngest/0.1 (https://averray.com; operator@averray.com)"
+    },
+    body: JSON.stringify({
+      queries: packages.map((target) => ({
+        version: target.version,
+        package: {
+          name: target.name,
+          ecosystem: target.ecosystem
+        }
+      }))
+    })
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`OSV querybatch failed (${response.status}): ${body}`);
+  }
+  const payload = await response.json();
+  return payload.results ?? [];
+}
+
+export function parsePackages(raw) {
+  const parsed = typeof raw === "string" ? parsePackageString(raw) : raw;
+  if (!Array.isArray(parsed)) return [];
+  return parsed.map(normalizePackageTarget).filter(Boolean);
+}
+
+export function scoreAdvisory(advisory, { fixedVersion } = {}) {
+  let score = 30;
+  const severity = maxCvssScore(advisory);
+  if (fixedVersion) score += 30;
+  if (severity >= 9) score += 25;
+  else if (severity >= 7) score += 20;
+  else if (severity >= 4) score += 10;
+  if (hasAlias(advisory, "CVE-")) score += 10;
+  if (hasAlias(advisory, "GHSA-")) score += 5;
+  if (String(advisory.details ?? advisory.summary ?? "").length > 2000) score -= 10;
+  return Math.max(0, Math.min(100, score));
+}
+
+export function toPlatformJob({ target, advisory, fixedVersion, score = scoreAdvisory(advisory, { fixedVersion }) }) {
+  const advisoryId = String(advisory.id ?? "OSV-UNKNOWN");
+  const aliases = advisoryAliases(advisory);
+  const cves = aliases.filter((alias) => alias.startsWith("CVE-"));
+  const references = advisoryReferences(advisory);
+  const repo = target.repo ? normalizeRepo(target.repo) : undefined;
+  const manifestPath = target.manifestPath ?? "package.json";
+  const title = `Remediate ${advisoryId} in ${target.name}`;
+  const id = `osv-npm-${slugify(repo ?? "repo")}-${slugify(target.name)}-${slugify(target.version)}-${slugify(advisoryId)}`.slice(0, 120);
+
+  return {
+    id,
+    title,
+    description:
+      `Update npm package ${target.name} from vulnerable version ${target.version} to ${fixedVersion} or a newer safe release. Advisory: ${advisoryId}.`,
+    jobType: "work",
+    requiredRole: "worker",
+    category: "security",
+    tier: "starter-plus",
+    rewardAsset: "DOT",
+    rewardAmount: 3,
+    verifierMode: "github_pr",
+    verifierMinimumScore: 70,
+    requireTestEvidence: true,
+    inputSchemaRef: "schema://jobs/dependency-remediation-input",
+    outputSchemaRef: "schema://jobs/dependency-remediation-output",
+    claimTtlSeconds: 7200,
+    retryLimit: 1,
+    requiresSponsoredGas: true,
+    source: {
+      type: "osv_advisory",
+      provider: "osv",
+      ecosystem: target.ecosystem,
+      packageName: target.name,
+      vulnerableVersion: target.version,
+      fixedVersion,
+      repo,
+      manifestPath,
+      advisoryId,
+      aliases,
+      cves,
+      nvdUrls: cves.map((cve) => `https://nvd.nist.gov/vuln/detail/${cve}`),
+      summary: String(advisory.summary ?? "").trim(),
+      details: summarise(String(advisory.details ?? "")),
+      references,
+      severity: advisory.severity ?? [],
+      published: advisory.published,
+      modified: advisory.modified,
+      score,
+      discoveryApi: "https://api.osv.dev/v1/querybatch"
+    },
+    acceptanceCriteria: [
+      `Update ${target.name} in ${manifestPath} so ${target.version} is no longer selected.`,
+      `Use ${fixedVersion} or a newer non-vulnerable version when compatible.`,
+      "Update the lockfile when the ecosystem uses one.",
+      "Run the relevant package manager install/check/test commands, or explain why a command cannot be run.",
+      "Open a focused pull request that references the OSV advisory and any CVE/GHSA aliases."
+    ],
+    estimatedDifficulty: estimateDifficulty(score),
+    agentInstructions: [
+      ...(repo ? [`Work in https://github.com/${repo}.`] : ["Use the repository supplied by the operator before making changes."]),
+      `Review OSV advisory ${advisoryId}${aliases.length ? ` (${aliases.join(", ")})` : ""}.`,
+      `Find every occurrence of ${target.name}@${target.version} in ${manifestPath} and related lockfiles.`,
+      "Prefer the smallest safe dependency bump that satisfies the advisory.",
+      "Run tests or at least dependency installation/lockfile validation before submitting.",
+      "Submit structured evidence with prUrl, packageName, vulnerableVersion, fixedVersion, advisoryIds, tests, and notes."
+    ],
+    verification: {
+      method: "github_pr",
+      suggestedCheck: "dependency_no_longer_vulnerable",
+      evidenceSchemaRef: "schema://jobs/dependency-remediation-output",
+      signals: ["pr_opened", "advisory_referenced", "dependency_updated", "lockfile_updated", "tests_submitted", "ci_passed"]
+    }
+  };
+}
+
+export async function postJobs({ baseUrl, adminToken, jobs, fetchImpl = fetch }) {
+  const results = [];
+  for (const job of jobs) {
+    results.push(await createJob({ baseUrl, adminToken, job, fetchImpl }));
+  }
+  return results;
+}
+
+export async function createJob({ baseUrl, adminToken, job, fetchImpl = fetch }) {
+  const response = await fetchImpl(`${trimTrailingSlash(baseUrl)}/admin/jobs`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${adminToken}`,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify(job)
+  });
+  const body = await response.text();
+  let payload;
+  try {
+    payload = body ? JSON.parse(body) : {};
+  } catch {
+    payload = { raw: body };
+  }
+  return { id: job.id, status: response.status, ok: response.ok, payload };
+}
+
+function parsePackageString(raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed;
+  } catch {
+    // Fall through to compact line parser.
+  }
+  return String(raw)
+    .split(/\n|,/u)
+    .map((entry) => {
+      const [nameVersion, repo, manifestPath] = entry.split("|").map((part) => part?.trim());
+      const at = nameVersion?.lastIndexOf("@") ?? -1;
+      if (!nameVersion || at <= 0) return undefined;
+      return {
+        name: nameVersion.slice(0, at),
+        version: nameVersion.slice(at + 1),
+        repo,
+        manifestPath
+      };
+    })
+    .filter(Boolean);
+}
+
+function normalizePackageTarget(raw) {
+  const ecosystem = normalizeEcosystem(raw?.ecosystem ?? DEFAULT_ECOSYSTEM);
+  const name = String(raw?.name ?? "").trim();
+  const version = String(raw?.version ?? "").trim();
+  if (!name || !version || !ecosystem) return undefined;
+  return {
+    name,
+    version,
+    ecosystem,
+    ...(raw?.repo ? { repo: normalizeRepo(raw.repo) } : {}),
+    ...(raw?.manifestPath ? { manifestPath: String(raw.manifestPath).trim() } : {})
+  };
+}
+
+function normalizeEcosystem(value) {
+  const ecosystem = String(value ?? "").trim().toLowerCase();
+  if (ecosystem === "npm") return "npm";
+  return ECOSYSTEMS.has(ecosystem) ? ecosystem : undefined;
+}
+
+function normalizeRepo(value) {
+  return String(value ?? "")
+    .trim()
+    .replace(/^https:\/\/github\.com\//u, "")
+    .replace(/\.git$/u, "")
+    .replace(/^\/+|\/+$/gu, "");
+}
+
+export function findFixedVersion(advisory, target) {
+  const affected = advisory.affected ?? [];
+  const fixed = [];
+  for (const entry of affected) {
+    const pkg = entry.package ?? {};
+    if (String(pkg.ecosystem ?? "").toLowerCase() !== target.ecosystem) continue;
+    if (String(pkg.name ?? "") !== target.name) continue;
+    for (const range of entry.ranges ?? []) {
+      for (const event of range.events ?? []) {
+        if (event.fixed) fixed.push(String(event.fixed));
+      }
+    }
+  }
+  return fixed.sort(compareSemverish)[0];
+}
+
+function compareSemverish(left, right) {
+  const leftParts = String(left).split(/[.-]/u).map((part) => Number.parseInt(part, 10));
+  const rightParts = String(right).split(/[.-]/u).map((part) => Number.parseInt(part, 10));
+  for (let index = 0; index < Math.max(leftParts.length, rightParts.length); index += 1) {
+    const a = Number.isFinite(leftParts[index]) ? leftParts[index] : 0;
+    const b = Number.isFinite(rightParts[index]) ? rightParts[index] : 0;
+    if (a !== b) return a - b;
+  }
+  return String(left).localeCompare(String(right));
+}
+
+function maxCvssScore(advisory) {
+  return Math.max(
+    0,
+    ...(advisory.severity ?? []).map((entry) => {
+      const vector = String(entry.score ?? "");
+      const match = vector.match(/\/AV:[A-Z]\/AC:[A-Z]\/PR:[A-Z]\/UI:[A-Z]\/S:[A-Z]\/C:[A-Z]\/I:[A-Z]\/A:[A-Z]/u)
+        ? undefined
+        : vector.match(/^(\d+(?:\.\d+)?)$/u);
+      return match ? Number(match[1]) : 0;
+    })
+  );
+}
+
+function advisoryAliases(advisory) {
+  return [...new Set([advisory.id, ...(advisory.aliases ?? [])].map((alias) => String(alias ?? "").trim()).filter(Boolean))];
+}
+
+function hasAlias(advisory, prefix) {
+  return advisoryAliases(advisory).some((alias) => alias.startsWith(prefix));
+}
+
+function advisoryReferences(advisory) {
+  return (advisory.references ?? [])
+    .map((reference) => ({
+      type: String(reference.type ?? "REFERENCE"),
+      url: String(reference.url ?? "").trim()
+    }))
+    .filter((reference) => reference.url);
+}
+
+function estimateDifficulty(score) {
+  if (score >= 85) return "starter-plus";
+  if (score >= 70) return "starter";
+  return "review-needed";
+}
+
+function summarise(value) {
+  return value.length > 4000 ? `${value.slice(0, 3997)}...` : value;
+}
+
+function slugify(value) {
+  return String(value ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, "-")
+    .replace(/^-+|-+$/gu, "")
+    .replace(/-{2,}/gu, "-");
+}
+
+function parsePositiveInt(raw, fallback) {
+  const value = Number(raw);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function trimTrailingSlash(value) {
+  return String(value).replace(/\/+$/u, "");
+}
+
+async function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  const dryRun = Boolean(args["dry-run"]);
+  const packages = args.packages ?? process.env.OSV_INGEST_PACKAGES_JSON ?? process.env.OSV_INGEST_PACKAGES;
+  const limit = parsePositiveInt(args.limit, 10);
+  const minScore = parsePositiveInt(args["min-score"], 55);
+  const baseUrl = trimTrailingSlash(String(args.baseUrl ?? process.env.AGENT_API_BASE_URL ?? DEFAULT_BASE_URL));
+  const adminToken = process.env.AGENT_ADMIN_TOKEN?.trim();
+
+  if (!dryRun && !adminToken) {
+    fail("AGENT_ADMIN_TOKEN is required unless --dry-run is set.");
+  }
+
+  const dryRunPayload = await ingestOsvAdvisories({ packages, limit, minScore });
+  if (dryRun) {
+    console.log(JSON.stringify(dryRunPayload, null, 2));
+    return;
+  }
+
+  const results = await postJobs({ baseUrl, adminToken, jobs: dryRunPayload.jobs });
+  console.log(JSON.stringify({ ...dryRunPayload, results }, null, 2));
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await runCli();
+}

--- a/mcp-server/src/jobs/ingest-osv-advisories.test.js
+++ b/mcp-server/src/jobs/ingest-osv-advisories.test.js
@@ -1,0 +1,125 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  findFixedVersion,
+  ingestOsvAdvisories,
+  parsePackages,
+  scoreAdvisory,
+  toPlatformJob
+} from "./ingest-osv-advisories.js";
+
+const TARGET = {
+  name: "minimist",
+  version: "0.0.8",
+  ecosystem: "npm",
+  repo: "example/app",
+  manifestPath: "package.json"
+};
+
+const ADVISORY = {
+  id: "GHSA-vh95-rmgr-6w4m",
+  aliases: ["CVE-2020-7598"],
+  summary: "Prototype pollution in minimist",
+  details: "minimist before 1.2.3 allows prototype pollution.",
+  published: "2020-03-11T00:00:00Z",
+  modified: "2024-01-01T00:00:00Z",
+  severity: [{ type: "CVSS_V3", score: "7.5" }],
+  references: [
+    { type: "ADVISORY", url: "https://osv.dev/vulnerability/GHSA-vh95-rmgr-6w4m" },
+    { type: "WEB", url: "https://nvd.nist.gov/vuln/detail/CVE-2020-7598" }
+  ],
+  affected: [
+    {
+      package: { ecosystem: "npm", name: "minimist" },
+      ranges: [
+        {
+          type: "SEMVER",
+          events: [{ introduced: "0" }, { fixed: "1.2.3" }]
+        }
+      ]
+    }
+  ]
+};
+
+test("parsePackages accepts JSON and compact line syntax", () => {
+  assert.deepEqual(parsePackages(JSON.stringify([TARGET])), [TARGET]);
+  assert.deepEqual(parsePackages("minimist@0.0.8|example/app|package.json"), [TARGET]);
+});
+
+test("findFixedVersion extracts the first npm fixed release", () => {
+  assert.equal(findFixedVersion(ADVISORY, TARGET), "1.2.3");
+});
+
+test("scoreAdvisory prefers fixed CVE-backed advisories", () => {
+  assert.ok(scoreAdvisory(ADVISORY, { fixedVersion: "1.2.3" }) >= 85);
+});
+
+test("toPlatformJob creates a PR-shaped dependency remediation job", () => {
+  const job = toPlatformJob({ target: TARGET, advisory: ADVISORY, fixedVersion: "1.2.3", score: 92 });
+
+  assert.equal(job.id, "osv-npm-example-app-minimist-0-0-8-ghsa-vh95-rmgr-6w4m");
+  assert.equal(job.category, "security");
+  assert.equal(job.verifierMode, "github_pr");
+  assert.equal(job.inputSchemaRef, "schema://jobs/dependency-remediation-input");
+  assert.equal(job.outputSchemaRef, "schema://jobs/dependency-remediation-output");
+  assert.equal(job.source.type, "osv_advisory");
+  assert.equal(job.source.provider, "osv");
+  assert.equal(job.source.packageName, "minimist");
+  assert.equal(job.source.fixedVersion, "1.2.3");
+  assert.deepEqual(job.source.cves, ["CVE-2020-7598"]);
+  assert.ok(job.source.nvdUrls[0].includes("CVE-2020-7598"));
+  assert.ok(job.acceptanceCriteria.some((entry) => entry.includes("package.json")));
+  assert.ok(job.agentInstructions.some((entry) => entry.includes("GHSA-vh95-rmgr-6w4m")));
+});
+
+test("ingestOsvAdvisories queries OSV and filters jobs", async () => {
+  const payload = await ingestOsvAdvisories({
+    packages: [TARGET],
+    limit: 5,
+    minScore: 55,
+    fetchImpl: async (_url, request) => {
+      const body = JSON.parse(request.body);
+      assert.equal(body.queries[0].package.name, "minimist");
+      assert.equal(body.queries[0].package.ecosystem, "npm");
+      assert.equal(body.queries[0].version, "0.0.8");
+      return {
+        ok: true,
+        async json() {
+          return { results: [{ vulns: [ADVISORY] }] };
+        }
+      };
+    }
+  });
+
+  assert.equal(payload.count, 1);
+  assert.equal(payload.jobs[0].source.advisoryId, "GHSA-vh95-rmgr-6w4m");
+  assert.equal(payload.jobs[0].source.vulnerableVersion, "0.0.8");
+  assert.equal(payload.skipped.length, 0);
+});
+
+test("ingestOsvAdvisories skips advisories without a fixed version", async () => {
+  const payload = await ingestOsvAdvisories({
+    packages: [TARGET],
+    fetchImpl: async () => ({
+      ok: true,
+      async json() {
+        return {
+          results: [
+            {
+              vulns: [
+                {
+                  ...ADVISORY,
+                  affected: [{ package: { ecosystem: "npm", name: "minimist" }, ranges: [{ events: [{ introduced: "0" }] }] }]
+                }
+              ]
+            }
+          ]
+        };
+      }
+    })
+  });
+
+  assert.equal(payload.count, 0);
+  assert.equal(payload.skipped[0].reason, "no_fixed_version");
+});

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -23,6 +23,7 @@ import {
   schemaRefToJobSchemaPath
 } from "../../core/job-schema-registry.js";
 import { ingestGithubIssues } from "../../jobs/ingest-github-issues.js";
+import { ingestOsvAdvisories, parsePackages as parseOsvPackages } from "../../jobs/ingest-osv-advisories.js";
 import { ingestWikipediaMaintenance, parseCategories } from "../../jobs/ingest-wikipedia-maintenance.js";
 
 const {
@@ -817,6 +818,8 @@ function metricPathLabel(pathname) {
     "/strategies",
     "/admin/jobs",
     "/admin/jobs/ingest/github",
+    "/admin/jobs/ingest/osv",
+    "/admin/jobs/ingest/wikipedia",
     "/admin/jobs/pause",
     "/admin/jobs/resume",
     "/admin/xcm/observe",
@@ -1094,6 +1097,7 @@ const server = createServer(async (request, response) => {
           "/verifier/replay",
           "/admin/jobs",
           "/admin/jobs/ingest/github",
+          "/admin/jobs/ingest/osv",
           "/admin/jobs/ingest/wikipedia",
           "/admin/jobs/fire",
           "/admin/jobs/pause",
@@ -2203,6 +2207,58 @@ const server = createServer(async (request, response) => {
           ...skipped,
           ...(Number.isFinite(result.skipped) ? [{ reason: "below_min_score_or_over_limit", count: result.skipped }] : [])
         ],
+        errors
+      });
+    }
+
+    if (request.method === "POST" && pathname === "/admin/jobs/ingest/osv") {
+      const auth = await authMiddleware(request, url, { requireRole: "admin" });
+      await enforceLimit("admin_jobs", auth.wallet, rateLimitConfig.adminJobs);
+      const payload = await readJsonBody(request);
+      const packages = Array.isArray(payload?.packages) || typeof payload?.packages === "string"
+        ? parseOsvPackages(payload.packages)
+        : parseOsvPackages(process.env.OSV_INGEST_PACKAGES_JSON ?? process.env.OSV_INGEST_PACKAGES);
+      const limit = parsePositiveInteger(payload?.limit, 10, 50);
+      const minScore = parsePositiveInteger(payload?.minScore, 55, 100);
+      const dryRun = payload?.dryRun !== false;
+      const result = await ingestOsvAdvisories({ packages, limit, minScore });
+
+      if (dryRun) {
+        return respond(response, 200, {
+          ...result,
+          dryRun: true,
+          created: []
+        });
+      }
+
+      const created = [];
+      const skipped = [];
+      const errors = [];
+      for (const job of result.jobs) {
+        try {
+          created.push(service.createJob(job));
+        } catch (error) {
+          const normalized = normalizeError(error);
+          if (normalized.code === "job_exists") {
+            skipped.push({ id: job.id, reason: "already_exists" });
+            continue;
+          }
+          errors.push({
+            id: job.id,
+            code: normalized.code,
+            message: normalized.message
+          });
+        }
+      }
+
+      const status = errors.length ? 207 : 201;
+      return respond(response, status, {
+        ecosystem: result.ecosystem,
+        minScore: result.minScore,
+        dryRun: false,
+        candidateCount: result.count,
+        created,
+        skipped: [...skipped, ...(Array.isArray(result.skipped) ? result.skipped : [])],
         errors
       });
     }


### PR DESCRIPTION
## Summary
- add an OSV npm advisory ingestor that turns allowlisted package/version/repo targets into dependency remediation jobs
- add dependency remediation input/output schemas and registry validation
- expose POST /admin/jobs/ingest/osv plus CLI script and operator docs

## Checks
- npm --workspace mcp-server test
- git diff --check HEAD~1..HEAD

## Deploy impact
- Backend/admin API change only
- No new production secrets required
- OSV ingestion is manual/admin-triggered in this slice; no scheduler is enabled