### PR TITLE
operator-app: cross-page polish bundle + disputes Run column wrap fix

### DIFF
--- a/app/app/(authed)/audit-log/page.tsx
+++ b/app/app/(authed)/audit-log/page.tsx
@@ -138,6 +138,21 @@ function source(value: unknown): AuditSource {
   return "system";
 }
 
+/**
+ * Normalise the category emitted by the audit event stream into the
+ * fixed `AuditCategory` set the timeline filter rail knows how to
+ * render. The backend uses a finer-grained taxonomy than the UI
+ * (e.g. `session`, `escrow`, `reputation`, `admin`) so we collapse
+ * those into the closest UI bucket here:
+ *
+ *   - `session`                            → `runs`     (sessions are run lifecycle events)
+ *   - `escrow` / `reputation` / `admin`    → `treasury` (capital + control-plane)
+ *
+ * If you add a new audit category in the backend, add a passthrough
+ * here OR map it to one of the existing UI buckets — DO NOT silently
+ * drop it; the catch-all returns `"runs"` so unknown events still
+ * surface somewhere instead of disappearing.
+ */
 function category(value: unknown): AuditCategory {
   if (
     value === "policy" ||

--- a/app/app/(authed)/runs/page.tsx
+++ b/app/app/(authed)/runs/page.tsx
@@ -88,11 +88,13 @@ function RunsPageInner() {
   // verification path and implies a direct GitHub flow that doesn't
   // exist for that run.
   const selectedRow = rows.find((row) => row.id === selectedId) ?? rows[0];
-  const selectedSourceType = selectedRow?.source?.type;
-  const selectedOsvSource =
-    selectedRow?.source?.type === "osv_advisory" ? selectedRow.source : null;
+  // One source-of-truth narrow on `selectedRow.source`. The lifecycle
+  // copy below switches on `selectedSource?.type` and TS narrows to the
+  // right per-source field set inside each branch — no per-source
+  // intermediate variables needed.
+  const selectedSource = selectedRow?.source;
   const lifecycleContextNote =
-    selectedSourceType === "wikipedia_article" ? (
+    selectedSource?.type === "wikipedia_article" ? (
       <>
         Window closes in{" "}
         <b className="font-semibold text-[var(--avy-ink)]">21m 46s</b>
@@ -104,7 +106,7 @@ function RunsPageInner() {
         <b className="font-semibold text-[var(--avy-ink)]">submitted</b> ·
         pending Averray review
       </>
-    ) : selectedOsvSource ? (
+    ) : selectedSource?.type === "osv_advisory" ? (
       <>
         Window closes in{" "}
         <b className="font-semibold text-[var(--avy-ink)]">21m 46s</b>
@@ -112,11 +114,11 @@ function RunsPageInner() {
         <b className="font-semibold text-[var(--avy-ink)]">osv_dependency_pr</b>
         {" · "}advisory{" "}
         <b className="font-semibold text-[var(--avy-ink)]">
-          {selectedOsvSource.advisoryId}
+          {selectedSource.advisoryId}
         </b>{" "}
         · PR pending merge
       </>
-    ) : selectedSourceType === "open_data_dataset" ? (
+    ) : selectedSource?.type === "open_data_dataset" ? (
       <>
         Window closes in{" "}
         <b className="font-semibold text-[var(--avy-ink)]">21m 46s</b>
@@ -138,19 +140,19 @@ function RunsPageInner() {
       </>
     );
   const lifecycleNext =
-    selectedSourceType === "wikipedia_article"
+    selectedSource?.type === "wikipedia_article"
       ? {
           label: "Next",
           value: "Averray review → Pay",
           sub: "auto-pays on Averray-approved review",
         }
-      : selectedSourceType === "osv_advisory"
+      : selectedSource?.type === "osv_advisory"
         ? {
             label: "Next",
             value: "Maintainer merge → Pay",
             sub: "auto-pays on PR merge + CI green + lockfile resolves",
           }
-        : selectedSourceType === "open_data_dataset"
+        : selectedSource?.type === "open_data_dataset"
           ? {
               label: "Next",
               value: "Verifier check → Pay",

--- a/app/app/(authed)/treasury/page.tsx
+++ b/app/app/(authed)/treasury/page.tsx
@@ -228,15 +228,18 @@ const POSITIONS: PositionCard[] = [
 ];
 
 const POLICIES: PolicyItem[] = [
+  // Each row carries a consistent `Role · who/what` prefix so the
+  // enforcement mode reads at a glance (manual co-sign / governance
+  // review / contract-enforced). The right-side detail varies by
+  // enforcement type but the left-side label is uniform across rows.
   {
     tag: "treasury/alloc-dual-sign",
     name: "Allocations > 50k DOT require co-signer",
     meta: "Blocks any Allocate/Deallocate action on lanes 01, 02, 04, 05 without a second signer.",
     signerNote: (
       <>
-        Signer <b className="font-semibold text-[var(--avy-ink)]">0xFd2E…6519</b> ·
-        co-signer{" "}
-        <b className="font-semibold text-[var(--avy-ink)]">0x9A13…0cb2</b>
+        <b className="font-semibold text-[var(--avy-ink)]">Signers</b> ·{" "}
+        <span>0xFd2E…6519</span> + <span>0x9A13…0cb2</span>
       </>
     ),
   },
@@ -244,7 +247,12 @@ const POLICIES: PolicyItem[] = [
     tag: "treasury/debt-cap-85",
     name: "Debt may not exceed 85% of collateral",
     meta: "Currently at 82%. New borrows auto-blocked at 85%. Debt card tints warn when ≥ 80%.",
-    signerNote: <>Governance review · quarterly · next 2026-07-01</>,
+    signerNote: (
+      <>
+        <b className="font-semibold text-[var(--avy-ink)]">Owner</b> ·
+        governance council · quarterly review · next 2026-07-01
+      </>
+    ),
   },
   {
     tag: "xcm/observe-before-settle",
@@ -252,9 +260,8 @@ const POLICIES: PolicyItem[] = [
     meta: "Phase 03 cannot run until phase 02 has recorded a relay receipt. Enforced per-lane.",
     signerNote: (
       <>
-        Enforced by{" "}
-        <b className="font-semibold text-[var(--avy-ink)]">AgentAccountCore</b> ·
-        non-overridable
+        <b className="font-semibold text-[var(--avy-ink)]">Enforcement</b> ·
+        AgentAccountCore contract · non-overridable
       </>
     ),
   },

--- a/app/components/disputes/DisputesTable.tsx
+++ b/app/components/disputes/DisputesTable.tsx
@@ -39,7 +39,7 @@ export function DisputesTable({
           <thead>
             <tr>
               <Th width={100}>Dispute</Th>
-              <Th width={100}>Run</Th>
+              <Th width={130}>Run</Th>
               <Th>Opener</Th>
               <Th>Respondent</Th>
               <Th width={90} align="right">Stake</Th>
@@ -56,7 +56,7 @@ export function DisputesTable({
                   className="p-8 text-center font-[family-name:var(--font-mono)] text-[13px] text-[var(--avy-muted)]"
                   style={{ letterSpacing: 0 }}
                 >
-                  No disputes match these filters. Queue is clear.
+                  No disputes match these filters.
                 </td>
               </tr>
             ) : (
@@ -83,7 +83,7 @@ export function DisputesTable({
                       <div className="flex items-center gap-1.5">
                         {d.source ? <SourceBadge kind={d.source} /> : null}
                         <span
-                          className="font-[family-name:var(--font-mono)] text-[12.5px] text-[var(--avy-ink)]"
+                          className="whitespace-nowrap font-[family-name:var(--font-mono)] text-[12.5px] text-[var(--avy-ink)]"
                           style={{ letterSpacing: 0 }}
                         >
                           {d.runRef}


### PR DESCRIPTION
## Summary
Five small follow-ups from the second-pass audit, bundled because each is a few lines and they all touch the same operator surfaces.

**Treasury `PolicyGateFooter` signer-role copy** — three rows used three different voices (`Signer / co-signer`, `Governance review · quarterly`, `Enforced by AgentAccountCore`), obscuring that they're three intentionally-different enforcement modes. Each row now opens with a uniform `Role · …` prefix (`Signers` / `Owner` / `Enforcement`) so the mode reads at a glance while the substantive detail still varies.

**Empty-state tone** — `DisputesTable` said `No disputes match these filters. Queue is clear.` while `ReceiptsTable` said `No receipts match these filters.` Aligned to the shorter form on both.

**`runs/page.tsx` pattern symmetry** — the page-level `LifecycleRail` used a `selectedOsvSource` intermediate variable for OSV but plain `selectedSourceType ===` checks for the other three source kinds. Replaced with a single `const selectedSource = selectedRow?.source` narrow at the top — TS narrows to the right per-source field set inside each branch, no per-source intermediates.

**Audit-log category aliasing** — `category()` in `audit-log/page.tsx` silently downgraded `session → runs` and `escrow|reputation|admin → treasury`. Added a comment block above the function explaining the mapping + a note to add new categories explicitly rather than letting them fall through the catch-all return `"runs"`.

**DisputesTable Run column** — second recon flagged `OriginPill + SourceBadge` co-existing. After actually reading the table the OriginPill is in a *separate* Origin column, not co-located with the runRef — so the only real risk is narrow-column wrap. Bumped the Run column width to 130px and added `whitespace-nowrap` to the runRef span so badge + run id never break mid-token.

## Files (4)
- `app/app/(authed)/treasury/page.tsx` — `POLICIES` signerNote uniform role prefix
- `app/components/disputes/DisputesTable.tsx` — empty-state tone + Run column width + nowrap
- `app/app/(authed)/runs/page.tsx` — collapse `selectedOsvSource` into `selectedSource`
- `app/app/(authed)/audit-log/page.tsx` — comment block on `category()` aliasing

## Test plan
- [x] `npm run typecheck:app`
- [x] `npm run build:frontend` (15/15 pages)
- [ ] /treasury policy footer: each row opens with `Signers` / `Owner` / `Enforcement` in bold
- [ ] /receipts and /disputes with no rows: both render `No <X> match these filters.`
- [ ] /runs: select an OSV run — lifecycle rail still shows advisory id correctly (no regression from the refactor)
- [ ] /disputes Run column at narrow widths: SourceBadge + runRef stay on one line

🤖 Generated with [Claude Code](https://claude.com/claude-code)