### PR TITLE
operator-app: UI support for Data.gov / open-data dataset audit jobs

### DIFF
--- a/app/app/(authed)/runs/page.tsx
+++ b/app/app/(authed)/runs/page.tsx
@@ -116,6 +116,17 @@ function RunsPageInner() {
         </b>{" "}
         · PR pending merge
       </>
+    ) : selectedSourceType === "open_data_dataset" ? (
+      <>
+        Window closes in{" "}
+        <b className="font-semibold text-[var(--avy-ink)]">21m 46s</b>
+        {" · "}verification{" "}
+        <b className="font-semibold text-[var(--avy-ink)]">
+          open_data_quality_audit
+        </b>
+        {" · "}audit{" "}
+        <b className="font-semibold text-[var(--avy-ink)]">submitted</b>
+      </>
     ) : (
       <>
         Window closes in{" "}
@@ -139,11 +150,17 @@ function RunsPageInner() {
             value: "Maintainer merge → Pay",
             sub: "auto-pays on PR merge + CI green + lockfile resolves",
           }
-        : {
-            label: "Next",
-            value: "Maintainer review → Pay",
-            sub: "auto-pays on PR merge + CI green",
-          };
+        : selectedSourceType === "open_data_dataset"
+          ? {
+              label: "Next",
+              value: "Verifier check → Pay",
+              sub: "auto-pays on audit verifier signals green",
+            }
+          : {
+              label: "Next",
+              value: "Maintainer review → Pay",
+              sub: "auto-pays on PR merge + CI green",
+            };
 
   const assignedToMe = rows.filter((row) => row.worker.isSelf).length;
   const liveStatus = jobs.error

--- a/app/components/runs/LoadedRunPanel.tsx
+++ b/app/components/runs/LoadedRunPanel.tsx
@@ -6,6 +6,7 @@ import { SourceBadge, type RunState } from "./StatePill";
 import { IssueMarkdown } from "./IssueMarkdown";
 import type {
   GitHubJobContext,
+  OpenDataJobContext,
   OsvJobContext,
   WikipediaJobContext,
 } from "./types";
@@ -142,6 +143,14 @@ export interface LoadedRunPanelProps {
    * other two source contexts at runtime.
    */
   osv?: OsvJobContext;
+  /**
+   * Same shape as the others but for open-data dataset quality-audit
+   * runs (Data.gov today). The panel renders an audit-only evidence
+   * block that highlights the dataset/resource identity, agency, and
+   * format, with Dataset / Checks / Findings / Submission tabs.
+   * Mutually exclusive with the other source contexts at runtime.
+   */
+  openData?: OpenDataJobContext;
   /**
    * Lifecycle state of the loaded run. Drives the stake block's pill +
    * aux copy so the panel doesn't shout "LOCKED" on a run that hasn't
@@ -289,13 +298,15 @@ export function LoadedRunPanel(props: LoadedRunPanelProps) {
 
           {/* Evidence — switches to a source-specific 4-tab layout when the
                loaded run was ingested from a third-party tracker (GitHub
-               issue, Wikipedia maintenance, OSV advisory), so the operator
-               sees real job context instead of generic placeholder
-               governance text. */}
+               issue, Wikipedia maintenance, OSV advisory, Data.gov
+               dataset audit), so the operator sees real job context
+               instead of generic placeholder governance text. */}
           {props.github ? (
             <GitHubEvidenceBlock ctx={props.github} />
           ) : props.wikipedia ? (
             <WikipediaEvidenceBlock ctx={props.wikipedia} />
+          ) : props.openData ? (
+            <OpenDataEvidenceBlock ctx={props.openData} />
           ) : props.osv ? (
             <OsvEvidenceBlock ctx={props.osv} />
           ) : (
@@ -511,6 +522,14 @@ export function LoadedRunPanel(props: LoadedRunPanelProps) {
                   <SmallGhostBtn className="flex-1">Ping maintainer</SmallGhostBtn>
                   <SmallGhostBtn>Raise dispute</SmallGhostBtn>
                   <SmallGhostBtn>Skip advisory</SmallGhostBtn>
+                </>
+              ) : props.openData ? (
+                <>
+                  <SmallGhostBtn className="flex-1">
+                    Flag stale catalog metadata
+                  </SmallGhostBtn>
+                  <SmallGhostBtn>Raise dispute</SmallGhostBtn>
+                  <SmallGhostBtn>Skip dataset</SmallGhostBtn>
                 </>
               ) : (
                 <>
@@ -1352,6 +1371,398 @@ function OsvSubmissionTab({ ctx }: { ctx: OsvJobContext }) {
           style={{ letterSpacing: 0 }}
         />
       </div>
+    </div>
+  );
+}
+
+/**
+ * Open-data quality-audit equivalent of `GitHubEvidenceBlock` /
+ * `WikipediaEvidenceBlock` / `OsvEvidenceBlock`. Same four-tab shape so
+ * an operator reads the surface the same way regardless of source —
+ * here labelled **Dataset · Checks · Findings · Submission** to match
+ * the spec for open-data audit jobs. The header source strip carries
+ * Data.gov · agency · format and degrades gracefully when those
+ * optional catalog fields are missing.
+ *
+ * Critically renders an "audit only" policy banner above the tabs.
+ * The platform never edits source data and never contacts the
+ * publishing agency from this workflow.
+ */
+type OpenDataTab = "dataset" | "checks" | "findings" | "submission";
+
+function OpenDataEvidenceBlock({ ctx }: { ctx: OpenDataJobContext }) {
+  const [tab, setTab] = useState<OpenDataTab>("dataset");
+
+  const tabs: { id: OpenDataTab; label: string; sub?: string }[] = [
+    { id: "dataset", label: "Dataset" },
+    { id: "checks", label: "Checks" },
+    {
+      id: "findings",
+      label: "Findings",
+      sub: `·${ctx.acceptanceCriteria.length}`,
+    },
+    { id: "submission", label: "Submission" },
+  ];
+
+  return (
+    <div>
+      <BlockLabel
+        right={
+          <a
+            href={ctx.datasetUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center gap-1 text-[var(--avy-accent)] hover:underline"
+          >
+            Open Data.gov dataset ↗
+          </a>
+        }
+      >
+        Job context
+      </BlockLabel>
+      <div className="flex flex-col overflow-hidden rounded-[8px] border border-[var(--avy-line)] bg-white">
+        {/* Source strip — pinned above the tabs so portal, agency,
+            format, and Fit score stay readable on every tab. Agency
+            and format are optional in the catalog; we drop the chip
+            entirely instead of rendering an empty bullet. */}
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-b border-[var(--avy-line-soft)] bg-[color:rgba(17,19,21,0.03)] px-3 py-2">
+          <SourceBadge kind="data_gov" />
+          <a
+            href={ctx.datasetUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="truncate whitespace-nowrap font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-ink)] hover:text-[var(--avy-accent)]"
+            style={{ letterSpacing: 0 }}
+            title={ctx.datasetTitle}
+          >
+            <span className="text-[var(--avy-accent)]">{ctx.datasetTitle}</span>
+          </a>
+          {ctx.agency ? (
+            <>
+              <span className="opacity-40">·</span>
+              <span
+                className="whitespace-nowrap font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
+                style={{ letterSpacing: 0 }}
+              >
+                {ctx.agency}
+              </span>
+            </>
+          ) : null}
+          {ctx.resourceFormat ? (
+            <>
+              <span className="opacity-40">·</span>
+              <span
+                className="whitespace-nowrap font-[family-name:var(--font-mono)] text-[11px] uppercase text-[var(--avy-muted)]"
+                style={{ letterSpacing: "0.08em" }}
+              >
+                {ctx.resourceFormat}
+              </span>
+            </>
+          ) : null}
+          {typeof ctx.score === "number" ? (
+            <span className="ml-auto inline-flex items-center gap-1 whitespace-nowrap font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]">
+              Fit score{" "}
+              <b className="font-semibold text-[var(--avy-ink)]">{ctx.score}</b>
+              <span className="text-[var(--avy-muted)]">/100</span>
+            </span>
+          ) : null}
+        </div>
+
+        {/* Audit-only policy banner — non-negotiable, rendered on every
+            open-data run. Same warn-tinted box as the Wikipedia /
+            OSV scope banners so the visual rhythm of "important, but
+            not error" notes stays consistent across source kinds. */}
+        <div
+          className="flex items-start gap-2 border-b border-[var(--avy-line-soft)] bg-[color:rgba(211,145,27,0.08)] px-3 py-2 font-[family-name:var(--font-mono)] text-[11px] leading-[1.5] text-[var(--avy-ink)]"
+          style={{ letterSpacing: 0 }}
+        >
+          <span
+            className="mt-px shrink-0 rounded-full bg-[var(--avy-warn)] px-1.5 py-0.5 font-[family-name:var(--font-display)] text-[9.5px] font-extrabold uppercase text-white"
+            style={{ letterSpacing: "0.1em" }}
+          >
+            Audit only
+          </span>
+          <span>
+            Report dataset/resource quality issues. Do not edit source
+            data or contact agencies from this workflow.
+          </span>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex items-center gap-2 border-b border-[var(--avy-line-soft)] bg-[#faf8f1] px-2.5 py-1.5">
+          {tabs.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => setTab(t.id)}
+              className={cn(
+                "rounded-[5px] px-2 py-0.5 font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-muted)]",
+                tab === t.id &&
+                  "bg-[var(--avy-paper-solid)] text-[var(--avy-ink)] shadow-[inset_0_0_0_1px_var(--avy-line)]"
+              )}
+              style={{ letterSpacing: "0.12em" }}
+            >
+              {t.label}
+              {t.sub ? (
+                <small className="ml-1 opacity-50" style={{ letterSpacing: 0 }}>
+                  {t.sub}
+                </small>
+              ) : null}
+            </button>
+          ))}
+        </div>
+
+        <div className="px-3.5 py-3">
+          {tab === "dataset" ? <OpenDataDatasetTab ctx={ctx} /> : null}
+          {tab === "checks" ? <OpenDataChecksTab ctx={ctx} /> : null}
+          {tab === "findings" ? <OpenDataFindingsTab ctx={ctx} /> : null}
+          {tab === "submission" ? <OpenDataSubmissionTab ctx={ctx} /> : null}
+        </div>
+
+        {/* Verification footer — same shape as the other source blocks;
+            reads as a quality-audit signal sequence. */}
+        <div
+          className="flex flex-wrap items-center gap-x-2 gap-y-1 border-t border-[var(--avy-line-soft)] bg-[#faf8f1] px-3 py-2 font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]"
+          style={{ letterSpacing: 0 }}
+        >
+          <span className="text-[var(--avy-accent)]">Verification</span>
+          <span className="inline-flex items-center whitespace-nowrap rounded-full bg-[color:rgba(17,19,21,0.06)] px-1.5 py-px font-medium text-[var(--avy-ink)]">
+            {ctx.verification.method}
+          </span>
+          {ctx.verification.signals.map((s) => (
+            <span key={s}>· {s}</span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function OpenDataDatasetTab({ ctx }: { ctx: OpenDataJobContext }) {
+  return (
+    <>
+      <h3 className="m-0 font-[family-name:var(--font-display)] text-[14px] font-bold leading-[1.3] text-[var(--avy-ink)]">
+        {ctx.datasetTitle}
+      </h3>
+
+      <dl
+        className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 font-[family-name:var(--font-mono)] text-[11.5px]"
+        style={{ letterSpacing: 0 }}
+      >
+        <dt className="text-[var(--avy-muted)]">Portal</dt>
+        <dd className="m-0 font-medium text-[var(--avy-ink)]">
+          {ctx.provider}
+        </dd>
+        {ctx.agency ? (
+          <>
+            <dt className="text-[var(--avy-muted)]">Agency</dt>
+            <dd className="m-0 truncate font-medium text-[var(--avy-ink)]">
+              {ctx.agency}
+            </dd>
+          </>
+        ) : null}
+        {ctx.resourceTitle ? (
+          <>
+            <dt className="text-[var(--avy-muted)]">Resource</dt>
+            <dd className="m-0 truncate font-medium text-[var(--avy-ink)]">
+              {ctx.resourceTitle}
+            </dd>
+          </>
+        ) : null}
+        {ctx.resourceFormat ? (
+          <>
+            <dt className="text-[var(--avy-muted)]">Format</dt>
+            <dd className="m-0 font-medium text-[var(--avy-ink)]">
+              {ctx.resourceFormat}
+            </dd>
+          </>
+        ) : null}
+        {ctx.license ? (
+          <>
+            <dt className="text-[var(--avy-muted)]">License</dt>
+            <dd className="m-0 truncate font-medium text-[var(--avy-ink)]">
+              {ctx.license}
+            </dd>
+          </>
+        ) : null}
+        {ctx.modified ? (
+          <>
+            <dt className="text-[var(--avy-muted)]">Modified</dt>
+            <dd className="m-0 font-medium text-[var(--avy-ink)]">
+              {ctx.modified}
+            </dd>
+          </>
+        ) : null}
+        {ctx.metadataModified ? (
+          <>
+            <dt className="text-[var(--avy-muted)]">Metadata modified</dt>
+            <dd className="m-0 font-medium text-[var(--avy-ink)]">
+              {ctx.metadataModified}
+            </dd>
+          </>
+        ) : null}
+      </dl>
+
+      {ctx.body ? (
+        <p
+          className="mt-3 max-h-[220px] overflow-y-auto whitespace-pre-wrap font-[family-name:var(--font-body)] text-[12.5px] leading-[1.5] text-[var(--avy-ink)]"
+          style={{ letterSpacing: 0 }}
+        >
+          {ctx.body}
+        </p>
+      ) : null}
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        <a
+          href={ctx.datasetUrl}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="inline-flex h-7 items-center gap-1.5 rounded-[8px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-3 font-[family-name:var(--font-display)] text-[11px] font-bold uppercase text-[var(--avy-ink)] transition-transform hover:-translate-y-px hover:border-[color:rgba(30,102,66,0.24)] hover:text-[var(--avy-accent)]"
+          style={{ letterSpacing: "0.04em" }}
+        >
+          Open dataset ↗
+        </a>
+        <a
+          href={ctx.resourceUrl}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="inline-flex h-7 items-center gap-1.5 rounded-[8px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-3 font-[family-name:var(--font-display)] text-[11px] font-bold uppercase text-[var(--avy-ink)] transition-transform hover:-translate-y-px hover:border-[color:rgba(30,102,66,0.24)] hover:text-[var(--avy-accent)]"
+          style={{ letterSpacing: "0.04em" }}
+        >
+          Open resource ↗
+        </a>
+      </div>
+    </>
+  );
+}
+
+function OpenDataChecksTab({ ctx }: { ctx: OpenDataJobContext }) {
+  // The instructions field is the worker-facing "what to do" prose
+  // emitted by the ingestor — re-purposed here as the "Checks" copy
+  // since the open-data audit instructions ARE the check list.
+  if (!ctx.agentInstructions) {
+    return (
+      <p
+        className="m-0 font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]"
+        style={{ letterSpacing: 0 }}
+      >
+        No check list was generated for this dataset.
+      </p>
+    );
+  }
+  return (
+    <p
+      className="m-0 whitespace-pre-wrap rounded-[6px] border border-[color:rgba(30,102,66,0.18)] bg-[color:rgba(30,102,66,0.04)] px-3 py-2.5 font-[family-name:var(--font-mono)] text-[12px] leading-[1.55] text-[var(--avy-ink)]"
+      style={{ letterSpacing: 0 }}
+    >
+      {ctx.agentInstructions}
+    </p>
+  );
+}
+
+function OpenDataFindingsTab({ ctx }: { ctx: OpenDataJobContext }) {
+  // Acceptance criteria are the "what counts as a complete audit"
+  // checklist the verifier runs against; rendered as a numbered list
+  // so the worker can see the bar before they submit.
+  if (ctx.acceptanceCriteria.length === 0) {
+    return (
+      <p
+        className="m-0 font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]"
+        style={{ letterSpacing: 0 }}
+      >
+        No acceptance criteria were attached to this audit.
+      </p>
+    );
+  }
+  return (
+    <ul className="m-0 flex flex-col gap-2 pl-0">
+      {ctx.acceptanceCriteria.map((item, i) => (
+        <li
+          key={i}
+          className="grid grid-cols-[18px_1fr] items-start gap-2 font-[family-name:var(--font-body)] text-[12.5px] leading-[1.45] text-[var(--avy-ink)]"
+          style={{ letterSpacing: 0 }}
+        >
+          <span
+            className="mt-px inline-grid h-[16px] w-[16px] place-items-center rounded-[4px] border border-[color:rgba(30,102,66,0.25)] bg-[color:rgba(30,102,66,0.06)] font-[family-name:var(--font-mono)] text-[9px] font-bold text-[var(--avy-accent)]"
+            style={{ letterSpacing: 0 }}
+            aria-hidden="true"
+          >
+            {i + 1}
+          </span>
+          <span>{item}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function OpenDataSubmissionTab({ ctx }: { ctx: OpenDataJobContext }) {
+  return (
+    <div className="flex flex-col gap-2.5">
+      <p
+        className="m-0 font-[family-name:var(--font-mono)] text-[11px] leading-[1.5] text-[var(--avy-muted)]"
+        style={{ letterSpacing: 0 }}
+      >
+        Submit a dataset quality audit report. Do not edit source data
+        and do not contact the publishing agency from this workflow.
+      </p>
+      <SubField
+        label="Dataset URL"
+        required
+        placeholder={ctx.datasetUrl}
+        mono
+      />
+      <SubField
+        label="Resource URL"
+        required
+        placeholder={ctx.resourceUrl}
+        mono
+      />
+      <div>
+        <SubLabel>Checks performed</SubLabel>
+        <textarea
+          spellCheck={false}
+          placeholder="One per line. e.g. dataset_landing_page=200, resource_url=200 (csv), schema_columns_listed, missing_metadata=license"
+          className="min-h-[90px] w-full resize-y rounded-[6px] border border-[var(--avy-line)] bg-white px-2.5 py-2 font-[family-name:var(--font-mono)] text-[11.5px] leading-[1.5] text-[var(--avy-ink)] outline-none placeholder:text-[var(--avy-muted)] focus:border-[var(--avy-accent)] focus:ring-2 focus:ring-[color:rgba(30,102,66,0.15)]"
+          style={{ letterSpacing: 0 }}
+        />
+      </div>
+      <div>
+        <SubLabel>Findings</SubLabel>
+        <textarea
+          spellCheck={false}
+          placeholder={`Concrete findings, or "no_issue_found" with evidence per check.`}
+          className="min-h-[90px] w-full resize-y rounded-[6px] border border-[var(--avy-line)] bg-white px-2.5 py-2 font-[family-name:var(--font-body)] text-[12.5px] leading-[1.5] text-[var(--avy-ink)] outline-none placeholder:text-[var(--avy-muted)] focus:border-[var(--avy-accent)] focus:ring-2 focus:ring-[color:rgba(30,102,66,0.15)]"
+          style={{ letterSpacing: 0 }}
+        />
+      </div>
+      <div>
+        <SubLabel>Recommended actions</SubLabel>
+        <textarea
+          spellCheck={false}
+          placeholder="Concrete cleanup recommendations the agency could action — separate from findings."
+          className="min-h-[60px] w-full resize-y rounded-[6px] border border-[var(--avy-line)] bg-white px-2.5 py-2 font-[family-name:var(--font-body)] text-[12.5px] leading-[1.5] text-[var(--avy-ink)] outline-none placeholder:text-[var(--avy-muted)] focus:border-[var(--avy-accent)] focus:ring-2 focus:ring-[color:rgba(30,102,66,0.15)]"
+          style={{ letterSpacing: 0 }}
+        />
+      </div>
+      <div>
+        <SubLabel>Notes for verifier (optional)</SubLabel>
+        <textarea
+          spellCheck={false}
+          placeholder="Caveats, partial-data notes, anything the verifier should know."
+          className="min-h-[60px] w-full resize-y rounded-[6px] border border-[var(--avy-line)] bg-white px-2.5 py-2 font-[family-name:var(--font-mono)] text-[11.5px] leading-[1.5] text-[var(--avy-ink)] outline-none placeholder:text-[var(--avy-muted)] focus:border-[var(--avy-accent)] focus:ring-2 focus:ring-[color:rgba(30,102,66,0.15)]"
+          style={{ letterSpacing: 0 }}
+        />
+      </div>
+      {ctx.discoveryApi ? (
+        <p
+          className="m-0 font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]"
+          style={{ letterSpacing: 0 }}
+        >
+          Discovered via{" "}
+          <span className="text-[var(--avy-ink)]">{ctx.discoveryApi}</span>
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/app/components/runs/LoadedRunView.tsx
+++ b/app/components/runs/LoadedRunView.tsx
@@ -18,6 +18,7 @@ import { swrFetcher } from "@/lib/api/client";
 import { useJobDefinition, useJobs } from "@/lib/api/hooks";
 import {
   buildGitHubContext,
+  buildOpenDataContext,
   buildOsvContext,
   buildRunRows,
   buildWikipediaContext,
@@ -72,6 +73,7 @@ export function LoadedRunView({
   const loadedGitHub = buildGitHubContext(loadedRow, selectedJob);
   const loadedWikipedia = buildWikipediaContext(loadedRow, selectedJob);
   const loadedOsv = buildOsvContext(loadedRow, selectedJob);
+  const loadedOpenData = buildOpenDataContext(loadedRow, selectedJob);
 
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -123,7 +125,9 @@ export function LoadedRunView({
       ? "Loaded run · GitHub issue"
       : loadedOsv
         ? "Loaded run · OSV advisory"
-        : "Loaded run";
+        : loadedOpenData
+          ? "Loaded run · Open data dataset"
+          : "Loaded run";
 
   return (
     <div className="flex flex-col gap-3.5">
@@ -135,6 +139,7 @@ export function LoadedRunView({
         github={loadedGitHub}
         wikipedia={loadedWikipedia}
         osv={loadedOsv}
+        openData={loadedOpenData}
         onReceiptPreview={() => setReceiptOpen(true)}
         standaloneUrl={standaloneUrl}
         stake={{
@@ -175,6 +180,14 @@ export function LoadedRunView({
               to the verifier. Window{" "}
               <b className="text-[var(--avy-ink)]">00:08:14 / 02:00:00</b>.
             </>
+          ) : loadedOpenData ? (
+            <>
+              Submits{" "}
+              <b className="text-[var(--avy-ink)]">checks + findings + recommended actions</b>{" "}
+              to the verifier. Audit only — no edits to source data.
+              Window{" "}
+              <b className="text-[var(--avy-ink)]">00:08:14 / 02:00:00</b>.
+            </>
           ) : (
             <>
               Submits <b className="text-[var(--avy-ink)]">PR URL + evidence</b>{" "}
@@ -186,13 +199,102 @@ export function LoadedRunView({
             ? "Submit proposal for review"
             : loadedOsv
               ? "Submit remediation PR"
-              : "Submit for verification",
+              : loadedOpenData
+                ? "Submit audit report"
+                : "Submit for verification",
           onSubmit: handleSubmit,
           submitting,
           error: submitError,
         }}
         verifier={
-          loadedOsv
+          loadedOpenData
+            ? {
+                runner: "verifier-2 · open_data_quality_audit · handler-v0.14",
+                elapsed: "stream · 2.8s",
+                modeNote: "open_data_quality_audit · audit only",
+                lines: [
+                  {
+                    time: "14:28:01",
+                    level: "info",
+                    label: "dataset",
+                    message: (
+                      <>
+                        loaded{" "}
+                        <span className="text-[#f4c989]">
+                          {loadedOpenData.datasetTitle}
+                        </span>
+                        {loadedOpenData.agency
+                          ? ` · ${loadedOpenData.agency}`
+                          : null}
+                      </>
+                    ),
+                  },
+                  {
+                    time: "14:28:01",
+                    level: "ok",
+                    label: "pass",
+                    message: <>dataset URL reachable · landing page 200</>,
+                  },
+                  {
+                    time: "14:28:02",
+                    level: "ok",
+                    label: "pass",
+                    message: (
+                      <>
+                        resource URL reachable
+                        {loadedOpenData.resourceFormat ? (
+                          <>
+                            {" · "}
+                            <span className="text-[#9bd7b5]">
+                              {loadedOpenData.resourceFormat}
+                            </span>
+                          </>
+                        ) : null}
+                      </>
+                    ),
+                  },
+                  {
+                    time: "14:28:02",
+                    level: "info",
+                    label: "policy",
+                    message: (
+                      <>
+                        audit-only path enforced ·{" "}
+                        <span className="text-[#f4c989]">no source edits</span>
+                      </>
+                    ),
+                  },
+                  {
+                    time: "14:28:03",
+                    level: "warn",
+                    label: "note",
+                    message: (
+                      <>
+                        catalog metadata{" "}
+                        <span className="text-[#f4c989]">stale</span> ·
+                        recommendations attached
+                      </>
+                    ),
+                  },
+                  {
+                    time: "14:28:03",
+                    level: "ok",
+                    label: "verdict",
+                    message: (
+                      <>
+                        4/5 signals pass · receipt draft{" "}
+                        <span className="text-[#f4c989]">r_4e133</span>
+                      </>
+                    ),
+                  },
+                ],
+                verdict: {
+                  status: "Audit complete (advisory)",
+                  score: "4 / 5",
+                  scoreLabel: "0.84 confidence",
+                },
+              }
+            : loadedOsv
             ? {
                 runner: "verifier-2 · osv_dependency_pr · handler-v0.14",
                 elapsed: "stream · 3.4s",
@@ -442,7 +544,9 @@ export function LoadedRunView({
             ? "pays worker & verifier once an Averray editor approves the proposal"
             : loadedOsv
               ? "pays worker & verifier once the maintainer merges the remediation PR"
-              : "pays worker & verifier once the maintainer approves the PR",
+              : loadedOpenData
+                ? "pays worker & verifier once the audit report verifies"
+                : "pays worker & verifier once the maintainer approves the PR",
         }}
       />
 
@@ -476,6 +580,17 @@ export function LoadedRunView({
                 </b>{" "}
                 · PR pending merge
               </>
+            ) : loadedOpenData ? (
+              <>
+                Window closes in{" "}
+                <b className="font-semibold text-[var(--avy-ink)]">21m 46s</b>
+                {" · "}verification{" "}
+                <b className="font-semibold text-[var(--avy-ink)]">
+                  {loadedOpenData.verification.method}
+                </b>
+                {" · "}audit{" "}
+                <b className="font-semibold text-[var(--avy-ink)]">submitted</b>
+              </>
             ) : (
               <>
                 Window closes in{" "}
@@ -494,12 +609,16 @@ export function LoadedRunView({
               ? "Averray review → Pay"
               : loadedOsv
                 ? "Maintainer merge → Pay"
-                : "Maintainer review → Pay",
+                : loadedOpenData
+                  ? "Verifier check → Pay"
+                  : "Maintainer review → Pay",
             sub: loadedWikipedia
               ? "auto-pays on Averray-approved review"
               : loadedOsv
                 ? "auto-pays on PR merge + CI green + lockfile resolves"
-                : "auto-pays on PR merge + CI green",
+                : loadedOpenData
+                  ? "auto-pays on audit verifier signals green"
+                  : "auto-pays on PR merge + CI green",
           }}
         />
       ) : null}
@@ -511,7 +630,8 @@ export function LoadedRunView({
           loadedRow,
           loadedGitHub,
           loadedWikipedia,
-          loadedOsv
+          loadedOsv,
+          loadedOpenData
         )}
       />
     </div>
@@ -538,7 +658,8 @@ function buildReceiptDraft(
   row: RunRow,
   github: ReturnType<typeof buildGitHubContext>,
   wikipedia: ReturnType<typeof buildWikipediaContext>,
-  osv: ReturnType<typeof buildOsvContext>
+  osv: ReturnType<typeof buildOsvContext>,
+  openData: ReturnType<typeof buildOpenDataContext>
 ): ReceiptPreviewDraft {
   const workerSignerLabel = row.worker.isSelf
     ? `Worker · ${row.worker.label} (you)`
@@ -562,11 +683,17 @@ function buildReceiptDraft(
             score: "3 / 4",
             confidence: "0.91 confidence",
           }
-        : {
-            status: "Verified (pending cosign)",
-            score: "4 / 5",
-            confidence: "0.92 confidence",
-          };
+        : openData
+          ? {
+              status: "Audit complete (advisory)",
+              score: "4 / 5",
+              confidence: "0.84 confidence",
+            }
+          : {
+              status: "Verified (pending cosign)",
+              score: "4 / 5",
+              confidence: "0.92 confidence",
+            };
 
   const reviewerSigner = github
     ? "Maintainer · awaiting review"
@@ -574,7 +701,9 @@ function buildReceiptDraft(
       ? "Averray editor reviewer · awaiting review"
       : osv
         ? "Maintainer · awaiting merge"
-        : "Cosigner · 0x9A13…0cb2";
+        : openData
+          ? "Verifier · audit signed"
+          : "Cosigner · 0x9A13…0cb2";
 
   return {
     receiptRef: "r_4e133",
@@ -595,6 +724,7 @@ function buildReceiptDraft(
     ...(github ? { github } : {}),
     ...(wikipedia ? { wikipedia } : {}),
     ...(osv ? { osv } : {}),
+    ...(openData ? { openData } : {}),
     prUrl: github
       ? `https://github.com/${github.repo}/pull/4931`
       : osv

--- a/app/components/runs/ReceiptPreviewDrawer.tsx
+++ b/app/components/runs/ReceiptPreviewDrawer.tsx
@@ -4,6 +4,7 @@ import { DetailDrawer, DrawerSection } from "@/components/shell/DetailDrawer";
 import { SourceBadge, StatePill, type RunState } from "./StatePill";
 import type {
   GitHubJobContext,
+  OpenDataJobContext,
   OsvJobContext,
   WikipediaJobContext,
 } from "./types";
@@ -50,6 +51,14 @@ export interface ReceiptPreviewDraft {
    * attribution line. Mutually exclusive with `github`/`wikipedia`.
    */
   osv?: OsvJobContext;
+  /**
+   * Set when the loaded run is an open-data dataset quality-audit job
+   * (Data.gov today). The drawer surfaces dataset/resource identity,
+   * agency + format, and an "Averray open-data quality audit"
+   * attribution line. Mutually exclusive with the other source
+   * contexts.
+   */
+  openData?: OpenDataJobContext;
   prUrl?: string;
   signers: { label: string; status: "pending" | "signed" }[];
 }
@@ -330,6 +339,124 @@ export function ReceiptPreviewDrawer({
               View remediation PR ↗
             </a>
           ) : null}
+        </DrawerSection>
+      ) : null}
+
+      {draft.openData ? (
+        <DrawerSection title="Source">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 rounded-[8px] border border-[var(--avy-line)] bg-[color:rgba(17,19,21,0.02)] px-3 py-2">
+            <SourceBadge kind="data_gov" />
+            {/* Glanceable attribution pill so the reviewer sees the
+                audit-only stance without having to read the warning
+                paragraph below. Same warn token as the policy banner
+                on the loaded-run panel. */}
+            <span
+              className="inline-flex items-center whitespace-nowrap rounded-full bg-[var(--avy-warn)] px-1.5 py-0.5 font-[family-name:var(--font-display)] text-[9.5px] font-extrabold uppercase text-white"
+              style={{ letterSpacing: "0.1em" }}
+              title="Averray open-data quality audit — no edits to source data"
+            >
+              Audit only
+            </span>
+            <a
+              href={draft.openData.datasetUrl}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="truncate whitespace-nowrap font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-ink)] hover:text-[var(--avy-accent)]"
+              style={{ letterSpacing: 0 }}
+              title={draft.openData.datasetTitle}
+            >
+              <span className="text-[var(--avy-accent)]">
+                {draft.openData.datasetTitle}
+              </span>
+            </a>
+            {draft.openData.agency ? (
+              <>
+                <span className="opacity-40">·</span>
+                <span
+                  className="whitespace-nowrap font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]"
+                  style={{ letterSpacing: 0 }}
+                >
+                  {draft.openData.agency}
+                </span>
+              </>
+            ) : null}
+            {draft.openData.resourceFormat ? (
+              <>
+                <span className="opacity-40">·</span>
+                <span
+                  className="whitespace-nowrap font-[family-name:var(--font-mono)] text-[11.5px] uppercase text-[var(--avy-muted)]"
+                  style={{ letterSpacing: "0.08em" }}
+                >
+                  {draft.openData.resourceFormat}
+                </span>
+              </>
+            ) : null}
+          </div>
+
+          <dl
+            className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 font-[family-name:var(--font-mono)] text-[11.5px]"
+            style={{ letterSpacing: 0 }}
+          >
+            <dt className="text-[var(--avy-muted)]">Portal</dt>
+            <dd className="m-0 font-medium text-[var(--avy-ink)]">
+              {draft.openData.provider}
+            </dd>
+            <dt className="text-[var(--avy-muted)]">Dataset</dt>
+            <dd className="m-0 truncate font-medium text-[var(--avy-ink)]">
+              {draft.openData.datasetTitle}
+            </dd>
+            {draft.openData.agency ? (
+              <>
+                <dt className="text-[var(--avy-muted)]">Agency</dt>
+                <dd className="m-0 truncate font-medium text-[var(--avy-ink)]">
+                  {draft.openData.agency}
+                </dd>
+              </>
+            ) : null}
+            <dt className="text-[var(--avy-muted)]">Resource URL</dt>
+            <dd className="m-0">
+              <a
+                href={draft.openData.resourceUrl}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="block truncate font-medium text-[var(--avy-accent)] hover:underline"
+                title={draft.openData.resourceUrl}
+              >
+                {draft.openData.resourceUrl}
+              </a>
+            </dd>
+            {draft.openData.resourceFormat ? (
+              <>
+                <dt className="text-[var(--avy-muted)]">Format</dt>
+                <dd className="m-0 font-medium text-[var(--avy-ink)]">
+                  {draft.openData.resourceFormat}
+                </dd>
+              </>
+            ) : null}
+          </dl>
+
+          {/* Attribution. Spec calls for `Averray open-data quality
+              audit` as the verbatim attribution string in the receipt.
+              Mirrors the structure of the Wikipedia and OSV blocks. */}
+          <p
+            className="mt-2 rounded-[6px] border border-[var(--avy-warn)] bg-[color:rgba(211,145,27,0.08)] px-2.5 py-2 font-[family-name:var(--font-mono)] text-[11px] leading-[1.5] text-[var(--avy-ink)]"
+            style={{ letterSpacing: 0 }}
+          >
+            <b className="font-semibold">Attribution:</b> Averray open-data
+            quality audit. Findings + recommended actions are advisory; the
+            agent does not edit source data and does not contact the
+            publishing agency from this workflow.
+          </p>
+
+          <a
+            href={draft.openData.datasetUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="mt-2 inline-flex h-7 items-center gap-1.5 rounded-[8px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-3 font-[family-name:var(--font-display)] text-[11px] font-bold uppercase text-[var(--avy-ink)] transition-transform hover:-translate-y-px hover:border-[color:rgba(30,102,66,0.24)] hover:text-[var(--avy-accent)]"
+            style={{ letterSpacing: "0.04em" }}
+          >
+            Open Data.gov dataset ↗
+          </a>
         </DrawerSection>
       ) : null}
 

--- a/app/components/runs/StatePill.tsx
+++ b/app/components/runs/StatePill.tsx
@@ -87,12 +87,20 @@ export function VerifierModePill({
  * the established neutral fills the rest of the app already uses for
  * inverted chips.
  */
-export type SourceKind = "github" | "wikipedia" | "osv" | "oss";
+export type SourceKind =
+  | "github"
+  | "wikipedia"
+  | "osv"
+  | "data_gov"
+  | "oss";
 
 const SOURCE_CLASSES: Record<SourceKind, string> = {
   github: "bg-[#111418] text-white",
   wikipedia: "bg-[var(--avy-ink)] text-white",
   osv: "bg-[#3a1f1f] text-white",
+  // Open-data family — slate-tinted dark to keep visual weight in line
+  // with the other dark badges while staying distinct from osv's red ink.
+  data_gov: "bg-[#1f2a3a] text-white",
   oss: "bg-[color:rgba(17,19,21,0.06)] text-[var(--avy-ink)]",
 };
 
@@ -100,6 +108,7 @@ const SOURCE_LABEL: Record<SourceKind, string> = {
   github: "GitHub",
   wikipedia: "Wikipedia",
   osv: "OSV",
+  data_gov: "Data.gov",
   oss: "OSS",
 };
 
@@ -133,6 +142,8 @@ export function SourceBadge({
         <WikipediaGlyph />
       ) : kind === "osv" ? (
         <OsvGlyph />
+      ) : kind === "data_gov" ? (
+        <OpenDataGlyph />
       ) : (
         <span className="h-[5px] w-[5px] rounded-full bg-current opacity-80" />
       )}
@@ -158,6 +169,41 @@ function GitHubGlyph() {
       fill="currentColor"
     >
       <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.19 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+    </svg>
+  );
+}
+
+function OpenDataGlyph() {
+  // Stylised database / dataset cylinder. Sits in the same 10px slot as
+  // GitHub's octocat, Wikipedia's W, and OSV's shield so the badge row
+  // reads as a coherent family of provenance marks.
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      width="10"
+      height="10"
+      fill="none"
+    >
+      <ellipse
+        cx="8"
+        cy="3.6"
+        rx="5"
+        ry="1.8"
+        stroke="currentColor"
+        strokeWidth="1.4"
+      />
+      <path
+        d="M3 3.6v8.8c0 1 2.24 1.8 5 1.8s5-.8 5-1.8V3.6"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M3 8c0 1 2.24 1.8 5 1.8s5-.8 5-1.8"
+        stroke="currentColor"
+        strokeWidth="1.4"
+      />
     </svg>
   );
 }

--- a/app/components/runs/fixtures.ts
+++ b/app/components/runs/fixtures.ts
@@ -194,6 +194,39 @@ export const FIXTURE_RUN_ROWS: RunRow[] = [
     lastEventMeta:
       "averray-agent/agent · frontend/package.json · 1.2.5 → 1.2.6",
   },
+  {
+    id: "run-2752",
+    title:
+      "Audit Federal sample spending data resource (CSV) for reachability + schema clarity",
+    jobMeta: "Data.gov · GSA · CSV · quality audit · T1",
+    source: {
+      type: "open_data_dataset",
+      provider: "data.gov",
+      portal: "data.gov",
+      datasetId: "federal-sample-spending-data",
+      datasetTitle: "Federal sample spending data",
+      datasetUrl:
+        "https://catalog.data.gov/dataset/federal-sample-spending-data",
+      resourceId: "fed-sample-spending-csv",
+      resourceTitle: "Spending records (CSV)",
+      resourceUrl: "https://example.gov/fed-sample-spending.csv",
+      resourceFormat: "CSV",
+      agency: "General Services Administration",
+      license: "U.S. Government Work",
+      modified: "2025-11-02",
+      metadataModified: "2026-02-14",
+      score: 71,
+      discoveryApi:
+        "https://catalog.data.gov/api/3/action/package_search",
+    },
+    worker: { variant: "unclaimed", initials: "—", label: "unclaimed" },
+    state: "ready",
+    stake: "2.0",
+    age: "00:00:48",
+    lastEvent: "Ingested from Data.gov · audit only",
+    lastEventMeta:
+      "General Services Administration · CSV · Federal sample spending data",
+  },
 ];
 
 // Counts are seeded higher than the row list because the fixture is a
@@ -324,6 +357,40 @@ export const FIXTURE_RECOMMENDATIONS: JobCardData[] = [
       { label: "Fit score", value: "88/100" },
     ],
     fit: 5,
+  },
+  {
+    id: "job-0432",
+    jobMeta: "Data.gov · GSA · CSV · quality audit",
+    category: "data",
+    title:
+      "Audit Federal sample spending data resource (CSV) for reachability + schema clarity",
+    source: {
+      type: "open_data_dataset",
+      provider: "data.gov",
+      portal: "data.gov",
+      datasetId: "federal-sample-spending-data",
+      datasetTitle: "Federal sample spending data",
+      datasetUrl:
+        "https://catalog.data.gov/dataset/federal-sample-spending-data",
+      resourceTitle: "Spending records (CSV)",
+      resourceUrl: "https://example.gov/fed-sample-spending.csv",
+      resourceFormat: "CSV",
+      agency: "General Services Administration",
+      score: 71,
+    },
+    rewardValue: "2.0",
+    rewardCurrency: "DOT",
+    rewardUsd: "~ $14",
+    tier: "T1",
+    modeLabel: "Quality audit",
+    modeTone: "ready",
+    meta: [
+      { label: "Stake", value: "1.0 DOT" },
+      { label: "Verifier", value: "open_data_quality_audit" },
+      { label: "Window", value: "2 h", accent: true },
+      { label: "Fit score", value: "71/100" },
+    ],
+    fit: 3,
   },
   {
     id: "job-0421",
@@ -526,6 +593,58 @@ Repro: run \`cargo test --test claim_race -- --test-threads=1 --ignored\` in a l
         "PR opened against the vulnerable manifest",
         "Lockfile updated to fixed version",
         "Install + test evidence attached",
+      ],
+    },
+  },
+  {
+    id: "run-2752",
+    title:
+      "Audit Federal sample spending data resource (CSV) for reachability + schema clarity",
+    category: "data",
+    description:
+      "Run a quality audit on the Federal sample spending data CSV resource published on Data.gov. Confirm the dataset landing page and resource URL resolve, summarise the columns/headers, surface any stale catalog metadata (missing license, format, modified date), and report concrete recommendations the publishing agency could action. Audit only — do not edit the source data and do not contact the agency from this workflow.",
+    source: {
+      type: "open_data_dataset",
+      provider: "data.gov",
+      portal: "data.gov",
+      datasetId: "federal-sample-spending-data",
+      datasetTitle: "Federal sample spending data",
+      datasetUrl:
+        "https://catalog.data.gov/dataset/federal-sample-spending-data",
+      resourceId: "fed-sample-spending-csv",
+      resourceTitle: "Spending records (CSV)",
+      resourceUrl: "https://example.gov/fed-sample-spending.csv",
+      resourceFormat: "CSV",
+      agency: "General Services Administration",
+      license: "U.S. Government Work",
+      modified: "2025-11-02",
+      metadataModified: "2026-02-14",
+      score: 71,
+      discoveryApi:
+        "https://catalog.data.gov/api/3/action/package_search",
+    },
+    acceptanceCriteria: [
+      "Fetch the dataset landing page and resource URL and record their status, content type, and final URL if redirected.",
+      "Summarise the resource format and columns/headers when the resource is CSV, JSON, GeoJSON, XML, or spreadsheet-like.",
+      "Check for stale or incomplete catalog metadata such as missing format, license, agency, modified date, or broken resource links.",
+      "Report at least one concrete finding, or set no_issue_found=true with evidence for each completed check.",
+      "Do not edit the government dataset directly or contact the agency; submit a reviewable audit report only.",
+    ],
+    agentInstructions: [
+      "Treat this as a public-data quality audit, not a direct edit task.",
+      "Review the Data.gov dataset page: https://catalog.data.gov/dataset/federal-sample-spending-data.",
+      "Inspect the resource URL: https://example.gov/fed-sample-spending.csv.",
+      "If the resource is tabular, capture the header/field summary and obvious missing-value or schema problems without downloading huge files.",
+      "Submit structured evidence with dataset_title, dataset_url, resource_url, checks, findings, no_issue_found, summary, and recommended_actions.",
+    ],
+    verification: {
+      method: "open_data_quality_audit",
+      signals: [
+        "Dataset URL reachable",
+        "Resource URL reachable",
+        "Checks performed",
+        "Findings or no_issue_found recorded",
+        "Recommended actions present",
       ],
     },
   },

--- a/app/components/runs/types.ts
+++ b/app/components/runs/types.ts
@@ -79,10 +79,47 @@ export interface OsvJobSource {
   discoveryApi?: string;
 }
 
+/**
+ * Provenance for runs ingested from open-data catalogs (Data.gov today,
+ * with other portals reserved for the future). These are dataset/
+ * resource quality AUDIT jobs — the worker reports reachability, format
+ * clarity, schema, and stale-metadata findings on a public dataset and
+ * its resource. The platform never edits source data and never contacts
+ * the publishing agency from this workflow.
+ *
+ * Field set mirrors what `mcp-server/src/jobs/ingest-open-data-datasets.js`
+ * emits today: dataset + resource identity, optional agency/license/
+ * modified-at, and the discovery-API endpoint that found the record.
+ */
+export interface OpenDataJobSource {
+  type: "open_data_dataset";
+  /** "data.gov" today; reserved for future portals. */
+  provider: string;
+  /** Mirror of `provider` from the backend payload. */
+  portal?: string;
+  datasetId?: string;
+  datasetTitle: string;
+  datasetUrl: string;
+  resourceId?: string;
+  resourceTitle?: string;
+  resourceUrl: string;
+  /** "CSV", "JSON", "ZIP", "GeoJSON", … — free string from the catalog. */
+  resourceFormat?: string;
+  /** Publishing agency / organisation. Optional. */
+  agency?: string;
+  license?: string;
+  modified?: string;
+  metadataModified?: string;
+  score?: number;
+  /** Catalog API endpoint that discovered the dataset; surfaced in the receipt for audit. */
+  discoveryApi?: string;
+}
+
 export type JobSource =
   | GitHubJobSource
   | WikipediaJobSource
   | OsvJobSource
+  | OpenDataJobSource
   | { type: "native" };
 
 /**
@@ -133,6 +170,23 @@ export interface OsvJobContext extends OsvJobSource {
   agentInstructions: string;
   verification: {
     method: string; // e.g. "osv_dependency_pr"
+    signals: string[];
+  };
+}
+
+/**
+ * Rich context for open-data dataset quality-audit runs. Same shape as
+ * the other source contexts so the Loaded-run panel can render a fourth
+ * source-specific evidence block without a new code path.
+ */
+export interface OpenDataJobContext extends OpenDataJobSource {
+  title: string;
+  body: string; // human-readable description of the audit scope
+  category: string; // always "data" today; reserved for future sub-types
+  acceptanceCriteria: string[];
+  agentInstructions: string;
+  verification: {
+    method: string; // e.g. "open_data_quality_audit"
     signals: string[];
   };
 }

--- a/app/lib/api/run-adapters.ts
+++ b/app/lib/api/run-adapters.ts
@@ -5,6 +5,7 @@ import type { RunState, Tier } from "@/components/runs/StatePill";
 import type {
   GitHubJobContext,
   JobSource,
+  OpenDataJobContext,
   OsvJobContext,
   WikipediaJobContext,
 } from "@/components/runs/types";
@@ -218,6 +219,39 @@ export function buildJobSource(job: unknown): JobSource | undefined {
       ...(text(src.discoveryApi) ? { discoveryApi: text(src.discoveryApi) } : {}),
     };
   }
+  if (sourceType === "open_data_dataset") {
+    const provider = text(src.provider, "data.gov");
+    const datasetTitle = text(src.datasetTitle);
+    const datasetUrl = text(src.datasetUrl);
+    const resourceUrl = text(src.resourceUrl);
+    if (!datasetTitle || !datasetUrl || !resourceUrl) return undefined;
+    return {
+      type: "open_data_dataset",
+      provider,
+      ...(text(src.portal) ? { portal: text(src.portal) } : {}),
+      ...(text(src.datasetId) ? { datasetId: text(src.datasetId) } : {}),
+      datasetTitle,
+      datasetUrl,
+      ...(text(src.resourceId) ? { resourceId: text(src.resourceId) } : {}),
+      ...(text(src.resourceTitle)
+        ? { resourceTitle: text(src.resourceTitle) }
+        : {}),
+      resourceUrl,
+      ...(text(src.resourceFormat)
+        ? { resourceFormat: text(src.resourceFormat) }
+        : {}),
+      ...(text(src.agency) ? { agency: text(src.agency) } : {}),
+      ...(text(src.license) ? { license: text(src.license) } : {}),
+      ...(text(src.modified) ? { modified: text(src.modified) } : {}),
+      ...(text(src.metadataModified)
+        ? { metadataModified: text(src.metadataModified) }
+        : {}),
+      ...(typeof src.score === "number" ? { score: src.score } : {}),
+      ...(text(src.discoveryApi)
+        ? { discoveryApi: text(src.discoveryApi) }
+        : {}),
+    };
+  }
   return undefined;
 }
 
@@ -343,6 +377,52 @@ export function buildOsvContext(
   };
 }
 
+/**
+ * Mirror of `buildOsvContext` for open-data dataset quality-audit runs.
+ * Returns undefined for any non-open-data row so the panel falls back to
+ * the generic layout. Defaults bake in the audit-only verification path
+ * since the platform never edits source data and never contacts the
+ * publishing agency from this workflow.
+ */
+export function buildOpenDataContext(
+  row: Pick<RunRow, "source" | "title">,
+  job: unknown
+): OpenDataJobContext | undefined {
+  if (row.source?.type !== "open_data_dataset") return undefined;
+  const record = asRecord(job);
+  const verification = asRecord(record.verification);
+  const verificationMethod = text(
+    verification.method,
+    "open_data_quality_audit"
+  );
+  const verificationSignals = Array.isArray(verification.signals)
+    ? verification.signals.filter(
+        (signal): signal is string => typeof signal === "string"
+      )
+    : [
+        "Dataset URL reachable",
+        "Resource URL reachable",
+        "Checks performed",
+        "Findings or no_issue_found recorded",
+        "Recommended actions present",
+      ];
+  const acceptance = Array.isArray(record.acceptanceCriteria)
+    ? record.acceptanceCriteria.filter(
+        (item): item is string => typeof item === "string"
+      )
+    : [];
+
+  return {
+    ...row.source,
+    title: text(record.title, row.title),
+    category: text(record.category, "data"),
+    body: text(record.description, text(record.body, "")),
+    acceptanceCriteria: acceptance,
+    agentInstructions: textOrLines(record.agentInstructions),
+    verification: { method: verificationMethod, signals: verificationSignals },
+  };
+}
+
 export function extractRunJobs(payload: unknown): RawRecord[] {
   return asArray(payload);
 }
@@ -379,7 +459,25 @@ export function buildRunRows(payload: unknown): RunRow[] {
           ? `${category} · ${tier}`
           : source?.type === "osv_advisory"
             ? `${source.ecosystem} / ${source.packageName} · ${source.advisoryId} · ${tier}`
-            : `${id} · ${category} · ${tier}`;
+            : source?.type === "open_data_dataset"
+              ? // Spec: `Data.gov · <agency> · <resource_format> · quality
+                // audit`. Agency and format are optional in the catalog;
+                // drop the missing parts and any leading/trailing
+                // separators so the meta line never reads
+                // `Data.gov ·  ·  · quality audit`.
+                [
+                  "Data.gov",
+                  source.agency,
+                  source.resourceFormat,
+                  "quality audit",
+                  tier,
+                ]
+                  .filter(
+                    (part): part is string =>
+                      typeof part === "string" && part.length > 0
+                  )
+                  .join(" · ")
+              : `${id} · ${category} · ${tier}`;
     return {
       id,
       sessionId: text(job.sessionId),
@@ -407,9 +505,13 @@ export function buildRunRows(payload: unknown): RunRow[] {
               ? state === "ready"
                 ? "Ingested from OSV · dependency remediation"
                 : `State: ${state}`
-              : state === "ready"
-                ? "Job listed"
-                : `State: ${state}`,
+              : source?.type === "open_data_dataset"
+                ? state === "ready"
+                  ? "Ingested from Data.gov · audit only"
+                  : `State: ${state}`
+                : state === "ready"
+                  ? "Job listed"
+                  : `State: ${state}`,
       lastEventMeta:
         source?.type === "github_issue"
           ? `${source.repo} #${source.issueNumber} · verifier ${verifierLabel(job.verifierMode)}`
@@ -417,7 +519,17 @@ export function buildRunRows(payload: unknown): RunRow[] {
             ? `${source.language}.wikipedia · rev ${source.revisionId} · ${source.taskType.replace(/_/g, " ")}`
             : source?.type === "osv_advisory"
               ? `${source.repo} · ${source.manifestPath} · ${source.vulnerableVersion} → ${source.fixedVersion}`
-              : `${text(job.rewardAsset, "DOT")} · verifier ${verifierLabel(job.verifierMode)}`,
+              : source?.type === "open_data_dataset"
+                ? // Same graceful-degrade rule as jobMeta: drop missing
+                  // optional parts so the meta never has empty bullets.
+                  [source.agency, source.resourceFormat, source.datasetTitle]
+                    .filter(
+                      (part): part is string =>
+                        typeof part === "string" && part.length > 0
+                    )
+                    .join(" · ") ||
+                  `verifier ${verifierLabel(job.verifierMode)}`
+                : `${text(job.rewardAsset, "DOT")} · verifier ${verifierLabel(job.verifierMode)}`,
     };
   });
 }
@@ -455,11 +567,24 @@ export function buildRecommendationCards(
     const jobMeta =
       source?.type === "osv_advisory"
         ? `${source.ecosystem} / ${source.packageName} · ${source.advisoryId}`
-        : category;
+        : source?.type === "open_data_dataset"
+          ? [
+              "Data.gov",
+              source.agency,
+              source.resourceFormat,
+              "quality audit",
+            ]
+              .filter(
+                (part): part is string =>
+                  typeof part === "string" && part.length > 0
+              )
+              .join(" · ")
+          : category;
     const isIngested =
       source?.type === "github_issue" ||
       source?.type === "wikipedia_article" ||
-      source?.type === "osv_advisory";
+      source?.type === "osv_advisory" ||
+      source?.type === "open_data_dataset";
     return {
       id,
       title: text(job.title, text(job.description, titleFromId(id))),


### PR DESCRIPTION
## Summary
Wires the Data.gov backend ingest (#27, fixed in #32) into the operator UI as a fourth first-class source kind alongside GitHub PR-review, Wikipedia proposal-review, and OSV dependency-remediation. Pattern-matches PR #29 (OSV).

These are dataset/resource quality **audit** jobs. The platform never edits source data and never contacts the publishing agency from this workflow. That stance is reinforced in three places: the panel "Audit only" policy banner, the panel submission note + CTA, and the receipt drawer's verbatim "Averray open-data quality audit" attribution paragraph.

**Source shape**

`source.type === "open_data_dataset"` carries the dataset + resource identity, optional agency/license/modified, and the catalog discovery API. Three identity fields (`datasetTitle`, `datasetUrl`, `resourceUrl`) are required; everything else is optional and **degrades gracefully** — a sparse catalog record renders `Data.gov · quality audit · T1` with no empty bullets per spec section 8.

**SourceBadge**

New `"data_gov"` variant in `SourceKind` with a stylised database-cylinder glyph that pairs with the existing octocat/W/shield marks at the same 10px slot. Label `"Data.gov"` per spec section 1. Slate-tinted dark fill keeps visual weight aligned with the other dark badges while staying distinct from OSV's red ink.

**Adapters**

- `buildJobSource` parses `open_data_dataset` blocks, preserves every optional field when present.
- `buildOpenDataContext` defaults `verification.method` to `open_data_quality_audit`.
- `buildRunRows` jobMeta reads `Data.gov · <agency> · <resource_format> · quality audit · <tier>` with missing parts dropped (filter+join, never `Data.gov ·  ·  · quality audit`).
- `lastEventMeta` shows agency · format · dataset title (whichever exist).
- Recommendation cards mirror the same identity and use `source.score` for the Fit-score chip.

**LoadedRunPanel**

New `openData?: OpenDataJobContext` prop. New `OpenDataEvidenceBlock` with the spec-mandated tabs: **Dataset · Checks · Findings · Submission**. Submission tab asks for the exact fields from spec section 4: Dataset URL, Resource URL, Checks performed, Findings, Recommended actions, optional notes. Settle-row ghost buttons gain an open-data variant (`Flag stale catalog metadata` / `Raise dispute` / `Skip dataset`).

**Audit-only policy banner** (spec section 5):

> Audit only · Report dataset/resource quality issues. Do not edit source data or contact agencies from this workflow.

**LoadedRunView** — source-aware kicker (`Loaded run · Open data dataset`), submission note, verifier output (dataset reachable, resource reachable, audit-only policy enforced), settle copy, lifecycle context. `buildReceiptDraft` threads `openData` through.

**ReceiptPreviewDrawer** — new open-data source block: portal/agency/dataset/resource URL/format, `Audit only` pill next to the SourceBadge, and the verbatim attribution per spec section 6:

> Attribution: Averray open-data quality audit. Findings + recommended actions are advisory; the agent does not edit source data and does not contact the publishing agency from this workflow.

**Queue page** — page-level `LifecycleRail` is now open-data-aware (`open_data_quality_audit` / `Verifier check → Pay`), so selecting an open-data run no longer shows GitHub PR / Wikipedia proposal / OSV merge copy.

**Fixtures** — `run-2752` (Federal sample spending data / GSA / CSV / job-0432 recommendation card) flows through queue + rail + loaded-run panel + receipt preview.

## Domain-leak audit (spec section 7)

Verified by grep on the open-data block: no `PR`, `pull request`, `issue`, `repository`, `maintainer`, `article`, `revision`, `wikitext`, `proposal`, `github_pr`, or `wikipedia_article` user-facing strings. The only match for those tokens in the diff is a code comment in `LoadedRunPanel` listing the source kinds the panel supports — not user-facing copy.

## Files (8)
- `app/components/runs/types.ts`
- `app/components/runs/StatePill.tsx`
- `app/components/runs/LoadedRunPanel.tsx`
- `app/components/runs/LoadedRunView.tsx`
- `app/components/runs/ReceiptPreviewDrawer.tsx`
- `app/components/runs/fixtures.ts`
- `app/lib/api/run-adapters.ts`
- `app/app/(authed)/runs/page.tsx`

## Test plan
- [x] `npm run typecheck:app`
- [x] `npm run build:frontend` (15/15 pages)
- [ ] /runs — queue row for run-2752 shows the Data.gov badge, jobMeta `Data.gov · GSA · CSV · quality audit · T1`
- [ ] Select run-2752 — kicker reads `Loaded run · Open data dataset`, panel shows portal/agency/format/license/modified, "Audit only" banner above tabs, Dataset / Checks / Findings / Submission tabs
- [ ] Submission tab asks for Dataset URL / Resource URL / Checks performed / Findings / Recommended actions / optional notes
- [ ] Open Receipt preview — open-data source block renders with `Audit only` pill, the verbatim attribution paragraph, and `Open Data.gov dataset ↗`
- [ ] Queue-page LifecycleRail reads `open_data_quality_audit` + `Verifier check → Pay`
- [ ] Sparse-record fallback: clear `agency` and `resourceFormat` from the fixture and confirm the meta line degrades to `Data.gov · quality audit · T1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)