### PR TITLE
Add early content publish endpoint

### DIFF
--- a/mcp-server/src/auth/capabilities.js
+++ b/mcp-server/src/auth/capabilities.js
@@ -76,6 +76,7 @@ export function capabilityMatrix() {
       "/badges": ["badges:list"],
       "/content": ["content:write"],
       "/content/:hash": ["content:read"],
+      "/content/:hash/publish": ["content:write"],
       "/disputes": ["disputes:list"],
       "/disputes/:id": ["disputes:read"],
       "/disputes/:id/verdict": ["disputes:verdict"],

--- a/mcp-server/src/core/content-addressed-store.js
+++ b/mcp-server/src/core/content-addressed-store.js
@@ -82,6 +82,17 @@ export function requireContentAccess(record, auth = undefined, options = {}) {
   return access;
 }
 
+export function publishContentRecord(record, { publishedAt = new Date().toISOString() } = {}) {
+  assertContentHashMatches(record);
+  if (record.publishedAt) {
+    return record;
+  }
+  return {
+    ...record,
+    publishedAt: normalizeIsoTimestamp(publishedAt, "publishedAt")
+  };
+}
+
 export function publicContentHeaders(record, access, { now = new Date() } = {}) {
   if (access?.public) {
     return { "cache-control": "public, max-age=31536000, immutable" };

--- a/mcp-server/src/core/content-addressed-store.test.js
+++ b/mcp-server/src/core/content-addressed-store.test.js
@@ -5,6 +5,7 @@ import {
   buildContentRecord,
   contentResponse,
   defaultAutoPublicAt,
+  publishContentRecord,
   requireContentAccess,
   resolveContentAccess
 } from "./content-addressed-store.js";
@@ -63,6 +64,23 @@ test("passes and explicitly published content are public immediately", () => {
 
   assert.equal(resolveContentAccess(pass).public, true);
   assert.equal(resolveContentAccess(published).public, true);
+});
+
+test("publishContentRecord sets publishedAt once and makes failed content public", () => {
+  const record = buildContentRecord({
+    ownerWallet: OWNER,
+    payload: { rationale: "owner chose to publish" },
+    contentType: "arbitrator_reasoning",
+    verdict: "fail",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    autoPublicAt: "2026-07-01T00:00:00.000Z"
+  });
+  const published = publishContentRecord(record, { publishedAt: "2026-02-01T00:00:00.000Z" });
+  const republished = publishContentRecord(published, { publishedAt: "2026-03-01T00:00:00.000Z" });
+
+  assert.equal(published.publishedAt, "2026-02-01T00:00:00.000Z");
+  assert.equal(republished.publishedAt, "2026-02-01T00:00:00.000Z");
+  assert.equal(resolveContentAccess(published, undefined, { now: new Date("2026-02-01T00:00:01.000Z") }).public, true);
 });
 
 test("contentResponse includes the stored payload and visibility", () => {

--- a/mcp-server/src/core/discovery-manifest.js
+++ b/mcp-server/src/core/discovery-manifest.js
@@ -45,6 +45,7 @@ const DISCOVERY_AUTHENTICATED_ENDPOINTS = [
   { path: "/admin/jobs/ingest/osv", description: "Admin-gated OSV npm advisory ingestion preview/create endpoint." },
   { path: "/admin/jobs/ingest/wikipedia", description: "Admin-gated Wikipedia maintenance ingestion preview/create endpoint." },
   { path: "/content/:hash", description: "Hash-addressed content blob with read-time disclosure visibility." },
+  { path: "/content/:hash/publish", description: "Owner/admin one-way early publish for private hash-addressed content." },
   { path: "/disputes", description: "Operator dispute queue derived from sessions requiring human review." },
   { path: "/disputes/:id", description: "Detailed dispute evidence, timeline, verdict, and stake release state." },
   { path: "/session", description: "Fetch a single session by id (owner-scoped)." },

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -22,6 +22,7 @@ import {
   buildContentRecord,
   contentResponse,
   normalizeContentHash,
+  publishContentRecord,
   publicContentHeaders,
   requireContentAccess,
   resolveContentAccess
@@ -976,6 +977,7 @@ function metricPathLabel(pathname) {
   if (/^\/disputes\/[^/]+\/verdict$/u.test(pathname)) return "/disputes/:id/verdict";
   if (/^\/disputes\/[^/]+\/release$/u.test(pathname)) return "/disputes/:id/release";
   if (pathname.startsWith("/disputes/")) return "/disputes/:id";
+  if (/^\/content\/[^/]+\/publish$/u.test(pathname)) return "/content/:hash/publish";
   if (pathname.startsWith("/content/")) return "/content/:hash";
   if (pathname.startsWith("/policies/")) return "/policies/:tag";
   if (pathname.startsWith("/badges/")) return "/badges/:sessionId";
@@ -1569,6 +1571,25 @@ const server = createServer(async (request, response) => {
         ...contentResponse(record, access),
         contentURI: publicContentUri(record.hash)
       });
+    }
+
+    if (request.method === "POST" && /^\/content\/[^/]+\/publish$/u.test(pathname)) {
+      const auth = await authMiddleware(request, url);
+      const hash = normalizeContentHash(decodeURIComponent(pathname.slice("/content/".length, -"/publish".length)));
+      const record = await stateStore.getContent?.(hash);
+      if (!record) {
+        return respond(response, 404, { status: "not_found", hash });
+      }
+      if (!walletsMatch(record.ownerWallet, auth.wallet) && !hasRole(auth.claims, "admin")) {
+        throw new AuthorizationError("Only the owner wallet or an admin can publish this content.", "content_publish_forbidden");
+      }
+      const published = publishContentRecord(record);
+      await persistContentRecord(published);
+      const access = resolveContentAccess(published, auth);
+      return respond(response, 200, {
+        ...contentResponse(published, access),
+        contentURI: publicContentUri(published.hash)
+      }, publicContentHeaders(published, access));
     }
 
     if (request.method === "GET" && pathname.startsWith("/content/")) {

--- a/mcp-server/src/protocols/http/server.smoke.test.js
+++ b/mcp-server/src/protocols/http/server.smoke.test.js
@@ -488,6 +488,26 @@ test("http smoke: /disputes exposes human-review sessions and records verdict/re
     assert.equal(contentBody.visibility, "owner_only");
     assert.equal(contentBody.payload.rationale, "Submission needs correction.");
 
+    const strangerToken = issueToken("0x3333333333333333333333333333333333333333");
+    const forbiddenPublish = await fetch(`${base}/content/${encodeURIComponent(verdictBody.reasoningHash)}/publish`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${strangerToken}` }
+    });
+    assert.equal(forbiddenPublish.status, 403);
+
+    const published = await fetch(`${base}/content/${encodeURIComponent(verdictBody.reasoningHash)}/publish`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${adminToken}` }
+    });
+    assert.equal(published.status, 200);
+    const publishedBody = await published.json();
+    assert.equal(publishedBody.visibility, "public");
+    assert.match(publishedBody.publishedAt, /^\d{4}-\d{2}-\d{2}T/u);
+
+    const publicContent = await fetch(`${base}/content/${encodeURIComponent(verdictBody.reasoningHash)}`);
+    assert.equal(publicContent.status, 200);
+    assert.equal((await publicContent.json()).visibility, "public");
+
     const release = await fetch(`${base}/disputes/${encodeURIComponent(dispute.id)}/release`, {
       method: "POST",
       headers: { "content-type": "application/json", authorization: `Bearer ${adminToken}` },


### PR DESCRIPTION
## What changed
- Added `POST /content/:hash/publish` for one-way owner/admin early publishing.
- Kept publish idempotent: an existing `publishedAt` timestamp is preserved.
- Reused the existing recovery-log + state-store persistence path so publish updates are recoverable.
- Added capability/discovery entries and tests for publish semantics.

## Checks run
- `npm --workspace mcp-server test`
- `RUN_HTTP_SMOKE=1 node --test mcp-server/src/protocols/http/server.smoke.test.js` with chain/env vars scrubbed
- `git diff --check`

## Affected surfaces
- Backend: yes
- Frontend/operator app: no
- Indexer: no
- Contracts: no
- Public site: no
- Caddy/VPS secrets: no

## Notes
- Polkadot docs check: this stays API-level disclosure state only. On-chain `Disclosed` event emission remains a later contract/API slice.