### PR TITLE
Add Data.gov open-data ingestion

### DIFF
--- a/docs/PUBLIC_JOB_SOURCES.md
+++ b/docs/PUBLIC_JOB_SOURCES.md
@@ -101,6 +101,9 @@ After Wikipedia, use the same pattern for:
 2. **Government open data portals**
    - CSV/schema checks, metadata cleanup, broken links
    - before/after dataset reports
+   - v1 ingestion targets the US Data.gov CKAN catalog:
+     `POST /admin/jobs/ingest/open-data` searches catalog metadata or accepts
+     explicit dataset/resource targets, then emits proposal-only audit jobs.
 
 3. **OSV/NVD advisories**
    - package-to-CVE mapping, remediation summaries

--- a/docs/READY_TO_POST_JOBS.md
+++ b/docs/READY_TO_POST_JOBS.md
@@ -373,6 +373,38 @@ OSV/GHSA/CVE identifiers, and includes test or install evidence.
 
 ---
 
+## Data.gov open-data quality jobs
+
+The first government open-data provider targets the US Data.gov CKAN catalog.
+Data.gov exposes dataset metadata and resource URLs, not the actual data
+contents, so Averray jobs should stay audit/report shaped. Workers inspect the
+catalog landing page and referenced resource, then submit structured quality
+evidence rather than editing government systems.
+
+Preview jobs through:
+
+```bash
+npm --workspace mcp-server run ingest:open-data -- --dry-run \
+  --query 'res_format:CSV'
+```
+
+Or through the admin API:
+
+```http
+POST /admin/jobs/ingest/open-data
+```
+
+The generated jobs use:
+
+- `schema://jobs/open-data-quality-audit-input`
+- `schema://jobs/open-data-quality-audit-output`
+
+Each submission must include reachable dataset/resource evidence, completed
+checks, findings plus recommendations, or `no_issue_found=true` with evidence.
+Workers must not contact agencies or make direct edits to government datasets.
+
+---
+
 ## Before posting
 
 Quick operator checklist:

--- a/docs/schemas/jobs/open-data-quality-audit-input.json
+++ b/docs/schemas/jobs/open-data-quality-audit-input.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "schema://jobs/open-data-quality-audit-input",
+  "type": "object",
+  "description": "Public open-data dataset/resource quality audit input.",
+  "required": ["portal", "datasetTitle", "datasetUrl", "resourceUrl", "instructions"],
+  "properties": {
+    "portal": {
+      "type": "string",
+      "enum": ["data.gov"]
+    },
+    "datasetId": {
+      "type": "string"
+    },
+    "datasetTitle": {
+      "type": "string",
+      "minLength": 1
+    },
+    "datasetUrl": {
+      "type": "string",
+      "minLength": 1
+    },
+    "resourceId": {
+      "type": "string"
+    },
+    "resourceTitle": {
+      "type": "string"
+    },
+    "resourceUrl": {
+      "type": "string",
+      "minLength": 1
+    },
+    "resourceFormat": {
+      "type": "string"
+    },
+    "agency": {
+      "type": "string"
+    },
+    "license": {
+      "type": "string"
+    },
+    "modified": {
+      "type": "string"
+    },
+    "metadataModified": {
+      "type": "string"
+    },
+    "instructions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/docs/schemas/jobs/open-data-quality-audit-output.json
+++ b/docs/schemas/jobs/open-data-quality-audit-output.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "schema://jobs/open-data-quality-audit-output",
+  "type": "object",
+  "description": "Structured evidence for a public open-data dataset/resource quality audit.",
+  "required": [
+    "dataset_title",
+    "dataset_url",
+    "resource_url",
+    "checks",
+    "findings",
+    "no_issue_found",
+    "summary",
+    "recommended_actions"
+  ],
+  "properties": {
+    "dataset_title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "dataset_url": {
+      "type": "string",
+      "minLength": 1
+    },
+    "resource_url": {
+      "type": "string",
+      "minLength": 1
+    },
+    "resource_format": {
+      "type": "string"
+    },
+    "checks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "status", "evidence"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "status": {
+            "type": "string",
+            "enum": ["pass", "warn", "fail", "unknown"]
+          },
+          "evidence": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["severity", "issue", "evidence", "recommendation"],
+        "properties": {
+          "severity": {
+            "type": "string",
+            "enum": ["low", "medium", "high"]
+          },
+          "issue": {
+            "type": "string",
+            "minLength": 1
+          },
+          "evidence": {
+            "type": "string",
+            "minLength": 1
+          },
+          "recommendation": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "no_issue_found": {
+      "type": "boolean"
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "recommended_actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    },
+    "notes": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": true
+}

--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -143,6 +143,19 @@ AUTH_CHAIN_ID=420420417
 # Admin preview/create endpoint: POST /admin/jobs/ingest/osv
 # OSV_INGEST_PACKAGES_JSON=[{"name":"minimist","version":"0.0.8","repo":"example/app","manifestPath":"package.json"}]
 
+# --- Data.gov open-data quality-audit job ingestion --------------------------
+# v1 targets the US Data.gov CKAN catalog. The catalog API is metadata-only, so
+# jobs ask workers for reviewable dataset/resource audit reports: reachability,
+# schema/format notes, stale metadata, broken resource links, and recommended
+# cleanup actions.
+# CLI preview:
+# npm --workspace mcp-server run ingest:open-data -- --dry-run --query 'res_format:CSV'
+# Explicit dataset preview:
+# npm --workspace mcp-server run ingest:open-data -- --dry-run --datasets '[{"datasetTitle":"Federal sample spending data","datasetUrl":"https://catalog.data.gov/dataset/example","resourceUrl":"https://example.gov/data.csv","resourceFormat":"CSV","agency":"GSA"}]'
+# Admin preview/create endpoint: POST /admin/jobs/ingest/open-data
+# OPEN_DATA_INGEST_QUERY=res_format:CSV
+# OPEN_DATA_INGEST_DATASETS_JSON=[{"datasetTitle":"Federal sample spending data","datasetUrl":"https://catalog.data.gov/dataset/example","resourceUrl":"https://example.gov/data.csv","resourceFormat":"CSV","agency":"GSA"}]
+
 # --- Supported on-chain assets ------------------------------------------------
 # Legacy shorthand still works:
 # SUPPORTED_ASSETS=DOT:0x5555555555555555555555555555555555555555

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -12,7 +12,8 @@
     "check:redis": "node src/demo/redis-persistence-check.js",
     "ingest:github-issues": "node src/jobs/ingest-github-issues.js",
     "ingest:wikipedia": "node src/jobs/ingest-wikipedia-maintenance.js",
-    "ingest:osv-advisories": "node src/jobs/ingest-osv-advisories.js"
+    "ingest:osv-advisories": "node src/jobs/ingest-osv-advisories.js",
+    "ingest:open-data": "node src/jobs/ingest-open-data-datasets.js"
   },
   "dependencies": {
     "ethers": "^6.16.0",

--- a/mcp-server/src/core/discovery-manifest.js
+++ b/mcp-server/src/core/discovery-manifest.js
@@ -41,6 +41,7 @@ const DISCOVERY_AUTHENTICATED_ENDPOINTS = [
   { path: "/jobs/recommendations", description: "Tier-gated recommendation list with fit score + unlock hints." },
   { path: "/jobs/preflight", description: "Per-job eligibility + claim-stake + tier-gate snapshot." },
   { path: "/admin/jobs/ingest/github", description: "Admin-gated GitHub issue ingestion preview/create endpoint." },
+  { path: "/admin/jobs/ingest/open-data", description: "Admin-gated Data.gov open-data quality audit ingestion preview/create endpoint." },
   { path: "/admin/jobs/ingest/osv", description: "Admin-gated OSV npm advisory ingestion preview/create endpoint." },
   { path: "/admin/jobs/ingest/wikipedia", description: "Admin-gated Wikipedia maintenance ingestion preview/create endpoint." },
   { path: "/disputes", description: "Operator dispute queue derived from sessions requiring human review." },

--- a/mcp-server/src/core/job-schema-registry.js
+++ b/mcp-server/src/core/job-schema-registry.js
@@ -213,6 +213,65 @@ const BUILTIN_JOB_SCHEMAS = new Map([
       notes: stringSchema()
     }
   })],
+  ["schema://jobs/open-data-quality-audit-input", objectSchema({
+    $id: "schema://jobs/open-data-quality-audit-input",
+    description: "Public open-data dataset/resource quality audit input.",
+    required: ["portal", "datasetTitle", "datasetUrl", "resourceUrl", "instructions"],
+    properties: {
+      portal: enumString(["data.gov"]),
+      datasetId: stringSchema(),
+      datasetTitle: stringSchema({ minLength: 1 }),
+      datasetUrl: stringSchema({ minLength: 1 }),
+      resourceId: stringSchema(),
+      resourceTitle: stringSchema(),
+      resourceUrl: stringSchema({ minLength: 1 }),
+      resourceFormat: stringSchema(),
+      agency: stringSchema(),
+      license: stringSchema(),
+      modified: stringSchema(),
+      metadataModified: stringSchema(),
+      instructions: arrayOfStrings({ minItems: 1 })
+    }
+  })],
+  ["schema://jobs/open-data-quality-audit-output", objectSchema({
+    $id: "schema://jobs/open-data-quality-audit-output",
+    description: "Structured evidence for a public open-data dataset/resource quality audit.",
+    required: ["dataset_title", "dataset_url", "resource_url", "checks", "findings", "no_issue_found", "summary", "recommended_actions"],
+    properties: {
+      dataset_title: stringSchema({ minLength: 1 }),
+      dataset_url: stringSchema({ minLength: 1 }),
+      resource_url: stringSchema({ minLength: 1 }),
+      resource_format: stringSchema(),
+      checks: {
+        type: "array",
+        minItems: 1,
+        items: objectSchema({
+          required: ["name", "status", "evidence"],
+          properties: {
+            name: stringSchema({ minLength: 1 }),
+            status: enumString(["pass", "warn", "fail", "unknown"]),
+            evidence: stringSchema({ minLength: 1 })
+          }
+        })
+      },
+      findings: {
+        type: "array",
+        items: objectSchema({
+          required: ["severity", "issue", "evidence", "recommendation"],
+          properties: {
+            severity: enumString(["low", "medium", "high"]),
+            issue: stringSchema({ minLength: 1 }),
+            evidence: stringSchema({ minLength: 1 }),
+            recommendation: stringSchema({ minLength: 1 })
+          }
+        })
+      },
+      no_issue_found: booleanSchema(),
+      summary: stringSchema({ minLength: 1 }),
+      recommended_actions: arrayOfStrings({ minItems: 1 }),
+      notes: stringSchema()
+    }
+  })],
   ["schema://jobs/wikipedia-maintenance-input", objectSchema({
     $id: "schema://jobs/wikipedia-maintenance-input",
     description: "Wikipedia public article maintenance job input.",

--- a/mcp-server/src/core/job-schema-registry.test.js
+++ b/mcp-server/src/core/job-schema-registry.test.js
@@ -101,6 +101,37 @@ test("validateStructuredSubmission accepts dependency remediation evidence", () 
   });
 });
 
+test("validateStructuredSubmission accepts open-data audit evidence", () => {
+  const payload = {
+    dataset_title: "Federal sample spending data",
+    dataset_url: "https://catalog.data.gov/dataset/federal-sample-spending-data",
+    resource_url: "https://example.gov/spending.csv",
+    resource_format: "CSV",
+    checks: [
+      {
+        name: "resource_reachability",
+        status: "pass",
+        evidence: "HTTP 200 with text/csv content type."
+      }
+    ],
+    findings: [
+      {
+        severity: "low",
+        issue: "Metadata modified date is present but resource last_modified is five years old.",
+        evidence: "resource last_modified=2021-01-01",
+        recommendation: "Ask the publisher to confirm whether the resource is still refreshed."
+      }
+    ],
+    no_issue_found: false,
+    summary: "Resource is reachable; metadata freshness needs review.",
+    recommended_actions: ["Confirm refresh cadence", "Document column names in resource metadata"]
+  };
+
+  assert.doesNotThrow(() => {
+    validateStructuredSubmission("schema://jobs/open-data-quality-audit-output", payload);
+  });
+});
+
 test("validateStructuredSubmission rejects missing required fields", () => {
   assert.throws(
     () => validateStructuredSubmission("schema://jobs/pr-review-findings-output", {

--- a/mcp-server/src/jobs/ingest-open-data-datasets.js
+++ b/mcp-server/src/jobs/ingest-open-data-datasets.js
@@ -1,0 +1,376 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+
+/**
+ * Ingest public open-data dataset/resource quality-audit jobs.
+ *
+ * The v1 provider targets the US Data.gov CKAN catalog. Data.gov's API is a
+ * metadata catalog, not the dataset host, so generated jobs ask agents to
+ * produce reviewable audit reports: reachability, format/schema notes, stale
+ * metadata, broken resource links, and concrete improvement recommendations.
+ *
+ * Example:
+ *   AGENT_ADMIN_TOKEN=... npm run ingest:open-data -- \
+ *     --query 'res_format:CSV' \
+ *     --dry-run
+ */
+
+export const DEFAULT_BASE_URL = "http://localhost:8787";
+export const DEFAULT_PROVIDER = "data.gov";
+export const DEFAULT_QUERY = "res_format:CSV";
+export const DATA_GOV_PACKAGE_SEARCH_URL = "https://catalog.data.gov/api/3/action/package_search";
+
+const PREFERRED_RESOURCE_FORMATS = new Set(["CSV", "JSON", "GEOJSON", "API", "XLS", "XLSX", "XML"]);
+
+export function parseArgs(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith("--")) continue;
+    const key = arg.slice(2);
+    if (key.includes("=")) {
+      const [name, ...rest] = key.split("=");
+      parsed[name] = rest.join("=");
+      continue;
+    }
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      parsed[key] = true;
+      continue;
+    }
+    parsed[key] = next;
+    index += 1;
+  }
+  return parsed;
+}
+
+export async function ingestOpenDataDatasets({
+  datasets = [],
+  query = DEFAULT_QUERY,
+  limit = 10,
+  minScore = 55,
+  fetchImpl = fetch
+} = {}) {
+  const explicitTargets = parseDatasets(datasets);
+  const targets = explicitTargets.length
+    ? explicitTargets
+    : await searchDataGovDatasets({ query, limit: Math.max(limit * 3, 30), fetchImpl });
+
+  const skipped = [];
+  const candidates = [];
+  for (const target of targets) {
+    const score = scoreDatasetTarget(target);
+    if (!target.resourceUrl) {
+      skipped.push({ datasetId: target.datasetId, resourceId: target.resourceId, reason: "missing_resource_url" });
+      continue;
+    }
+    if (score < minScore) {
+      skipped.push({ datasetId: target.datasetId, resourceId: target.resourceId, reason: "below_min_score", score });
+      continue;
+    }
+    candidates.push({ target, score });
+  }
+
+  const jobs = candidates
+    .sort((left, right) => right.score - left.score)
+    .slice(0, limit)
+    .map(({ target, score }) => toPlatformJob(target, score));
+
+  if (candidates.length > jobs.length) {
+    skipped.push({ reason: "over_limit", count: candidates.length - jobs.length });
+  }
+
+  return {
+    provider: DEFAULT_PROVIDER,
+    query: explicitTargets.length ? undefined : query,
+    minScore,
+    count: jobs.length,
+    jobs,
+    skipped
+  };
+}
+
+export async function searchDataGovDatasets({ query = DEFAULT_QUERY, limit = 30, fetchImpl = fetch } = {}) {
+  const url = new URL(DATA_GOV_PACKAGE_SEARCH_URL);
+  url.searchParams.set("q", query);
+  url.searchParams.set("rows", String(Math.min(limit, 100)));
+  url.searchParams.set("sort", "metadata_modified desc");
+
+  const response = await fetchImpl(url, {
+    headers: {
+      accept: "application/json",
+      "user-agent": "AverrayOpenDataIngest/0.1 (https://averray.com; operator@averray.com)"
+    }
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Data.gov package_search failed (${response.status}): ${body}`);
+  }
+
+  const payload = await response.json();
+  const packages = payload.result?.results ?? [];
+  return packages.flatMap(extractPackageTargets);
+}
+
+export function parseDatasets(raw) {
+  const parsed = typeof raw === "string" ? parseDatasetString(raw) : raw;
+  if (!Array.isArray(parsed)) return [];
+  return parsed.map(normalizeDatasetTarget).filter(Boolean);
+}
+
+export function extractPackageTargets(pkg) {
+  const datasetId = text(pkg.id ?? pkg.name);
+  const datasetTitle = text(pkg.title ?? pkg.name);
+  const datasetUrl = pkg.name ? `https://catalog.data.gov/dataset/${pkg.name}` : text(pkg.url);
+  const agency = agencyName(pkg);
+  const license = text(pkg.license_title ?? pkg.license_id);
+  const metadataModified = text(pkg.metadata_modified);
+  const resources = Array.isArray(pkg.resources) ? pkg.resources : [];
+
+  return resources
+    .map((resource) => normalizeDatasetTarget({
+      portal: DEFAULT_PROVIDER,
+      datasetId,
+      datasetTitle,
+      datasetUrl,
+      resourceId: resource.id,
+      resourceTitle: resource.name ?? resource.description,
+      resourceUrl: resource.url,
+      resourceFormat: resource.format ?? resource.mimetype,
+      agency,
+      license,
+      modified: resource.last_modified ?? resource.revision_timestamp ?? metadataModified,
+      metadataModified
+    }))
+    .filter(Boolean);
+}
+
+export function scoreDatasetTarget(target) {
+  let score = 25;
+  if (target.datasetTitle) score += 8;
+  if (target.datasetUrl) score += 10;
+  if (target.resourceUrl) score += 22;
+  if (PREFERRED_RESOURCE_FORMATS.has(normalizeFormat(target.resourceFormat))) score += 16;
+  if (target.agency) score += 6;
+  if (target.license) score += 5;
+  if (target.modified || target.metadataModified) score += 8;
+  if (looksOld(target.modified ?? target.metadataModified)) score += 8;
+  if (!target.resourceUrl) score -= 40;
+  return Math.max(0, Math.min(100, score));
+}
+
+export function toPlatformJob(target, score = scoreDatasetTarget(target)) {
+  const format = normalizeFormat(target.resourceFormat) || "UNKNOWN";
+  const title = `Audit open-data resource: ${target.datasetTitle}`;
+  const id = `open-data-datagov-${slugify(target.datasetId || target.datasetTitle)}-${slugify(target.resourceId || target.resourceTitle || format)}`.slice(0, 120);
+
+  return {
+    id,
+    title,
+    description:
+      `Audit the Data.gov catalog resource "${target.resourceTitle || target.datasetTitle}" for reachability, format/schema clarity, stale metadata, and actionable cleanup recommendations.`,
+    jobType: "work",
+    requiredRole: "worker",
+    category: "data",
+    tier: "starter",
+    rewardAsset: "DOT",
+    rewardAmount: 2,
+    verifierMode: "benchmark",
+    verifierTerms: ["dataset_url", "resource_url", "checks", "recommended_actions"],
+    verifierMinimumMatches: 3,
+    inputSchemaRef: "schema://jobs/open-data-quality-audit-input",
+    outputSchemaRef: "schema://jobs/open-data-quality-audit-output",
+    claimTtlSeconds: 7200,
+    retryLimit: 1,
+    requiresSponsoredGas: true,
+    source: {
+      type: "open_data_dataset",
+      provider: DEFAULT_PROVIDER,
+      portal: DEFAULT_PROVIDER,
+      datasetId: target.datasetId,
+      datasetTitle: target.datasetTitle,
+      datasetUrl: target.datasetUrl,
+      resourceId: target.resourceId,
+      resourceTitle: target.resourceTitle,
+      resourceUrl: target.resourceUrl,
+      resourceFormat: format,
+      agency: target.agency,
+      license: target.license,
+      modified: target.modified,
+      metadataModified: target.metadataModified,
+      score,
+      discoveryApi: DATA_GOV_PACKAGE_SEARCH_URL
+    },
+    acceptanceCriteria: [
+      "Fetch the dataset landing page and resource URL and record their status, content type, and final URL if redirected.",
+      "Summarize the resource format and schema/columns when the resource is CSV, JSON, GeoJSON, XML, or spreadsheet-like.",
+      "Check for stale or incomplete catalog metadata such as missing format, license, agency, modified date, or broken resource links.",
+      "Report at least one concrete finding, or set no_issue_found=true with evidence for each completed check.",
+      "Do not edit the government dataset directly or contact agencies; submit a reviewable audit report only."
+    ],
+    estimatedDifficulty: estimateDifficulty(score),
+    agentInstructions: [
+      "Treat this as a public-data quality audit, not a direct edit task.",
+      `Review the Data.gov dataset page: ${target.datasetUrl}.`,
+      `Inspect the resource URL: ${target.resourceUrl}.`,
+      "If the resource is tabular, capture the header/field summary and obvious missing-value or schema problems without downloading huge files.",
+      "Submit structured evidence with dataset_title, dataset_url, resource_url, checks, findings, no_issue_found, summary, and recommended_actions."
+    ],
+    verification: {
+      method: "benchmark",
+      suggestedCheck: "open_data_quality_report_complete",
+      evidenceSchemaRef: "schema://jobs/open-data-quality-audit-output",
+      signals: ["dataset_url_present", "resource_url_present", "checks_present", "finding_or_no_issue", "recommendations_present"]
+    }
+  };
+}
+
+export async function postJobs({ baseUrl, adminToken, jobs, fetchImpl = fetch }) {
+  const results = [];
+  for (const job of jobs) {
+    results.push(await createJob({ baseUrl, adminToken, job, fetchImpl }));
+  }
+  return results;
+}
+
+export async function createJob({ baseUrl, adminToken, job, fetchImpl = fetch }) {
+  const response = await fetchImpl(`${trimTrailingSlash(baseUrl)}/admin/jobs`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${adminToken}`,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify(job)
+  });
+  const body = await response.text();
+  let payload;
+  try {
+    payload = body ? JSON.parse(body) : {};
+  } catch {
+    payload = { raw: body };
+  }
+  return { id: job.id, status: response.status, ok: response.ok, payload };
+}
+
+function parseDatasetString(raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed;
+  } catch {
+    // Fall through to compact line parser.
+  }
+  return String(raw)
+    .split(/\n/u)
+    .map((entry) => {
+      const [datasetTitle, datasetUrl, resourceUrl, resourceFormat, agency] = entry.split("|").map((part) => part?.trim());
+      if (!datasetTitle || !datasetUrl || !resourceUrl) return undefined;
+      return { datasetTitle, datasetUrl, resourceUrl, resourceFormat, agency };
+    })
+    .filter(Boolean);
+}
+
+function normalizeDatasetTarget(raw) {
+  const portal = text(raw?.portal ?? DEFAULT_PROVIDER).toLowerCase();
+  const datasetTitle = text(raw?.datasetTitle ?? raw?.title ?? raw?.name);
+  const datasetUrl = text(raw?.datasetUrl ?? raw?.landingPage ?? raw?.landing_page ?? raw?.packageUrl);
+  const resourceUrl = text(raw?.resourceUrl ?? raw?.downloadURL ?? raw?.downloadUrl ?? raw?.accessURL ?? raw?.accessUrl ?? raw?.url);
+  if (portal !== DEFAULT_PROVIDER || !datasetTitle || !datasetUrl || !resourceUrl) return undefined;
+
+  return {
+    portal: DEFAULT_PROVIDER,
+    datasetId: text(raw?.datasetId ?? raw?.packageId ?? raw?.id),
+    datasetTitle,
+    datasetUrl,
+    resourceId: text(raw?.resourceId),
+    resourceTitle: text(raw?.resourceTitle ?? raw?.resourceName),
+    resourceUrl,
+    resourceFormat: normalizeFormat(raw?.resourceFormat ?? raw?.format),
+    agency: text(raw?.agency ?? raw?.publisher),
+    license: text(raw?.license),
+    modified: text(raw?.modified ?? raw?.lastModified),
+    metadataModified: text(raw?.metadataModified ?? raw?.metadata_modified)
+  };
+}
+
+function agencyName(pkg) {
+  const organization = pkg.organization;
+  if (organization && typeof organization === "object") {
+    return text(organization.title ?? organization.name);
+  }
+  const publisher = pkg.publisher;
+  if (publisher && typeof publisher === "object") {
+    return text(publisher.name ?? publisher.title);
+  }
+  return text(publisher ?? pkg.agency);
+}
+
+function normalizeFormat(value) {
+  return text(value).toUpperCase().replace(/^APPLICATION\//u, "");
+}
+
+function looksOld(value) {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) return false;
+  const ageMs = Date.now() - timestamp;
+  return ageMs > 1000 * 60 * 60 * 24 * 365 * 2;
+}
+
+function estimateDifficulty(score) {
+  if (score >= 80) return "starter";
+  return "review-needed";
+}
+
+function text(value) {
+  return String(value ?? "").trim();
+}
+
+function slugify(value) {
+  return String(value ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, "-")
+    .replace(/^-+|-+$/gu, "")
+    .replace(/-{2,}/gu, "-");
+}
+
+function parsePositiveInt(raw, fallback) {
+  const value = Number(raw);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function trimTrailingSlash(value) {
+  return String(value).replace(/\/+$/u, "");
+}
+
+async function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  const dryRun = Boolean(args["dry-run"]);
+  const datasets = args.datasets ?? process.env.OPEN_DATA_INGEST_DATASETS_JSON ?? process.env.OPEN_DATA_INGEST_DATASETS;
+  const query = String(args.query ?? process.env.OPEN_DATA_INGEST_QUERY ?? DEFAULT_QUERY);
+  const limit = parsePositiveInt(args.limit, 10);
+  const minScore = parsePositiveInt(args["min-score"], 55);
+  const baseUrl = trimTrailingSlash(String(args.baseUrl ?? process.env.AGENT_API_BASE_URL ?? DEFAULT_BASE_URL));
+  const adminToken = process.env.AGENT_ADMIN_TOKEN?.trim();
+
+  if (!dryRun && !adminToken) {
+    fail("AGENT_ADMIN_TOKEN is required unless --dry-run is set.");
+  }
+
+  const dryRunPayload = await ingestOpenDataDatasets({ datasets, query, limit, minScore });
+  if (dryRun) {
+    console.log(JSON.stringify(dryRunPayload, null, 2));
+    return;
+  }
+
+  const results = await postJobs({ baseUrl, adminToken, jobs: dryRunPayload.jobs });
+  console.log(JSON.stringify({ ...dryRunPayload, results }, null, 2));
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await runCli();
+}

--- a/mcp-server/src/jobs/ingest-open-data-datasets.test.js
+++ b/mcp-server/src/jobs/ingest-open-data-datasets.test.js
@@ -1,0 +1,163 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  extractPackageTargets,
+  ingestOpenDataDatasets,
+  parseDatasets,
+  scoreDatasetTarget,
+  searchDataGovDatasets,
+  toPlatformJob
+} from "./ingest-open-data-datasets.js";
+
+const TARGET = {
+  portal: "data.gov",
+  datasetId: "dataset-123",
+  datasetTitle: "Federal sample spending data",
+  datasetUrl: "https://catalog.data.gov/dataset/federal-sample-spending-data",
+  resourceId: "resource-456",
+  resourceTitle: "Spending CSV",
+  resourceUrl: "https://example.gov/spending.csv",
+  resourceFormat: "CSV",
+  agency: "General Services Administration",
+  license: "CC0",
+  modified: "2021-01-01T00:00:00Z",
+  metadataModified: "2026-01-01T00:00:00Z"
+};
+
+const CKAN_PACKAGE = {
+  id: "dataset-123",
+  name: "federal-sample-spending-data",
+  title: "Federal sample spending data",
+  license_title: "CC0",
+  metadata_modified: "2026-01-01T00:00:00Z",
+  organization: { title: "General Services Administration" },
+  resources: [
+    {
+      id: "resource-456",
+      name: "Spending CSV",
+      url: "https://example.gov/spending.csv",
+      format: "CSV",
+      last_modified: "2021-01-01T00:00:00Z"
+    }
+  ]
+};
+
+test("parseDatasets accepts JSON and compact line syntax", () => {
+  assert.deepEqual(parseDatasets(JSON.stringify([TARGET])), [TARGET]);
+  assert.deepEqual(
+    parseDatasets("Federal sample spending data|https://catalog.data.gov/dataset/federal-sample-spending-data|https://example.gov/spending.csv|CSV|General Services Administration"),
+    [
+      {
+        portal: "data.gov",
+        datasetId: "",
+        datasetTitle: "Federal sample spending data",
+        datasetUrl: "https://catalog.data.gov/dataset/federal-sample-spending-data",
+        resourceId: "",
+        resourceTitle: "",
+        resourceUrl: "https://example.gov/spending.csv",
+        resourceFormat: "CSV",
+        agency: "General Services Administration",
+        license: "",
+        modified: "",
+        metadataModified: ""
+      }
+    ]
+  );
+});
+
+test("extractPackageTargets maps CKAN package resources", () => {
+  const targets = extractPackageTargets(CKAN_PACKAGE);
+
+  assert.equal(targets.length, 1);
+  assert.equal(targets[0].datasetUrl, "https://catalog.data.gov/dataset/federal-sample-spending-data");
+  assert.equal(targets[0].resourceUrl, "https://example.gov/spending.csv");
+  assert.equal(targets[0].agency, "General Services Administration");
+});
+
+test("scoreDatasetTarget prefers concrete resource audit targets", () => {
+  assert.ok(scoreDatasetTarget(TARGET) >= 80);
+  assert.equal(scoreDatasetTarget({ ...TARGET, resourceUrl: "" }), 46);
+});
+
+test("toPlatformJob creates a benchmark open-data audit job", () => {
+  const job = toPlatformJob(TARGET, 92);
+
+  assert.equal(job.id, "open-data-datagov-dataset-123-resource-456");
+  assert.equal(job.category, "data");
+  assert.equal(job.tier, "starter");
+  assert.equal(job.verifierMode, "benchmark");
+  assert.equal(job.inputSchemaRef, "schema://jobs/open-data-quality-audit-input");
+  assert.equal(job.outputSchemaRef, "schema://jobs/open-data-quality-audit-output");
+  assert.equal(job.source.type, "open_data_dataset");
+  assert.equal(job.source.provider, "data.gov");
+  assert.equal(job.source.resourceFormat, "CSV");
+  assert.ok(job.acceptanceCriteria.some((entry) => entry.includes("no_issue_found")));
+  assert.ok(job.verifierTerms.includes("recommended_actions"));
+});
+
+test("searchDataGovDatasets queries the Data.gov CKAN API", async () => {
+  const targets = await searchDataGovDatasets({
+    query: "res_format:CSV",
+    limit: 5,
+    fetchImpl: async (url, request) => {
+      assert.equal(url.searchParams.get("q"), "res_format:CSV");
+      assert.equal(url.searchParams.get("rows"), "5");
+      assert.equal(request.headers.accept, "application/json");
+      return {
+        ok: true,
+        async json() {
+          return { result: { results: [CKAN_PACKAGE] } };
+        }
+      };
+    }
+  });
+
+  assert.equal(targets.length, 1);
+  assert.equal(targets[0].datasetId, "dataset-123");
+});
+
+test("ingestOpenDataDatasets uses explicit targets before remote search", async () => {
+  const payload = await ingestOpenDataDatasets({
+    datasets: [TARGET],
+    limit: 5,
+    minScore: 55,
+    fetchImpl: async () => {
+      throw new Error("fetch should not run for explicit datasets");
+    }
+  });
+
+  assert.equal(payload.provider, "data.gov");
+  assert.equal(payload.count, 1);
+  assert.equal(payload.jobs[0].source.datasetTitle, "Federal sample spending data");
+  assert.equal(payload.skipped.length, 0);
+});
+
+test("ingestOpenDataDatasets searches Data.gov and filters low-score resources", async () => {
+  const payload = await ingestOpenDataDatasets({
+    query: "res_format:CSV",
+    limit: 5,
+    minScore: 90,
+    fetchImpl: async () => ({
+      ok: true,
+      async json() {
+        return {
+          result: {
+            results: [
+              CKAN_PACKAGE,
+              {
+                id: "low",
+                name: "low-score-resource",
+                title: "Low-score resource",
+                resources: [{ id: "low-resource", name: "Low URL", url: "https://example.gov/file.txt", format: "TXT" }]
+              }
+            ]
+          }
+        };
+      }
+    })
+  });
+
+  assert.equal(payload.count, 1);
+  assert.equal(payload.skipped[0].reason, "below_min_score");
+});

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -23,6 +23,7 @@ import {
   schemaRefToJobSchemaPath
 } from "../../core/job-schema-registry.js";
 import { ingestGithubIssues } from "../../jobs/ingest-github-issues.js";
+import { ingestOpenDataDatasets, parseDatasets as parseOpenDataDatasets } from "../../jobs/ingest-open-data-datasets.js";
 import { ingestOsvAdvisories, parsePackages as parseOsvPackages } from "../../jobs/ingest-osv-advisories.js";
 import { ingestWikipediaMaintenance, parseCategories } from "../../jobs/ingest-wikipedia-maintenance.js";
 
@@ -818,6 +819,7 @@ function metricPathLabel(pathname) {
     "/strategies",
     "/admin/jobs",
     "/admin/jobs/ingest/github",
+    "/admin/jobs/ingest/open-data",
     "/admin/jobs/ingest/osv",
     "/admin/jobs/ingest/wikipedia",
     "/admin/jobs/pause",
@@ -1097,6 +1099,7 @@ const server = createServer(async (request, response) => {
           "/verifier/replay",
           "/admin/jobs",
           "/admin/jobs/ingest/github",
+          "/admin/jobs/ingest/open-data",
           "/admin/jobs/ingest/osv",
           "/admin/jobs/ingest/wikipedia",
           "/admin/jobs/fire",
@@ -2254,6 +2257,62 @@ const server = createServer(async (request, response) => {
       const status = errors.length ? 207 : 201;
       return respond(response, status, {
         ecosystem: result.ecosystem,
+        minScore: result.minScore,
+        dryRun: false,
+        candidateCount: result.count,
+        created,
+        skipped: [...skipped, ...(Array.isArray(result.skipped) ? result.skipped : [])],
+        errors
+      });
+    }
+
+    if (request.method === "POST" && pathname === "/admin/jobs/ingest/open-data") {
+      const auth = await authMiddleware(request, url, { requireRole: "admin" });
+      await enforceLimit("admin_jobs", auth.wallet, rateLimitConfig.adminJobs);
+      const payload = await readJsonBody(request);
+      const datasets = Array.isArray(payload?.datasets) || typeof payload?.datasets === "string"
+        ? parseOpenDataDatasets(payload.datasets)
+        : parseOpenDataDatasets(process.env.OPEN_DATA_INGEST_DATASETS_JSON ?? process.env.OPEN_DATA_INGEST_DATASETS);
+      const query = typeof payload?.query === "string" && payload.query.trim()
+        ? payload.query.trim()
+        : process.env.OPEN_DATA_INGEST_QUERY;
+      const limit = parsePositiveInteger(payload?.limit, 10, 50);
+      const minScore = parsePositiveInteger(payload?.minScore, 55, 100);
+      const dryRun = payload?.dryRun !== false;
+      const result = await ingestOpenDataDatasets({ datasets, query, limit, minScore });
+
+      if (dryRun) {
+        return respond(response, 200, {
+          ...result,
+          dryRun: true,
+          created: []
+        });
+      }
+
+      const created = [];
+      const skipped = [];
+      const errors = [];
+      for (const job of result.jobs) {
+        try {
+          created.push(service.createJob(job));
+        } catch (error) {
+          const normalized = normalizeError(error);
+          if (normalized.code === "job_exists") {
+            skipped.push({ id: job.id, reason: "already_exists" });
+            continue;
+          }
+          errors.push({
+            id: job.id,
+            code: normalized.code,
+            message: normalized.message
+          });
+        }
+      }
+
+      const status = errors.length ? 207 : 201;
+      return respond(response, status, {
+        provider: result.provider,
+        query: result.query,
         minScore: result.minScore,
         dryRun: false,
         candidateCount: result.count,


### PR DESCRIPTION
## Summary
- add Data.gov open-data dataset/resource quality-audit schemas
- add allowlist/search ingestor plus CLI and admin endpoint at /admin/jobs/ingest/open-data
- document Data.gov as the first government open-data provider

## Tests
- node --test mcp-server/src/jobs/ingest-open-data-datasets.test.js
- node --test mcp-server/src/core/job-schema-registry.test.js
- npm --workspace mcp-server test
- npm --workspace mcp-server run ingest:open-data -- --dry-run --datasets '[{"datasetTitle":"Federal sample spending data","datasetUrl":"https://catalog.data.gov/dataset/example","resourceUrl":"https://example.gov/data.csv","resourceFormat":"CSV","agency":"GSA"}]'
- git diff --check