### PR TITLE
Fix Data.gov open-data catalog fallback

### DIFF
--- a/docs/READY_TO_POST_JOBS.md
+++ b/docs/READY_TO_POST_JOBS.md
@@ -389,7 +389,9 @@ OSV/GHSA/CVE identifiers, and includes test or install evidence.
 
 ## Data.gov open-data quality jobs
 
-The first government open-data provider targets the US Data.gov CKAN catalog.
+The first government open-data provider targets the US Data.gov catalog. It
+tries the legacy CKAN `package_search` endpoint first, then falls back to the
+current Catalog API `/search` endpoint when CKAN is unavailable.
 Data.gov exposes dataset metadata and resource URLs, not the actual data
 contents, so Averray jobs should stay audit/report shaped. Workers inspect the
 catalog landing page and referenced resource, then submit structured quality

--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -168,6 +168,10 @@ AUTH_CHAIN_ID=420420417
 # OPEN_DATA_INGEST_MAX_JOBS_PER_RUN=2
 # OPEN_DATA_INGEST_MAX_OPEN_JOBS=20
 # OPEN_DATA_INGEST_QUERY=res_format:CSV
+# Optional endpoint overrides. The ingester tries the legacy CKAN endpoint first,
+# then falls back to the current Data.gov Catalog API /search endpoint.
+# DATA_GOV_PACKAGE_SEARCH_URL=https://catalog.data.gov/api/3/action/package_search
+# DATA_GOV_CATALOG_SEARCH_URL=https://catalog.data.gov/search
 # OPEN_DATA_INGEST_DATASETS_JSON=[{"datasetTitle":"Federal sample spending data","datasetUrl":"https://catalog.data.gov/dataset/example","resourceUrl":"https://example.gov/data.csv","resourceFormat":"CSV","agency":"GSA"}]
 
 # --- Supported on-chain assets ------------------------------------------------

--- a/mcp-server/src/jobs/ingest-open-data-datasets.js
+++ b/mcp-server/src/jobs/ingest-open-data-datasets.js
@@ -20,6 +20,7 @@ export const DEFAULT_BASE_URL = "http://localhost:8787";
 export const DEFAULT_PROVIDER = "data.gov";
 export const DEFAULT_QUERY = "res_format:CSV";
 export const DATA_GOV_PACKAGE_SEARCH_URL = "https://catalog.data.gov/api/3/action/package_search";
+export const DATA_GOV_CATALOG_SEARCH_URL = "https://catalog.data.gov/search";
 
 const PREFERRED_RESOURCE_FORMATS = new Set(["CSV", "JSON", "GEOJSON", "API", "XLS", "XLSX", "XML"]);
 
@@ -92,25 +93,52 @@ export async function ingestOpenDataDatasets({
 }
 
 export async function searchDataGovDatasets({ query = DEFAULT_QUERY, limit = 30, fetchImpl = fetch } = {}) {
-  const url = new URL(DATA_GOV_PACKAGE_SEARCH_URL);
+  const ckanUrl = new URL(process.env.DATA_GOV_PACKAGE_SEARCH_URL?.trim() || DATA_GOV_PACKAGE_SEARCH_URL);
+  ckanUrl.searchParams.set("q", query);
+  ckanUrl.searchParams.set("rows", String(Math.min(limit, 100)));
+  ckanUrl.searchParams.set("sort", "metadata_modified desc");
+
+  const ckanResponse = await fetchImpl(ckanUrl, {
+    headers: dataGovHeaders()
+  });
+  if (ckanResponse.ok) {
+    const payload = await ckanResponse.json();
+    const packages = payload.result?.results ?? [];
+    return packages.flatMap(extractPackageTargets);
+  }
+
+  const ckanBody = await ckanResponse.text();
+  if (![404, 410].includes(ckanResponse.status)) {
+    throw new Error(`Data.gov package_search failed (${ckanResponse.status}): ${ckanBody}`);
+  }
+
+  return searchDataGovCatalog({ query, limit, fetchImpl, previousStatus: ckanResponse.status, previousBody: ckanBody });
+}
+
+export async function searchDataGovCatalog({
+  query = DEFAULT_QUERY,
+  limit = 30,
+  fetchImpl = fetch,
+  previousStatus = undefined,
+  previousBody = undefined
+} = {}) {
+  const url = new URL(process.env.DATA_GOV_CATALOG_SEARCH_URL?.trim() || DATA_GOV_CATALOG_SEARCH_URL);
   url.searchParams.set("q", query);
-  url.searchParams.set("rows", String(Math.min(limit, 100)));
-  url.searchParams.set("sort", "metadata_modified desc");
+  url.searchParams.set("per_page", String(Math.min(limit, 100)));
+  url.searchParams.set("sort", "last_harvested_date");
 
   const response = await fetchImpl(url, {
-    headers: {
-      accept: "application/json",
-      "user-agent": "AverrayOpenDataIngest/0.1 (https://averray.com; operator@averray.com)"
-    }
+    headers: dataGovHeaders()
   });
   if (!response.ok) {
     const body = await response.text();
-    throw new Error(`Data.gov package_search failed (${response.status}): ${body}`);
+    const previous = previousStatus ? `; package_search failed first (${previousStatus}): ${previousBody}` : "";
+    throw new Error(`Data.gov catalog search failed (${response.status}): ${body}${previous}`);
   }
 
   const payload = await response.json();
-  const packages = payload.result?.results ?? [];
-  return packages.flatMap(extractPackageTargets);
+  const results = payload.results ?? [];
+  return results.flatMap(extractCatalogResultTargets);
 }
 
 export function parseDatasets(raw) {
@@ -142,6 +170,37 @@ export function extractPackageTargets(pkg) {
       license,
       modified: resource.last_modified ?? resource.revision_timestamp ?? metadataModified,
       metadataModified
+    }))
+    .filter(Boolean);
+}
+
+export function extractCatalogResultTargets(result) {
+  const dcat = result.dcat && typeof result.dcat === "object" ? result.dcat : {};
+  const datasetId = text(result.identifier ?? dcat.identifier ?? result.slug);
+  const datasetTitle = text(result.title ?? dcat.title ?? result.slug);
+  const slug = text(result.slug);
+  const datasetUrl = text(dcat.landingPage ?? result.landingPage)
+    || (slug ? `https://catalog.data.gov/dataset/${slug}` : "");
+  const agency = text(result.publisher ?? dcat.publisher?.name ?? result.organization?.name);
+  const license = text(dcat.license);
+  const metadataModified = text(dcat.modified ?? result.last_harvested_date);
+  const distributions = Array.isArray(dcat.distribution) ? dcat.distribution : [];
+
+  return distributions
+    .map((distribution, index) => normalizeDatasetTarget({
+      portal: DEFAULT_PROVIDER,
+      datasetId,
+      datasetTitle,
+      datasetUrl,
+      resourceId: text(distribution.identifier ?? distribution["@id"] ?? distribution.title) || `${datasetId || slug}-distribution-${index + 1}`,
+      resourceTitle: distribution.title ?? distribution.name ?? distribution.description,
+      resourceUrl: firstText(distribution.downloadURL, distribution.accessURL, distribution.url),
+      resourceFormat: distribution.format ?? distribution.mediaType ?? distribution["dcat:mediaType"],
+      agency,
+      license,
+      modified: distribution.modified ?? metadataModified,
+      metadataModified,
+      discoveryApi: DATA_GOV_CATALOG_SEARCH_URL
     }))
     .filter(Boolean);
 }
@@ -200,7 +259,7 @@ export function toPlatformJob(target, score = scoreDatasetTarget(target)) {
       modified: target.modified,
       metadataModified: target.metadataModified,
       score,
-      discoveryApi: DATA_GOV_PACKAGE_SEARCH_URL
+      discoveryApi: target.discoveryApi || DATA_GOV_PACKAGE_SEARCH_URL
     },
     acceptanceCriteria: [
       "Fetch the dataset landing page and resource URL and record their status, content type, and final URL if redirected.",
@@ -289,7 +348,8 @@ function normalizeDatasetTarget(raw) {
     agency: text(raw?.agency ?? raw?.publisher),
     license: text(raw?.license),
     modified: text(raw?.modified ?? raw?.lastModified),
-    metadataModified: text(raw?.metadataModified ?? raw?.metadata_modified)
+    metadataModified: text(raw?.metadataModified ?? raw?.metadata_modified),
+    ...(text(raw?.discoveryApi) ? { discoveryApi: text(raw.discoveryApi) } : {})
   };
 }
 
@@ -323,6 +383,17 @@ function estimateDifficulty(score) {
 
 function text(value) {
   return String(value ?? "").trim();
+}
+
+function firstText(...values) {
+  return values.map(text).find(Boolean) ?? "";
+}
+
+function dataGovHeaders() {
+  return {
+    accept: "application/json",
+    "user-agent": "AverrayOpenDataIngest/0.1 (https://averray.com; operator@averray.com)"
+  };
 }
 
 function slugify(value) {

--- a/mcp-server/src/jobs/ingest-open-data-datasets.test.js
+++ b/mcp-server/src/jobs/ingest-open-data-datasets.test.js
@@ -2,7 +2,9 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  DATA_GOV_CATALOG_SEARCH_URL,
   extractPackageTargets,
+  extractCatalogResultTargets,
   ingestOpenDataDatasets,
   parseDatasets,
   scoreDatasetTarget,
@@ -43,6 +45,27 @@ const CKAN_PACKAGE = {
   ]
 };
 
+const CATALOG_RESULT = {
+  identifier: "catalog-dataset-123",
+  slug: "federal-sample-spending-data",
+  title: "Federal sample spending data",
+  publisher: "General Services Administration",
+  last_harvested_date: "2026-02-01T00:00:00Z",
+  dcat: {
+    title: "Federal sample spending data",
+    modified: "2026-01-01T00:00:00Z",
+    license: "https://creativecommons.org/publicdomain/zero/1.0/",
+    distribution: [
+      {
+        title: "Spending CSV",
+        downloadURL: "https://example.gov/spending.csv",
+        format: "CSV",
+        modified: "2021-01-01T00:00:00Z"
+      }
+    ]
+  }
+};
+
 test("parseDatasets accepts JSON and compact line syntax", () => {
   assert.deepEqual(parseDatasets(JSON.stringify([TARGET])), [TARGET]);
   assert.deepEqual(
@@ -73,6 +96,51 @@ test("extractPackageTargets maps CKAN package resources", () => {
   assert.equal(targets[0].datasetUrl, "https://catalog.data.gov/dataset/federal-sample-spending-data");
   assert.equal(targets[0].resourceUrl, "https://example.gov/spending.csv");
   assert.equal(targets[0].agency, "General Services Administration");
+});
+
+test("extractCatalogResultTargets maps current Data.gov catalog search results", () => {
+  const targets = extractCatalogResultTargets(CATALOG_RESULT);
+
+  assert.equal(targets.length, 1);
+  assert.equal(targets[0].datasetId, "catalog-dataset-123");
+  assert.equal(targets[0].datasetUrl, "https://catalog.data.gov/dataset/federal-sample-spending-data");
+  assert.equal(targets[0].resourceUrl, "https://example.gov/spending.csv");
+  assert.equal(targets[0].resourceFormat, "CSV");
+  assert.equal(targets[0].discoveryApi, DATA_GOV_CATALOG_SEARCH_URL);
+});
+
+test("searchDataGovDatasets falls back to current catalog search when CKAN is unavailable", async () => {
+  const calls = [];
+  const targets = await searchDataGovDatasets({
+    query: "res_format:CSV",
+    limit: 5,
+    fetchImpl: async (url, request) => {
+      calls.push(url.toString());
+      assert.equal(request.headers.accept, "application/json");
+      if (url.pathname === "/api/3/action/package_search") {
+        return {
+          ok: false,
+          status: 404,
+          async text() {
+            return '{"message":"Not Found"}';
+          }
+        };
+      }
+      assert.equal(url.pathname, "/search");
+      assert.equal(url.searchParams.get("q"), "res_format:CSV");
+      assert.equal(url.searchParams.get("per_page"), "5");
+      return {
+        ok: true,
+        async json() {
+          return { results: [CATALOG_RESULT] };
+        }
+      };
+    }
+  });
+
+  assert.equal(calls.length, 2);
+  assert.equal(targets.length, 1);
+  assert.equal(targets[0].resourceUrl, "https://example.gov/spending.csv");
 });
 
 test("scoreDatasetTarget prefers concrete resource audit targets", () => {


### PR DESCRIPTION
## Summary
- fall back from legacy Data.gov CKAN package_search to the current Catalog API /search when CKAN returns 404/410
- map DCAT catalog search distributions into open-data audit job targets
- document endpoint overrides for Data.gov ingestion

## Tests
- node --test mcp-server/src/jobs/ingest-open-data-datasets.test.js
- npm --workspace mcp-server test