### PR TITLE
Cap GitHub jobs per query

### DIFF
--- a/docs/PUBLIC_JOB_SOURCES.md
+++ b/docs/PUBLIC_JOB_SOURCES.md
@@ -178,11 +178,11 @@ operator dashboard. It is keyed by source:
 - `openApi`
 
 Each provider entry reports `label`, `enabled`, `running`, `dryRun`, `mode`,
-`health`, `intervalMs`, `maxJobsPerRun`, `maxOpenJobs`, `currentOpenJobs`,
-`targetCount`, `lastRunAt`, and a compact `lastRun` summary. The older
-provider-specific fields such as `osvIngestion` and `openDataIngestion` remain
-available for compatibility, but new admin UI should render from
-`providerOperations`.
+`health`, `intervalMs`, `maxJobsPerRun`, optional provider-specific caps such as
+`maxJobsPerQuery`, `maxOpenJobs`, `currentOpenJobs`, `targetCount`, `lastRunAt`,
+and a compact `lastRun` summary. The older provider-specific fields such as
+`osvIngestion` and `openDataIngestion` remain available for compatibility, but
+new admin UI should render from `providerOperations`.
 
 ### Public status endpoint
 

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -759,6 +759,7 @@ function buildProviderOperationStatus({ label, status, targetCountField }) {
     mode: !status.enabled ? "disabled" : (status.dryRun === false ? "live" : "dry_run"),
     intervalMs: toNonNegativeInteger(status.intervalMs),
     maxJobsPerRun: toNonNegativeInteger(status.maxJobsPerRun),
+    ...(status.maxJobsPerQuery !== undefined ? { maxJobsPerQuery: toNonNegativeInteger(status.maxJobsPerQuery) } : {}),
     maxOpenJobs: toNonNegativeInteger(status.maxOpenJobs),
     currentOpenJobs,
     targetCount: toNonNegativeInteger(status[targetCountField]),

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -147,6 +147,7 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
         intervalMs: 900000,
         queryCount: 2,
         maxJobsPerRun: 2,
+        maxJobsPerQuery: 2,
         maxOpenJobs: 12,
         currentOpenJobs: 3,
         lastRun: {
@@ -266,6 +267,7 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
   assert.equal(status.providerOperations.github.label, "GitHub issues");
   assert.equal(status.providerOperations.github.mode, "dry_run");
   assert.equal(status.providerOperations.github.currentOpenJobs, 3);
+  assert.equal(status.providerOperations.github.maxJobsPerQuery, 2);
   assert.equal(status.providerOperations.github.lastRun.createdCount, 1);
   assert.equal(status.providerOperations.github.lastRun.skippedCount, 1);
   assert.equal(status.providerOperations.github.lastRun.skipped[0].reason, "source_already_ingested");

--- a/mcp-server/src/services/github-issue-ingestion-scheduler.js
+++ b/mcp-server/src/services/github-issue-ingestion-scheduler.js
@@ -8,6 +8,7 @@ export class GithubIssueIngestionScheduler {
     queries = [],
     minScore = 75,
     maxJobsPerRun = 2,
+    maxJobsPerQuery = 2,
     maxOpenJobs = 20,
     githubToken = undefined,
     fetchImpl = fetch,
@@ -21,6 +22,7 @@ export class GithubIssueIngestionScheduler {
     this.queries = queries;
     this.minScore = minScore;
     this.maxJobsPerRun = maxJobsPerRun;
+    this.maxJobsPerQuery = maxJobsPerQuery;
     this.maxOpenJobs = maxOpenJobs;
     this.githubToken = githubToken;
     this.fetchImpl = fetchImpl;
@@ -55,6 +57,7 @@ export class GithubIssueIngestionScheduler {
       queryCount: this.queries.length,
       minScore: this.minScore,
       maxJobsPerRun: this.maxJobsPerRun,
+      maxJobsPerQuery: this.maxJobsPerQuery,
       maxOpenJobs: this.maxOpenJobs,
       currentOpenJobs: this.countOpenGithubJobs(),
       lastRun: this.lastRun
@@ -93,10 +96,11 @@ export class GithubIssueIngestionScheduler {
     const seenSources = this.existingGithubIssueKeys();
     for (const query of this.queries) {
       if (remaining <= 0) break;
+      const queryLimit = Math.min(remaining, this.maxJobsPerQuery);
       try {
         const result = await ingestGithubIssues({
           query,
-          limit: remaining,
+          limit: queryLimit,
           minScore: this.minScore,
           githubToken: this.githubToken,
           fetchImpl: this.fetchImpl
@@ -106,6 +110,7 @@ export class GithubIssueIngestionScheduler {
           query,
           candidates: result.count,
           created: 0,
+          maxJobsPerQuery: queryLimit,
           skipped: []
         };
         for (const job of result.jobs) {
@@ -198,6 +203,7 @@ export function loadGithubIssueIngestionConfig(env = process.env) {
     queries,
     minScore: parsePositiveInt(env.GITHUB_INGEST_MIN_SCORE, 75),
     maxJobsPerRun: parsePositiveInt(env.GITHUB_INGEST_MAX_JOBS_PER_RUN, 2),
+    maxJobsPerQuery: parsePositiveInt(env.GITHUB_INGEST_MAX_JOBS_PER_QUERY, 2),
     maxOpenJobs: parsePositiveInt(env.GITHUB_INGEST_MAX_OPEN_JOBS, 20),
     githubToken: env.GITHUB_TOKEN?.trim() || undefined
   };

--- a/mcp-server/src/services/github-issue-ingestion-scheduler.test.js
+++ b/mcp-server/src/services/github-issue-ingestion-scheduler.test.js
@@ -123,6 +123,40 @@ test("GithubIssueIngestionScheduler stops when max open GitHub jobs is reached",
   assert.equal(summary.skipped[0].reason, "max_open_jobs_reached");
 });
 
+test("GithubIssueIngestionScheduler caps noisy queries within a run", async () => {
+  const platform = makePlatformService();
+  const scheduler = new GithubIssueIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    queries: ["q1", "q2"],
+    minScore: 55,
+    maxJobsPerRun: 8,
+    maxJobsPerQuery: 2,
+    fetchImpl: async (url) => {
+      const query = new URL(url).searchParams.get("q") ?? "";
+      const offset = query.includes("q2") ? 100 : 0;
+      return {
+        ok: true,
+        async json() {
+          return {
+            items: Array.from({ length: 5 }, (_, index) => ({
+              ...ISSUE,
+              number: offset + index + 1,
+              html_url: `https://github.com/example/project/issues/${offset + index + 1}`
+            }))
+          };
+        }
+      };
+    }
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-24T10:00:00.000Z"));
+  assert.equal(summary.createdCount, 4);
+  assert.equal(platform.listJobs().length, 4);
+  assert.deepEqual(summary.queries.map((query) => query.created), [2, 2]);
+  assert.deepEqual(summary.queries.map((query) => query.maxJobsPerQuery), [2, 2]);
+});
+
 test("loadGithubIssueIngestionConfig parses env knobs safely", () => {
   const config = loadGithubIssueIngestionConfig({
     GITHUB_INGEST_ENABLED: "true",
@@ -130,6 +164,7 @@ test("loadGithubIssueIngestionConfig parses env knobs safely", () => {
     GITHUB_INGEST_INTERVAL_MS: "900000",
     GITHUB_INGEST_MIN_SCORE: "80",
     GITHUB_INGEST_MAX_JOBS_PER_RUN: "3",
+    GITHUB_INGEST_MAX_JOBS_PER_QUERY: "2",
     GITHUB_INGEST_MAX_OPEN_JOBS: "12",
     GITHUB_INGEST_QUERIES_JSON: '["q1","q2"]',
     GITHUB_TOKEN: "ghp_test"
@@ -140,6 +175,7 @@ test("loadGithubIssueIngestionConfig parses env knobs safely", () => {
   assert.equal(config.intervalMs, 900000);
   assert.equal(config.minScore, 80);
   assert.equal(config.maxJobsPerRun, 3);
+  assert.equal(config.maxJobsPerQuery, 2);
   assert.equal(config.maxOpenJobs, 12);
   assert.deepEqual(config.queries, ["q1", "q2"]);
   assert.equal(config.githubToken, "ghp_test");


### PR DESCRIPTION
## Summary

- Add GITHUB_INGEST_MAX_JOBS_PER_QUERY with a default cap of 2 jobs per query.
- Apply that cap inside the GitHub ingestion scheduler so one noisy query cannot consume the full run budget.
- Surface maxJobsPerQuery in providerOperations and document the optional provider-specific cap.

## Validation

- node --test mcp-server/src/jobs/ingest-github-issues.test.js mcp-server/src/services/github-issue-ingestion-scheduler.test.js mcp-server/src/core/platform-service.test.js
- npm --workspace mcp-server test
- git diff --check origin/main..HEAD