### PR TITLE
Show github maxJobsPerQuery cap on provider operations card

### DIFF
--- a/app/components/overview/ProviderOperationsCard.tsx
+++ b/app/components/overview/ProviderOperationsCard.tsx
@@ -81,6 +81,16 @@ function ProviderRow({ provider }: { provider: ProviderOperation }) {
               </span>
             </>
           ) : null}
+          {provider.maxJobsPerQuery !== undefined ? (
+            <>
+              <span>·</span>
+              <span>
+                cap{" "}
+                <span className="text-[var(--avy-ink)]">{provider.maxJobsPerRun}</span>/run ·{" "}
+                <span className="text-[var(--avy-ink)]">{provider.maxJobsPerQuery}</span>/query
+              </span>
+            </>
+          ) : null}
         </div>
       </div>
 
@@ -204,6 +214,7 @@ export const PROVIDER_OPERATIONS_FIXTURE: ProviderOperation[] = [
     running: false,
     intervalMs: 5 * 60_000,
     maxJobsPerRun: 8,
+    maxJobsPerQuery: 2,
     maxOpenJobs: 24,
     currentOpenJobs: 11,
     targetCount: 14,

--- a/app/lib/api/provider-operations.ts
+++ b/app/lib/api/provider-operations.ts
@@ -59,6 +59,9 @@ export interface ProviderOperation {
   running: boolean;
   intervalMs: number;
   maxJobsPerRun: number;
+  /** Per-query throttle so one noisy query can't eat the whole run
+   *  budget. Only github emits this today. */
+  maxJobsPerQuery?: number;
   maxOpenJobs: number;
   currentOpenJobs: number;
   /** Upstream queries / categories / packages / datasets / specs scanned. */
@@ -127,6 +130,9 @@ function buildProvider(
     running: Boolean(raw.running),
     intervalMs: nonNegInt(raw.intervalMs),
     maxJobsPerRun: nonNegInt(raw.maxJobsPerRun),
+    ...(typeof raw.maxJobsPerQuery === "number" && Number.isFinite(raw.maxJobsPerQuery) && raw.maxJobsPerQuery > 0
+      ? { maxJobsPerQuery: Math.floor(raw.maxJobsPerQuery) }
+      : {}),
     maxOpenJobs: nonNegInt(raw.maxOpenJobs),
     currentOpenJobs: nonNegInt(raw.currentOpenJobs),
     targetCount: nonNegInt(raw.targetCount),

--- a/site/trust-providers.js
+++ b/site/trust-providers.js
@@ -101,12 +101,18 @@
     const queryCount = typeof queryCountRaw === "number" && Number.isFinite(queryCountRaw) && queryCountRaw >= 0
       ? Math.floor(queryCountRaw)
       : null;
+    const maxJobsPerQueryRaw = raw && raw.maxJobsPerQuery;
+    const maxJobsPerQuery = typeof maxJobsPerQueryRaw === "number" && Number.isFinite(maxJobsPerQueryRaw) && maxJobsPerQueryRaw > 0
+      ? Math.floor(maxJobsPerQueryRaw)
+      : null;
     return {
       key: key,
       label: asString(raw && raw.label, PROVIDER_LABEL[key] || key),
       mode: ["live", "dry_run", "disabled"].includes(raw && raw.mode) ? raw.mode : "disabled",
       health: ["healthy", "dry_run", "at_capacity", "error", "disabled"].includes(raw && raw.health) ? raw.health : "disabled",
       running: Boolean(raw && raw.running),
+      maxJobsPerRun: nonNegInt(raw && raw.maxJobsPerRun),
+      maxJobsPerQuery: maxJobsPerQuery,
       maxOpenJobs: nonNegInt(raw && raw.maxOpenJobs),
       currentOpenJobs: nonNegInt(raw && raw.currentOpenJobs),
       targetCount: nonNegInt(raw && raw.targetCount),
@@ -159,6 +165,9 @@
             : "") +
           (provider.nextQuery
             ? ' · next <strong>&ldquo;' + escapeHtml(provider.nextQuery) + '&rdquo;</strong>'
+            : "") +
+          (provider.maxJobsPerQuery !== null
+            ? ' · cap <strong>' + escapeHtml(String(provider.maxJobsPerRun)) + '</strong>/run · <strong>' + escapeHtml(String(provider.maxJobsPerQuery)) + '</strong>/query'
             : "") +
           ' · open jobs <strong>' + escapeHtml(String(open)) + '</strong> / ' + escapeHtml(String(cap)) +
         '</p>' +


### PR DESCRIPTION
## Summary
- Surface the new `maxJobsPerQuery` field (added in #61) inline on the github provider row so the operator sees both the per-run and per-query throttle at a glance: `cap 8/run · 2/query`
- Public trust page mirrors it via the existing sanitized endpoint

## Test plan
- [x] `npm run typecheck:app`
- [x] `npm run build:frontend`
- [x] `npm run build:site`
- [ ] After deploy: confirm the github row on `/overview` and `/trust/` shows the new cap line