### PR TITLE
ops: fix finish-agent-worktree.sh squash-merge fallback

### DIFF
--- a/scripts/ops/finish-agent-worktree.sh
+++ b/scripts/ops/finish-agent-worktree.sh
@@ -56,7 +56,7 @@ github_repo_from_remote() {
 }
 
 branch_has_merged_pr() {
-  local repo state
+  local repo merged_count
   repo="$(github_repo_from_remote)"
   if [[ -z "$repo" ]]; then
     return 1
@@ -65,15 +65,26 @@ branch_has_merged_pr() {
     return 1
   fi
 
-  state="$(
-    GH_PAGER= gh pr view "$branch" \
+  # `gh pr view <branch>` requires the branch to still exist locally OR
+  # remotely to resolve a PR. The merge queue auto-deletes the remote
+  # branch on merge (GitHub default), so by the time this script runs
+  # the branch usually no longer exists on the remote and `gh pr view`
+  # fails to find the PR even though it WAS merged. `gh pr list
+  # --search "head:<branch> is:merged"` searches GitHub by the
+  # historical head-ref name, regardless of whether the branch still
+  # exists, which is what we actually want.
+  merged_count="$(
+    GH_PAGER= gh pr list \
       --repo "$repo" \
-      --json state,mergedAt \
-      --jq 'if (.state == "MERGED" or .mergedAt != null) then "merged" else "not_merged" end' \
+      --state merged \
+      --search "head:$branch" \
+      --limit 5 \
+      --json number \
+      --jq 'length' \
       2>/dev/null || true
   )"
 
-  [[ "$state" == "merged" ]]
+  [[ -n "$merged_count" && "$merged_count" =~ ^[0-9]+$ && "$merged_count" -gt 0 ]]
 }
 
 if [[ $# -ne 1 ]]; then


### PR DESCRIPTION
## Summary
The `branch_has_merged_pr` fallback from [#37](https://github.com/averray-agent/agent/pull/37) was supposed to cover queue-squash merges by calling `gh pr view <branch>` when `git merge-base --is-ancestor` fails. In practice it's been rejecting every queue-merged branch since #37 shipped — every PR in the recent operator-app series (#39, #41, #44) had to be cleaned up by hand.

## Root cause
GitHub's merge queue auto-deletes the remote branch on merge (default repo setting). By the time this script runs the branch is gone from the remote, and `gh pr view <branch>` needs the branch to still exist locally OR remotely to resolve to a PR. So it returns nothing, the fallback returns false, and the script refuses.

## Fix
Switch to `gh pr list --search "head:<branch> is:merged"`, which searches GitHub by the historical head-ref name regardless of whether the branch currently exists.

## Smoke test (already verified locally)

Three just-merged-and-remote-deleted branches:

```
$ gh pr list --repo averray-agent/agent --state merged \
  --search "head:agent/operator-app-polish-bundle" --limit 5 \
  --json number --jq 'length'
1
```

Same for `agent/sessions-source-wire-agents-strip` (#41) and `agent/receipts-source-coverage` (#39) — all return `1`. An unmerged branch returns `0`.

## Safety rails preserved
- Refuses to run from inside the target worktree.
- Refuses to finish the base branch (`main`).
- Still tries the fast `git merge-base --is-ancestor` check first for non-squash merges; the GitHub query only runs when the ancestor check fails.

## Files (1)
- `scripts/ops/finish-agent-worktree.sh` — replace `gh pr view` with `gh pr list --search`

## Test plan
- [x] Smoke-tested the new query against three recently-merged-and-deleted branches; all return `1`.
- [x] Verified an unmerged branch returns `0`.
- [ ] **Self-test** — once this PR merges, the next agent worktree finishes (any subsequent PR) should run the script cleanly without falling back to manual cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)