### PR TITLE
Allow worktree cleanup after merge queue

### DIFF
--- a/scripts/ops/finish-agent-worktree.sh
+++ b/scripts/ops/finish-agent-worktree.sh
@@ -2,7 +2,10 @@
 set -euo pipefail
 
 # Remove a merged task worktree and delete its local/remote task branch. This
-# refuses to proceed if the branch is not merged into the remote base branch.
+# refuses to proceed unless the branch is either an ancestor of the remote base
+# branch or has a merged GitHub pull request. The GitHub check covers merge
+# queue/squash merges, where main contains the branch content but is not a
+# descendant of the source branch tip.
 
 REMOTE=${REMOTE:-origin}
 BASE_BRANCH=${BASE_BRANCH:-main}
@@ -21,6 +24,56 @@ Environment:
   BASE_BRANCH=main     base branch that must contain the task branch
   DELETE_REMOTE=1      delete the remote task branch when present
 USAGE
+}
+
+github_repo_from_remote() {
+  local remote_url repo
+  remote_url="$(git remote get-url "$REMOTE" 2>/dev/null || true)"
+
+  case "$remote_url" in
+    git@github.com:*.git)
+      repo="${remote_url#git@github.com:}"
+      repo="${repo%.git}"
+      ;;
+    git@github.com:*)
+      repo="${remote_url#git@github.com:}"
+      ;;
+    https://github.com/*.git)
+      repo="${remote_url#https://github.com/}"
+      repo="${repo%.git}"
+      ;;
+    https://github.com/*)
+      repo="${remote_url#https://github.com/}"
+      ;;
+    *)
+      repo=""
+      ;;
+  esac
+
+  if [[ "$repo" == */* ]]; then
+    printf '%s\n' "$repo"
+  fi
+}
+
+branch_has_merged_pr() {
+  local repo state
+  repo="$(github_repo_from_remote)"
+  if [[ -z "$repo" ]]; then
+    return 1
+  fi
+  if ! command -v gh >/dev/null 2>&1; then
+    return 1
+  fi
+
+  state="$(
+    GH_PAGER= gh pr view "$branch" \
+      --repo "$repo" \
+      --json state,mergedAt \
+      --jq 'if (.state == "MERGED" or .mergedAt != null) then "merged" else "not_merged" end' \
+      2>/dev/null || true
+  )"
+
+  [[ "$state" == "merged" ]]
 }
 
 if [[ $# -ne 1 ]]; then
@@ -52,8 +105,12 @@ if ! git show-ref --verify --quiet "refs/heads/$branch"; then
   exit 1
 fi
 
-if ! git merge-base --is-ancestor "$branch" "$REMOTE/$BASE_BRANCH"; then
-  echo "Refusing to delete $branch because it is not merged into $REMOTE/$BASE_BRANCH" >&2
+if git merge-base --is-ancestor "$branch" "$REMOTE/$BASE_BRANCH"; then
+  echo "$branch is merged into $REMOTE/$BASE_BRANCH"
+elif branch_has_merged_pr; then
+  echo "$branch has a merged GitHub pull request"
+else
+  echo "Refusing to delete $branch because it is not merged into $REMOTE/$BASE_BRANCH and no merged GitHub PR was found" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- keep the existing ancestry safety check for normally merged branches
- add a GitHub merged-PR fallback for merge queue / squash-merged branches
- parse the GitHub repo from the configured remote so the helper works after org migration

## Tests
- `bash -n scripts/ops/finish-agent-worktree.sh`
- `git diff --check`
- verified `gh pr view agent/osv-valid-tier --repo averray-agent/agent` reports `merged`, matching a branch that previously failed cleanup