### PR TITLE
Add dispute SLA timeout path

### DIFF
--- a/contracts/EscrowCore.sol
+++ b/contracts/EscrowCore.sol
@@ -7,7 +7,8 @@ import {ReputationSBT} from "./ReputationSBT.sol";
 import {ReentrancyGuard} from "./lib/ReentrancyGuard.sol";
 
 contract EscrowCore is ReentrancyGuard {
-    uint256 public constant DISPUTE_WINDOW = 1 days;
+    uint256 public constant DISPUTE_WINDOW = 7 days;
+    uint256 public constant ARBITRATOR_SLA = 14 days;
     // Caps the per-job milestone count so the settlement loop in
     // resolveMilestone() has a known upper gas bound. 32 leaves plenty of
     // headroom for multi-stage deliverables while ruling out griefing via
@@ -15,6 +16,7 @@ contract EscrowCore is ReentrancyGuard {
     uint256 public constant MAX_MILESTONES = 32;
     bytes32 public constant REASON_REJECTED = bytes32("REJECTED");
     bytes32 public constant REASON_DISPUTE_LOST = bytes32("DISPUTE_LOST");
+    bytes32 public constant REASON_ARBITRATOR_TIMEOUT = bytes32("ARB_TIMEOUT");
 
     TreasuryPolicy public immutable policy;
     AgentAccountCore public immutable accounts;
@@ -49,6 +51,8 @@ contract EscrowCore is ReentrancyGuard {
         uint256 claimExpiry;
         uint256 claimStake;
         uint16 claimStakeBps;
+        uint256 rejectedAt;
+        uint256 disputedAt;
         PayoutMode payoutMode;
         JobState state;
     }
@@ -59,7 +63,6 @@ contract EscrowCore is ReentrancyGuard {
     mapping(bytes32 => mapping(bytes32 => bool)) public settlementExecuted;
     mapping(bytes32 => bytes32) public latestEvidence;
     mapping(bytes32 => uint256) public claimTtls;
-    mapping(bytes32 => uint256) public rejectionTimestamps;
     mapping(bytes32 => bool) public autoDisclosed;
 
     event JobFunded(bytes32 indexed jobId, address indexed poster, address indexed asset, uint256 totalReserved, PayoutMode payoutMode);
@@ -70,7 +73,9 @@ contract EscrowCore is ReentrancyGuard {
     event JobReopened(bytes32 indexed jobId);
     event JobRejected(bytes32 indexed jobId, bytes32 reasonCode);
     event Verified(bytes32 indexed jobId, address indexed verifier, bool approved, bytes32 reasonCode, bytes32 reasoningHash);
-    event DisputeOpened(bytes32 indexed jobId, address indexed opener);
+    event DisputeOpened(bytes32 indexed jobId, address indexed opener, uint256 disputedAt);
+    event DisputeResolved(bytes32 indexed jobId, address indexed arbitrator, uint256 workerPayout, bytes32 reasonCode, string metadataURI);
+    event AutoResolvedOnTimeout(bytes32 indexed jobId, address indexed caller, uint256 workerPayout, bytes32 reasonCode);
     event JobClosed(bytes32 indexed jobId, address indexed worker, uint256 releasedAmount);
     event Disclosed(bytes32 indexed hash, address indexed byWallet, uint64 timestamp);
     event AutoDisclosed(bytes32 indexed hash, uint64 timestamp);
@@ -150,6 +155,8 @@ contract EscrowCore is ReentrancyGuard {
             claimExpiry: 0,
             claimStake: 0,
             claimStakeBps: 0,
+            rejectedAt: 0,
+            disputedAt: 0,
             payoutMode: PayoutMode.Single,
             state: JobState.Open
         });
@@ -193,6 +200,8 @@ contract EscrowCore is ReentrancyGuard {
             claimExpiry: 0,
             claimStake: 0,
             claimStakeBps: 0,
+            rejectedAt: 0,
+            disputedAt: 0,
             payoutMode: PayoutMode.Milestone,
             state: JobState.Open
         });
@@ -272,7 +281,8 @@ contract EscrowCore is ReentrancyGuard {
 
         if (!approved) {
             job.state = JobState.Rejected;
-            rejectionTimestamps[jobId] = block.timestamp;
+            job.rejectedAt = block.timestamp;
+            job.disputedAt = 0;
             emit JobRejected(jobId, reasonCode);
             return;
         }
@@ -312,7 +322,8 @@ contract EscrowCore is ReentrancyGuard {
 
         if (!approved) {
             job.state = JobState.Rejected;
-            rejectionTimestamps[jobId] = block.timestamp;
+            job.rejectedAt = block.timestamp;
+            job.disputedAt = 0;
             emit JobRejected(jobId, reasonCode);
             return;
         }
@@ -354,21 +365,22 @@ contract EscrowCore is ReentrancyGuard {
 
     function openDispute(bytes32 jobId) external whenNotPaused onlyParticipant(jobId) {
         JobEscrow storage job = _jobs[jobId];
-        if (job.state != JobState.Rejected && job.state != JobState.Submitted) revert InvalidState();
-        rejectionTimestamps[jobId] = 0;
+        if (job.state != JobState.Rejected) revert InvalidState();
+        require(job.rejectedAt != 0, "NO_REJECTION_TIMESTAMP");
+        require(block.timestamp <= job.rejectedAt + DISPUTE_WINDOW, "DISPUTE_WINDOW_CLOSED");
+        job.disputedAt = block.timestamp;
         job.state = JobState.Disputed;
-        emit DisputeOpened(jobId, msg.sender);
+        emit DisputeOpened(jobId, msg.sender, job.disputedAt);
     }
 
     function finalizeRejectedJob(bytes32 jobId) external whenNotPaused nonReentrant {
         JobEscrow storage job = _jobs[jobId];
         if (job.state != JobState.Rejected) revert InvalidState();
-        require(rejectionTimestamps[jobId] != 0, "NO_REJECTION_TIMESTAMP");
-        require(block.timestamp > rejectionTimestamps[jobId] + DISPUTE_WINDOW, "DISPUTE_WINDOW_ACTIVE");
+        require(job.rejectedAt != 0, "NO_REJECTION_TIMESTAMP");
+        require(block.timestamp > job.rejectedAt + DISPUTE_WINDOW, "DISPUTE_WINDOW_ACTIVE");
 
         _slashRejectedWorker(job);
         _refundPosterBalances(job);
-        rejectionTimestamps[jobId] = 0;
         job.claimExpiry = 0;
         job.state = JobState.Closed;
         emit JobClosed(jobId, job.worker, job.released);
@@ -383,6 +395,33 @@ contract EscrowCore is ReentrancyGuard {
         JobEscrow storage job = _jobs[jobId];
         if (job.state != JobState.Disputed) revert InvalidState();
         require(workerPayout <= (job.reward - job.released), "EXCESS_PAYOUT");
+        _resolveDispute(jobId, job, workerPayout, reasonCode, metadataURI);
+        emit DisputeResolved(jobId, msg.sender, workerPayout, reasonCode, metadataURI);
+        emit JobClosed(jobId, job.worker, job.released);
+    }
+
+    function autoResolveOnTimeout(bytes32 jobId) external whenNotPaused nonReentrant {
+        JobEscrow storage job = _jobs[jobId];
+        if (job.state != JobState.Disputed) revert InvalidState();
+        require(job.disputedAt != 0, "NO_DISPUTE_TIMESTAMP");
+        require(block.timestamp >= job.disputedAt + ARBITRATOR_SLA, "ARBITRATOR_SLA_ACTIVE");
+
+        uint256 workerPayout = job.reward - job.released;
+        _resolveDispute(jobId, job, workerPayout, REASON_ARBITRATOR_TIMEOUT, "");
+        emit DisputeResolved(jobId, msg.sender, workerPayout, REASON_ARBITRATOR_TIMEOUT, "");
+        emit AutoResolvedOnTimeout(jobId, msg.sender, workerPayout, REASON_ARBITRATOR_TIMEOUT);
+        emit JobClosed(jobId, job.worker, job.released);
+    }
+
+    function _resolveDispute(
+        bytes32 jobId,
+        JobEscrow storage job,
+        uint256 workerPayout,
+        bytes32 reasonCode,
+        string memory metadataURI
+    )
+        internal
+    {
         if (workerPayout > 0) {
             accounts.settleReservedTo(job.poster, job.asset, job.worker, workerPayout);
             job.released += workerPayout;
@@ -393,13 +432,11 @@ contract EscrowCore is ReentrancyGuard {
         }
 
         _refundPosterBalances(job);
-        rejectionTimestamps[jobId] = 0;
         job.claimExpiry = 0;
         job.state = JobState.Closed;
         if (workerPayout > 0) {
             reputation.mintBadge(job.worker, job.category, 1, metadataURI);
         }
-        emit JobClosed(jobId, job.worker, job.released);
     }
 
     function _refundPosterBalances(JobEscrow storage job) internal {

--- a/docs/AUDIT_PACKAGE.md
+++ b/docs/AUDIT_PACKAGE.md
@@ -148,8 +148,9 @@ In the order we'd like auditors to break:
   (via `recordOutflow`). Not parameterized.
 - **Single verifier per job**, verifier chosen by `TreasuryPolicy.verifiers`
   allowlist, not per-job assignment. Multi-verifier consensus is out of scope.
-- **Dispute window is 1 day** (`EscrowCore.DISPUTE_WINDOW`). Constant, not
-  per-job.
+- **Dispute window is 7 days** (`EscrowCore.DISPUTE_WINDOW`). Constant, not
+  per-job. Disputed jobs also carry `disputedAt` and can be auto-resolved in
+  the worker's favor after the 14-day `ARBITRATOR_SLA`.
 - **`IERC20Like` vs full ERC20.** We never call `approve`/`allowance`
   on-chain (the deposit flow expects the EOA to pre-approve). SafeTransfer
   handles tokens that don't return a bool (USDT-style) and tokens that
@@ -185,7 +186,8 @@ Current testnet values (reproducible via [deploy_contracts.sh](../scripts/deploy
 | `disputeLossSkillPenalty` | `30` | Applied when arbitrator sides against worker. |
 | `disputeLossReliabilityPenalty` | `50` | |
 | `MAX_MILESTONES` | `32` | Constant in `EscrowCore`. |
-| `DISPUTE_WINDOW` | `1 days` | Constant in `EscrowCore`. |
+| `DISPUTE_WINDOW` | `7 days` | Constant in `EscrowCore`. |
+| `ARBITRATOR_SLA` | `14 days` | Constant in `EscrowCore`; gates `autoResolveOnTimeout`. |
 
 The deploy script now treats those policy values as testnet-friendly defaults
 only. `PROFILE=mainnet` refuses to proceed unless the outflow cap, borrow cap,

--- a/docs/DISPUTE_CODES.md
+++ b/docs/DISPUTE_CODES.md
@@ -38,9 +38,14 @@ uses payout amount as the settlement branch:
   penalized with dispute-loss policy values, and `JobRejected(jobId,
   reasonCode)` is emitted.
 
-That means `reasonCode` is descriptive today, not a policy switch. Contract
-changes that add `autoResolveOnTimeout`, mutual release, or richer partial
-settlement must document whether they keep or change that branch behavior.
+`EscrowCore.autoResolveOnTimeout(jobId)` is permissionless after the
+arbitrator SLA elapses and uses `ARB_TIMEOUT` with a full remaining worker
+payout. That path returns the claim stake and mints a badge, matching the
+worker-favorable dispute branch.
+
+That means `reasonCode` is descriptive today, not a policy switch. Future
+contract changes that add mutual release or richer partial settlement must
+document whether they keep or change that branch behavior.
 
 ## Indexer Guidance
 

--- a/indexer/abis/contractsAbi.ts
+++ b/indexer/abis/contractsAbi.ts
@@ -9,11 +9,13 @@ export const EscrowCoreAbi = parseAbi([
   "event JobReopened(bytes32 indexed jobId)",
   "event JobRejected(bytes32 indexed jobId, bytes32 reasonCode)",
   "event Verified(bytes32 indexed jobId, address indexed verifier, bool approved, bytes32 reasonCode, bytes32 reasoningHash)",
-  "event DisputeOpened(bytes32 indexed jobId, address indexed opener)",
+  "event DisputeOpened(bytes32 indexed jobId, address indexed opener, uint256 disputedAt)",
+  "event DisputeResolved(bytes32 indexed jobId, address indexed arbitrator, uint256 workerPayout, bytes32 reasonCode, string metadataURI)",
+  "event AutoResolvedOnTimeout(bytes32 indexed jobId, address indexed caller, uint256 workerPayout, bytes32 reasonCode)",
   "event JobClosed(bytes32 indexed jobId, address indexed worker, uint256 releasedAmount)",
   "event Disclosed(bytes32 indexed hash, address indexed byWallet, uint64 timestamp)",
   "event AutoDisclosed(bytes32 indexed hash, uint64 timestamp)",
-  "function jobs(bytes32 jobId) view returns ((address poster, address worker, address asset, bytes32 verifierMode, bytes32 category, bytes32 specHash, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 released, uint256 claimExpiry, uint256 claimStake, uint16 claimStakeBps, uint8 payoutMode, uint8 state))"
+  "function jobs(bytes32 jobId) view returns ((address poster, address worker, address asset, bytes32 verifierMode, bytes32 category, bytes32 specHash, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 released, uint256 claimExpiry, uint256 claimStake, uint16 claimStakeBps, uint256 rejectedAt, uint256 disputedAt, uint8 payoutMode, uint8 state))"
 ]);
 
 export const ReputationSbtAbi = parseAbi([

--- a/indexer/ponder.schema.ts
+++ b/indexer/ponder.schema.ts
@@ -17,6 +17,8 @@ export const job = onchainTable("job", (p) => ({
   claimExpiry: p.bigint().notNull(),
   claimStake: p.bigint().notNull(),
   claimStakeBps: p.integer().notNull(),
+  rejectedAt: p.bigint(),
+  disputedAt: p.bigint(),
   payoutMode: p.integer().notNull(),
   payoutModeLabel: p.text().notNull(),
   state: p.integer().notNull(),
@@ -40,6 +42,8 @@ export const jobEvent = onchainTable("job_event", (p) => ({
   reasoningHash: p.hex(),
   approved: p.boolean(),
   reasonCode: p.hex(),
+  metadataUri: p.text(),
+  disputedAt: p.bigint(),
   txHash: p.hex().notNull(),
   blockNumber: p.bigint().notNull(),
   timestamp: p.bigint().notNull()

--- a/indexer/src/index.ts
+++ b/indexer/src/index.ts
@@ -65,6 +65,8 @@ const syncJob = async ({
     claimExpiry,
     claimStake,
     claimStakeBps,
+    rejectedAt,
+    disputedAt,
     payoutMode,
     state
   ] = live;
@@ -88,6 +90,8 @@ const syncJob = async ({
       claimExpiry,
       claimStake,
       claimStakeBps,
+      rejectedAt: rejectedAt === 0n ? null : rejectedAt,
+      disputedAt: disputedAt === 0n ? null : disputedAt,
       payoutMode,
       payoutModeLabel: payoutModeLabels[payoutMode] ?? "unknown",
       state,
@@ -105,6 +109,8 @@ const syncJob = async ({
       claimExpiry: row.claimExpiry,
       claimStake: row.claimStake,
       claimStakeBps: row.claimStakeBps,
+      rejectedAt: row.rejectedAt,
+      disputedAt: row.disputedAt,
       payoutMode: row.payoutMode,
       payoutModeLabel: row.payoutModeLabel,
       state: row.state,
@@ -257,6 +263,42 @@ ponder.on("EscrowCore:DisputeOpened", async ({ event, context }) => {
     amount: null,
     evidenceHash: null,
     reasonCode: null,
+    disputedAt: event.args.disputedAt,
+    txHash: event.transaction.hash,
+    blockNumber: event.block.number,
+    timestamp: event.block.timestamp
+  });
+});
+
+ponder.on("EscrowCore:DisputeResolved", async ({ event, context }) => {
+  await syncJob({ context, event, jobId: event.args.jobId });
+  await context.db.insert(schema.jobEvent).values({
+    id: toEventId(event.transaction.hash, event.log.logIndex),
+    jobId: event.args.jobId,
+    kind: "DisputeResolved",
+    actor: event.args.arbitrator,
+    amount: event.args.workerPayout,
+    evidenceHash: null,
+    approved: event.args.workerPayout > 0n,
+    reasonCode: event.args.reasonCode,
+    metadataUri: event.args.metadataURI,
+    txHash: event.transaction.hash,
+    blockNumber: event.block.number,
+    timestamp: event.block.timestamp
+  });
+});
+
+ponder.on("EscrowCore:AutoResolvedOnTimeout", async ({ event, context }) => {
+  await syncJob({ context, event, jobId: event.args.jobId });
+  await context.db.insert(schema.jobEvent).values({
+    id: toEventId(event.transaction.hash, event.log.logIndex),
+    jobId: event.args.jobId,
+    kind: "AutoResolvedOnTimeout",
+    actor: event.args.caller,
+    amount: event.args.workerPayout,
+    evidenceHash: null,
+    approved: true,
+    reasonCode: event.args.reasonCode,
     txHash: event.transaction.hash,
     blockNumber: event.block.number,
     timestamp: event.block.timestamp

--- a/mcp-server/src/blockchain/abis.js
+++ b/mcp-server/src/blockchain/abis.js
@@ -33,8 +33,9 @@ export const ESCROW_CORE_ABI = [
   "function submitWork(bytes32 jobId, bytes32 evidenceHash)",
   "function resolveSinglePayout(bytes32 jobId, bool approved, bytes32 reasonCode, string metadataURI, bytes32 reasoningHash)",
   "function finalizeRejectedJob(bytes32 jobId)",
+  "function autoResolveOnTimeout(bytes32 jobId)",
   "function resolveDispute(bytes32 jobId, uint256 workerPayout, bytes32 reasonCode, string metadataURI)",
-  "function jobs(bytes32 jobId) view returns ((address poster, address worker, address asset, bytes32 verifierMode, bytes32 category, bytes32 specHash, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 released, uint256 claimExpiry, uint256 claimStake, uint16 claimStakeBps, uint8 payoutMode, uint8 state))",
+  "function jobs(bytes32 jobId) view returns ((address poster, address worker, address asset, bytes32 verifierMode, bytes32 category, bytes32 specHash, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 released, uint256 claimExpiry, uint256 claimStake, uint16 claimStakeBps, uint256 rejectedAt, uint256 disputedAt, uint8 payoutMode, uint8 state))",
   "event JobFunded(bytes32 indexed jobId, address indexed poster, address indexed asset, uint256 totalReserved, uint8 payoutMode)",
   "event JobCreated(bytes32 indexed jobId, address indexed poster, bytes32 indexed specHash, address asset, uint256 totalReserved, uint8 payoutMode)",
   "event JobClaimed(bytes32 indexed jobId, address indexed worker, uint256 claimExpiry, uint256 claimStake)",
@@ -44,7 +45,9 @@ export const ESCROW_CORE_ABI = [
   "event Verified(bytes32 indexed jobId, address indexed verifier, bool approved, bytes32 reasonCode, bytes32 reasoningHash)",
   "event JobClosed(bytes32 indexed jobId, address indexed worker, uint256 releasedAmount)",
   "event JobReopened(bytes32 indexed jobId)",
-  "event DisputeOpened(bytes32 indexed jobId, address indexed opener)",
+  "event DisputeOpened(bytes32 indexed jobId, address indexed opener, uint256 disputedAt)",
+  "event DisputeResolved(bytes32 indexed jobId, address indexed arbitrator, uint256 workerPayout, bytes32 reasonCode, string metadataURI)",
+  "event AutoResolvedOnTimeout(bytes32 indexed jobId, address indexed caller, uint256 workerPayout, bytes32 reasonCode)",
   "event Disclosed(bytes32 indexed hash, address indexed byWallet, uint64 timestamp)",
   "event AutoDisclosed(bytes32 indexed hash, uint64 timestamp)"
 ];

--- a/mcp-server/src/blockchain/event-listener.js
+++ b/mcp-server/src/blockchain/event-listener.js
@@ -126,6 +126,41 @@ export class EventListener {
       });
     });
 
+    this.registerEscrow("DisputeResolved", "escrow.dispute_resolved", async ({ args, payload }) => {
+      const job = await this.readJob(args.jobId);
+      return this.buildChainEvent({
+        topic: "escrow.dispute_resolved",
+        args,
+        payload,
+        wallet: normalizeAddress(job.worker),
+        wallets: [job.poster, job.worker, args.arbitrator],
+        sessionId: buildSessionId(args.jobId, job.worker),
+        job,
+        data: {
+          workerPayout: args.workerPayout.toString(),
+          reasonCode: args.reasonCode,
+          metadataURI: args.metadataURI
+        }
+      });
+    });
+
+    this.registerEscrow("AutoResolvedOnTimeout", "escrow.auto_resolved_on_timeout", async ({ args, payload }) => {
+      const job = await this.readJob(args.jobId);
+      return this.buildChainEvent({
+        topic: "escrow.auto_resolved_on_timeout",
+        args,
+        payload,
+        wallet: normalizeAddress(job.worker),
+        wallets: [job.poster, job.worker, args.caller],
+        sessionId: buildSessionId(args.jobId, job.worker),
+        job,
+        data: {
+          workerPayout: args.workerPayout.toString(),
+          reasonCode: args.reasonCode
+        }
+      });
+    });
+
     this.registerAccount("JobStakeLocked", "account.job_stake_locked", async ({ args, payload }) =>
       this.buildChainEvent({
         topic: "account.job_stake_locked",
@@ -340,6 +375,8 @@ export class EventListener {
       claimExpiry: Number(job.claimExpiry),
       claimStake: job.claimStake?.toString?.() ?? `${job.claimStake}`,
       claimStakeBps: Number(job.claimStakeBps),
+      rejectedAt: Number(job.rejectedAt),
+      disputedAt: Number(job.disputedAt),
       state: Number(job.state)
     };
   }

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -583,7 +583,9 @@ export class BlockchainGateway {
         claimStake: Number(job.claimStake),
         claimStakeBps: Number(job.claimStakeBps),
         state: Number(job.state),
-        claimExpiry: Number(job.claimExpiry)
+        claimExpiry: Number(job.claimExpiry),
+        rejectedAt: Number(job.rejectedAt),
+        disputedAt: Number(job.disputedAt)
       };
     });
   }

--- a/test/AgentPlatform.t.sol
+++ b/test/AgentPlatform.t.sol
@@ -288,6 +288,8 @@ contract AgentPlatformTest is Test {
 
         vm.prank(worker);
         escrow.openDispute(jobId);
+        EscrowCore.JobEscrow memory disputedJob = escrow.jobs(jobId);
+        assertEq(disputedJob.disputedAt, block.timestamp);
 
         vm.warp(block.timestamp + escrow.DISPUTE_WINDOW() + 1);
         (bool finalizedDisputed,) = address(escrow).call(abi.encodeCall(escrow.finalizeRejectedJob, (jobId)));
@@ -299,6 +301,16 @@ contract AgentPlatformTest is Test {
         assertEq(workerJobStake, 2.5 ether);
         assertEq(skillAfter, 100);
         assertEq(reliabilityAfter, 100);
+    }
+
+    function testOpenDisputeRejectsAfterDisputeWindow() public {
+        bytes32 jobId = createRejectedSinglePayoutJob("job/rejected/late-dispute", 50 ether);
+
+        vm.warp(block.timestamp + escrow.DISPUTE_WINDOW() + 1);
+
+        vm.prank(worker);
+        (bool ok,) = address(escrow).call(abi.encodeCall(escrow.openDispute, (jobId)));
+        require(!ok, "EXPECTED_DISPUTE_WINDOW_REVERT");
     }
 
     function testResolveDisputeAgainstWorkerSlashesStakeAndReputation() public {
@@ -338,6 +350,42 @@ contract AgentPlatformTest is Test {
         assertEq(reliabilityAfter, 50);
     }
 
+    function testAutoResolveOnTimeoutRejectsBeforeArbitratorSla() public {
+        bytes32 jobId = createRejectedSinglePayoutJob("job/dispute/timeout/early", 50 ether);
+
+        vm.prank(worker);
+        escrow.openDispute(jobId);
+
+        vm.warp(block.timestamp + escrow.ARBITRATOR_SLA() - 1);
+        (bool ok,) = address(escrow).call(abi.encodeCall(escrow.autoResolveOnTimeout, (jobId)));
+        require(!ok, "EXPECTED_ARBITRATOR_SLA_REVERT");
+    }
+
+    function testAutoResolveOnTimeoutPaysWorkerAndReleasesStake() public {
+        bytes32 jobId = createRejectedSinglePayoutJob("job/dispute/timeout/success", 50 ether);
+        uint256 workerTokenBalanceBefore = dot.balanceOf(worker);
+
+        vm.prank(worker);
+        escrow.openDispute(jobId);
+
+        vm.warp(block.timestamp + escrow.ARBITRATOR_SLA());
+        escrow.autoResolveOnTimeout(jobId);
+
+        EscrowCore.JobEscrow memory job = escrow.jobs(jobId);
+        (uint256 liquidPoster, uint256 reservedPoster,,,,) = accounts.positions(poster, address(dot));
+        (uint256 liquidWorker,,,, uint256 workerJobStake,) = accounts.positions(worker, address(dot));
+
+        assertEq(uint256(job.state), uint256(EscrowCore.JobState.Closed));
+        assertEq(job.released, 50 ether);
+        require(job.disputedAt > 0, "EXPECTED_DISPUTED_AT");
+        assertEq(liquidPoster, POSTER_DEPOSIT - 50 ether);
+        assertEq(reservedPoster, 0);
+        assertEq(liquidWorker, WORKER_DEPOSIT);
+        assertEq(workerJobStake, 0);
+        assertEq(dot.balanceOf(worker), workerTokenBalanceBefore + 50 ether);
+        assertEq(reputation.balanceOf(worker), 1);
+    }
+
     function testSlashReputationSaturatesAtZero() public {
         reputation.updateReputation(worker, 5, 3, 1);
         reputation.slashReputation(worker, 10, 10, 10, bytes32("SATURATE"));
@@ -354,5 +402,31 @@ contract AgentPlatformTest is Test {
             abi.encodeCall(reputation.slashReputation, (worker, 1, 1, 0, bytes32("NOPE")))
         );
         require(!ok, "EXPECTED_UNAUTHORIZED_REVERT");
+    }
+
+    function createRejectedSinglePayoutJob(string memory label, uint256 reward) internal returns (bytes32 jobId) {
+        jobId = keccak256(bytes(label));
+
+        vm.prank(poster);
+        escrow.createSinglePayoutJob(
+            jobId,
+            address(dot),
+            reward,
+            5 ether,
+            5 ether,
+            1 days,
+            bytes32("AUTO"),
+            bytes32("DATA"),
+            SPEC_HASH
+        );
+
+        vm.prank(worker);
+        escrow.claimJob(jobId);
+
+        vm.prank(worker);
+        escrow.submitWork(jobId, keccak256(bytes(label)));
+
+        vm.prank(verifier);
+        escrow.resolveSinglePayout(jobId, false, bytes32("REJECTED"), "ipfs://badge/rejected", REASONING_HASH);
     }
 }


### PR DESCRIPTION
## Summary
- Bump EscrowCore.DISPUTE_WINDOW to 7 days and enforce it in openDispute.
- Add rejectedAt/disputedAt timestamps to escrow job state and include disputedAt on DisputeOpened.
- Add ARBITRATOR_SLA, permissionless autoResolveOnTimeout, and DisputeResolved / AutoResolvedOnTimeout events.
- Update backend/indexer ABIs, event listeners, indexer schema/handlers, tests, and dispute/audit docs.

## Checks
- forge test
- npm --workspace mcp-server test
- npm run typecheck:indexer
- npm --workspace indexer run codegen

## Affected areas
- Contracts: yes
- Backend: yes
- Indexer: yes
- Frontend/public site: no
- Caddy: no

## Deployment notes
- Contract storage/event surface changes require the planned rc1 contract redeployment wave.
- No manual production deploy performed.