### PR TITLE
operator-app: polish ResolvedCard on-chain settlement meta

### DIFF
--- a/app/components/disputes/DisputeDrawerBody.tsx
+++ b/app/components/disputes/DisputeDrawerBody.tsx
@@ -306,6 +306,51 @@ function PartyBlock({
   );
 }
 
+// Polkadot Asset Hub block-explorer (Subscan). Hardcoded as the
+// platform's settlement chain today; if/when settlement moves to
+// another chain, swap this constant or thread the explorer URL
+// through the dispute payload.
+const SUBSCAN_EXTRINSIC_BASE =
+  "https://assethub-polkadot.subscan.io/extrinsic/";
+
+const CHAIN_STATUS_LABEL: Record<string, string> = {
+  confirmed: "Confirmed",
+  submitted: "Submitted",
+  local_only: "Local only",
+  settled_by_verdict: "Settled by verdict",
+};
+
+const CHAIN_STATUS_DOT_CLASS: Record<string, string> = {
+  confirmed: "bg-[var(--avy-accent)]",
+  settled_by_verdict: "bg-[var(--avy-accent)]",
+  submitted: "bg-[#254e9a]",
+  local_only: "bg-[var(--avy-warn)]",
+};
+
+function humaniseChainStatus(status: string): string {
+  return CHAIN_STATUS_LABEL[status] ?? status.replace(/_/g, " ");
+}
+
+function chainStatusDotClass(status: string): string {
+  return CHAIN_STATUS_DOT_CLASS[status] ?? "bg-[var(--avy-muted)]";
+}
+
+function shortHash(hash: string): string {
+  if (hash.length <= 14) return hash;
+  return `${hash.slice(0, 8)}…${hash.slice(-4)}`;
+}
+
+function isLinkableUri(value: string): boolean {
+  return /^(?:https?|ipfs):\/\//u.test(value);
+}
+
+function formatPayoutAmount(value: number): string {
+  return value.toLocaleString("en-US", {
+    minimumFractionDigits: Number.isInteger(value) ? 0 : 2,
+    maximumFractionDigits: 4,
+  });
+}
+
 function ResolvedCard({ dispute }: { dispute: Dispute }) {
   if (!dispute.resolution) return null;
   const {
@@ -319,7 +364,15 @@ function ResolvedCard({ dispute }: { dispute: Dispute }) {
     txHash,
     chainStatus,
     metadataURI,
+    reasoningHash,
   } = dispute.resolution;
+  const hasOnchainMeta =
+    Boolean(reasonCode) ||
+    typeof workerPayout === "number" ||
+    Boolean(chainStatus) ||
+    Boolean(txHash) ||
+    Boolean(metadataURI) ||
+    Boolean(reasoningHash);
   const decisionLabel =
     decision === "uphold"
       ? "Upheld"
@@ -358,36 +411,83 @@ function ResolvedCard({ dispute }: { dispute: Dispute }) {
       >
         Stake → {destinationLabel}
       </div>
-      <div
-        className="grid gap-1 rounded-[8px] border border-[var(--avy-line-soft)] bg-[var(--avy-paper-solid)] px-3 py-2 font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]"
-        style={{ letterSpacing: 0 }}
-      >
-        {reasonCode ? (
-          <span>
-            Reason · <b className="font-semibold text-[var(--avy-ink)]">{reasonCode}</b>
-          </span>
-        ) : null}
-        {typeof workerPayout === "number" ? (
-          <span>
-            Worker payout · <b className="font-semibold text-[var(--avy-ink)]">{workerPayout} DOT</b>
-          </span>
-        ) : null}
-        {chainStatus ? (
-          <span>
-            Chain · <b className="font-semibold text-[var(--avy-ink)]">{chainStatus}</b>
-          </span>
-        ) : null}
-        {txHash ? (
-          <span className="break-all">
-            Tx · <b className="font-semibold text-[var(--avy-accent)]">{txHash}</b>
-          </span>
-        ) : null}
-        {metadataURI ? (
-          <span className="break-all">
-            Reasoning · <b className="font-semibold text-[var(--avy-ink)]">{metadataURI}</b>
-          </span>
-        ) : null}
-      </div>
+      {hasOnchainMeta ? (
+        <div
+          className="grid gap-1 rounded-[8px] border border-[var(--avy-line-soft)] bg-[var(--avy-paper-solid)] px-3 py-2 font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]"
+          style={{ letterSpacing: 0 }}
+        >
+          {reasonCode ? (
+            <span>
+              Reason ·{" "}
+              <b className="font-semibold text-[var(--avy-ink)]">{reasonCode}</b>
+            </span>
+          ) : null}
+          {typeof workerPayout === "number" ? (
+            <span>
+              Worker payout ·{" "}
+              <b className="font-semibold text-[var(--avy-ink)]">
+                {formatPayoutAmount(workerPayout)} DOT
+              </b>
+            </span>
+          ) : null}
+          {chainStatus ? (
+            <span className="inline-flex items-center gap-1.5">
+              <span
+                className={`h-1.5 w-1.5 rounded-full ${chainStatusDotClass(chainStatus)}`}
+                aria-hidden="true"
+              />
+              <span>
+                Chain ·{" "}
+                <b className="font-semibold text-[var(--avy-ink)]">
+                  {humaniseChainStatus(chainStatus)}
+                </b>
+              </span>
+            </span>
+          ) : null}
+          {txHash ? (
+            <span>
+              Tx ·{" "}
+              <a
+                href={`${SUBSCAN_EXTRINSIC_BASE}${txHash}`}
+                target="_blank"
+                rel="noreferrer noopener"
+                title={txHash}
+                className="font-semibold text-[var(--avy-accent)] hover:underline"
+              >
+                {shortHash(txHash)} ↗
+              </a>
+            </span>
+          ) : null}
+          {metadataURI ? (
+            <span className="break-all">
+              Reasoning URI ·{" "}
+              {isLinkableUri(metadataURI) ? (
+                <a
+                  href={metadataURI}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="font-semibold text-[var(--avy-ink)] hover:text-[var(--avy-accent)] hover:underline"
+                >
+                  {metadataURI} ↗
+                </a>
+              ) : (
+                <b className="font-semibold text-[var(--avy-ink)]">{metadataURI}</b>
+              )}
+            </span>
+          ) : null}
+          {reasoningHash ? (
+            <span>
+              Reasoning hash ·{" "}
+              <b
+                className="font-semibold text-[var(--avy-ink)]"
+                title={reasoningHash}
+              >
+                {shortHash(reasoningHash)}
+              </b>
+            </span>
+          ) : null}
+        </div>
+      ) : null}
       <p
         className="m-0 text-[13px] leading-snug text-[var(--avy-ink)]"
         style={{ letterSpacing: 0 }}

--- a/app/components/disputes/types.ts
+++ b/app/components/disputes/types.ts
@@ -119,5 +119,11 @@ export interface Dispute {
     txHash?: string;
     chainStatus?: string;
     metadataURI?: string;
+    /**
+     * Mirrors the top-level `reasoningHash` so the resolved-verdict
+     * card can render the verifier-attested content hash alongside
+     * the metadataURI it points to.
+     */
+    reasoningHash?: string;
   };
 }

--- a/app/lib/api/dispute-adapters.ts
+++ b/app/lib/api/dispute-adapters.ts
@@ -45,6 +45,7 @@ export function extractDispute(data: unknown): Dispute | null {
   const chainStatus = text(record.chainStatus, "");
   const reasonCode = text(record.reasonCode, "");
   const metadataURI = text(record.metadataURI, "");
+  const reasoningHash = text(record.reasoningHash, "");
 
   return {
     id,
@@ -61,7 +62,7 @@ export function extractDispute(data: unknown): Dispute | null {
     workerPayout,
     remainingPayout,
     reasonCode: reasonCode || undefined,
-    reasoningHash: text(record.reasoningHash, "") || undefined,
+    reasoningHash: reasoningHash || undefined,
     metadataURI: metadataURI || undefined,
     txHash: txHash || undefined,
     chainStatus: chainStatus || undefined,
@@ -85,6 +86,7 @@ export function extractDispute(data: unknown): Dispute | null {
           txHash: txHash || undefined,
           chainStatus: chainStatus || undefined,
           metadataURI: metadataURI || undefined,
+          reasoningHash: reasoningHash || undefined,
         }
       : undefined,
   };


### PR DESCRIPTION
## Summary
Audit follow-ups against PR [#42](https://github.com/averray-agent/agent/pull/42)'s resolved-verdict card. One bug, five small polish items, all in the same drawer card.

**Bug**: the meta block (Reason / Worker payout / Chain / Tx / Reasoning) always rendered an empty bordered card on resolved disputes that carried none of those optional fields — e.g. local-only verdicts that decided before the on-chain settlement landed. Now the whole grid is wrapped in a `hasOnchainMeta` conditional that only renders when at least one field is truthy.

**Polish**

- **`chainStatus` humanised + tone-coded dot.** Raw backend literals (`confirmed | submitted | local_only | settled_by_verdict`) now map to human labels and a coloured dot — green for confirmed / settled_by_verdict, blue for submitted, amber for local_only, neutral for anything else. Operators scan chain status fastest, so visual weight matters.
- **`txHash` linked to Subscan.** `https://assethub-polkadot.subscan.io/extrinsic/{hash}` opens in a new tab. Visually rendered as `0x12345678…abcd ↗` with the full hash in `title` + `href`. Click → verify on chain.
- **`metadataURI` is now an anchor when it's URI-like.** `https?://` or `ipfs://` values render as a real link with a `↗`. Opaque values fall back to plain text.
- **`workerPayout` formatted.** `1234.5 DOT` reads as `1,234.5 DOT` (locale-aware, 0 fraction digits for whole numbers, up to 4 for decimals).
- **`reasoningHash` mirrored onto `resolution`** (was top-level only). Now renders as a new `Reasoning hash` row alongside `Reasoning URI` so the verifier-attested content hash and the URI it points to are both visible without scrolling. Also renamed the existing label `Reasoning` → `Reasoning URI` to differentiate.

## Files (3)
- `app/components/disputes/types.ts` — add `reasoningHash?` to `Dispute["resolution"]`
- `app/lib/api/dispute-adapters.ts` — thread `reasoningHash` into the resolution branch
- `app/components/disputes/DisputeDrawerBody.tsx` — helpers (Subscan base, chain-status maps, hash shortener, URI sniff, payout format) + rewritten meta block

## Test plan
- [x] `npm run typecheck:app`
- [x] `npm run build:frontend` (15/15 pages)
- [ ] /disputes → resolved fixture (`d_4df10`): meta block omitted (no on-chain fields) instead of rendering empty bordered box
- [ ] /disputes → resolved dispute with on-chain fields populated: chain dot tone matches status; tx hash shows shortened with `↗` and links to Subscan; metadataURI clickable when URL-like; workerPayout formatted; reasoning hash row visible
- [ ] Long txHash + metadataURI render with `break-all` and don't push the drawer wider

🤖 Generated with [Claude Code](https://claude.com/claude-code)