### PR TITLE
Add bootstrap upstream instrumentation

### DIFF
--- a/docs/RC1_IMPLEMENTATION_PLAN.md
+++ b/docs/RC1_IMPLEMENTATION_PLAN.md
@@ -34,8 +34,8 @@ The shortest path to a coherent rc1 launch is:
 
 ## Current Position
 
-As of the disclosure event coupling work, **slice 4: Content Addressing And
-Disclosure Reads** is implemented.
+As of the bootstrap instrumentation work, **slice 5: Bootstrap
+Instrumentation** is in progress.
 
 Completed and deployed in this lane:
 
@@ -51,10 +51,13 @@ Completed and deployed in this lane:
 - `discloseFor(hash, byWallet)` requires the rc1 contract redeploy; until then
   the backend reports `chain_write_failed` for that event while still serving
   content normally
+- `funded_jobs` records are now written on claim, enriched on submission and
+  verification, and polled against upstream GitHub/MediaWiki status
+- weekly bootstrap self-report generation exists as a backend service/CLI
 
 Still open in the broader rc1 path:
 
-- full bootstrap instrumentation and upstream status polling, which is slice 5
+- scheduler/email hardening for weekly reports after enough real jobs exist
 - claim economics, maintainer controls, and XCM work in later slices
 
 ## PR Slices
@@ -159,16 +162,21 @@ land here.
 
 ### 5. Bootstrap Instrumentation
 
+**Status:** in progress; funded-job storage, upstream polling, and report
+generation are implemented as backend foundations.
+
 **Goal:** make the week-12 gate measurable before funded jobs begin.
 
 **Changes:**
 
-- Add `funded_jobs` storage/model.
-- Add daily GitHub and MediaWiki upstream status pollers.
-- Track final statuses: `merged`, `closed_unmerged`, `open_stale`,
+- [x] Add `funded_jobs` storage/model.
+- [x] Add daily-capable GitHub and MediaWiki upstream status pollers.
+- [x] Track final statuses: `merged`, `closed_unmerged`, `open_stale`,
   `reverted`.
-- Add weekly self-report generation with merge rate, spend, receipts, and top
+- [x] Add weekly self-report generation with merge rate, spend, receipts, and top
   close reasons.
+- [ ] Wire scheduled email delivery once report recipients and cadence are
+  finalized.
 
 **Checks:** `npm --workspace mcp-server test`.
 

--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -119,6 +119,16 @@ AUTH_CHAIN_ID=420420417
 # GITHUB_INGEST_MAX_OPEN_JOBS=20
 # GITHUB_INGEST_QUERIES_JSON=["is:issue is:open label:\"good first issue\" language:TypeScript","is:issue is:open label:\"help wanted\" label:tests"]
 
+# --- Bootstrap upstream status instrumentation -------------------------------
+# Disabled by default. When enabled, the server periodically refreshes
+# funded_jobs records from GitHub PR / MediaWiki evidence so the week-12 gate
+# can report upstream merge/survival rate, spend, receipts, and close reasons.
+# The same logic can run on demand:
+# npm --workspace mcp-server run bootstrap:upstream-status -- --poll --report
+# UPSTREAM_STATUS_POLLER_ENABLED=false
+# UPSTREAM_STATUS_POLLER_INTERVAL_MS=86400000
+# UPSTREAM_STATUS_POLLER_BATCH_SIZE=50
+
 # --- Wikipedia maintenance job ingestion -------------------------------------
 # Production defaults to enabled with dry-run disabled, capped at two jobs per
 # run and twenty open Wikipedia jobs. Non-production stays opt-in. Uses stable

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -16,7 +16,8 @@
     "ingest:osv-advisories": "node src/jobs/ingest-osv-advisories.js",
     "ingest:open-data": "node src/jobs/ingest-open-data-datasets.js",
     "ingest:standards-specs": "node src/jobs/ingest-standards-specs.js",
-    "ingest:openapi-specs": "node src/jobs/ingest-openapi-specs.js"
+    "ingest:openapi-specs": "node src/jobs/ingest-openapi-specs.js",
+    "bootstrap:upstream-status": "node src/jobs/bootstrap-upstream-status.js"
   },
   "dependencies": {
     "ethers": "^6.16.0",

--- a/mcp-server/src/core/funded-jobs.js
+++ b/mcp-server/src/core/funded-jobs.js
@@ -1,0 +1,256 @@
+export const FUNDED_JOB_STATUSES = Object.freeze({
+  OPEN: "open",
+  MERGED: "merged",
+  CLOSED_UNMERGED: "closed_unmerged",
+  OPEN_STALE: "open_stale",
+  REVERTED: "reverted"
+});
+
+export const FINAL_FUNDED_JOB_STATUSES = new Set([
+  FUNDED_JOB_STATUSES.MERGED,
+  FUNDED_JOB_STATUSES.CLOSED_UNMERGED,
+  FUNDED_JOB_STATUSES.OPEN_STALE,
+  FUNDED_JOB_STATUSES.REVERTED
+]);
+
+const DEFAULT_GITHUB_DEADLINE_DAYS = 30;
+const DEFAULT_WIKIPEDIA_DEADLINE_DAYS = 14;
+
+export function buildFundedJobFromClaim({ job, session, now = new Date() }) {
+  const fundedAt = session?.claimedAt ?? now.toISOString();
+  return compact({
+    jobId: session?.jobId ?? job?.id,
+    sessionId: session?.sessionId,
+    chainJobId: session?.chainJobId,
+    wallet: session?.wallet,
+    sourceType: job?.source?.type ?? "manual",
+    source: job?.source ? { ...job.source } : undefined,
+    rewardAsset: job?.rewardAsset ?? "DOT",
+    rewardAmount: finiteNumber(job?.rewardAmount, 0),
+    claimStake: finiteNumber(session?.claimStake, 0),
+    fundedAt,
+    claimedAt: session?.claimedAt ?? fundedAt,
+    submittedAt: session?.submittedAt,
+    finalStatus: FUNDED_JOB_STATUSES.OPEN,
+    upstreamStatus: "not_submitted",
+    deadlineAt: computeDeadlineAt({ job, session }),
+    closeReason: undefined,
+    lastPolledAt: undefined,
+    updatedAt: now.toISOString()
+  });
+}
+
+export function updateFundedJobFromSession(existing, { job, session, verification = undefined, now = new Date() }) {
+  const upstream = resolveUpstreamFromSession({ job, session, existing });
+  const patch = compact({
+    jobId: session?.jobId ?? existing?.jobId,
+    sessionId: session?.sessionId ?? existing?.sessionId,
+    chainJobId: session?.chainJobId ?? existing?.chainJobId,
+    wallet: session?.wallet ?? existing?.wallet,
+    sourceType: job?.source?.type ?? existing?.sourceType,
+    source: job?.source ? { ...job.source } : existing?.source,
+    rewardAsset: job?.rewardAsset ?? existing?.rewardAsset,
+    rewardAmount: job ? finiteNumber(job.rewardAmount, 0) : existing?.rewardAmount,
+    claimStake: session ? finiteNumber(session.claimStake, 0) : existing?.claimStake,
+    claimedAt: session?.claimedAt ?? existing?.claimedAt,
+    submittedAt: session?.submittedAt ?? existing?.submittedAt,
+    deadlineAt: computeDeadlineAt({ job, session }) ?? existing?.deadlineAt,
+    upstream,
+    upstreamStatus: upstream?.kind === "github_pull_request" ? "submitted" : existing?.upstreamStatus,
+    verificationOutcome: verification?.outcome ?? session?.verificationSummary?.outcome ?? existing?.verificationOutcome,
+    verificationReasonCode: verification?.reasonCode ?? session?.verificationSummary?.reasonCode ?? existing?.verificationReasonCode,
+    receiptCount: verification || session?.verificationSummary ? 1 : existing?.receiptCount,
+    updatedAt: now.toISOString()
+  });
+  return normalizeFundedJobRecord({
+    ...(existing ?? {}),
+    ...patch
+  });
+}
+
+export function applyUpstreamStatus(record, upstreamStatus, { now = new Date() } = {}) {
+  const finalStatus = upstreamStatus.finalStatus ?? record.finalStatus ?? FUNDED_JOB_STATUSES.OPEN;
+  return normalizeFundedJobRecord(compact({
+    ...record,
+    finalStatus,
+    upstreamStatus: upstreamStatus.upstreamStatus,
+    upstream: upstreamStatus.upstream ?? record.upstream,
+    closeReason: upstreamStatus.closeReason ?? record.closeReason,
+    upstreamCheckedAt: upstreamStatus.checkedAt ?? now.toISOString(),
+    lastPolledAt: now.toISOString(),
+    updatedAt: now.toISOString(),
+    finalizedAt: FINAL_FUNDED_JOB_STATUSES.has(finalStatus)
+      ? (record.finalizedAt ?? now.toISOString())
+      : record.finalizedAt
+  }));
+}
+
+export function summarizeFundedJobs(records, {
+  from = undefined,
+  to = undefined,
+  now = new Date()
+} = {}) {
+  const windowed = records.filter((record) => withinWindow(record, { from, to }));
+  const finalRecords = windowed.filter((record) => FINAL_FUNDED_JOB_STATUSES.has(record.finalStatus));
+  const successful = finalRecords.filter((record) => record.finalStatus === FUNDED_JOB_STATUSES.MERGED);
+  const closeReasonCounts = new Map();
+  for (const record of finalRecords) {
+    if (record.finalStatus === FUNDED_JOB_STATUSES.MERGED) continue;
+    const reason = record.closeReason || record.finalStatus || "unknown";
+    closeReasonCounts.set(reason, (closeReasonCounts.get(reason) ?? 0) + 1);
+  }
+  const totalReserved = sum(windowed.map((record) => finiteNumber(record.rewardAmount, 0)));
+  const confirmedPayout = sum(successful.map((record) => finiteNumber(record.rewardAmount, 0)));
+  return {
+    generatedAt: now.toISOString(),
+    window: {
+      from: from ? new Date(from).toISOString() : undefined,
+      to: to ? new Date(to).toISOString() : undefined
+    },
+    totalFundedJobs: windowed.length,
+    finalJobs: finalRecords.length,
+    successfulJobs: successful.length,
+    mergeRate: finalRecords.length ? successful.length / finalRecords.length : null,
+    totalReserved,
+    confirmedPayout,
+    totalReceipts: windowed.reduce((accumulator, record) => accumulator + finiteNumber(record.receiptCount, 0), 0),
+    statuses: countBy(windowed, (record) => record.finalStatus ?? FUNDED_JOB_STATUSES.OPEN),
+    sourceTypes: countBy(windowed, (record) => record.sourceType ?? "unknown"),
+    topCloseReasons: [...closeReasonCounts.entries()]
+      .map(([reason, count]) => ({ reason, count }))
+      .sort((left, right) => right.count - left.count || left.reason.localeCompare(right.reason))
+      .slice(0, 3)
+  };
+}
+
+export function normalizeFundedJobRecord(record) {
+  return compact({
+    ...record,
+    rewardAmount: finiteNumber(record?.rewardAmount, 0),
+    claimStake: finiteNumber(record?.claimStake, 0),
+    finalStatus: FINAL_FUNDED_JOB_STATUSES.has(record?.finalStatus)
+      ? record.finalStatus
+      : record?.finalStatus === FUNDED_JOB_STATUSES.OPEN
+        ? FUNDED_JOB_STATUSES.OPEN
+        : FUNDED_JOB_STATUSES.OPEN,
+    updatedAt: record?.updatedAt ?? new Date().toISOString()
+  });
+}
+
+export function isFinalFundedJob(record) {
+  return FINAL_FUNDED_JOB_STATUSES.has(record?.finalStatus);
+}
+
+function resolveUpstreamFromSession({ job, session, existing }) {
+  const source = job?.source ?? existing?.source;
+  const submission = session?.submission?.structured ?? session?.submission;
+  const prUrl = firstText(
+    submission?.prUrl,
+    submission?.pullRequestUrl,
+    findGithubPullRequestUrl(JSON.stringify(submission ?? "")),
+    existing?.upstream?.url
+  );
+  const parsedPr = parseGithubPullRequestUrl(prUrl);
+  if (parsedPr) {
+    return {
+      kind: "github_pull_request",
+      url: prUrl,
+      repo: parsedPr.repo,
+      owner: parsedPr.owner,
+      name: parsedPr.name,
+      pullNumber: parsedPr.pullNumber,
+      issueNumber: source?.type === "github_issue" ? Number(source.issueNumber) : undefined
+    };
+  }
+
+  if (source?.type === "wikipedia_article") {
+    const editRevisionId = firstText(
+      submission?.editRevisionId,
+      submission?.publishedRevisionId,
+      existing?.upstream?.editRevisionId
+    );
+    return compact({
+      kind: "mediawiki_revision",
+      project: source.project ?? "wikipedia",
+      language: source.language,
+      pageId: source.pageId,
+      pageTitle: source.pageTitle,
+      pageUrl: source.pageUrl,
+      reviewRevisionId: source.revisionId,
+      editRevisionId,
+      proposalOnly: !editRevisionId
+    });
+  }
+
+  return existing?.upstream;
+}
+
+function computeDeadlineAt({ job, session }) {
+  const sourceType = job?.source?.type;
+  const submittedAt = session?.submittedAt;
+  const base = submittedAt ?? session?.claimedAt;
+  if (!base) return undefined;
+  const days = sourceType === "wikipedia_article"
+    ? DEFAULT_WIKIPEDIA_DEADLINE_DAYS
+    : sourceType === "github_issue"
+      ? DEFAULT_GITHUB_DEADLINE_DAYS
+      : undefined;
+  if (!days) return undefined;
+  return addDays(base, days).toISOString();
+}
+
+function withinWindow(record, { from, to }) {
+  const timestamp = Date.parse(record?.fundedAt ?? record?.claimedAt ?? record?.updatedAt ?? "");
+  if (!Number.isFinite(timestamp)) return false;
+  if (from && timestamp < Date.parse(from)) return false;
+  if (to && timestamp > Date.parse(to)) return false;
+  return true;
+}
+
+function addDays(value, days) {
+  const date = new Date(value);
+  date.setUTCDate(date.getUTCDate() + days);
+  return date;
+}
+
+function sum(values) {
+  return values.reduce((accumulator, value) => accumulator + value, 0);
+}
+
+function countBy(records, selector) {
+  const counts = {};
+  for (const record of records) {
+    const key = selector(record);
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function finiteNumber(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function firstText(...values) {
+  return values.find((value) => typeof value === "string" && value.trim())?.trim() ?? "";
+}
+
+function findGithubPullRequestUrl(text) {
+  return String(text ?? "").match(/https:\/\/github\.com\/[a-z0-9_.-]+\/[a-z0-9_.-]+\/pull\/\d+/iu)?.[0] ?? "";
+}
+
+function parseGithubPullRequestUrl(url) {
+  const match = String(url ?? "").trim().match(/^https:\/\/github\.com\/([a-z0-9_.-]+)\/([a-z0-9_.-]+)\/pull\/(\d+)(?:[/?#].*)?$/iu);
+  if (!match) return undefined;
+  return {
+    owner: match[1],
+    name: match[2],
+    repo: `${match[1]}/${match[2]}`.toLowerCase(),
+    pullNumber: Number(match[3])
+  };
+}
+
+function compact(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}

--- a/mcp-server/src/core/funded-jobs.test.js
+++ b/mcp-server/src/core/funded-jobs.test.js
@@ -1,0 +1,115 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildFundedJobFromClaim,
+  summarizeFundedJobs,
+  updateFundedJobFromSession
+} from "./funded-jobs.js";
+
+const githubJob = {
+  id: "oss-example-42",
+  rewardAsset: "DOT",
+  rewardAmount: 5,
+  source: {
+    type: "github_issue",
+    repo: "example/project",
+    issueNumber: 42,
+    issueUrl: "https://github.com/example/project/issues/42"
+  }
+};
+
+test("buildFundedJobFromClaim captures funded job economics and deadline", () => {
+  const record = buildFundedJobFromClaim({
+    job: githubJob,
+    session: {
+      sessionId: "oss-example-42:0xabc",
+      jobId: "oss-example-42",
+      chainJobId: "0xjob",
+      wallet: "0xabc",
+      claimStake: 0.5,
+      claimedAt: "2026-01-01T00:00:00.000Z"
+    }
+  });
+
+  assert.equal(record.jobId, "oss-example-42");
+  assert.equal(record.sourceType, "github_issue");
+  assert.equal(record.rewardAmount, 5);
+  assert.equal(record.claimStake, 0.5);
+  assert.equal(record.finalStatus, "open");
+  assert.equal(record.deadlineAt, "2026-01-31T00:00:00.000Z");
+});
+
+test("updateFundedJobFromSession extracts GitHub PR evidence from structured submission", () => {
+  const initial = buildFundedJobFromClaim({
+    job: githubJob,
+    session: {
+      sessionId: "oss-example-42:0xabc",
+      jobId: "oss-example-42",
+      wallet: "0xabc",
+      claimedAt: "2026-01-01T00:00:00.000Z"
+    }
+  });
+  const updated = updateFundedJobFromSession(initial, {
+    job: githubJob,
+    session: {
+      ...initial,
+      submittedAt: "2026-01-02T00:00:00.000Z",
+      submission: {
+        kind: "structured",
+        structured: {
+          prUrl: "https://github.com/example/project/pull/77",
+          summary: "Fixed issue"
+        }
+      }
+    }
+  });
+
+  assert.equal(updated.upstream.kind, "github_pull_request");
+  assert.equal(updated.upstream.repo, "example/project");
+  assert.equal(updated.upstream.pullNumber, 77);
+  assert.equal(updated.upstreamStatus, "submitted");
+});
+
+test("summarizeFundedJobs reports merge rate, spend, receipts, and close reasons", () => {
+  const report = summarizeFundedJobs([
+    {
+      jobId: "a",
+      fundedAt: "2026-01-01T00:00:00.000Z",
+      finalStatus: "merged",
+      rewardAmount: 5,
+      receiptCount: 1,
+      sourceType: "github_issue"
+    },
+    {
+      jobId: "b",
+      fundedAt: "2026-01-02T00:00:00.000Z",
+      finalStatus: "closed_unmerged",
+      closeReason: "wrong_fix",
+      rewardAmount: 1,
+      receiptCount: 1,
+      sourceType: "github_issue"
+    },
+    {
+      jobId: "c",
+      fundedAt: "2026-01-03T00:00:00.000Z",
+      finalStatus: "open",
+      rewardAmount: 1,
+      receiptCount: 0,
+      sourceType: "wikipedia_article"
+    }
+  ], {
+    from: "2026-01-01T00:00:00.000Z",
+    to: "2026-01-08T00:00:00.000Z",
+    now: new Date("2026-01-08T00:00:00.000Z")
+  });
+
+  assert.equal(report.totalFundedJobs, 3);
+  assert.equal(report.finalJobs, 2);
+  assert.equal(report.successfulJobs, 1);
+  assert.equal(report.mergeRate, 0.5);
+  assert.equal(report.totalReserved, 7);
+  assert.equal(report.confirmedPayout, 5);
+  assert.equal(report.totalReceipts, 2);
+  assert.deepEqual(report.topCloseReasons, [{ reason: "wrong_fix", count: 1 }]);
+});

--- a/mcp-server/src/core/job-execution-service.js
+++ b/mcp-server/src/core/job-execution-service.js
@@ -6,6 +6,10 @@ import {
 import { buildSessionLifecycle, describeSessionStatus, transitionSession } from "./session-state-machine.js";
 import { hashSubmission, normalizeSubmission } from "./submission.js";
 import { getBuiltinJobSchema, validateStructuredSubmission } from "./job-schema-registry.js";
+import {
+  buildFundedJobFromClaim,
+  updateFundedJobFromSession
+} from "./funded-jobs.js";
 
 export class JobExecutionService {
   constructor(
@@ -105,6 +109,7 @@ export class JobExecutionService {
       });
 
       const persisted = await this.stateStore.upsertSession(session);
+      await this.stateStore.upsertFundedJob?.(buildFundedJobFromClaim({ job, session: persisted }));
       this.publishSessionEvent("session.claimed", persisted);
       return persisted;
     } finally {
@@ -137,6 +142,8 @@ export class JobExecutionService {
       }
     });
     const persisted = await this.stateStore.upsertSession(transitioned);
+    const fundedJob = await this.stateStore.getFundedJob?.(persisted.jobId);
+    await this.stateStore.upsertFundedJob?.(updateFundedJobFromSession(fundedJob, { job, session: persisted }));
     this.publishSessionEvent("session.submitted", persisted, {
       submissionKind: submission.kind,
       schemaRef: job.outputSchemaRef

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -54,6 +54,7 @@ export class PlatformService {
     this.openApiSpecIngestionScheduler = undefined;
     this.xcmSettlementWatcher = undefined;
     this.xcmObservationRelay = undefined;
+    this.upstreamStatusPoller = undefined;
 
     this.accountMutationService = new AccountMutationService(
       this.accounts,
@@ -124,6 +125,7 @@ export class PlatformService {
       openDataIngestion,
       standardsIngestion,
       openApiIngestion,
+      upstreamStatus,
       recentSessions
     ] = await Promise.all([
       this.blockchainGateway?.getTreasuryPolicyStatus?.() ?? {
@@ -208,6 +210,13 @@ export class PlatformService {
         maxJobsPerRun: 0,
         maxOpenJobs: 0,
         currentOpenJobs: 0,
+        lastRun: undefined
+      },
+      this.upstreamStatusPoller?.getStatus?.() ?? {
+        enabled: false,
+        running: false,
+        intervalMs: 0,
+        batchSize: 0,
         lastRun: undefined
       },
       this.jobExecutionService.listRecentSessions(14)
@@ -314,6 +323,7 @@ export class PlatformService {
       openDataIngestion: openDataIngestion,
       standardsIngestion: standardsIngestion,
       openApiIngestion: openApiIngestion,
+      upstreamStatus,
       xcmSettlementWatcher: await this.xcmSettlementWatcher?.getStatus?.() ?? {
         enabled: false,
         running: false,

--- a/mcp-server/src/core/state-store.js
+++ b/mcp-server/src/core/state-store.js
@@ -45,6 +45,7 @@ export class MemoryStateStore {
     this.xcmObservations = new Map();
     this.serviceStates = new Map();
     this.content = new Map();
+    this.fundedJobs = new Map();
   }
 
   async getSession(sessionId) {
@@ -212,6 +213,22 @@ export class MemoryStateStore {
     const key = String(record?.hash ?? "").toLowerCase();
     this.content.set(key, record);
     return record;
+  }
+
+  async getFundedJob(jobId) {
+    return this.fundedJobs.get(String(jobId ?? ""));
+  }
+
+  async upsertFundedJob(record) {
+    this.fundedJobs.set(String(record?.jobId ?? ""), record);
+    return record;
+  }
+
+  async listFundedJobs({ limit = 100, offset = 0, finalOnly = false } = {}) {
+    return [...this.fundedJobs.values()]
+      .filter((record) => !finalOnly || ["merged", "closed_unmerged", "open_stale", "reverted"].includes(record?.finalStatus))
+      .sort((left, right) => String(right.fundedAt ?? right.updatedAt ?? "").localeCompare(String(left.fundedAt ?? left.updatedAt ?? "")))
+      .slice(Math.max(offset, 0), Math.max(offset, 0) + Math.max(limit, 0));
   }
 
   async getXcmObservation(requestId) {
@@ -497,6 +514,34 @@ export class RedisStateStore {
     const key = String(record?.hash ?? "").toLowerCase();
     await this.client.set(this.key("content", key), JSON.stringify(record));
     return record;
+  }
+
+  async getFundedJob(jobId) {
+    await this.connect();
+    const raw = await this.client.get(this.key("funded-job", String(jobId ?? "")));
+    return raw ? JSON.parse(raw) : undefined;
+  }
+
+  async upsertFundedJob(record) {
+    await this.connect();
+    const jobId = String(record?.jobId ?? "");
+    await this.client.set(this.key("funded-job", jobId), JSON.stringify(record));
+    await this.client.zAdd(this.key("funded-jobs", "all"), {
+      score: Date.parse(record?.fundedAt ?? record?.updatedAt ?? "") || Date.now(),
+      value: jobId
+    });
+    return record;
+  }
+
+  async listFundedJobs({ limit = 100, offset = 0, finalOnly = false } = {}) {
+    await this.connect();
+    const start = Math.max(offset, 0);
+    const stop = start + Math.max(limit - 1, 0);
+    const jobIds = await this.client.zRange(this.key("funded-jobs", "all"), start, stop, { REV: true });
+    const records = await Promise.all(jobIds.map((jobId) => this.getFundedJob(jobId)));
+    return records
+      .filter(Boolean)
+      .filter((record) => !finalOnly || ["merged", "closed_unmerged", "open_stale", "reverted"].includes(record.finalStatus));
   }
 
   async getXcmObservation(requestId) {

--- a/mcp-server/src/core/state-store.test.js
+++ b/mcp-server/src/core/state-store.test.js
@@ -82,6 +82,24 @@ test("MemoryStateStore content blobs round-trip by lowercase hash", async () => 
   );
 });
 
+test("MemoryStateStore funded jobs round-trip and list latest first", async () => {
+  const store = new MemoryStateStore();
+  await store.upsertFundedJob({
+    jobId: "job-1",
+    fundedAt: "2026-01-01T00:00:00.000Z",
+    finalStatus: "open"
+  });
+  await store.upsertFundedJob({
+    jobId: "job-2",
+    fundedAt: "2026-01-02T00:00:00.000Z",
+    finalStatus: "merged"
+  });
+
+  assert.equal((await store.getFundedJob("job-1")).finalStatus, "open");
+  assert.deepEqual((await store.listFundedJobs({ limit: 2 })).map((entry) => entry.jobId), ["job-2", "job-1"]);
+  assert.deepEqual((await store.listFundedJobs({ finalOnly: true })).map((entry) => entry.jobId), ["job-2"]);
+});
+
 test("MemoryStateStore xcm observations round-trip and clear from pending when processed", async () => {
   const store = new MemoryStateStore();
   await store.upsertXcmObservation({

--- a/mcp-server/src/jobs/bootstrap-upstream-status.js
+++ b/mcp-server/src/jobs/bootstrap-upstream-status.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+import { createStateStore } from "../core/state-store.js";
+import {
+  UpstreamStatusPollerService,
+  loadUpstreamStatusPollerConfig
+} from "../services/upstream-status-poller.js";
+
+export function parseArgs(argv) {
+  const parsed = { poll: false, report: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith("--")) continue;
+    const key = arg.slice(2);
+    if (key === "poll") {
+      parsed.poll = true;
+      continue;
+    }
+    if (key === "report") {
+      parsed.report = true;
+      continue;
+    }
+    const next = argv[index + 1];
+    parsed[key] = next && !next.startsWith("--") ? next : true;
+    if (next && !next.startsWith("--")) index += 1;
+  }
+  if (!parsed.poll && !parsed.report) {
+    parsed.poll = true;
+    parsed.report = true;
+  }
+  return parsed;
+}
+
+export async function runBootstrapUpstreamStatusCli({
+  argv = process.argv.slice(2),
+  env = process.env,
+  fetchImpl = fetch,
+  stdout = process.stdout,
+  logger = console
+} = {}) {
+  const args = parseArgs(argv);
+  const stateStore = createStateStore(env, { logger });
+  const poller = new UpstreamStatusPollerService(stateStore, undefined, {
+    ...loadUpstreamStatusPollerConfig(env),
+    enabled: true,
+    fetchImpl,
+    logger
+  });
+  const result = {};
+  if (args.poll) {
+    result.poll = await poller.runOnce(new Date(args.now ?? Date.now()));
+  }
+  if (args.report) {
+    result.report = await poller.generateWeeklyReport({
+      now: new Date(args.now ?? Date.now()),
+      from: args.from,
+      to: args.to
+    });
+  }
+  stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  await stateStore.client?.quit?.();
+  return result;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runBootstrapUpstreamStatusCli().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/mcp-server/src/services/bootstrap.js
+++ b/mcp-server/src/services/bootstrap.js
@@ -41,6 +41,10 @@ import {
 } from "./openapi-spec-ingestion-scheduler.js";
 import { XcmSettlementWatcherService } from "./xcm-settlement-watcher.js";
 import { XcmObservationRelayService } from "./xcm-observation-relay.js";
+import {
+  UpstreamStatusPollerService,
+  loadUpstreamStatusPollerConfig
+} from "./upstream-status-poller.js";
 import { normaliseStrategyAssetConfig } from "./strategy-asset-config.js";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -224,6 +228,12 @@ export async function createPlatformRuntime() {
       logger
     })
   );
+  const upstreamStatusPoller = initStep("init-upstream-status-poller", logger, () =>
+    new UpstreamStatusPollerService(stateStore, eventBus, {
+      ...loadUpstreamStatusPollerConfig(process.env),
+      logger
+    })
+  );
   platformService.recurringScheduler = recurringScheduler;
   platformService.githubIssueIngestionScheduler = githubIssueIngestionScheduler;
   platformService.wikipediaMaintenanceIngestionScheduler = wikipediaMaintenanceIngestionScheduler;
@@ -233,6 +243,7 @@ export async function createPlatformRuntime() {
   platformService.openApiSpecIngestionScheduler = openApiSpecIngestionScheduler;
   platformService.xcmSettlementWatcher = xcmSettlementWatcher;
   platformService.xcmObservationRelay = xcmObservationRelay;
+  platformService.upstreamStatusPoller = upstreamStatusPoller;
   recurringScheduler.start();
   githubIssueIngestionScheduler.start();
   wikipediaMaintenanceIngestionScheduler.start();
@@ -242,6 +253,7 @@ export async function createPlatformRuntime() {
   openApiSpecIngestionScheduler.start();
   xcmSettlementWatcher.start();
   xcmObservationRelay.start();
+  upstreamStatusPoller.start();
 
   const authMiddleware = createAuthMiddleware({ authConfig, stateStore, logger });
   const rateLimiter = createRateLimiter({ stateStore, logger });
@@ -273,6 +285,7 @@ export async function createPlatformRuntime() {
     openApiSpecIngestionScheduler,
     xcmSettlementWatcher,
     xcmObservationRelay,
+    upstreamStatusPoller,
     authConfig,
     authMiddleware,
     authCapabilities: {

--- a/mcp-server/src/services/upstream-status-poller.js
+++ b/mcp-server/src/services/upstream-status-poller.js
@@ -1,0 +1,369 @@
+import {
+  FUNDED_JOB_STATUSES,
+  applyUpstreamStatus,
+  isFinalFundedJob,
+  summarizeFundedJobs
+} from "../core/funded-jobs.js";
+
+export class UpstreamStatusPollerService {
+  constructor(stateStore, eventBus = undefined, {
+    enabled = false,
+    intervalMs = 24 * 60 * 60 * 1000,
+    batchSize = 50,
+    githubToken = undefined,
+    githubApiBaseUrl = "https://api.github.com",
+    fetchImpl = fetch,
+    logger = console
+  } = {}) {
+    this.stateStore = stateStore;
+    this.eventBus = eventBus;
+    this.enabled = enabled;
+    this.intervalMs = intervalMs;
+    this.batchSize = batchSize;
+    this.githubToken = githubToken;
+    this.githubApiBaseUrl = githubApiBaseUrl;
+    this.fetchImpl = fetchImpl;
+    this.logger = logger;
+    this.running = false;
+    this.timer = undefined;
+    this.lastRun = undefined;
+  }
+
+  start() {
+    if (!this.enabled || this.running) return;
+    this.running = true;
+    void this.runOnceAndSchedule();
+  }
+
+  stop() {
+    this.running = false;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  async getStatus() {
+    return {
+      enabled: this.enabled,
+      running: this.running,
+      intervalMs: this.intervalMs,
+      batchSize: this.batchSize,
+      lastRun: this.lastRun
+    };
+  }
+
+  async runOnce(now = new Date()) {
+    const startedAt = now.toISOString();
+    const records = await this.stateStore.listFundedJobs?.({ limit: this.batchSize }) ?? [];
+    const summary = {
+      startedAt,
+      finishedAt: undefined,
+      checked: 0,
+      updated: 0,
+      skipped: [],
+      errors: []
+    };
+
+    for (const record of records) {
+      if (isFinalFundedJob(record)) {
+        summary.skipped.push({ jobId: record.jobId, reason: "final" });
+        continue;
+      }
+      try {
+        const upstreamStatus = await this.resolveUpstreamStatus(record, { now });
+        if (!upstreamStatus) {
+          summary.skipped.push({ jobId: record.jobId, reason: "no_pollable_upstream" });
+          continue;
+        }
+        summary.checked += 1;
+        const updated = applyUpstreamStatus(record, upstreamStatus, { now });
+        await this.stateStore.upsertFundedJob?.(updated);
+        summary.updated += 1;
+        this.eventBus?.publish?.({
+          id: `upstream-status-${updated.jobId}-${Date.now()}`,
+          topic: "funded_jobs.upstream_status",
+          jobId: updated.jobId,
+          sessionId: updated.sessionId,
+          wallet: updated.wallet,
+          wallets: [updated.wallet].filter(Boolean),
+          timestamp: now.toISOString(),
+          data: {
+            jobId: updated.jobId,
+            finalStatus: updated.finalStatus,
+            upstreamStatus: updated.upstreamStatus,
+            closeReason: updated.closeReason
+          }
+        });
+      } catch (error) {
+        summary.errors.push({ jobId: record.jobId, message: error?.message ?? String(error) });
+        this.logger.warn?.({ jobId: record.jobId, err: error }, "upstream_status.poll_failed");
+      }
+    }
+
+    return this.finishRun(summary);
+  }
+
+  async generateWeeklyReport({ now = new Date(), from = undefined, to = undefined } = {}) {
+    const end = to ? new Date(to) : now;
+    const start = from ? new Date(from) : new Date(end.getTime() - 7 * 24 * 60 * 60 * 1000);
+    const records = await this.stateStore.listFundedJobs?.({ limit: 10_000 }) ?? [];
+    return summarizeFundedJobs(records, { from: start, to: end, now });
+  }
+
+  async runOnceAndSchedule() {
+    await this.runOnce(new Date());
+    if (!this.running) return;
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      void this.runOnceAndSchedule();
+    }, this.intervalMs);
+  }
+
+  finishRun(summary) {
+    summary.finishedAt = new Date().toISOString();
+    this.lastRun = summary;
+    return summary;
+  }
+
+  async resolveUpstreamStatus(record, { now = new Date() } = {}) {
+    if (record?.upstream?.kind === "github_pull_request") {
+      return pollGithubPullRequest(record, {
+        now,
+        fetchImpl: this.fetchImpl,
+        githubToken: this.githubToken,
+        githubApiBaseUrl: this.githubApiBaseUrl
+      });
+    }
+    if (record?.upstream?.kind === "mediawiki_revision") {
+      return pollMediaWikiRevision(record, {
+        now,
+        fetchImpl: this.fetchImpl
+      });
+    }
+    if (isPastDeadline(record, now)) {
+      return {
+        finalStatus: FUNDED_JOB_STATUSES.OPEN_STALE,
+        upstreamStatus: "deadline_elapsed",
+        closeReason: "no_upstream_submission",
+        checkedAt: now.toISOString()
+      };
+    }
+    return undefined;
+  }
+}
+
+export async function pollGithubPullRequest(record, {
+  now = new Date(),
+  fetchImpl = fetch,
+  githubToken = undefined,
+  githubApiBaseUrl = "https://api.github.com"
+} = {}) {
+  const upstream = record?.upstream;
+  if (!upstream?.owner || !upstream?.name || !upstream?.pullNumber) return undefined;
+  const baseUrl = String(githubApiBaseUrl ?? "https://api.github.com").replace(/\/+$/u, "");
+  const url = `${baseUrl}/repos/${encodeURIComponent(upstream.owner)}/${encodeURIComponent(upstream.name)}/pulls/${upstream.pullNumber}`;
+  const headers = {
+    accept: "application/vnd.github+json",
+    "user-agent": "averray-upstream-status-poller"
+  };
+  if (githubToken) headers.authorization = `Bearer ${githubToken}`;
+  const response = await fetchImpl(url, { headers });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub pull request lookup failed (${response.status}): ${body}`);
+  }
+  const pull = await response.json();
+  const merged = Boolean(pull.merged || pull.merged_at);
+  if (merged) {
+    return {
+      finalStatus: FUNDED_JOB_STATUSES.MERGED,
+      upstreamStatus: "merged",
+      closeReason: undefined,
+      checkedAt: now.toISOString(),
+      upstream: {
+        ...upstream,
+        mergedAt: pull.merged_at ?? now.toISOString(),
+        state: pull.state
+      }
+    };
+  }
+  if (pull.state === "closed") {
+    return {
+      finalStatus: FUNDED_JOB_STATUSES.CLOSED_UNMERGED,
+      upstreamStatus: "closed_unmerged",
+      closeReason: "closed_unmerged",
+      checkedAt: now.toISOString(),
+      upstream: {
+        ...upstream,
+        closedAt: pull.closed_at ?? now.toISOString(),
+        state: pull.state
+      }
+    };
+  }
+  if (isPastDeadline(record, now)) {
+    return {
+      finalStatus: FUNDED_JOB_STATUSES.OPEN_STALE,
+      upstreamStatus: "open_stale",
+      closeReason: "deadline_elapsed",
+      checkedAt: now.toISOString(),
+      upstream: {
+        ...upstream,
+        state: pull.state
+      }
+    };
+  }
+  return {
+    finalStatus: FUNDED_JOB_STATUSES.OPEN,
+    upstreamStatus: "open",
+    checkedAt: now.toISOString(),
+    upstream: {
+      ...upstream,
+      state: pull.state
+    }
+  };
+}
+
+export async function pollMediaWikiRevision(record, {
+  now = new Date(),
+  fetchImpl = fetch
+} = {}) {
+  const upstream = record?.upstream;
+  if (!upstream || upstream.proposalOnly || !upstream.editRevisionId || !upstream.language) {
+    return undefined;
+  }
+  const url = new URL(`https://${upstream.language}.wikipedia.org/w/api.php`);
+  url.searchParams.set("action", "query");
+  url.searchParams.set("format", "json");
+  url.searchParams.set("prop", "revisions");
+  url.searchParams.set("revids", String(upstream.editRevisionId));
+  url.searchParams.set("rvprop", "ids|timestamp|tags");
+  url.searchParams.set("origin", "*");
+  const headers = {
+    accept: "application/json",
+    "user-agent": "AverrayUpstreamStatusPoller/0.1 (https://averray.com; operator@averray.com)"
+  };
+  const response = await fetchImpl(url, { headers });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`MediaWiki revision lookup failed (${response.status}): ${body}`);
+  }
+  const payload = await response.json();
+  const page = Object.values(payload?.query?.pages ?? {})[0];
+  const revision = page?.revisions?.[0];
+  if (!revision) {
+    return {
+      finalStatus: FUNDED_JOB_STATUSES.REVERTED,
+      upstreamStatus: "revision_missing",
+      closeReason: "revision_not_found",
+      checkedAt: now.toISOString(),
+      upstream
+    };
+  }
+  if (hasRevertSignal(revision, upstream.editRevisionId)) {
+    return {
+      finalStatus: FUNDED_JOB_STATUSES.REVERTED,
+      upstreamStatus: "reverted",
+      closeReason: "revision_tagged_reverted",
+      checkedAt: now.toISOString(),
+      upstream: {
+        ...upstream,
+        revisionTimestamp: revision.timestamp
+      }
+    };
+  }
+  const revisionAt = Date.parse(revision.timestamp);
+  const survivedSevenDays = Number.isFinite(revisionAt)
+    && now.getTime() >= revisionAt + 7 * 24 * 60 * 60 * 1000;
+  if (survivedSevenDays) {
+    const newer = await fetchNewerMediaWikiRevisions({
+      language: upstream.language,
+      pageId: upstream.pageId ?? page?.pageid,
+      since: revision.timestamp,
+      fetchImpl,
+      headers
+    });
+    const revertRevision = newer.find((entry) =>
+      String(entry.revid) !== String(upstream.editRevisionId) && hasRevertSignal(entry, upstream.editRevisionId)
+    );
+    if (revertRevision) {
+      return {
+        finalStatus: FUNDED_JOB_STATUSES.REVERTED,
+        upstreamStatus: "reverted",
+        closeReason: "later_revert_detected",
+        checkedAt: now.toISOString(),
+        upstream: {
+          ...upstream,
+          revisionTimestamp: revision.timestamp,
+          revertRevisionId: String(revertRevision.revid ?? "")
+        }
+      };
+    }
+  }
+  return {
+    finalStatus: survivedSevenDays ? FUNDED_JOB_STATUSES.MERGED : FUNDED_JOB_STATUSES.OPEN,
+    upstreamStatus: survivedSevenDays ? "survived_7_days" : "pending_survival_window",
+    checkedAt: now.toISOString(),
+    upstream: {
+      ...upstream,
+      revisionTimestamp: revision.timestamp
+    }
+  };
+}
+
+async function fetchNewerMediaWikiRevisions({ language, pageId, since, fetchImpl, headers }) {
+  if (!pageId || !since) return [];
+  const url = new URL(`https://${language}.wikipedia.org/w/api.php`);
+  url.searchParams.set("action", "query");
+  url.searchParams.set("format", "json");
+  url.searchParams.set("prop", "revisions");
+  url.searchParams.set("pageids", String(pageId));
+  url.searchParams.set("rvprop", "ids|timestamp|comment|tags");
+  url.searchParams.set("rvlimit", "50");
+  url.searchParams.set("rvdir", "newer");
+  url.searchParams.set("rvstart", since);
+  url.searchParams.set("origin", "*");
+  const response = await fetchImpl(url, { headers });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`MediaWiki newer revision lookup failed (${response.status}): ${body}`);
+  }
+  const payload = await response.json();
+  const page = Object.values(payload?.query?.pages ?? {})[0];
+  return Array.isArray(page?.revisions) ? page.revisions : [];
+}
+
+function hasRevertSignal(revision, targetRevisionId) {
+  const tags = new Set((revision?.tags ?? []).map((tag) => String(tag).toLowerCase()));
+  if (tags.has("mw-reverted") || tags.has("mw-rollback") || tags.has("mw-manual-revert") || tags.has("mw-undo")) {
+    return true;
+  }
+  const comment = String(revision?.comment ?? "").toLowerCase();
+  return comment.includes(`revision ${String(targetRevisionId).toLowerCase()}`)
+    && /\b(revert|reverted|undo|undid|rollback)\b/u.test(comment);
+}
+
+export function loadUpstreamStatusPollerConfig(env = process.env) {
+  return {
+    enabled: parseBooleanEnv(env.UPSTREAM_STATUS_POLLER_ENABLED),
+    intervalMs: parsePositiveInt(env.UPSTREAM_STATUS_POLLER_INTERVAL_MS, 24 * 60 * 60 * 1000),
+    batchSize: parsePositiveInt(env.UPSTREAM_STATUS_POLLER_BATCH_SIZE, 50),
+    githubToken: env.GITHUB_TOKEN?.trim() || undefined,
+    githubApiBaseUrl: env.GITHUB_API_BASE_URL?.trim() || "https://api.github.com"
+  };
+}
+
+function isPastDeadline(record, now) {
+  const deadline = Date.parse(record?.deadlineAt ?? "");
+  return Number.isFinite(deadline) && now.getTime() > deadline;
+}
+
+function parseBooleanEnv(raw) {
+  if (raw === undefined || raw === null || raw === "") return false;
+  return ["1", "true", "yes", "on"].includes(String(raw).trim().toLowerCase());
+}
+
+function parsePositiveInt(raw, fallback) {
+  const value = Number(raw);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}

--- a/mcp-server/src/services/upstream-status-poller.test.js
+++ b/mcp-server/src/services/upstream-status-poller.test.js
@@ -1,0 +1,198 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { MemoryStateStore } from "../core/state-store.js";
+import {
+  UpstreamStatusPollerService,
+  pollGithubPullRequest,
+  pollMediaWikiRevision
+} from "./upstream-status-poller.js";
+
+function jsonResponse(payload, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    async json() {
+      return payload;
+    },
+    async text() {
+      return JSON.stringify(payload);
+    }
+  };
+}
+
+const githubRecord = {
+  jobId: "oss-example-42",
+  sessionId: "oss-example-42:0xabc",
+  wallet: "0xabc",
+  sourceType: "github_issue",
+  rewardAmount: 5,
+  fundedAt: "2026-01-01T00:00:00.000Z",
+  submittedAt: "2026-01-02T00:00:00.000Z",
+  deadlineAt: "2026-02-01T00:00:00.000Z",
+  finalStatus: "open",
+  upstream: {
+    kind: "github_pull_request",
+    owner: "example",
+    name: "project",
+    repo: "example/project",
+    pullNumber: 77,
+    url: "https://github.com/example/project/pull/77"
+  }
+};
+
+test("pollGithubPullRequest marks merged pull requests as merged", async () => {
+  const result = await pollGithubPullRequest(githubRecord, {
+    now: new Date("2026-01-05T00:00:00.000Z"),
+    fetchImpl: async (url, options) => {
+      assert.equal(String(url), "https://api.github.com/repos/example/project/pulls/77");
+      assert.equal(options.headers["user-agent"], "averray-upstream-status-poller");
+      return jsonResponse({ state: "closed", merged: true, merged_at: "2026-01-04T00:00:00Z" });
+    }
+  });
+
+  assert.equal(result.finalStatus, "merged");
+  assert.equal(result.upstreamStatus, "merged");
+  assert.equal(result.upstream.mergedAt, "2026-01-04T00:00:00Z");
+});
+
+test("pollGithubPullRequest marks closed unmerged pull requests", async () => {
+  const result = await pollGithubPullRequest(githubRecord, {
+    now: new Date("2026-01-05T00:00:00.000Z"),
+    fetchImpl: async () => jsonResponse({ state: "closed", merged: false, closed_at: "2026-01-04T00:00:00Z" })
+  });
+
+  assert.equal(result.finalStatus, "closed_unmerged");
+  assert.equal(result.closeReason, "closed_unmerged");
+});
+
+test("pollGithubPullRequest marks open pull requests stale after deadline", async () => {
+  const result = await pollGithubPullRequest(githubRecord, {
+    now: new Date("2026-02-02T00:00:00.000Z"),
+    fetchImpl: async () => jsonResponse({ state: "open", merged: false })
+  });
+
+  assert.equal(result.finalStatus, "open_stale");
+  assert.equal(result.closeReason, "deadline_elapsed");
+});
+
+test("pollMediaWikiRevision skips proposal-only records", async () => {
+  const result = await pollMediaWikiRevision({
+    upstream: {
+      kind: "mediawiki_revision",
+      proposalOnly: true,
+      language: "en",
+      reviewRevisionId: "123"
+    }
+  });
+
+  assert.equal(result, undefined);
+});
+
+test("pollMediaWikiRevision marks direct edits after survival window", async () => {
+  const result = await pollMediaWikiRevision({
+    upstream: {
+      kind: "mediawiki_revision",
+      proposalOnly: false,
+      language: "en",
+      editRevisionId: "456"
+    }
+  }, {
+    now: new Date("2026-01-10T00:00:00.000Z"),
+    fetchImpl: async (url) => {
+      if (String(url).includes("revids=456")) {
+        return jsonResponse({
+          query: {
+            pages: {
+              1: {
+                pageid: 1,
+                revisions: [{ revid: 456, timestamp: "2026-01-01T00:00:00Z", tags: [] }]
+              }
+            }
+          }
+        });
+      }
+      assert.match(String(url), /pageids=1/u);
+      return jsonResponse({
+        query: {
+          pages: {
+            1: {
+              revisions: [{ revid: 789, timestamp: "2026-01-02T00:00:00Z", tags: [] }]
+            }
+          }
+        }
+      });
+    }
+  });
+
+  assert.equal(result.finalStatus, "merged");
+  assert.equal(result.upstreamStatus, "survived_7_days");
+});
+
+test("pollMediaWikiRevision marks direct edits reverted when later revision signals undo", async () => {
+  const result = await pollMediaWikiRevision({
+    upstream: {
+      kind: "mediawiki_revision",
+      proposalOnly: false,
+      language: "en",
+      editRevisionId: "456"
+    }
+  }, {
+    now: new Date("2026-01-10T00:00:00.000Z"),
+    fetchImpl: async (url) => {
+      if (String(url).includes("revids=456")) {
+        return jsonResponse({
+          query: {
+            pages: {
+              1: {
+                pageid: 1,
+                revisions: [{ revid: 456, timestamp: "2026-01-01T00:00:00Z", tags: [] }]
+              }
+            }
+          }
+        });
+      }
+      return jsonResponse({
+        query: {
+          pages: {
+            1: {
+              revisions: [{
+                revid: 790,
+                timestamp: "2026-01-02T00:00:00Z",
+                tags: ["mw-undo"],
+                comment: "Undid revision 456 by Example"
+              }]
+            }
+          }
+        }
+      });
+    }
+  });
+
+  assert.equal(result.finalStatus, "reverted");
+  assert.equal(result.closeReason, "later_revert_detected");
+});
+
+test("UpstreamStatusPollerService updates records and generates report", async () => {
+  const stateStore = new MemoryStateStore();
+  await stateStore.upsertFundedJob(githubRecord);
+  const poller = new UpstreamStatusPollerService(stateStore, undefined, {
+    enabled: true,
+    fetchImpl: async () => jsonResponse({ state: "closed", merged: true, merged_at: "2026-01-03T00:00:00Z" })
+  });
+
+  const run = await poller.runOnce(new Date("2026-01-04T00:00:00.000Z"));
+  assert.equal(run.checked, 1);
+  assert.equal(run.updated, 1);
+
+  const updated = await stateStore.getFundedJob(githubRecord.jobId);
+  assert.equal(updated.finalStatus, "merged");
+
+  const report = await poller.generateWeeklyReport({
+    now: new Date("2026-01-08T00:00:00.000Z"),
+    from: "2026-01-01T00:00:00.000Z",
+    to: "2026-01-08T00:00:00.000Z"
+  });
+  assert.equal(report.mergeRate, 1);
+  assert.equal(report.confirmedPayout, 5);
+});

--- a/mcp-server/src/services/verification-ingestion-service.js
+++ b/mcp-server/src/services/verification-ingestion-service.js
@@ -1,4 +1,5 @@
 import { transitionSession } from "../core/session-state-machine.js";
+import { updateFundedJobFromSession } from "../core/funded-jobs.js";
 
 export class VerificationIngestionService {
   constructor(stateStore, eventBus = undefined) {
@@ -37,6 +38,11 @@ export class VerificationIngestionService {
       }
     });
     const updatedSession = await this.stateStore.upsertSession(transitioned);
+    const fundedJob = await this.stateStore.getFundedJob?.(updatedSession.jobId);
+    await this.stateStore.upsertFundedJob?.(updateFundedJobFromSession(fundedJob, {
+      session: updatedSession,
+      verification: verdict
+    }));
     await this.stateStore.upsertVerificationResult(updatedSession.sessionId, {
       ...verdict,
       session: {


### PR DESCRIPTION
## What changed
- Added durable `funded_jobs` records to the memory and Redis state stores.
- Record funded jobs on claim, enrich them on submission, and attach verification outcome/receipt data after verifier resolution.
- Added upstream status polling for GitHub PRs and direct MediaWiki revisions.
- Added weekly bootstrap report generation with merge rate, spend/reserved totals, receipts, status counts, source counts, and top close reasons.
- Added an on-demand CLI: `npm --workspace mcp-server run bootstrap:upstream-status -- --poll --report`.
- Wired the poller into runtime behind `UPSTREAM_STATUS_POLLER_ENABLED=false` by default.
- Updated `.env.example` and `docs/RC1_IMPLEMENTATION_PLAN.md` for slice 5 status.

## Checks run
- `node --test mcp-server/src/core/funded-jobs.test.js mcp-server/src/core/state-store.test.js mcp-server/src/services/upstream-status-poller.test.js`
- `npm --workspace mcp-server test`
- `npm --workspace mcp-server run bootstrap:upstream-status -- --report --now 2026-01-08T00:00:00.000Z`
- `git diff --check`

## Affected surfaces
- Backend: yes.
- Frontend/operator app: no.
- Indexer: no.
- Contracts: no.
- Public site: no.
- VPS secrets: no new required secrets. Optional env knobs are documented and disabled by default.

## Notes
This is the backend foundation for the week-12 gate. It does not add scheduled email delivery yet; the plan keeps that as a small follow-up once recipients and cadence are final.