### PR TITLE
Add job lifecycle cleanup controls

### DIFF
--- a/docs/PUBLIC_JOB_SOURCES.md
+++ b/docs/PUBLIC_JOB_SOURCES.md
@@ -184,6 +184,21 @@ and a compact `lastRun` summary. The older provider-specific fields such as
 `osvIngestion` and `openDataIngestion` remain available for compatibility, but
 new admin UI should render from `providerOperations`.
 
+### Job lifecycle cleanup
+
+Provider-created jobs are now lifecycle-managed so live sources can be tuned
+without leaving stale work on the public board forever.
+
+- New jobs default to `lifecycle.status=open` and receive a `staleAt` timestamp
+  14 days after creation.
+- Public `/jobs`, `/jobs/definition`, `/jobs/recommendations`, preflight, and
+  claim flows treat `paused`, `archived`, and computed `stale` jobs as not
+  claimable.
+- Operators can use `POST /admin/jobs/lifecycle` with `action=pause`,
+  `archive`, `reopen`, or `mark_stale` plus an optional `reason`.
+- `/admin/status.jobLifecycle` reports total, open, claimable, stale, paused,
+  and archived counts for the provider operations UI.
+
 ### Public status endpoint
 
 `GET /status/providers` is the **public, sanitized** counterpart to

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -435,6 +435,65 @@
         }
       }
     },
+    "/admin/jobs/lifecycle": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "operationId": "updateJobLifecycle",
+        "summary": "Update job lifecycle state",
+        "description": "Pauses, archives, reopens, or marks a job stale so operators can age out provider-created work without deleting the underlying definition.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JobLifecycleUpdateRequest"
+              },
+              "examples": {
+                "pause": {
+                  "value": {
+                    "jobId": "openapi-averray-averray-http-api",
+                    "action": "pause",
+                    "reason": "Waiting for upstream provider fix"
+                  }
+                },
+                "archive": {
+                  "value": {
+                    "jobId": "github-averray-agent-123",
+                    "action": "archive",
+                    "reason": "Superseded by newer provider run"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Lifecycle state updated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobLifecycleUpdateResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
     "/admin/jobs/ingest/openapi": {
       "post": {
         "tags": [
@@ -670,6 +729,104 @@
           "source": {
             "type": "object",
             "additionalProperties": true
+          },
+          "lifecycle": {
+            "$ref": "#/components/schemas/JobLifecycle"
+          }
+        },
+        "additionalProperties": true
+      },
+      "JobLifecycle": {
+        "type": "object",
+        "required": [
+          "status",
+          "state"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "open",
+              "paused",
+              "archived"
+            ]
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "open",
+              "stale",
+              "paused",
+              "archived"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "staleAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "reason": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "JobLifecycleUpdateRequest": {
+        "type": "object",
+        "required": [
+          "jobId"
+        ],
+        "properties": {
+          "jobId": {
+            "type": "string"
+          },
+          "action": {
+            "type": "string",
+            "enum": [
+              "pause",
+              "archive",
+              "reopen",
+              "mark_stale"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "open",
+              "paused",
+              "archived"
+            ]
+          },
+          "staleAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "reason": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "JobLifecycleUpdateResponse": {
+        "type": "object",
+        "required": [
+          "job",
+          "jobLifecycle"
+        ],
+        "properties": {
+          "job": {
+            "$ref": "#/components/schemas/Job"
+          },
+          "jobLifecycle": {
+            "type": "object",
+            "additionalProperties": true
           }
         },
         "additionalProperties": true
@@ -747,6 +904,11 @@
         "properties": {
           "jobs": {
             "type": "object",
+            "additionalProperties": true
+          },
+          "jobLifecycle": {
+            "type": "object",
+            "description": "Counts for open, stale, paused, archived, and claimable jobs.",
             "additionalProperties": true
           },
           "githubIngestion": {

--- a/mcp-server/src/core/job-catalog-metadata.test.js
+++ b/mcp-server/src/core/job-catalog-metadata.test.js
@@ -71,6 +71,82 @@ test("jobs default to worker work when role fields are omitted", () => {
   assert.equal(job.requiredRole, "worker");
 });
 
+test("job lifecycle hides paused, archived, and stale jobs from public discovery", async () => {
+  const service = makeService();
+  const now = new Date("2026-04-27T10:00:00.000Z");
+  const open = service.createJob({
+    ...BASE_JOB,
+    id: "open-lifecycle-001",
+    lifecycle: {
+      createdAt: "2026-04-27T09:00:00.000Z",
+      updatedAt: "2026-04-27T09:00:00.000Z",
+      staleAt: "2026-05-11T09:00:00.000Z"
+    }
+  });
+  service.createJob({
+    ...BASE_JOB,
+    id: "stale-lifecycle-001",
+    lifecycle: {
+      createdAt: "2026-04-01T00:00:00.000Z",
+      updatedAt: "2026-04-01T00:00:00.000Z",
+      staleAt: "2026-04-15T00:00:00.000Z"
+    }
+  });
+
+  assert.equal(open.lifecycle.status, "open");
+  assert.equal(open.lifecycle.staleAt, "2026-05-11T09:00:00.000Z");
+  service.updateJobLifecycle("open-lifecycle-001", { action: "pause", reason: "waiting for provider fix" }, now);
+
+  assert.deepEqual(service.listJobs({ now }).map((job) => job.id), []);
+  assert.deepEqual(
+    service.listJobs({ includePaused: true, includeStale: true, now }).map((job) => [job.id, job.lifecycle.state]),
+    [
+      ["stale-lifecycle-001", "stale"],
+      ["open-lifecycle-001", "paused"]
+    ]
+  );
+
+  const preflight = await service.preflightJob("0xagent", "open-lifecycle-001");
+  assert.equal(preflight.eligible, false);
+  assert.equal(preflight.lifecycle.state, "paused");
+});
+
+test("job lifecycle supports archival and claimability guardrails", () => {
+  const service = makeService();
+  service.createJob({
+    ...BASE_JOB,
+    id: "archive-lifecycle-001",
+    lifecycle: {
+      createdAt: "2026-04-27T09:00:00.000Z",
+      updatedAt: "2026-04-27T09:00:00.000Z",
+      staleAt: "2026-05-11T09:00:00.000Z"
+    }
+  });
+
+  const archived = service.updateJobLifecycle("archive-lifecycle-001", {
+    action: "archive",
+    reason: "superseded"
+  }, new Date("2026-04-27T10:00:00.000Z"));
+
+  assert.equal(archived.lifecycle.state, "archived");
+  assert.throws(
+    () => service.getPublicJobDefinition("archive-lifecycle-001"),
+    /Unknown job: archive-lifecycle-001/
+  );
+  assert.throws(
+    () => service.getClaimableJobDefinition("archive-lifecycle-001"),
+    /not claimable/
+  );
+  assert.deepEqual(service.getJobLifecycleSummary(), {
+    total: 1,
+    open: 0,
+    claimable: 0,
+    stale: 0,
+    paused: 0,
+    archived: 1
+  });
+});
+
 test("createJob accepts github_pr verifier configuration", () => {
   const service = makeService();
   const job = service.createJob({

--- a/mcp-server/src/core/job-catalog-service.js
+++ b/mcp-server/src/core/job-catalog-service.js
@@ -19,6 +19,8 @@ const VALID_TIERS = new Set(["starter", "pro", "elite"]);
 const VALID_VERIFIER_MODES = new Set(["benchmark", "deterministic", "human_fallback", "github_pr"]);
 const VALID_JOB_TYPES = new Set(["work", "curation", "review", "publish", "verification"]);
 const VALID_AGENT_ROLES = new Set(["worker", "curator", "reviewer", "publisher", "verifier", "arbitrator"]);
+const VALID_JOB_LIFECYCLE_STATUSES = new Set(["open", "paused", "archived"]);
+const DEFAULT_STALE_AFTER_MS = 14 * 24 * 60 * 60 * 1000;
 
 export const ROLE_REQUIREMENTS = {
   worker: { skill: 0 },
@@ -128,14 +130,16 @@ export class JobCatalogService {
     this.getDefaultClaimStakeBps = getDefaultClaimStakeBps;
   }
 
-  listJobs() {
-    return [...this.jobs];
+  listJobs({ includePaused = false, includeArchived = false, includeStale = false, now = new Date() } = {}) {
+    return this.jobs
+      .filter((job) => this.isVisibleJob(job, { includePaused, includeArchived, includeStale, now }))
+      .map((job) => this.withLifecycle(job, now));
   }
 
   listJobsByParentSession(parentSessionId) {
     return this.jobs
       .filter((job) => job.parentSessionId === parentSessionId)
-      .map((job) => ({ ...job }));
+      .map((job) => this.withLifecycle(job));
   }
 
   getRecurringTemplate(templateId) {
@@ -154,6 +158,70 @@ export class JobCatalogService {
 
     this.jobs.unshift(job);
     return job;
+  }
+
+  getJobLifecycleSummary(now = new Date()) {
+    const summary = {
+      total: this.jobs.length,
+      open: 0,
+      claimable: 0,
+      stale: 0,
+      paused: 0,
+      archived: 0
+    };
+    for (const job of this.jobs) {
+      const lifecycle = this.buildLifecycle(job, now);
+      if (lifecycle.status === "open") summary.open += 1;
+      if (lifecycle.status === "paused") summary.paused += 1;
+      if (lifecycle.status === "archived") summary.archived += 1;
+      if (lifecycle.state === "stale") summary.stale += 1;
+      if (this.isClaimableJob(job, now)) summary.claimable += 1;
+    }
+    return summary;
+  }
+
+  updateJobLifecycle(jobId, patch = {}, updatedAt = new Date()) {
+    const job = this.requireJob(jobId);
+    const current = this.buildLifecycle(job, updatedAt);
+    const action = typeof patch?.action === "string" ? patch.action.trim().toLowerCase() : "";
+    const requestedStatus = typeof patch?.status === "string"
+      ? patch.status.trim().toLowerCase()
+      : undefined;
+    const status = this.resolveLifecycleStatus({ action, requestedStatus, currentStatus: current.status });
+    const timestamp = updatedAt.toISOString();
+    const lifecycle = {
+      ...current,
+      status,
+      updatedAt: timestamp
+    };
+
+    if (typeof patch?.reason === "string" && patch.reason.trim()) {
+      lifecycle.reason = patch.reason.trim().slice(0, 500);
+    }
+    if (typeof patch?.staleAt === "string" && patch.staleAt.trim()) {
+      lifecycle.staleAt = normalizeIsoTimestamp(patch.staleAt, "staleAt");
+    }
+    if (action === "mark_stale") {
+      lifecycle.staleAt = timestamp;
+      lifecycle.staleReason = lifecycle.reason;
+    }
+    if (status === "paused" && current.status !== "paused") {
+      lifecycle.pausedAt = timestamp;
+    }
+    if (status === "archived" && current.status !== "archived") {
+      lifecycle.archivedAt = timestamp;
+    }
+    if (status === "open" && current.status !== "open") {
+      lifecycle.reopenedAt = timestamp;
+      lifecycle.staleAt = new Date(updatedAt.getTime() + DEFAULT_STALE_AFTER_MS).toISOString();
+      delete lifecycle.pausedAt;
+      delete lifecycle.archivedAt;
+      delete lifecycle.staleReason;
+    }
+
+    delete lifecycle.state;
+    job.lifecycle = lifecycle;
+    return this.withLifecycle(job, updatedAt);
   }
 
   getRecurringTemplateStatus() {
@@ -233,13 +301,13 @@ export class JobCatalogService {
     const reputation = await this.getReputation(wallet);
     const claimStakeBps = await this.getDefaultClaimStakeBps();
 
-    return Promise.all(this.jobs.map(async (job) => {
+    return Promise.all(this.listJobs().map(async (job) => {
       const netReward = await this.estimateNetReward(wallet, job.id);
       const tierGate = summarizeTierGate(job.tier, reputation);
       const jobType = effectiveJobType(job);
       const requiredRole = effectiveRequiredRole(job);
       const roleGate = summarizeRoleGate(requiredRole, reputation);
-      const eligible = this.isEligible(job, profile, reputation);
+      const eligible = this.isClaimableJob(job) && this.isEligible(job, profile, reputation);
       const liquid = account.liquid[job.rewardAsset] ?? 0;
       const claimStake = Math.max((job.rewardAmount * claimStakeBps) / 10_000, 0);
       const fitScore = this.computeFitScore(job, profile, reputation, liquid, claimStake);
@@ -260,7 +328,28 @@ export class JobCatalogService {
   }
 
   getJobDefinition(jobId) {
-    return this.requireJob(jobId);
+    return this.withLifecycle(this.requireJob(jobId));
+  }
+
+  getPublicJobDefinition(jobId) {
+    const job = this.requireJob(jobId);
+    if (!this.isVisibleJob(job)) {
+      throw new NotFoundError(`Unknown job: ${jobId}`, "job_not_found");
+    }
+    return this.withLifecycle(job);
+  }
+
+  getClaimableJobDefinition(jobId) {
+    const job = this.requireJob(jobId);
+    if (!this.isClaimableJob(job)) {
+      const lifecycle = this.buildLifecycle(job);
+      throw new ConflictError(
+        `Job ${jobId} is not claimable (${lifecycle.state}).`,
+        "job_not_claimable",
+        { lifecycle }
+      );
+    }
+    return this.withLifecycle(job);
   }
 
   async preflightJob(wallet, jobId) {
@@ -271,7 +360,8 @@ export class JobCatalogService {
     const liquid = account.liquid[job.rewardAsset] ?? 0;
     const claimStakeBps = await this.getDefaultClaimStakeBps();
     const claimStake = Math.max((job.rewardAmount * claimStakeBps) / 10_000, 0);
-    const eligible = this.isEligible(job, profile, reputation);
+    const lifecycle = this.buildLifecycle(job);
+    const eligible = this.isClaimableJob(job) && this.isEligible(job, profile, reputation);
     const tierGate = summarizeTierGate(job.tier, reputation);
     const jobType = effectiveJobType(job);
     const requiredRole = effectiveRequiredRole(job);
@@ -290,6 +380,7 @@ export class JobCatalogService {
       verifierMode: job.verifierMode,
       verifierConfig: job.verifierConfig,
       tier: job.tier,
+      lifecycle,
       tierGate,
       jobType,
       requiredRole,
@@ -312,11 +403,13 @@ export class JobCatalogService {
     const jobType = effectiveJobType(job);
     const requiredRole = effectiveRequiredRole(job);
     const roleGate = summarizeRoleGate(requiredRole, reputation);
+    const lifecycle = this.buildLifecycle(job);
 
     return {
       jobId,
       wallet,
       tier: job.tier,
+      lifecycle,
       tierGate,
       jobType,
       requiredRole,
@@ -325,7 +418,7 @@ export class JobCatalogService {
       supportsVerifier: profile.verifierCompatibility.includes(job.verifierMode),
       reputationTier: reputation.tier,
       verifierHandler: job.verifierConfig.handler,
-      eligible: this.isEligible(job, profile, reputation)
+      eligible: this.isClaimableJob(job) && this.isEligible(job, profile, reputation)
     };
   }
 
@@ -368,6 +461,63 @@ export class JobCatalogService {
       throw new NotFoundError(`Unknown job: ${jobId}`, "job_not_found");
     }
     return job;
+  }
+
+  isVisibleJob(job, { includePaused = false, includeArchived = false, includeStale = false, now = new Date() } = {}) {
+    const lifecycle = this.buildLifecycle(job, now);
+    if (lifecycle.status === "paused") return includePaused;
+    if (lifecycle.status === "archived") return includeArchived;
+    if (lifecycle.state === "stale") return includeStale;
+    return true;
+  }
+
+  isClaimableJob(job, now = new Date()) {
+    const lifecycle = this.buildLifecycle(job, now);
+    return lifecycle.status === "open" && lifecycle.state === "open";
+  }
+
+  withLifecycle(job, now = new Date()) {
+    return {
+      ...job,
+      lifecycle: this.buildLifecycle(job, now)
+    };
+  }
+
+  buildLifecycle(job, now = new Date()) {
+    const raw = normalisePlainObject(job?.lifecycle, "lifecycle") ?? {};
+    const status = VALID_JOB_LIFECYCLE_STATUSES.has(raw.status) ? raw.status : "open";
+    const staleAt = typeof raw.staleAt === "string" && raw.staleAt.trim()
+      ? raw.staleAt.trim()
+      : undefined;
+    const stale = status === "open" && staleAt && Date.parse(staleAt) <= now.getTime();
+    return {
+      status,
+      state: stale ? "stale" : status,
+      ...(typeof raw.createdAt === "string" ? { createdAt: raw.createdAt } : {}),
+      ...(typeof raw.updatedAt === "string" ? { updatedAt: raw.updatedAt } : {}),
+      ...(staleAt ? { staleAt } : {}),
+      ...(typeof raw.pausedAt === "string" ? { pausedAt: raw.pausedAt } : {}),
+      ...(typeof raw.archivedAt === "string" ? { archivedAt: raw.archivedAt } : {}),
+      ...(typeof raw.reopenedAt === "string" ? { reopenedAt: raw.reopenedAt } : {}),
+      ...(typeof raw.reason === "string" && raw.reason.trim() ? { reason: raw.reason.trim() } : {}),
+      ...(typeof raw.staleReason === "string" && raw.staleReason.trim() ? { staleReason: raw.staleReason.trim() } : {})
+    };
+  }
+
+  resolveLifecycleStatus({ action, requestedStatus, currentStatus }) {
+    if (requestedStatus !== undefined) {
+      if (!VALID_JOB_LIFECYCLE_STATUSES.has(requestedStatus)) {
+        throw new ValidationError(`Invalid job lifecycle status: ${requestedStatus}`);
+      }
+      return requestedStatus;
+    }
+    if (!action) {
+      return currentStatus;
+    }
+    if (action === "pause") return "paused";
+    if (action === "archive") return "archived";
+    if (action === "reopen" || action === "mark_stale") return "open";
+    throw new ValidationError(`Invalid job lifecycle action: ${action}`);
   }
 
   requireProfile(wallet) {
@@ -465,6 +615,7 @@ export class JobCatalogService {
     const estimatedDifficulty = normaliseTextField(input?.estimatedDifficulty);
     const source = normalisePlainObject(input?.source, "source");
     const verification = normalisePlainObject(input?.verification, "verification");
+    const lifecycle = normaliseLifecycle(input?.lifecycle, { disableStale: recurring });
 
     return {
       id,
@@ -481,6 +632,7 @@ export class JobCatalogService {
       claimTtlSeconds,
       retryLimit,
       requiresSponsoredGas: Boolean(input?.requiresSponsoredGas),
+      lifecycle,
       ...(title ? { title } : {}),
       ...(description ? { description } : {}),
       ...(source ? { source } : {}),
@@ -515,7 +667,14 @@ export class JobCatalogService {
       id: derivativeId,
       recurring: false,
       templateId,
-      firedAt: firedAt.toISOString()
+      firedAt: firedAt.toISOString(),
+      lifecycle: normaliseLifecycle({
+        ...(template.lifecycle ?? {}),
+        status: "open",
+        createdAt: firedAt.toISOString(),
+        updatedAt: firedAt.toISOString(),
+        staleAt: new Date(firedAt.getTime() + DEFAULT_STALE_AFTER_MS).toISOString()
+      })
     };
     delete derivative.schedule;
     this.jobs.unshift(derivative);
@@ -693,6 +852,54 @@ function normalisePlainObject(value, field) {
     throw new ValidationError(`${field} must be an object if provided.`);
   }
   return JSON.parse(JSON.stringify(value));
+}
+
+function normaliseLifecycle(value, { disableStale = false, now = new Date() } = {}) {
+  const raw = normalisePlainObject(value, "lifecycle") ?? {};
+  const createdAt = typeof raw.createdAt === "string" && raw.createdAt.trim()
+    ? normalizeIsoTimestamp(raw.createdAt, "lifecycle.createdAt")
+    : now.toISOString();
+  const updatedAt = typeof raw.updatedAt === "string" && raw.updatedAt.trim()
+    ? normalizeIsoTimestamp(raw.updatedAt, "lifecycle.updatedAt")
+    : createdAt;
+  const status = typeof raw.status === "string" && raw.status.trim()
+    ? raw.status.trim().toLowerCase()
+    : "open";
+  if (!VALID_JOB_LIFECYCLE_STATUSES.has(status)) {
+    throw new ValidationError(`Invalid job lifecycle status: ${status}`);
+  }
+  const lifecycle = {
+    status,
+    createdAt,
+    updatedAt
+  };
+  const defaultStaleAt = disableStale
+    ? undefined
+    : new Date(Date.parse(createdAt) + DEFAULT_STALE_AFTER_MS).toISOString();
+  const staleAt = typeof raw.staleAt === "string" && raw.staleAt.trim()
+    ? normalizeIsoTimestamp(raw.staleAt, "lifecycle.staleAt")
+    : defaultStaleAt;
+  if (staleAt) lifecycle.staleAt = staleAt;
+
+  for (const key of ["pausedAt", "archivedAt", "reopenedAt"]) {
+    if (typeof raw[key] === "string" && raw[key].trim()) {
+      lifecycle[key] = normalizeIsoTimestamp(raw[key], `lifecycle.${key}`);
+    }
+  }
+  for (const key of ["reason", "staleReason"]) {
+    if (typeof raw[key] === "string" && raw[key].trim()) {
+      lifecycle[key] = raw[key].trim().slice(0, 500);
+    }
+  }
+  return lifecycle;
+}
+
+function normalizeIsoTimestamp(value, field) {
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) {
+    throw new ValidationError(`${field} must be ISO-8601 if provided.`);
+  }
+  return new Date(parsed).toISOString();
 }
 
 function buildRecommendationExplanation({ job, eligible, tierGate, roleGate, profile }) {

--- a/mcp-server/src/core/job-execution-service.js
+++ b/mcp-server/src/core/job-execution-service.js
@@ -14,11 +14,13 @@ export class JobExecutionService {
     getJobDefinition,
     eventBus = undefined,
     accountMutationService = undefined,
-    getDefaultClaimStakeBps = async () => 500
+    getDefaultClaimStakeBps = async () => 500,
+    getClaimableJobDefinition = getJobDefinition
   ) {
     this.stateStore = stateStore;
     this.blockchainGateway = blockchainGateway;
     this.getJobDefinition = getJobDefinition;
+    this.getClaimableJobDefinition = getClaimableJobDefinition;
     this.eventBus = eventBus;
     this.accountMutationService = accountMutationService;
     this.getDefaultClaimStakeBps = getDefaultClaimStakeBps;
@@ -30,7 +32,7 @@ export class JobExecutionService {
       return existing;
     }
 
-    const job = this.getJobDefinition(jobId);
+    const job = this.getClaimableJobDefinition(jobId);
     const sessionId = `${jobId}:${wallet}`;
     const sessionLockId = sessionId;
     const lockOwner = randomUUID();

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -73,7 +73,8 @@ export class PlatformService {
       this.getJobDefinition.bind(this),
       this.eventBus,
       this.accountMutationService,
-      this.getDefaultClaimStakeBps.bind(this)
+      this.getDefaultClaimStakeBps.bind(this),
+      this.getClaimableJobDefinition.bind(this)
     );
     this.verificationIngestionService = new VerificationIngestionService(this.stateStore, this.eventBus);
   }
@@ -95,6 +96,14 @@ export class PlatformService {
 
   createJob(input) {
     return this.jobCatalogService.createJob(input);
+  }
+
+  updateJobLifecycle(jobId, patch = {}) {
+    return this.jobCatalogService.updateJobLifecycle(jobId, patch);
+  }
+
+  getJobLifecycleSummary() {
+    return this.jobCatalogService.getJobLifecycleSummary();
   }
 
   getRecurringTemplateStatus() {
@@ -306,6 +315,7 @@ export class PlatformService {
         }
       },
       recurring: recurring,
+      jobLifecycle: this.jobCatalogService.getJobLifecycleSummary(),
       scheduler,
       providerOperations,
       githubIngestion: githubIngestion,
@@ -338,6 +348,14 @@ export class PlatformService {
 
   getJobDefinition(jobId) {
     return this.jobCatalogService.getJobDefinition(jobId);
+  }
+
+  getPublicJobDefinition(jobId) {
+    return this.jobCatalogService.getPublicJobDefinition(jobId);
+  }
+
+  getClaimableJobDefinition(jobId) {
+    return this.jobCatalogService.getClaimableJobDefinition(jobId);
   }
 
   async recommendJobs(wallet) {

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -107,6 +107,10 @@ test("getSessionTimeline includes transitions and verification state", async () 
 
 test("getAdminStatus surfaces recurring scheduler anomalies", async () => {
   const service = makePlatformService();
+  service.updateJobLifecycle("parent-job-001", {
+    action: "pause",
+    reason: "operator hold"
+  });
   service.recurringScheduler = {
     getStatus() {
       return {
@@ -134,6 +138,9 @@ test("getAdminStatus surfaces recurring scheduler anomalies", async () => {
 
   assert.equal(status.auth.wallet, WALLET);
   assert.ok(status.anomalies.some((entry) => entry.code === "recurring_attention"));
+  assert.equal(status.jobLifecycle.total, 1);
+  assert.equal(status.jobLifecycle.paused, 1);
+  assert.equal(status.jobLifecycle.claimable, 0);
 });
 
 test("getAdminStatus surfaces public source ingestion scheduler status", async () => {

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -970,6 +970,7 @@ function metricPathLabel(pathname) {
     "/admin/jobs/ingest/osv",
     "/admin/jobs/ingest/standards",
     "/admin/jobs/ingest/wikipedia",
+    "/admin/jobs/lifecycle",
     "/admin/jobs/pause",
     "/admin/jobs/resume",
     "/admin/xcm/observe",
@@ -1256,6 +1257,7 @@ const server = createServer(async (request, response) => {
           "/admin/jobs/ingest/standards",
           "/admin/jobs/ingest/wikipedia",
           "/admin/jobs/fire",
+          "/admin/jobs/lifecycle",
           "/admin/jobs/pause",
           "/admin/jobs/resume",
           "/admin/xcm/observe",
@@ -1405,7 +1407,7 @@ const server = createServer(async (request, response) => {
     }
 
     if (request.method === "GET" && pathname === "/jobs/definition") {
-      return respond(response, 200, service.getJobDefinition(url.searchParams.get("jobId") ?? ""));
+      return respond(response, 200, service.getPublicJobDefinition(url.searchParams.get("jobId") ?? ""));
     }
 
     if (request.method === "GET" && pathname === "/gas/health") {
@@ -2765,6 +2767,26 @@ const server = createServer(async (request, response) => {
         await stateStore.upsertMutationReceipt?.("admin_jobs_fire", mutationKey, derivative);
       }
       return respond(response, 201, derivative);
+    }
+
+    if (request.method === "POST" && pathname === "/admin/jobs/lifecycle") {
+      const auth = await authMiddleware(request, url, { requireRole: "admin" });
+      await enforceLimit("admin_jobs", auth.wallet, rateLimitConfig.adminJobs);
+      const payload = await readJsonBody(request);
+      const jobId = typeof payload?.jobId === "string" ? payload.jobId.trim() : "";
+      if (!jobId) {
+        throw new ValidationError("jobId is required.");
+      }
+      const updated = service.updateJobLifecycle(jobId, {
+        action: payload?.action,
+        status: payload?.status,
+        staleAt: payload?.staleAt,
+        reason: payload?.reason
+      });
+      return respond(response, 200, {
+        job: updated,
+        jobLifecycle: service.getJobLifecycleSummary()
+      });
     }
 
     if (request.method === "POST" && pathname === "/admin/jobs/pause") {


### PR DESCRIPTION
## Summary
- add job lifecycle metadata with open/paused/archived status and computed stale state
- hide paused, archived, and stale jobs from public discovery/recommendations and block new claims
- expose POST /admin/jobs/lifecycle and /admin/status.jobLifecycle for operator cleanup UI
- document the lifecycle policy and update the OpenAPI contract

## Verification
- npm --workspace mcp-server test -- job-catalog-metadata.test.js platform-service.test.js job-execution-service.test.js
- node -e 'JSON.parse(require("node:fs").readFileSync("docs/api/openapi.json", "utf8")); console.log("openapi ok")'
- git diff --check

## Frontend contract
- Read /admin/status.jobLifecycle for counts: total, open, claimable, stale, paused, archived
- Use POST /admin/jobs/lifecycle with { jobId, action: "pause" | "archive" | "reopen" | "mark_stale", reason? }
- Jobs now include lifecycle.status and lifecycle.state; public job lists omit paused/archived/stale jobs by default