### PR TITLE
Add content recovery log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ out/
 broadcast/
 .ponder/
 .pglite/
+.content-recovery-log/
 marketing/.astro/
 marketing/dist/
 app/.next/

--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -19,6 +19,11 @@ REDIS_NAMESPACE=agent-platform
 # when deliberately running on ephemeral in-memory state (dev, CI, short-lived
 # demos). Booting without Redis in production otherwise fails fast.
 # STATE_STORE_ALLOW_MEMORY=0
+# Append-only JSONL recovery log for content-addressed blobs written by
+# POST /content and dispute verdict reasoning. Defaults to .content-recovery-log
+# under the app working directory. Keep this path on durable private storage.
+# CONTENT_RECOVERY_LOG_DIR=/srv/agent-stack/content-recovery-log
+# CONTENT_RECOVERY_LOG_ENABLED=1
 
 # --- Authentication -----------------------------------------------------------
 # AUTH_MODE controls whether signed-in JWTs are required on protected routes.

--- a/mcp-server/src/core/content-recovery-log.js
+++ b/mcp-server/src/core/content-recovery-log.js
@@ -1,0 +1,60 @@
+import { appendFile, mkdir } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+import { canonicalizeContent } from "./canonical-content.js";
+import { assertContentHashMatches } from "./content-addressed-store.js";
+import { ConfigError, ExternalServiceError } from "./errors.js";
+
+export const DEFAULT_CONTENT_RECOVERY_LOG_DIR = ".content-recovery-log";
+
+export class ContentRecoveryLog {
+  constructor({ dir = DEFAULT_CONTENT_RECOVERY_LOG_DIR, enabled = true, logger = console } = {}) {
+    this.dir = resolve(dir);
+    this.enabled = Boolean(enabled);
+    this.logger = logger;
+  }
+
+  async append(record, { loggedAt = new Date().toISOString() } = {}) {
+    if (!this.enabled) {
+      return { enabled: false };
+    }
+    assertContentHashMatches(record);
+    const entry = {
+      kind: "content.upserted",
+      loggedAt,
+      hash: record.hash,
+      contentType: record.contentType,
+      ownerWallet: record.ownerWallet,
+      verdict: record.verdict,
+      createdAt: record.createdAt,
+      publishedAt: record.publishedAt,
+      autoPublicAt: record.autoPublicAt,
+      payload: record.payload
+    };
+
+    try {
+      await mkdir(this.dir, { recursive: true, mode: 0o700 });
+      const file = join(this.dir, `${loggedAt.slice(0, 10)}.jsonl`);
+      await appendFile(file, `${canonicalizeContent(entry)}\n`, { encoding: "utf8", mode: 0o600 });
+      return { enabled: true, file, hash: record.hash };
+    } catch (error) {
+      throw new ExternalServiceError(`Content recovery log append failed: ${error?.message ?? "unknown_error"}`);
+    }
+  }
+
+}
+
+export function createContentRecoveryLog(env = process.env, { logger = console } = {}) {
+  const enabled = env.CONTENT_RECOVERY_LOG_ENABLED === undefined
+    ? true
+    : parseBooleanEnv(env.CONTENT_RECOVERY_LOG_ENABLED);
+  const dir = env.CONTENT_RECOVERY_LOG_DIR?.trim() || DEFAULT_CONTENT_RECOVERY_LOG_DIR;
+  return new ContentRecoveryLog({ dir, enabled, logger });
+}
+
+function parseBooleanEnv(value) {
+  const normalized = String(value ?? "").trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  throw new ConfigError("CONTENT_RECOVERY_LOG_ENABLED must be a boolean-like value.");
+}

--- a/mcp-server/src/core/content-recovery-log.test.js
+++ b/mcp-server/src/core/content-recovery-log.test.js
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { buildContentRecord } from "./content-addressed-store.js";
+import { ContentRecoveryLog, createContentRecoveryLog } from "./content-recovery-log.js";
+import { ConfigError } from "./errors.js";
+
+const OWNER = "0x1111111111111111111111111111111111111111";
+
+test("ContentRecoveryLog appends canonical JSONL entries to the daily file", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "averray-content-log-"));
+  const recoveryLog = new ContentRecoveryLog({ dir });
+  const record = buildContentRecord({
+    ownerWallet: OWNER,
+    contentType: "arbitrator_reasoning",
+    verdict: "fail",
+    createdAt: "2026-04-27T12:00:00.000Z",
+    payload: { b: 2, a: 1 }
+  });
+
+  const result = await recoveryLog.append(record, { loggedAt: "2026-04-27T12:01:00.000Z" });
+
+  assert.equal(result.enabled, true);
+  assert.equal(result.hash, record.hash);
+  const raw = await readFile(join(dir, "2026-04-27.jsonl"), "utf8");
+  const lines = raw.trim().split("\n");
+  assert.equal(lines.length, 1);
+  const entry = JSON.parse(lines[0]);
+  assert.equal(entry.kind, "content.upserted");
+  assert.equal(entry.hash, record.hash);
+  assert.deepEqual(entry.payload, { a: 1, b: 2 });
+});
+
+test("ContentRecoveryLog validates hash before writing", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "averray-content-log-"));
+  const recoveryLog = new ContentRecoveryLog({ dir });
+  const record = buildContentRecord({
+    ownerWallet: OWNER,
+    payload: { ok: true }
+  });
+
+  await assert.rejects(
+    () => recoveryLog.append({ ...record, hash: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" }),
+    /content hash does not match/u
+  );
+});
+
+test("ContentRecoveryLog disabled mode is a no-op", async () => {
+  const recoveryLog = new ContentRecoveryLog({ enabled: false });
+  const record = buildContentRecord({
+    ownerWallet: OWNER,
+    payload: { ok: true }
+  });
+
+  assert.deepEqual(await recoveryLog.append(record), { enabled: false });
+});
+
+test("createContentRecoveryLog parses boolean env", () => {
+  assert.equal(createContentRecoveryLog({ CONTENT_RECOVERY_LOG_ENABLED: "0" }).enabled, false);
+  assert.equal(createContentRecoveryLog({ CONTENT_RECOVERY_LOG_ENABLED: "yes" }).enabled, true);
+  assert.throws(
+    () => createContentRecoveryLog({ CONTENT_RECOVERY_LOG_ENABLED: "sometimes" }),
+    ConfigError
+  );
+});

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -48,6 +48,7 @@ const {
   platformService: service,
   verifierService,
   stateStore,
+  contentRecoveryLog,
   gateway,
   pimlicoClient,
   eventBus,
@@ -747,6 +748,12 @@ async function optionalAuth(request, url) {
     }
     throw error;
   }
+}
+
+async function persistContentRecord(record) {
+  await contentRecoveryLog?.append?.(record);
+  await stateStore.upsertContent?.(record);
+  return record;
 }
 
 async function resolveRemainingPayout(session) {
@@ -1547,7 +1554,7 @@ const server = createServer(async (request, response) => {
       if (payload?.hash !== undefined) {
         assertContentHashMatches({ hash: payload.hash, payload: payload.payload });
       }
-      await stateStore.upsertContent?.(record);
+      await persistContentRecord(record);
       const access = resolveContentAccess(record, auth);
       return respond(response, 201, {
         ...contentResponse(record, access),
@@ -1614,7 +1621,7 @@ const server = createServer(async (request, response) => {
         verdict: resolution.verdict,
         decidedAt
       });
-      await stateStore.upsertContent?.(reasoning.contentRecord);
+      await persistContentRecord(reasoning.contentRecord);
       const chainReceipt = gateway?.isEnabled?.() && typeof gateway.resolveDispute === "function"
         ? await gateway.resolveDispute(
             session.chainJobId ?? session.jobId,

--- a/mcp-server/src/services/bootstrap.js
+++ b/mcp-server/src/services/bootstrap.js
@@ -13,6 +13,7 @@ import { resolveCapabilities, capabilityMatrix } from "../auth/capabilities.js";
 import { createLogger } from "../core/logger.js";
 import { MetricRegistry } from "../core/metrics.js";
 import { createObservability } from "../core/observability.js";
+import { createContentRecoveryLog } from "../core/content-recovery-log.js";
 import { RecurringSchedulerService } from "./recurring-scheduler.js";
 import {
   GithubIssueIngestionScheduler,
@@ -142,6 +143,9 @@ export async function createPlatformRuntime() {
   const gateway = initStep("init-blockchain-gateway", logger, () => new BlockchainGateway());
   const pimlicoClient = initStep("init-pimlico-client", logger, () => new PimlicoClient());
   const stateStore = initStep("init-state-store", logger, () => createStateStore(process.env, { logger }));
+  const contentRecoveryLog = initStep("init-content-recovery-log", logger, () =>
+    createContentRecoveryLog(process.env, { logger })
+  );
   const eventBus = initStep("init-event-bus", logger, () => new EventBus());
   const platformService = initStep(
     "init-platform-service",
@@ -257,6 +261,7 @@ export async function createPlatformRuntime() {
     gateway,
     pimlicoClient,
     stateStore,
+    contentRecoveryLog,
     eventBus,
     eventListener,
     recurringScheduler,


### PR DESCRIPTION
## What changed
- Added an append-only JSONL recovery log for content-addressed blobs.
- Wired content writes so the recovery log is appended before Redis/memory persistence.
- Added env controls: `CONTENT_RECOVERY_LOG_DIR` and `CONTENT_RECOVERY_LOG_ENABLED`.
- Ignored the default local `.content-recovery-log/` directory.

## Checks run
- `npm --workspace mcp-server test`
- `RUN_HTTP_SMOKE=1 node --test mcp-server/src/protocols/http/server.smoke.test.js` with chain/env vars scrubbed
- `node --test mcp-server/src/core/content-recovery-log.test.js`
- `git diff --check`

## Affected surfaces
- Backend: yes
- Frontend/operator app: no
- Indexer: no
- Contracts: no
- Public site: no
- Caddy/VPS secrets: no

## Notes
- Polkadot docs check: Bulletin Chain/IPFS storage has authorization and retention mechanics, so this PR intentionally remains an operator-side recovery log rather than claiming decentralized persistence.
- The default log path is local to the app working directory; production can override it to durable private storage with `CONTENT_RECOVERY_LOG_DIR`.