### PR TITLE
operator-app: wire Sessions source from job, strip dead Agents source field

### DIFF
--- a/app/app/(authed)/agents/page.tsx
+++ b/app/app/(authed)/agents/page.tsx
@@ -40,7 +40,7 @@ const AGENTS: AgentRecord[] = [
     },
     specialty: "writer-gov",
     stake: { deposited: 1200, locked: 240, available: 960, slashed30: 0 },
-    activity: { msg: "Claimed run-2744", ref: "run-2744", when: "2m ago", source: "wikipedia" },
+    activity: { msg: "Claimed run-2744", ref: "run-2744", when: "2m ago" },
     state: "active",
     recentRuns: [
       { id: "run-2744", title: "docs refresh — v3.2", receipt: "r_4e14a", state: "Verified" },
@@ -70,7 +70,7 @@ const AGENTS: AgentRecord[] = [
     },
     specialty: "coding",
     stake: { deposited: 1500, locked: 420, available: 1080, slashed30: 0 },
-    activity: { msg: "Verified run-2735", ref: "run-2735", when: "14m ago", source: "github" },
+    activity: { msg: "Verified run-2735", ref: "run-2735", when: "14m ago" },
     state: "active",
     recentRuns: [
       { id: "run-2735", title: "lint & format sweep", receipt: "r_4e0c2", state: "Verified" },

--- a/app/components/agents/AgentDirectoryTable.tsx
+++ b/app/components/agents/AgentDirectoryTable.tsx
@@ -4,7 +4,6 @@ import { cn } from "@/lib/utils/cn";
 import { Sparkline } from "@/components/overview/Sparkline";
 import { BadgeStrip } from "./BadgeStrip";
 import { TierChip } from "./TierChip";
-import { SourceBadge } from "@/components/runs/StatePill";
 import type { AgentRecord } from "./types";
 
 export interface AgentDirectoryTableProps {
@@ -125,26 +124,21 @@ export function AgentDirectoryTable({
                       </div>
                     </Td>
                     <Td>
-                      <div className="flex items-center gap-2">
-                        {a.activity.source ? (
-                          <SourceBadge kind={a.activity.source} />
-                        ) : null}
-                        <span
-                          className="text-[13px] leading-[1.3] text-[var(--avy-ink)]"
-                          style={{ letterSpacing: 0 }}
-                        >
-                          {activityParts.map((chunk, i, arr) => (
-                            <span key={i}>
-                              {chunk}
-                              {i < arr.length - 1 ? (
-                                <span className="font-[family-name:var(--font-mono)] text-[var(--avy-accent)]">
-                                  {a.activity.ref}
-                                </span>
-                              ) : null}
-                            </span>
-                          ))}
-                        </span>
-                      </div>
+                      <span
+                        className="text-[13px] leading-[1.3] text-[var(--avy-ink)]"
+                        style={{ letterSpacing: 0 }}
+                      >
+                        {activityParts.map((chunk, i, arr) => (
+                          <span key={i}>
+                            {chunk}
+                            {i < arr.length - 1 ? (
+                              <span className="font-[family-name:var(--font-mono)] text-[var(--avy-accent)]">
+                                {a.activity.ref}
+                              </span>
+                            ) : null}
+                          </span>
+                        ))}
+                      </span>
                       <div
                         className="mt-0.5 font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
                         style={{ letterSpacing: 0 }}

--- a/app/components/agents/types.ts
+++ b/app/components/agents/types.ts
@@ -1,5 +1,3 @@
-import type { SourceKind } from "@/components/runs/StatePill";
-
 export type AgentTier = "T1" | "T2" | "T3";
 export type AgentState = "active" | "idle" | "slashed";
 export type AgentSpecialty = "coding" | "writer-gov" | "ops" | "gov-review";
@@ -44,12 +42,13 @@ export interface AgentRecord {
   specialty: AgentSpecialty;
   stake: AgentStake;
   /**
-   * Last meaningful action by this agent. `source` is set when the
-   * activity is on an ingested-source run (GitHub PR / Wikipedia
-   * proposal) so the directory row can render a SourceBadge — receipts
-   * and policy refs leave it undefined.
+   * Last meaningful action by this agent. The `ref` here is heterogeneous
+   * — it can be a run id, a receipt id, or a policy tag — so we don't
+   * carry a SourceBadge here; an inconsistently-rendering badge would
+   * confuse more than it clarifies. Sessions are 1:1 with runs and do
+   * carry a source badge.
    */
-  activity: { msg: string; ref: string; when: string; source?: SourceKind };
+  activity: { msg: string; ref: string; when: string };
   state: AgentState;
   recentRuns: AgentRecentRun[];
   slashes: AgentSlash[];

--- a/app/lib/api/session-adapters.ts
+++ b/app/lib/api/session-adapters.ts
@@ -1,3 +1,4 @@
+import type { SourceKind } from "@/components/runs/StatePill";
 import type {
   LifecycleStageState,
   SessionAsset,
@@ -138,6 +139,33 @@ function jobFor(jobs: RawRecord[], jobId: string): RawRecord {
   return jobs.find((job) => text(job.id) === jobId) ?? {};
 }
 
+/**
+ * Map a job's source.type onto the operator-app SourceKind enum so the
+ * sessions table can render the same SourceBadge already shown on the
+ * runs surface. Returns undefined for native or unknown sources so the
+ * row simply omits the badge — there's no fallback "OSS" treatment.
+ *
+ * Sessions are 1:1 with runs, so we read straight off the linked job
+ * record. If the backend later adds new source kinds to JobSource, the
+ * SourceKind union will need a corresponding extension; until then,
+ * unknown source.type values fall through to undefined.
+ */
+function sourceKindFromJob(job: RawRecord): SourceKind | undefined {
+  const sourceType = text(asRecord(job.source).type);
+  switch (sourceType) {
+    case "github_issue":
+      return "github";
+    case "wikipedia_article":
+      return "wikipedia";
+    case "osv_advisory":
+      return "osv";
+    case "open_data_dataset":
+      return "data_gov";
+    default:
+      return undefined;
+  }
+}
+
 function lifecycle(session: RawRecord) {
   const status = text(session.status, "claimed");
   const entries = asArray(session.statusHistory);
@@ -169,9 +197,12 @@ export function buildSessionDetails(sessionPayload: unknown, jobsPayload: unknow
     const updatedAt = session.updatedAt ?? session.resolvedAt ?? session.submittedAt ?? session.claimedAt;
     const verification = asRecord(session.verification);
 
+    const sourceKind = sourceKindFromJob(job);
+
     return {
       id,
       runRef: jobId,
+      ...(sourceKind ? { source: sourceKind } : {}),
       job: {
         title: text(job.title, text(job.description, titleFromId(jobId))),
         meta: `${jobId} · ${text(job.category, "work")} · ${tierLabel(job.tier)}`,


### PR DESCRIPTION
## Summary
Closes the Sessions/Agents `source?: SourceKind` dead-affordance gap caught in the second-pass audit. Both row types got the optional field in [#22](https://github.com/averray-agent/agent/pull/22), but neither adapter ever populated it from live data — only fixtures did. So in production the badge would have been invisible regardless of the underlying job.

**Sessions — wired (option a)**

- `buildSessionDetails` now reads `job.source.type` off the linked job record (already in scope — sessions are 1:1 with runs) and maps it through a new `sourceKindFromJob` helper to the `SourceKind` enum:
  - `github_issue` → `"github"`
  - `wikipedia_article` → `"wikipedia"`
  - `osv_advisory` → `"osv"`
  - `open_data_dataset` → `"data_gov"`
  - native / unknown → `undefined` (row omits the badge cleanly)
- `SessionsTable` already conditionally renders the badge from the row's `source` field, so no table change needed. The live API path now lights up the same way the fixtures do.

**Agents — stripped (option b)**

- Removed `source?: SourceKind` from `AgentRecord["activity"]`.
- Dropped the conditional `SourceBadge` render in `AgentDirectoryTable` plus the now-unused `SourceBadge` + `SourceKind` imports.
- Dropped `source: "wikipedia"` / `source: "github"` from the two fixture activity entries.

**Why strip not wire?** Agent activity refs are heterogeneous — `activity.ref` can be a run id, a receipt id, or a policy tag. A SourceBadge that only renders for run-id refs is a half-feature. Cleaner to drop it than to wire a complex per-ref-type adapter that would only light up on a subset of activity rows.

## Files (4)
- `app/lib/api/session-adapters.ts` — new `sourceKindFromJob` + threading
- `app/components/agents/types.ts` — drop `source?: SourceKind` from activity
- `app/components/agents/AgentDirectoryTable.tsx` — drop conditional badge + unused imports
- `app/app/(authed)/agents/page.tsx` — drop fixture-tagged sources from two activity entries

## Test plan
- [x] `npm run typecheck:app`
- [x] `npm run build:frontend` (15/15 pages)
- [ ] /sessions against the live `/sessions` API: rows for jobs with a `source.type` (e.g. live Wikipedia citation-repair runs, live Data.gov audits) render the corresponding `SourceBadge`. Rows for native jobs render with no badge.
- [ ] /agents directory: no `SourceBadge` in the recent-activity column anywhere — neither in fixtures nor live data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)