### PR TITLE
Add provider operations status

### DIFF
--- a/docs/PUBLIC_JOB_SOURCES.md
+++ b/docs/PUBLIC_JOB_SOURCES.md
@@ -160,3 +160,22 @@ Each source should get:
 - one or more output schemas
 - a small ready-to-post job bundle
 - a later ingestion script only after the job shape is proven useful
+
+## Provider Operations Status
+
+`GET /admin/status` includes a normalized `providerOperations` object for the
+operator dashboard. It is keyed by source:
+
+- `github`
+- `wikipedia`
+- `osv`
+- `openData`
+- `standards`
+- `openApi`
+
+Each provider entry reports `label`, `enabled`, `running`, `dryRun`, `mode`,
+`health`, `intervalMs`, `maxJobsPerRun`, `maxOpenJobs`, `currentOpenJobs`,
+`targetCount`, `lastRunAt`, and a compact `lastRun` summary. The older
+provider-specific fields such as `osvIngestion` and `openDataIngestion` remain
+available for compatibility, but new admin UI should render from
+`providerOperations`.

--- a/docs/READY_TO_POST_JOBS.md
+++ b/docs/READY_TO_POST_JOBS.md
@@ -535,6 +535,13 @@ OPENAPI_INGEST_SPECS_JSON='[{"provider":"averray","specId":"averray-http-api","a
 Review `openApiIngestion.lastRun` in `/admin/status`, then switch
 `OPENAPI_INGEST_DRY_RUN=false` when the candidates are ready to create jobs.
 
+The operator dashboard should prefer `/admin/status.providerOperations` over
+the individual ingestion fields. It normalizes GitHub, Wikipedia, OSV,
+Data.gov, standards, and OpenAPI providers into one shape with `mode`,
+`health`, queue caps, current open-job count, target count, and last-run
+summary. The individual fields such as `openApiIngestion` remain for
+backward-compatible diagnostics.
+
 The generated jobs use:
 
 - `schema://jobs/openapi-quality-audit-input`

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -18,6 +18,15 @@ const STARTER_REPUTATION = {
   tier: "starter"
 };
 
+const INGESTION_PROVIDER_DEFINITIONS = [
+  ["github", "githubIngestion", "GitHub issues", "queryCount"],
+  ["wikipedia", "wikipediaIngestion", "Wikipedia maintenance", "categoryCount"],
+  ["osv", "osvIngestion", "OSV advisories", "packageCount"],
+  ["openData", "openDataIngestion", "Open data", "datasetCount"],
+  ["standards", "standardsIngestion", "Standards freshness", "specCount"],
+  ["openApi", "openApiIngestion", "OpenAPI quality", "specCount"]
+];
+
 export class PlatformService {
   constructor(
     jobs,
@@ -136,6 +145,7 @@ export class PlatformService {
         minScore: 0,
         maxJobsPerRun: 0,
         maxOpenJobs: 0,
+        currentOpenJobs: 0,
         lastRun: undefined
       },
       this.wikipediaMaintenanceIngestionScheduler?.getStatus?.() ?? {
@@ -148,6 +158,7 @@ export class PlatformService {
         minScore: 0,
         maxJobsPerRun: 0,
         maxOpenJobs: 0,
+        currentOpenJobs: 0,
         lastRun: undefined
       },
       this.osvAdvisoryIngestionScheduler?.getStatus?.() ?? {
@@ -159,6 +170,7 @@ export class PlatformService {
         minScore: 0,
         maxJobsPerRun: 0,
         maxOpenJobs: 0,
+        currentOpenJobs: 0,
         lastRun: undefined
       },
       this.openDataIngestionScheduler?.getStatus?.() ?? {
@@ -171,6 +183,7 @@ export class PlatformService {
         minScore: 0,
         maxJobsPerRun: 0,
         maxOpenJobs: 0,
+        currentOpenJobs: 0,
         lastRun: undefined
       },
       this.standardsSpecIngestionScheduler?.getStatus?.() ?? {
@@ -182,6 +195,7 @@ export class PlatformService {
         minScore: 0,
         maxJobsPerRun: 0,
         maxOpenJobs: 0,
+        currentOpenJobs: 0,
         lastRun: undefined
       },
       this.openApiSpecIngestionScheduler?.getStatus?.() ?? {
@@ -193,6 +207,7 @@ export class PlatformService {
         minScore: 0,
         maxJobsPerRun: 0,
         maxOpenJobs: 0,
+        currentOpenJobs: 0,
         lastRun: undefined
       },
       this.jobExecutionService.listRecentSessions(14)
@@ -244,6 +259,14 @@ export class PlatformService {
         });
       }
     }
+    const providerOperations = buildProviderOperations({
+      githubIngestion,
+      wikipediaIngestion,
+      osvIngestion,
+      openDataIngestion,
+      standardsIngestion,
+      openApiIngestion
+    });
 
     return {
       auth: auth
@@ -284,6 +307,7 @@ export class PlatformService {
       },
       recurring: recurring,
       scheduler,
+      providerOperations,
       githubIngestion: githubIngestion,
       wikipediaIngestion: wikipediaIngestion,
       osvIngestion: osvIngestion,
@@ -617,4 +641,123 @@ export class PlatformService {
   async ingestVerification(sessionId, verdict) {
     return this.verificationIngestionService.ingest(sessionId, verdict);
   }
+}
+
+function buildProviderOperations(statuses) {
+  const entries = INGESTION_PROVIDER_DEFINITIONS.map(([key, statusKey, label, targetCountField]) => {
+    const status = statuses[statusKey] ?? {};
+    return [key, buildProviderOperationStatus({
+      label,
+      status,
+      targetCountField
+    })];
+  });
+  return Object.fromEntries(entries);
+}
+
+function buildProviderOperationStatus({ label, status, targetCountField }) {
+  const lastRun = summarizeProviderLastRun(status.lastRun);
+  const currentOpenJobs = status.currentOpenJobs !== undefined
+    ? toNonNegativeInteger(status.currentOpenJobs)
+    : inferCurrentOpenJobs(status.lastRun);
+  return {
+    label,
+    enabled: Boolean(status.enabled),
+    running: Boolean(status.running),
+    dryRun: status.dryRun !== false,
+    mode: !status.enabled ? "disabled" : (status.dryRun === false ? "live" : "dry_run"),
+    intervalMs: toNonNegativeInteger(status.intervalMs),
+    maxJobsPerRun: toNonNegativeInteger(status.maxJobsPerRun),
+    maxOpenJobs: toNonNegativeInteger(status.maxOpenJobs),
+    currentOpenJobs,
+    targetCount: toNonNegativeInteger(status[targetCountField]),
+    lastRunAt: lastRun?.finishedAt ?? lastRun?.startedAt,
+    lastRun,
+    health: summarizeProviderHealth({
+      enabled: Boolean(status.enabled),
+      dryRun: status.dryRun !== false,
+      currentOpenJobs,
+      maxOpenJobs: toNonNegativeInteger(status.maxOpenJobs),
+      lastRun
+    })
+  };
+}
+
+function summarizeProviderLastRun(lastRun) {
+  if (!lastRun || typeof lastRun !== "object") {
+    return undefined;
+  }
+  const skippedCount = countSkipped(lastRun);
+  const errorCount = Array.isArray(lastRun.errors) ? lastRun.errors.length : 0;
+  const createdCount = toNonNegativeInteger(lastRun.createdCount);
+  const candidateCount = toNonNegativeInteger(lastRun.candidateCount);
+  const skipped = collectSkipped(lastRun);
+  return {
+    startedAt: stringOrUndefined(lastRun.startedAt),
+    finishedAt: stringOrUndefined(lastRun.finishedAt),
+    dryRun: lastRun.dryRun !== false,
+    candidateCount,
+    createdCount,
+    skippedCount,
+    errorCount,
+    summary: summarizeLastRunText({ candidateCount, createdCount, skippedCount, errorCount }),
+    skipped: skipped.slice(0, 5),
+    errors: Array.isArray(lastRun.errors) ? lastRun.errors.slice(0, 5) : []
+  };
+}
+
+function summarizeLastRunText({ candidateCount, createdCount, skippedCount, errorCount }) {
+  return `${candidateCount} candidate(s), ${createdCount} created, ${skippedCount} skipped, ${errorCount} error(s)`;
+}
+
+function summarizeProviderHealth({ enabled, dryRun, currentOpenJobs, maxOpenJobs, lastRun }) {
+  if (!enabled) {
+    return "disabled";
+  }
+  if (lastRun?.errorCount > 0) {
+    return "error";
+  }
+  if (maxOpenJobs > 0 && currentOpenJobs >= maxOpenJobs) {
+    return "at_capacity";
+  }
+  if (dryRun) {
+    return "dry_run";
+  }
+  return "healthy";
+}
+
+function countSkipped(lastRun) {
+  return collectSkipped(lastRun).length;
+}
+
+function collectSkipped(lastRun) {
+  const topLevel = Array.isArray(lastRun.skipped) ? lastRun.skipped : [];
+  const queryLevel = Array.isArray(lastRun.queries)
+    ? lastRun.queries.flatMap((query) => Array.isArray(query.skipped) ? query.skipped : [])
+    : [];
+  return [...topLevel, ...queryLevel];
+}
+
+function inferCurrentOpenJobs(lastRun) {
+  if (!lastRun || typeof lastRun !== "object") {
+    return 0;
+  }
+  for (const key of ["openGithubJobs", "openWikipediaJobs", "openOsvJobs", "openDataJobs", "openStandardsJobs", "openApiJobs"]) {
+    if (lastRun[key] !== undefined) {
+      return toNonNegativeInteger(lastRun[key]);
+    }
+  }
+  return 0;
+}
+
+function toNonNegativeInteger(value) {
+  const number = Number(value ?? 0);
+  if (!Number.isFinite(number) || number < 0) {
+    return 0;
+  }
+  return Math.trunc(number);
+}
+
+function stringOrUndefined(value) {
+  return typeof value === "string" && value.trim() ? value : undefined;
 }

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -138,6 +138,49 @@ test("getAdminStatus surfaces recurring scheduler anomalies", async () => {
 
 test("getAdminStatus surfaces public source ingestion scheduler status", async () => {
   const service = makePlatformService();
+  service.githubIssueIngestionScheduler = {
+    getStatus() {
+      return {
+        enabled: true,
+        running: true,
+        dryRun: true,
+        intervalMs: 900000,
+        queryCount: 2,
+        maxJobsPerRun: 2,
+        maxOpenJobs: 12,
+        currentOpenJobs: 3,
+        lastRun: {
+          startedAt: "2026-04-27T08:00:00.000Z",
+          finishedAt: "2026-04-27T08:00:02.000Z",
+          candidateCount: 4,
+          createdCount: 1,
+          errors: [],
+          queries: [
+            {
+              query: "repo:averray-agent/agent label:good-first-issue",
+              skipped: [{ id: "github-1", reason: "source_already_ingested" }]
+            }
+          ]
+        }
+      };
+    }
+  };
+  service.wikipediaMaintenanceIngestionScheduler = {
+    getStatus() {
+      return {
+        enabled: true,
+        running: true,
+        dryRun: true,
+        intervalMs: 1800000,
+        language: "en",
+        categoryCount: 1,
+        maxJobsPerRun: 2,
+        maxOpenJobs: 10,
+        currentOpenJobs: 0,
+        lastRun: { candidateCount: 0, createdCount: 0, skipped: [{ reason: "no_candidates" }], errors: [] }
+      };
+    }
+  };
   service.osvAdvisoryIngestionScheduler = {
     getStatus() {
       return {
@@ -146,7 +189,10 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
         dryRun: true,
         intervalMs: 3600000,
         packageCount: 1,
-        lastRun: { createdCount: 0 }
+        maxJobsPerRun: 2,
+        maxOpenJobs: 20,
+        currentOpenJobs: 2,
+        lastRun: { candidateCount: 2, createdCount: 0, skipped: [], errors: [] }
       };
     }
   };
@@ -159,7 +205,10 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
         intervalMs: 3600000,
         query: "res_format:CSV",
         datasetCount: 0,
-        lastRun: { createdCount: 2 }
+        maxJobsPerRun: 2,
+        maxOpenJobs: 20,
+        currentOpenJobs: 4,
+        lastRun: { candidateCount: 2, createdCount: 2, skipped: [], errors: [] }
       };
     }
   };
@@ -171,7 +220,10 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
         dryRun: true,
         intervalMs: 3600000,
         specCount: 2,
-        lastRun: { createdCount: 1 }
+        maxJobsPerRun: 2,
+        maxOpenJobs: 20,
+        currentOpenJobs: 1,
+        lastRun: { candidateCount: 1, createdCount: 1, skipped: [], errors: [] }
       };
     }
   };
@@ -183,7 +235,10 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
         dryRun: true,
         intervalMs: 3600000,
         specCount: 1,
-        lastRun: { createdCount: 1 }
+        maxJobsPerRun: 2,
+        maxOpenJobs: 20,
+        currentOpenJobs: 1,
+        lastRun: { candidateCount: 1, createdCount: 1, skipped: [], errors: [{ message: "temporary upstream failure" }] }
       };
     }
   };
@@ -194,6 +249,17 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
   assert.equal(status.openDataIngestion.lastRun.createdCount, 2);
   assert.equal(status.standardsIngestion.specCount, 2);
   assert.equal(status.openApiIngestion.specCount, 1);
+  assert.equal(status.providerOperations.github.label, "GitHub issues");
+  assert.equal(status.providerOperations.github.mode, "dry_run");
+  assert.equal(status.providerOperations.github.currentOpenJobs, 3);
+  assert.equal(status.providerOperations.github.lastRun.createdCount, 1);
+  assert.equal(status.providerOperations.github.lastRun.skippedCount, 1);
+  assert.equal(status.providerOperations.github.lastRun.skipped[0].reason, "source_already_ingested");
+  assert.equal(status.providerOperations.openData.mode, "live");
+  assert.equal(status.providerOperations.openData.health, "healthy");
+  assert.equal(status.providerOperations.openData.lastRun.summary, "2 candidate(s), 2 created, 0 skipped, 0 error(s)");
+  assert.equal(status.providerOperations.openApi.health, "error");
+  assert.equal(status.providerOperations.openApi.lastRun.errorCount, 1);
 });
 
 test("finalizeXcmRequest records async treasury settlement when the request is strategy-backed", async () => {

--- a/mcp-server/src/services/github-issue-ingestion-scheduler.js
+++ b/mcp-server/src/services/github-issue-ingestion-scheduler.js
@@ -56,6 +56,7 @@ export class GithubIssueIngestionScheduler {
       minScore: this.minScore,
       maxJobsPerRun: this.maxJobsPerRun,
       maxOpenJobs: this.maxOpenJobs,
+      currentOpenJobs: this.countOpenGithubJobs(),
       lastRun: this.lastRun
     };
   }

--- a/mcp-server/src/services/open-data-ingestion-scheduler.js
+++ b/mcp-server/src/services/open-data-ingestion-scheduler.js
@@ -57,6 +57,7 @@ export class OpenDataIngestionScheduler {
       minScore: this.minScore,
       maxJobsPerRun: this.maxJobsPerRun,
       maxOpenJobs: this.maxOpenJobs,
+      currentOpenJobs: this.countOpenDataJobs(),
       lastRun: this.lastRun
     };
   }

--- a/mcp-server/src/services/openapi-spec-ingestion-scheduler.js
+++ b/mcp-server/src/services/openapi-spec-ingestion-scheduler.js
@@ -54,6 +54,7 @@ export class OpenApiSpecIngestionScheduler {
       minScore: this.minScore,
       maxJobsPerRun: this.maxJobsPerRun,
       maxOpenJobs: this.maxOpenJobs,
+      currentOpenJobs: this.countOpenApiJobs(),
       lastRun: this.lastRun
     };
   }

--- a/mcp-server/src/services/osv-advisory-ingestion-scheduler.js
+++ b/mcp-server/src/services/osv-advisory-ingestion-scheduler.js
@@ -60,6 +60,7 @@ export class OsvAdvisoryIngestionScheduler {
       maxJobsPerRun: this.maxJobsPerRun,
       maxPackageTargets: this.maxPackageTargets,
       maxOpenJobs: this.maxOpenJobs,
+      currentOpenJobs: this.countOpenOsvJobs(),
       lastRun: this.lastRun
     };
   }

--- a/mcp-server/src/services/standards-spec-ingestion-scheduler.js
+++ b/mcp-server/src/services/standards-spec-ingestion-scheduler.js
@@ -54,6 +54,7 @@ export class StandardsSpecIngestionScheduler {
       minScore: this.minScore,
       maxJobsPerRun: this.maxJobsPerRun,
       maxOpenJobs: this.maxOpenJobs,
+      currentOpenJobs: this.countOpenStandardsJobs(),
       lastRun: this.lastRun
     };
   }

--- a/mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.js
+++ b/mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.js
@@ -57,6 +57,7 @@ export class WikipediaMaintenanceIngestionScheduler {
       minScore: this.minScore,
       maxJobsPerRun: this.maxJobsPerRun,
       maxOpenJobs: this.maxOpenJobs,
+      currentOpenJobs: this.countOpenWikipediaJobs(),
       lastRun: this.lastRun
     };
   }


### PR DESCRIPTION
## Summary
- add normalized /admin/status.providerOperations for all public ingestion providers
- expose current open-job counts from provider schedulers
- document the frontend/operator dashboard contract while preserving raw ingestion fields

## Tests
- npm --workspace mcp-server test
- git diff --check