### PR TITLE
operator-app: surface source attribution in receipts drawer + fixture coverage

### DIFF
--- a/app/app/(authed)/receipts/page.tsx
+++ b/app/app/(authed)/receipts/page.tsx
@@ -21,6 +21,7 @@ import {
 import { KindChip } from "@/components/receipts/KindChip";
 import { DetailDrawer } from "@/components/shell/DetailDrawer";
 import { ReceiptDrawerBody } from "@/components/receipts/ReceiptDrawerBody";
+import { SourceBadge } from "@/components/runs/StatePill";
 import {
   buildReceiptDrawer,
   extractReceiptRows,
@@ -152,6 +153,35 @@ const ROWS: ReceiptRow[] = [
     policy: "writer-gov/cited@v3",
     size: "14.2 KB",
     signedAt: "14:11:18 UTC",
+  },
+  {
+    id: "r_4e145",
+    kind: "run",
+    subject: "run-2751",
+    subjectSub: "coding-hand-3",
+    source: "osv",
+    signers: [
+      { initials: "P", tone: "sage", role: "operator", address: "0xFd2EAE…6519" },
+      { initials: "C", tone: "ink", role: "cosigner", address: "0x9A13BC…0cb2" },
+      { initials: "V", tone: "blue", role: "verifier", address: "0x4D1E…7EbC" },
+    ],
+    policy: "security/osv-deps@v1",
+    size: "11.8 KB",
+    signedAt: "14:09:52 UTC",
+  },
+  {
+    id: "r_4e144",
+    kind: "run",
+    subject: "run-2752",
+    subjectSub: "writer-gov-1",
+    source: "data_gov",
+    signers: [
+      { initials: "P", tone: "sage", role: "operator", address: "0xFd2EAE…6519" },
+      { initials: "V", tone: "blue", role: "verifier", address: "0x4D1E…7EbC" },
+    ],
+    policy: "data/open-data-audit@v1",
+    size: "9.1 KB",
+    signedAt: "14:09:21 UTC",
   },
   {
     id: "r_4e139",
@@ -347,6 +377,7 @@ export default function ReceiptsPage() {
               style={{ letterSpacing: 0 }}
             >
               <KindChip kind={selected.kind} />
+              {selected.source ? <SourceBadge kind={selected.source} /> : null}
               <span className="text-[var(--avy-ink)]">{selected.policy}</span>
               <span>·</span>
               <span>{selected.issuedAtIso ? receiptDate(selected.issuedAtIso) : "2026-04-24"} · {selected.signedAt}</span>
@@ -361,6 +392,7 @@ export default function ReceiptsPage() {
             evidenceMeta={drawerModel.evidenceMeta}
             evidenceRawHref={drawerModel.evidenceRawHref}
             links={drawerModel.links}
+            source={drawerModel.source}
           />
         ) : null}
       </DetailDrawer>

--- a/app/components/audit/data.tsx
+++ b/app/components/audit/data.tsx
@@ -49,6 +49,44 @@ const CHAIN = {
 
 export const AUDIT_EVENTS: AuditEvent[] = [
   {
+    id: "ev-osv-01",
+    at: "14:09:52",
+    day: "today",
+    source: "operator",
+    category: "verifier",
+    action: "receipt.signed",
+    actor: FD,
+    summary: (
+      <>
+        Signed receipt <b>r_4e145</b> for OSV remediation run-2751 ·
+        npm/minimist <b>1.2.5 → 1.2.6</b> (GHSA-vh95-rmgr-6w4m).
+      </>
+    ),
+    target: "r_4e145",
+    hash: "0x4f12…aa83",
+    tone: "accent",
+    link: { label: "Open receipt →", href: "/receipts" },
+  },
+  {
+    id: "ev-datagov-01",
+    at: "14:09:21",
+    day: "today",
+    source: "operator",
+    category: "verifier",
+    action: "receipt.signed",
+    actor: FD,
+    summary: (
+      <>
+        Signed receipt <b>r_4e144</b> for Data.gov audit run-2752 · GSA{" "}
+        <b>Federal sample spending data</b> (CSV).
+      </>
+    ),
+    target: "r_4e144",
+    hash: "0x9b04…42c1",
+    tone: "accent",
+    link: { label: "Open receipt →", href: "/receipts" },
+  },
+  {
     id: "ev-01",
     at: "14:08:42",
     day: "today",

--- a/app/components/disputes/data.ts
+++ b/app/components/disputes/data.ts
@@ -237,6 +237,7 @@ export const DISPUTES: Dispute[] = [
   {
     id: "d_4df10",
     runRef: "run-2711",
+    source: "wikipedia",
     openingReceipt: "r_4df10",
     summary:
       "Writer output cited external link in violation of writer-gov/cited@v3; upheld after review.",
@@ -343,5 +344,164 @@ export const DISPUTES: Dispute[] = [
         tone: "sage",
       },
     },
+  },
+  {
+    id: "d_4e0a2",
+    runRef: "run-2751",
+    source: "osv",
+    openingReceipt: "r_4e145",
+    summary:
+      "Lockfile resolves to a downstream package version that no longer satisfies the OSV-fixed range; verifier flagged the bump as ineffective.",
+    origin: "schema",
+    severity: "gating",
+    state: "under-review",
+    opener: {
+      handle: "verifier-2",
+      address: "0x9A13…0cb2",
+      initials: "V2",
+      tone: "blue",
+    },
+    respondent: {
+      handle: "coding-hand-3",
+      address: "0x4F88AD…19c0",
+      initials: "CH",
+      tone: "clay",
+    },
+    reviewer: {
+      handle: "you · operator-primary",
+      address: "0xFd2E…6519",
+      initials: "FD",
+      tone: "sage",
+    },
+    stakeFrozen: 18,
+    stakeBreakdown: { worker: 12, verifier: 4, treasury: 2 },
+    openedAt: "14:32:11 UTC",
+    windowSeconds: 30 * 60,
+    windowElapsed: 8 * 60 + 22,
+    evidence: [
+      {
+        label: "advisory_id",
+        worker: "GHSA-vh95-rmgr-6w4m",
+        expected: "GHSA-vh95-rmgr-6w4m",
+        match: "ok",
+      },
+      {
+        label: "manifest.minimist",
+        worker: "1.2.6",
+        expected: "1.2.6",
+        match: "ok",
+      },
+      {
+        label: "lockfile.minimist",
+        worker: "1.2.5",
+        expected: "1.2.6",
+        match: "fail",
+        note: "transitive dep still resolves to 1.2.5; advisory range not actually closed",
+      },
+    ],
+    workerPayload: `{
+  "advisoryId": "GHSA-vh95-rmgr-6w4m",
+  "manifestPath": "frontend/package.json",
+  "from": "1.2.5",
+  "to": "1.2.6",
+  "lockfileResolved": "1.2.5"
+}`,
+    expectedPayload: `{
+  "advisoryId": "GHSA-vh95-rmgr-6w4m",
+  "manifestPath": "frontend/package.json",
+  "from": "1.2.5",
+  "to": "1.2.6",
+  "lockfileResolved": "1.2.6"
+}`,
+    timeline: [
+      {
+        at: "14:32:11 UTC",
+        label: "opened",
+        body: "verifier-2 flagged a lockfile mismatch — bump landed in package.json but transitive resolution still pins the vulnerable version.",
+      },
+      {
+        at: "14:32:14 UTC",
+        label: "stake.locked",
+        body: "18 DOT frozen pending verdict.",
+        tone: "warn",
+      },
+    ],
+  },
+  {
+    id: "d_4e09b",
+    runRef: "run-2752",
+    source: "data_gov",
+    openingReceipt: "r_4e144",
+    summary:
+      "Audit report omitted resource-format check on a CSV resource; verifier flagged missing checks signal.",
+    origin: "schema",
+    severity: "advisory",
+    state: "awaiting-evidence",
+    opener: {
+      handle: "verifier-2",
+      address: "0x9A13…0cb2",
+      initials: "V2",
+      tone: "blue",
+    },
+    respondent: {
+      handle: "writer-gov-1",
+      address: "0xFd2E…6519",
+      initials: "FD",
+      tone: "sage",
+    },
+    reviewer: {
+      handle: "you · operator-primary",
+      address: "0xFd2E…6519",
+      initials: "FD",
+      tone: "sage",
+    },
+    stakeFrozen: 4,
+    stakeBreakdown: { worker: 2, verifier: 1, treasury: 1 },
+    openedAt: "14:14:48 UTC",
+    windowSeconds: 30 * 60,
+    windowElapsed: 4 * 60 + 9,
+    evidence: [
+      {
+        label: "dataset_url_present",
+        worker: "true",
+        expected: "true",
+        match: "ok",
+      },
+      {
+        label: "resource_url_present",
+        worker: "true",
+        expected: "true",
+        match: "ok",
+      },
+      {
+        label: "checks.format_summary",
+        worker: "absent",
+        expected: "present",
+        match: "fail",
+        note: "CSV resources require a header/columns summary — missing in the audit report",
+      },
+    ],
+    workerPayload: `{
+  "datasetTitle": "Federal sample spending data",
+  "resourceFormat": "CSV",
+  "checks": ["dataset_url_reachable", "resource_url_reachable"]
+}`,
+    expectedPayload: `{
+  "datasetTitle": "Federal sample spending data",
+  "resourceFormat": "CSV",
+  "checks": ["dataset_url_reachable", "resource_url_reachable", "format_summary"]
+}`,
+    timeline: [
+      {
+        at: "14:14:48 UTC",
+        label: "opened",
+        body: "verifier-2 requested an additional checks signal for tabular resources.",
+      },
+      {
+        at: "14:14:52 UTC",
+        label: "stake.locked",
+        body: "4 DOT frozen — advisory severity, no slash by default.",
+      },
+    ],
   },
 ];

--- a/app/components/receipts/ReceiptDrawerBody.tsx
+++ b/app/components/receipts/ReceiptDrawerBody.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { DrawerSection } from "@/components/shell/DetailDrawer";
+import { SourceBadge, type SourceKind } from "@/components/runs/StatePill";
 import { cn } from "@/lib/utils/cn";
 
 export interface SignatureEntry {
@@ -16,12 +17,29 @@ export interface LinkedArtifact {
   href?: string;
 }
 
+export interface ReceiptDrawerSource {
+  kind: SourceKind;
+  /** Optional secondary tag inside the badge — e.g. "NVD" on OSV with CVEs. */
+  secondary?: string;
+  /** One-line attribution. */
+  attribution: string;
+  /** Optional inline identity, e.g. "owner/repo #123" or dataset title. */
+  identity?: string;
+  href?: string;
+}
+
 export interface ReceiptDrawerBodyProps {
   signatures: SignatureEntry[];
   evidenceJson: string;
   evidenceMeta: string;
   evidenceRawHref: string;
   links: LinkedArtifact[];
+  /**
+   * Source provenance + attribution for run-kind receipts. Unset for
+   * non-run receipts (badge, settle on a loan, policy revision) where
+   * the platform-source concept doesn't apply.
+   */
+  source?: ReceiptDrawerSource;
 }
 
 export function ReceiptDrawerBody({
@@ -30,9 +48,47 @@ export function ReceiptDrawerBody({
   evidenceMeta,
   evidenceRawHref,
   links,
+  source,
 }: ReceiptDrawerBodyProps) {
   return (
     <>
+      {source ? (
+        <DrawerSection title="Source">
+          <div
+            className="flex flex-wrap items-center gap-x-2 gap-y-1 rounded-[8px] border border-[var(--avy-line)] bg-[color:rgba(17,19,21,0.02)] px-3 py-2"
+            style={{ letterSpacing: 0 }}
+          >
+            <SourceBadge kind={source.kind} secondary={source.secondary} />
+            {source.identity ? (
+              source.href ? (
+                <a
+                  href={source.href}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="truncate whitespace-nowrap font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-ink)] hover:text-[var(--avy-accent)]"
+                  title={source.identity}
+                >
+                  {source.identity}
+                </a>
+              ) : (
+                <span
+                  className="truncate whitespace-nowrap font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-ink)]"
+                  title={source.identity}
+                >
+                  {source.identity}
+                </span>
+              )
+            ) : null}
+          </div>
+          <p
+            className="mt-2 m-0 rounded-[6px] border border-[var(--avy-warn)] bg-[color:rgba(211,145,27,0.08)] px-2.5 py-2 font-[family-name:var(--font-mono)] text-[11px] leading-[1.5] text-[var(--avy-ink)]"
+            style={{ letterSpacing: 0 }}
+          >
+            <b className="font-semibold">Attribution:</b> {source.attribution}.
+          </p>
+        </DrawerSection>
+      ) : null}
+
       <DrawerSection title="Signature chain">
         <div className="flex flex-col gap-1.5 rounded-[10px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-3.5 py-3">
           {signatures.map((sig, i) => (

--- a/app/lib/api/receipt-adapters.ts
+++ b/app/lib/api/receipt-adapters.ts
@@ -5,6 +5,7 @@ import type {
 } from "@/components/receipts/ReceiptDrawerBody";
 import type { ReceiptRow } from "@/components/receipts/ReceiptsTable";
 import type { Signer, SignerTone } from "@/components/receipts/SignerAvatars";
+import type { SourceKind } from "@/components/runs/StatePill";
 
 export type ReceiptRowWithMeta = ReceiptRow & {
   sessionId: string;
@@ -20,7 +21,33 @@ export interface ReceiptDrawerModel {
   evidenceMeta: string;
   evidenceRawHref: string;
   links: LinkedArtifact[];
+  /**
+   * Provenance + attribution for the underlying run, when known. Used to
+   * render a SourceBadge + a short attribution line in the drawer so an
+   * auditor opening a receipt sees the same source context the table row
+   * shows. Optional because non-run receipts (badge, settle on a loan,
+   * policy revision) don't carry a platform source.
+   */
+  source?: {
+    kind: SourceKind;
+    /** Optional secondary chip — e.g. "NVD" on OSV advisories with CVEs. */
+    secondary?: string;
+    /** Short single-line attribution. */
+    attribution: string;
+    /** Optional inline identity, e.g. "owner/repo #123" or dataset title. */
+    identity?: string;
+    /** Optional URL the identity links out to. */
+    href?: string;
+  };
 }
+
+const SOURCE_ATTRIBUTION: Record<SourceKind, string> = {
+  github: "Averray-attributed PR review",
+  wikipedia: "Averray proposal — agent never edits Wikipedia",
+  osv: "Averray dependency remediation",
+  data_gov: "Averray open-data quality audit",
+  oss: "Open-source contribution",
+};
 
 export function extractReceiptRows(data: unknown): ReceiptRowWithMeta[] {
   const rows = Array.isArray(data)
@@ -100,6 +127,25 @@ export function buildReceiptDrawer(
       { role: "Session", ref: row.sessionId },
       { role: "Block ref", ref: text(averray?.chainJobId, row.blockRef ?? "pending") },
     ],
+    ...(row.source ? { source: receiptSource(row.source) } : {}),
+  };
+}
+
+/**
+ * Build the optional source-attribution block surfaced in the receipt
+ * drawer. Today we only know the source `kind` from the row itself —
+ * the rich source object (repo + issue, dataset + agency) lives on the
+ * underlying run, not on the receipt payload. So we render a badge +
+ * a short attribution line, and let the existing "Linked artifacts"
+ * section continue to carry the run id / evidence hash. Once receipts
+ * carry a richer source field this can hydrate identity/href too.
+ */
+function receiptSource(
+  kind: SourceKind
+): NonNullable<ReceiptDrawerModel["source"]> {
+  return {
+    kind,
+    attribution: SOURCE_ATTRIBUTION[kind] ?? "Averray-attributed run",
   };
 }
 


### PR DESCRIPTION
## Summary
Second-pass audit caught two related coverage gaps after the OSV ([#29](https://github.com/averray-agent/agent/pull/29)) and Data.gov ([#33](https://github.com/averray-agent/agent/pull/33)) source kinds shipped:

1. **`ReceiptDrawerBody` silently ignored `row.source`** — the receipts page table renders a `SourceBadge`, but opening the drawer dropped all provenance. The receipt-preview drawer that ships from the runs surface is a different component; this PR brings the receipts-page drawer up to the same bar.
2. **Receipts / Disputes / Audit-log fixtures had no OSV or Data.gov rows** — those rendering paths had never been visually exercised. Could ship broken and we'd never see it locally.

**Drawer wiring**

- `ReceiptDrawerModel` gains an optional `source` block (kind + attribution + optional identity/href) populated from the row's `source: SourceKind` in `buildReceiptDrawer`.
- `ReceiptDrawerBody` renders a new **"Source"** section at the top of the drawer, with a `SourceBadge` and a warn-tinted attribution paragraph mirroring the receipt-preview drawer style.
- Drawer header `meta` slot renders the `SourceBadge` next to the existing `KindChip` so the source is visible without scrolling.

**Attribution copy** (single source of truth in `receipt-adapters.ts`):

| kind | line |
|---|---|
| `github` | Averray-attributed PR review |
| `wikipedia` | Averray proposal — agent never edits Wikipedia |
| `osv` | Averray dependency remediation |
| `data_gov` | Averray open-data quality audit |

**Fixtures**

- Receipts: `r_4e145` (OSV remediation → run-2751) and `r_4e144` (Data.gov audit → run-2752).
- Disputes: `d_4e0a2` (OSV schema dispute on run-2751) and `d_4e09b` (Data.gov schema dispute on run-2752). Also fixes the missing `source: "wikipedia"` field on existing `d_4df10` flagged in the second recon.
- Audit log: two new events at the top of `AUDIT_EVENTS` referencing the OSV and Data.gov receipts so an operator scanning the timeline sees four-source coverage immediately.

No type changes to `AuditEvent` — the audit log's `source` field is the actor type (`operator | system | contract`), not the platform source kind, so OSV/Data.gov events surface through summary copy + receipt link.

## Files (5)
- `app/lib/api/receipt-adapters.ts` — `ReceiptDrawerModel.source` + `SOURCE_ATTRIBUTION` map
- `app/components/receipts/ReceiptDrawerBody.tsx` — new "Source" drawer section
- `app/app/(authed)/receipts/page.tsx` — thread `source` through to drawer + meta `SourceBadge` + 2 new fixtures
- `app/components/disputes/data.ts` — 2 new fixtures + `d_4df10` source fix
- `app/components/audit/data.tsx` — 2 new top-of-timeline events

## Test plan
- [x] `npm run typecheck:app`
- [x] `npm run build:frontend` (15/15 pages)
- [ ] /receipts: click `r_4e14a` (Wikipedia) — drawer header shows Wikipedia badge next to KindChip; new "Source" section at top with attribution paragraph
- [ ] Click `r_4e145` (OSV): drawer shows OSV badge + "Averray dependency remediation" attribution
- [ ] Click `r_4e144` (Data.gov): drawer shows Data.gov badge + "Averray open-data quality audit" attribution
- [ ] Click a non-run receipt (e.g. `r_4e139` badge): no Source section renders (correct — non-run receipts don't carry platform source)
- [ ] /disputes: every row in the table has a SourceBadge (no asymmetric blanks); OSV dispute `d_4e0a2` and Data.gov dispute `d_4e09b` render with their badges
- [ ] /audit-log: top of timeline shows the OSV + Data.gov receipt events

🤖 Generated with [Claude Code](https://claude.com/claude-code)