### PR TITLE
Fix OSV manifest target count status

### DIFF
--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -21,7 +21,7 @@ const STARTER_REPUTATION = {
 const INGESTION_PROVIDER_DEFINITIONS = [
   ["github", "githubIngestion", "GitHub issues", "queryCount"],
   ["wikipedia", "wikipediaIngestion", "Wikipedia maintenance", "categoryCount"],
-  ["osv", "osvIngestion", "OSV advisories", "packageCount"],
+  ["osv", "osvIngestion", "OSV advisories", "targetCount"],
   ["openData", "openDataIngestion", "Open data", "targetCount"],
   ["standards", "standardsIngestion", "Standards freshness", "specCount"],
   ["openApi", "openApiIngestion", "OpenAPI quality", "specCount"]

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -188,7 +188,9 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
         running: true,
         dryRun: true,
         intervalMs: 3600000,
-        packageCount: 1,
+        packageCount: 0,
+        manifestCount: 1,
+        targetCount: 1,
         maxJobsPerRun: 2,
         maxOpenJobs: 20,
         currentOpenJobs: 2,
@@ -245,7 +247,9 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
   };
 
   const status = await service.getAdminStatus();
-  assert.equal(status.osvIngestion.packageCount, 1);
+  assert.equal(status.osvIngestion.packageCount, 0);
+  assert.equal(status.osvIngestion.manifestCount, 1);
+  assert.equal(status.osvIngestion.targetCount, 1);
   assert.equal(status.openDataIngestion.query, "res_format:CSV");
   assert.equal(status.openDataIngestion.lastRun.createdCount, 2);
   assert.equal(status.standardsIngestion.specCount, 2);
@@ -256,6 +260,7 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
   assert.equal(status.providerOperations.github.lastRun.createdCount, 1);
   assert.equal(status.providerOperations.github.lastRun.skippedCount, 1);
   assert.equal(status.providerOperations.github.lastRun.skipped[0].reason, "source_already_ingested");
+  assert.equal(status.providerOperations.osv.targetCount, 1);
   assert.equal(status.providerOperations.openData.mode, "live");
   assert.equal(status.providerOperations.openData.health, "healthy");
   assert.equal(status.providerOperations.openData.targetCount, 3);

--- a/mcp-server/src/services/osv-advisory-ingestion-scheduler.js
+++ b/mcp-server/src/services/osv-advisory-ingestion-scheduler.js
@@ -56,6 +56,7 @@ export class OsvAdvisoryIngestionScheduler {
       intervalMs: this.intervalMs,
       packageCount: this.packages.length,
       manifestCount: this.manifests.length,
+      targetCount: this.packages.length || this.manifests.length,
       minScore: this.minScore,
       maxJobsPerRun: this.maxJobsPerRun,
       maxPackageTargets: this.maxPackageTargets,

--- a/mcp-server/src/services/osv-advisory-ingestion-scheduler.test.js
+++ b/mcp-server/src/services/osv-advisory-ingestion-scheduler.test.js
@@ -111,7 +111,9 @@ test("OsvAdvisoryIngestionScheduler can source targets from manifests", async ()
   const summary = await scheduler.runOnce(new Date("2026-04-26T10:00:00.000Z"));
   assert.equal(summary.createdCount, 1);
   assert.equal(platform.listJobs()[0].source.packageName, "minimist");
-  assert.equal((await scheduler.getStatus()).manifestCount, 1);
+  const status = await scheduler.getStatus();
+  assert.equal(status.manifestCount, 1);
+  assert.equal(status.targetCount, 1);
 });
 
 test("OsvAdvisoryIngestionScheduler prefers explicit packages over manifests", async () => {
@@ -131,6 +133,10 @@ test("OsvAdvisoryIngestionScheduler prefers explicit packages over manifests", a
 
   const summary = await scheduler.runOnce(new Date("2026-04-26T10:00:00.000Z"));
   assert.equal(summary.createdCount, 1);
+  const status = await scheduler.getStatus();
+  assert.equal(status.packageCount, 1);
+  assert.equal(status.manifestCount, 1);
+  assert.equal(status.targetCount, 1);
 });
 
 test("OsvAdvisoryIngestionScheduler dedupes by advisory package target", async () => {


### PR DESCRIPTION
## Summary

- Add an OSV scheduler targetCount that reflects the active configured source set.
- Use that field for providerOperations.osv.targetCount so manifest mode no longer shows 0.
- Cover manifest-only and explicit-package-preferred status behavior in tests.

## Validation

- node --test mcp-server/src/services/osv-advisory-ingestion-scheduler.test.js mcp-server/src/core/platform-service.test.js
- npm --workspace mcp-server test
- git diff --check