### PR TITLE
operator-app: SourceBadge on OSV/Data.gov queue rows + rail wrap

### DIFF
--- a/app/components/runs/JobCard.tsx
+++ b/app/components/runs/JobCard.tsx
@@ -69,6 +69,33 @@ export function JobCard({ job }: { job: JobCardData }) {
                 / {job.source.pageTitle}
               </span>
             </p>
+          ) : job.source?.type === "osv_advisory" ? (
+            <p
+              className="mt-1 flex items-center gap-1 font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]"
+              style={{ letterSpacing: 0 }}
+            >
+              <span className="shrink-0">
+                {job.source.ecosystem} / {job.source.packageName}
+              </span>
+              <span className="truncate text-[var(--avy-accent)]">
+                · {job.source.advisoryId}
+              </span>
+            </p>
+          ) : job.source?.type === "open_data_dataset" ? (
+            <p
+              className="mt-1 flex items-center gap-1 font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]"
+              style={{ letterSpacing: 0 }}
+            >
+              <span className="truncate text-[var(--avy-ink)]">
+                {job.source.datasetTitle}
+              </span>
+              {job.source.agency ? (
+                <>
+                  <span className="shrink-0 opacity-40">·</span>
+                  <span className="shrink-0 truncate">{job.source.agency}</span>
+                </>
+              ) : null}
+            </p>
           ) : (
             <p
               className="mt-1 truncate font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]"
@@ -97,7 +124,18 @@ export function JobCard({ job }: { job: JobCardData }) {
       </header>
 
       <div className="flex flex-wrap items-center gap-1">
-        {job.source?.type === "github_issue" ? <SourceBadge kind="github" /> : null}
+        {job.source?.type === "github_issue" ? (
+          <SourceBadge kind="github" />
+        ) : job.source?.type === "wikipedia_article" ? (
+          <SourceBadge kind="wikipedia" />
+        ) : job.source?.type === "osv_advisory" ? (
+          <SourceBadge
+            kind="osv"
+            secondary={(job.source.cves?.length ?? 0) > 0 ? "NVD" : undefined}
+          />
+        ) : job.source?.type === "open_data_dataset" ? (
+          <SourceBadge kind="data_gov" />
+        ) : null}
         <TierPill tier={job.tier} />
         {job.category ? (
           <span

--- a/app/components/runs/RecommendationRail.tsx
+++ b/app/components/runs/RecommendationRail.tsx
@@ -9,9 +9,10 @@ export interface RecommendationRailProps {
   /**
    * `"vertical"` stacks cards in a narrow sidebar (original shape, used when
    * there's real estate to the right of the queue). `"horizontal"` lays the
-   * cards out left-to-right and scrolls on overflow — used when the rail sits
-   * below a split-pane queue+detail area so it doesn't fight for vertical
-   * space.
+   * cards out in a flex-wrap grid — used when the rail sits below a
+   * split-pane queue+detail area so it doesn't fight for vertical space.
+   * Reflows to multiple rows at narrow widths instead of scrolling
+   * horizontally so trailing cards don't get silently clipped.
    */
   layout?: "vertical" | "horizontal";
 }
@@ -42,26 +43,20 @@ export function RecommendationRail({
       </header>
 
       {isHorizontal ? (
-        <div className="relative">
-          <div
-            className="flex gap-2 overflow-x-auto p-2.5 [-webkit-overflow-scrolling:touch]"
-            // Tuck a little extra padding on the right so the last card
-            // doesn't butt up against the fade overlay.
-            style={{ paddingRight: "2.5rem" }}
-          >
-            {jobs.map((job) => (
-              <div key={job.id} className="w-[300px] shrink-0">
-                <JobCard job={job} />
-              </div>
-            ))}
-          </div>
-          {/* Right-edge fade: tells the user there's more content past the
-              visible edge without relying on a visible scrollbar. Pointer-
-              events-none so it doesn't block clicks on the card underneath. */}
-          <div
-            aria-hidden="true"
-            className="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-[var(--avy-paper-solid)] to-transparent"
-          />
+        // Flex-wrap grid: cards keep a ~300px target width and reflow into
+        // additional rows at narrow viewports instead of overflowing the
+        // container. Avoids the previous behaviour where the rail's
+        // horizontal scroll silently clipped the last card on operator
+        // monitors that don't render a visible scrollbar.
+        <div className="flex flex-wrap gap-2 p-2.5">
+          {jobs.map((job) => (
+            <div
+              key={job.id}
+              className="min-w-[260px] grow basis-[280px]"
+            >
+              <JobCard job={job} />
+            </div>
+          ))}
         </div>
       ) : (
         <div className="flex flex-col gap-2 p-2.5">

--- a/app/components/runs/RunQueueTable.tsx
+++ b/app/components/runs/RunQueueTable.tsx
@@ -186,6 +186,37 @@ function RunRowCard({
                     {row.jobMeta}
                   </span>
                 </>
+              ) : row.source?.type === "osv_advisory" ? (
+                <>
+                  <SourceBadge
+                    kind="osv"
+                    secondary={
+                      (row.source.cves?.length ?? 0) > 0 ? "NVD" : undefined
+                    }
+                    className="shrink-0"
+                  />
+                  <span className="truncate">
+                    {row.source.ecosystem} / {row.source.packageName}
+                    <span className="text-[var(--avy-accent)]">
+                      {" "}· {row.source.advisoryId}
+                    </span>
+                  </span>
+                  <span className="shrink-0 opacity-40">·</span>
+                  <span className="shrink-0 whitespace-nowrap">
+                    {row.jobMeta}
+                  </span>
+                </>
+              ) : row.source?.type === "open_data_dataset" ? (
+                <>
+                  <SourceBadge kind="data_gov" className="shrink-0" />
+                  <span className="truncate text-[var(--avy-ink)]">
+                    {row.source.datasetTitle}
+                  </span>
+                  <span className="shrink-0 opacity-40">·</span>
+                  <span className="shrink-0 truncate whitespace-nowrap">
+                    {row.jobMeta}
+                  </span>
+                </>
               ) : (
                 <span className="truncate">{row.jobMeta}</span>
               )}


### PR DESCRIPTION
## Summary
Two production bugs reported on the live `/runs` page after #29 and #33.

**Bug 1 — no SourceBadge on OSV / Data.gov rows.** The queue-row badge ladder in `RunQueueTable.tsx:161` and the recommendation-card ladder in `JobCard.tsx:50,100` were both hardcoded to only `github_issue` + `wikipedia_article`. OSV (since #29) and Data.gov (since #33) fell through the `else` branch that renders the plain native fallback — no badge, and the meta line showed the raw job-id slug (`open-data-datagov-https-www-arcgis-com-home-item-html-…`) instead of the formatted `Data.gov · agency · format · quality audit · tier` that `buildRunRows` already emits. JobCard's source-meta paragraph had the same gap.

The recommendation card's SourceBadge chip was even narrower — only rendered for `github_issue`. Wikipedia recommendation cards have been silently dropping their badge since #14.

**Fix:** extend both ladders to all four ingested-source kinds:

- GitHub: `<SourceBadge kind="github" />` + `repo #N`
- Wikipedia: `<SourceBadge kind="wikipedia" />` + `lang.wikipedia / page`
- OSV: `<SourceBadge kind="osv" secondary={cves ? "NVD" : undefined} />` + `ecosystem / package · advisoryId`
- Open-data: `<SourceBadge kind="data_gov" />` + `datasetTitle (· agency)`

**Bug 2 — recommendation rail clips silently at narrow viewports.** The horizontal layout uses `overflow-x-auto` with fixed `w-[300px]` cards plus a right-edge fade gradient. The fade was meant to signal "more content past the edge" but on macOS with hidden scrollbars and a sub-1280px viewport that signal vanishes — the user just sees the trailing card visually truncated mid-content with no obvious scroll affordance. Reported as "text drops out of the window".

**Fix:** switch the horizontal layout to `flex-wrap` with each card sized `min-w-[260px] grow basis-[280px]`. Cards reflow into multiple rows at narrow widths and grow to fill each row at wide widths. Vertical (sidebar) layout is unchanged. The horizontal-rail fade overlay is removed since there's nothing to fade now.

## Files
- `app/components/runs/RunQueueTable.tsx` — queue-row badge + meta ladder
- `app/components/runs/JobCard.tsx` — recommendation-card source-meta + badge ladder
- `app/components/runs/RecommendationRail.tsx` — flex-wrap horizontal layout

## Test plan
- [x] `npm run typecheck:app`
- [x] `npm run build:frontend` (15/15 pages)
- [ ] /runs queue: OSV rows (e.g. fixture `run-2751`) show `OSV · NVD` badge + `npm / minimist · GHSA-...`; Data.gov rows (live `Audit open-data resource: Crashes in DC` runs from the API) show `Data.gov` badge + `Crashes in DC` + `Data.gov · Metropolitan Police Department · GEOJSON · quality audit · T1`
- [ ] /runs recommendation rail: at <1100px viewport the cards wrap to a second row instead of being clipped on the right
- [ ] /runs recommendation rail: at ≥1280px the cards still fit on one row (4-card layout) and stretch evenly
- [ ] Recommendation cards: Wikipedia cards now show `Wikipedia` badge (regression from #14, fixed); OSV cards show `OSV · NVD`; Data.gov cards show `Data.gov`

🤖 Generated with [Claude Code](https://claude.com/claude-code)