### PR TITLE
Schedule OSV and open-data ingestion

### DIFF
--- a/docs/PUBLIC_JOB_SOURCES.md
+++ b/docs/PUBLIC_JOB_SOURCES.md
@@ -104,6 +104,9 @@ After Wikipedia, use the same pattern for:
    - v1 ingestion targets the US Data.gov CKAN catalog:
      `POST /admin/jobs/ingest/open-data` searches catalog metadata or accepts
      explicit dataset/resource targets, then emits proposal-only audit jobs.
+   - Scheduled ingestion is available behind `OPEN_DATA_INGEST_ENABLED`; keep
+     `OPEN_DATA_INGEST_DRY_RUN=true` until `/admin/status` shows good
+     candidates.
 
 3. **OSV/NVD advisories**
    - package-to-CVE mapping, remediation summaries
@@ -112,6 +115,9 @@ After Wikipedia, use the same pattern for:
      `POST /admin/jobs/ingest/osv` accepts package/version/repo targets,
      queries OSV, and emits dependency remediation PR jobs when a fixed version
      exists. CVE aliases link to NVD for operator review.
+   - Scheduled ingestion is available behind `OSV_INGEST_ENABLED`; configure
+     package targets explicitly and keep `OSV_INGEST_DRY_RUN=true` until
+     candidate quality is reviewed.
 
 4. **Stack Exchange / Discourse**
    - unanswered-question triage, duplicate detection, answer summaries

--- a/docs/READY_TO_POST_JOBS.md
+++ b/docs/READY_TO_POST_JOBS.md
@@ -362,6 +362,20 @@ Or through the admin API:
 POST /admin/jobs/ingest/osv
 ```
 
+To let the backend pull these periodically, configure:
+
+```bash
+OSV_INGEST_ENABLED=true
+OSV_INGEST_DRY_RUN=true
+OSV_INGEST_INTERVAL_MS=3600000
+OSV_INGEST_MAX_JOBS_PER_RUN=2
+OSV_INGEST_MAX_OPEN_JOBS=20
+OSV_INGEST_PACKAGES_JSON='[{"name":"minimist","version":"0.0.8","repo":"example/app","manifestPath":"package.json"}]'
+```
+
+Review `osvIngestion.lastRun` in `/admin/status`, then switch
+`OSV_INGEST_DRY_RUN=false` when the candidates are ready to create jobs.
+
 The generated jobs use:
 
 - `schema://jobs/dependency-remediation-input`
@@ -393,6 +407,20 @@ Or through the admin API:
 ```http
 POST /admin/jobs/ingest/open-data
 ```
+
+To let the backend pull these periodically, configure:
+
+```bash
+OPEN_DATA_INGEST_ENABLED=true
+OPEN_DATA_INGEST_DRY_RUN=true
+OPEN_DATA_INGEST_INTERVAL_MS=3600000
+OPEN_DATA_INGEST_MAX_JOBS_PER_RUN=2
+OPEN_DATA_INGEST_MAX_OPEN_JOBS=20
+OPEN_DATA_INGEST_QUERY='res_format:CSV'
+```
+
+Review `openDataIngestion.lastRun` in `/admin/status`, then switch
+`OPEN_DATA_INGEST_DRY_RUN=false` when the candidates are ready to create jobs.
 
 The generated jobs use:
 

--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -139,6 +139,14 @@ AUTH_CHAIN_ID=420420417
 # CLI preview:
 # npm --workspace mcp-server run ingest:osv-advisories -- --dry-run --packages '[{"name":"minimist","version":"0.0.8","repo":"example/app","manifestPath":"package.json"}]'
 # Admin preview/create endpoint: POST /admin/jobs/ingest/osv
+# Scheduled ingestion is opt-in. Keep dry-run enabled until /admin/status shows
+# the candidate quality you want.
+# OSV_INGEST_ENABLED=false
+# OSV_INGEST_DRY_RUN=true
+# OSV_INGEST_INTERVAL_MS=3600000
+# OSV_INGEST_MIN_SCORE=55
+# OSV_INGEST_MAX_JOBS_PER_RUN=2
+# OSV_INGEST_MAX_OPEN_JOBS=20
 # OSV_INGEST_PACKAGES_JSON=[{"name":"minimist","version":"0.0.8","repo":"example/app","manifestPath":"package.json"}]
 
 # --- Data.gov open-data quality-audit job ingestion --------------------------
@@ -151,6 +159,14 @@ AUTH_CHAIN_ID=420420417
 # Explicit dataset preview:
 # npm --workspace mcp-server run ingest:open-data -- --dry-run --datasets '[{"datasetTitle":"Federal sample spending data","datasetUrl":"https://catalog.data.gov/dataset/example","resourceUrl":"https://example.gov/data.csv","resourceFormat":"CSV","agency":"GSA"}]'
 # Admin preview/create endpoint: POST /admin/jobs/ingest/open-data
+# Scheduled ingestion is opt-in. Keep dry-run enabled until /admin/status shows
+# the candidate quality you want.
+# OPEN_DATA_INGEST_ENABLED=false
+# OPEN_DATA_INGEST_DRY_RUN=true
+# OPEN_DATA_INGEST_INTERVAL_MS=3600000
+# OPEN_DATA_INGEST_MIN_SCORE=55
+# OPEN_DATA_INGEST_MAX_JOBS_PER_RUN=2
+# OPEN_DATA_INGEST_MAX_OPEN_JOBS=20
 # OPEN_DATA_INGEST_QUERY=res_format:CSV
 # OPEN_DATA_INGEST_DATASETS_JSON=[{"datasetTitle":"Federal sample spending data","datasetUrl":"https://catalog.data.gov/dataset/example","resourceUrl":"https://example.gov/data.csv","resourceFormat":"CSV","agency":"GSA"}]
 

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -38,6 +38,9 @@ export class PlatformService {
     this.eventBus = eventBus;
     this.recurringScheduler = recurringScheduler;
     this.githubIssueIngestionScheduler = undefined;
+    this.wikipediaMaintenanceIngestionScheduler = undefined;
+    this.osvAdvisoryIngestionScheduler = undefined;
+    this.openDataIngestionScheduler = undefined;
     this.xcmSettlementWatcher = undefined;
     this.xcmObservationRelay = undefined;
 
@@ -100,7 +103,16 @@ export class PlatformService {
   }
 
   async getAdminStatus({ auth = undefined } = {}) {
-    const [policy, recurring, scheduler, githubIngestion, wikipediaIngestion, recentSessions] = await Promise.all([
+    const [
+      policy,
+      recurring,
+      scheduler,
+      githubIngestion,
+      wikipediaIngestion,
+      osvIngestion,
+      openDataIngestion,
+      recentSessions
+    ] = await Promise.all([
       this.blockchainGateway?.getTreasuryPolicyStatus?.() ?? {
         enabled: false,
         policyAddress: undefined,
@@ -129,6 +141,29 @@ export class PlatformService {
         intervalMs: 0,
         language: "en",
         categoryCount: 0,
+        minScore: 0,
+        maxJobsPerRun: 0,
+        maxOpenJobs: 0,
+        lastRun: undefined
+      },
+      this.osvAdvisoryIngestionScheduler?.getStatus?.() ?? {
+        enabled: false,
+        running: false,
+        dryRun: true,
+        intervalMs: 0,
+        packageCount: 0,
+        minScore: 0,
+        maxJobsPerRun: 0,
+        maxOpenJobs: 0,
+        lastRun: undefined
+      },
+      this.openDataIngestionScheduler?.getStatus?.() ?? {
+        enabled: false,
+        running: false,
+        dryRun: true,
+        intervalMs: 0,
+        query: undefined,
+        datasetCount: 0,
         minScore: 0,
         maxJobsPerRun: 0,
         maxOpenJobs: 0,
@@ -225,6 +260,8 @@ export class PlatformService {
       scheduler,
       githubIngestion: githubIngestion,
       wikipediaIngestion: wikipediaIngestion,
+      osvIngestion: osvIngestion,
+      openDataIngestion: openDataIngestion,
       xcmSettlementWatcher: await this.xcmSettlementWatcher?.getStatus?.() ?? {
         enabled: false,
         running: false,

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -136,6 +136,40 @@ test("getAdminStatus surfaces recurring scheduler anomalies", async () => {
   assert.ok(status.anomalies.some((entry) => entry.code === "recurring_attention"));
 });
 
+test("getAdminStatus surfaces public source ingestion scheduler status", async () => {
+  const service = makePlatformService();
+  service.osvAdvisoryIngestionScheduler = {
+    getStatus() {
+      return {
+        enabled: true,
+        running: true,
+        dryRun: true,
+        intervalMs: 3600000,
+        packageCount: 1,
+        lastRun: { createdCount: 0 }
+      };
+    }
+  };
+  service.openDataIngestionScheduler = {
+    getStatus() {
+      return {
+        enabled: true,
+        running: true,
+        dryRun: false,
+        intervalMs: 3600000,
+        query: "res_format:CSV",
+        datasetCount: 0,
+        lastRun: { createdCount: 2 }
+      };
+    }
+  };
+
+  const status = await service.getAdminStatus();
+  assert.equal(status.osvIngestion.packageCount, 1);
+  assert.equal(status.openDataIngestion.query, "res_format:CSV");
+  assert.equal(status.openDataIngestion.lastRun.createdCount, 2);
+});
+
 test("finalizeXcmRequest records async treasury settlement when the request is strategy-backed", async () => {
   const gateway = {
     isEnabled: () => true,

--- a/mcp-server/src/services/bootstrap.js
+++ b/mcp-server/src/services/bootstrap.js
@@ -22,6 +22,14 @@ import {
   WikipediaMaintenanceIngestionScheduler,
   loadWikipediaMaintenanceIngestionConfig
 } from "./wikipedia-maintenance-ingestion-scheduler.js";
+import {
+  OsvAdvisoryIngestionScheduler,
+  loadOsvAdvisoryIngestionConfig
+} from "./osv-advisory-ingestion-scheduler.js";
+import {
+  OpenDataIngestionScheduler,
+  loadOpenDataIngestionConfig
+} from "./open-data-ingestion-scheduler.js";
 import { XcmSettlementWatcherService } from "./xcm-settlement-watcher.js";
 import { XcmObservationRelayService } from "./xcm-observation-relay.js";
 import { normaliseStrategyAssetConfig } from "./strategy-asset-config.js";
@@ -159,6 +167,18 @@ export async function createPlatformRuntime() {
       logger
     })
   );
+  const osvAdvisoryIngestionScheduler = initStep("init-osv-advisory-ingestion-scheduler", logger, () =>
+    new OsvAdvisoryIngestionScheduler(platformService, eventBus, {
+      ...loadOsvAdvisoryIngestionConfig(process.env),
+      logger
+    })
+  );
+  const openDataIngestionScheduler = initStep("init-open-data-ingestion-scheduler", logger, () =>
+    new OpenDataIngestionScheduler(platformService, eventBus, {
+      ...loadOpenDataIngestionConfig(process.env),
+      logger
+    })
+  );
   const xcmSettlementWatcher = initStep("init-xcm-settlement-watcher", logger, () =>
     new XcmSettlementWatcherService(platformService, stateStore, eventBus, {
       enabled: process.env.XCM_SETTLEMENT_WATCHER_ENABLED === undefined
@@ -183,11 +203,15 @@ export async function createPlatformRuntime() {
   platformService.recurringScheduler = recurringScheduler;
   platformService.githubIssueIngestionScheduler = githubIssueIngestionScheduler;
   platformService.wikipediaMaintenanceIngestionScheduler = wikipediaMaintenanceIngestionScheduler;
+  platformService.osvAdvisoryIngestionScheduler = osvAdvisoryIngestionScheduler;
+  platformService.openDataIngestionScheduler = openDataIngestionScheduler;
   platformService.xcmSettlementWatcher = xcmSettlementWatcher;
   platformService.xcmObservationRelay = xcmObservationRelay;
   recurringScheduler.start();
   githubIssueIngestionScheduler.start();
   wikipediaMaintenanceIngestionScheduler.start();
+  osvAdvisoryIngestionScheduler.start();
+  openDataIngestionScheduler.start();
   xcmSettlementWatcher.start();
   xcmObservationRelay.start();
 
@@ -214,6 +238,8 @@ export async function createPlatformRuntime() {
     recurringScheduler,
     githubIssueIngestionScheduler,
     wikipediaMaintenanceIngestionScheduler,
+    osvAdvisoryIngestionScheduler,
+    openDataIngestionScheduler,
     xcmSettlementWatcher,
     xcmObservationRelay,
     authConfig,

--- a/mcp-server/src/services/open-data-ingestion-scheduler.js
+++ b/mcp-server/src/services/open-data-ingestion-scheduler.js
@@ -1,0 +1,222 @@
+import { DEFAULT_QUERY, ingestOpenDataDatasets, parseDatasets } from "../jobs/ingest-open-data-datasets.js";
+
+export class OpenDataIngestionScheduler {
+  constructor(platformService, eventBus = undefined, {
+    enabled = false,
+    dryRun = true,
+    intervalMs = 60 * 60 * 1000,
+    query = DEFAULT_QUERY,
+    datasets = [],
+    minScore = 55,
+    maxJobsPerRun = 2,
+    maxOpenJobs = 20,
+    fetchImpl = fetch,
+    logger = console
+  } = {}) {
+    this.platformService = platformService;
+    this.eventBus = eventBus;
+    this.enabled = enabled;
+    this.dryRun = dryRun;
+    this.intervalMs = intervalMs;
+    this.query = String(query || DEFAULT_QUERY).trim();
+    this.datasets = parseDatasets(datasets);
+    this.minScore = minScore;
+    this.maxJobsPerRun = maxJobsPerRun;
+    this.maxOpenJobs = maxOpenJobs;
+    this.fetchImpl = fetchImpl;
+    this.logger = logger;
+    this.timer = undefined;
+    this.running = false;
+    this.lastRun = undefined;
+  }
+
+  start() {
+    if (!this.enabled || this.running) {
+      return;
+    }
+    this.running = true;
+    void this.runOnceAndSchedule();
+  }
+
+  stop() {
+    this.running = false;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  async getStatus() {
+    return {
+      enabled: this.enabled,
+      running: this.running,
+      dryRun: this.dryRun,
+      intervalMs: this.intervalMs,
+      query: this.query,
+      datasetCount: this.datasets.length,
+      minScore: this.minScore,
+      maxJobsPerRun: this.maxJobsPerRun,
+      maxOpenJobs: this.maxOpenJobs,
+      lastRun: this.lastRun
+    };
+  }
+
+  async runOnce(now = new Date()) {
+    const startedAt = now.toISOString();
+    const openDataJobs = this.countOpenDataJobs();
+    const summary = {
+      startedAt,
+      finishedAt: undefined,
+      dryRun: this.dryRun,
+      openDataJobs,
+      candidateCount: 0,
+      createdCount: 0,
+      skipped: [],
+      errors: []
+    };
+
+    if (!this.enabled) {
+      summary.skipped.push({ reason: "disabled" });
+      return this.finishRun(summary);
+    }
+    if (openDataJobs >= this.maxOpenJobs) {
+      summary.skipped.push({ reason: "max_open_jobs_reached", openDataJobs, maxOpenJobs: this.maxOpenJobs });
+      return this.finishRun(summary);
+    }
+
+    const remaining = Math.max(0, Math.min(this.maxJobsPerRun, this.maxOpenJobs - openDataJobs));
+    const seenSources = this.existingOpenDataKeys();
+    try {
+      const result = await ingestOpenDataDatasets({
+        datasets: this.datasets,
+        query: this.query,
+        limit: remaining,
+        minScore: this.minScore,
+        fetchImpl: this.fetchImpl
+      });
+      summary.candidateCount = result.count;
+      summary.query = result.query;
+      summary.skipped.push(...(Array.isArray(result.skipped) ? result.skipped : []));
+      for (const job of result.jobs) {
+        const sourceKey = openDataJobKey(job);
+        if (sourceKey && seenSources.has(sourceKey)) {
+          summary.skipped.push({ id: job.id, reason: "source_already_ingested" });
+          continue;
+        }
+        if (this.platformService.getJobDefinition) {
+          try {
+            this.platformService.getJobDefinition(job.id);
+            summary.skipped.push({ id: job.id, reason: "job_already_exists" });
+            continue;
+          } catch {
+            // Missing jobs are expected and created below.
+          }
+        }
+        if (!this.dryRun) {
+          this.platformService.createJob(job);
+        }
+        seenSources.add(sourceKey);
+        summary.createdCount += 1;
+        this.eventBus?.publish?.({
+          id: `platform-open-data-ingest-${job.id}-${Date.now()}`,
+          topic: "jobs.ingest.open_data",
+          jobId: job.id,
+          timestamp: new Date().toISOString(),
+          data: {
+            dryRun: this.dryRun,
+            jobId: job.id,
+            source: job.source
+          }
+        });
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      summary.errors.push({ message });
+      this.logger.warn?.({ err: error }, "open_data_ingest.run_failed");
+    }
+
+    return this.finishRun(summary);
+  }
+
+  async runOnceAndSchedule() {
+    await this.runOnce(new Date());
+    if (!this.running) {
+      return;
+    }
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+    this.timer = setTimeout(() => {
+      void this.runOnceAndSchedule();
+    }, this.intervalMs);
+  }
+
+  finishRun(summary) {
+    summary.finishedAt = new Date().toISOString();
+    this.lastRun = summary;
+    return summary;
+  }
+
+  countOpenDataJobs() {
+    return this.platformService.listJobs()
+      .filter((job) => job.source?.type === "open_data_dataset")
+      .filter((job) => !job.recurring)
+      .length;
+  }
+
+  existingOpenDataKeys() {
+    return new Set(
+      this.platformService.listJobs()
+        .map((job) => openDataJobKey(job))
+        .filter(Boolean)
+    );
+  }
+}
+
+export function loadOpenDataIngestionConfig(env = process.env) {
+  return {
+    enabled: parseBooleanEnv(env.OPEN_DATA_INGEST_ENABLED),
+    dryRun: env.OPEN_DATA_INGEST_DRY_RUN === undefined ? true : parseBooleanEnv(env.OPEN_DATA_INGEST_DRY_RUN),
+    intervalMs: parsePositiveInt(env.OPEN_DATA_INGEST_INTERVAL_MS, 60 * 60 * 1000),
+    query: env.OPEN_DATA_INGEST_QUERY?.trim() || DEFAULT_QUERY,
+    datasets: parseDatasets(env.OPEN_DATA_INGEST_DATASETS_JSON ?? env.OPEN_DATA_INGEST_DATASETS),
+    minScore: parsePositiveInt(env.OPEN_DATA_INGEST_MIN_SCORE, 55),
+    maxJobsPerRun: parsePositiveInt(env.OPEN_DATA_INGEST_MAX_JOBS_PER_RUN, 2),
+    maxOpenJobs: parsePositiveInt(env.OPEN_DATA_INGEST_MAX_OPEN_JOBS, 20)
+  };
+}
+
+function openDataJobKey(job) {
+  const source = job?.source;
+  if (source?.type !== "open_data_dataset") {
+    return undefined;
+  }
+  const resourceIdentity = source.resourceId || source.resourceUrl;
+  const datasetIdentity = source.datasetId || source.datasetUrl || source.datasetTitle;
+  if (!resourceIdentity || !datasetIdentity) {
+    return undefined;
+  }
+  return [
+    String(source.provider ?? source.portal ?? "data.gov").toLowerCase(),
+    String(datasetIdentity).toLowerCase(),
+    String(resourceIdentity).toLowerCase()
+  ].join("|");
+}
+
+function parsePositiveInt(raw, fallback) {
+  if (raw === undefined || raw === null || raw === "") {
+    return fallback;
+  }
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    return fallback;
+  }
+  return value;
+}
+
+function parseBooleanEnv(raw) {
+  if (raw === undefined || raw === null || raw === "") {
+    return false;
+  }
+  return ["1", "true", "yes", "on"].includes(String(raw).trim().toLowerCase());
+}

--- a/mcp-server/src/services/open-data-ingestion-scheduler.test.js
+++ b/mcp-server/src/services/open-data-ingestion-scheduler.test.js
@@ -1,0 +1,164 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  OpenDataIngestionScheduler,
+  loadOpenDataIngestionConfig
+} from "./open-data-ingestion-scheduler.js";
+
+const TARGET = {
+  portal: "data.gov",
+  datasetId: "dataset-123",
+  datasetTitle: "Federal sample spending data",
+  datasetUrl: "https://catalog.data.gov/dataset/federal-sample-spending-data",
+  resourceId: "resource-456",
+  resourceTitle: "Spending CSV",
+  resourceUrl: "https://example.gov/spending.csv",
+  resourceFormat: "CSV",
+  agency: "General Services Administration",
+  license: "CC0",
+  modified: "2021-01-01T00:00:00Z",
+  metadataModified: "2026-01-01T00:00:00Z"
+};
+
+const CKAN_PACKAGE = {
+  id: "dataset-123",
+  name: "federal-sample-spending-data",
+  title: "Federal sample spending data",
+  license_title: "CC0",
+  metadata_modified: "2026-01-01T00:00:00Z",
+  organization: { title: "General Services Administration" },
+  resources: [
+    {
+      id: "resource-456",
+      name: "Spending CSV",
+      url: "https://example.gov/spending.csv",
+      format: "CSV",
+      last_modified: "2021-01-01T00:00:00Z"
+    }
+  ]
+};
+
+function makeFetch() {
+  return async () => ({
+    ok: true,
+    async json() {
+      return { result: { results: [CKAN_PACKAGE] } };
+    }
+  });
+}
+
+function makePlatformService(initialJobs = []) {
+  const jobs = [...initialJobs];
+  return {
+    listJobs() {
+      return [...jobs];
+    },
+    createJob(job) {
+      jobs.unshift(job);
+      return job;
+    },
+    getJobDefinition(jobId) {
+      const job = jobs.find((candidate) => candidate.id === jobId);
+      if (!job) {
+        throw new Error("not found");
+      }
+      return job;
+    }
+  };
+}
+
+test("OpenDataIngestionScheduler dry-run does not create jobs", async () => {
+  const platform = makePlatformService();
+  const scheduler = new OpenDataIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: true,
+    query: "res_format:CSV",
+    fetchImpl: makeFetch()
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-26T10:00:00.000Z"));
+  assert.equal(summary.createdCount, 1);
+  assert.equal(platform.listJobs().length, 0);
+  assert.equal((await scheduler.getStatus()).lastRun.dryRun, true);
+});
+
+test("OpenDataIngestionScheduler creates jobs when dryRun is false", async () => {
+  const platform = makePlatformService();
+  const scheduler = new OpenDataIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    datasets: [TARGET],
+    fetchImpl: makeFetch()
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-26T10:00:00.000Z"));
+  assert.equal(summary.createdCount, 1);
+  assert.equal(platform.listJobs().length, 1);
+  assert.equal(platform.listJobs()[0].source.type, "open_data_dataset");
+  assert.equal(platform.listJobs()[0].source.resourceId, "resource-456");
+});
+
+test("OpenDataIngestionScheduler dedupes by dataset resource", async () => {
+  const platform = makePlatformService([
+    {
+      id: "existing",
+      source: {
+        type: "open_data_dataset",
+        provider: "data.gov",
+        datasetId: "dataset-123",
+        resourceId: "resource-456"
+      }
+    }
+  ]);
+  const scheduler = new OpenDataIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    datasets: [TARGET],
+    fetchImpl: makeFetch()
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-26T10:00:00.000Z"));
+  assert.equal(summary.createdCount, 0);
+  assert.equal(platform.listJobs().length, 1);
+  assert.equal(summary.skipped.at(-1).reason, "source_already_ingested");
+});
+
+test("OpenDataIngestionScheduler stops when max open open-data jobs is reached", async () => {
+  const platform = makePlatformService([
+    { id: "a", source: { type: "open_data_dataset", datasetId: "a", resourceId: "a" } }
+  ]);
+  const scheduler = new OpenDataIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    datasets: [TARGET],
+    maxOpenJobs: 1,
+    fetchImpl: makeFetch()
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-26T10:00:00.000Z"));
+  assert.equal(summary.createdCount, 0);
+  assert.equal(summary.skipped[0].reason, "max_open_jobs_reached");
+});
+
+test("loadOpenDataIngestionConfig parses env knobs safely", () => {
+  const config = loadOpenDataIngestionConfig({
+    OPEN_DATA_INGEST_ENABLED: "true",
+    OPEN_DATA_INGEST_DRY_RUN: "false",
+    OPEN_DATA_INGEST_INTERVAL_MS: "3600000",
+    OPEN_DATA_INGEST_QUERY: "res_format:JSON",
+    OPEN_DATA_INGEST_MIN_SCORE: "70",
+    OPEN_DATA_INGEST_MAX_JOBS_PER_RUN: "4",
+    OPEN_DATA_INGEST_MAX_OPEN_JOBS: "11",
+    OPEN_DATA_INGEST_DATASETS_JSON: JSON.stringify([TARGET])
+  });
+
+  assert.equal(config.enabled, true);
+  assert.equal(config.dryRun, false);
+  assert.equal(config.intervalMs, 3600000);
+  assert.equal(config.query, "res_format:JSON");
+  assert.equal(config.minScore, 70);
+  assert.equal(config.maxJobsPerRun, 4);
+  assert.equal(config.maxOpenJobs, 11);
+  assert.deepEqual(config.datasets, [TARGET]);
+});

--- a/mcp-server/src/services/osv-advisory-ingestion-scheduler.js
+++ b/mcp-server/src/services/osv-advisory-ingestion-scheduler.js
@@ -1,0 +1,222 @@
+import { ingestOsvAdvisories, parsePackages } from "../jobs/ingest-osv-advisories.js";
+
+export class OsvAdvisoryIngestionScheduler {
+  constructor(platformService, eventBus = undefined, {
+    enabled = false,
+    dryRun = true,
+    intervalMs = 60 * 60 * 1000,
+    packages = [],
+    minScore = 55,
+    maxJobsPerRun = 2,
+    maxOpenJobs = 20,
+    fetchImpl = fetch,
+    logger = console
+  } = {}) {
+    this.platformService = platformService;
+    this.eventBus = eventBus;
+    this.enabled = enabled;
+    this.dryRun = dryRun;
+    this.intervalMs = intervalMs;
+    this.packages = parsePackagesConfig(packages);
+    this.minScore = minScore;
+    this.maxJobsPerRun = maxJobsPerRun;
+    this.maxOpenJobs = maxOpenJobs;
+    this.fetchImpl = fetchImpl;
+    this.logger = logger;
+    this.timer = undefined;
+    this.running = false;
+    this.lastRun = undefined;
+  }
+
+  start() {
+    if (!this.enabled || this.running) {
+      return;
+    }
+    this.running = true;
+    void this.runOnceAndSchedule();
+  }
+
+  stop() {
+    this.running = false;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  async getStatus() {
+    return {
+      enabled: this.enabled,
+      running: this.running,
+      dryRun: this.dryRun,
+      intervalMs: this.intervalMs,
+      packageCount: this.packages.length,
+      minScore: this.minScore,
+      maxJobsPerRun: this.maxJobsPerRun,
+      maxOpenJobs: this.maxOpenJobs,
+      lastRun: this.lastRun
+    };
+  }
+
+  async runOnce(now = new Date()) {
+    const startedAt = now.toISOString();
+    const openOsvJobs = this.countOpenOsvJobs();
+    const summary = {
+      startedAt,
+      finishedAt: undefined,
+      dryRun: this.dryRun,
+      openOsvJobs,
+      candidateCount: 0,
+      createdCount: 0,
+      skipped: [],
+      errors: []
+    };
+
+    if (!this.enabled) {
+      summary.skipped.push({ reason: "disabled" });
+      return this.finishRun(summary);
+    }
+    if (!this.packages.length) {
+      summary.skipped.push({ reason: "no_packages_configured" });
+      return this.finishRun(summary);
+    }
+    if (openOsvJobs >= this.maxOpenJobs) {
+      summary.skipped.push({ reason: "max_open_jobs_reached", openOsvJobs, maxOpenJobs: this.maxOpenJobs });
+      return this.finishRun(summary);
+    }
+
+    const remaining = Math.max(0, Math.min(this.maxJobsPerRun, this.maxOpenJobs - openOsvJobs));
+    const seenSources = this.existingOsvAdvisoryKeys();
+    try {
+      const result = await ingestOsvAdvisories({
+        packages: this.packages,
+        limit: remaining,
+        minScore: this.minScore,
+        fetchImpl: this.fetchImpl
+      });
+      summary.candidateCount = result.count;
+      summary.skipped.push(...(Array.isArray(result.skipped) ? result.skipped : []));
+      for (const job of result.jobs) {
+        const sourceKey = osvJobKey(job);
+        if (sourceKey && seenSources.has(sourceKey)) {
+          summary.skipped.push({ id: job.id, reason: "source_already_ingested" });
+          continue;
+        }
+        if (this.platformService.getJobDefinition) {
+          try {
+            this.platformService.getJobDefinition(job.id);
+            summary.skipped.push({ id: job.id, reason: "job_already_exists" });
+            continue;
+          } catch {
+            // Missing jobs are expected and created below.
+          }
+        }
+        if (!this.dryRun) {
+          this.platformService.createJob(job);
+        }
+        seenSources.add(sourceKey);
+        summary.createdCount += 1;
+        this.eventBus?.publish?.({
+          id: `platform-osv-ingest-${job.id}-${Date.now()}`,
+          topic: "jobs.ingest.osv",
+          jobId: job.id,
+          timestamp: new Date().toISOString(),
+          data: {
+            dryRun: this.dryRun,
+            jobId: job.id,
+            source: job.source
+          }
+        });
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      summary.errors.push({ message });
+      this.logger.warn?.({ err: error }, "osv_ingest.run_failed");
+    }
+
+    return this.finishRun(summary);
+  }
+
+  async runOnceAndSchedule() {
+    await this.runOnce(new Date());
+    if (!this.running) {
+      return;
+    }
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+    this.timer = setTimeout(() => {
+      void this.runOnceAndSchedule();
+    }, this.intervalMs);
+  }
+
+  finishRun(summary) {
+    summary.finishedAt = new Date().toISOString();
+    this.lastRun = summary;
+    return summary;
+  }
+
+  countOpenOsvJobs() {
+    return this.platformService.listJobs()
+      .filter((job) => job.source?.type === "osv_advisory")
+      .filter((job) => !job.recurring)
+      .length;
+  }
+
+  existingOsvAdvisoryKeys() {
+    return new Set(
+      this.platformService.listJobs()
+        .map((job) => osvJobKey(job))
+        .filter(Boolean)
+    );
+  }
+}
+
+export function loadOsvAdvisoryIngestionConfig(env = process.env) {
+  return {
+    enabled: parseBooleanEnv(env.OSV_INGEST_ENABLED),
+    dryRun: env.OSV_INGEST_DRY_RUN === undefined ? true : parseBooleanEnv(env.OSV_INGEST_DRY_RUN),
+    intervalMs: parsePositiveInt(env.OSV_INGEST_INTERVAL_MS, 60 * 60 * 1000),
+    packages: parsePackagesConfig(env.OSV_INGEST_PACKAGES_JSON ?? env.OSV_INGEST_PACKAGES),
+    minScore: parsePositiveInt(env.OSV_INGEST_MIN_SCORE, 55),
+    maxJobsPerRun: parsePositiveInt(env.OSV_INGEST_MAX_JOBS_PER_RUN, 2),
+    maxOpenJobs: parsePositiveInt(env.OSV_INGEST_MAX_OPEN_JOBS, 20)
+  };
+}
+
+function osvJobKey(job) {
+  const source = job?.source;
+  if (source?.type !== "osv_advisory" || !source.packageName || !source.vulnerableVersion || !source.advisoryId) {
+    return undefined;
+  }
+  return [
+    String(source.ecosystem ?? "npm").toLowerCase(),
+    String(source.repo ?? "").toLowerCase(),
+    String(source.manifestPath ?? "").toLowerCase(),
+    String(source.packageName).toLowerCase(),
+    String(source.vulnerableVersion),
+    String(source.advisoryId).toUpperCase()
+  ].join("|");
+}
+
+function parsePackagesConfig(raw) {
+  return parsePackages(raw);
+}
+
+function parsePositiveInt(raw, fallback) {
+  if (raw === undefined || raw === null || raw === "") {
+    return fallback;
+  }
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    return fallback;
+  }
+  return value;
+}
+
+function parseBooleanEnv(raw) {
+  if (raw === undefined || raw === null || raw === "") {
+    return false;
+  }
+  return ["1", "true", "yes", "on"].includes(String(raw).trim().toLowerCase());
+}

--- a/mcp-server/src/services/osv-advisory-ingestion-scheduler.test.js
+++ b/mcp-server/src/services/osv-advisory-ingestion-scheduler.test.js
@@ -1,0 +1,156 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  OsvAdvisoryIngestionScheduler,
+  loadOsvAdvisoryIngestionConfig
+} from "./osv-advisory-ingestion-scheduler.js";
+
+const TARGET = {
+  name: "minimist",
+  version: "0.0.8",
+  ecosystem: "npm",
+  repo: "example/app",
+  manifestPath: "package.json"
+};
+
+const ADVISORY = {
+  id: "GHSA-vh95-rmgr-6w4m",
+  aliases: ["CVE-2020-7598"],
+  summary: "Prototype pollution in minimist",
+  details: "minimist before 1.2.3 allows prototype pollution.",
+  severity: [{ type: "CVSS_V3", score: "7.5" }],
+  references: [{ type: "ADVISORY", url: "https://osv.dev/vulnerability/GHSA-vh95-rmgr-6w4m" }],
+  affected: [
+    {
+      package: { ecosystem: "npm", name: "minimist" },
+      ranges: [{ type: "SEMVER", events: [{ introduced: "0" }, { fixed: "1.2.3" }] }]
+    }
+  ]
+};
+
+function makeFetch() {
+  return async () => ({
+    ok: true,
+    async json() {
+      return { results: [{ vulns: [ADVISORY] }] };
+    }
+  });
+}
+
+function makePlatformService(initialJobs = []) {
+  const jobs = [...initialJobs];
+  return {
+    listJobs() {
+      return [...jobs];
+    },
+    createJob(job) {
+      jobs.unshift(job);
+      return job;
+    },
+    getJobDefinition(jobId) {
+      const job = jobs.find((candidate) => candidate.id === jobId);
+      if (!job) {
+        throw new Error("not found");
+      }
+      return job;
+    }
+  };
+}
+
+test("OsvAdvisoryIngestionScheduler dry-run does not create jobs", async () => {
+  const platform = makePlatformService();
+  const scheduler = new OsvAdvisoryIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: true,
+    packages: [TARGET],
+    fetchImpl: makeFetch()
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-26T10:00:00.000Z"));
+  assert.equal(summary.createdCount, 1);
+  assert.equal(platform.listJobs().length, 0);
+  assert.equal((await scheduler.getStatus()).lastRun.dryRun, true);
+});
+
+test("OsvAdvisoryIngestionScheduler creates jobs when dryRun is false", async () => {
+  const platform = makePlatformService();
+  const scheduler = new OsvAdvisoryIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    packages: [TARGET],
+    fetchImpl: makeFetch()
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-26T10:00:00.000Z"));
+  assert.equal(summary.createdCount, 1);
+  assert.equal(platform.listJobs().length, 1);
+  assert.equal(platform.listJobs()[0].source.type, "osv_advisory");
+  assert.equal(platform.listJobs()[0].source.advisoryId, "GHSA-vh95-rmgr-6w4m");
+});
+
+test("OsvAdvisoryIngestionScheduler dedupes by advisory package target", async () => {
+  const platform = makePlatformService([
+    {
+      id: "existing",
+      source: {
+        type: "osv_advisory",
+        provider: "osv",
+        ecosystem: "npm",
+        repo: "example/app",
+        manifestPath: "package.json",
+        packageName: "minimist",
+        vulnerableVersion: "0.0.8",
+        advisoryId: "GHSA-vh95-rmgr-6w4m"
+      }
+    }
+  ]);
+  const scheduler = new OsvAdvisoryIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    packages: [TARGET],
+    fetchImpl: makeFetch()
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-26T10:00:00.000Z"));
+  assert.equal(summary.createdCount, 0);
+  assert.equal(platform.listJobs().length, 1);
+  assert.equal(summary.skipped.at(-1).reason, "source_already_ingested");
+});
+
+test("OsvAdvisoryIngestionScheduler stops when max open OSV jobs is reached", async () => {
+  const platform = makePlatformService([
+    { id: "a", source: { type: "osv_advisory", packageName: "a", vulnerableVersion: "1.0.0", advisoryId: "OSV-A" } }
+  ]);
+  const scheduler = new OsvAdvisoryIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    packages: [TARGET],
+    maxOpenJobs: 1,
+    fetchImpl: makeFetch()
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-26T10:00:00.000Z"));
+  assert.equal(summary.createdCount, 0);
+  assert.equal(summary.skipped[0].reason, "max_open_jobs_reached");
+});
+
+test("loadOsvAdvisoryIngestionConfig parses env knobs safely", () => {
+  const config = loadOsvAdvisoryIngestionConfig({
+    OSV_INGEST_ENABLED: "true",
+    OSV_INGEST_DRY_RUN: "false",
+    OSV_INGEST_INTERVAL_MS: "3600000",
+    OSV_INGEST_MIN_SCORE: "70",
+    OSV_INGEST_MAX_JOBS_PER_RUN: "4",
+    OSV_INGEST_MAX_OPEN_JOBS: "11",
+    OSV_INGEST_PACKAGES_JSON: JSON.stringify([TARGET])
+  });
+
+  assert.equal(config.enabled, true);
+  assert.equal(config.dryRun, false);
+  assert.equal(config.intervalMs, 3600000);
+  assert.equal(config.minScore, 70);
+  assert.equal(config.maxJobsPerRun, 4);
+  assert.equal(config.maxOpenJobs, 11);
+  assert.deepEqual(config.packages, [TARGET]);
+});


### PR DESCRIPTION
## Summary
- add opt-in schedulers for OSV/NVD advisory jobs and Data.gov open-data audit jobs
- expose both scheduler statuses in /admin/status and backend runtime startup
- document env knobs for dry-run, cadence, limits, and source targets

## Tests
- node --test mcp-server/src/services/osv-advisory-ingestion-scheduler.test.js
- node --test mcp-server/src/services/open-data-ingestion-scheduler.test.js
- node --test mcp-server/src/core/platform-service.test.js
- npm --workspace mcp-server test