### PR TITLE
Improve open data rotation and dedupe

### DIFF
--- a/docs/PUBLIC_JOB_SOURCES.md
+++ b/docs/PUBLIC_JOB_SOURCES.md
@@ -109,6 +109,10 @@ After Wikipedia, use the same pattern for:
    - Scheduled ingestion is available behind `OPEN_DATA_INGEST_ENABLED`; keep
      `OPEN_DATA_INGEST_DRY_RUN=true` until `/admin/status` shows good
      candidates.
+   - Production rotation can use `OPEN_DATA_INGEST_QUERIES_JSON` to cycle
+     through multiple Data.gov searches. The scheduler dedupes whole datasets
+     already represented in the job catalog, so sibling CSV/GeoJSON/API
+     resources do not crowd out new datasets in later runs.
 
 3. **OSV/NVD advisories**
    - package-to-CVE mapping, remediation summaries

--- a/docs/READY_TO_POST_JOBS.md
+++ b/docs/READY_TO_POST_JOBS.md
@@ -435,10 +435,18 @@ OPEN_DATA_INGEST_INTERVAL_MS=3600000
 OPEN_DATA_INGEST_MAX_JOBS_PER_RUN=2
 OPEN_DATA_INGEST_MAX_OPEN_JOBS=20
 OPEN_DATA_INGEST_QUERY='res_format:CSV'
+# Optional v2 rotation. When set, this wins over the single query knob.
+OPEN_DATA_INGEST_QUERIES_JSON='["traffic crashes","food safety","water quality","building permits"]'
 ```
 
 Review `openDataIngestion.lastRun` in `/admin/status`, then switch
 `OPEN_DATA_INGEST_DRY_RUN=false` when the candidates are ready to create jobs.
+
+The scheduler rotates through `OPEN_DATA_INGEST_QUERIES_JSON` across runs and
+keeps Data.gov audits diverse by refusing sibling resources from datasets that
+already have an open-data job in the catalog. For example, if `Crashes in DC`
+already produced a CSV audit job, a later GeoJSON resource from the same
+dataset is skipped as `dataset_already_ingested`.
 
 The generated jobs use:
 

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -22,7 +22,7 @@ const INGESTION_PROVIDER_DEFINITIONS = [
   ["github", "githubIngestion", "GitHub issues", "queryCount"],
   ["wikipedia", "wikipediaIngestion", "Wikipedia maintenance", "categoryCount"],
   ["osv", "osvIngestion", "OSV advisories", "packageCount"],
-  ["openData", "openDataIngestion", "Open data", "datasetCount"],
+  ["openData", "openDataIngestion", "Open data", "targetCount"],
   ["standards", "standardsIngestion", "Standards freshness", "specCount"],
   ["openApi", "openApiIngestion", "OpenAPI quality", "specCount"]
 ];

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -205,6 +205,7 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
         intervalMs: 3600000,
         query: "res_format:CSV",
         datasetCount: 0,
+        targetCount: 3,
         maxJobsPerRun: 2,
         maxOpenJobs: 20,
         currentOpenJobs: 4,
@@ -257,6 +258,7 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
   assert.equal(status.providerOperations.github.lastRun.skipped[0].reason, "source_already_ingested");
   assert.equal(status.providerOperations.openData.mode, "live");
   assert.equal(status.providerOperations.openData.health, "healthy");
+  assert.equal(status.providerOperations.openData.targetCount, 3);
   assert.equal(status.providerOperations.openData.lastRun.summary, "2 candidate(s), 2 created, 0 skipped, 0 error(s)");
   assert.equal(status.providerOperations.openApi.health, "error");
   assert.equal(status.providerOperations.openApi.lastRun.errorCount, 1);

--- a/mcp-server/src/jobs/ingest-open-data-datasets.js
+++ b/mcp-server/src/jobs/ingest-open-data-datasets.js
@@ -60,9 +60,13 @@ export async function ingestOpenDataDatasets({
   query = DEFAULT_QUERY,
   limit = 10,
   minScore = 55,
+  excludeDatasetKeys = [],
+  excludeResourceKeys = [],
   fetchImpl = fetch
 } = {}) {
   const explicitTargets = parseDatasets(datasets);
+  const excludedDatasets = normalizeKeySet(excludeDatasetKeys);
+  const excludedResources = normalizeKeySet(excludeResourceKeys);
   const targets = explicitTargets.length
     ? explicitTargets
     : await searchDataGovDatasets({ query, limit: Math.max(limit * 3, 30), fetchImpl });
@@ -73,6 +77,16 @@ export async function ingestOpenDataDatasets({
     const score = scoreDatasetTarget(target);
     if (!target.resourceUrl) {
       skipped.push({ datasetId: target.datasetId, resourceId: target.resourceId, reason: "missing_resource_url" });
+      continue;
+    }
+    const resourceKey = openDataResourceKey(target);
+    if (resourceKey && excludedResources.has(resourceKey)) {
+      skipped.push({ datasetId: target.datasetId, resourceId: target.resourceId, reason: "source_already_ingested" });
+      continue;
+    }
+    const datasetKey = openDataDatasetKey(target);
+    if (datasetKey && excludedDatasets.has(datasetKey)) {
+      skipped.push({ datasetId: target.datasetId, resourceId: target.resourceId, reason: "dataset_already_ingested" });
       continue;
     }
     if (score < minScore) {
@@ -232,7 +246,7 @@ export function scoreDatasetTarget(target) {
 export function selectBestResourcePerDataset(candidates, skipped = []) {
   const byDataset = new Map();
   for (const candidate of candidates) {
-    const key = datasetKey(candidate.target);
+    const key = openDataDatasetKey(candidate.target);
     const current = byDataset.get(key);
     if (!current || compareDatasetCandidates(candidate, current) < 0) {
       byDataset.set(key, candidate);
@@ -242,7 +256,7 @@ export function selectBestResourcePerDataset(candidates, skipped = []) {
   const selected = new Set(byDataset.values());
   for (const candidate of candidates) {
     if (selected.has(candidate)) continue;
-    const winner = byDataset.get(datasetKey(candidate.target));
+    const winner = byDataset.get(openDataDatasetKey(candidate.target));
     skipped.push({
       datasetId: candidate.target.datasetId,
       resourceId: candidate.target.resourceId,
@@ -252,6 +266,34 @@ export function selectBestResourcePerDataset(candidates, skipped = []) {
   }
 
   return [...byDataset.values()];
+}
+
+export function openDataDatasetKey(value) {
+  const source = value?.source ?? value;
+  if (!source || (source.type && source.type !== "open_data_dataset")) {
+    return undefined;
+  }
+  const datasetIdentity = source.datasetId || source.datasetUrl || source.datasetTitle;
+  if (!datasetIdentity) {
+    return undefined;
+  }
+  return [
+    String(source.provider ?? source.portal ?? DEFAULT_PROVIDER).trim().toLowerCase(),
+    String(datasetIdentity).trim().toLowerCase()
+  ].join("|");
+}
+
+export function openDataResourceKey(value) {
+  const source = value?.source ?? value;
+  const datasetIdentity = openDataDatasetKey(source);
+  const resourceIdentity = source?.resourceId || source?.resourceUrl;
+  if (!datasetIdentity || !resourceIdentity) {
+    return undefined;
+  }
+  return [
+    datasetIdentity,
+    String(resourceIdentity).trim().toLowerCase()
+  ].join("|");
 }
 
 export function toPlatformJob(target, score = scoreDatasetTarget(target)) {
@@ -416,13 +458,6 @@ function estimateDifficulty(score) {
   return "review-needed";
 }
 
-function datasetKey(target) {
-  return [
-    DEFAULT_PROVIDER,
-    target.datasetId || target.datasetUrl || target.datasetTitle
-  ].map((part) => String(part ?? "").trim().toLowerCase()).join("|");
-}
-
 function compareDatasetCandidates(left, right) {
   const scoreDiff = right.score - left.score;
   if (scoreDiff !== 0) return scoreDiff;
@@ -463,6 +498,13 @@ function slugify(value) {
 function parsePositiveInt(raw, fallback) {
   const value = Number(raw);
   return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function normalizeKeySet(values) {
+  if (!Array.isArray(values)) {
+    return new Set();
+  }
+  return new Set(values.map((value) => String(value ?? "").trim().toLowerCase()).filter(Boolean));
 }
 
 function trimTrailingSlash(value) {

--- a/mcp-server/src/jobs/ingest-open-data-datasets.test.js
+++ b/mcp-server/src/jobs/ingest-open-data-datasets.test.js
@@ -6,6 +6,8 @@ import {
   extractPackageTargets,
   extractCatalogResultTargets,
   ingestOpenDataDatasets,
+  openDataDatasetKey,
+  openDataResourceKey,
   parseDatasets,
   scoreDatasetTarget,
   searchDataGovDatasets,
@@ -172,6 +174,15 @@ test("selectBestResourcePerDataset keeps one high-signal resource per dataset", 
   assert.equal(skipped[0].selectedResourceId, "resource-456");
 });
 
+test("open-data source keys dedupe resources and whole datasets", () => {
+  const job = toPlatformJob(TARGET, 92);
+
+  assert.equal(openDataDatasetKey(TARGET), "data.gov|dataset-123");
+  assert.equal(openDataDatasetKey(job), "data.gov|dataset-123");
+  assert.equal(openDataResourceKey(TARGET), "data.gov|dataset-123|resource-456");
+  assert.equal(openDataResourceKey(job), "data.gov|dataset-123|resource-456");
+});
+
 test("toPlatformJob creates a benchmark open-data audit job", () => {
   const job = toPlatformJob(TARGET, 92);
 
@@ -252,6 +263,36 @@ test("ingestOpenDataDatasets searches Data.gov and filters low-score resources",
 
   assert.equal(payload.count, 1);
   assert.equal(payload.skipped[0].reason, "below_min_score");
+});
+
+test("ingestOpenDataDatasets skips excluded resources and datasets before selecting jobs", async () => {
+  const siblingResource = {
+    ...TARGET,
+    resourceId: "resource-geojson",
+    resourceTitle: "Spending GeoJSON",
+    resourceUrl: "https://example.gov/spending.geojson",
+    resourceFormat: "GEOJSON"
+  };
+
+  const resourceExcluded = await ingestOpenDataDatasets({
+    datasets: [TARGET],
+    excludeResourceKeys: [openDataResourceKey(TARGET)],
+    limit: 5,
+    minScore: 55
+  });
+
+  assert.equal(resourceExcluded.count, 0);
+  assert.equal(resourceExcluded.skipped[0].reason, "source_already_ingested");
+
+  const datasetExcluded = await ingestOpenDataDatasets({
+    datasets: [siblingResource],
+    excludeDatasetKeys: [openDataDatasetKey(TARGET)],
+    limit: 5,
+    minScore: 55
+  });
+
+  assert.equal(datasetExcluded.count, 0);
+  assert.equal(datasetExcluded.skipped[0].reason, "dataset_already_ingested");
 });
 
 test("ingestOpenDataDatasets avoids duplicate resource jobs for one dataset", async () => {

--- a/mcp-server/src/services/open-data-ingestion-scheduler.js
+++ b/mcp-server/src/services/open-data-ingestion-scheduler.js
@@ -1,4 +1,10 @@
-import { DEFAULT_QUERY, ingestOpenDataDatasets, parseDatasets } from "../jobs/ingest-open-data-datasets.js";
+import {
+  DEFAULT_QUERY,
+  ingestOpenDataDatasets,
+  openDataDatasetKey,
+  openDataResourceKey,
+  parseDatasets
+} from "../jobs/ingest-open-data-datasets.js";
 
 export class OpenDataIngestionScheduler {
   constructor(platformService, eventBus = undefined, {
@@ -6,6 +12,7 @@ export class OpenDataIngestionScheduler {
     dryRun = true,
     intervalMs = 60 * 60 * 1000,
     query = DEFAULT_QUERY,
+    queries = undefined,
     datasets = [],
     minScore = 55,
     maxJobsPerRun = 2,
@@ -18,7 +25,8 @@ export class OpenDataIngestionScheduler {
     this.enabled = enabled;
     this.dryRun = dryRun;
     this.intervalMs = intervalMs;
-    this.query = String(query || DEFAULT_QUERY).trim();
+    this.queries = normalizeQueries(queries, query);
+    this.query = this.queries[0] ?? DEFAULT_QUERY;
     this.datasets = parseDatasets(datasets);
     this.minScore = minScore;
     this.maxJobsPerRun = maxJobsPerRun;
@@ -28,6 +36,7 @@ export class OpenDataIngestionScheduler {
     this.timer = undefined;
     this.running = false;
     this.lastRun = undefined;
+    this.nextQueryIndex = 0;
   }
 
   start() {
@@ -53,7 +62,11 @@ export class OpenDataIngestionScheduler {
       dryRun: this.dryRun,
       intervalMs: this.intervalMs,
       query: this.query,
+      queries: this.queries,
+      queryCount: this.queries.length,
+      nextQuery: this.datasets.length ? undefined : this.queries[this.nextQueryIndex % Math.max(1, this.queries.length)],
       datasetCount: this.datasets.length,
+      targetCount: this.datasets.length || this.queries.length,
       minScore: this.minScore,
       maxJobsPerRun: this.maxJobsPerRun,
       maxOpenJobs: this.maxOpenJobs,
@@ -73,7 +86,8 @@ export class OpenDataIngestionScheduler {
       candidateCount: 0,
       createdCount: 0,
       skipped: [],
-      errors: []
+      errors: [],
+      queries: []
     };
 
     if (!this.enabled) {
@@ -84,56 +98,82 @@ export class OpenDataIngestionScheduler {
       summary.skipped.push({ reason: "max_open_jobs_reached", openDataJobs, maxOpenJobs: this.maxOpenJobs });
       return this.finishRun(summary);
     }
+    if (!this.datasets.length && !this.queries.length) {
+      summary.skipped.push({ reason: "no_queries_configured" });
+      return this.finishRun(summary);
+    }
 
-    const remaining = Math.max(0, Math.min(this.maxJobsPerRun, this.maxOpenJobs - openDataJobs));
-    const seenSources = this.existingOpenDataKeys();
-    try {
-      const result = await ingestOpenDataDatasets({
-        datasets: this.datasets,
-        query: this.query,
-        limit: remaining,
-        minScore: this.minScore,
-        fetchImpl: this.fetchImpl
-      });
-      summary.candidateCount = result.count;
-      summary.query = result.query;
-      summary.skipped.push(...(Array.isArray(result.skipped) ? result.skipped : []));
-      for (const job of result.jobs) {
-        const sourceKey = openDataJobKey(job);
-        if (sourceKey && seenSources.has(sourceKey)) {
-          summary.skipped.push({ id: job.id, reason: "source_already_ingested" });
-          continue;
-        }
-        if (this.platformService.getJobDefinition) {
-          try {
-            this.platformService.getJobDefinition(job.id);
-            summary.skipped.push({ id: job.id, reason: "job_already_exists" });
-            continue;
-          } catch {
-            // Missing jobs are expected and created below.
-          }
-        }
-        if (!this.dryRun) {
-          this.platformService.createJob(job);
-        }
-        seenSources.add(sourceKey);
-        summary.createdCount += 1;
-        this.eventBus?.publish?.({
-          id: `platform-open-data-ingest-${job.id}-${Date.now()}`,
-          topic: "jobs.ingest.open_data",
-          jobId: job.id,
-          timestamp: new Date().toISOString(),
-          data: {
-            dryRun: this.dryRun,
-            jobId: job.id,
-            source: job.source
-          }
+    let remaining = Math.max(0, Math.min(this.maxJobsPerRun, this.maxOpenJobs - openDataJobs));
+    const seenResources = this.existingOpenDataResourceKeys();
+    const seenDatasets = this.existingOpenDataDatasetKeys();
+    const runQueries = this.datasets.length ? [undefined] : this.rotateQueriesForRun();
+    for (const query of runQueries) {
+      if (remaining <= 0) break;
+      try {
+        const result = await ingestOpenDataDatasets({
+          datasets: this.datasets,
+          query: query ?? this.query,
+          limit: remaining,
+          minScore: this.minScore,
+          excludeDatasetKeys: [...seenDatasets],
+          excludeResourceKeys: [...seenResources],
+          fetchImpl: this.fetchImpl
         });
+        summary.candidateCount += result.count;
+        summary.query ??= result.query;
+        const querySummary = {
+          query: result.query,
+          candidates: result.count,
+          created: 0,
+          skipped: Array.isArray(result.skipped) ? result.skipped : []
+        };
+        for (const job of result.jobs) {
+          if (remaining <= 0) break;
+          const datasetKey = openDataDatasetKey(job);
+          if (datasetKey && seenDatasets.has(datasetKey)) {
+            querySummary.skipped.push({ id: job.id, reason: "dataset_already_ingested" });
+            continue;
+          }
+          const resourceKey = openDataResourceKey(job);
+          if (resourceKey && seenResources.has(resourceKey)) {
+            querySummary.skipped.push({ id: job.id, reason: "source_already_ingested" });
+            continue;
+          }
+          if (this.platformService.getJobDefinition) {
+            try {
+              this.platformService.getJobDefinition(job.id);
+              querySummary.skipped.push({ id: job.id, reason: "job_already_exists" });
+              continue;
+            } catch {
+              // Missing jobs are expected and created below.
+            }
+          }
+          if (!this.dryRun) {
+            this.platformService.createJob(job);
+          }
+          if (resourceKey) seenResources.add(resourceKey);
+          if (datasetKey) seenDatasets.add(datasetKey);
+          querySummary.created += 1;
+          summary.createdCount += 1;
+          remaining -= 1;
+          this.eventBus?.publish?.({
+            id: `platform-open-data-ingest-${job.id}-${Date.now()}`,
+            topic: "jobs.ingest.open_data",
+            jobId: job.id,
+            timestamp: new Date().toISOString(),
+            data: {
+              dryRun: this.dryRun,
+              jobId: job.id,
+              source: job.source
+            }
+          });
+        }
+        summary.queries.push(querySummary);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        summary.errors.push({ query, message });
+        this.logger.warn?.({ query, err: error }, "open_data_ingest.run_failed");
       }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      summary.errors.push({ message });
-      this.logger.warn?.({ err: error }, "open_data_ingest.run_failed");
     }
 
     return this.finishRun(summary);
@@ -165,43 +205,50 @@ export class OpenDataIngestionScheduler {
       .length;
   }
 
-  existingOpenDataKeys() {
+  existingOpenDataDatasetKeys() {
     return new Set(
       this.platformService.listJobs()
-        .map((job) => openDataJobKey(job))
+        .map((job) => openDataDatasetKey(job))
         .filter(Boolean)
     );
+  }
+
+  existingOpenDataResourceKeys() {
+    return new Set(
+      this.platformService.listJobs()
+        .map((job) => openDataResourceKey(job))
+        .filter(Boolean)
+    );
+  }
+
+  rotateQueriesForRun() {
+    if (!this.queries.length) {
+      return [];
+    }
+    const start = this.nextQueryIndex % this.queries.length;
+    const rotated = [
+      ...this.queries.slice(start),
+      ...this.queries.slice(0, start)
+    ];
+    this.nextQueryIndex = (start + 1) % this.queries.length;
+    return rotated;
   }
 }
 
 export function loadOpenDataIngestionConfig(env = process.env) {
+  const query = env.OPEN_DATA_INGEST_QUERY?.trim() || DEFAULT_QUERY;
+  const queries = parseQueries(env.OPEN_DATA_INGEST_QUERIES_JSON ?? env.OPEN_DATA_INGEST_QUERIES);
   return {
     enabled: parseBooleanEnv(env.OPEN_DATA_INGEST_ENABLED),
     dryRun: env.OPEN_DATA_INGEST_DRY_RUN === undefined ? true : parseBooleanEnv(env.OPEN_DATA_INGEST_DRY_RUN),
     intervalMs: parsePositiveInt(env.OPEN_DATA_INGEST_INTERVAL_MS, 60 * 60 * 1000),
-    query: env.OPEN_DATA_INGEST_QUERY?.trim() || DEFAULT_QUERY,
+    query,
+    queries: queries.length ? queries : [query],
     datasets: parseDatasets(env.OPEN_DATA_INGEST_DATASETS_JSON ?? env.OPEN_DATA_INGEST_DATASETS),
     minScore: parsePositiveInt(env.OPEN_DATA_INGEST_MIN_SCORE, 55),
     maxJobsPerRun: parsePositiveInt(env.OPEN_DATA_INGEST_MAX_JOBS_PER_RUN, 2),
     maxOpenJobs: parsePositiveInt(env.OPEN_DATA_INGEST_MAX_OPEN_JOBS, 20)
   };
-}
-
-function openDataJobKey(job) {
-  const source = job?.source;
-  if (source?.type !== "open_data_dataset") {
-    return undefined;
-  }
-  const resourceIdentity = source.resourceId || source.resourceUrl;
-  const datasetIdentity = source.datasetId || source.datasetUrl || source.datasetTitle;
-  if (!resourceIdentity || !datasetIdentity) {
-    return undefined;
-  }
-  return [
-    String(source.provider ?? source.portal ?? "data.gov").toLowerCase(),
-    String(datasetIdentity).toLowerCase(),
-    String(resourceIdentity).toLowerCase()
-  ].join("|");
 }
 
 function parsePositiveInt(raw, fallback) {
@@ -220,4 +267,33 @@ function parseBooleanEnv(raw) {
     return false;
   }
   return ["1", "true", "yes", "on"].includes(String(raw).trim().toLowerCase());
+}
+
+function parseQueries(raw) {
+  if (!raw || typeof raw !== "string") {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed.map((query) => String(query).trim()).filter(Boolean);
+    }
+  } catch {
+    // Fall through to newline/comma parsing.
+  }
+  return raw
+    .split(/\n|,/u)
+    .map((query) => query.trim())
+    .filter(Boolean);
+}
+
+function normalizeQueries(queries, fallbackQuery) {
+  const parsed = Array.isArray(queries)
+    ? queries.map((query) => String(query).trim()).filter(Boolean)
+    : parseQueries(queries);
+  if (parsed.length) {
+    return parsed;
+  }
+  const fallback = String(fallbackQuery || DEFAULT_QUERY).trim();
+  return fallback ? [fallback] : [];
 }

--- a/mcp-server/src/services/open-data-ingestion-scheduler.test.js
+++ b/mcp-server/src/services/open-data-ingestion-scheduler.test.js
@@ -121,7 +121,84 @@ test("OpenDataIngestionScheduler dedupes by dataset resource", async () => {
   const summary = await scheduler.runOnce(new Date("2026-04-26T10:00:00.000Z"));
   assert.equal(summary.createdCount, 0);
   assert.equal(platform.listJobs().length, 1);
-  assert.equal(summary.skipped.at(-1).reason, "source_already_ingested");
+  assert.equal(summary.queries[0].skipped.at(-1).reason, "source_already_ingested");
+});
+
+test("OpenDataIngestionScheduler dedupes sibling resources from existing datasets", async () => {
+  const platform = makePlatformService([
+    {
+      id: "existing",
+      source: {
+        type: "open_data_dataset",
+        provider: "data.gov",
+        datasetId: "dataset-123",
+        resourceId: "resource-456"
+      }
+    }
+  ]);
+  const scheduler = new OpenDataIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    datasets: [{
+      ...TARGET,
+      resourceId: "resource-geojson",
+      resourceTitle: "Spending GeoJSON",
+      resourceUrl: "https://example.gov/spending.geojson",
+      resourceFormat: "GEOJSON"
+    }],
+    fetchImpl: makeFetch()
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-26T10:00:00.000Z"));
+  assert.equal(summary.createdCount, 0);
+  assert.equal(platform.listJobs().length, 1);
+  assert.equal(summary.queries[0].skipped.at(-1).reason, "dataset_already_ingested");
+});
+
+test("OpenDataIngestionScheduler rotates configured queries across runs", async () => {
+  const platform = makePlatformService();
+  const calls = [];
+  const scheduler = new OpenDataIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    queries: ["traffic crashes", "food safety"],
+    maxJobsPerRun: 1,
+    fetchImpl: async (url) => {
+      const query = url.searchParams.get("q");
+      calls.push(query);
+      const dataset = query === "food safety"
+        ? {
+            ...CKAN_PACKAGE,
+            id: "dataset-food",
+            name: "food-inspections",
+            title: "Food inspections",
+            resources: [{ ...CKAN_PACKAGE.resources[0], id: "food-csv", url: "https://example.gov/food.csv" }]
+          }
+        : {
+            ...CKAN_PACKAGE,
+            id: "dataset-crashes",
+            name: "crashes-in-dc",
+            title: "Crashes in DC",
+            resources: [{ ...CKAN_PACKAGE.resources[0], id: "crashes-csv", url: "https://example.gov/crashes.csv" }]
+          };
+      return {
+        ok: true,
+        async json() {
+          return { result: { results: [dataset] } };
+        }
+      };
+    }
+  });
+
+  const first = await scheduler.runOnce(new Date("2026-04-26T10:00:00.000Z"));
+  const second = await scheduler.runOnce(new Date("2026-04-26T11:00:00.000Z"));
+  const status = await scheduler.getStatus();
+
+  assert.equal(first.createdCount, 1);
+  assert.equal(second.createdCount, 1);
+  assert.deepEqual(calls, ["traffic crashes", "food safety"]);
+  assert.equal(platform.listJobs().length, 2);
+  assert.equal(status.nextQuery, "traffic crashes");
 });
 
 test("OpenDataIngestionScheduler stops when max open open-data jobs is reached", async () => {
@@ -150,6 +227,7 @@ test("loadOpenDataIngestionConfig parses env knobs safely", () => {
     OPEN_DATA_INGEST_MIN_SCORE: "70",
     OPEN_DATA_INGEST_MAX_JOBS_PER_RUN: "4",
     OPEN_DATA_INGEST_MAX_OPEN_JOBS: "11",
+    OPEN_DATA_INGEST_QUERIES_JSON: JSON.stringify(["traffic crashes", "food safety"]),
     OPEN_DATA_INGEST_DATASETS_JSON: JSON.stringify([TARGET])
   });
 
@@ -157,6 +235,7 @@ test("loadOpenDataIngestionConfig parses env knobs safely", () => {
   assert.equal(config.dryRun, false);
   assert.equal(config.intervalMs, 3600000);
   assert.equal(config.query, "res_format:JSON");
+  assert.deepEqual(config.queries, ["traffic crashes", "food safety"]);
   assert.equal(config.minScore, 70);
   assert.equal(config.maxJobsPerRun, 4);
   assert.equal(config.maxOpenJobs, 11);


### PR DESCRIPTION
## Summary
- add OPEN_DATA_INGEST_QUERIES(_JSON) support and rotate Data.gov queries across scheduler runs
- dedupe Data.gov jobs by both resource and whole dataset so sibling CSV/GeoJSON/API resources do not crowd out new datasets
- surface query rotation target counts in providerOperations and document the production env knob

## Tests
- npm --workspace mcp-server test
- git diff --check