### PR TITLE
Use valid starter tier for OSV jobs

### DIFF
--- a/mcp-server/src/jobs/ingest-osv-advisories.js
+++ b/mcp-server/src/jobs/ingest-osv-advisories.js
@@ -187,7 +187,7 @@ export function toPlatformJob({ target, advisory, fixedVersion, score = scoreAdv
     jobType: "work",
     requiredRole: "worker",
     category: "security",
-    tier: "starter-plus",
+    tier: "starter",
     rewardAsset: "DOT",
     rewardAmount: 3,
     verifierMode: "github_pr",

--- a/mcp-server/src/jobs/ingest-osv-advisories.test.js
+++ b/mcp-server/src/jobs/ingest-osv-advisories.test.js
@@ -95,6 +95,7 @@ test("toPlatformJob creates a PR-shaped dependency remediation job", () => {
 
   assert.equal(job.id, "osv-npm-example-app-minimist-0-0-8-ghsa-vh95-rmgr-6w4m");
   assert.equal(job.category, "security");
+  assert.equal(job.tier, "starter");
   assert.equal(job.verifierMode, "github_pr");
   assert.equal(job.inputSchemaRef, "schema://jobs/dependency-remediation-input");
   assert.equal(job.outputSchemaRef, "schema://jobs/dependency-remediation-output");


### PR DESCRIPTION
## Summary
- change OSV advisory generated jobs from invalid tier `starter-plus` to valid platform tier `starter`
- add a regression assertion on the OSV job tier

## Tests
- `node --test mcp-server/src/jobs/ingest-osv-advisories.test.js`
- `npm --workspace mcp-server test`

## Production context
Live OSV ingestion reached job posting but production rejected the payload with `Invalid tier: starter-plus`. This keeps the existing reward/difficulty shape but uses a valid platform tier.