### PR TITLE
Hydrate OSV advisories for fixed versions

### DIFF
--- a/mcp-server/src/jobs/ingest-osv-advisories.js
+++ b/mcp-server/src/jobs/ingest-osv-advisories.js
@@ -18,6 +18,7 @@ import { pathToFileURL } from "node:url";
 export const DEFAULT_BASE_URL = "http://localhost:8787";
 export const DEFAULT_ECOSYSTEM = "npm";
 export const OSV_QUERY_BATCH_URL = "https://api.osv.dev/v1/querybatch";
+export const OSV_VULN_URL = "https://api.osv.dev/v1/vulns";
 
 const ECOSYSTEMS = new Set(["npm"]);
 
@@ -58,15 +59,16 @@ export async function ingestOsvAdvisories({
   const skipped = [];
   const candidates = [];
 
-  targets.forEach((target, index) => {
+  for (const [index, target] of targets.entries()) {
     const vulns = results[index]?.vulns ?? [];
     if (!vulns.length) {
       skipped.push({ package: target.name, version: target.version, reason: "no_vulnerabilities" });
-      return;
+      continue;
     }
     for (const advisory of vulns) {
-      const fixedVersion = findFixedVersion(advisory, target);
-      const score = scoreAdvisory(advisory, { fixedVersion });
+      const hydratedAdvisory = await hydrateAdvisoryIfNeeded({ advisory, target, fetchImpl });
+      const fixedVersion = findFixedVersion(hydratedAdvisory, target);
+      const score = scoreAdvisory(hydratedAdvisory, { fixedVersion });
       if (!fixedVersion) {
         skipped.push({ package: target.name, version: target.version, advisoryId: advisory.id, reason: "no_fixed_version" });
         continue;
@@ -75,9 +77,9 @@ export async function ingestOsvAdvisories({
         skipped.push({ package: target.name, version: target.version, advisoryId: advisory.id, reason: "below_min_score", score });
         continue;
       }
-      candidates.push({ target, advisory, fixedVersion, score });
+      candidates.push({ target, advisory: hydratedAdvisory, fixedVersion, score });
     }
-  });
+  }
 
   const jobs = candidates
     .sort((left, right) => right.score - left.score)
@@ -121,6 +123,31 @@ export async function queryOsvBatch({ packages, fetchImpl = fetch }) {
   }
   const payload = await response.json();
   return payload.results ?? [];
+}
+
+export async function queryOsvVulnerability({ advisoryId, fetchImpl = fetch }) {
+  const response = await fetchImpl(`${OSV_VULN_URL}/${encodeURIComponent(advisoryId)}`, {
+    headers: {
+      accept: "application/json",
+      "user-agent": "AverrayOsvIngest/0.1 (https://averray.com; operator@averray.com)"
+    }
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`OSV vulnerability lookup failed (${response.status}): ${body}`);
+  }
+  return response.json();
+}
+
+async function hydrateAdvisoryIfNeeded({ advisory, target, fetchImpl }) {
+  if (findFixedVersion(advisory, target) || !advisory?.id) {
+    return advisory;
+  }
+  try {
+    return await queryOsvVulnerability({ advisoryId: advisory.id, fetchImpl });
+  } catch {
+    return advisory;
+  }
 }
 
 export function parsePackages(raw) {
@@ -305,11 +332,49 @@ export function findFixedVersion(advisory, target) {
     if (String(pkg.name ?? "") !== target.name) continue;
     for (const range of entry.ranges ?? []) {
       for (const event of range.events ?? []) {
-        if (event.fixed) fixed.push(String(event.fixed));
+        fixed.push(...extractVersionStrings(event.fixed));
       }
     }
+    fixed.push(...extractFixedVersionsFromMetadata(entry.database_specific));
+    fixed.push(...extractFixedVersionsFromMetadata(entry.ecosystem_specific));
   }
+  fixed.push(...extractFixedVersionsFromMetadata(advisory.database_specific));
   return fixed.sort(compareSemverish)[0];
+}
+
+function extractFixedVersionsFromMetadata(metadata) {
+  if (!metadata || typeof metadata !== "object") {
+    return [];
+  }
+  return [
+    ...extractVersionStrings(metadata.fixed_version),
+    ...extractVersionStrings(metadata.fixedVersion),
+    ...extractVersionStrings(metadata.fixed_versions),
+    ...extractVersionStrings(metadata.fixedVersions),
+    ...extractVersionStrings(metadata.all_fixed_versions),
+    ...extractVersionStrings(metadata.allFixedVersions),
+    ...extractVersionStrings(metadata.upstream_version),
+    ...extractVersionStrings(metadata.upstreamVersion),
+    ...extractVersionStrings(metadata.root_patch_version),
+    ...extractVersionStrings(metadata.rootPatchVersion)
+  ];
+}
+
+function extractVersionStrings(value) {
+  if (Array.isArray(value)) {
+    return value.flatMap(extractVersionStrings);
+  }
+  if (value === undefined || value === null) {
+    return [];
+  }
+  return String(value)
+    .split(/[,;\s]+/u)
+    .map((version) => version.trim())
+    .filter(isSemverish);
+}
+
+function isSemverish(value) {
+  return /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/u.test(value);
 }
 
 function compareSemverish(left, right) {

--- a/mcp-server/src/jobs/ingest-osv-advisories.test.js
+++ b/mcp-server/src/jobs/ingest-osv-advisories.test.js
@@ -5,6 +5,7 @@ import {
   findFixedVersion,
   ingestOsvAdvisories,
   parsePackages,
+  queryOsvVulnerability,
   scoreAdvisory,
   toPlatformJob
 } from "./ingest-osv-advisories.js";
@@ -49,6 +50,40 @@ test("parsePackages accepts JSON and compact line syntax", () => {
 
 test("findFixedVersion extracts the first npm fixed release", () => {
   assert.equal(findFixedVersion(ADVISORY, TARGET), "1.2.3");
+});
+
+test("findFixedVersion falls back to advisory metadata fixed versions", () => {
+  const advisory = {
+    ...ADVISORY,
+    affected: [
+      {
+        package: { ecosystem: "npm", name: "minimist" },
+        ranges: [{ type: "SEMVER", events: [{ introduced: "0" }] }],
+        database_specific: {
+          all_fixed_versions: ["1.2.6", "1.2.5"]
+        }
+      }
+    ]
+  };
+
+  assert.equal(findFixedVersion(advisory, TARGET), "1.2.5");
+});
+
+test("findFixedVersion reads Snyk/root-style advisory fixed metadata", () => {
+  const advisory = {
+    ...ADVISORY,
+    affected: [
+      {
+        package: { ecosystem: "npm", name: "minimist" },
+        ranges: [{ type: "SEMVER", events: [{ introduced: "0" }] }],
+        database_specific: {
+          upstream_version: "1.2.8-root.io.1"
+        }
+      }
+    ]
+  };
+
+  assert.equal(findFixedVersion(advisory, TARGET), "1.2.8-root.io.1");
 });
 
 test("scoreAdvisory prefers fixed CVE-backed advisories", () => {
@@ -98,28 +133,73 @@ test("ingestOsvAdvisories queries OSV and filters jobs", async () => {
   assert.equal(payload.skipped.length, 0);
 });
 
+test("ingestOsvAdvisories hydrates sparse querybatch advisories before filtering", async () => {
+  const urls = [];
+  const payload = await ingestOsvAdvisories({
+    packages: [TARGET],
+    limit: 5,
+    minScore: 55,
+    fetchImpl: async (url, request = {}) => {
+      urls.push(String(url));
+      if (request.method === "POST") {
+        return {
+          ok: true,
+          async json() {
+            return { results: [{ vulns: [{ id: ADVISORY.id, summary: ADVISORY.summary }] }] };
+          }
+        };
+      }
+      return {
+        ok: true,
+        async json() {
+          return ADVISORY;
+        }
+      };
+    }
+  });
+
+  assert.equal(payload.count, 1);
+  assert.equal(payload.jobs[0].source.fixedVersion, "1.2.3");
+  assert.ok(urls.some((url) => url.endsWith(`/vulns/${ADVISORY.id}`)));
+});
+
 test("ingestOsvAdvisories skips advisories without a fixed version", async () => {
   const payload = await ingestOsvAdvisories({
     packages: [TARGET],
-    fetchImpl: async () => ({
-      ok: true,
-      async json() {
-        return {
-          results: [
-            {
-              vulns: [
-                {
-                  ...ADVISORY,
-                  affected: [{ package: { ecosystem: "npm", name: "minimist" }, ranges: [{ events: [{ introduced: "0" }] }] }]
-                }
-              ]
-            }
-          ]
-        };
-      }
-    })
+    fetchImpl: async (_url, request = {}) => {
+      const advisory = {
+        ...ADVISORY,
+        affected: [{ package: { ecosystem: "npm", name: "minimist" }, ranges: [{ events: [{ introduced: "0" }] }] }]
+      };
+      return {
+        ok: true,
+        async json() {
+          return request.method === "POST"
+            ? { results: [{ vulns: [advisory] }] }
+            : advisory;
+        }
+      };
+    }
   });
 
   assert.equal(payload.count, 0);
   assert.equal(payload.skipped[0].reason, "no_fixed_version");
+});
+
+test("queryOsvVulnerability fetches the full advisory document", async () => {
+  const advisory = await queryOsvVulnerability({
+    advisoryId: ADVISORY.id,
+    fetchImpl: async (url, request = {}) => {
+      assert.equal(String(url), `https://api.osv.dev/v1/vulns/${ADVISORY.id}`);
+      assert.equal(request.headers.accept, "application/json");
+      return {
+        ok: true,
+        async json() {
+          return ADVISORY;
+        }
+      }
+    }
+  });
+
+  assert.equal(advisory.id, ADVISORY.id);
 });


### PR DESCRIPTION
## Summary
- hydrate sparse OSV querybatch advisories via /v1/vulns/{id} before fixed-version filtering
- read fixed versions from OSV ranges plus database/ecosystem metadata shapes such as all_fixed_versions and upstream_version
- add tests for sparse querybatch hydration and metadata fallback

## Tests
- node --test mcp-server/src/jobs/ingest-osv-advisories.test.js
- npm --workspace mcp-server test
- live dry-run: lodash@4.17.20 produced 2 remediation job candidates fixed to 4.17.21