### PR TITLE
Add OpenAPI quality audit jobs

### DIFF
--- a/docs/PUBLIC_JOB_SOURCES.md
+++ b/docs/PUBLIC_JOB_SOURCES.md
@@ -133,11 +133,21 @@ After Wikipedia, use the same pattern for:
      `STANDARDS_INGEST_DRY_RUN=true` until `/admin/status` shows useful
      candidates.
 
-5. **Stack Exchange / Discourse**
+5. **API schema / OpenAPI cleanup**
+   - broken examples, missing operation descriptions, stale endpoint docs
+   - schema drift checks between public specs and local API/docs surfaces
+   - v1 ingestion is allowlist-driven:
+     `POST /admin/jobs/ingest/openapi` accepts configured public OpenAPI
+     documents and emits review-only API quality audit jobs.
+   - Scheduled ingestion is available behind `OPENAPI_INGEST_ENABLED`; keep
+     `OPENAPI_INGEST_DRY_RUN=true` until `/admin/status` shows useful
+     candidates.
+
+6. **Stack Exchange / Discourse**
    - unanswered-question triage, duplicate detection, answer summaries
    - community-reviewable outputs
 
-6. **Common Crawl / public docs sites**
+7. **Common Crawl / public docs sites**
    - broken-link checks, metadata extraction, stale-doc detection
    - batch outputs with crawl evidence
 

--- a/docs/READY_TO_POST_JOBS.md
+++ b/docs/READY_TO_POST_JOBS.md
@@ -497,6 +497,52 @@ They must not edit external standards pages.
 
 ---
 
+## OpenAPI quality audit jobs
+
+The first API-schema provider is allowlist-driven. Operators point it at public
+OpenAPI JSON or YAML documents plus the local implementation/docs surface that
+should stay aligned. The generated jobs ask workers to validate endpoint
+coverage, descriptions, operation ids, examples, schema references, and drift
+against local docs or code.
+
+Preview jobs through:
+
+```bash
+npm --workspace mcp-server run ingest:openapi-specs -- --dry-run \
+  --specs '[{"provider":"stripe","specId":"stripe-openapi","apiTitle":"Stripe OpenAPI","specUrl":"https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json","localSurface":"mcp-server/src/protocols/http/server.js","repo":"averray-agent/agent"}]'
+```
+
+Or through the admin API:
+
+```http
+POST /admin/jobs/ingest/openapi
+```
+
+To let the backend pull these periodically, configure:
+
+```bash
+OPENAPI_INGEST_ENABLED=true
+OPENAPI_INGEST_DRY_RUN=true
+OPENAPI_INGEST_INTERVAL_MS=3600000
+OPENAPI_INGEST_MAX_JOBS_PER_RUN=2
+OPENAPI_INGEST_MAX_OPEN_JOBS=20
+OPENAPI_INGEST_SPECS_JSON='[{"provider":"stripe","specId":"stripe-openapi","apiTitle":"Stripe OpenAPI","specUrl":"https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json","localSurface":"mcp-server/src/protocols/http/server.js","repo":"averray-agent/agent"}]'
+```
+
+Review `openApiIngestion.lastRun` in `/admin/status`, then switch
+`OPENAPI_INGEST_DRY_RUN=false` when the candidates are ready to create jobs.
+
+The generated jobs use:
+
+- `schema://jobs/openapi-quality-audit-input`
+- `schema://jobs/openapi-quality-audit-output`
+
+Each submission must include `api_title`, `spec_url`, completed `checks`,
+findings plus recommendations, or `no_issue_found=true` with evidence. Workers
+must not mutate the public API spec directly.
+
+---
+
 ## Before posting
 
 Quick operator checklist:

--- a/docs/schemas/jobs/openapi-quality-audit-input.json
+++ b/docs/schemas/jobs/openapi-quality-audit-input.json
@@ -1,0 +1,22 @@
+{
+  "$id": "schema://jobs/openapi-quality-audit-input",
+  "title": "OpenAPI Quality Audit Input",
+  "type": "object",
+  "required": ["apiTitle", "specUrl", "instructions"],
+  "properties": {
+    "apiTitle": { "type": "string", "minLength": 1 },
+    "specUrl": { "type": "string", "minLength": 1 },
+    "localSurface": { "type": "string" },
+    "repo": { "type": "string" },
+    "openapiVersion": { "type": "string" },
+    "pathCount": { "type": "integer", "minimum": 0 },
+    "operationCount": { "type": "integer", "minimum": 0 },
+    "schemaCount": { "type": "integer", "minimum": 0 },
+    "instructions": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/schemas/jobs/openapi-quality-audit-output.json
+++ b/docs/schemas/jobs/openapi-quality-audit-output.json
@@ -1,0 +1,50 @@
+{
+  "$id": "schema://jobs/openapi-quality-audit-output",
+  "title": "OpenAPI Quality Audit Output",
+  "type": "object",
+  "required": ["api_title", "spec_url", "checks", "findings", "no_issue_found", "summary", "recommended_actions"],
+  "properties": {
+    "api_title": { "type": "string", "minLength": 1 },
+    "spec_url": { "type": "string", "minLength": 1 },
+    "local_surface": { "type": "string" },
+    "openapi_version": { "type": "string" },
+    "checks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "status", "evidence"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "status": { "type": "string", "enum": ["pass", "warn", "fail", "unknown"] },
+          "evidence": { "type": "string", "minLength": 1 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["severity", "location", "issue", "evidence", "recommendation"],
+        "properties": {
+          "severity": { "type": "string", "enum": ["low", "medium", "high"] },
+          "location": { "type": "string", "minLength": 1 },
+          "issue": { "type": "string", "minLength": 1 },
+          "evidence": { "type": "string", "minLength": 1 },
+          "recommendation": { "type": "string", "minLength": 1 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "no_issue_found": { "type": "boolean" },
+    "summary": { "type": "string", "minLength": 1 },
+    "recommended_actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "notes": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -14,7 +14,8 @@
     "ingest:wikipedia": "node src/jobs/ingest-wikipedia-maintenance.js",
     "ingest:osv-advisories": "node src/jobs/ingest-osv-advisories.js",
     "ingest:open-data": "node src/jobs/ingest-open-data-datasets.js",
-    "ingest:standards-specs": "node src/jobs/ingest-standards-specs.js"
+    "ingest:standards-specs": "node src/jobs/ingest-standards-specs.js",
+    "ingest:openapi-specs": "node src/jobs/ingest-openapi-specs.js"
   },
   "dependencies": {
     "ethers": "^6.16.0",

--- a/mcp-server/src/core/job-schema-registry.js
+++ b/mcp-server/src/core/job-schema-registry.js
@@ -272,6 +272,62 @@ const BUILTIN_JOB_SCHEMAS = new Map([
       notes: stringSchema()
     }
   })],
+  ["schema://jobs/openapi-quality-audit-input", objectSchema({
+    $id: "schema://jobs/openapi-quality-audit-input",
+    description: "Public OpenAPI quality audit input.",
+    required: ["apiTitle", "specUrl", "instructions"],
+    properties: {
+      apiTitle: stringSchema({ minLength: 1 }),
+      specUrl: stringSchema({ minLength: 1 }),
+      localSurface: stringSchema(),
+      repo: stringSchema(),
+      openapiVersion: stringSchema(),
+      pathCount: integerSchema({ minimum: 0 }),
+      operationCount: integerSchema({ minimum: 0 }),
+      schemaCount: integerSchema({ minimum: 0 }),
+      instructions: arrayOfStrings({ minItems: 1 })
+    }
+  })],
+  ["schema://jobs/openapi-quality-audit-output", objectSchema({
+    $id: "schema://jobs/openapi-quality-audit-output",
+    description: "Structured evidence for an OpenAPI spec quality audit.",
+    required: ["api_title", "spec_url", "checks", "findings", "no_issue_found", "summary", "recommended_actions"],
+    properties: {
+      api_title: stringSchema({ minLength: 1 }),
+      spec_url: stringSchema({ minLength: 1 }),
+      local_surface: stringSchema(),
+      openapi_version: stringSchema(),
+      checks: {
+        type: "array",
+        minItems: 1,
+        items: objectSchema({
+          required: ["name", "status", "evidence"],
+          properties: {
+            name: stringSchema({ minLength: 1 }),
+            status: enumString(["pass", "warn", "fail", "unknown"]),
+            evidence: stringSchema({ minLength: 1 })
+          }
+        })
+      },
+      findings: {
+        type: "array",
+        items: objectSchema({
+          required: ["severity", "location", "issue", "evidence", "recommendation"],
+          properties: {
+            severity: enumString(["low", "medium", "high"]),
+            location: stringSchema({ minLength: 1 }),
+            issue: stringSchema({ minLength: 1 }),
+            evidence: stringSchema({ minLength: 1 }),
+            recommendation: stringSchema({ minLength: 1 })
+          }
+        })
+      },
+      no_issue_found: booleanSchema(),
+      summary: stringSchema({ minLength: 1 }),
+      recommended_actions: arrayOfStrings({ minItems: 1 }),
+      notes: stringSchema()
+    }
+  })],
   ["schema://jobs/wikipedia-maintenance-input", objectSchema({
     $id: "schema://jobs/wikipedia-maintenance-input",
     description: "Wikipedia public article maintenance job input.",

--- a/mcp-server/src/core/job-schema-registry.test.js
+++ b/mcp-server/src/core/job-schema-registry.test.js
@@ -132,6 +132,38 @@ test("validateStructuredSubmission accepts open-data audit evidence", () => {
   });
 });
 
+test("validateStructuredSubmission accepts OpenAPI audit evidence", () => {
+  const payload = {
+    api_title: "Stripe OpenAPI",
+    spec_url: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json",
+    local_surface: "mcp-server/src/protocols/http/server.js",
+    openapi_version: "3.1.0",
+    checks: [
+      {
+        name: "operation_descriptions",
+        status: "warn",
+        evidence: "One sampled operation has no summary or description."
+      }
+    ],
+    findings: [
+      {
+        severity: "low",
+        location: "GET /v1/customers",
+        issue: "Operation lacks a human-readable description.",
+        evidence: "summary and description are absent in the OpenAPI operation object.",
+        recommendation: "Add a concise description or link local docs to the canonical operation docs."
+      }
+    ],
+    no_issue_found: false,
+    summary: "Spec is reachable but one sampled operation needs documentation polish.",
+    recommended_actions: ["Add operation description", "Confirm local docs mention the endpoint"]
+  };
+
+  assert.doesNotThrow(() => {
+    validateStructuredSubmission("schema://jobs/openapi-quality-audit-output", payload);
+  });
+});
+
 test("validateStructuredSubmission rejects missing required fields", () => {
   assert.throws(
     () => validateStructuredSubmission("schema://jobs/pr-review-findings-output", {

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -42,6 +42,7 @@ export class PlatformService {
     this.osvAdvisoryIngestionScheduler = undefined;
     this.openDataIngestionScheduler = undefined;
     this.standardsSpecIngestionScheduler = undefined;
+    this.openApiSpecIngestionScheduler = undefined;
     this.xcmSettlementWatcher = undefined;
     this.xcmObservationRelay = undefined;
 
@@ -113,6 +114,7 @@ export class PlatformService {
       osvIngestion,
       openDataIngestion,
       standardsIngestion,
+      openApiIngestion,
       recentSessions
     ] = await Promise.all([
       this.blockchainGateway?.getTreasuryPolicyStatus?.() ?? {
@@ -172,6 +174,17 @@ export class PlatformService {
         lastRun: undefined
       },
       this.standardsSpecIngestionScheduler?.getStatus?.() ?? {
+        enabled: false,
+        running: false,
+        dryRun: true,
+        intervalMs: 0,
+        specCount: 0,
+        minScore: 0,
+        maxJobsPerRun: 0,
+        maxOpenJobs: 0,
+        lastRun: undefined
+      },
+      this.openApiSpecIngestionScheduler?.getStatus?.() ?? {
         enabled: false,
         running: false,
         dryRun: true,
@@ -276,6 +289,7 @@ export class PlatformService {
       osvIngestion: osvIngestion,
       openDataIngestion: openDataIngestion,
       standardsIngestion: standardsIngestion,
+      openApiIngestion: openApiIngestion,
       xcmSettlementWatcher: await this.xcmSettlementWatcher?.getStatus?.() ?? {
         enabled: false,
         running: false,

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -175,12 +175,25 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
       };
     }
   };
+  service.openApiSpecIngestionScheduler = {
+    getStatus() {
+      return {
+        enabled: true,
+        running: true,
+        dryRun: true,
+        intervalMs: 3600000,
+        specCount: 1,
+        lastRun: { createdCount: 1 }
+      };
+    }
+  };
 
   const status = await service.getAdminStatus();
   assert.equal(status.osvIngestion.packageCount, 1);
   assert.equal(status.openDataIngestion.query, "res_format:CSV");
   assert.equal(status.openDataIngestion.lastRun.createdCount, 2);
   assert.equal(status.standardsIngestion.specCount, 2);
+  assert.equal(status.openApiIngestion.specCount, 1);
 });
 
 test("finalizeXcmRequest records async treasury settlement when the request is strategy-backed", async () => {

--- a/mcp-server/src/jobs/ingest-openapi-specs.js
+++ b/mcp-server/src/jobs/ingest-openapi-specs.js
@@ -1,0 +1,442 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+
+/**
+ * Ingest OpenAPI quality audit jobs.
+ *
+ * Operators configure public OpenAPI documents and the local/API surface that
+ * should stay aligned with them. Generated jobs ask workers to validate the
+ * spec shape, examples, descriptions, and drift evidence, then submit a
+ * reviewable audit report or PR recommendation.
+ */
+
+export const DEFAULT_BASE_URL = "http://localhost:8787";
+export const DEFAULT_PROVIDER = "openapi";
+
+const HTTP_METHODS = new Set(["get", "put", "post", "delete", "options", "head", "patch", "trace"]);
+
+export function parseArgs(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith("--")) continue;
+    const key = arg.slice(2);
+    if (key.includes("=")) {
+      const [name, ...rest] = key.split("=");
+      parsed[name] = rest.join("=");
+      continue;
+    }
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      parsed[key] = true;
+      continue;
+    }
+    parsed[key] = next;
+    index += 1;
+  }
+  return parsed;
+}
+
+export async function ingestOpenApiSpecs({
+  specs = [],
+  limit = 10,
+  minScore = 55,
+  fetchImpl = fetch
+} = {}) {
+  const targets = parseOpenApiSpecs(specs);
+  const skipped = [];
+  const candidates = [];
+
+  for (const target of targets) {
+    try {
+      const enriched = await fetchOpenApiDetails({ target, fetchImpl });
+      const score = scoreOpenApiTarget(enriched);
+      if (score < minScore) {
+        skipped.push({ specUrl: target.specUrl, reason: "below_min_score", score });
+        continue;
+      }
+      candidates.push({ target: enriched, score });
+    } catch (error) {
+      skipped.push({
+        specUrl: target.specUrl,
+        reason: "fetch_failed",
+        message: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  const jobs = candidates
+    .sort((left, right) => right.score - left.score)
+    .slice(0, limit)
+    .map(({ target, score }) => toPlatformJob(target, score));
+
+  if (candidates.length > jobs.length) {
+    skipped.push({ reason: "over_limit", count: candidates.length - jobs.length });
+  }
+
+  return {
+    provider: DEFAULT_PROVIDER,
+    specCount: targets.length,
+    minScore,
+    count: jobs.length,
+    jobs,
+    skipped
+  };
+}
+
+export async function fetchOpenApiDetails({ target, fetchImpl = fetch }) {
+  const response = await fetchImpl(target.specUrl, {
+    headers: requestHeaders()
+  });
+  const rawBody = await response.text();
+  const parsed = parseOpenApiDocument(rawBody, headerValue(response.headers, "content-type"));
+  return {
+    ...target,
+    apiTitle: target.apiTitle || parsed.title || target.specUrl,
+    finalUrl: response.url || target.specUrl,
+    httpStatus: response.status,
+    ok: response.ok,
+    contentType: headerValue(response.headers, "content-type"),
+    lastModified: headerValue(response.headers, "last-modified"),
+    etag: headerValue(response.headers, "etag"),
+    openapiVersion: parsed.openapiVersion,
+    documentVersion: parsed.documentVersion,
+    pathCount: parsed.pathCount,
+    operationCount: parsed.operationCount,
+    schemaCount: parsed.schemaCount,
+    missingOperationDescriptions: parsed.missingOperationDescriptions,
+    missingOperationIds: parsed.missingOperationIds,
+    exampleCount: parsed.exampleCount,
+    parseMode: parsed.parseMode
+  };
+}
+
+export function parseOpenApiSpecs(raw) {
+  const parsed = typeof raw === "string" ? parseSpecString(raw) : raw;
+  if (!Array.isArray(parsed)) return [];
+  return parsed.map(normalizeOpenApiTarget).filter(Boolean);
+}
+
+export function parseOpenApiDocument(rawBody, contentType = "") {
+  const body = String(rawBody ?? "");
+  const json = parseJson(body);
+  if (json && typeof json === "object") {
+    return inspectOpenApiJson(json);
+  }
+  return inspectOpenApiText(body, contentType);
+}
+
+export function scoreOpenApiTarget(target) {
+  let score = 20;
+  if (target.provider) score += 5;
+  if (target.apiTitle) score += 10;
+  if (target.specUrl) score += 15;
+  if (target.localSurface) score += 8;
+  if (target.ok) score += 18;
+  if (target.httpStatus && target.httpStatus !== 200) score -= 20;
+  if (target.openapiVersion) score += 12;
+  if (target.pathCount > 0) score += 10;
+  if (target.operationCount > 0) score += 8;
+  if (target.schemaCount > 0) score += 5;
+  if (target.missingOperationDescriptions > 0) score += 4;
+  if (target.missingOperationIds > 0) score += 3;
+  if (target.exampleCount === 0 && target.operationCount > 0) score += 3;
+  return Math.max(0, Math.min(100, score));
+}
+
+export function openApiSpecKey(source) {
+  if (!source?.specUrl) return undefined;
+  return [
+    String(source.provider ?? DEFAULT_PROVIDER).toLowerCase(),
+    String(source.specUrl).toLowerCase(),
+    String(source.localSurface ?? "").toLowerCase()
+  ].join("|");
+}
+
+export function toPlatformJob(target, score = scoreOpenApiTarget(target)) {
+  const provider = normalizeProvider(target.provider);
+  const apiTitle = target.apiTitle || target.specUrl;
+  const localSurface = target.localSurface || target.repo || "configured API implementation or docs";
+  const id = `openapi-${slugify(provider)}-${slugify(target.specId || apiTitle)}`.slice(0, 120);
+
+  return {
+    id,
+    title: `Audit OpenAPI quality: ${apiTitle}`,
+    description:
+      `Validate the public OpenAPI document "${apiTitle}" and compare it with "${localSurface}" for broken examples, missing descriptions, schema drift, and endpoint documentation gaps.`,
+    jobType: "review",
+    requiredRole: "worker",
+    category: "api",
+    tier: "starter",
+    rewardAsset: "DOT",
+    rewardAmount: 3,
+    verifierMode: "benchmark",
+    verifierTerms: ["spec_url", "checks", "findings", "recommended_actions"],
+    verifierMinimumMatches: 3,
+    inputSchemaRef: "schema://jobs/openapi-quality-audit-input",
+    outputSchemaRef: "schema://jobs/openapi-quality-audit-output",
+    claimTtlSeconds: 7200,
+    retryLimit: 1,
+    requiresSponsoredGas: true,
+    source: {
+      type: "openapi_spec",
+      provider,
+      specId: target.specId,
+      apiTitle,
+      specUrl: target.specUrl,
+      finalUrl: target.finalUrl,
+      localSurface,
+      repo: target.repo,
+      httpStatus: target.httpStatus,
+      contentType: target.contentType,
+      lastModified: target.lastModified,
+      etag: target.etag,
+      openapiVersion: target.openapiVersion,
+      documentVersion: target.documentVersion,
+      pathCount: target.pathCount,
+      operationCount: target.operationCount,
+      schemaCount: target.schemaCount,
+      missingOperationDescriptions: target.missingOperationDescriptions,
+      missingOperationIds: target.missingOperationIds,
+      exampleCount: target.exampleCount,
+      parseMode: target.parseMode,
+      score,
+      discoveryApi: target.specUrl
+    },
+    acceptanceCriteria: [
+      "Fetch the OpenAPI document and record status, content type, final URL, and OpenAPI version.",
+      "Check endpoint coverage, operation descriptions, operationIds, request/response examples, and schema references.",
+      "Compare the configured local surface against the public spec for stale endpoint names, missing changelog/docs references, or schema drift.",
+      "Report at least one concrete finding, or set no_issue_found=true with evidence for each completed check.",
+      "Submit a reviewable audit report or PR recommendation; do not mutate the public API spec directly."
+    ],
+    estimatedDifficulty: score >= 80 ? "starter" : "review-needed",
+    agentInstructions: [
+      `Review the OpenAPI document: ${target.specUrl}.`,
+      `Audit this local/API surface: ${localSurface}.`,
+      "Inspect operation descriptions, operationIds, examples, response schemas, and stale endpoint references.",
+      "Submit structured evidence with api_title, spec_url, checks, findings, no_issue_found, summary, and recommended_actions.",
+      "Keep the output reviewable and cite exact paths, methods, schema names, or section links."
+    ],
+    verification: {
+      method: "benchmark",
+      suggestedCheck: "openapi_quality_report_complete",
+      evidenceSchemaRef: "schema://jobs/openapi-quality-audit-output",
+      signals: ["spec_url_present", "checks_present", "finding_or_no_issue", "recommendations_present"]
+    }
+  };
+}
+
+export async function postJobs({ baseUrl, adminToken, jobs, fetchImpl = fetch }) {
+  const results = [];
+  for (const job of jobs) {
+    results.push(await createJob({ baseUrl, adminToken, job, fetchImpl }));
+  }
+  return results;
+}
+
+export async function createJob({ baseUrl, adminToken, job, fetchImpl = fetch }) {
+  const response = await fetchImpl(`${trimTrailingSlash(baseUrl)}/admin/jobs`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${adminToken}`,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify(job)
+  });
+  const body = await response.text();
+  let payload;
+  try {
+    payload = body ? JSON.parse(body) : {};
+  } catch {
+    payload = { raw: body };
+  }
+  return { id: job.id, status: response.status, ok: response.ok, payload };
+}
+
+function parseSpecString(raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed;
+  } catch {
+    // Fall through to compact line parser.
+  }
+  return String(raw)
+    .split(/\n/u)
+    .map((entry) => {
+      const [apiTitle, specUrl, provider, localSurface, repo] = entry.split("|").map((part) => part?.trim());
+      if (!apiTitle || !specUrl) return undefined;
+      return { apiTitle, specUrl, provider, localSurface, repo };
+    })
+    .filter(Boolean);
+}
+
+function normalizeOpenApiTarget(raw) {
+  const specUrl = text(raw?.specUrl ?? raw?.url);
+  const apiTitle = text(raw?.apiTitle ?? raw?.title ?? raw?.name);
+  if (!specUrl || !isHttpUrl(specUrl)) return undefined;
+  return {
+    provider: normalizeProvider(raw?.provider),
+    specId: text(raw?.specId ?? raw?.id),
+    apiTitle,
+    specUrl,
+    localSurface: text(raw?.localSurface ?? raw?.surface ?? raw?.path),
+    repo: text(raw?.repo)
+  };
+}
+
+function inspectOpenApiJson(document) {
+  const paths = objectOrEmpty(document.paths);
+  const operations = [];
+  for (const [path, pathItem] of Object.entries(paths)) {
+    for (const [method, operation] of Object.entries(objectOrEmpty(pathItem))) {
+      if (!HTTP_METHODS.has(method.toLowerCase())) continue;
+      operations.push({ path, method: method.toLowerCase(), operation: objectOrEmpty(operation) });
+    }
+  }
+  const schemas = objectOrEmpty(document.components?.schemas ?? document.definitions);
+  return {
+    parseMode: "json",
+    openapiVersion: text(document.openapi ?? document.swagger),
+    title: text(document.info?.title),
+    documentVersion: text(document.info?.version),
+    pathCount: Object.keys(paths).length,
+    operationCount: operations.length,
+    schemaCount: Object.keys(schemas).length,
+    missingOperationDescriptions: operations.filter(({ operation }) => !text(operation.summary) && !text(operation.description)).length,
+    missingOperationIds: operations.filter(({ operation }) => !text(operation.operationId)).length,
+    exampleCount: countExamples(document)
+  };
+}
+
+function inspectOpenApiText(body, contentType) {
+  const openapiVersion = firstMatch(body, /^\s*(?:openapi|swagger)\s*:\s*["']?([^"'\n]+)["']?\s*$/imu);
+  const title = firstMatch(body, /^\s*title\s*:\s*["']?([^"'\n]+)["']?\s*$/imu);
+  const documentVersion = firstMatch(body, /^\s*version\s*:\s*["']?([^"'\n]+)["']?\s*$/imu);
+  const methodMatches = body.match(/^\s+(get|put|post|delete|options|head|patch|trace)\s*:/gimu) ?? [];
+  const pathMatches = body.match(/^\s{2}\/[^:\n]+:/gmu) ?? [];
+  return {
+    parseMode: contentType.includes("yaml") || /\.ya?ml(?:$|\?)/iu.test(contentType) ? "yaml" : "text",
+    openapiVersion,
+    title,
+    documentVersion,
+    pathCount: pathMatches.length,
+    operationCount: methodMatches.length,
+    schemaCount: (body.match(/^\s{4}[A-Za-z0-9_.-]+\s*:\s*$/gmu) ?? []).length,
+    missingOperationDescriptions: 0,
+    missingOperationIds: 0,
+    exampleCount: (body.match(/\bexamples?\s*:/giu) ?? []).length
+  };
+}
+
+function countExamples(value) {
+  let count = 0;
+  const visit = (node) => {
+    if (!node || typeof node !== "object") return;
+    for (const [key, child] of Object.entries(node)) {
+      if (key === "example" || key === "examples") count += 1;
+      visit(child);
+    }
+  };
+  visit(value);
+  return count;
+}
+
+function parseJson(value) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function firstMatch(value, pattern) {
+  return text(String(value).match(pattern)?.[1]);
+}
+
+function objectOrEmpty(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function requestHeaders() {
+  return {
+    accept: "application/json,application/yaml,text/yaml,text/plain;q=0.9,*/*;q=0.8",
+    "user-agent": "AverrayOpenApiIngest/0.1 (https://averray.com; operator@averray.com)"
+  };
+}
+
+function headerValue(headers, name) {
+  if (!headers) return "";
+  if (typeof headers.get === "function") {
+    return text(headers.get(name));
+  }
+  const direct = headers[name] ?? headers[name.toLowerCase()] ?? headers[name.toUpperCase()];
+  return text(direct);
+}
+
+function normalizeProvider(value) {
+  return text(value || DEFAULT_PROVIDER).toLowerCase();
+}
+
+function isHttpUrl(value) {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+function text(value) {
+  return String(value ?? "").trim();
+}
+
+function slugify(value) {
+  return String(value ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, "-")
+    .replace(/^-+|-+$/gu, "")
+    .replace(/-{2,}/gu, "-");
+}
+
+function parsePositiveInt(raw, fallback) {
+  const value = Number(raw);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function trimTrailingSlash(value) {
+  return String(value).replace(/\/+$/u, "");
+}
+
+async function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  const dryRun = Boolean(args["dry-run"]);
+  const specs = args.specs ?? process.env.OPENAPI_INGEST_SPECS_JSON ?? process.env.OPENAPI_INGEST_SPECS;
+  const limit = parsePositiveInt(args.limit, 10);
+  const minScore = parsePositiveInt(args["min-score"], 55);
+  const baseUrl = trimTrailingSlash(String(args.baseUrl ?? process.env.AGENT_API_BASE_URL ?? DEFAULT_BASE_URL));
+  const adminToken = process.env.AGENT_ADMIN_TOKEN?.trim();
+
+  if (!dryRun && !adminToken) {
+    fail("AGENT_ADMIN_TOKEN is required unless --dry-run is set.");
+  }
+
+  const dryRunPayload = await ingestOpenApiSpecs({ specs, limit, minScore });
+  if (dryRun) {
+    console.log(JSON.stringify(dryRunPayload, null, 2));
+    return;
+  }
+
+  const results = await postJobs({ baseUrl, adminToken, jobs: dryRunPayload.jobs });
+  console.log(JSON.stringify({ ...dryRunPayload, results }, null, 2));
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await runCli();
+}

--- a/mcp-server/src/jobs/ingest-openapi-specs.test.js
+++ b/mcp-server/src/jobs/ingest-openapi-specs.test.js
@@ -1,0 +1,172 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  fetchOpenApiDetails,
+  ingestOpenApiSpecs,
+  openApiSpecKey,
+  parseOpenApiDocument,
+  parseOpenApiSpecs,
+  scoreOpenApiTarget,
+  toPlatformJob
+} from "./ingest-openapi-specs.js";
+
+const SPEC = {
+  provider: "stripe",
+  specId: "stripe-openapi",
+  apiTitle: "Stripe OpenAPI",
+  specUrl: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json",
+  localSurface: "mcp-server/src/protocols/http/server.js",
+  repo: "averray-agent/agent"
+};
+
+const OPENAPI_DOC = {
+  openapi: "3.1.0",
+  info: { title: "Stripe OpenAPI", version: "2026-01-01" },
+  paths: {
+    "/v1/customers": {
+      get: {
+        operationId: "listCustomers",
+        responses: { "200": { description: "ok" } }
+      },
+      post: {
+        summary: "Create a customer",
+        responses: { "200": { description: "ok" } }
+      }
+    }
+  },
+  components: {
+    schemas: {
+      customer: { type: "object", properties: { id: { type: "string", example: "cus_123" } } }
+    }
+  }
+};
+
+function makeFetch({ status = 200, ok = true } = {}) {
+  return async (url, request) => {
+    assert.equal(url, SPEC.specUrl);
+    assert.match(request.headers.accept, /application\/json/u);
+    return {
+      ok,
+      status,
+      url: `${SPEC.specUrl}?from=test`,
+      headers: new Map([
+        ["content-type", "application/json"],
+        ["last-modified", "Mon, 27 Apr 2026 08:00:00 GMT"],
+        ["etag", "\"abc123\""]
+      ]),
+      async text() {
+        return JSON.stringify(OPENAPI_DOC);
+      }
+    };
+  };
+}
+
+test("parseOpenApiSpecs accepts JSON and compact line syntax", () => {
+  assert.deepEqual(parseOpenApiSpecs(JSON.stringify([SPEC])), [SPEC]);
+  assert.deepEqual(
+    parseOpenApiSpecs("Stripe OpenAPI|https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json|stripe|mcp-server/src/protocols/http/server.js|averray-agent/agent"),
+    [
+      {
+        provider: "stripe",
+        specId: "",
+        apiTitle: "Stripe OpenAPI",
+        specUrl: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json",
+        localSurface: "mcp-server/src/protocols/http/server.js",
+        repo: "averray-agent/agent"
+      }
+    ]
+  );
+});
+
+test("parseOpenApiDocument inspects JSON OpenAPI documents", () => {
+  const details = parseOpenApiDocument(JSON.stringify(OPENAPI_DOC), "application/json");
+
+  assert.equal(details.parseMode, "json");
+  assert.equal(details.openapiVersion, "3.1.0");
+  assert.equal(details.title, "Stripe OpenAPI");
+  assert.equal(details.documentVersion, "2026-01-01");
+  assert.equal(details.pathCount, 1);
+  assert.equal(details.operationCount, 2);
+  assert.equal(details.schemaCount, 1);
+  assert.equal(details.missingOperationDescriptions, 1);
+  assert.equal(details.missingOperationIds, 1);
+  assert.equal(details.exampleCount, 1);
+});
+
+test("parseOpenApiDocument captures simple YAML metadata", () => {
+  const details = parseOpenApiDocument("openapi: 3.0.3\ninfo:\n  title: Sample API\n  version: 1.0.0\npaths:\n  /health:\n    get:\n      responses: {}\n", "application/yaml");
+
+  assert.equal(details.parseMode, "yaml");
+  assert.equal(details.openapiVersion, "3.0.3");
+  assert.equal(details.title, "Sample API");
+  assert.equal(details.documentVersion, "1.0.0");
+  assert.equal(details.operationCount, 1);
+});
+
+test("fetchOpenApiDetails captures spec metadata", async () => {
+  const details = await fetchOpenApiDetails({ target: SPEC, fetchImpl: makeFetch() });
+
+  assert.equal(details.finalUrl, `${SPEC.specUrl}?from=test`);
+  assert.equal(details.openapiVersion, "3.1.0");
+  assert.equal(details.operationCount, 2);
+  assert.equal(details.lastModified, "Mon, 27 Apr 2026 08:00:00 GMT");
+  assert.equal(details.etag, "\"abc123\"");
+});
+
+test("scoreOpenApiTarget prefers reachable auditable OpenAPI specs", async () => {
+  const details = await fetchOpenApiDetails({ target: SPEC, fetchImpl: makeFetch() });
+
+  assert.ok(scoreOpenApiTarget(details) >= 90);
+  assert.ok(scoreOpenApiTarget({ ...details, ok: false, httpStatus: 404 }) < scoreOpenApiTarget(details));
+});
+
+test("toPlatformJob creates OpenAPI quality audit job", async () => {
+  const details = await fetchOpenApiDetails({ target: SPEC, fetchImpl: makeFetch() });
+  const job = toPlatformJob(details, 95);
+
+  assert.equal(job.id, "openapi-stripe-stripe-openapi");
+  assert.equal(job.category, "api");
+  assert.equal(job.tier, "starter");
+  assert.equal(job.verifierMode, "benchmark");
+  assert.equal(job.inputSchemaRef, "schema://jobs/openapi-quality-audit-input");
+  assert.equal(job.outputSchemaRef, "schema://jobs/openapi-quality-audit-output");
+  assert.equal(job.source.type, "openapi_spec");
+  assert.equal(job.source.operationCount, 2);
+  assert.ok(job.verifierTerms.includes("recommended_actions"));
+});
+
+test("openApiSpecKey dedupes by provider, URL, and local surface", () => {
+  assert.equal(
+    openApiSpecKey({ provider: "Stripe", specUrl: SPEC.specUrl, localSurface: SPEC.localSurface }),
+    "stripe|https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json|mcp-server/src/protocols/http/server.js"
+  );
+});
+
+test("ingestOpenApiSpecs fetches configured specs and returns jobs", async () => {
+  const payload = await ingestOpenApiSpecs({
+    specs: [SPEC],
+    limit: 5,
+    minScore: 55,
+    fetchImpl: makeFetch()
+  });
+
+  assert.equal(payload.provider, "openapi");
+  assert.equal(payload.specCount, 1);
+  assert.equal(payload.count, 1);
+  assert.equal(payload.jobs[0].source.apiTitle, SPEC.apiTitle);
+  assert.deepEqual(payload.skipped, []);
+});
+
+test("ingestOpenApiSpecs reports fetch failures as skipped targets", async () => {
+  const payload = await ingestOpenApiSpecs({
+    specs: [SPEC],
+    fetchImpl: async () => {
+      throw new Error("network unavailable");
+    }
+  });
+
+  assert.equal(payload.count, 0);
+  assert.equal(payload.skipped[0].reason, "fetch_failed");
+  assert.equal(payload.skipped[0].message, "network unavailable");
+});

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -27,6 +27,7 @@ import {
 } from "../../core/job-schema-registry.js";
 import { ingestGithubIssues } from "../../jobs/ingest-github-issues.js";
 import { ingestOpenDataDatasets, parseDatasets as parseOpenDataDatasets } from "../../jobs/ingest-open-data-datasets.js";
+import { ingestOpenApiSpecs, parseOpenApiSpecs } from "../../jobs/ingest-openapi-specs.js";
 import {
   ingestOsvAdvisories,
   parseManifests as parseOsvManifests,
@@ -891,6 +892,7 @@ function metricPathLabel(pathname) {
     "/strategies",
     "/admin/jobs",
     "/admin/jobs/ingest/github",
+    "/admin/jobs/ingest/openapi",
     "/admin/jobs/ingest/open-data",
     "/admin/jobs/ingest/osv",
     "/admin/jobs/ingest/standards",
@@ -1172,6 +1174,7 @@ const server = createServer(async (request, response) => {
           "/verifier/replay",
           "/admin/jobs",
           "/admin/jobs/ingest/github",
+          "/admin/jobs/ingest/openapi",
           "/admin/jobs/ingest/open-data",
           "/admin/jobs/ingest/osv",
           "/admin/jobs/ingest/standards",
@@ -2463,6 +2466,59 @@ const server = createServer(async (request, response) => {
       return respond(response, status, {
         provider: result.provider,
         query: result.query,
+        minScore: result.minScore,
+        dryRun: false,
+        candidateCount: result.count,
+        created,
+        skipped: [...skipped, ...(Array.isArray(result.skipped) ? result.skipped : [])],
+        errors
+      });
+    }
+
+    if (request.method === "POST" && pathname === "/admin/jobs/ingest/openapi") {
+      const auth = await authMiddleware(request, url, { requireRole: "admin" });
+      await enforceLimit("admin_jobs", auth.wallet, rateLimitConfig.adminJobs);
+      const payload = await readJsonBody(request);
+      const specs = Array.isArray(payload?.specs) || typeof payload?.specs === "string"
+        ? parseOpenApiSpecs(payload.specs)
+        : parseOpenApiSpecs(process.env.OPENAPI_INGEST_SPECS_JSON ?? process.env.OPENAPI_INGEST_SPECS);
+      const limit = parsePositiveInteger(payload?.limit, 10, 50);
+      const minScore = parsePositiveInteger(payload?.minScore, 55, 100);
+      const dryRun = payload?.dryRun !== false;
+      const result = await ingestOpenApiSpecs({ specs, limit, minScore });
+
+      if (dryRun) {
+        return respond(response, 200, {
+          ...result,
+          dryRun: true,
+          created: []
+        });
+      }
+
+      const created = [];
+      const skipped = [];
+      const errors = [];
+      for (const job of result.jobs) {
+        try {
+          created.push(service.createJob(job));
+        } catch (error) {
+          const normalized = normalizeError(error);
+          if (normalized.code === "job_exists") {
+            skipped.push({ id: job.id, reason: "already_exists" });
+            continue;
+          }
+          errors.push({
+            id: job.id,
+            code: normalized.code,
+            message: normalized.message
+          });
+        }
+      }
+
+      const status = errors.length ? 207 : 201;
+      return respond(response, status, {
+        provider: result.provider,
+        specCount: result.specCount,
         minScore: result.minScore,
         dryRun: false,
         candidateCount: result.count,

--- a/mcp-server/src/services/bootstrap.js
+++ b/mcp-server/src/services/bootstrap.js
@@ -34,6 +34,10 @@ import {
   StandardsSpecIngestionScheduler,
   loadStandardsSpecIngestionConfig
 } from "./standards-spec-ingestion-scheduler.js";
+import {
+  OpenApiSpecIngestionScheduler,
+  loadOpenApiSpecIngestionConfig
+} from "./openapi-spec-ingestion-scheduler.js";
 import { XcmSettlementWatcherService } from "./xcm-settlement-watcher.js";
 import { XcmObservationRelayService } from "./xcm-observation-relay.js";
 import { normaliseStrategyAssetConfig } from "./strategy-asset-config.js";
@@ -189,6 +193,12 @@ export async function createPlatformRuntime() {
       logger
     })
   );
+  const openApiSpecIngestionScheduler = initStep("init-openapi-spec-ingestion-scheduler", logger, () =>
+    new OpenApiSpecIngestionScheduler(platformService, eventBus, {
+      ...loadOpenApiSpecIngestionConfig(process.env),
+      logger
+    })
+  );
   const xcmSettlementWatcher = initStep("init-xcm-settlement-watcher", logger, () =>
     new XcmSettlementWatcherService(platformService, stateStore, eventBus, {
       enabled: process.env.XCM_SETTLEMENT_WATCHER_ENABLED === undefined
@@ -216,6 +226,7 @@ export async function createPlatformRuntime() {
   platformService.osvAdvisoryIngestionScheduler = osvAdvisoryIngestionScheduler;
   platformService.openDataIngestionScheduler = openDataIngestionScheduler;
   platformService.standardsSpecIngestionScheduler = standardsSpecIngestionScheduler;
+  platformService.openApiSpecIngestionScheduler = openApiSpecIngestionScheduler;
   platformService.xcmSettlementWatcher = xcmSettlementWatcher;
   platformService.xcmObservationRelay = xcmObservationRelay;
   recurringScheduler.start();
@@ -224,6 +235,7 @@ export async function createPlatformRuntime() {
   osvAdvisoryIngestionScheduler.start();
   openDataIngestionScheduler.start();
   standardsSpecIngestionScheduler.start();
+  openApiSpecIngestionScheduler.start();
   xcmSettlementWatcher.start();
   xcmObservationRelay.start();
 
@@ -253,6 +265,7 @@ export async function createPlatformRuntime() {
     osvAdvisoryIngestionScheduler,
     openDataIngestionScheduler,
     standardsSpecIngestionScheduler,
+    openApiSpecIngestionScheduler,
     xcmSettlementWatcher,
     xcmObservationRelay,
     authConfig,

--- a/mcp-server/src/services/openapi-spec-ingestion-scheduler.js
+++ b/mcp-server/src/services/openapi-spec-ingestion-scheduler.js
@@ -1,0 +1,211 @@
+import { ingestOpenApiSpecs, openApiSpecKey, parseOpenApiSpecs } from "../jobs/ingest-openapi-specs.js";
+
+export class OpenApiSpecIngestionScheduler {
+  constructor(platformService, eventBus = undefined, {
+    enabled = false,
+    dryRun = true,
+    intervalMs = 60 * 60 * 1000,
+    specs = [],
+    minScore = 55,
+    maxJobsPerRun = 2,
+    maxOpenJobs = 20,
+    fetchImpl = fetch,
+    logger = console
+  } = {}) {
+    this.platformService = platformService;
+    this.eventBus = eventBus;
+    this.enabled = enabled;
+    this.dryRun = dryRun;
+    this.intervalMs = intervalMs;
+    this.specs = parseOpenApiSpecs(specs);
+    this.minScore = minScore;
+    this.maxJobsPerRun = maxJobsPerRun;
+    this.maxOpenJobs = maxOpenJobs;
+    this.fetchImpl = fetchImpl;
+    this.logger = logger;
+    this.timer = undefined;
+    this.running = false;
+    this.lastRun = undefined;
+  }
+
+  start() {
+    if (!this.enabled || this.running) {
+      return;
+    }
+    this.running = true;
+    void this.runOnceAndSchedule();
+  }
+
+  stop() {
+    this.running = false;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  async getStatus() {
+    return {
+      enabled: this.enabled,
+      running: this.running,
+      dryRun: this.dryRun,
+      intervalMs: this.intervalMs,
+      specCount: this.specs.length,
+      minScore: this.minScore,
+      maxJobsPerRun: this.maxJobsPerRun,
+      maxOpenJobs: this.maxOpenJobs,
+      lastRun: this.lastRun
+    };
+  }
+
+  async runOnce(now = new Date()) {
+    const startedAt = now.toISOString();
+    const openApiJobs = this.countOpenApiJobs();
+    const summary = {
+      startedAt,
+      finishedAt: undefined,
+      dryRun: this.dryRun,
+      openApiJobs,
+      candidateCount: 0,
+      createdCount: 0,
+      skipped: [],
+      errors: []
+    };
+
+    if (!this.enabled) {
+      summary.skipped.push({ reason: "disabled" });
+      return this.finishRun(summary);
+    }
+    if (!this.specs.length) {
+      summary.skipped.push({ reason: "no_specs_configured" });
+      return this.finishRun(summary);
+    }
+    if (openApiJobs >= this.maxOpenJobs) {
+      summary.skipped.push({ reason: "max_open_jobs_reached", openApiJobs, maxOpenJobs: this.maxOpenJobs });
+      return this.finishRun(summary);
+    }
+
+    const remaining = Math.max(0, Math.min(this.maxJobsPerRun, this.maxOpenJobs - openApiJobs));
+    const seenSources = this.existingOpenApiKeys();
+    try {
+      const result = await ingestOpenApiSpecs({
+        specs: this.specs,
+        limit: remaining,
+        minScore: this.minScore,
+        fetchImpl: this.fetchImpl
+      });
+      summary.candidateCount = result.count;
+      summary.skipped.push(...(Array.isArray(result.skipped) ? result.skipped : []));
+      for (const job of result.jobs) {
+        const sourceKey = openApiJobKey(job);
+        if (sourceKey && seenSources.has(sourceKey)) {
+          summary.skipped.push({ id: job.id, reason: "source_already_ingested" });
+          continue;
+        }
+        if (this.platformService.getJobDefinition) {
+          try {
+            this.platformService.getJobDefinition(job.id);
+            summary.skipped.push({ id: job.id, reason: "job_already_exists" });
+            continue;
+          } catch {
+            // Missing jobs are expected and created below.
+          }
+        }
+        if (!this.dryRun) {
+          this.platformService.createJob(job);
+        }
+        seenSources.add(sourceKey);
+        summary.createdCount += 1;
+        this.eventBus?.publish?.({
+          id: `platform-openapi-ingest-${job.id}-${Date.now()}`,
+          topic: "jobs.ingest.openapi",
+          jobId: job.id,
+          timestamp: new Date().toISOString(),
+          data: {
+            dryRun: this.dryRun,
+            jobId: job.id,
+            source: job.source
+          }
+        });
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      summary.errors.push({ message });
+      this.logger.warn?.({ err: error }, "openapi_ingest.run_failed");
+    }
+
+    return this.finishRun(summary);
+  }
+
+  async runOnceAndSchedule() {
+    await this.runOnce(new Date());
+    if (!this.running) {
+      return;
+    }
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+    this.timer = setTimeout(() => {
+      void this.runOnceAndSchedule();
+    }, this.intervalMs);
+  }
+
+  finishRun(summary) {
+    summary.finishedAt = new Date().toISOString();
+    this.lastRun = summary;
+    return summary;
+  }
+
+  countOpenApiJobs() {
+    return this.platformService.listJobs()
+      .filter((job) => job.source?.type === "openapi_spec")
+      .filter((job) => !job.recurring)
+      .length;
+  }
+
+  existingOpenApiKeys() {
+    return new Set(
+      this.platformService.listJobs()
+        .map((job) => openApiJobKey(job))
+        .filter(Boolean)
+    );
+  }
+}
+
+export function loadOpenApiSpecIngestionConfig(env = process.env) {
+  return {
+    enabled: parseBooleanEnv(env.OPENAPI_INGEST_ENABLED),
+    dryRun: env.OPENAPI_INGEST_DRY_RUN === undefined ? true : parseBooleanEnv(env.OPENAPI_INGEST_DRY_RUN),
+    intervalMs: parsePositiveInt(env.OPENAPI_INGEST_INTERVAL_MS, 60 * 60 * 1000),
+    specs: parseOpenApiSpecs(env.OPENAPI_INGEST_SPECS_JSON ?? env.OPENAPI_INGEST_SPECS),
+    minScore: parsePositiveInt(env.OPENAPI_INGEST_MIN_SCORE, 55),
+    maxJobsPerRun: parsePositiveInt(env.OPENAPI_INGEST_MAX_JOBS_PER_RUN, 2),
+    maxOpenJobs: parsePositiveInt(env.OPENAPI_INGEST_MAX_OPEN_JOBS, 20)
+  };
+}
+
+function openApiJobKey(job) {
+  const source = job?.source;
+  if (source?.type !== "openapi_spec") {
+    return undefined;
+  }
+  return openApiSpecKey(source);
+}
+
+function parsePositiveInt(raw, fallback) {
+  if (raw === undefined || raw === null || raw === "") {
+    return fallback;
+  }
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    return fallback;
+  }
+  return value;
+}
+
+function parseBooleanEnv(raw) {
+  if (raw === undefined || raw === null || raw === "") {
+    return false;
+  }
+  return ["1", "true", "yes", "on"].includes(String(raw).trim().toLowerCase());
+}

--- a/mcp-server/src/services/openapi-spec-ingestion-scheduler.test.js
+++ b/mcp-server/src/services/openapi-spec-ingestion-scheduler.test.js
@@ -1,0 +1,144 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  OpenApiSpecIngestionScheduler,
+  loadOpenApiSpecIngestionConfig
+} from "./openapi-spec-ingestion-scheduler.js";
+
+const SPEC = {
+  provider: "stripe",
+  specId: "stripe-openapi",
+  apiTitle: "Stripe OpenAPI",
+  specUrl: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json",
+  localSurface: "mcp-server/src/protocols/http/server.js",
+  repo: "averray-agent/agent"
+};
+
+function makeFetch() {
+  return async () => ({
+    ok: true,
+    status: 200,
+    url: SPEC.specUrl,
+    headers: new Map([
+      ["content-type", "application/json"],
+      ["last-modified", "Mon, 27 Apr 2026 08:00:00 GMT"]
+    ]),
+    async text() {
+      return JSON.stringify({
+        openapi: "3.1.0",
+        info: { title: SPEC.apiTitle, version: "2026-01-01" },
+        paths: { "/health": { get: { operationId: "health", responses: { "200": { description: "ok" } } } } }
+      });
+    }
+  });
+}
+
+function makePlatformService(initialJobs = []) {
+  const jobs = [...initialJobs];
+  return {
+    listJobs() {
+      return [...jobs];
+    },
+    createJob(job) {
+      jobs.unshift(job);
+      return job;
+    },
+    getJobDefinition(jobId) {
+      const job = jobs.find((candidate) => candidate.id === jobId);
+      if (!job) {
+        throw new Error("not found");
+      }
+      return job;
+    }
+  };
+}
+
+test("OpenApiSpecIngestionScheduler dry-run does not create jobs", async () => {
+  const platform = makePlatformService();
+  const scheduler = new OpenApiSpecIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: true,
+    specs: [SPEC],
+    fetchImpl: makeFetch()
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-27T08:00:00.000Z"));
+  assert.equal(summary.createdCount, 1);
+  assert.equal(platform.listJobs().length, 0);
+  assert.equal((await scheduler.getStatus()).lastRun.dryRun, true);
+});
+
+test("OpenApiSpecIngestionScheduler creates jobs when dryRun is false", async () => {
+  const platform = makePlatformService();
+  const scheduler = new OpenApiSpecIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    specs: [SPEC],
+    fetchImpl: makeFetch()
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-27T08:00:00.000Z"));
+  assert.equal(summary.createdCount, 1);
+  assert.equal(platform.listJobs().length, 1);
+  assert.equal(platform.listJobs()[0].source.type, "openapi_spec");
+});
+
+test("OpenApiSpecIngestionScheduler dedupes by OpenAPI source", async () => {
+  const platform = makePlatformService([
+    {
+      id: "existing",
+      source: {
+        type: "openapi_spec",
+        provider: "stripe",
+        specUrl: SPEC.specUrl,
+        localSurface: SPEC.localSurface
+      }
+    }
+  ]);
+  const scheduler = new OpenApiSpecIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    specs: [SPEC],
+    fetchImpl: makeFetch()
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-27T08:00:00.000Z"));
+  assert.equal(summary.createdCount, 0);
+  assert.equal(platform.listJobs().length, 1);
+  assert.equal(summary.skipped.at(-1).reason, "source_already_ingested");
+});
+
+test("OpenApiSpecIngestionScheduler skips when no specs are configured", async () => {
+  const platform = makePlatformService();
+  const scheduler = new OpenApiSpecIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    specs: [],
+    fetchImpl: makeFetch()
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-27T08:00:00.000Z"));
+  assert.equal(summary.createdCount, 0);
+  assert.equal(summary.skipped[0].reason, "no_specs_configured");
+});
+
+test("loadOpenApiSpecIngestionConfig parses env knobs safely", () => {
+  const config = loadOpenApiSpecIngestionConfig({
+    OPENAPI_INGEST_ENABLED: "true",
+    OPENAPI_INGEST_DRY_RUN: "false",
+    OPENAPI_INGEST_INTERVAL_MS: "3600000",
+    OPENAPI_INGEST_SPECS_JSON: JSON.stringify([SPEC]),
+    OPENAPI_INGEST_MIN_SCORE: "70",
+    OPENAPI_INGEST_MAX_JOBS_PER_RUN: "4",
+    OPENAPI_INGEST_MAX_OPEN_JOBS: "11"
+  });
+
+  assert.equal(config.enabled, true);
+  assert.equal(config.dryRun, false);
+  assert.equal(config.intervalMs, 3600000);
+  assert.equal(config.specs.length, 1);
+  assert.equal(config.minScore, 70);
+  assert.equal(config.maxJobsPerRun, 4);
+  assert.equal(config.maxOpenJobs, 11);
+});


### PR DESCRIPTION
## Summary
- add allowlist-driven OpenAPI quality audit ingestion
- wire scheduler status, backend startup, admin ingest endpoint, and schemas
- document dry-run and production env knobs for API schema cleanup jobs

## Tests
- node --test mcp-server/src/jobs/ingest-openapi-specs.test.js mcp-server/src/services/openapi-spec-ingestion-scheduler.test.js mcp-server/src/core/platform-service.test.js mcp-server/src/core/job-schema-registry.test.js
- npm --workspace mcp-server test
- git diff --check HEAD~1..HEAD