### PR TITLE
frontend: provider operations card on /overview and /trust

### DIFF
--- a/app/app/(authed)/overview/page.tsx
+++ b/app/app/(authed)/overview/page.tsx
@@ -16,9 +16,14 @@ import {
   PlatformPulse,
   type PulseEvent,
 } from "@/components/overview/PlatformPulse";
-import { useAccount, useAlerts, useHealth, useJobs, useSessions, useStrategyPositions } from "@/lib/api/hooks";
+import {
+  ProviderOperationsCard,
+  PROVIDER_OPERATIONS_FIXTURE,
+} from "@/components/overview/ProviderOperationsCard";
+import { useAccount, useAlerts, useHealth, useJobs, useProviderOperations, useSessions, useStrategyPositions } from "@/lib/api/hooks";
 import { freshnessFromRequests } from "@/components/shell/DataFreshnessPill";
 import { extractRunJobs } from "@/lib/api/run-adapters";
+import { buildProviderOperations } from "@/lib/api/provider-operations";
 import {
   buildLaneCards,
   buildOverviewAlerts,
@@ -350,6 +355,7 @@ export default function OverviewPage() {
   const strategyPositions = useStrategyPositions();
   const health = useHealth();
   const apiAlerts = useAlerts();
+  const providerOps = useProviderOperations();
 
   const liveVitals = useMemo(
     () => buildRoomVitals(jobs.data, sessions.data, account.data, strategyPositions.data),
@@ -365,6 +371,13 @@ export default function OverviewPage() {
     [jobs.data, sessions.data, strategyPositions.data]
   );
   const liveJobs = extractRunJobs(jobs.data);
+  const liveProviderOps = useMemo(
+    () => buildProviderOperations(providerOps.data),
+    [providerOps.data]
+  );
+  const providerRows = liveProviderOps.length
+    ? liveProviderOps
+    : PROVIDER_OPERATIONS_FIXTURE;
   const hasLiveOverview = Boolean(jobs.data || sessions.data || account.data || strategyPositions.data);
   const vitals = hasLiveOverview ? liveVitals : ROOM_VITALS;
   const alerts = endpointAlerts.length ? endpointAlerts : liveAlerts.length ? liveAlerts : NEEDS_ACTION;
@@ -379,7 +392,8 @@ export default function OverviewPage() {
     account,
     strategyPositions,
     health,
-    apiAlerts
+    apiAlerts,
+    providerOps
   );
 
   return (
@@ -399,6 +413,14 @@ export default function OverviewPage() {
       <RoomVitals vitals={vitals} comparedTo={hasLiveOverview ? "live API" : "14:08 UTC yesterday"} />
       <NeedsActionList alerts={alerts} meta={`${alerts.length} open`} />
       <LaneStatusGrid lanes={lanes} meta={hasLiveOverview ? "live API snapshot" : undefined} />
+      <ProviderOperationsCard
+        providers={providerRows}
+        meta={
+          liveProviderOps.length
+            ? `${liveProviderOps.length} sources · live API`
+            : `${PROVIDER_OPERATIONS_FIXTURE.length} sources`
+        }
+      />
       <PlatformPulse
         events={PULSE_EVENTS}
         endpoint={health.data ? "/events" : "wss://events.averray.com/v1/pulse"}

--- a/app/components/overview/ProviderOperationsCard.tsx
+++ b/app/components/overview/ProviderOperationsCard.tsx
@@ -1,0 +1,305 @@
+import { SectionHead } from "./SectionHead";
+import { cn } from "@/lib/utils/cn";
+import {
+  type ProviderOperation,
+  type ProviderHealth,
+  type ProviderMode,
+  PROVIDER_HEALTH_LABEL,
+  PROVIDER_MODE_LABEL,
+  PROVIDER_TARGET_UNIT,
+} from "@/lib/api/provider-operations";
+
+export interface ProviderOperationsCardProps {
+  providers: ProviderOperation[];
+  meta?: string;
+}
+
+export function ProviderOperationsCard({
+  providers,
+  meta,
+}: ProviderOperationsCardProps) {
+  return (
+    <section>
+      <SectionHead
+        title="Provider operations"
+        meta={meta ?? `${providers.length} sources`}
+      />
+      <div className="overflow-hidden rounded-[10px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] shadow-[var(--shadow-card)]">
+        {providers.length === 0 ? (
+          <EmptyRow />
+        ) : (
+          providers.map((provider) => (
+            <ProviderRow key={provider.key} provider={provider} />
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+function ProviderRow({ provider }: { provider: ProviderOperation }) {
+  const openJobs = provider.currentOpenJobs;
+  const cap = provider.maxOpenJobs;
+  const fillPct = cap > 0 ? Math.min(100, Math.round((openJobs / cap) * 100)) : 0;
+  const lastRun = provider.lastRun;
+  const errored = lastRun ? lastRun.errorCount > 0 : false;
+  const targetUnit = PROVIDER_TARGET_UNIT[provider.key];
+
+  return (
+    <div className="grid grid-cols-1 gap-3 border-b border-[var(--avy-line-soft)] p-[0.95rem_1.15rem] last:border-b-0 md:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)_minmax(0,1.6fr)]">
+      <div className="flex min-w-0 flex-col gap-1.5">
+        <div className="flex items-center gap-2">
+          <span className="truncate font-[family-name:var(--font-display)] text-[14px] font-bold text-[var(--avy-ink)]">
+            {provider.label}
+          </span>
+          <HealthPill tone={provider.health} />
+        </div>
+        <div
+          className="flex flex-wrap items-center gap-1.5 font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]"
+        >
+          <ModeBadge mode={provider.mode} />
+          <span>·</span>
+          <span>
+            <span className="text-[var(--avy-ink)]">{provider.targetCount}</span>{" "}
+            {targetUnit}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <div className="flex items-baseline justify-between gap-2 font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-ink)]">
+          <span className="text-[var(--avy-muted)]">open jobs</span>
+          <span>
+            {openJobs}
+            <span className="text-[var(--avy-muted)]"> / {cap}</span>
+          </span>
+        </div>
+        <div className="h-1 overflow-hidden rounded-full bg-[color:rgba(17,19,21,0.06)]">
+          <div
+            className={cn(
+              "h-full rounded-full transition-[width]",
+              fillPct >= 100
+                ? "bg-[var(--avy-warn)]"
+                : "bg-[var(--avy-accent)]"
+            )}
+            style={{ width: `${fillPct}%` }}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1 font-[family-name:var(--font-body)] text-[12.5px] leading-[1.45] text-[var(--avy-ink)]">
+        {lastRun && lastRun.summary ? (
+          <span>{lastRun.summary}</span>
+        ) : (
+          <span className="text-[var(--avy-muted)]">No runs recorded yet.</span>
+        )}
+        <div className="flex flex-wrap items-center gap-1.5 font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]">
+          <span>{provider.lastRunAt ? `last run ${formatRelative(provider.lastRunAt)}` : "never"}</span>
+          {errored ? (
+            <span className="rounded-full bg-[var(--avy-warn-soft)] px-1.5 py-px font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-warn)]" style={{ letterSpacing: "0.08em" }}>
+              {lastRun!.errorCount} error{lastRun!.errorCount === 1 ? "" : "s"}
+            </span>
+          ) : null}
+          {provider.running ? (
+            <span className="inline-flex items-center gap-1 font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-accent)]" style={{ letterSpacing: "0.08em" }}>
+              <span className="h-1.5 w-1.5 rounded-full bg-[var(--avy-accent)] [animation:pulse_2.2s_ease-in-out_infinite]" />
+              Running
+            </span>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function HealthPill({ tone }: { tone: ProviderHealth }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase",
+        tone === "healthy" && "bg-[var(--avy-accent-soft)] text-[var(--avy-accent)]",
+        tone === "dry_run" && "bg-[var(--avy-blue-soft,#dde8f1)] text-[var(--avy-blue,#3a6f9a)]",
+        tone === "at_capacity" && "bg-[var(--avy-warn-soft)] text-[var(--avy-warn)]",
+        tone === "error" && "bg-[#f3d7d4] text-[#a0322a]",
+        tone === "disabled" && "bg-[#ebe7da] text-[#756d58]"
+      )}
+      style={{ letterSpacing: "0.1em" }}
+    >
+      <span className="h-[5px] w-[5px] rounded-full bg-current" />
+      {PROVIDER_HEALTH_LABEL[tone]}
+    </span>
+  );
+}
+
+function ModeBadge({ mode }: { mode: ProviderMode }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-[4px] px-1.5 py-px font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase",
+        mode === "live" && "bg-[var(--avy-accent-wash)] text-[var(--avy-accent)]",
+        mode === "dry_run" && "bg-[color:rgba(17,19,21,0.04)] text-[var(--avy-ink)]",
+        mode === "disabled" && "bg-[color:rgba(17,19,21,0.04)] text-[var(--avy-muted)]"
+      )}
+      style={{ letterSpacing: "0.08em" }}
+    >
+      {PROVIDER_MODE_LABEL[mode]}
+    </span>
+  );
+}
+
+function EmptyRow() {
+  return (
+    <div className="p-[1.05rem_1.15rem] font-[family-name:var(--font-body)] text-[13px] text-[var(--avy-muted)]">
+      Provider operations status is unavailable right now.
+    </div>
+  );
+}
+
+function formatRelative(iso: string): string {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return iso;
+  const deltaSec = Math.max(0, Math.round((Date.now() - t) / 1000));
+  if (deltaSec < 60) return `${deltaSec}s ago`;
+  const deltaMin = Math.round(deltaSec / 60);
+  if (deltaMin < 60) return `${deltaMin}m ago`;
+  const deltaHr = Math.round(deltaMin / 60);
+  if (deltaHr < 24) return `${deltaHr}h ago`;
+  const deltaDay = Math.round(deltaHr / 24);
+  return `${deltaDay}d ago`;
+}
+
+export const PROVIDER_OPERATIONS_FIXTURE: ProviderOperation[] = [
+  {
+    key: "github",
+    label: "GitHub issues",
+    mode: "live",
+    health: "healthy",
+    enabled: true,
+    running: false,
+    intervalMs: 5 * 60_000,
+    maxJobsPerRun: 8,
+    maxOpenJobs: 24,
+    currentOpenJobs: 11,
+    targetCount: 14,
+    lastRunAt: new Date(Date.now() - 90_000).toISOString(),
+    lastRun: {
+      startedAt: new Date(Date.now() - 120_000).toISOString(),
+      finishedAt: new Date(Date.now() - 90_000).toISOString(),
+      dryRun: false,
+      candidateCount: 26,
+      createdCount: 4,
+      skippedCount: 22,
+      errorCount: 0,
+      summary: "26 candidates, 4 created, 22 skipped, 0 errors",
+    },
+  },
+  {
+    key: "wikipedia",
+    label: "Wikipedia maintenance",
+    mode: "live",
+    health: "healthy",
+    enabled: true,
+    running: true,
+    intervalMs: 10 * 60_000,
+    maxJobsPerRun: 6,
+    maxOpenJobs: 18,
+    currentOpenJobs: 4,
+    targetCount: 9,
+    lastRunAt: new Date(Date.now() - 240_000).toISOString(),
+    lastRun: {
+      startedAt: new Date(Date.now() - 280_000).toISOString(),
+      finishedAt: new Date(Date.now() - 240_000).toISOString(),
+      dryRun: false,
+      candidateCount: 18,
+      createdCount: 2,
+      skippedCount: 16,
+      errorCount: 0,
+      summary: "18 candidates, 2 created, 16 skipped, 0 errors",
+    },
+  },
+  {
+    key: "osv",
+    label: "OSV advisories",
+    mode: "live",
+    health: "at_capacity",
+    enabled: true,
+    running: false,
+    intervalMs: 15 * 60_000,
+    maxJobsPerRun: 4,
+    maxOpenJobs: 12,
+    currentOpenJobs: 12,
+    targetCount: 31,
+    lastRunAt: new Date(Date.now() - 600_000).toISOString(),
+    lastRun: {
+      startedAt: new Date(Date.now() - 660_000).toISOString(),
+      finishedAt: new Date(Date.now() - 600_000).toISOString(),
+      dryRun: false,
+      candidateCount: 9,
+      createdCount: 0,
+      skippedCount: 9,
+      errorCount: 0,
+      summary: "9 candidates, 0 created, 9 skipped (cap reached), 0 errors",
+    },
+  },
+  {
+    key: "openData",
+    label: "Open data",
+    mode: "dry_run",
+    health: "dry_run",
+    enabled: true,
+    running: false,
+    intervalMs: 30 * 60_000,
+    maxJobsPerRun: 3,
+    maxOpenJobs: 10,
+    currentOpenJobs: 2,
+    targetCount: 7,
+    lastRunAt: new Date(Date.now() - 1_500_000).toISOString(),
+    lastRun: {
+      startedAt: new Date(Date.now() - 1_540_000).toISOString(),
+      finishedAt: new Date(Date.now() - 1_500_000).toISOString(),
+      dryRun: true,
+      candidateCount: 12,
+      createdCount: 0,
+      skippedCount: 12,
+      errorCount: 0,
+      summary: "12 candidates, 0 created (dry run), 12 skipped, 0 errors",
+    },
+  },
+  {
+    key: "standards",
+    label: "Standards freshness",
+    mode: "live",
+    health: "error",
+    enabled: true,
+    running: false,
+    intervalMs: 60 * 60_000,
+    maxJobsPerRun: 2,
+    maxOpenJobs: 8,
+    currentOpenJobs: 1,
+    targetCount: 5,
+    lastRunAt: new Date(Date.now() - 1_800_000).toISOString(),
+    lastRun: {
+      startedAt: new Date(Date.now() - 1_840_000).toISOString(),
+      finishedAt: new Date(Date.now() - 1_800_000).toISOString(),
+      dryRun: false,
+      candidateCount: 5,
+      createdCount: 0,
+      skippedCount: 3,
+      errorCount: 2,
+      summary: "5 candidates, 0 created, 3 skipped, 2 errors",
+    },
+  },
+  {
+    key: "openApi",
+    label: "OpenAPI quality",
+    mode: "disabled",
+    health: "disabled",
+    enabled: false,
+    running: false,
+    intervalMs: 60 * 60_000,
+    maxJobsPerRun: 2,
+    maxOpenJobs: 6,
+    currentOpenJobs: 0,
+    targetCount: 4,
+  },
+];

--- a/app/lib/api/hooks.ts
+++ b/app/lib/api/hooks.ts
@@ -52,6 +52,18 @@ export const useSessionTimeline = (sessionId: string | null) =>
   useApi(sessionId ? `/session/timeline?sessionId=${encodeURIComponent(sessionId)}` : null);
 export const useStrategies = () => useApi("/strategies");
 export const useHealth = () => useApi("/health");
+/**
+ * Operator-app provider operations status. Authed via `/admin/status`,
+ * which carries the full `lastRun.errors[]` / `lastRun.skipped[]` arrays.
+ * Polls every 30s — the upstream schedulers tick on minute-ish cadences,
+ * so 30s gives an "alive" feel without thrashing the SWR cache.
+ *
+ * The public /trust page uses the sanitized `/status/providers` route
+ * (no auth, empty errors/skipped) — that surface is rendered by a
+ * vanilla JS hydrator, not this hook.
+ */
+export const useProviderOperations = () =>
+  useApi("/admin/status", { refreshInterval: 30_000 });
 export const useOnboarding = () => useApi("/onboarding");
 export const useVerifierHandlers = () => useApi("/verifier/handlers");
 export const useSessionStateMachine = () => useApi("/session/state-machine");

--- a/app/lib/api/provider-operations.ts
+++ b/app/lib/api/provider-operations.ts
@@ -1,0 +1,233 @@
+/**
+ * Provider operations adapter.
+ *
+ * Normalises the `providerOperations` slice of `/admin/status` (operator
+ * app, authed) and `/status/providers` (public, sanitized) into a flat
+ * `ProviderOperation[]` sorted by operator priority — the rows that need
+ * attention float to the top.
+ *
+ * Both endpoints emit the same per-provider shape; the only difference is
+ * that the public endpoint always returns empty `lastRun.skipped[]` and
+ * `lastRun.errors[]`. The adapter doesn't care which one fed it.
+ */
+
+export type ProviderKey =
+  | "github"
+  | "wikipedia"
+  | "osv"
+  | "openData"
+  | "standards"
+  | "openApi";
+
+export type ProviderHealth =
+  | "healthy"
+  | "dry_run"
+  | "at_capacity"
+  | "error"
+  | "disabled";
+
+export type ProviderMode = "live" | "dry_run" | "disabled";
+
+export interface ProviderLastRun {
+  startedAt?: string;
+  finishedAt?: string;
+  dryRun: boolean;
+  candidateCount: number;
+  createdCount: number;
+  skippedCount: number;
+  errorCount: number;
+  /** Pre-formatted "X candidate(s), Y created, Z skipped, W error(s)". */
+  summary: string;
+}
+
+export interface ProviderOperation {
+  key: ProviderKey;
+  label: string;
+  mode: ProviderMode;
+  health: ProviderHealth;
+  enabled: boolean;
+  running: boolean;
+  intervalMs: number;
+  maxJobsPerRun: number;
+  maxOpenJobs: number;
+  currentOpenJobs: number;
+  /** Upstream queries / categories / packages / datasets / specs scanned. */
+  targetCount: number;
+  lastRunAt?: string;
+  lastRun?: ProviderLastRun;
+}
+
+const PROVIDER_ORDER: ProviderKey[] = [
+  "github",
+  "wikipedia",
+  "osv",
+  "openData",
+  "standards",
+  "openApi",
+];
+
+// Lower number = higher priority for the operator's eye. The first row
+// the operator sees should be the one that wants attention.
+const HEALTH_PRIORITY: Record<ProviderHealth, number> = {
+  error: 0,
+  at_capacity: 1,
+  dry_run: 2,
+  healthy: 3,
+  disabled: 4,
+};
+
+/**
+ * Extract `providerOperations` from either:
+ *   - `/admin/status` (whose top level carries many other slices)
+ *   - `/status/providers` (whose top level is just `{ providerOperations }`)
+ *
+ * Returns an empty array when the payload is missing/malformed so the
+ * card can render a "no data" state instead of erroring out.
+ */
+export function buildProviderOperations(payload: unknown): ProviderOperation[] {
+  const root = asRecord(payload);
+  if (!root) return [];
+  const providerOperations = asRecord(root.providerOperations);
+  if (!providerOperations) return [];
+
+  const ordered: ProviderOperation[] = [];
+  for (const key of PROVIDER_ORDER) {
+    const entry = asRecord(providerOperations[key]);
+    if (!entry) continue;
+    ordered.push(buildProvider(key, entry));
+  }
+  return ordered.sort(byOperatorPriority);
+}
+
+function buildProvider(
+  key: ProviderKey,
+  raw: Record<string, unknown>
+): ProviderOperation {
+  return {
+    key,
+    label: text(raw.label, defaultLabel(key)),
+    mode: mode(raw.mode),
+    health: health(raw.health),
+    enabled: Boolean(raw.enabled),
+    running: Boolean(raw.running),
+    intervalMs: nonNegInt(raw.intervalMs),
+    maxJobsPerRun: nonNegInt(raw.maxJobsPerRun),
+    maxOpenJobs: nonNegInt(raw.maxOpenJobs),
+    currentOpenJobs: nonNegInt(raw.currentOpenJobs),
+    targetCount: nonNegInt(raw.targetCount),
+    ...(text(raw.lastRunAt) ? { lastRunAt: text(raw.lastRunAt) } : {}),
+    ...(buildLastRun(raw.lastRun)
+      ? { lastRun: buildLastRun(raw.lastRun)! }
+      : {}),
+  };
+}
+
+function buildLastRun(raw: unknown): ProviderLastRun | undefined {
+  const record = asRecord(raw);
+  if (!record) return undefined;
+  return {
+    ...(text(record.startedAt) ? { startedAt: text(record.startedAt) } : {}),
+    ...(text(record.finishedAt) ? { finishedAt: text(record.finishedAt) } : {}),
+    dryRun: record.dryRun !== false,
+    candidateCount: nonNegInt(record.candidateCount),
+    createdCount: nonNegInt(record.createdCount),
+    skippedCount: nonNegInt(record.skippedCount),
+    errorCount: nonNegInt(record.errorCount),
+    summary: text(record.summary, ""),
+  };
+}
+
+function byOperatorPriority(
+  a: ProviderOperation,
+  b: ProviderOperation
+): number {
+  const healthDelta = HEALTH_PRIORITY[a.health] - HEALTH_PRIORITY[b.health];
+  if (healthDelta !== 0) return healthDelta;
+  // Within the same health bucket, fall back to the canonical
+  // PROVIDER_ORDER so the layout is stable across renders.
+  return PROVIDER_ORDER.indexOf(a.key) - PROVIDER_ORDER.indexOf(b.key);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function text(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function nonNegInt(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  return Math.floor(parsed);
+}
+
+function mode(value: unknown): ProviderMode {
+  return value === "live" || value === "dry_run" || value === "disabled"
+    ? value
+    : "disabled";
+}
+
+function health(value: unknown): ProviderHealth {
+  return value === "healthy" ||
+    value === "dry_run" ||
+    value === "at_capacity" ||
+    value === "error" ||
+    value === "disabled"
+    ? value
+    : "disabled";
+}
+
+const PROVIDER_LABEL: Record<ProviderKey, string> = {
+  github: "GitHub issues",
+  wikipedia: "Wikipedia maintenance",
+  osv: "OSV advisories",
+  openData: "Open data",
+  standards: "Standards freshness",
+  openApi: "OpenAPI quality",
+};
+
+function defaultLabel(key: ProviderKey): string {
+  return PROVIDER_LABEL[key];
+}
+
+/**
+ * Per-provider unit label used next to `targetCount` in the card.
+ * The backend already documents what each `targetCount` represents:
+ *   - github → query count
+ *   - wikipedia → category count
+ *   - osv → package count
+ *   - openData → dataset count
+ *   - standards → spec count
+ *   - openApi → spec count
+ */
+export const PROVIDER_TARGET_UNIT: Record<ProviderKey, string> = {
+  github: "queries",
+  wikipedia: "categories",
+  osv: "packages",
+  openData: "datasets",
+  standards: "specs",
+  openApi: "specs",
+};
+
+/**
+ * Pretty-printed mode label for the chip.
+ */
+export const PROVIDER_MODE_LABEL: Record<ProviderMode, string> = {
+  live: "Live",
+  dry_run: "Dry run",
+  disabled: "Disabled",
+};
+
+/**
+ * Pretty-printed health label for the chip.
+ */
+export const PROVIDER_HEALTH_LABEL: Record<ProviderHealth, string> = {
+  healthy: "Healthy",
+  dry_run: "Dry run",
+  at_capacity: "At capacity",
+  error: "Error",
+  disabled: "Disabled",
+};

--- a/site/styles.css
+++ b/site/styles.css
@@ -875,3 +875,152 @@ code {
     width: fit-content;
   }
 }
+
+.provider-operations-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 0.9rem;
+}
+
+.provider-row {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.provider-row-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.provider-row-head h3 {
+  margin: 0;
+  font-size: 1.02rem;
+  line-height: 1.3;
+}
+
+.provider-row-meta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.provider-row-meta strong {
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.provider-row-summary {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  color: var(--ink);
+}
+
+.provider-row-foot {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+
+.provider-error {
+  color: #a0322a;
+  font-weight: 700;
+}
+
+.provider-running {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.provider-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-family: var(--display);
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.provider-pill--healthy {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.provider-pill--dry_run {
+  background: #dde8f1;
+  color: #254e9a;
+}
+
+.provider-pill--at_capacity {
+  background: var(--warm-soft);
+  color: #a76122;
+}
+
+.provider-pill--error {
+  background: #f3d7d4;
+  color: #a0322a;
+}
+
+.provider-pill--disabled {
+  background: rgba(17, 19, 21, 0.06);
+  color: var(--muted);
+}
+
+.provider-mode {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.05rem 0.4rem;
+  border-radius: 4px;
+  font-family: var(--display);
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.provider-mode--live {
+  background: rgba(29, 106, 70, 0.10);
+  color: var(--accent);
+}
+
+.provider-mode--dry_run {
+  background: rgba(17, 19, 21, 0.05);
+  color: var(--ink);
+}
+
+.provider-mode--disabled {
+  background: rgba(17, 19, 21, 0.05);
+  color: var(--muted);
+}
+
+.provider-bar {
+  height: 4px;
+  border-radius: 4px;
+  background: rgba(17, 19, 21, 0.06);
+  overflow: hidden;
+}
+
+.provider-bar > span {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+  border-radius: inherit;
+  transition: width 220ms ease;
+}
+
+.provider-row--at_capacity .provider-bar > span {
+  background: #a76122;
+}
+
+.provider-row--error .provider-bar > span {
+  background: #a0322a;
+}

--- a/site/trust-providers.js
+++ b/site/trust-providers.js
@@ -1,0 +1,209 @@
+(function () {
+  const ENDPOINT = "https://api.averray.com/status/providers";
+
+  const PROVIDER_LABEL = {
+    github: "GitHub issues",
+    wikipedia: "Wikipedia maintenance",
+    osv: "OSV advisories",
+    openData: "Open data",
+    standards: "Standards freshness",
+    openApi: "OpenAPI quality",
+  };
+
+  const PROVIDER_TARGET_UNIT = {
+    github: "queries",
+    wikipedia: "categories",
+    osv: "packages",
+    openData: "datasets",
+    standards: "specs",
+    openApi: "specs",
+  };
+
+  const HEALTH_LABEL = {
+    healthy: "Healthy",
+    dry_run: "Dry run",
+    at_capacity: "At capacity",
+    error: "Error",
+    disabled: "Disabled",
+  };
+
+  const MODE_LABEL = {
+    live: "Live",
+    dry_run: "Dry run",
+    disabled: "Disabled",
+  };
+
+  const HEALTH_PRIORITY = {
+    error: 0,
+    at_capacity: 1,
+    dry_run: 2,
+    healthy: 3,
+    disabled: 4,
+  };
+
+  const PROVIDER_ORDER = [
+    "github",
+    "wikipedia",
+    "osv",
+    "openData",
+    "standards",
+    "openApi",
+  ];
+
+  function escapeHtml(value) {
+    return String(value).replace(/[&<>"']/g, (ch) =>
+      ch === "&"
+        ? "&amp;"
+        : ch === "<"
+        ? "&lt;"
+        : ch === ">"
+        ? "&gt;"
+        : ch === '"'
+        ? "&quot;"
+        : "&#39;"
+    );
+  }
+
+  function nonNegInt(value) {
+    const n = Number(value);
+    if (!Number.isFinite(n) || n < 0) return 0;
+    return Math.floor(n);
+  }
+
+  function asString(value, fallback) {
+    if (typeof value === "string" && value.trim()) return value.trim();
+    return fallback;
+  }
+
+  function formatRelative(iso) {
+    if (!iso) return "never";
+    const t = Date.parse(iso);
+    if (!Number.isFinite(t)) return "—";
+    const deltaSec = Math.max(0, Math.round((Date.now() - t) / 1000));
+    if (deltaSec < 60) return deltaSec + "s ago";
+    const deltaMin = Math.round(deltaSec / 60);
+    if (deltaMin < 60) return deltaMin + "m ago";
+    const deltaHr = Math.round(deltaMin / 60);
+    if (deltaHr < 24) return deltaHr + "h ago";
+    return Math.round(deltaHr / 24) + "d ago";
+  }
+
+  function buildProvider(key, raw) {
+    const lastRunRaw = raw && typeof raw.lastRun === "object" ? raw.lastRun : null;
+    const lastRun = lastRunRaw
+      ? {
+          dryRun: lastRunRaw.dryRun !== false,
+          summary: asString(lastRunRaw.summary, ""),
+          errorCount: nonNegInt(lastRunRaw.errorCount),
+        }
+      : null;
+    return {
+      key: key,
+      label: asString(raw && raw.label, PROVIDER_LABEL[key] || key),
+      mode: ["live", "dry_run", "disabled"].includes(raw && raw.mode) ? raw.mode : "disabled",
+      health: ["healthy", "dry_run", "at_capacity", "error", "disabled"].includes(raw && raw.health) ? raw.health : "disabled",
+      running: Boolean(raw && raw.running),
+      maxOpenJobs: nonNegInt(raw && raw.maxOpenJobs),
+      currentOpenJobs: nonNegInt(raw && raw.currentOpenJobs),
+      targetCount: nonNegInt(raw && raw.targetCount),
+      lastRunAt: asString(raw && raw.lastRunAt, ""),
+      lastRun: lastRun,
+    };
+  }
+
+  function extractProviders(payload) {
+    const root = payload && typeof payload === "object" && payload.providerOperations;
+    if (!root || typeof root !== "object") return [];
+    const out = [];
+    for (const key of PROVIDER_ORDER) {
+      const entry = root[key];
+      if (!entry || typeof entry !== "object") continue;
+      out.push(buildProvider(key, entry));
+    }
+    out.sort((a, b) => {
+      const delta = HEALTH_PRIORITY[a.health] - HEALTH_PRIORITY[b.health];
+      if (delta !== 0) return delta;
+      return PROVIDER_ORDER.indexOf(a.key) - PROVIDER_ORDER.indexOf(b.key);
+    });
+    return out;
+  }
+
+  function renderProvider(provider) {
+    const cap = provider.maxOpenJobs;
+    const open = provider.currentOpenJobs;
+    const fillPct = cap > 0 ? Math.min(100, Math.round((open / cap) * 100)) : 0;
+    const unit = PROVIDER_TARGET_UNIT[provider.key] || "items";
+    const lastRunSummary = provider.lastRun && provider.lastRun.summary
+      ? provider.lastRun.summary
+      : "No runs recorded yet.";
+    const errorCount = provider.lastRun ? provider.lastRun.errorCount : 0;
+    const lastRunRel = provider.lastRunAt ? "last run " + formatRelative(provider.lastRunAt) : "never";
+
+    return (
+      '<article class="site-card provider-row provider-row--' + escapeHtml(provider.health) + '">' +
+        '<header class="provider-row-head">' +
+          '<h3>' + escapeHtml(provider.label) + '</h3>' +
+          '<span class="provider-pill provider-pill--' + escapeHtml(provider.health) + '">' + escapeHtml(HEALTH_LABEL[provider.health]) + '</span>' +
+        '</header>' +
+        '<p class="provider-row-meta">' +
+          '<span class="provider-mode provider-mode--' + escapeHtml(provider.mode) + '">' + escapeHtml(MODE_LABEL[provider.mode]) + '</span>' +
+          ' · <strong>' + escapeHtml(String(provider.targetCount)) + '</strong> ' + escapeHtml(unit) +
+          ' · open jobs <strong>' + escapeHtml(String(open)) + '</strong> / ' + escapeHtml(String(cap)) +
+        '</p>' +
+        '<div class="provider-bar"><span style="width:' + fillPct + '%"></span></div>' +
+        '<p class="provider-row-summary">' + escapeHtml(lastRunSummary) + '</p>' +
+        '<p class="provider-row-foot">' +
+          escapeHtml(lastRunRel) +
+          (errorCount > 0
+            ? ' · <span class="provider-error">' + errorCount + " error" + (errorCount === 1 ? "" : "s") + "</span>"
+            : "") +
+          (provider.running ? ' · <span class="provider-running">Running</span>' : "") +
+        '</p>' +
+      '</article>'
+    );
+  }
+
+  function renderEmpty(message) {
+    return (
+      '<article class="site-card">' +
+        '<p class="label">Live status</p>' +
+        '<p class="section-copy">' + escapeHtml(message) + '</p>' +
+      '</article>'
+    );
+  }
+
+  function setMeta(text) {
+    const el = document.getElementById("provider-operations-meta");
+    if (el) el.textContent = text;
+  }
+
+  function setList(html) {
+    const el = document.getElementById("provider-operations-list");
+    if (el) el.innerHTML = html;
+  }
+
+  async function load() {
+    try {
+      const res = await fetch(ENDPOINT, { credentials: "omit" });
+      if (!res.ok) throw new Error("HTTP " + res.status);
+      const payload = await res.json();
+      const providers = extractProviders(payload);
+      if (!providers.length) {
+        setMeta("No provider data available.");
+        setList(renderEmpty("Provider status is unavailable right now. The endpoint returned no rows."));
+        return;
+      }
+      setMeta(providers.length + " sources · live");
+      setList(providers.map(renderProvider).join(""));
+    } catch (err) {
+      setMeta("Live status unavailable.");
+      setList(renderEmpty("We could not reach " + ENDPOINT + " from this browser. The same data is available there directly."));
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", load, { once: true });
+  } else {
+    load();
+  }
+})();

--- a/site/trust/index.html
+++ b/site/trust/index.html
@@ -220,6 +220,25 @@
           </div>
         </section>
 
+        <section class="site-section" aria-labelledby="provider-operations-heading">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow">Provider operations</p>
+              <h2 id="provider-operations-heading">What we are reading from, and how it ran most recently.</h2>
+              <p class="section-note">
+                Averray pulls candidate work from a fixed set of public sources. This card lists each one, the mode it is running in, how it last looked, and whether it currently has capacity. Errors and skipped items are summarised here; the operator app shows the full per-row detail.
+              </p>
+            </div>
+            <p class="section-note" id="provider-operations-meta">Loading live status…</p>
+          </div>
+          <div id="provider-operations-list" class="provider-operations-list" aria-live="polite">
+            <article class="site-card">
+              <p class="label">Live status</p>
+              <p class="section-copy">Fetching the latest provider snapshot from <code>api.averray.com/status/providers</code>…</p>
+            </article>
+          </div>
+        </section>
+
         <section class="site-section">
           <article class="site-card">
             <p class="label">Operational checklist</p>
@@ -251,5 +270,6 @@
       </footer>
     </div>
     <script src="../site.js"></script>
+    <script src="../trust-providers.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Adds `useProviderOperations()` hook + `buildProviderOperations` adapter (both endpoint shapes accepted, sorted by health bucket then canonical order)
- New `ProviderOperationsCard` component on the operator `/overview` page between Lanes and Platform pulse, fed by `/admin/status` (full detail, 30s SWR refresh)
- Same card on the public `site/trust/` page just before "Operational checklist", fed by the sanitized `/status/providers` endpoint via a vanilla JS hydrator (no auth required from a browser)
- Threads the new request into `freshnessFromRequests(...)` so the topbar pill reflects provider-status freshness too

## Why
Operators want a single glance at which ingest sources are alive, in dry-run, near capacity, or erroring. Public viewers also benefit from seeing the same posture without needing access — but with the errors/skipped detail stripped (already handled server-side in #51).

## Test plan
- [x] `npm run typecheck:app`
- [x] `npm run build:frontend`
- [x] `npm run build:site`
- [ ] After deploy: confirm `https://app.averray.com/overview` shows the new card with live data
- [ ] After deploy: confirm `https://averray.com/trust/` populates the new section from `https://api.averray.com/status/providers`