### PR TITLE
Surface open data rotation + friendly skip reasons

### DIFF
--- a/app/components/overview/ProviderOperationsCard.tsx
+++ b/app/components/overview/ProviderOperationsCard.tsx
@@ -7,6 +7,7 @@ import {
   PROVIDER_HEALTH_LABEL,
   PROVIDER_MODE_LABEL,
   PROVIDER_TARGET_UNIT,
+  summarizeSkipReasons,
 } from "@/lib/api/provider-operations";
 
 export interface ProviderOperationsCardProps {
@@ -63,6 +64,23 @@ function ProviderRow({ provider }: { provider: ProviderOperation }) {
             <span className="text-[var(--avy-ink)]">{provider.targetCount}</span>{" "}
             {targetUnit}
           </span>
+          {provider.queryCount !== undefined ? (
+            <>
+              <span>·</span>
+              <span>
+                <span className="text-[var(--avy-ink)]">{provider.queryCount}</span>{" "}
+                queries
+              </span>
+            </>
+          ) : null}
+          {provider.nextQuery ? (
+            <>
+              <span>·</span>
+              <span>
+                next <span className="text-[var(--avy-ink)]">&ldquo;{provider.nextQuery}&rdquo;</span>
+              </span>
+            </>
+          ) : null}
         </div>
       </div>
 
@@ -93,6 +111,14 @@ function ProviderRow({ provider }: { provider: ProviderOperation }) {
         ) : (
           <span className="text-[var(--avy-muted)]">No runs recorded yet.</span>
         )}
+        {lastRun && lastRun.skipped.length > 0 ? (
+          <span className="font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]">
+            skipped:{" "}
+            {summarizeSkipReasons(lastRun.skipped)
+              .map((entry) => `${entry.count} ${entry.label}`)
+              .join(" · ")}
+          </span>
+        ) : null}
         <div className="flex flex-wrap items-center gap-1.5 font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]">
           <span>{provider.lastRunAt ? `last run ${formatRelative(provider.lastRunAt)}` : "never"}</span>
           {errored ? (
@@ -191,6 +217,11 @@ export const PROVIDER_OPERATIONS_FIXTURE: ProviderOperation[] = [
       skippedCount: 22,
       errorCount: 0,
       summary: "26 candidates, 4 created, 22 skipped, 0 errors",
+      skipped: [
+        { reason: "source_already_ingested" },
+        { reason: "source_already_ingested" },
+        { reason: "source_already_ingested" },
+      ],
     },
   },
   {
@@ -215,6 +246,7 @@ export const PROVIDER_OPERATIONS_FIXTURE: ProviderOperation[] = [
       skippedCount: 16,
       errorCount: 0,
       summary: "18 candidates, 2 created, 16 skipped, 0 errors",
+      skipped: [],
     },
   },
   {
@@ -239,6 +271,7 @@ export const PROVIDER_OPERATIONS_FIXTURE: ProviderOperation[] = [
       skippedCount: 9,
       errorCount: 0,
       summary: "9 candidates, 0 created, 9 skipped (cap reached), 0 errors",
+      skipped: [],
     },
   },
   {
@@ -253,6 +286,8 @@ export const PROVIDER_OPERATIONS_FIXTURE: ProviderOperation[] = [
     maxOpenJobs: 10,
     currentOpenJobs: 2,
     targetCount: 7,
+    queryCount: 12,
+    nextQuery: "transport",
     lastRunAt: new Date(Date.now() - 1_500_000).toISOString(),
     lastRun: {
       startedAt: new Date(Date.now() - 1_540_000).toISOString(),
@@ -263,6 +298,11 @@ export const PROVIDER_OPERATIONS_FIXTURE: ProviderOperation[] = [
       skippedCount: 12,
       errorCount: 0,
       summary: "12 candidates, 0 created (dry run), 12 skipped, 0 errors",
+      skipped: [
+        { reason: "dataset_already_ingested" },
+        { reason: "dataset_already_ingested" },
+        { reason: "source_already_ingested" },
+      ],
     },
   },
   {
@@ -287,6 +327,7 @@ export const PROVIDER_OPERATIONS_FIXTURE: ProviderOperation[] = [
       skippedCount: 3,
       errorCount: 2,
       summary: "5 candidates, 0 created, 3 skipped, 2 errors",
+      skipped: [],
     },
   },
   {

--- a/app/lib/api/provider-operations.ts
+++ b/app/lib/api/provider-operations.ts
@@ -28,6 +28,13 @@ export type ProviderHealth =
 
 export type ProviderMode = "live" | "dry_run" | "disabled";
 
+export interface ProviderLastRunSkipped {
+  /** Free-form reason code such as "source_already_ingested" or
+   *  "dataset_already_ingested". `formatSkipReason` maps the known ones
+   *  to human-readable labels for the operator UI. */
+  reason: string;
+}
+
 export interface ProviderLastRun {
   startedAt?: string;
   finishedAt?: string;
@@ -38,6 +45,9 @@ export interface ProviderLastRun {
   errorCount: number;
   /** Pre-formatted "X candidate(s), Y created, Z skipped, W error(s)". */
   summary: string;
+  /** Up to 5 detailed skip records on `/admin/status`. Always empty on
+   *  the public `/status/providers` mirror. */
+  skipped: ProviderLastRunSkipped[];
 }
 
 export interface ProviderOperation {
@@ -53,6 +63,11 @@ export interface ProviderOperation {
   currentOpenJobs: number;
   /** Upstream queries / categories / packages / datasets / specs scanned. */
   targetCount: number;
+  /** Rotation pool size, only emitted when distinct from targetCount
+   *  (open data is the only provider where the two differ today). */
+  queryCount?: number;
+  /** The next rotation query, when the provider rotates a query list. */
+  nextQuery?: string;
   lastRunAt?: string;
   lastRun?: ProviderLastRun;
 }
@@ -115,6 +130,10 @@ function buildProvider(
     maxOpenJobs: nonNegInt(raw.maxOpenJobs),
     currentOpenJobs: nonNegInt(raw.currentOpenJobs),
     targetCount: nonNegInt(raw.targetCount),
+    ...(typeof raw.queryCount === "number" && Number.isFinite(raw.queryCount) && raw.queryCount >= 0
+      ? { queryCount: Math.floor(raw.queryCount) }
+      : {}),
+    ...(text(raw.nextQuery) ? { nextQuery: text(raw.nextQuery) } : {}),
     ...(text(raw.lastRunAt) ? { lastRunAt: text(raw.lastRunAt) } : {}),
     ...(buildLastRun(raw.lastRun)
       ? { lastRun: buildLastRun(raw.lastRun)! }
@@ -134,7 +153,60 @@ function buildLastRun(raw: unknown): ProviderLastRun | undefined {
     skippedCount: nonNegInt(record.skippedCount),
     errorCount: nonNegInt(record.errorCount),
     summary: text(record.summary, ""),
+    skipped: buildSkippedList(record.skipped),
   };
+}
+
+function buildSkippedList(value: unknown): ProviderLastRunSkipped[] {
+  if (!Array.isArray(value)) return [];
+  const out: ProviderLastRunSkipped[] = [];
+  for (const entry of value) {
+    const record = asRecord(entry);
+    if (!record) continue;
+    const reason = text(record.reason);
+    if (!reason) continue;
+    out.push({ reason });
+  }
+  return out;
+}
+
+/**
+ * Map machine reason codes from `lastRun.skipped[].reason` to a label
+ * the operator can read at a glance. Unknown reasons fall back to the
+ * raw code so we don't silently swallow new reason kinds the backend
+ * starts emitting.
+ *
+ * `dataset_already_ingested` is intentionally NOT framed as an error —
+ * it's the "the candidate would just duplicate something we already
+ * have" outcome from the open-data dedupe path, and operators want to
+ * see it as part of normal scheduler housekeeping.
+ */
+export function formatSkipReason(reason: string): string {
+  switch (reason) {
+    case "source_already_ingested":
+      return "source already ingested";
+    case "dataset_already_ingested":
+      return "dataset already represented";
+    default:
+      return reason;
+  }
+}
+
+/** Group skip details into "{count} {friendly label}" tokens. */
+export function summarizeSkipReasons(
+  skipped: ProviderLastRunSkipped[]
+): { reason: string; label: string; count: number }[] {
+  const counts = new Map<string, number>();
+  for (const entry of skipped) {
+    counts.set(entry.reason, (counts.get(entry.reason) ?? 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([reason, count]) => ({
+      reason,
+      label: formatSkipReason(reason),
+      count,
+    }));
 }
 
 function byOperatorPriority(

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -742,6 +742,15 @@ function buildProviderOperationStatus({ label, status, targetCountField }) {
   const currentOpenJobs = status.currentOpenJobs !== undefined
     ? toNonNegativeInteger(status.currentOpenJobs)
     : inferCurrentOpenJobs(status.lastRun);
+  // queryCount/nextQuery describe the rotation pool — only meaningful
+  // when the provider rotates a query list distinct from its
+  // targetCount. github's queryCount IS its targetCount, so don't
+  // duplicate it; openData rotates queries against a dataset list, so
+  // queryCount and targetCount are genuinely different signals.
+  const queryCount = status.queryCount !== undefined && targetCountField !== "queryCount"
+    ? toNonNegativeInteger(status.queryCount)
+    : undefined;
+  const nextQuery = stringOrUndefined(status.nextQuery);
   return {
     label,
     enabled: Boolean(status.enabled),
@@ -753,6 +762,8 @@ function buildProviderOperationStatus({ label, status, targetCountField }) {
     maxOpenJobs: toNonNegativeInteger(status.maxOpenJobs),
     currentOpenJobs,
     targetCount: toNonNegativeInteger(status[targetCountField]),
+    ...(queryCount !== undefined ? { queryCount } : {}),
+    ...(nextQuery ? { nextQuery } : {}),
     lastRunAt: lastRun?.finishedAt ?? lastRun?.startedAt,
     lastRun,
     health: summarizeProviderHealth({

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -204,12 +204,21 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
         dryRun: false,
         intervalMs: 3600000,
         query: "res_format:CSV",
+        queryCount: 7,
+        nextQuery: "transport",
         datasetCount: 0,
         targetCount: 3,
         maxJobsPerRun: 2,
         maxOpenJobs: 20,
         currentOpenJobs: 4,
-        lastRun: { candidateCount: 2, createdCount: 2, skipped: [], errors: [] }
+        lastRun: {
+          candidateCount: 2,
+          createdCount: 1,
+          skipped: [
+            { datasetId: "abc", resourceId: "abc-1", reason: "dataset_already_ingested" }
+          ],
+          errors: []
+        }
       };
     }
   };
@@ -247,7 +256,7 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
   const status = await service.getAdminStatus();
   assert.equal(status.osvIngestion.packageCount, 1);
   assert.equal(status.openDataIngestion.query, "res_format:CSV");
-  assert.equal(status.openDataIngestion.lastRun.createdCount, 2);
+  assert.equal(status.openDataIngestion.lastRun.createdCount, 1);
   assert.equal(status.standardsIngestion.specCount, 2);
   assert.equal(status.openApiIngestion.specCount, 1);
   assert.equal(status.providerOperations.github.label, "GitHub issues");
@@ -259,7 +268,16 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
   assert.equal(status.providerOperations.openData.mode, "live");
   assert.equal(status.providerOperations.openData.health, "healthy");
   assert.equal(status.providerOperations.openData.targetCount, 3);
-  assert.equal(status.providerOperations.openData.lastRun.summary, "2 candidate(s), 2 created, 0 skipped, 0 error(s)");
+  // Open data rotates a query pool that's distinct from the dataset
+  // target list — both signals reach the operator UI.
+  assert.equal(status.providerOperations.openData.queryCount, 7);
+  assert.equal(status.providerOperations.openData.nextQuery, "transport");
+  assert.equal(status.providerOperations.openData.lastRun.summary, "2 candidate(s), 1 created, 1 skipped, 0 error(s)");
+  assert.equal(status.providerOperations.openData.lastRun.skipped[0].reason, "dataset_already_ingested");
+  // github's queryCount IS its targetCount — don't duplicate the
+  // field at the top level.
+  assert.equal(status.providerOperations.github.queryCount, undefined);
+  assert.equal(status.providerOperations.github.nextQuery, undefined);
   assert.equal(status.providerOperations.openApi.health, "error");
   assert.equal(status.providerOperations.openApi.lastRun.errorCount, 1);
 

--- a/site/trust-providers.js
+++ b/site/trust-providers.js
@@ -97,6 +97,10 @@
           errorCount: nonNegInt(lastRunRaw.errorCount),
         }
       : null;
+    const queryCountRaw = raw && raw.queryCount;
+    const queryCount = typeof queryCountRaw === "number" && Number.isFinite(queryCountRaw) && queryCountRaw >= 0
+      ? Math.floor(queryCountRaw)
+      : null;
     return {
       key: key,
       label: asString(raw && raw.label, PROVIDER_LABEL[key] || key),
@@ -106,6 +110,8 @@
       maxOpenJobs: nonNegInt(raw && raw.maxOpenJobs),
       currentOpenJobs: nonNegInt(raw && raw.currentOpenJobs),
       targetCount: nonNegInt(raw && raw.targetCount),
+      queryCount: queryCount,
+      nextQuery: asString(raw && raw.nextQuery, ""),
       lastRunAt: asString(raw && raw.lastRunAt, ""),
       lastRun: lastRun,
     };
@@ -148,6 +154,12 @@
         '<p class="provider-row-meta">' +
           '<span class="provider-mode provider-mode--' + escapeHtml(provider.mode) + '">' + escapeHtml(MODE_LABEL[provider.mode]) + '</span>' +
           ' · <strong>' + escapeHtml(String(provider.targetCount)) + '</strong> ' + escapeHtml(unit) +
+          (provider.queryCount !== null
+            ? ' · <strong>' + escapeHtml(String(provider.queryCount)) + '</strong> queries'
+            : "") +
+          (provider.nextQuery
+            ? ' · next <strong>&ldquo;' + escapeHtml(provider.nextQuery) + '&rdquo;</strong>'
+            : "") +
           ' · open jobs <strong>' + escapeHtml(String(open)) + '</strong> / ' + escapeHtml(String(cap)) +
         '</p>' +
         '<div class="provider-bar"><span style="width:' + fillPct + '%"></span></div>' +


### PR DESCRIPTION
## Summary
- Plumbs `queryCount` and `nextQuery` from the open-data scheduler status through `providerOperations` (gated so we don't duplicate github's queryCount which already feeds its targetCount)
- Operator card on `/overview` now shows the open-data rotation hint (`12 queries · next \"transport\"`) and breaks down `lastRun.skipped[]` with friendly labels
- `dataset_already_ingested` is rendered as **\"dataset already represented\"** — it's the dedupe outcome, not an error
- Public trust page mirrors the rotation hint via the sanitized `/status/providers` endpoint (skip details remain suppressed there)

## Why
PR #52 added open-data query rotation + dataset-level dedupe. The operator UI didn't reflect either signal, so the open-data row looked the same whether the scheduler was rotating queries or stuck on one.

## Test plan
- [x] `npm --workspace mcp-server test` — 306/306 pass
- [x] `npm run typecheck:app`
- [x] `npm run build:frontend`
- [x] `npm run build:site`
- [ ] After deploy: confirm `/admin/status` openData entry carries `queryCount` + `nextQuery`; confirm `/overview` and `/trust/` render the rotation hint