### PR TITLE
Wire dispute verdicts to escrow resolution

### DIFF
--- a/app/components/disputes/DisputeDrawerBody.tsx
+++ b/app/components/disputes/DisputeDrawerBody.tsx
@@ -308,7 +308,18 @@ function PartyBlock({
 
 function ResolvedCard({ dispute }: { dispute: Dispute }) {
   if (!dispute.resolution) return null;
-  const { decision, destination, rationale, at, signer } = dispute.resolution;
+  const {
+    decision,
+    destination,
+    rationale,
+    at,
+    signer,
+    reasonCode,
+    workerPayout,
+    txHash,
+    chainStatus,
+    metadataURI,
+  } = dispute.resolution;
   const decisionLabel =
     decision === "uphold"
       ? "Upheld"
@@ -346,6 +357,36 @@ function ResolvedCard({ dispute }: { dispute: Dispute }) {
         style={{ letterSpacing: 0 }}
       >
         Stake → {destinationLabel}
+      </div>
+      <div
+        className="grid gap-1 rounded-[8px] border border-[var(--avy-line-soft)] bg-[var(--avy-paper-solid)] px-3 py-2 font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]"
+        style={{ letterSpacing: 0 }}
+      >
+        {reasonCode ? (
+          <span>
+            Reason · <b className="font-semibold text-[var(--avy-ink)]">{reasonCode}</b>
+          </span>
+        ) : null}
+        {typeof workerPayout === "number" ? (
+          <span>
+            Worker payout · <b className="font-semibold text-[var(--avy-ink)]">{workerPayout} DOT</b>
+          </span>
+        ) : null}
+        {chainStatus ? (
+          <span>
+            Chain · <b className="font-semibold text-[var(--avy-ink)]">{chainStatus}</b>
+          </span>
+        ) : null}
+        {txHash ? (
+          <span className="break-all">
+            Tx · <b className="font-semibold text-[var(--avy-accent)]">{txHash}</b>
+          </span>
+        ) : null}
+        {metadataURI ? (
+          <span className="break-all">
+            Reasoning · <b className="font-semibold text-[var(--avy-ink)]">{metadataURI}</b>
+          </span>
+        ) : null}
       </div>
       <p
         className="m-0 text-[13px] leading-snug text-[var(--avy-ink)]"

--- a/app/components/disputes/WindowCountdown.tsx
+++ b/app/components/disputes/WindowCountdown.tsx
@@ -48,8 +48,15 @@ export function WindowCountdown({
   const expired = remaining === 0;
   const hot = !expired && pct <= 0.1;
 
-  const mm = String(Math.floor(remaining / 60)).padStart(2, "0");
+  const dd = Math.floor(remaining / 86_400);
+  const hh = Math.floor((remaining % 86_400) / 3_600);
+  const mm = String(Math.floor((remaining % 3_600) / 60)).padStart(2, "0");
   const ss = String(remaining % 60).padStart(2, "0");
+  const label = dd > 0
+    ? `${dd}d ${String(hh).padStart(2, "0")}h`
+    : hh > 0
+      ? `${hh}h ${mm}m`
+      : `${mm}:${ss}`;
 
   return (
     <span
@@ -69,7 +76,7 @@ export function WindowCountdown({
           expired && "opacity-70"
         )}
       />
-      {expired ? "expired" : `${mm}:${ss}`}
+      {expired ? "expired" : label}
     </span>
   );
 }

--- a/app/components/disputes/types.ts
+++ b/app/components/disputes/types.ts
@@ -83,6 +83,15 @@ export interface Dispute {
   reviewer: DisputeParty;
   /** DOT. Sum of worker + verifier + treasury portions. */
   stakeFrozen: number;
+  /** Remaining worker payout available to the arbitrator settlement. */
+  remainingPayout?: number;
+  /** Worker payout selected in the final settlement. */
+  workerPayout?: number;
+  reasonCode?: string;
+  reasoningHash?: string;
+  metadataURI?: string;
+  txHash?: string;
+  chainStatus?: "confirmed" | "submitted" | "local_only" | "settled_by_verdict" | string;
   stakeBreakdown: StakeBreakdown;
   /** ISO-ish string opened-at used only for the window countdown seed. */
   openedAt: string;
@@ -105,5 +114,10 @@ export interface Dispute {
     rationale: string;
     at: string;
     signer: DisputeParty;
+    reasonCode?: string;
+    workerPayout?: number;
+    txHash?: string;
+    chainStatus?: string;
+    metadataURI?: string;
   };
 }

--- a/app/components/shell/LiveDataBridge.tsx
+++ b/app/components/shell/LiveDataBridge.tsx
@@ -16,6 +16,8 @@ const INVALIDATE_BY_TOPIC: Partial<Record<EventTopic, string[]>> = {
   "escrow.job_closed": ["/jobs", "/sessions", "/badges", "/agents", "/audit"],
   "escrow.job_reopened": ["/jobs", "/sessions"],
   "escrow.dispute_opened": ["/disputes", "/alerts", "/jobs", "/sessions"],
+  "escrow.dispute_resolved": ["/disputes", "/alerts", "/jobs", "/sessions", "/badges", "/agents", "/audit"],
+  "escrow.auto_resolved_on_timeout": ["/disputes", "/alerts", "/jobs", "/sessions", "/badges", "/agents", "/audit"],
   "account.job_stake_locked": ["/account", "/sessions"],
   "account.job_stake_released": ["/account", "/sessions", "/disputes"],
   "account.job_stake_slashed": ["/account", "/agents", "/disputes"],

--- a/app/lib/api/dispute-adapters.ts
+++ b/app/lib/api/dispute-adapters.ts
@@ -39,6 +39,12 @@ export function extractDispute(data: unknown): Dispute | null {
   const release = objectField(record, "release");
   const releaseDestination = releaseToDestination(release, verdict);
   const stakeFrozen = number(record.stakedAmount, number(record.stakeFrozen, 0));
+  const workerPayout = optionalNumber(record.workerPayout);
+  const remainingPayout = optionalNumber(record.remainingPayout);
+  const txHash = text(record.txHash, "");
+  const chainStatus = text(record.chainStatus, "");
+  const reasonCode = text(record.reasonCode, "");
+  const metadataURI = text(record.metadataURI, "");
 
   return {
     id,
@@ -52,6 +58,13 @@ export function extractDispute(data: unknown): Dispute | null {
     respondent: party(record.respondent, "respondent", "clay"),
     reviewer: party(record.reviewer ?? DEFAULT_REVIEWER, "operator-primary", "sage"),
     stakeFrozen,
+    workerPayout,
+    remainingPayout,
+    reasonCode: reasonCode || undefined,
+    reasoningHash: text(record.reasoningHash, "") || undefined,
+    metadataURI: metadataURI || undefined,
+    txHash: txHash || undefined,
+    chainStatus: chainStatus || undefined,
     stakeBreakdown: stakeBreakdown(stakeFrozen),
     openedAt: displayDate(openedAt),
     windowSeconds,
@@ -67,6 +80,11 @@ export function extractDispute(data: unknown): Dispute | null {
           rationale: text(record.rationale, text(record.reason, "Resolved by operator verdict.")),
           at: displayDate(text(release?.releasedAt, text(record.decidedAt, new Date().toISOString()))),
           signer: party(record.decidedBy ?? release?.releasedBy ?? record.reviewer ?? DEFAULT_REVIEWER, "operator-primary", "sage"),
+          reasonCode: reasonCode || undefined,
+          workerPayout,
+          txHash: txHash || undefined,
+          chainStatus: chainStatus || undefined,
+          metadataURI: metadataURI || undefined,
         }
       : undefined,
   };
@@ -194,6 +212,11 @@ function timelineBody(record: Record<string, unknown>, action: string): string {
   const data = objectField(record, "data");
   const reason = text(data?.reason, "");
   if (reason) return `${actor} recorded ${reason}.`;
+  const reasonCode = text(data?.reasonCode, "");
+  const txHash = text(data?.txHash, "");
+  if (action.includes("verdict") && reasonCode) {
+    return `${actor} recorded ${reasonCode}${txHash ? ` · ${shortAddress(txHash)}` : ""}.`;
+  }
   return `${actor} recorded ${action.replace(/_/gu, " ")}.`;
 }
 
@@ -280,6 +303,10 @@ function text(value: unknown, fallback: string): string {
 
 function number(value: unknown, fallback: number): number {
   return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function optionalNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 function objectField(value: unknown, key: string): Record<string, unknown> | null {

--- a/app/lib/events/stream.ts
+++ b/app/lib/events/stream.ts
@@ -23,6 +23,8 @@ export const EVENT_TOPICS = [
   "escrow.job_closed",
   "escrow.job_reopened",
   "escrow.dispute_opened",
+  "escrow.dispute_resolved",
+  "escrow.auto_resolved_on_timeout",
   "account.job_stake_locked",
   "account.job_stake_released",
   "account.job_stake_slashed",

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -571,6 +571,24 @@ export class BlockchainGateway {
     });
   }
 
+  async resolveDispute(jobId, workerPayout, reasonCode, metadataURI = "") {
+    return this.withGatewayError("resolveDispute", async () => {
+      this.requireSigner("resolveDispute");
+      const tx = await this.escrowContract.resolveDispute(
+        this.toJobId(jobId),
+        workerPayout,
+        this.toDisputeReasonCode(reasonCode),
+        metadataURI
+      );
+      const receipt = await tx.wait();
+      return {
+        txHash: tx.hash,
+        blockNumber: receipt?.blockNumber,
+        status: Number(receipt?.status ?? 0)
+      };
+    });
+  }
+
   async getJob(jobId) {
     return this.withGatewayError("getJob", async () => {
       const job = await this.escrowContract.jobs(this.toJobId(jobId));
@@ -580,8 +598,12 @@ export class BlockchainGateway {
         asset: job.asset,
         specHash: job.specHash,
         reward: Number(job.reward),
+        rewardRaw: job.reward?.toString?.() ?? String(job.reward),
         claimStake: Number(job.claimStake),
+        claimStakeRaw: job.claimStake?.toString?.() ?? String(job.claimStake),
         claimStakeBps: Number(job.claimStakeBps),
+        released: Number(job.released),
+        releasedRaw: job.released?.toString?.() ?? String(job.released),
         state: Number(job.state),
         claimExpiry: Number(job.claimExpiry),
         rejectedAt: Number(job.rejectedAt),
@@ -758,6 +780,10 @@ export class BlockchainGateway {
 
   toReasonCode(reasonCode) {
     return id(reasonCode);
+  }
+
+  toDisputeReasonCode(reasonCode) {
+    return this.toBytes32Value(reasonCode, "reasonCode");
   }
 
   toRequestId(requestId) {

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { encodeBytes32String } from "ethers";
+
+import { BlockchainGateway } from "./gateway.js";
+
+test("toDisputeReasonCode uses Solidity bytes32 string encoding", () => {
+  const gateway = new BlockchainGateway({ enabled: false });
+
+  assert.equal(
+    gateway.toDisputeReasonCode("DISPUTE_LOST"),
+    encodeBytes32String("DISPUTE_LOST")
+  );
+});

--- a/mcp-server/src/core/dispute-resolution.js
+++ b/mcp-server/src/core/dispute-resolution.js
@@ -1,0 +1,82 @@
+import { ValidationError } from "./errors.js";
+
+export const ARBITRATOR_SLA_SECONDS = 14 * 24 * 60 * 60;
+
+export const DISPUTE_REASON_CODES = Object.freeze({
+  upheld: "DISPUTE_LOST",
+  dismissed: "DISPUTE_OVERTURNED",
+  split: "DISPUTE_PARTIAL",
+  timeout: "ARB_TIMEOUT"
+});
+
+export function normalizeDisputeVerdict(value) {
+  const verdict = String(value ?? "").trim().toLowerCase();
+  if (verdict === "upheld" || verdict === "uphold") return "upheld";
+  if (verdict === "dismissed" || verdict === "dismiss" || verdict === "rejected" || verdict === "reject") {
+    return "dismissed";
+  }
+  if (verdict === "split" || verdict === "partial" || verdict === "request-more") return "split";
+  if (verdict === "timeout" || verdict === "arb_timeout") return "timeout";
+  throw new ValidationError("verdict must be one of upheld, dismissed, split.");
+}
+
+export function buildDisputeResolution({ verdict, remainingPayout, workerPayout = undefined } = {}) {
+  const normalized = normalizeDisputeVerdict(verdict);
+  const remaining = normalizePayout(remainingPayout, "remainingPayout");
+
+  if (normalized === "upheld") {
+    return {
+      verdict: normalized,
+      workerPayout: 0,
+      reasonCode: DISPUTE_REASON_CODES.upheld,
+      nextSessionStatus: "rejected",
+      releaseAction: "slash-to-treasury"
+    };
+  }
+
+  if (normalized === "dismissed" || normalized === "timeout") {
+    return {
+      verdict: normalized,
+      workerPayout: remaining,
+      reasonCode: DISPUTE_REASON_CODES[normalized],
+      nextSessionStatus: "resolved",
+      releaseAction: "return-to-depositor"
+    };
+  }
+
+  const explicit = workerPayout === undefined || workerPayout === null || workerPayout === ""
+    ? defaultPartialPayout(remaining)
+    : normalizePayout(workerPayout, "workerPayout");
+  if (explicit <= 0 || explicit > remaining) {
+    throw new ValidationError("workerPayout for split verdicts must be greater than zero and no more than the remaining payout.", {
+      workerPayout: explicit,
+      remainingPayout: remaining
+    });
+  }
+
+  return {
+    verdict: normalized,
+    workerPayout: explicit,
+    reasonCode: DISPUTE_REASON_CODES.split,
+    nextSessionStatus: "resolved",
+    releaseAction: "return-to-depositor",
+    payoutSource: workerPayout === undefined || workerPayout === null || workerPayout === ""
+      ? "default_half_remaining"
+      : "operator_supplied"
+  };
+}
+
+function normalizePayout(value, label) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new ValidationError(`${label} must be a non-negative number.`);
+  }
+  return parsed;
+}
+
+function defaultPartialPayout(remaining) {
+  if (remaining <= 1) {
+    return remaining;
+  }
+  return Math.floor(remaining / 2);
+}

--- a/mcp-server/src/core/dispute-resolution.test.js
+++ b/mcp-server/src/core/dispute-resolution.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ARBITRATOR_SLA_SECONDS,
+  buildDisputeResolution,
+  normalizeDisputeVerdict
+} from "./dispute-resolution.js";
+import { ValidationError } from "./errors.js";
+
+test("buildDisputeResolution maps upheld disputes to zero-payout dispute loss", () => {
+  const result = buildDisputeResolution({ verdict: "upheld", remainingPayout: 5 });
+
+  assert.equal(result.workerPayout, 0);
+  assert.equal(result.reasonCode, "DISPUTE_LOST");
+  assert.equal(result.nextSessionStatus, "rejected");
+  assert.equal(result.releaseAction, "slash-to-treasury");
+});
+
+test("buildDisputeResolution maps dismissed disputes to full worker payout", () => {
+  const result = buildDisputeResolution({ verdict: "dismissed", remainingPayout: 5 });
+
+  assert.equal(result.workerPayout, 5);
+  assert.equal(result.reasonCode, "DISPUTE_OVERTURNED");
+  assert.equal(result.nextSessionStatus, "resolved");
+});
+
+test("buildDisputeResolution supports operator-supplied partial payouts", () => {
+  const result = buildDisputeResolution({ verdict: "split", remainingPayout: 7, workerPayout: 3 });
+
+  assert.equal(result.workerPayout, 3);
+  assert.equal(result.reasonCode, "DISPUTE_PARTIAL");
+  assert.equal(result.payoutSource, "operator_supplied");
+});
+
+test("buildDisputeResolution has a timeout-shaped worker-favorable outcome", () => {
+  const result = buildDisputeResolution({ verdict: "timeout", remainingPayout: 9 });
+
+  assert.equal(result.workerPayout, 9);
+  assert.equal(result.reasonCode, "ARB_TIMEOUT");
+  assert.equal(result.nextSessionStatus, "resolved");
+  assert.equal(ARBITRATOR_SLA_SECONDS, 14 * 24 * 60 * 60);
+});
+
+test("normalizeDisputeVerdict rejects unknown values", () => {
+  assert.throws(
+    () => normalizeDisputeVerdict("maybe"),
+    (error) => error instanceof ValidationError && /verdict must be/u.test(error.message)
+  );
+});

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -16,6 +16,9 @@ import { getAddress, keccak256, toUtf8Bytes } from "ethers";
 import { buildBadgeFromSession } from "../../core/badge-metadata.js";
 import { buildAgentProfile } from "../../core/agent-profile.js";
 import { buildDiscoveryManifest } from "../../core/discovery-manifest.js";
+import { hashCanonicalContent } from "../../core/canonical-content.js";
+import { buildDisputeResolution, ARBITRATOR_SLA_SECONDS } from "../../core/dispute-resolution.js";
+import { transitionSession } from "../../core/session-state-machine.js";
 import { TIER_REQUIREMENTS } from "../../core/job-catalog-service.js";
 import {
   getPublicBuiltinJobSchemaByName,
@@ -671,10 +674,53 @@ async function listAlerts(limit = 20) {
   return alerts.slice(0, limit);
 }
 
-function addHoursIso(value, hours) {
+function addSecondsIso(value, seconds) {
   const parsed = Date.parse(value ?? "");
   const base = Number.isFinite(parsed) ? parsed : Date.now();
-  return new Date(base + hours * 60 * 60 * 1000).toISOString();
+  return new Date(base + seconds * 1000).toISOString();
+}
+
+function publicContentUri(hash) {
+  const normalized = typeof hash === "string" && /^0x[a-fA-F0-9]{64}$/u.test(hash)
+    ? hash
+    : undefined;
+  if (!normalized) {
+    return "";
+  }
+  const base = process.env.PUBLIC_BASE_URL?.trim()?.replace(/\/+$/u, "");
+  return base ? `${base}/content/${normalized}` : `urn:averray:content:${normalized}`;
+}
+
+function buildDisputeReasoningReceipt({ id, dispute, payload, auth, verdict, decidedAt }) {
+  const rationale = typeof payload?.rationale === "string" ? payload.rationale.trim() : "";
+  const explicitHash = typeof payload?.reasoningHash === "string" && /^0x[a-fA-F0-9]{64}$/u.test(payload.reasoningHash)
+    ? payload.reasoningHash
+    : undefined;
+  const reasoningHash = explicitHash ?? hashCanonicalContent({
+    disputeId: id,
+    sessionId: dispute.sessionId,
+    verdict,
+    rationale,
+    decidedBy: auth.wallet,
+    decidedAt
+  });
+  const metadataURI = typeof payload?.metadataURI === "string" && payload.metadataURI.trim()
+    ? payload.metadataURI.trim()
+    : publicContentUri(reasoningHash);
+  return { rationale, reasoningHash, metadataURI };
+}
+
+async function resolveRemainingPayout(session) {
+  if (gateway?.isEnabled?.() && typeof gateway.getJob === "function") {
+    const live = await gateway.getJob(session.chainJobId ?? session.jobId);
+    return Math.max(Number(live.reward ?? 0) - Number(live.released ?? 0), 0);
+  }
+  try {
+    const job = service.getJobDefinition(session.jobId);
+    return Math.max(Number(job.rewardAmount ?? 0), 0);
+  } catch {
+    return 0;
+  }
 }
 
 async function buildDisputeFromSession(session) {
@@ -684,7 +730,7 @@ async function buildDisputeFromSession(session) {
     stateStore.getMutationReceipt?.("dispute_release", id)
   ]);
   const openedAt = session.disputedAt ?? session.updatedAt ?? new Date().toISOString();
-  const windowEndsAt = addHoursIso(openedAt, 72);
+  const windowEndsAt = addSecondsIso(openedAt, ARBITRATOR_SLA_SECONDS);
   const timeline = (session.statusHistory ?? []).map((entry, index) => ({
     id: `${id}:session:${index}`,
     at: entry.at,
@@ -722,10 +768,12 @@ async function buildDisputeFromSession(session) {
     id,
     status: releaseReceipt || verdictReceipt ? "resolved" : "open",
     sessionId: session.sessionId,
+    chainJobId: session.chainJobId,
     claimant: session.wallet,
     respondent: process.env.DEFAULT_VERIFIER_ADDRESS ?? "0x0000000000000000000000000000000000000000",
     openedAt,
     windowEndsAt,
+    slaSeconds: ARBITRATOR_SLA_SECONDS,
     evidence: {
       before: compactObject({
         jobId: session.jobId,
@@ -739,6 +787,13 @@ async function buildDisputeFromSession(session) {
       })
     },
     verdict: verdictReceipt?.verdict ?? null,
+    reasonCode: verdictReceipt?.reasonCode,
+    reasoningHash: verdictReceipt?.reasoningHash,
+    metadataURI: verdictReceipt?.metadataURI,
+    txHash: verdictReceipt?.txHash,
+    chainStatus: verdictReceipt?.chainStatus,
+    workerPayout: verdictReceipt?.workerPayout,
+    remainingPayout: verdictReceipt?.remainingPayout,
     stakedAmount: Number(session.claimStake ?? 0),
     release: releaseReceipt ?? null,
     timeline: timeline.sort((left, right) => String(left.at ?? "").localeCompare(String(right.at ?? "")))
@@ -747,8 +802,20 @@ async function buildDisputeFromSession(session) {
 
 async function listDisputes(limit = 100) {
   const sessions = await service.listRecentSessions(limit);
-  const disputed = sessions.filter((session) => session.status === "disputed");
-  return Promise.all(disputed.map((session) => buildDisputeFromSession(session)));
+  const candidates = await Promise.all(
+    sessions.map(async (session) => {
+      if (session.status === "disputed") {
+        return session;
+      }
+      const id = disputeIdForSession(session.sessionId);
+      const [verdictReceipt, releaseReceipt] = await Promise.all([
+        stateStore.getMutationReceipt?.("dispute_verdict", id),
+        stateStore.getMutationReceipt?.("dispute_release", id)
+      ]);
+      return verdictReceipt || releaseReceipt ? session : undefined;
+    })
+  );
+  return Promise.all(candidates.filter(Boolean).map((session) => buildDisputeFromSession(session)));
 }
 
 async function findDispute(id, limit = 250) {
@@ -1434,27 +1501,84 @@ const server = createServer(async (request, response) => {
     }
 
     if (request.method === "POST" && /^\/disputes\/[^/]+\/verdict$/u.test(pathname)) {
-      const auth = await authMiddleware(request, url, { requireRole: "verifier" });
+      const auth = await authMiddleware(request, url);
+      if (!hasRole(auth.claims, "admin") && !hasRole(auth.claims, "verifier")) {
+        throw new AuthorizationError("Requires admin or verifier role.", "missing_role");
+      }
       const id = decodeURIComponent(pathname.slice("/disputes/".length, -"/verdict".length));
       const dispute = await findDispute(id);
       if (!dispute) {
         return respond(response, 404, { status: "not_found", id });
       }
-      const payload = await readJsonBody(request);
-      const verdict = String(payload?.verdict ?? payload?.outcome ?? "").trim();
-      if (!["upheld", "dismissed", "split"].includes(verdict)) {
-        throw new ValidationError("verdict must be one of upheld, dismissed, split.");
+      if (dispute.verdict || dispute.reasonCode) {
+        return respond(response, 200, dispute);
       }
+      const payload = await readJsonBody(request);
+      const session = await service.resumeSession(dispute.sessionId);
+      const decidedAt = new Date().toISOString();
+      const remainingPayout = await resolveRemainingPayout(session);
+      const resolution = buildDisputeResolution({
+        verdict: payload?.verdict ?? payload?.outcome,
+        remainingPayout,
+        workerPayout: payload?.workerPayout ?? payload?.payoutAmount
+      });
+      const reasoning = buildDisputeReasoningReceipt({
+        id,
+        dispute,
+        payload,
+        auth,
+        verdict: resolution.verdict,
+        decidedAt
+      });
+      const chainReceipt = gateway?.isEnabled?.() && typeof gateway.resolveDispute === "function"
+        ? await gateway.resolveDispute(
+            session.chainJobId ?? session.jobId,
+            resolution.workerPayout,
+            resolution.reasonCode,
+            reasoning.metadataURI
+          )
+        : {
+            txHash: undefined,
+            blockNumber: undefined,
+            status: undefined
+          };
       const receipt = {
         id,
         disputeId: id,
         sessionId: dispute.sessionId,
-        verdict,
-        rationale: typeof payload?.rationale === "string" ? payload.rationale.trim() : undefined,
+        chainJobId: session.chainJobId,
+        verdict: resolution.verdict,
+        workerPayout: resolution.workerPayout,
+        remainingPayout,
+        reasonCode: resolution.reasonCode,
+        reasoningHash: reasoning.reasoningHash,
+        metadataURI: reasoning.metadataURI,
+        rationale: reasoning.rationale || undefined,
+        releaseAction: resolution.releaseAction,
+        payoutSource: resolution.payoutSource,
+        txHash: chainReceipt.txHash,
+        blockNumber: chainReceipt.blockNumber,
+        chainStatus: gateway?.isEnabled?.()
+          ? (chainReceipt.status === 1 ? "confirmed" : "submitted")
+          : "local_only",
         decidedBy: auth.wallet,
-        decidedAt: new Date().toISOString()
+        decidedAt
       };
       await stateStore.upsertMutationReceipt?.("dispute_verdict", id, receipt);
+      if (session.status === "disputed") {
+        const transitioned = transitionSession(session, resolution.nextSessionStatus, {
+          reason: resolution.reasonCode,
+          timestamp: decidedAt,
+          metadata: {
+            disputeId: id,
+            verdict: resolution.verdict,
+            workerPayout: resolution.workerPayout,
+            reasonCode: resolution.reasonCode,
+            txHash: receipt.txHash
+          }
+        });
+        await stateStore.upsertSession?.(transitioned);
+      }
       eventBus?.publish({
         id: `dispute-verdict-${id}-${Date.now()}`,
         topic: "escrow.dispute_resolved",
@@ -1462,12 +1586,25 @@ const server = createServer(async (request, response) => {
         wallets: [dispute.claimant, auth.wallet],
         sessionId: dispute.sessionId,
         timestamp: receipt.decidedAt,
-        data: { disputeId: id, verdict }
+        data: {
+          disputeId: id,
+          verdict: resolution.verdict,
+          workerPayout: resolution.workerPayout,
+          reasonCode: resolution.reasonCode,
+          txHash: receipt.txHash
+        }
       });
       return respond(response, 200, {
         ...dispute,
         status: "resolved",
-        verdict,
+        verdict: resolution.verdict,
+        reasonCode: resolution.reasonCode,
+        reasoningHash: reasoning.reasoningHash,
+        metadataURI: reasoning.metadataURI,
+        txHash: receipt.txHash,
+        chainStatus: receipt.chainStatus,
+        workerPayout: resolution.workerPayout,
+        remainingPayout,
         timeline: [
           ...dispute.timeline,
           {
@@ -1495,6 +1632,8 @@ const server = createServer(async (request, response) => {
         sessionId: dispute.sessionId,
         action: typeof payload?.action === "string" && payload.action.trim() ? payload.action.trim() : "release",
         amount: Number(payload?.amount ?? dispute.stakedAmount ?? 0),
+        chainStatus: dispute.txHash ? "settled_by_verdict" : "local_only",
+        txHash: dispute.txHash,
         releasedBy: auth.wallet,
         releasedAt: new Date().toISOString()
       };


### PR DESCRIPTION
## What changed
- Added backend dispute resolution mapping for upheld, dismissed, split, and timeout-shaped outcomes.
- Added `BlockchainGateway.resolveDispute()` and ASCII `bytes32` dispute reason-code encoding for `EscrowCore.resolveDispute`.
- Updated `/disputes/:id/verdict` to submit the on-chain dispute settlement, persist receipt metadata, transition sessions, and keep `/release` as audit-only compatibility.
- Surfaced dispute SLA timing, reason codes, payout, metadata URI, and tx status in the operator dispute UI.

## Checks run
- `npm --workspace mcp-server test`
- `npm run typecheck:app`
- `npm run build:frontend` (generated `frontend/` export cleaned from PR per repo policy)

## Affected areas
- Backend: yes
- Operator app/frontend source: yes
- Indexer: no
- Contracts: no
- Public site: no
- Caddy: no

## Env / deployment notes
- No new environment variables or VPS secrets required.
- Requires the backend signer to be an authorized `TreasuryPolicy` arbitrator on deployments where blockchain mode is enabled.