### PR TITLE
site: bug fixes + nav coherence + per-page social meta + a11y polish

### DIFF
--- a/marketing/src/layouts/BaseLayout.astro
+++ b/marketing/src/layouts/BaseLayout.astro
@@ -2,11 +2,14 @@
 interface Props {
   title: string;
   description?: string;
+  /** Optional override for the canonical / og:url. Defaults to the marketing root. */
+  canonicalUrl?: string;
 }
 
 const {
   title,
-  description = "Averray is agent-native work, identity, and verifier-aware execution infrastructure for the machine economy."
+  description = "Averray is agent-native work, identity, and verifier-aware execution infrastructure for the machine economy.",
+  canonicalUrl = "https://averray.com/"
 } = Astro.props;
 
 const structuredData = {
@@ -33,6 +36,22 @@ const structuredData = {
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{title}</title>
     <meta name="description" content={description} />
+    <link rel="canonical" href={canonicalUrl} />
+
+    <!-- Open Graph + Twitter card. og:image is intentionally not set
+         today — we don't yet have a brand-approved social preview asset.
+         Adding one is a small drop-in: set `og:image` (1200x630),
+         `og:image:alt`, `twitter:image`, and the card type will pick
+         it up. -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:site_name" content="Averray" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/marketing/src/pages/index.astro
+++ b/marketing/src/pages/index.astro
@@ -2,6 +2,14 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 import "../styles/global.css";
 
+// Full canonical example wallet — used wherever the homepage links out
+// to a live profile read. Truncated forms are display-only; never use a
+// shortened address as an `href` because the API path matches the full
+// 0x{40} hex string and a truncated href 404s on api.averray.com.
+const EXAMPLE_WALLET_FULL = "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519";
+const EXAMPLE_WALLET_DISPLAY = "0xFd2EAE…6519";
+const FOOTER_YEAR = new Date().getFullYear();
+
 const pillars = [
   {
     num: "01",
@@ -64,7 +72,7 @@ const lifecycle = [
     num: "04",
     title: "Compound",
     body: "The receipt joins the wallet's public trail. Next counterparty reads it before they hire.",
-    proof: "/agents/0xFd2EAE…6519"
+    proof: `/agents/${EXAMPLE_WALLET_DISPLAY}`
   }
 ];
 
@@ -86,8 +94,8 @@ const proofLinks = [
   },
   {
     label: "Public worker profile",
-    endpoint: "/agents/0xFd2EAE…6519",
-    href: "https://api.averray.com/agents/0xFd2EAE6519"
+    endpoint: `/agents/${EXAMPLE_WALLET_DISPLAY}`,
+    href: `https://api.averray.com/agents/${EXAMPLE_WALLET_FULL}`
   }
 ];
 
@@ -113,8 +121,8 @@ const receipts = [
   {
     label: "Profile",
     claim: "A wallet's public trail, signed and cumulative.",
-    endpoint: "/agents/0xFd2EAE…6519",
-    href: "https://api.averray.com/agents/0xFd2EAE6519"
+    endpoint: `/agents/${EXAMPLE_WALLET_DISPLAY}`,
+    href: `https://api.averray.com/agents/${EXAMPLE_WALLET_FULL}`
   }
 ];
 
@@ -172,6 +180,8 @@ const capital = [
         <a href="#lifecycle">How it works</a>
         <a href="#receipts">Receipts</a>
         <a href="#builders">Builders</a>
+        <a href="https://averray.com/trust/">Trust</a>
+        <a href="https://averray.com/schemas/">Schemas</a>
       </div>
       <a class="nav__cta" href="https://app.averray.com">
         Open operator app <span class="arrow" aria-hidden="true">→</span>
@@ -353,7 +363,6 @@ const capital = [
       <div class="audiences">
         {audiences.map((a) => (
           <article class="aud">
-            <p class="eyebrow">{a.name}</p>
             <h3 class="aud__who">{a.name}</h3>
             <p class="aud__claim">{a.claim}</p>
             <a class="aud__link" href={a.href}>{a.linkLabel}</a>
@@ -400,7 +409,7 @@ const capital = [
     <footer class="footer">
       <div class="footer__brand">
         <span class="footer__brand-mark" aria-hidden="true">A</span>
-        Averray · © 2026 · receipts, not vibes.
+        Averray · © {FOOTER_YEAR} · receipts, not vibes.
       </div>
       <div class="footer__links">
         <a href="https://docs.averray.com">Docs</a>

--- a/marketing/src/styles/global.css
+++ b/marketing/src/styles/global.css
@@ -9,30 +9,32 @@
 :root {
   color-scheme: light;
 
-  /* ----- Palette ----- */
-  --avy-bg:           #f3f1ea;
-  --avy-bg-marketing: #f6f1e8;
-  --avy-paper:        rgba(255, 253, 247, 0.88);
-  --avy-paper-solid:  #fffdf7;
-  --avy-paper-alt:    #f7f9fa;
+  /* ----- Palette -----
+     Mirrors handoffs/.../colors_and_type.css. Comments preserved
+     so future edits remember what each token means semantically. */
+  --avy-bg:           #f3f1ea; /* paper · room background */
+  --avy-bg-marketing: #f6f1e8; /* paper · marketing wash, slightly warmer */
+  --avy-paper:        rgba(255, 253, 247, 0.88); /* card surface, layered */
+  --avy-paper-solid:  #fffdf7; /* card surface, solid */
+  --avy-paper-alt:    #f7f9fa; /* console / data surface */
 
-  --avy-ink:          #111315;
-  --avy-muted:        #5f655f;
-  --avy-line:         rgba(17, 19, 21, 0.12);
-  --avy-line-soft:    rgba(17, 19, 21, 0.08);
+  --avy-ink:          #111315; /* primary text, near-black */
+  --avy-muted:        #5f655f; /* secondary text, sage-tinted grey */
+  --avy-line:         rgba(17, 19, 21, 0.12); /* hairline border */
+  --avy-line-soft:    rgba(17, 19, 21, 0.08); /* whisper border */
 
-  --avy-accent:       #1e6642;
-  --avy-accent-2:     #0f6b4f;
-  --avy-accent-soft:  #d6eadf;
-  --avy-accent-wash:  rgba(30, 102, 66, 0.10);
+  --avy-accent:       #1e6642; /* sage — primary brand */
+  --avy-accent-2:     #0f6b4f; /* sage — pressed / hovered */
+  --avy-accent-soft:  #d6eadf; /* sage tint — chip background */
+  --avy-accent-wash:  rgba(30, 102, 66, 0.10); /* sage wash, transparent */
 
-  --avy-warm:         #f1d8b8;
-  --avy-warn:         #a76122;
-  --avy-warn-soft:    #f4e3cf;
+  --avy-warm:         #f1d8b8; /* warm tan — paper accent */
+  --avy-warn:         #a76122; /* terracotta — caution */
+  --avy-warn-soft:    #f4e3cf; /* terracotta wash */
 
-  --avy-blue:         #254e9a;
-  --avy-dark:         #101419;
-  --avy-dark-soft:    #171f28;
+  --avy-blue:         #254e9a; /* blue — info / submitted state */
+  --avy-dark:         #101419; /* deep hero ink */
+  --avy-dark-soft:    #171f28; /* deep hero alt */
 
   --fg1: var(--avy-ink);
   --fg2: var(--avy-muted);
@@ -130,6 +132,21 @@ a:hover { color: var(--avy-ink); }
 .btn--ghost { background: rgba(255, 255, 255, 0.65); color: var(--avy-ink); border-color: var(--avy-line); }
 .btn--ghost:hover { background: #fffdf7; border-color: rgba(30, 102, 66, 0.22); }
 .btn .arrow { font-family: var(--font-body); font-weight: 500; letter-spacing: 0; }
+
+/* ----- focus-visible -----
+   Browser default focus rings render as a thin dark line that mostly
+   disappears against the cream paper background. Replace with a
+   sage-tinted ring + ink underline so keyboard users always see where
+   they are. Only applies on `:focus-visible` (real keyboard nav), not
+   on mouse `:focus`, so click targets don't pick up a ring. */
+:where(a, button, [role="button"], input, select, textarea, summary):focus {
+  outline: none;
+}
+:where(a, button, [role="button"], input, select, textarea, summary):focus-visible {
+  outline: 2px solid var(--avy-accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
 
 /* ==========================================
    1. TOP NAV

--- a/site/agent.html
+++ b/site/agent.html
@@ -9,6 +9,20 @@
       content="Public agent profile for Averray wallets, rendered from the live agent profile JSON surface."
     />
     <link rel="canonical" href="https://averray.com/agent.html" />
+    <meta property="og:type" content="profile" />
+    <meta property="og:title" content="Averray — Public agent profile" />
+    <meta
+      property="og:description"
+      content="Public agent profile for Averray wallets, rendered from the live agent profile JSON surface."
+    />
+    <meta property="og:url" content="https://averray.com/agent.html" />
+    <meta property="og:site_name" content="Averray" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Averray — Public agent profile" />
+    <meta
+      name="twitter:description"
+      content="Public agent profile for Averray wallets, rendered from the live agent profile JSON surface."
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -17,7 +31,7 @@
     />
     <link rel="stylesheet" href="./styles.css" />
   </head>
-  <body>
+  <body data-nav="agents">
     <div class="site-shell">
       <nav class="site-nav">
         <div class="brand">
@@ -25,8 +39,11 @@
           <span class="brand-copy">Public agent profile</span>
         </div>
         <div class="nav-links">
-          <a href="./">Home</a>
-          <a href="./agents/">Agents</a>
+          <a href="./" data-nav-link="home">Home</a>
+          <a href="./agents/" data-nav-link="agents">Agents</a>
+          <a href="./builders/" data-nav-link="builders">Builders</a>
+          <a href="./trust/" data-nav-link="trust">Trust</a>
+          <a href="./schemas/" data-nav-link="schemas">Schemas</a>
           <a href="https://app.averray.com" class="button">Open app</a>
         </div>
       </nav>

--- a/site/agents/index.html
+++ b/site/agents/index.html
@@ -9,6 +9,20 @@
       content="Agent guide for Averray: discovery manifest, SIWE auth, onboarding, starter loop, and public profile and badge surfaces."
     />
     <link rel="canonical" href="https://averray.com/agents/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Averray — For agents" />
+    <meta
+      property="og:description"
+      content="Agent guide for Averray: discovery manifest, SIWE auth, onboarding, starter loop, and public profile and badge surfaces."
+    />
+    <meta property="og:url" content="https://averray.com/agents/" />
+    <meta property="og:site_name" content="Averray" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Averray — For agents" />
+    <meta
+      name="twitter:description"
+      content="Agent guide for Averray: discovery manifest, SIWE auth, onboarding, starter loop, and public profile and badge surfaces."
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/site/builders/index.html
+++ b/site/builders/index.html
@@ -9,6 +9,20 @@
       content="Builder entrypoints for Averray: API base, discovery manifest, auth model, public identity schemas, and integration surfaces."
     />
     <link rel="canonical" href="https://averray.com/builders/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Averray — Builders" />
+    <meta
+      property="og:description"
+      content="Builder entrypoints for Averray: API base, discovery manifest, auth model, public identity schemas, and integration surfaces."
+    />
+    <meta property="og:url" content="https://averray.com/builders/" />
+    <meta property="og:site_name" content="Averray" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Averray — Builders" />
+    <meta
+      name="twitter:description"
+      content="Builder entrypoints for Averray: API base, discovery manifest, auth model, public identity schemas, and integration surfaces."
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -94,7 +108,7 @@
             <article class="site-card">
               <p class="label">Read first</p>
               <ul class="muted-list">
-                <li><a href="https://api.averray.com/agent-tools.json" target="_blank" rel="noreferrer">/agent-tools.json</a></li>
+                <li><a href="https://averray.com/.well-known/agent-tools.json" target="_blank" rel="noreferrer">/.well-known/agent-tools.json</a></li>
                 <li><a href="https://api.averray.com/onboarding" target="_blank" rel="noreferrer">/onboarding</a></li>
                 <li><a href="https://api.averray.com/jobs/tiers" target="_blank" rel="noreferrer">/jobs/tiers</a></li>
                 <li><a href="https://api.averray.com/schemas/jobs" target="_blank" rel="noreferrer">/schemas/jobs</a></li>

--- a/site/schemas/index.html
+++ b/site/schemas/index.html
@@ -9,10 +9,24 @@
       content="Public schema index for Averray badge and profile documents, with hosted JSON schema files and example badge assets."
     />
     <link rel="canonical" href="https://averray.com/schemas/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Averray — Schemas" />
+    <meta
+      property="og:description"
+      content="Public schema index for Averray badge and profile documents, with hosted JSON schema files and example badge assets."
+    />
+    <meta property="og:url" content="https://averray.com/schemas/" />
+    <meta property="og:site_name" content="Averray" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Averray — Schemas" />
+    <meta
+      name="twitter:description"
+      content="Public schema index for Averray badge and profile documents, with hosted JSON schema files and example badge assets."
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;700&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../styles.css" />

--- a/site/trust/index.html
+++ b/site/trust/index.html
@@ -9,6 +9,20 @@
       content="Operational trust posture for Averray: deploy verification, multisig setup, audit package, and public schema-backed identity surfaces."
     />
     <link rel="canonical" href="https://averray.com/trust/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Averray — Trust" />
+    <meta
+      property="og:description"
+      content="Operational trust posture for Averray: deploy verification, multisig setup, audit package, and public schema-backed identity surfaces."
+    />
+    <meta property="og:url" content="https://averray.com/trust/" />
+    <meta property="og:site_name" content="Averray" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Averray — Trust" />
+    <meta
+      name="twitter:description"
+      content="Operational trust posture for Averray: deploy verification, multisig setup, audit package, and public schema-backed identity surfaces."
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
## Summary
Eleven follow-ups from the public-site recon. One PR because each is a few lines and they all touch the same surfaces.

**Bugs**

- `site/builders/index.html:97` — `agent-tools.json` link was pointing at `https://api.averray.com/agent-tools.json` (wrong domain prefix, missing `.well-known/`) and 404s in production. Fixed to `https://averray.com/.well-known/agent-tools.json`, matching the canonical URL used everywhere else.
- `site/agent.html` — `<body>` had no `data-nav` and the two nav links had no `data-nav-link`, so `site.js#markCurrentNav` couldn't light up any tab. Added `data-nav="agents"` (the profile is a child of the agents section) plus the full nav (Home / Agents / Builders / Trust / Schemas / Open app).
- `site/schemas/index.html:15` — font import only loaded `Manrope`, missing `Space Grotesk`. Headings were rendering in a fallback. Added Space Grotesk to match every other page.
- `marketing/src/pages/index.astro` — two `href`s pointed at `api.averray.com/agents/0xFd2EAE6519` (truncated 10-char address). The API needs the full 40-char hex string and 404s on the truncated form. Centralised the example wallet into `EXAMPLE_WALLET_FULL` (full address, used in `href`s) and `EXAMPLE_WALLET_DISPLAY` (truncated, used as display-only text).

**Nav coherence**

- Homepage nav was intra-page anchors only and didn't link to `/trust/` or `/schemas/` at all. Added both as cross-page links so all five static sections are reachable from the front door.
- `agent.html` nav restored to the full set the rest of the static pages use.

**Per-page social metadata**

- `BaseLayout.astro` now emits `canonical` + `og:*` + `twitter:card`, driven by a new optional `canonicalUrl` prop. Homepage gets full social-preview metadata.
- Each hand-written static page (`agents/`, `builders/`, `trust/`, `schemas/`, `agent.html`) gains the `og:type` / `og:title` / `og:description` / `og:url` + `twitter:card` block inline. Each carries the page's own title and description, not a generic blob.
- `og:image` is intentionally **not** set today — we don't yet have a brand-approved 1200×630 social preview asset. Documented inline in BaseLayout.astro for the next pass.

**Footer drift**

- Homepage footer hardcoded `© 2026`. Switched to a build-time `FOOTER_YEAR = new Date().getFullYear()` so the year always matches the build.

**Polish**

- `global.css` gains a `:focus-visible` block — browser default focus rings are nearly invisible on cream paper. New ring: 2px sage outline with a 2px offset. Only fires on real keyboard nav (not mouse focus), so click targets stay clean.
- `global.css` palette tokens regained the semantic comments from the design handoff (`sage — primary`, `terracotta — caution`, `deep hero ink` etc.) so future edits remember what each token means.
- Homepage audience section dropped the duplicate `eyebrow` + `aud__who` (each block was printing the audience name twice). Kept the h3 as the heading.

**False positive corrected**

- The recon flagged "no error fallback for profile-loading on agent.html". Verified false: `agent.js:120-122` already updates the loading element with the error message on fetch failure. No change.

## Files (8)
- `marketing/src/pages/index.astro`
- `marketing/src/layouts/BaseLayout.astro`
- `marketing/src/styles/global.css`
- `site/agent.html`
- `site/agents/index.html`
- `site/builders/index.html`
- `site/schemas/index.html`
- `site/trust/index.html`

Generated artifacts (`site/index.html`, `site/_astro/`) intentionally NOT committed per AGENTS.md — CI rebuilds the marketing landing from source.

## Test plan
- [x] `npm run build:site` succeeds (Astro builds, sync runs cleanly)
- [ ] /builders : `/.well-known/agent-tools.json` link in the "Read first" list resolves
- [ ] /agent.html : opening with `?wallet=0x…` lights up the Agents nav tab; nav now shows the full 5-section set
- [ ] /schemas : page headings render in Space Grotesk (matches the other pages)
- [ ] / (homepage) : "Profile" / "Public worker profile" links in proofLinks + receipts now hit a real 200 on api.averray.com (full address)
- [ ] / : nav now includes Trust + Schemas links
- [ ] All pages: `<meta property="og:title">` etc. present in `<head>`
- [ ] Tab through any page: focus ring is clearly visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)