### PR TITLE
Add content recovery replay tool

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -10,6 +10,7 @@
     "demo:e2e": "node src/demo/e2e-local.js",
     "demo:e2e:remote": "node src/demo/e2e-remote.js",
     "check:redis": "node src/demo/redis-persistence-check.js",
+    "replay:content-recovery": "node src/demo/replay-content-recovery-log.js",
     "ingest:github-issues": "node src/jobs/ingest-github-issues.js",
     "ingest:wikipedia": "node src/jobs/ingest-wikipedia-maintenance.js",
     "ingest:osv-advisories": "node src/jobs/ingest-osv-advisories.js",

--- a/mcp-server/src/core/content-recovery-log.js
+++ b/mcp-server/src/core/content-recovery-log.js
@@ -1,8 +1,8 @@
-import { appendFile, mkdir } from "node:fs/promises";
+import { appendFile, mkdir, readFile, readdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
 
 import { canonicalizeContent } from "./canonical-content.js";
-import { assertContentHashMatches } from "./content-addressed-store.js";
+import { assertContentHashMatches, buildContentRecord } from "./content-addressed-store.js";
 import { ConfigError, ExternalServiceError } from "./errors.js";
 
 export const DEFAULT_CONTENT_RECOVERY_LOG_DIR = ".content-recovery-log";
@@ -42,6 +42,101 @@ export class ContentRecoveryLog {
     }
   }
 
+}
+
+export async function replayContentRecoveryLog({
+  dir = DEFAULT_CONTENT_RECOVERY_LOG_DIR,
+  stateStore,
+  apply = false,
+  logger = console
+} = {}) {
+  if (!stateStore || typeof stateStore.getContent !== "function" || typeof stateStore.upsertContent !== "function") {
+    throw new ConfigError("replayContentRecoveryLog requires a stateStore with getContent/upsertContent methods.");
+  }
+  const root = resolve(dir);
+  const summary = {
+    dryRun: !apply,
+    directory: root,
+    filesRead: 0,
+    recordsSeen: 0,
+    restored: 0,
+    wouldRestore: 0,
+    skipped: 0,
+    invalid: 0,
+    errors: []
+  };
+
+  let files;
+  try {
+    files = (await readdir(root))
+      .filter((name) => /^\d{4}-\d{2}-\d{2}\.jsonl$/u.test(name))
+      .sort();
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return summary;
+    }
+    throw new ExternalServiceError(`Content recovery log read failed: ${error?.message ?? "unknown_error"}`);
+  }
+
+  for (const name of files) {
+    const file = join(root, name);
+    summary.filesRead += 1;
+    const raw = await readFile(file, "utf8");
+    const lines = raw.split("\n");
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index].trim();
+      if (!line) continue;
+      summary.recordsSeen += 1;
+      const location = `${name}:${index + 1}`;
+      try {
+        const record = recordFromRecoveryLine(line);
+        const existing = await stateStore.getContent(record.hash);
+        if (existing && canonicalizeContent(existing) === canonicalizeContent(record)) {
+          summary.skipped += 1;
+          continue;
+        }
+        if (existing && contentVersionTime(existing) > contentVersionTime(record)) {
+          summary.skipped += 1;
+          continue;
+        }
+        if (apply) {
+          await stateStore.upsertContent(record);
+          summary.restored += 1;
+        } else {
+          summary.wouldRestore += 1;
+        }
+      } catch (error) {
+        summary.invalid += 1;
+        const message = error?.message ?? String(error ?? "unknown_error");
+        logger.warn?.({ location, err: error instanceof Error ? error : new Error(message) }, "content_recovery.invalid_record");
+        summary.errors.push({ location, message });
+      }
+    }
+  }
+
+  return summary;
+}
+
+export function recordFromRecoveryLine(line) {
+  const entry = JSON.parse(line);
+  if (entry?.kind !== "content.upserted") {
+    throw new ConfigError("Unsupported content recovery log entry kind.");
+  }
+  const record = buildContentRecord({
+    payload: entry.payload,
+    contentType: entry.contentType,
+    ownerWallet: entry.ownerWallet,
+    verdict: entry.verdict,
+    createdAt: entry.createdAt,
+    publishedAt: entry.publishedAt,
+    autoPublicAt: entry.autoPublicAt
+  });
+  assertContentHashMatches({ ...record, hash: entry.hash });
+  return { ...record, hash: String(entry.hash).toLowerCase() };
+}
+
+function contentVersionTime(record) {
+  return Date.parse(record?.publishedAt ?? record?.createdAt ?? "") || 0;
 }
 
 export function createContentRecoveryLog(env = process.env, { logger = console } = {}) {

--- a/mcp-server/src/core/content-recovery-log.test.js
+++ b/mcp-server/src/core/content-recovery-log.test.js
@@ -1,12 +1,18 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, readFile } from "node:fs/promises";
+import { appendFile, mkdtemp, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { buildContentRecord } from "./content-addressed-store.js";
-import { ContentRecoveryLog, createContentRecoveryLog } from "./content-recovery-log.js";
+import {
+  ContentRecoveryLog,
+  createContentRecoveryLog,
+  recordFromRecoveryLine,
+  replayContentRecoveryLog
+} from "./content-recovery-log.js";
 import { ConfigError } from "./errors.js";
+import { MemoryStateStore } from "./state-store.js";
 
 const OWNER = "0x1111111111111111111111111111111111111111";
 
@@ -65,4 +71,71 @@ test("createContentRecoveryLog parses boolean env", () => {
     () => createContentRecoveryLog({ CONTENT_RECOVERY_LOG_ENABLED: "sometimes" }),
     ConfigError
   );
+});
+
+test("recordFromRecoveryLine validates canonical content hash", () => {
+  const record = buildContentRecord({
+    ownerWallet: OWNER,
+    payload: { ok: true }
+  });
+  const line = JSON.stringify({
+    kind: "content.upserted",
+    loggedAt: "2026-04-27T12:01:00.000Z",
+    ...record
+  });
+
+  assert.deepEqual(recordFromRecoveryLine(line), record);
+  assert.throws(
+    () => recordFromRecoveryLine(line.replace(record.hash, "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")),
+    /content hash does not match/u
+  );
+});
+
+test("replayContentRecoveryLog dry-runs and applies valid entries in file order", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "averray-content-replay-"));
+  const recoveryLog = new ContentRecoveryLog({ dir });
+  const stateStore = new MemoryStateStore();
+  const first = buildContentRecord({
+    ownerWallet: OWNER,
+    payload: { a: 1 },
+    contentType: "arbitrator_reasoning",
+    verdict: "fail",
+    createdAt: "2026-04-27T12:00:00.000Z"
+  });
+  const published = { ...first, publishedAt: "2026-04-27T13:00:00.000Z" };
+  await recoveryLog.append(first, { loggedAt: "2026-04-27T12:01:00.000Z" });
+  await recoveryLog.append(published, { loggedAt: "2026-04-27T13:01:00.000Z" });
+
+  const dryRun = await replayContentRecoveryLog({ dir, stateStore });
+  assert.equal(dryRun.dryRun, true);
+  assert.equal(dryRun.filesRead, 1);
+  assert.equal(dryRun.recordsSeen, 2);
+  assert.equal(dryRun.wouldRestore, 2);
+  assert.equal(await stateStore.getContent(first.hash), undefined);
+
+  const applied = await replayContentRecoveryLog({ dir, stateStore, apply: true });
+  assert.equal(applied.restored, 2);
+  assert.equal((await stateStore.getContent(first.hash)).publishedAt, "2026-04-27T13:00:00.000Z");
+
+  const secondApply = await replayContentRecoveryLog({ dir, stateStore, apply: true });
+  assert.equal(secondApply.restored, 0);
+  assert.equal(secondApply.skipped, 2);
+});
+
+test("replayContentRecoveryLog reports invalid lines without applying them", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "averray-content-replay-"));
+  const stateStore = new MemoryStateStore();
+  await appendFile(join(dir, "2026-04-27.jsonl"), "{\"kind\":\"content.upserted\",\"hash\":\"0xnope\"}\n", "utf8");
+
+  const summary = await replayContentRecoveryLog({
+    dir,
+    stateStore,
+    apply: true,
+    logger: { warn() {} }
+  });
+
+  assert.equal(summary.recordsSeen, 1);
+  assert.equal(summary.invalid, 1);
+  assert.equal(summary.restored, 0);
+  assert.equal(summary.errors[0].location, "2026-04-27.jsonl:1");
 });

--- a/mcp-server/src/demo/replay-content-recovery-log.js
+++ b/mcp-server/src/demo/replay-content-recovery-log.js
@@ -1,0 +1,73 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { replayContentRecoveryLog } from "../core/content-recovery-log.js";
+import { createStateStore } from "../core/state-store.js";
+import { loadLocalEnv } from "../services/env-loader.js";
+
+const moduleDir = dirname(fileURLToPath(import.meta.url));
+loadLocalEnv(process.cwd(), resolve(moduleDir, "../../"));
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const stateStore = createStateStore(process.env, { logger: console });
+  const summary = await replayContentRecoveryLog({
+    dir: options.dir ?? process.env.CONTENT_RECOVERY_LOG_DIR,
+    stateStore,
+    apply: options.apply,
+    logger: console
+  });
+  console.log(JSON.stringify(summary, null, 2));
+  if (summary.invalid > 0) {
+    process.exitCode = 1;
+  }
+}
+
+function parseArgs(args) {
+  const options = { apply: false, dir: undefined };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--apply") {
+      options.apply = true;
+      continue;
+    }
+    if (arg === "--dry-run") {
+      options.apply = false;
+      continue;
+    }
+    if (arg === "--dir") {
+      if (!args[index + 1]) {
+        throw new Error("--dir requires a path.");
+      }
+      options.dir = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--dir=")) {
+      options.dir = arg.slice("--dir=".length);
+      if (!options.dir) {
+        throw new Error("--dir requires a path.");
+      }
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function printHelp() {
+  console.log(`Usage: npm --workspace mcp-server run replay:content-recovery -- [--apply] [--dir PATH]
+
+Replays append-only content recovery JSONL files into the configured state store.
+Dry-run is the default. Pass --apply to write records.
+`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## What changed
- Added recovery-log replay parsing and validation for content-addressed blobs.
- Added dry-run/apply replay CLI via `npm --workspace mcp-server run replay:content-recovery -- [--apply] [--dir PATH]`.
- Validates canonical payload hashes before restore and skips stale pre-publish records when a newer published record is already present.
- Added tests for dry-run, apply/idempotent replay, invalid lines, and hash mismatch.

## Checks run
- `node --test mcp-server/src/core/content-recovery-log.test.js`
- `npm --workspace mcp-server run replay:content-recovery -- --help`
- `npm --workspace mcp-server test`
- `RUN_HTTP_SMOKE=1 node --test mcp-server/src/protocols/http/server.smoke.test.js` with chain/env vars scrubbed
- `git diff --check`

## Affected surfaces
- Backend/ops: yes
- Frontend/operator app: no
- Indexer: no
- Contracts: no
- Public site: no
- VPS secrets: no

## Notes
- Polkadot docs check: this remains private operator replay tooling, not Bulletin/IPFS persistence and not on-chain disclosure.