### PR TITLE
Add standards spec freshness jobs

### DIFF
--- a/docs/PUBLIC_JOB_SOURCES.md
+++ b/docs/PUBLIC_JOB_SOURCES.md
@@ -123,11 +123,21 @@ After Wikipedia, use the same pattern for:
      package targets or `OSV_INGEST_MANIFESTS_JSON`, and keep
      `OSV_INGEST_DRY_RUN=true` until candidate quality is reviewed.
 
-4. **Stack Exchange / Discourse**
+4. **Standards/spec freshness**
+   - canonical W3C/IETF/WHATWG/ECMA spec vs local docs drift audits
+   - section-link evidence, status/version checks, missing-update reports
+   - v1 ingestion is allowlist-driven:
+     `POST /admin/jobs/ingest/standards` accepts configured spec URLs and
+     emits review-only docs drift jobs against a configured local surface.
+   - Scheduled ingestion is available behind `STANDARDS_INGEST_ENABLED`; keep
+     `STANDARDS_INGEST_DRY_RUN=true` until `/admin/status` shows useful
+     candidates.
+
+5. **Stack Exchange / Discourse**
    - unanswered-question triage, duplicate detection, answer summaries
    - community-reviewable outputs
 
-5. **Common Crawl / public docs sites**
+6. **Common Crawl / public docs sites**
    - broken-link checks, metadata extraction, stale-doc detection
    - batch outputs with crawl evidence
 

--- a/docs/READY_TO_POST_JOBS.md
+++ b/docs/READY_TO_POST_JOBS.md
@@ -451,6 +451,52 @@ Workers must not contact agencies or make direct edits to government datasets.
 
 ---
 
+## Standards/spec freshness jobs
+
+The first standards provider is intentionally allowlist-driven. Operators point
+it at canonical public spec URLs plus the local surface that should remain in
+sync. The generated jobs are review-only docs drift audits: workers compare the
+spec status, version, headings, and section-level requirements against local
+docs or implementation notes, then submit a structured recommendation.
+
+Preview jobs through:
+
+```bash
+npm --workspace mcp-server run ingest:standards-specs -- --dry-run \
+  --specs '[{"provider":"w3c","specId":"vc-data-model-2.0","specTitle":"Verifiable Credentials Data Model v2.0","specUrl":"https://www.w3.org/TR/vc-data-model-2.0/","expectedStatus":"W3C Recommendation","localSurface":"docs/RC1_WORKING_SPEC.md","repo":"averray-agent/agent"}]'
+```
+
+Or through the admin API:
+
+```http
+POST /admin/jobs/ingest/standards
+```
+
+To let the backend pull these periodically, configure:
+
+```bash
+STANDARDS_INGEST_ENABLED=true
+STANDARDS_INGEST_DRY_RUN=true
+STANDARDS_INGEST_INTERVAL_MS=3600000
+STANDARDS_INGEST_MAX_JOBS_PER_RUN=2
+STANDARDS_INGEST_MAX_OPEN_JOBS=20
+STANDARDS_INGEST_SPECS_JSON='[{"provider":"w3c","specId":"vc-data-model-2.0","specTitle":"Verifiable Credentials Data Model v2.0","specUrl":"https://www.w3.org/TR/vc-data-model-2.0/","expectedStatus":"W3C Recommendation","localSurface":"docs/RC1_WORKING_SPEC.md","repo":"averray-agent/agent"}]'
+```
+
+Review `standardsIngestion.lastRun` in `/admin/status`, then switch
+`STANDARDS_INGEST_DRY_RUN=false` when the candidates are ready to create jobs.
+
+The generated jobs use:
+
+- `schema://jobs/docs-input`
+- `schema://jobs/docs-drift-audit-output`
+
+Workers must cite the canonical spec URL and submit `source_surface`,
+`drift_findings`, `missing_updates`, `severity`, and `fix_recommendation`.
+They must not edit external standards pages.
+
+---
+
 ## Before posting
 
 Quick operator checklist:

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -13,7 +13,8 @@
     "ingest:github-issues": "node src/jobs/ingest-github-issues.js",
     "ingest:wikipedia": "node src/jobs/ingest-wikipedia-maintenance.js",
     "ingest:osv-advisories": "node src/jobs/ingest-osv-advisories.js",
-    "ingest:open-data": "node src/jobs/ingest-open-data-datasets.js"
+    "ingest:open-data": "node src/jobs/ingest-open-data-datasets.js",
+    "ingest:standards-specs": "node src/jobs/ingest-standards-specs.js"
   },
   "dependencies": {
     "ethers": "^6.16.0",

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -41,6 +41,7 @@ export class PlatformService {
     this.wikipediaMaintenanceIngestionScheduler = undefined;
     this.osvAdvisoryIngestionScheduler = undefined;
     this.openDataIngestionScheduler = undefined;
+    this.standardsSpecIngestionScheduler = undefined;
     this.xcmSettlementWatcher = undefined;
     this.xcmObservationRelay = undefined;
 
@@ -111,6 +112,7 @@ export class PlatformService {
       wikipediaIngestion,
       osvIngestion,
       openDataIngestion,
+      standardsIngestion,
       recentSessions
     ] = await Promise.all([
       this.blockchainGateway?.getTreasuryPolicyStatus?.() ?? {
@@ -164,6 +166,17 @@ export class PlatformService {
         intervalMs: 0,
         query: undefined,
         datasetCount: 0,
+        minScore: 0,
+        maxJobsPerRun: 0,
+        maxOpenJobs: 0,
+        lastRun: undefined
+      },
+      this.standardsSpecIngestionScheduler?.getStatus?.() ?? {
+        enabled: false,
+        running: false,
+        dryRun: true,
+        intervalMs: 0,
+        specCount: 0,
         minScore: 0,
         maxJobsPerRun: 0,
         maxOpenJobs: 0,
@@ -262,6 +275,7 @@ export class PlatformService {
       wikipediaIngestion: wikipediaIngestion,
       osvIngestion: osvIngestion,
       openDataIngestion: openDataIngestion,
+      standardsIngestion: standardsIngestion,
       xcmSettlementWatcher: await this.xcmSettlementWatcher?.getStatus?.() ?? {
         enabled: false,
         running: false,

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -163,11 +163,24 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
       };
     }
   };
+  service.standardsSpecIngestionScheduler = {
+    getStatus() {
+      return {
+        enabled: true,
+        running: true,
+        dryRun: true,
+        intervalMs: 3600000,
+        specCount: 2,
+        lastRun: { createdCount: 1 }
+      };
+    }
+  };
 
   const status = await service.getAdminStatus();
   assert.equal(status.osvIngestion.packageCount, 1);
   assert.equal(status.openDataIngestion.query, "res_format:CSV");
   assert.equal(status.openDataIngestion.lastRun.createdCount, 2);
+  assert.equal(status.standardsIngestion.specCount, 2);
 });
 
 test("finalizeXcmRequest records async treasury settlement when the request is strategy-backed", async () => {

--- a/mcp-server/src/jobs/ingest-standards-specs.js
+++ b/mcp-server/src/jobs/ingest-standards-specs.js
@@ -1,0 +1,377 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+
+/**
+ * Ingest standards/spec freshness audit jobs.
+ *
+ * The provider is allowlist-driven: operators configure canonical public
+ * specification URLs and the local/documentation surface that should stay in
+ * sync with them. Generated jobs ask agents to produce reviewable drift
+ * reports, not to edit external standards bodies directly.
+ *
+ * Example:
+ *   AGENT_ADMIN_TOKEN=... npm run ingest:standards-specs -- \
+ *     --specs '[{"provider":"w3c","specTitle":"Verifiable Credentials Data Model v2.0","specUrl":"https://www.w3.org/TR/vc-data-model-2.0/","localSurface":"docs/"}]' \
+ *     --dry-run
+ */
+
+export const DEFAULT_BASE_URL = "http://localhost:8787";
+export const DEFAULT_PROVIDER = "custom";
+
+export function parseArgs(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith("--")) continue;
+    const key = arg.slice(2);
+    if (key.includes("=")) {
+      const [name, ...rest] = key.split("=");
+      parsed[name] = rest.join("=");
+      continue;
+    }
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      parsed[key] = true;
+      continue;
+    }
+    parsed[key] = next;
+    index += 1;
+  }
+  return parsed;
+}
+
+export async function ingestStandardsSpecs({
+  specs = [],
+  limit = 10,
+  minScore = 55,
+  fetchImpl = fetch
+} = {}) {
+  const targets = parseSpecs(specs);
+  const skipped = [];
+  const candidates = [];
+
+  for (const target of targets) {
+    try {
+      const enriched = await fetchSpecDetails({ target, fetchImpl });
+      const score = scoreSpecTarget(enriched);
+      if (score < minScore) {
+        skipped.push({ specUrl: target.specUrl, reason: "below_min_score", score });
+        continue;
+      }
+      candidates.push({ target: enriched, score });
+    } catch (error) {
+      skipped.push({
+        specUrl: target.specUrl,
+        reason: "fetch_failed",
+        message: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  const jobs = candidates
+    .sort((left, right) => right.score - left.score)
+    .slice(0, limit)
+    .map(({ target, score }) => toPlatformJob(target, score));
+
+  if (candidates.length > jobs.length) {
+    skipped.push({ reason: "over_limit", count: candidates.length - jobs.length });
+  }
+
+  return {
+    provider: "standards",
+    specCount: targets.length,
+    minScore,
+    count: jobs.length,
+    jobs,
+    skipped
+  };
+}
+
+export async function fetchSpecDetails({ target, fetchImpl = fetch }) {
+  const response = await fetchImpl(target.specUrl, {
+    headers: requestHeaders()
+  });
+  const textBody = await response.text();
+  const htmlTitle = extractHtmlTitle(textBody);
+  const canonicalUrl = extractCanonicalUrl(textBody, target.specUrl);
+  return {
+    ...target,
+    specTitle: target.specTitle || htmlTitle || target.specUrl,
+    finalUrl: response.url || target.specUrl,
+    canonicalUrl,
+    httpStatus: response.status,
+    ok: response.ok,
+    contentType: headerValue(response.headers, "content-type"),
+    lastModified: headerValue(response.headers, "last-modified"),
+    etag: headerValue(response.headers, "etag")
+  };
+}
+
+export function parseSpecs(raw) {
+  const parsed = typeof raw === "string" ? parseSpecString(raw) : raw;
+  if (!Array.isArray(parsed)) return [];
+  return parsed.map(normalizeSpecTarget).filter(Boolean);
+}
+
+export function scoreSpecTarget(target) {
+  let score = 25;
+  if (target.provider) score += 5;
+  if (target.specTitle) score += 10;
+  if (target.specUrl) score += 15;
+  if (target.localSurface) score += 12;
+  if (target.ok) score += 20;
+  if (target.httpStatus && target.httpStatus !== 200) score -= 20;
+  if (target.canonicalUrl) score += 6;
+  if (target.lastModified) score += 6;
+  if (target.etag) score += 4;
+  if (target.expectedStatus) score += 4;
+  if (target.currentVersion) score += 4;
+  return Math.max(0, Math.min(100, score));
+}
+
+export function standardsSpecKey(source) {
+  if (!source?.specUrl) return undefined;
+  return [
+    String(source.provider ?? DEFAULT_PROVIDER).toLowerCase(),
+    String(source.specUrl).toLowerCase(),
+    String(source.localSurface ?? "").toLowerCase()
+  ].join("|");
+}
+
+export function toPlatformJob(target, score = scoreSpecTarget(target)) {
+  const provider = normalizeProvider(target.provider);
+  const specTitle = target.specTitle || target.specUrl;
+  const localSurface = target.localSurface || target.repo || "configured project docs";
+  const id = `standards-${slugify(provider)}-${slugify(target.specId || specTitle)}`.slice(0, 120);
+
+  return {
+    id,
+    title: `Audit standards freshness: ${specTitle}`,
+    description:
+      `Compare the local surface "${localSurface}" against the canonical ${provider} specification "${specTitle}" and report any drift or missing updates.`,
+    jobType: "review",
+    requiredRole: "worker",
+    category: "docs",
+    tier: "starter",
+    rewardAsset: "DOT",
+    rewardAmount: 3,
+    verifierMode: "benchmark",
+    verifierTerms: ["source_surface", "drift_findings", "missing_updates", "fix_recommendation"],
+    verifierMinimumMatches: 3,
+    inputSchemaRef: "schema://jobs/docs-input",
+    outputSchemaRef: "schema://jobs/docs-drift-audit-output",
+    claimTtlSeconds: 7200,
+    retryLimit: 1,
+    requiresSponsoredGas: true,
+    source: {
+      type: "standards_spec",
+      provider,
+      specId: target.specId,
+      specTitle,
+      specUrl: target.specUrl,
+      finalUrl: target.finalUrl,
+      canonicalUrl: target.canonicalUrl,
+      currentVersion: target.currentVersion,
+      expectedStatus: target.expectedStatus,
+      localSurface,
+      repo: target.repo,
+      httpStatus: target.httpStatus,
+      contentType: target.contentType,
+      lastModified: target.lastModified,
+      etag: target.etag,
+      score,
+      discoveryApi: target.specUrl
+    },
+    acceptanceCriteria: [
+      "Fetch the canonical specification URL and cite the exact version, status, or modified metadata that is visible.",
+      "Compare the configured local surface against the canonical spec for stale terminology, outdated requirements, missing links, or obsolete references.",
+      "Return at least one concrete drift finding, or set severity=low with evidence that no issue was found.",
+      "Include a focused fix recommendation that can become a follow-up PR or documentation task.",
+      "Do not edit the external standards body page; submit a reviewable audit report only."
+    ],
+    estimatedDifficulty: score >= 80 ? "starter" : "review-needed",
+    agentInstructions: [
+      `Review the canonical specification: ${target.specUrl}.`,
+      `Audit this local surface or repository area: ${localSurface}.`,
+      "Capture the source_surface, drift_findings, missing_updates, severity, and fix_recommendation fields exactly.",
+      "Prefer exact section links, version strings, headings, or status banners over broad summaries.",
+      "Treat the result as a standards freshness audit, not a direct standards edit."
+    ],
+    verification: {
+      method: "benchmark",
+      suggestedCheck: "docs_drift_audit_complete",
+      evidenceSchemaRef: "schema://jobs/docs-drift-audit-output",
+      signals: ["source_surface_present", "canonical_spec_cited", "drift_or_no_issue", "severity_present", "recommendation_present"]
+    }
+  };
+}
+
+export async function postJobs({ baseUrl, adminToken, jobs, fetchImpl = fetch }) {
+  const results = [];
+  for (const job of jobs) {
+    results.push(await createJob({ baseUrl, adminToken, job, fetchImpl }));
+  }
+  return results;
+}
+
+export async function createJob({ baseUrl, adminToken, job, fetchImpl = fetch }) {
+  const response = await fetchImpl(`${trimTrailingSlash(baseUrl)}/admin/jobs`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${adminToken}`,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify(job)
+  });
+  const body = await response.text();
+  let payload;
+  try {
+    payload = body ? JSON.parse(body) : {};
+  } catch {
+    payload = { raw: body };
+  }
+  return { id: job.id, status: response.status, ok: response.ok, payload };
+}
+
+function parseSpecString(raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed;
+  } catch {
+    // Fall through to compact line parser.
+  }
+  return String(raw)
+    .split(/\n/u)
+    .map((entry) => {
+      const [specTitle, specUrl, provider, localSurface, expectedStatus] = entry.split("|").map((part) => part?.trim());
+      if (!specTitle || !specUrl) return undefined;
+      return { specTitle, specUrl, provider, localSurface, expectedStatus };
+    })
+    .filter(Boolean);
+}
+
+function normalizeSpecTarget(raw) {
+  const specUrl = text(raw?.specUrl ?? raw?.url);
+  const specTitle = text(raw?.specTitle ?? raw?.title ?? raw?.name);
+  if (!specUrl || !isHttpUrl(specUrl)) return undefined;
+  return {
+    provider: normalizeProvider(raw?.provider),
+    specId: text(raw?.specId ?? raw?.id),
+    specTitle,
+    specUrl,
+    currentVersion: text(raw?.currentVersion ?? raw?.version),
+    expectedStatus: text(raw?.expectedStatus ?? raw?.status),
+    localSurface: text(raw?.localSurface ?? raw?.surface ?? raw?.path),
+    repo: text(raw?.repo)
+  };
+}
+
+function extractHtmlTitle(body) {
+  const match = String(body).match(/<title[^>]*>([^<]+)<\/title>/iu);
+  return match ? decodeHtml(match[1]).replace(/\s+/gu, " ").trim() : "";
+}
+
+function extractCanonicalUrl(body, baseUrl) {
+  const match = String(body).match(/<link[^>]+rel=["']canonical["'][^>]*>/iu)
+    ?? String(body).match(/<link[^>]+href=["'][^"']+["'][^>]+rel=["']canonical["'][^>]*>/iu);
+  if (!match) return "";
+  const href = match[0].match(/href=["']([^"']+)["']/iu)?.[1];
+  if (!href) return "";
+  try {
+    return new URL(href, baseUrl).toString();
+  } catch {
+    return "";
+  }
+}
+
+function headerValue(headers, name) {
+  if (!headers) return "";
+  if (typeof headers.get === "function") {
+    return text(headers.get(name));
+  }
+  const direct = headers[name] ?? headers[name.toLowerCase()] ?? headers[name.toUpperCase()];
+  return text(direct);
+}
+
+function normalizeProvider(value) {
+  return text(value || DEFAULT_PROVIDER).toLowerCase();
+}
+
+function requestHeaders() {
+  return {
+    accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "user-agent": "AverrayStandardsIngest/0.1 (https://averray.com; operator@averray.com)"
+  };
+}
+
+function isHttpUrl(value) {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+function decodeHtml(value) {
+  return String(value)
+    .replace(/&amp;/gu, "&")
+    .replace(/&lt;/gu, "<")
+    .replace(/&gt;/gu, ">")
+    .replace(/&quot;/gu, "\"")
+    .replace(/&#39;/gu, "'");
+}
+
+function text(value) {
+  return String(value ?? "").trim();
+}
+
+function slugify(value) {
+  return String(value ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, "-")
+    .replace(/^-+|-+$/gu, "")
+    .replace(/-{2,}/gu, "-");
+}
+
+function parsePositiveInt(raw, fallback) {
+  const value = Number(raw);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function trimTrailingSlash(value) {
+  return String(value).replace(/\/+$/u, "");
+}
+
+async function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  const dryRun = Boolean(args["dry-run"]);
+  const specs = args.specs ?? process.env.STANDARDS_INGEST_SPECS_JSON ?? process.env.STANDARDS_INGEST_SPECS;
+  const limit = parsePositiveInt(args.limit, 10);
+  const minScore = parsePositiveInt(args["min-score"], 55);
+  const baseUrl = trimTrailingSlash(String(args.baseUrl ?? process.env.AGENT_API_BASE_URL ?? DEFAULT_BASE_URL));
+  const adminToken = process.env.AGENT_ADMIN_TOKEN?.trim();
+
+  if (!dryRun && !adminToken) {
+    fail("AGENT_ADMIN_TOKEN is required unless --dry-run is set.");
+  }
+
+  const dryRunPayload = await ingestStandardsSpecs({ specs, limit, minScore });
+  if (dryRun) {
+    console.log(JSON.stringify(dryRunPayload, null, 2));
+    return;
+  }
+
+  const results = await postJobs({ baseUrl, adminToken, jobs: dryRunPayload.jobs });
+  console.log(JSON.stringify({ ...dryRunPayload, results }, null, 2));
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await runCli();
+}

--- a/mcp-server/src/jobs/ingest-standards-specs.test.js
+++ b/mcp-server/src/jobs/ingest-standards-specs.test.js
@@ -1,0 +1,132 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  fetchSpecDetails,
+  ingestStandardsSpecs,
+  parseSpecs,
+  scoreSpecTarget,
+  standardsSpecKey,
+  toPlatformJob
+} from "./ingest-standards-specs.js";
+
+const SPEC = {
+  provider: "w3c",
+  specId: "vc-data-model-2.0",
+  specTitle: "Verifiable Credentials Data Model v2.0",
+  specUrl: "https://www.w3.org/TR/vc-data-model-2.0/",
+  currentVersion: "2.0",
+  expectedStatus: "W3C Recommendation",
+  localSurface: "docs/RC1_WORKING_SPEC.md",
+  repo: "averray-agent/agent"
+};
+
+function makeFetch({ status = 200, ok = true } = {}) {
+  return async (url, request) => {
+    assert.equal(url, SPEC.specUrl);
+    assert.match(request.headers.accept, /text\/html/u);
+    return {
+      ok,
+      status,
+      url: `${SPEC.specUrl}?from=test`,
+      headers: new Map([
+        ["content-type", "text/html; charset=utf-8"],
+        ["last-modified", "Mon, 27 Apr 2026 08:00:00 GMT"],
+        ["etag", "\"abc123\""]
+      ]),
+      async text() {
+        return `<!doctype html><html><head>
+          <title>${SPEC.specTitle}</title>
+          <link rel="canonical" href="/TR/vc-data-model-2.0/">
+        </head><body></body></html>`;
+      }
+    };
+  };
+}
+
+test("parseSpecs accepts JSON and compact line syntax", () => {
+  assert.deepEqual(parseSpecs(JSON.stringify([SPEC])), [SPEC]);
+  assert.deepEqual(
+    parseSpecs("Verifiable Credentials Data Model v2.0|https://www.w3.org/TR/vc-data-model-2.0/|w3c|docs/RC1_WORKING_SPEC.md|W3C Recommendation"),
+    [
+      {
+        provider: "w3c",
+        specId: "",
+        specTitle: "Verifiable Credentials Data Model v2.0",
+        specUrl: "https://www.w3.org/TR/vc-data-model-2.0/",
+        currentVersion: "",
+        expectedStatus: "W3C Recommendation",
+        localSurface: "docs/RC1_WORKING_SPEC.md",
+        repo: ""
+      }
+    ]
+  );
+});
+
+test("fetchSpecDetails captures canonical metadata", async () => {
+  const details = await fetchSpecDetails({ target: SPEC, fetchImpl: makeFetch() });
+
+  assert.equal(details.finalUrl, `${SPEC.specUrl}?from=test`);
+  assert.equal(details.canonicalUrl, SPEC.specUrl);
+  assert.equal(details.lastModified, "Mon, 27 Apr 2026 08:00:00 GMT");
+  assert.equal(details.etag, "\"abc123\"");
+  assert.equal(details.contentType, "text/html; charset=utf-8");
+});
+
+test("scoreSpecTarget prefers reachable canonical spec audits", async () => {
+  const details = await fetchSpecDetails({ target: SPEC, fetchImpl: makeFetch() });
+
+  assert.ok(scoreSpecTarget(details) >= 90);
+  assert.ok(scoreSpecTarget({ ...details, ok: false, httpStatus: 404 }) < scoreSpecTarget(details));
+});
+
+test("toPlatformJob creates standards freshness audit job", async () => {
+  const details = await fetchSpecDetails({ target: SPEC, fetchImpl: makeFetch() });
+  const job = toPlatformJob(details, 92);
+
+  assert.equal(job.id, "standards-w3c-vc-data-model-2-0");
+  assert.equal(job.category, "docs");
+  assert.equal(job.tier, "starter");
+  assert.equal(job.verifierMode, "benchmark");
+  assert.equal(job.inputSchemaRef, "schema://jobs/docs-input");
+  assert.equal(job.outputSchemaRef, "schema://jobs/docs-drift-audit-output");
+  assert.equal(job.source.type, "standards_spec");
+  assert.equal(job.source.provider, "w3c");
+  assert.equal(job.source.localSurface, "docs/RC1_WORKING_SPEC.md");
+  assert.ok(job.verifierTerms.includes("fix_recommendation"));
+});
+
+test("standardsSpecKey dedupes by provider, URL, and local surface", () => {
+  assert.equal(
+    standardsSpecKey({ provider: "W3C", specUrl: SPEC.specUrl, localSurface: "docs/RC1_WORKING_SPEC.md" }),
+    "w3c|https://www.w3.org/tr/vc-data-model-2.0/|docs/rc1_working_spec.md"
+  );
+});
+
+test("ingestStandardsSpecs fetches configured specs and returns jobs", async () => {
+  const payload = await ingestStandardsSpecs({
+    specs: [SPEC],
+    limit: 5,
+    minScore: 55,
+    fetchImpl: makeFetch()
+  });
+
+  assert.equal(payload.provider, "standards");
+  assert.equal(payload.specCount, 1);
+  assert.equal(payload.count, 1);
+  assert.equal(payload.jobs[0].source.specTitle, SPEC.specTitle);
+  assert.deepEqual(payload.skipped, []);
+});
+
+test("ingestStandardsSpecs reports fetch failures as skipped targets", async () => {
+  const payload = await ingestStandardsSpecs({
+    specs: [SPEC],
+    fetchImpl: async () => {
+      throw new Error("network unavailable");
+    }
+  });
+
+  assert.equal(payload.count, 0);
+  assert.equal(payload.skipped[0].reason, "fetch_failed");
+  assert.equal(payload.skipped[0].message, "network unavailable");
+});

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -29,6 +29,7 @@ import {
   parseManifests as parseOsvManifests,
   parsePackages as parseOsvPackages
 } from "../../jobs/ingest-osv-advisories.js";
+import { ingestStandardsSpecs, parseSpecs as parseStandardsSpecs } from "../../jobs/ingest-standards-specs.js";
 import { ingestWikipediaMaintenance, parseCategories } from "../../jobs/ingest-wikipedia-maintenance.js";
 
 const {
@@ -825,6 +826,7 @@ function metricPathLabel(pathname) {
     "/admin/jobs/ingest/github",
     "/admin/jobs/ingest/open-data",
     "/admin/jobs/ingest/osv",
+    "/admin/jobs/ingest/standards",
     "/admin/jobs/ingest/wikipedia",
     "/admin/jobs/pause",
     "/admin/jobs/resume",
@@ -1105,6 +1107,7 @@ const server = createServer(async (request, response) => {
           "/admin/jobs/ingest/github",
           "/admin/jobs/ingest/open-data",
           "/admin/jobs/ingest/osv",
+          "/admin/jobs/ingest/standards",
           "/admin/jobs/ingest/wikipedia",
           "/admin/jobs/fire",
           "/admin/jobs/pause",
@@ -2321,6 +2324,59 @@ const server = createServer(async (request, response) => {
       return respond(response, status, {
         provider: result.provider,
         query: result.query,
+        minScore: result.minScore,
+        dryRun: false,
+        candidateCount: result.count,
+        created,
+        skipped: [...skipped, ...(Array.isArray(result.skipped) ? result.skipped : [])],
+        errors
+      });
+    }
+
+    if (request.method === "POST" && pathname === "/admin/jobs/ingest/standards") {
+      const auth = await authMiddleware(request, url, { requireRole: "admin" });
+      await enforceLimit("admin_jobs", auth.wallet, rateLimitConfig.adminJobs);
+      const payload = await readJsonBody(request);
+      const specs = Array.isArray(payload?.specs) || typeof payload?.specs === "string"
+        ? parseStandardsSpecs(payload.specs)
+        : parseStandardsSpecs(process.env.STANDARDS_INGEST_SPECS_JSON ?? process.env.STANDARDS_INGEST_SPECS);
+      const limit = parsePositiveInteger(payload?.limit, 10, 50);
+      const minScore = parsePositiveInteger(payload?.minScore, 55, 100);
+      const dryRun = payload?.dryRun !== false;
+      const result = await ingestStandardsSpecs({ specs, limit, minScore });
+
+      if (dryRun) {
+        return respond(response, 200, {
+          ...result,
+          dryRun: true,
+          created: []
+        });
+      }
+
+      const created = [];
+      const skipped = [];
+      const errors = [];
+      for (const job of result.jobs) {
+        try {
+          created.push(service.createJob(job));
+        } catch (error) {
+          const normalized = normalizeError(error);
+          if (normalized.code === "job_exists") {
+            skipped.push({ id: job.id, reason: "already_exists" });
+            continue;
+          }
+          errors.push({
+            id: job.id,
+            code: normalized.code,
+            message: normalized.message
+          });
+        }
+      }
+
+      const status = errors.length ? 207 : 201;
+      return respond(response, status, {
+        provider: result.provider,
+        specCount: result.specCount,
         minScore: result.minScore,
         dryRun: false,
         candidateCount: result.count,

--- a/mcp-server/src/services/bootstrap.js
+++ b/mcp-server/src/services/bootstrap.js
@@ -30,6 +30,10 @@ import {
   OpenDataIngestionScheduler,
   loadOpenDataIngestionConfig
 } from "./open-data-ingestion-scheduler.js";
+import {
+  StandardsSpecIngestionScheduler,
+  loadStandardsSpecIngestionConfig
+} from "./standards-spec-ingestion-scheduler.js";
 import { XcmSettlementWatcherService } from "./xcm-settlement-watcher.js";
 import { XcmObservationRelayService } from "./xcm-observation-relay.js";
 import { normaliseStrategyAssetConfig } from "./strategy-asset-config.js";
@@ -179,6 +183,12 @@ export async function createPlatformRuntime() {
       logger
     })
   );
+  const standardsSpecIngestionScheduler = initStep("init-standards-spec-ingestion-scheduler", logger, () =>
+    new StandardsSpecIngestionScheduler(platformService, eventBus, {
+      ...loadStandardsSpecIngestionConfig(process.env),
+      logger
+    })
+  );
   const xcmSettlementWatcher = initStep("init-xcm-settlement-watcher", logger, () =>
     new XcmSettlementWatcherService(platformService, stateStore, eventBus, {
       enabled: process.env.XCM_SETTLEMENT_WATCHER_ENABLED === undefined
@@ -205,6 +215,7 @@ export async function createPlatformRuntime() {
   platformService.wikipediaMaintenanceIngestionScheduler = wikipediaMaintenanceIngestionScheduler;
   platformService.osvAdvisoryIngestionScheduler = osvAdvisoryIngestionScheduler;
   platformService.openDataIngestionScheduler = openDataIngestionScheduler;
+  platformService.standardsSpecIngestionScheduler = standardsSpecIngestionScheduler;
   platformService.xcmSettlementWatcher = xcmSettlementWatcher;
   platformService.xcmObservationRelay = xcmObservationRelay;
   recurringScheduler.start();
@@ -212,6 +223,7 @@ export async function createPlatformRuntime() {
   wikipediaMaintenanceIngestionScheduler.start();
   osvAdvisoryIngestionScheduler.start();
   openDataIngestionScheduler.start();
+  standardsSpecIngestionScheduler.start();
   xcmSettlementWatcher.start();
   xcmObservationRelay.start();
 
@@ -240,6 +252,7 @@ export async function createPlatformRuntime() {
     wikipediaMaintenanceIngestionScheduler,
     osvAdvisoryIngestionScheduler,
     openDataIngestionScheduler,
+    standardsSpecIngestionScheduler,
     xcmSettlementWatcher,
     xcmObservationRelay,
     authConfig,

--- a/mcp-server/src/services/standards-spec-ingestion-scheduler.js
+++ b/mcp-server/src/services/standards-spec-ingestion-scheduler.js
@@ -1,0 +1,211 @@
+import { ingestStandardsSpecs, parseSpecs, standardsSpecKey } from "../jobs/ingest-standards-specs.js";
+
+export class StandardsSpecIngestionScheduler {
+  constructor(platformService, eventBus = undefined, {
+    enabled = false,
+    dryRun = true,
+    intervalMs = 60 * 60 * 1000,
+    specs = [],
+    minScore = 55,
+    maxJobsPerRun = 2,
+    maxOpenJobs = 20,
+    fetchImpl = fetch,
+    logger = console
+  } = {}) {
+    this.platformService = platformService;
+    this.eventBus = eventBus;
+    this.enabled = enabled;
+    this.dryRun = dryRun;
+    this.intervalMs = intervalMs;
+    this.specs = parseSpecs(specs);
+    this.minScore = minScore;
+    this.maxJobsPerRun = maxJobsPerRun;
+    this.maxOpenJobs = maxOpenJobs;
+    this.fetchImpl = fetchImpl;
+    this.logger = logger;
+    this.timer = undefined;
+    this.running = false;
+    this.lastRun = undefined;
+  }
+
+  start() {
+    if (!this.enabled || this.running) {
+      return;
+    }
+    this.running = true;
+    void this.runOnceAndSchedule();
+  }
+
+  stop() {
+    this.running = false;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  async getStatus() {
+    return {
+      enabled: this.enabled,
+      running: this.running,
+      dryRun: this.dryRun,
+      intervalMs: this.intervalMs,
+      specCount: this.specs.length,
+      minScore: this.minScore,
+      maxJobsPerRun: this.maxJobsPerRun,
+      maxOpenJobs: this.maxOpenJobs,
+      lastRun: this.lastRun
+    };
+  }
+
+  async runOnce(now = new Date()) {
+    const startedAt = now.toISOString();
+    const openStandardsJobs = this.countOpenStandardsJobs();
+    const summary = {
+      startedAt,
+      finishedAt: undefined,
+      dryRun: this.dryRun,
+      openStandardsJobs,
+      candidateCount: 0,
+      createdCount: 0,
+      skipped: [],
+      errors: []
+    };
+
+    if (!this.enabled) {
+      summary.skipped.push({ reason: "disabled" });
+      return this.finishRun(summary);
+    }
+    if (!this.specs.length) {
+      summary.skipped.push({ reason: "no_specs_configured" });
+      return this.finishRun(summary);
+    }
+    if (openStandardsJobs >= this.maxOpenJobs) {
+      summary.skipped.push({ reason: "max_open_jobs_reached", openStandardsJobs, maxOpenJobs: this.maxOpenJobs });
+      return this.finishRun(summary);
+    }
+
+    const remaining = Math.max(0, Math.min(this.maxJobsPerRun, this.maxOpenJobs - openStandardsJobs));
+    const seenSources = this.existingStandardsKeys();
+    try {
+      const result = await ingestStandardsSpecs({
+        specs: this.specs,
+        limit: remaining,
+        minScore: this.minScore,
+        fetchImpl: this.fetchImpl
+      });
+      summary.candidateCount = result.count;
+      summary.skipped.push(...(Array.isArray(result.skipped) ? result.skipped : []));
+      for (const job of result.jobs) {
+        const sourceKey = standardsJobKey(job);
+        if (sourceKey && seenSources.has(sourceKey)) {
+          summary.skipped.push({ id: job.id, reason: "source_already_ingested" });
+          continue;
+        }
+        if (this.platformService.getJobDefinition) {
+          try {
+            this.platformService.getJobDefinition(job.id);
+            summary.skipped.push({ id: job.id, reason: "job_already_exists" });
+            continue;
+          } catch {
+            // Missing jobs are expected and created below.
+          }
+        }
+        if (!this.dryRun) {
+          this.platformService.createJob(job);
+        }
+        seenSources.add(sourceKey);
+        summary.createdCount += 1;
+        this.eventBus?.publish?.({
+          id: `platform-standards-ingest-${job.id}-${Date.now()}`,
+          topic: "jobs.ingest.standards",
+          jobId: job.id,
+          timestamp: new Date().toISOString(),
+          data: {
+            dryRun: this.dryRun,
+            jobId: job.id,
+            source: job.source
+          }
+        });
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      summary.errors.push({ message });
+      this.logger.warn?.({ err: error }, "standards_ingest.run_failed");
+    }
+
+    return this.finishRun(summary);
+  }
+
+  async runOnceAndSchedule() {
+    await this.runOnce(new Date());
+    if (!this.running) {
+      return;
+    }
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+    this.timer = setTimeout(() => {
+      void this.runOnceAndSchedule();
+    }, this.intervalMs);
+  }
+
+  finishRun(summary) {
+    summary.finishedAt = new Date().toISOString();
+    this.lastRun = summary;
+    return summary;
+  }
+
+  countOpenStandardsJobs() {
+    return this.platformService.listJobs()
+      .filter((job) => job.source?.type === "standards_spec")
+      .filter((job) => !job.recurring)
+      .length;
+  }
+
+  existingStandardsKeys() {
+    return new Set(
+      this.platformService.listJobs()
+        .map((job) => standardsJobKey(job))
+        .filter(Boolean)
+    );
+  }
+}
+
+export function loadStandardsSpecIngestionConfig(env = process.env) {
+  return {
+    enabled: parseBooleanEnv(env.STANDARDS_INGEST_ENABLED),
+    dryRun: env.STANDARDS_INGEST_DRY_RUN === undefined ? true : parseBooleanEnv(env.STANDARDS_INGEST_DRY_RUN),
+    intervalMs: parsePositiveInt(env.STANDARDS_INGEST_INTERVAL_MS, 60 * 60 * 1000),
+    specs: parseSpecs(env.STANDARDS_INGEST_SPECS_JSON ?? env.STANDARDS_INGEST_SPECS),
+    minScore: parsePositiveInt(env.STANDARDS_INGEST_MIN_SCORE, 55),
+    maxJobsPerRun: parsePositiveInt(env.STANDARDS_INGEST_MAX_JOBS_PER_RUN, 2),
+    maxOpenJobs: parsePositiveInt(env.STANDARDS_INGEST_MAX_OPEN_JOBS, 20)
+  };
+}
+
+function standardsJobKey(job) {
+  const source = job?.source;
+  if (source?.type !== "standards_spec") {
+    return undefined;
+  }
+  return standardsSpecKey(source);
+}
+
+function parsePositiveInt(raw, fallback) {
+  if (raw === undefined || raw === null || raw === "") {
+    return fallback;
+  }
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    return fallback;
+  }
+  return value;
+}
+
+function parseBooleanEnv(raw) {
+  if (raw === undefined || raw === null || raw === "") {
+    return false;
+  }
+  return ["1", "true", "yes", "on"].includes(String(raw).trim().toLowerCase());
+}

--- a/mcp-server/src/services/standards-spec-ingestion-scheduler.test.js
+++ b/mcp-server/src/services/standards-spec-ingestion-scheduler.test.js
@@ -1,0 +1,140 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  StandardsSpecIngestionScheduler,
+  loadStandardsSpecIngestionConfig
+} from "./standards-spec-ingestion-scheduler.js";
+
+const SPEC = {
+  provider: "w3c",
+  specId: "vc-data-model-2.0",
+  specTitle: "Verifiable Credentials Data Model v2.0",
+  specUrl: "https://www.w3.org/TR/vc-data-model-2.0/",
+  expectedStatus: "W3C Recommendation",
+  localSurface: "docs/RC1_WORKING_SPEC.md"
+};
+
+function makeFetch() {
+  return async () => ({
+    ok: true,
+    status: 200,
+    url: SPEC.specUrl,
+    headers: new Map([
+      ["content-type", "text/html"],
+      ["last-modified", "Mon, 27 Apr 2026 08:00:00 GMT"]
+    ]),
+    async text() {
+      return `<title>${SPEC.specTitle}</title>`;
+    }
+  });
+}
+
+function makePlatformService(initialJobs = []) {
+  const jobs = [...initialJobs];
+  return {
+    listJobs() {
+      return [...jobs];
+    },
+    createJob(job) {
+      jobs.unshift(job);
+      return job;
+    },
+    getJobDefinition(jobId) {
+      const job = jobs.find((candidate) => candidate.id === jobId);
+      if (!job) {
+        throw new Error("not found");
+      }
+      return job;
+    }
+  };
+}
+
+test("StandardsSpecIngestionScheduler dry-run does not create jobs", async () => {
+  const platform = makePlatformService();
+  const scheduler = new StandardsSpecIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: true,
+    specs: [SPEC],
+    fetchImpl: makeFetch()
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-27T08:00:00.000Z"));
+  assert.equal(summary.createdCount, 1);
+  assert.equal(platform.listJobs().length, 0);
+  assert.equal((await scheduler.getStatus()).lastRun.dryRun, true);
+});
+
+test("StandardsSpecIngestionScheduler creates jobs when dryRun is false", async () => {
+  const platform = makePlatformService();
+  const scheduler = new StandardsSpecIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    specs: [SPEC],
+    fetchImpl: makeFetch()
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-27T08:00:00.000Z"));
+  assert.equal(summary.createdCount, 1);
+  assert.equal(platform.listJobs().length, 1);
+  assert.equal(platform.listJobs()[0].source.type, "standards_spec");
+});
+
+test("StandardsSpecIngestionScheduler dedupes by standards source", async () => {
+  const platform = makePlatformService([
+    {
+      id: "existing",
+      source: {
+        type: "standards_spec",
+        provider: "w3c",
+        specUrl: SPEC.specUrl,
+        localSurface: SPEC.localSurface
+      }
+    }
+  ]);
+  const scheduler = new StandardsSpecIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    specs: [SPEC],
+    fetchImpl: makeFetch()
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-27T08:00:00.000Z"));
+  assert.equal(summary.createdCount, 0);
+  assert.equal(platform.listJobs().length, 1);
+  assert.equal(summary.skipped.at(-1).reason, "source_already_ingested");
+});
+
+test("StandardsSpecIngestionScheduler skips when no specs are configured", async () => {
+  const platform = makePlatformService();
+  const scheduler = new StandardsSpecIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    specs: [],
+    fetchImpl: makeFetch()
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-27T08:00:00.000Z"));
+  assert.equal(summary.createdCount, 0);
+  assert.equal(summary.skipped[0].reason, "no_specs_configured");
+});
+
+test("loadStandardsSpecIngestionConfig parses env knobs safely", () => {
+  const config = loadStandardsSpecIngestionConfig({
+    STANDARDS_INGEST_ENABLED: "true",
+    STANDARDS_INGEST_DRY_RUN: "false",
+    STANDARDS_INGEST_INTERVAL_MS: "3600000",
+    STANDARDS_INGEST_SPECS_JSON: JSON.stringify([SPEC]),
+    STANDARDS_INGEST_MIN_SCORE: "70",
+    STANDARDS_INGEST_MAX_JOBS_PER_RUN: "4",
+    STANDARDS_INGEST_MAX_OPEN_JOBS: "11"
+  });
+
+  assert.equal(config.enabled, true);
+  assert.equal(config.dryRun, false);
+  assert.equal(config.intervalMs, 3600000);
+  assert.equal(config.specs.length, 1);
+  assert.equal(config.minScore, 70);
+  assert.equal(config.maxJobsPerRun, 4);
+  assert.equal(config.maxOpenJobs, 11);
+});


### PR DESCRIPTION
## Summary
- add allowlist-driven standards/spec freshness job ingestion
- wire scheduler status, backend startup, and admin ingest endpoint
- document dry-run and production env knobs for standards drift audits

## Tests
- node --test mcp-server/src/jobs/ingest-standards-specs.test.js mcp-server/src/services/standards-spec-ingestion-scheduler.test.js mcp-server/src/core/platform-service.test.js
- npm --workspace mcp-server test
- git diff --check HEAD~1..HEAD