### PR TITLE
Group OSV advisories by dependency target

### DIFF
--- a/mcp-server/src/jobs/ingest-osv-advisories.js
+++ b/mcp-server/src/jobs/ingest-osv-advisories.js
@@ -87,13 +87,14 @@ export async function ingestOsvAdvisories({
     }
   }
 
-  const jobs = candidates
+  const groupedCandidates = groupOsvCandidates(candidates);
+  const jobs = groupedCandidates
     .sort((left, right) => right.score - left.score)
     .slice(0, limit)
-    .map(({ target, advisory, fixedVersion, score }) => toPlatformJob({ target, advisory, fixedVersion, score }));
+    .map(({ target, advisories, fixedVersion, score }) => toPlatformJob({ target, advisories, fixedVersion, score }));
 
-  if (candidates.length > jobs.length) {
-    skipped.push({ reason: "over_limit", count: candidates.length - jobs.length });
+  if (groupedCandidates.length > jobs.length) {
+    skipped.push({ reason: "over_limit", count: groupedCandidates.length - jobs.length });
   }
 
   return {
@@ -204,21 +205,70 @@ export function scoreAdvisory(advisory, { fixedVersion } = {}) {
   return Math.max(0, Math.min(100, score));
 }
 
-export function toPlatformJob({ target, advisory, fixedVersion, score = scoreAdvisory(advisory, { fixedVersion }) }) {
-  const advisoryId = String(advisory.id ?? "OSV-UNKNOWN");
-  const aliases = advisoryAliases(advisory);
+function groupOsvCandidates(candidates) {
+  const groups = new Map();
+  for (const candidate of candidates) {
+    const key = osvTargetKey(candidate.target);
+    const group = groups.get(key) ?? {
+      target: candidate.target,
+      advisories: [],
+      fixedVersion: candidate.fixedVersion,
+      score: candidate.score
+    };
+    group.advisories.push(candidate);
+    if (compareSemverish(candidate.fixedVersion, group.fixedVersion) > 0) {
+      group.fixedVersion = candidate.fixedVersion;
+    }
+    group.score = Math.max(group.score, candidate.score);
+    groups.set(key, group);
+  }
+  return [...groups.values()].map((group) => ({
+    ...group,
+    advisories: group.advisories.sort((left, right) => {
+      if (right.score !== left.score) return right.score - left.score;
+      return String(left.advisory.id ?? "").localeCompare(String(right.advisory.id ?? ""));
+    })
+  }));
+}
+
+function osvTargetKey(target) {
+  return [
+    String(target.ecosystem ?? DEFAULT_ECOSYSTEM).toLowerCase(),
+    String(target.repo ?? "").toLowerCase(),
+    String(target.manifestPath ?? "").toLowerCase(),
+    String(target.name).toLowerCase(),
+    String(target.version)
+  ].join("|");
+}
+
+export function toPlatformJob({ target, advisory, advisories, fixedVersion, score }) {
+  const advisoryEntries = normalizeAdvisoryEntries({ advisory, advisories, fixedVersion, score });
+  const primaryEntry = advisoryEntries[0] ?? { advisory: {}, fixedVersion, score: 0 };
+  const primaryAdvisory = primaryEntry.advisory;
+  const primaryAdvisoryId = String(primaryAdvisory.id ?? "OSV-UNKNOWN");
+  const advisoryIds = [...new Set(advisoryEntries.map((entry) => String(entry.advisory.id ?? "").trim()).filter(Boolean))];
+  const aliases = [...new Set(advisoryEntries.flatMap((entry) => advisoryAliases(entry.advisory)))];
   const cves = aliases.filter((alias) => alias.startsWith("CVE-"));
-  const references = advisoryReferences(advisory);
+  const references = uniqueReferences(advisoryEntries.flatMap((entry) => advisoryReferences(entry.advisory)));
   const repo = target.repo ? normalizeRepo(target.repo) : undefined;
   const manifestPath = target.manifestPath ?? "package.json";
-  const title = `Remediate ${advisoryId} in ${target.name}`;
-  const id = `osv-npm-${slugify(repo ?? "repo")}-${slugify(target.name)}-${slugify(target.version)}-${slugify(advisoryId)}`.slice(0, 120);
+  const effectiveFixedVersion = fixedVersion ?? maxFixedVersion(advisoryEntries.map((entry) => entry.fixedVersion));
+  const effectiveScore = score ?? Math.max(...advisoryEntries.map((entry) => entry.score ?? scoreAdvisory(entry.advisory, { fixedVersion: entry.fixedVersion })));
+  const isGrouped = advisoryEntries.length > 1;
+  const advisoryLabel = advisoryIds.length ? advisoryIds.join(", ") : primaryAdvisoryId;
+  const title = isGrouped
+    ? `Remediate ${target.name} advisories`
+    : `Remediate ${primaryAdvisoryId} in ${target.name}`;
+  const id = (isGrouped
+    ? `osv-npm-${slugify(repo ?? "repo")}-${slugify(target.name)}-${slugify(target.version)}`
+    : `osv-npm-${slugify(repo ?? "repo")}-${slugify(target.name)}-${slugify(target.version)}-${slugify(primaryAdvisoryId)}`
+  ).slice(0, 120);
 
   return {
     id,
     title,
     description:
-      `Update npm package ${target.name} from vulnerable version ${target.version} to ${fixedVersion} or a newer safe release. Advisory: ${advisoryId}.`,
+      `Update npm package ${target.name} from vulnerable version ${target.version} to ${effectiveFixedVersion} or a newer safe release. ${isGrouped ? "Advisories" : "Advisory"}: ${advisoryLabel}.`,
     jobType: "work",
     requiredRole: "worker",
     category: "security",
@@ -239,35 +289,45 @@ export function toPlatformJob({ target, advisory, fixedVersion, score = scoreAdv
       ecosystem: target.ecosystem,
       packageName: target.name,
       vulnerableVersion: target.version,
-      fixedVersion,
+      fixedVersion: effectiveFixedVersion,
       repo,
       manifestPath,
-      advisoryId,
+      advisoryId: primaryAdvisoryId,
+      advisoryIds: aliases,
       aliases,
       cves,
       nvdUrls: cves.map((cve) => `https://nvd.nist.gov/vuln/detail/${cve}`),
-      summary: String(advisory.summary ?? "").trim(),
-      details: summarise(String(advisory.details ?? "")),
+      summary: String(primaryAdvisory.summary ?? "").trim(),
+      details: summarise(String(primaryAdvisory.details ?? "")),
+      advisories: advisoryEntries.map((entry) => ({
+        advisoryId: String(entry.advisory.id ?? "OSV-UNKNOWN"),
+        fixedVersion: entry.fixedVersion,
+        aliases: advisoryAliases(entry.advisory),
+        summary: String(entry.advisory.summary ?? "").trim(),
+        references: advisoryReferences(entry.advisory),
+        severity: entry.advisory.severity ?? [],
+        score: entry.score ?? scoreAdvisory(entry.advisory, { fixedVersion: entry.fixedVersion })
+      })),
       references,
-      severity: advisory.severity ?? [],
-      published: advisory.published,
-      modified: advisory.modified,
-      score,
+      severity: primaryAdvisory.severity ?? [],
+      published: primaryAdvisory.published,
+      modified: primaryAdvisory.modified,
+      score: effectiveScore,
       discoveryApi: "https://api.osv.dev/v1/querybatch"
     },
     acceptanceCriteria: [
       `Update ${target.name} in ${manifestPath} so ${target.version} is no longer selected.`,
-      `Use ${fixedVersion} or a newer non-vulnerable version when compatible.`,
+      `Use ${effectiveFixedVersion} or a newer non-vulnerable version when compatible.`,
       "Update the lockfile when the ecosystem uses one.",
       "Run the relevant package manager install/check/test commands, or explain why a command cannot be run.",
-      "Open a focused pull request that references the OSV advisory and any CVE/GHSA aliases."
+      "Open a focused pull request that references the OSV advisory/advisories and any CVE/GHSA aliases."
     ],
-    estimatedDifficulty: estimateDifficulty(score),
+    estimatedDifficulty: estimateDifficulty(effectiveScore),
     agentInstructions: [
       ...(repo ? [`Work in https://github.com/${repo}.`] : ["Use the repository supplied by the operator before making changes."]),
-      `Review OSV advisory ${advisoryId}${aliases.length ? ` (${aliases.join(", ")})` : ""}.`,
+      `Review OSV ${isGrouped ? "advisories" : "advisory"} ${advisoryLabel}${aliases.length ? ` (${aliases.join(", ")})` : ""}.`,
       `Find every occurrence of ${target.name}@${target.version} in ${manifestPath} and related lockfiles.`,
-      "Prefer the smallest safe dependency bump that satisfies the advisory.",
+      "Prefer the smallest safe dependency bump that satisfies every advisory.",
       "Run tests or at least dependency installation/lockfile validation before submitting.",
       "Submit structured evidence with prUrl, packageName, vulnerableVersion, fixedVersion, advisoryIds, tests, and notes."
     ],
@@ -278,6 +338,44 @@ export function toPlatformJob({ target, advisory, fixedVersion, score = scoreAdv
       signals: ["pr_opened", "advisory_referenced", "dependency_updated", "lockfile_updated", "tests_submitted", "ci_passed"]
     }
   };
+}
+
+function normalizeAdvisoryEntries({ advisory, advisories, fixedVersion, score }) {
+  const rawEntries = Array.isArray(advisories) && advisories.length
+    ? advisories
+    : [{ advisory, fixedVersion, score }];
+  return rawEntries
+    .map((entry) => {
+      const advisoryValue = entry?.advisory ?? entry;
+      if (!advisoryValue || typeof advisoryValue !== "object") return undefined;
+      const entryFixedVersion = entry?.fixedVersion ?? fixedVersion;
+      return {
+        advisory: advisoryValue,
+        fixedVersion: entryFixedVersion,
+        score: entry?.score ?? score ?? scoreAdvisory(advisoryValue, { fixedVersion: entryFixedVersion })
+      };
+    })
+    .filter(Boolean);
+}
+
+function maxFixedVersion(versions) {
+  return versions
+    .map((version) => String(version ?? "").trim())
+    .filter(isSemverish)
+    .sort(compareSemverish)
+    .at(-1);
+}
+
+function uniqueReferences(references) {
+  const seen = new Set();
+  const unique = [];
+  for (const reference of references) {
+    const key = `${reference.type}|${reference.url}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(reference);
+  }
+  return unique;
 }
 
 export async function postJobs({ baseUrl, adminToken, jobs, fetchImpl = fetch }) {

--- a/mcp-server/src/jobs/ingest-osv-advisories.test.js
+++ b/mcp-server/src/jobs/ingest-osv-advisories.test.js
@@ -190,6 +190,61 @@ test("ingestOsvAdvisories queries OSV and filters jobs", async () => {
   assert.equal(payload.skipped.length, 0);
 });
 
+test("ingestOsvAdvisories groups advisories by package target", async () => {
+  const firstAdvisory = {
+    ...ADVISORY,
+    id: "GHSA-wc8c-qw6v-h7f6",
+    aliases: ["CVE-2026-29087"],
+    summary: "Encoded slash bypass",
+    affected: [
+      {
+        package: { ecosystem: "npm", name: "minimist" },
+        ranges: [{ type: "SEMVER", events: [{ introduced: "0" }, { fixed: "1.19.10" }] }]
+      }
+    ]
+  };
+  const secondAdvisory = {
+    ...ADVISORY,
+    id: "GHSA-92pp-h63x-v22m",
+    aliases: ["CVE-2026-39406"],
+    summary: "Repeated slash bypass",
+    affected: [
+      {
+        package: { ecosystem: "npm", name: "minimist" },
+        ranges: [{ type: "SEMVER", events: [{ introduced: "0" }, { fixed: "1.19.13" }] }]
+      }
+    ]
+  };
+
+  const payload = await ingestOsvAdvisories({
+    packages: [TARGET],
+    limit: 5,
+    minScore: 55,
+    fetchImpl: async (_url, request) => ({
+      ok: true,
+      async json() {
+        assert.equal(JSON.parse(request.body).queries[0].package.name, "minimist");
+        return { results: [{ vulns: [firstAdvisory, secondAdvisory] }] };
+      }
+    })
+  });
+
+  assert.equal(payload.count, 1);
+  assert.equal(payload.jobs[0].id, "osv-npm-example-app-minimist-0-0-8");
+  assert.equal(payload.jobs[0].title, "Remediate minimist advisories");
+  assert.equal(payload.jobs[0].source.fixedVersion, "1.19.13");
+  assert.equal(payload.jobs[0].source.advisories.length, 2);
+  assert.deepEqual(payload.jobs[0].source.advisoryIds.sort(), [
+    "CVE-2026-29087",
+    "CVE-2026-39406",
+    "GHSA-92pp-h63x-v22m",
+    "GHSA-wc8c-qw6v-h7f6"
+  ]);
+  assert.ok(payload.jobs[0].agentInstructions[1].includes("GHSA-92pp-h63x-v22m"));
+  assert.ok(payload.jobs[0].agentInstructions[1].includes("GHSA-wc8c-qw6v-h7f6"));
+  assert.equal(payload.skipped.length, 0);
+});
+
 test("ingestOsvAdvisories can derive package targets from GitHub lockfiles", async () => {
   const payload = await ingestOsvAdvisories({
     manifests: [{ repo: "example/app", manifestPath: "package-lock.json", ref: "main" }],

--- a/mcp-server/src/services/osv-advisory-ingestion-scheduler.js
+++ b/mcp-server/src/services/osv-advisory-ingestion-scheduler.js
@@ -198,7 +198,7 @@ export function loadOsvAdvisoryIngestionConfig(env = process.env) {
 
 function osvJobKey(job) {
   const source = job?.source;
-  if (source?.type !== "osv_advisory" || !source.packageName || !source.vulnerableVersion || !source.advisoryId) {
+  if (source?.type !== "osv_advisory" || !source.packageName || !source.vulnerableVersion) {
     return undefined;
   }
   return [
@@ -206,8 +206,7 @@ function osvJobKey(job) {
     String(source.repo ?? "").toLowerCase(),
     String(source.manifestPath ?? "").toLowerCase(),
     String(source.packageName).toLowerCase(),
-    String(source.vulnerableVersion),
-    String(source.advisoryId).toUpperCase()
+    String(source.vulnerableVersion)
   ].join("|");
 }
 


### PR DESCRIPTION
## Summary

- Group OSV advisory candidates by package/version/repo/manifest before creating jobs.
- Use the highest fixed version across grouped advisories and include all advisory/CVE aliases in the job source and instructions.
- Dedupe existing OSV jobs by dependency target so old single-advisory jobs prevent grouped duplicates.

## Validation

- node --test mcp-server/src/jobs/ingest-osv-advisories.test.js mcp-server/src/services/osv-advisory-ingestion-scheduler.test.js
- npm --workspace mcp-server test
- git diff --check origin/main..HEAD