### PR TITLE
Improve public job provider quality

### DIFF
--- a/docs/PUBLIC_JOB_SOURCES.md
+++ b/docs/PUBLIC_JOB_SOURCES.md
@@ -104,6 +104,8 @@ After Wikipedia, use the same pattern for:
    - v1 ingestion targets the US Data.gov CKAN catalog:
      `POST /admin/jobs/ingest/open-data` searches catalog metadata or accepts
      explicit dataset/resource targets, then emits proposal-only audit jobs.
+     Each run selects one high-signal resource per dataset so CSV/GeoJSON/API
+     siblings do not flood the queue with duplicate audits.
    - Scheduled ingestion is available behind `OPEN_DATA_INGEST_ENABLED`; keep
      `OPEN_DATA_INGEST_DRY_RUN=true` until `/admin/status` shows good
      candidates.
@@ -111,13 +113,15 @@ After Wikipedia, use the same pattern for:
 3. **OSV/NVD advisories**
    - package-to-CVE mapping, remediation summaries
    - structured impact notes
-   - v1 ingestion is allowlist-driven and npm-only:
+   - v1 ingestion is npm-only:
      `POST /admin/jobs/ingest/osv` accepts package/version/repo targets,
      queries OSV, and emits dependency remediation PR jobs when a fixed version
      exists. CVE aliases link to NVD for operator review.
+     It can also discover package targets from configured GitHub npm lockfiles
+     when explicit package targets are not set.
    - Scheduled ingestion is available behind `OSV_INGEST_ENABLED`; configure
-     package targets explicitly and keep `OSV_INGEST_DRY_RUN=true` until
-     candidate quality is reviewed.
+     package targets or `OSV_INGEST_MANIFESTS_JSON`, and keep
+     `OSV_INGEST_DRY_RUN=true` until candidate quality is reviewed.
 
 4. **Stack Exchange / Discourse**
    - unanswered-question triage, duplicate detection, answer summaries

--- a/docs/READY_TO_POST_JOBS.md
+++ b/docs/READY_TO_POST_JOBS.md
@@ -356,6 +356,15 @@ npm --workspace mcp-server run ingest:osv-advisories -- --dry-run \
   --packages '[{"name":"minimist","version":"0.0.8","repo":"example/app","manifestPath":"package.json"}]'
 ```
 
+For repo-shaped ingestion, point the provider at one or more GitHub npm
+lockfiles. Explicit packages still win when both knobs are set.
+
+```bash
+npm --workspace mcp-server run ingest:osv-advisories -- --dry-run \
+  --manifests '[{"repo":"averray-agent/agent","manifestPath":"package-lock.json","ref":"main"}]' \
+  --max-package-targets 100
+```
+
 Or through the admin API:
 
 ```http
@@ -371,6 +380,9 @@ OSV_INGEST_INTERVAL_MS=3600000
 OSV_INGEST_MAX_JOBS_PER_RUN=2
 OSV_INGEST_MAX_OPEN_JOBS=20
 OSV_INGEST_PACKAGES_JSON='[{"name":"minimist","version":"0.0.8","repo":"example/app","manifestPath":"package.json"}]'
+# Or, for repo lockfile discovery when explicit packages are not set:
+OSV_INGEST_MANIFESTS_JSON='[{"repo":"averray-agent/agent","manifestPath":"package-lock.json","ref":"main"}]'
+OSV_INGEST_MAX_PACKAGE_TARGETS=100
 ```
 
 Review `osvIngestion.lastRun` in `/admin/status`, then switch
@@ -403,6 +415,10 @@ Preview jobs through:
 npm --workspace mcp-server run ingest:open-data -- --dry-run \
   --query 'res_format:CSV'
 ```
+
+The ingester keeps one resource per dataset per run, preferring simple,
+agent-auditable formats such as CSV over sibling GeoJSON/JSON resources. That
+avoids filling the queue with duplicate audits for the same dataset.
 
 Or through the admin API:
 

--- a/mcp-server/src/jobs/ingest-open-data-datasets.js
+++ b/mcp-server/src/jobs/ingest-open-data-datasets.js
@@ -23,6 +23,15 @@ export const DATA_GOV_PACKAGE_SEARCH_URL = "https://catalog.data.gov/api/3/actio
 export const DATA_GOV_CATALOG_SEARCH_URL = "https://catalog.data.gov/search";
 
 const PREFERRED_RESOURCE_FORMATS = new Set(["CSV", "JSON", "GEOJSON", "API", "XLS", "XLSX", "XML"]);
+const RESOURCE_FORMAT_PRIORITY = new Map([
+  ["CSV", 70],
+  ["JSON", 60],
+  ["GEOJSON", 55],
+  ["XLSX", 50],
+  ["XLS", 45],
+  ["API", 40],
+  ["XML", 35]
+]);
 
 export function parseArgs(argv) {
   const parsed = {};
@@ -73,13 +82,14 @@ export async function ingestOpenDataDatasets({
     candidates.push({ target, score });
   }
 
-  const jobs = candidates
+  const selectedCandidates = selectBestResourcePerDataset(candidates, skipped);
+  const jobs = selectedCandidates
     .sort((left, right) => right.score - left.score)
     .slice(0, limit)
     .map(({ target, score }) => toPlatformJob(target, score));
 
-  if (candidates.length > jobs.length) {
-    skipped.push({ reason: "over_limit", count: candidates.length - jobs.length });
+  if (selectedCandidates.length > jobs.length) {
+    skipped.push({ reason: "over_limit", count: selectedCandidates.length - jobs.length });
   }
 
   return {
@@ -217,6 +227,31 @@ export function scoreDatasetTarget(target) {
   if (looksOld(target.modified ?? target.metadataModified)) score += 8;
   if (!target.resourceUrl) score -= 40;
   return Math.max(0, Math.min(100, score));
+}
+
+export function selectBestResourcePerDataset(candidates, skipped = []) {
+  const byDataset = new Map();
+  for (const candidate of candidates) {
+    const key = datasetKey(candidate.target);
+    const current = byDataset.get(key);
+    if (!current || compareDatasetCandidates(candidate, current) < 0) {
+      byDataset.set(key, candidate);
+    }
+  }
+
+  const selected = new Set(byDataset.values());
+  for (const candidate of candidates) {
+    if (selected.has(candidate)) continue;
+    const winner = byDataset.get(datasetKey(candidate.target));
+    skipped.push({
+      datasetId: candidate.target.datasetId,
+      resourceId: candidate.target.resourceId,
+      reason: "duplicate_dataset_resource",
+      selectedResourceId: winner?.target?.resourceId
+    });
+  }
+
+  return [...byDataset.values()];
 }
 
 export function toPlatformJob(target, score = scoreDatasetTarget(target)) {
@@ -379,6 +414,27 @@ function looksOld(value) {
 function estimateDifficulty(score) {
   if (score >= 80) return "starter";
   return "review-needed";
+}
+
+function datasetKey(target) {
+  return [
+    DEFAULT_PROVIDER,
+    target.datasetId || target.datasetUrl || target.datasetTitle
+  ].map((part) => String(part ?? "").trim().toLowerCase()).join("|");
+}
+
+function compareDatasetCandidates(left, right) {
+  const scoreDiff = right.score - left.score;
+  if (scoreDiff !== 0) return scoreDiff;
+
+  const formatDiff = resourceFormatPriority(right.target) - resourceFormatPriority(left.target);
+  if (formatDiff !== 0) return formatDiff;
+
+  return String(left.target.resourceUrl).localeCompare(String(right.target.resourceUrl));
+}
+
+function resourceFormatPriority(target) {
+  return RESOURCE_FORMAT_PRIORITY.get(normalizeFormat(target.resourceFormat)) ?? 0;
 }
 
 function text(value) {

--- a/mcp-server/src/jobs/ingest-open-data-datasets.test.js
+++ b/mcp-server/src/jobs/ingest-open-data-datasets.test.js
@@ -9,6 +9,7 @@ import {
   parseDatasets,
   scoreDatasetTarget,
   searchDataGovDatasets,
+  selectBestResourcePerDataset,
   toPlatformJob
 } from "./ingest-open-data-datasets.js";
 
@@ -148,6 +149,29 @@ test("scoreDatasetTarget prefers concrete resource audit targets", () => {
   assert.equal(scoreDatasetTarget({ ...TARGET, resourceUrl: "" }), 46);
 });
 
+test("selectBestResourcePerDataset keeps one high-signal resource per dataset", () => {
+  const skipped = [];
+  const csv = { target: TARGET, score: 100 };
+  const geojson = {
+    target: {
+      ...TARGET,
+      resourceId: "resource-geojson",
+      resourceTitle: "Spending GeoJSON",
+      resourceUrl: "https://example.gov/spending.geojson",
+      resourceFormat: "GEOJSON"
+    },
+    score: 100
+  };
+
+  const selected = selectBestResourcePerDataset([geojson, csv], skipped);
+
+  assert.equal(selected.length, 1);
+  assert.equal(selected[0].target.resourceFormat, "CSV");
+  assert.equal(skipped.length, 1);
+  assert.equal(skipped[0].reason, "duplicate_dataset_resource");
+  assert.equal(skipped[0].selectedResourceId, "resource-456");
+});
+
 test("toPlatformJob creates a benchmark open-data audit job", () => {
   const job = toPlatformJob(TARGET, 92);
 
@@ -228,4 +252,40 @@ test("ingestOpenDataDatasets searches Data.gov and filters low-score resources",
 
   assert.equal(payload.count, 1);
   assert.equal(payload.skipped[0].reason, "below_min_score");
+});
+
+test("ingestOpenDataDatasets avoids duplicate resource jobs for one dataset", async () => {
+  const payload = await ingestOpenDataDatasets({
+    query: "traffic crashes",
+    limit: 5,
+    minScore: 55,
+    fetchImpl: async () => ({
+      ok: true,
+      async json() {
+        return {
+          result: {
+            results: [
+              {
+                ...CKAN_PACKAGE,
+                resources: [
+                  CKAN_PACKAGE.resources[0],
+                  {
+                    id: "resource-geojson",
+                    name: "Spending GeoJSON",
+                    url: "https://example.gov/spending.geojson",
+                    format: "GEOJSON",
+                    last_modified: "2021-01-01T00:00:00Z"
+                  }
+                ]
+              }
+            ]
+          }
+        };
+      }
+    })
+  });
+
+  assert.equal(payload.count, 1);
+  assert.equal(payload.jobs[0].source.resourceFormat, "CSV");
+  assert.equal(payload.skipped[0].reason, "duplicate_dataset_resource");
 });

--- a/mcp-server/src/jobs/ingest-osv-advisories.js
+++ b/mcp-server/src/jobs/ingest-osv-advisories.js
@@ -19,6 +19,7 @@ export const DEFAULT_BASE_URL = "http://localhost:8787";
 export const DEFAULT_ECOSYSTEM = "npm";
 export const OSV_QUERY_BATCH_URL = "https://api.osv.dev/v1/querybatch";
 export const OSV_VULN_URL = "https://api.osv.dev/v1/vulns";
+export const GITHUB_RAW_BASE_URL = "https://raw.githubusercontent.com";
 
 const ECOSYSTEMS = new Set(["npm"]);
 
@@ -46,11 +47,16 @@ export function parseArgs(argv) {
 
 export async function ingestOsvAdvisories({
   packages = [],
+  manifests = [],
   limit = 10,
   minScore = 55,
+  maxPackageTargets = 100,
   fetchImpl = fetch
 } = {}) {
-  const targets = parsePackages(packages);
+  const explicitTargets = parsePackages(packages);
+  const targets = explicitTargets.length
+    ? explicitTargets
+    : await collectPackageTargetsFromManifests({ manifests, maxPackageTargets, fetchImpl });
   if (!targets.length) {
     return { ecosystem: DEFAULT_ECOSYSTEM, minScore, count: 0, jobs: [], skipped: [] };
   }
@@ -154,6 +160,35 @@ export function parsePackages(raw) {
   const parsed = typeof raw === "string" ? parsePackageString(raw) : raw;
   if (!Array.isArray(parsed)) return [];
   return parsed.map(normalizePackageTarget).filter(Boolean);
+}
+
+export function parseManifests(raw) {
+  const parsed = typeof raw === "string" ? parseManifestString(raw) : raw;
+  if (!Array.isArray(parsed)) return [];
+  return parsed.map(normalizeManifestSource).filter(Boolean);
+}
+
+export async function collectPackageTargetsFromManifests({
+  manifests = [],
+  maxPackageTargets = 100,
+  fetchImpl = fetch
+} = {}) {
+  const sources = parseManifests(manifests);
+  const targets = [];
+  const seen = new Set();
+  for (const source of sources) {
+    const lockfile = await fetchNpmLockfile(source, fetchImpl);
+    for (const target of extractNpmLockfileTargets({ lockfile, source })) {
+      const key = `${target.ecosystem}|${target.repo}|${target.manifestPath}|${target.name}|${target.version}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      targets.push(target);
+      if (targets.length >= maxPackageTargets) {
+        return targets;
+      }
+    }
+  }
+  return targets;
 }
 
 export function scoreAdvisory(advisory, { fixedVersion } = {}) {
@@ -293,6 +328,84 @@ function parsePackageString(raw) {
       };
     })
     .filter(Boolean);
+}
+
+function parseManifestString(raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed;
+  } catch {
+    // Fall through to compact line parser.
+  }
+  return String(raw)
+    .split(/\n|,/u)
+    .map((entry) => {
+      const [repo, manifestPath = "package-lock.json", ref = "main"] = entry.split("|").map((part) => part?.trim());
+      if (!repo) return undefined;
+      return { repo, manifestPath, ref };
+    })
+    .filter(Boolean);
+}
+
+function normalizeManifestSource(raw) {
+  const repo = normalizeRepo(raw?.repo);
+  const manifestPath = String(raw?.manifestPath ?? raw?.path ?? "package-lock.json").trim().replace(/^\/+/u, "");
+  const ref = String(raw?.ref ?? raw?.branch ?? "main").trim();
+  if (!repo || !manifestPath || !ref) return undefined;
+  return { repo, manifestPath, ref };
+}
+
+async function fetchNpmLockfile(source, fetchImpl) {
+  const url = rawGithubUrl(source);
+  const response = await fetchImpl(url, {
+    headers: {
+      accept: "application/json",
+      "user-agent": "AverrayOsvIngest/0.1 (https://averray.com; operator@averray.com)"
+    }
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub lockfile fetch failed (${response.status}) for ${source.repo}/${source.manifestPath}@${source.ref}: ${body}`);
+  }
+  return response.json();
+}
+
+function rawGithubUrl(source) {
+  const repoPath = source.repo.split("/").map(encodeURIComponent).join("/");
+  const manifestPath = source.manifestPath.split("/").map(encodeURIComponent).join("/");
+  return `${GITHUB_RAW_BASE_URL}/${repoPath}/${encodeURIComponent(source.ref)}/${manifestPath}`;
+}
+
+export function extractNpmLockfileTargets({ lockfile, source }) {
+  const targets = [];
+  const packages = lockfile?.packages && typeof lockfile.packages === "object" ? lockfile.packages : undefined;
+  if (packages) {
+    for (const [path, entry] of Object.entries(packages)) {
+      if (!path.startsWith("node_modules/") || !entry || typeof entry !== "object") continue;
+      const name = entry.name || packageNameFromNodeModulesPath(path);
+      const version = String(entry.version ?? "").trim();
+      if (!name || !version || entry.dev === true) continue;
+      targets.push({ name, version, ecosystem: DEFAULT_ECOSYSTEM, repo: source.repo, manifestPath: source.manifestPath });
+    }
+    return targets;
+  }
+
+  const dependencies = lockfile?.dependencies && typeof lockfile.dependencies === "object" ? lockfile.dependencies : {};
+  for (const [name, entry] of Object.entries(dependencies)) {
+    const version = String(entry?.version ?? "").trim();
+    if (!name || !version || entry?.dev === true) continue;
+    targets.push({ name, version, ecosystem: DEFAULT_ECOSYSTEM, repo: source.repo, manifestPath: source.manifestPath });
+  }
+  return targets;
+}
+
+function packageNameFromNodeModulesPath(path) {
+  const relative = path.replace(/^node_modules\//u, "");
+  if (relative.startsWith("@")) {
+    const [scope, name] = relative.split("/");
+    return scope && name ? `${scope}/${name}` : "";
+  }
+  return relative.split("/")[0] ?? "";
 }
 
 function normalizePackageTarget(raw) {
@@ -449,8 +562,10 @@ async function runCli() {
   const args = parseArgs(process.argv.slice(2));
   const dryRun = Boolean(args["dry-run"]);
   const packages = args.packages ?? process.env.OSV_INGEST_PACKAGES_JSON ?? process.env.OSV_INGEST_PACKAGES;
+  const manifests = args.manifests ?? process.env.OSV_INGEST_MANIFESTS_JSON ?? process.env.OSV_INGEST_MANIFESTS;
   const limit = parsePositiveInt(args.limit, 10);
   const minScore = parsePositiveInt(args["min-score"], 55);
+  const maxPackageTargets = parsePositiveInt(args["max-package-targets"] ?? process.env.OSV_INGEST_MAX_PACKAGE_TARGETS, 100);
   const baseUrl = trimTrailingSlash(String(args.baseUrl ?? process.env.AGENT_API_BASE_URL ?? DEFAULT_BASE_URL));
   const adminToken = process.env.AGENT_ADMIN_TOKEN?.trim();
 
@@ -458,7 +573,7 @@ async function runCli() {
     fail("AGENT_ADMIN_TOKEN is required unless --dry-run is set.");
   }
 
-  const dryRunPayload = await ingestOsvAdvisories({ packages, limit, minScore });
+  const dryRunPayload = await ingestOsvAdvisories({ packages, manifests, limit, minScore, maxPackageTargets });
   if (dryRun) {
     console.log(JSON.stringify(dryRunPayload, null, 2));
     return;

--- a/mcp-server/src/jobs/ingest-osv-advisories.test.js
+++ b/mcp-server/src/jobs/ingest-osv-advisories.test.js
@@ -2,8 +2,11 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  collectPackageTargetsFromManifests,
+  extractNpmLockfileTargets,
   findFixedVersion,
   ingestOsvAdvisories,
+  parseManifests,
   parsePackages,
   queryOsvVulnerability,
   scoreAdvisory,
@@ -46,6 +49,59 @@ const ADVISORY = {
 test("parsePackages accepts JSON and compact line syntax", () => {
   assert.deepEqual(parsePackages(JSON.stringify([TARGET])), [TARGET]);
   assert.deepEqual(parsePackages("minimist@0.0.8|example/app|package.json"), [TARGET]);
+});
+
+test("parseManifests accepts JSON and compact line syntax", () => {
+  const manifest = { repo: "example/app", manifestPath: "package-lock.json", ref: "main" };
+  assert.deepEqual(parseManifests(JSON.stringify([manifest])), [manifest]);
+  assert.deepEqual(parseManifests("https://github.com/example/app.git|locks/package-lock.json|release/v1"), [
+    { repo: "example/app", manifestPath: "locks/package-lock.json", ref: "release/v1" }
+  ]);
+});
+
+test("extractNpmLockfileTargets reads npm package-lock v3 packages", () => {
+  const targets = extractNpmLockfileTargets({
+    source: { repo: "example/app", manifestPath: "package-lock.json", ref: "main" },
+    lockfile: {
+      packages: {
+        "": { name: "app", version: "1.0.0" },
+        "node_modules/minimist": { version: "0.0.8" },
+        "node_modules/@scope/pkg": { version: "1.2.3" },
+        "node_modules/dev-only": { version: "1.0.0", dev: true }
+      }
+    }
+  });
+
+  assert.deepEqual(targets, [
+    { name: "minimist", version: "0.0.8", ecosystem: "npm", repo: "example/app", manifestPath: "package-lock.json" },
+    { name: "@scope/pkg", version: "1.2.3", ecosystem: "npm", repo: "example/app", manifestPath: "package-lock.json" }
+  ]);
+});
+
+test("collectPackageTargetsFromManifests fetches GitHub lockfiles and caps targets", async () => {
+  const targets = await collectPackageTargetsFromManifests({
+    manifests: [{ repo: "example/app", manifestPath: "package-lock.json", ref: "main" }],
+    maxPackageTargets: 1,
+    fetchImpl: async (url, request = {}) => {
+      assert.equal(String(url), "https://raw.githubusercontent.com/example/app/main/package-lock.json");
+      assert.equal(request.headers.accept, "application/json");
+      return {
+        ok: true,
+        async json() {
+          return {
+            packages: {
+              "node_modules/minimist": { version: "0.0.8" },
+              "node_modules/left-pad": { version: "1.3.0" }
+            }
+          };
+        }
+      };
+    }
+  });
+
+  assert.deepEqual(targets, [
+    { name: "minimist", version: "0.0.8", ecosystem: "npm", repo: "example/app", manifestPath: "package-lock.json" }
+  ]);
 });
 
 test("findFixedVersion extracts the first npm fixed release", () => {
@@ -132,6 +188,36 @@ test("ingestOsvAdvisories queries OSV and filters jobs", async () => {
   assert.equal(payload.jobs[0].source.advisoryId, "GHSA-vh95-rmgr-6w4m");
   assert.equal(payload.jobs[0].source.vulnerableVersion, "0.0.8");
   assert.equal(payload.skipped.length, 0);
+});
+
+test("ingestOsvAdvisories can derive package targets from GitHub lockfiles", async () => {
+  const payload = await ingestOsvAdvisories({
+    manifests: [{ repo: "example/app", manifestPath: "package-lock.json", ref: "main" }],
+    limit: 5,
+    minScore: 55,
+    fetchImpl: async (url, request = {}) => {
+      if (String(url).includes("raw.githubusercontent.com")) {
+        return {
+          ok: true,
+          async json() {
+            return { packages: { "node_modules/minimist": { version: "0.0.8" } } };
+          }
+        };
+      }
+      const body = JSON.parse(request.body);
+      assert.equal(body.queries[0].package.name, "minimist");
+      return {
+        ok: true,
+        async json() {
+          return { results: [{ vulns: [ADVISORY] }] };
+        }
+      };
+    }
+  });
+
+  assert.equal(payload.count, 1);
+  assert.equal(payload.jobs[0].source.repo, "example/app");
+  assert.equal(payload.jobs[0].source.manifestPath, "package-lock.json");
 });
 
 test("ingestOsvAdvisories hydrates sparse querybatch advisories before filtering", async () => {

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -24,7 +24,11 @@ import {
 } from "../../core/job-schema-registry.js";
 import { ingestGithubIssues } from "../../jobs/ingest-github-issues.js";
 import { ingestOpenDataDatasets, parseDatasets as parseOpenDataDatasets } from "../../jobs/ingest-open-data-datasets.js";
-import { ingestOsvAdvisories, parsePackages as parseOsvPackages } from "../../jobs/ingest-osv-advisories.js";
+import {
+  ingestOsvAdvisories,
+  parseManifests as parseOsvManifests,
+  parsePackages as parseOsvPackages
+} from "../../jobs/ingest-osv-advisories.js";
 import { ingestWikipediaMaintenance, parseCategories } from "../../jobs/ingest-wikipedia-maintenance.js";
 
 const {
@@ -2221,10 +2225,14 @@ const server = createServer(async (request, response) => {
       const packages = Array.isArray(payload?.packages) || typeof payload?.packages === "string"
         ? parseOsvPackages(payload.packages)
         : parseOsvPackages(process.env.OSV_INGEST_PACKAGES_JSON ?? process.env.OSV_INGEST_PACKAGES);
+      const manifests = Array.isArray(payload?.manifests) || typeof payload?.manifests === "string"
+        ? parseOsvManifests(payload.manifests)
+        : parseOsvManifests(process.env.OSV_INGEST_MANIFESTS_JSON ?? process.env.OSV_INGEST_MANIFESTS);
       const limit = parsePositiveInteger(payload?.limit, 10, 50);
       const minScore = parsePositiveInteger(payload?.minScore, 55, 100);
+      const maxPackageTargets = parsePositiveInteger(payload?.maxPackageTargets, 100, 500);
       const dryRun = payload?.dryRun !== false;
-      const result = await ingestOsvAdvisories({ packages, limit, minScore });
+      const result = await ingestOsvAdvisories({ packages, manifests, limit, minScore, maxPackageTargets });
 
       if (dryRun) {
         return respond(response, 200, {

--- a/mcp-server/src/services/osv-advisory-ingestion-scheduler.js
+++ b/mcp-server/src/services/osv-advisory-ingestion-scheduler.js
@@ -1,4 +1,4 @@
-import { ingestOsvAdvisories, parsePackages } from "../jobs/ingest-osv-advisories.js";
+import { ingestOsvAdvisories, parseManifests, parsePackages } from "../jobs/ingest-osv-advisories.js";
 
 export class OsvAdvisoryIngestionScheduler {
   constructor(platformService, eventBus = undefined, {
@@ -6,8 +6,10 @@ export class OsvAdvisoryIngestionScheduler {
     dryRun = true,
     intervalMs = 60 * 60 * 1000,
     packages = [],
+    manifests = [],
     minScore = 55,
     maxJobsPerRun = 2,
+    maxPackageTargets = 100,
     maxOpenJobs = 20,
     fetchImpl = fetch,
     logger = console
@@ -18,8 +20,10 @@ export class OsvAdvisoryIngestionScheduler {
     this.dryRun = dryRun;
     this.intervalMs = intervalMs;
     this.packages = parsePackagesConfig(packages);
+    this.manifests = parseManifestsConfig(manifests);
     this.minScore = minScore;
     this.maxJobsPerRun = maxJobsPerRun;
+    this.maxPackageTargets = maxPackageTargets;
     this.maxOpenJobs = maxOpenJobs;
     this.fetchImpl = fetchImpl;
     this.logger = logger;
@@ -51,8 +55,10 @@ export class OsvAdvisoryIngestionScheduler {
       dryRun: this.dryRun,
       intervalMs: this.intervalMs,
       packageCount: this.packages.length,
+      manifestCount: this.manifests.length,
       minScore: this.minScore,
       maxJobsPerRun: this.maxJobsPerRun,
+      maxPackageTargets: this.maxPackageTargets,
       maxOpenJobs: this.maxOpenJobs,
       lastRun: this.lastRun
     };
@@ -76,8 +82,8 @@ export class OsvAdvisoryIngestionScheduler {
       summary.skipped.push({ reason: "disabled" });
       return this.finishRun(summary);
     }
-    if (!this.packages.length) {
-      summary.skipped.push({ reason: "no_packages_configured" });
+    if (!this.packages.length && !this.manifests.length) {
+      summary.skipped.push({ reason: "no_packages_or_manifests_configured" });
       return this.finishRun(summary);
     }
     if (openOsvJobs >= this.maxOpenJobs) {
@@ -90,8 +96,10 @@ export class OsvAdvisoryIngestionScheduler {
     try {
       const result = await ingestOsvAdvisories({
         packages: this.packages,
+        manifests: this.manifests,
         limit: remaining,
         minScore: this.minScore,
+        maxPackageTargets: this.maxPackageTargets,
         fetchImpl: this.fetchImpl
       });
       summary.candidateCount = result.count;
@@ -178,8 +186,10 @@ export function loadOsvAdvisoryIngestionConfig(env = process.env) {
     dryRun: env.OSV_INGEST_DRY_RUN === undefined ? true : parseBooleanEnv(env.OSV_INGEST_DRY_RUN),
     intervalMs: parsePositiveInt(env.OSV_INGEST_INTERVAL_MS, 60 * 60 * 1000),
     packages: parsePackagesConfig(env.OSV_INGEST_PACKAGES_JSON ?? env.OSV_INGEST_PACKAGES),
+    manifests: parseManifestsConfig(env.OSV_INGEST_MANIFESTS_JSON ?? env.OSV_INGEST_MANIFESTS),
     minScore: parsePositiveInt(env.OSV_INGEST_MIN_SCORE, 55),
     maxJobsPerRun: parsePositiveInt(env.OSV_INGEST_MAX_JOBS_PER_RUN, 2),
+    maxPackageTargets: parsePositiveInt(env.OSV_INGEST_MAX_PACKAGE_TARGETS, 100),
     maxOpenJobs: parsePositiveInt(env.OSV_INGEST_MAX_OPEN_JOBS, 20)
   };
 }
@@ -201,6 +211,10 @@ function osvJobKey(job) {
 
 function parsePackagesConfig(raw) {
   return parsePackages(raw);
+}
+
+function parseManifestsConfig(raw) {
+  return parseManifests(raw);
 }
 
 function parsePositiveInt(raw, fallback) {

--- a/mcp-server/src/services/osv-advisory-ingestion-scheduler.test.js
+++ b/mcp-server/src/services/osv-advisory-ingestion-scheduler.test.js
@@ -30,12 +30,22 @@ const ADVISORY = {
 };
 
 function makeFetch() {
-  return async () => ({
-    ok: true,
-    async json() {
-      return { results: [{ vulns: [ADVISORY] }] };
+  return async (url, request = {}) => {
+    if (String(url).includes("raw.githubusercontent.com")) {
+      return {
+        ok: true,
+        async json() {
+          return { packages: { "node_modules/minimist": { version: "0.0.8" } } };
+        }
+      };
     }
-  });
+    return {
+      ok: true,
+      async json() {
+        return { results: [{ vulns: [ADVISORY] }] };
+      }
+    };
+  };
 }
 
 function makePlatformService(initialJobs = []) {
@@ -87,6 +97,40 @@ test("OsvAdvisoryIngestionScheduler creates jobs when dryRun is false", async ()
   assert.equal(platform.listJobs().length, 1);
   assert.equal(platform.listJobs()[0].source.type, "osv_advisory");
   assert.equal(platform.listJobs()[0].source.advisoryId, "GHSA-vh95-rmgr-6w4m");
+});
+
+test("OsvAdvisoryIngestionScheduler can source targets from manifests", async () => {
+  const platform = makePlatformService();
+  const scheduler = new OsvAdvisoryIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    manifests: [{ repo: "example/app", manifestPath: "package-lock.json", ref: "main" }],
+    fetchImpl: makeFetch()
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-26T10:00:00.000Z"));
+  assert.equal(summary.createdCount, 1);
+  assert.equal(platform.listJobs()[0].source.packageName, "minimist");
+  assert.equal((await scheduler.getStatus()).manifestCount, 1);
+});
+
+test("OsvAdvisoryIngestionScheduler prefers explicit packages over manifests", async () => {
+  const platform = makePlatformService();
+  const scheduler = new OsvAdvisoryIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    packages: [TARGET],
+    manifests: [{ repo: "example/app", manifestPath: "package-lock.json", ref: "main" }],
+    fetchImpl: async (url, request = {}) => {
+      assert.equal(String(url), "https://api.osv.dev/v1/querybatch");
+      const body = JSON.parse(request.body);
+      assert.equal(body.queries[0].package.name, "minimist");
+      return makeFetch()(url, request);
+    }
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-26T10:00:00.000Z"));
+  assert.equal(summary.createdCount, 1);
 });
 
 test("OsvAdvisoryIngestionScheduler dedupes by advisory package target", async () => {
@@ -142,8 +186,10 @@ test("loadOsvAdvisoryIngestionConfig parses env knobs safely", () => {
     OSV_INGEST_INTERVAL_MS: "3600000",
     OSV_INGEST_MIN_SCORE: "70",
     OSV_INGEST_MAX_JOBS_PER_RUN: "4",
+    OSV_INGEST_MAX_PACKAGE_TARGETS: "25",
     OSV_INGEST_MAX_OPEN_JOBS: "11",
-    OSV_INGEST_PACKAGES_JSON: JSON.stringify([TARGET])
+    OSV_INGEST_PACKAGES_JSON: JSON.stringify([TARGET]),
+    OSV_INGEST_MANIFESTS_JSON: JSON.stringify([{ repo: "example/app", manifestPath: "package-lock.json", ref: "main" }])
   });
 
   assert.equal(config.enabled, true);
@@ -151,6 +197,8 @@ test("loadOsvAdvisoryIngestionConfig parses env knobs safely", () => {
   assert.equal(config.intervalMs, 3600000);
   assert.equal(config.minScore, 70);
   assert.equal(config.maxJobsPerRun, 4);
+  assert.equal(config.maxPackageTargets, 25);
   assert.equal(config.maxOpenJobs, 11);
   assert.deepEqual(config.packages, [TARGET]);
+  assert.deepEqual(config.manifests, [{ repo: "example/app", manifestPath: "package-lock.json", ref: "main" }]);
 });


### PR DESCRIPTION
## Summary
- Data.gov ingestion now selects one high-signal resource per dataset, preferring audit-friendly formats like CSV, so sibling CSV/GeoJSON/API resources don't duplicate the queue
- OSV ingestion can derive npm package targets from configured GitHub package-lock.json manifests when explicit package targets are not set
- Wire OSV manifests through scheduler config and the admin ingest endpoint
- Document the new OSV manifest knobs and Data.gov dataset-level dedupe behavior

## Tests
- `node --test mcp-server/src/jobs/ingest-open-data-datasets.test.js`
- `node --test mcp-server/src/jobs/ingest-osv-advisories.test.js mcp-server/src/services/osv-advisory-ingestion-scheduler.test.js`
- `npm --workspace mcp-server test`