### PR TITLE
Fix dead links in marketing footer and stale repo refs

### DIFF
--- a/marketing/src/layouts/BaseLayout.astro
+++ b/marketing/src/layouts/BaseLayout.astro
@@ -21,7 +21,7 @@ const structuredData = {
   applicationCategory: "DeveloperApplication",
   operatingSystem: "Web",
   url: "https://averray.com",
-  sameAs: ["https://github.com/depre-dev/agent"],
+  sameAs: ["https://github.com/averray-agent/agent"],
   potentialAction: {
     "@type": "ViewAction",
     target: "https://averray.com/.well-known/agent-tools.json"

--- a/marketing/src/pages/index.astro
+++ b/marketing/src/pages/index.astro
@@ -412,11 +412,11 @@ const capital = [
         Averray · © {FOOTER_YEAR} · receipts, not vibes.
       </div>
       <div class="footer__links">
-        <a href="https://docs.averray.com">Docs</a>
-        <a href="https://status.averray.com">Status</a>
+        <a href="https://github.com/averray-agent/agent/tree/main/docs">Docs</a>
+        <a href="https://averray.com/trust/">Status</a>
         <a href="https://averray.com/builders/">Builders</a>
         <a href="https://x.com/averray">X</a>
-        <a href="https://github.com/averray">GitHub</a>
+        <a href="https://github.com/averray-agent/agent">GitHub</a>
       </div>
     </footer>
   </main>

--- a/site/.well-known/agent-tools.json
+++ b/site/.well-known/agent-tools.json
@@ -95,14 +95,14 @@
     "jobSchemaRefPrefix": "schema://jobs/"
   },
   "docs": {
-    "vision": "https://github.com/depre-dev/agent/blob/main/docs/AGENT_BANKING.md",
-    "multisig": "https://github.com/depre-dev/agent/blob/main/docs/MULTISIG_SETUP.md",
-    "audit": "https://github.com/depre-dev/agent/blob/main/docs/AUDIT_PACKAGE.md",
-    "discovery": "https://github.com/depre-dev/agent/blob/main/docs/DISCOVERY.md",
-    "launchPlan": "https://github.com/depre-dev/agent/blob/main/docs/PHASE1_LAUNCH_PLAN.md",
-    "vdotStrategy": "https://github.com/depre-dev/agent/blob/main/docs/strategies/vdot.md",
-    "subJobEscrow": "https://github.com/depre-dev/agent/blob/main/docs/patterns/sub-job-escrow.md",
-    "sendToAgent": "https://github.com/depre-dev/agent/blob/main/docs/payments/send-to-agent.md"
+    "vision": "https://github.com/averray-agent/agent/blob/main/docs/AGENT_BANKING.md",
+    "multisig": "https://github.com/averray-agent/agent/blob/main/docs/MULTISIG_SETUP.md",
+    "audit": "https://github.com/averray-agent/agent/blob/main/docs/AUDIT_PACKAGE.md",
+    "discovery": "https://github.com/averray-agent/agent/blob/main/docs/DISCOVERY.md",
+    "launchPlan": "https://github.com/averray-agent/agent/blob/main/docs/PHASE1_LAUNCH_PLAN.md",
+    "vdotStrategy": "https://github.com/averray-agent/agent/blob/main/docs/strategies/vdot.md",
+    "subJobEscrow": "https://github.com/averray-agent/agent/blob/main/docs/patterns/sub-job-escrow.md",
+    "sendToAgent": "https://github.com/averray-agent/agent/blob/main/docs/payments/send-to-agent.md"
   },
   "executionSurfaces": {
     "operatorApp": "https://app.averray.com",

--- a/site/builders/index.html
+++ b/site/builders/index.html
@@ -127,8 +127,8 @@
             <article class="site-card">
               <p class="label">Source docs</p>
               <div class="link-row">
-                <a class="button-ghost" href="https://github.com/depre-dev/agent/blob/main/README.md" target="_blank" rel="noreferrer">README</a>
-                <a class="button-ghost" href="https://github.com/depre-dev/agent/blob/main/docs/AGENT_BANKING.md" target="_blank" rel="noreferrer">Agent banking vision</a>
+                <a class="button-ghost" href="https://github.com/averray-agent/agent/blob/main/README.md" target="_blank" rel="noreferrer">README</a>
+                <a class="button-ghost" href="https://github.com/averray-agent/agent/blob/main/docs/AGENT_BANKING.md" target="_blank" rel="noreferrer">Agent banking vision</a>
               </div>
             </article>
           </div>

--- a/site/trust/index.html
+++ b/site/trust/index.html
@@ -176,9 +176,9 @@
           <article class="site-card">
             <p class="label">Canonical docs</p>
             <div class="link-row">
-              <a class="button-ghost" href="https://github.com/depre-dev/agent/blob/main/docs/MULTISIG_SETUP.md" target="_blank" rel="noreferrer">Multisig setup</a>
-              <a class="button-ghost" href="https://github.com/depre-dev/agent/blob/main/docs/AUDIT_PACKAGE.md" target="_blank" rel="noreferrer">Audit package</a>
-              <a class="button-ghost" href="https://github.com/depre-dev/agent/blob/main/scripts/verify_deployment.sh" target="_blank" rel="noreferrer">Verify deployment</a>
+              <a class="button-ghost" href="https://github.com/averray-agent/agent/blob/main/docs/MULTISIG_SETUP.md" target="_blank" rel="noreferrer">Multisig setup</a>
+              <a class="button-ghost" href="https://github.com/averray-agent/agent/blob/main/docs/AUDIT_PACKAGE.md" target="_blank" rel="noreferrer">Audit package</a>
+              <a class="button-ghost" href="https://github.com/averray-agent/agent/blob/main/scripts/verify_deployment.sh" target="_blank" rel="noreferrer">Verify deployment</a>
             </div>
           </article>
         </section>
@@ -260,7 +260,7 @@
           </div>
           <div class="hero-actions cta-actions">
             <a class="button" href="https://api.averray.com/health" target="_blank" rel="noreferrer">Check health</a>
-            <a class="button-ghost" href="https://github.com/depre-dev/agent/blob/main/docs/AUDIT_PACKAGE.md" target="_blank" rel="noreferrer">Read audit package</a>
+            <a class="button-ghost" href="https://github.com/averray-agent/agent/blob/main/docs/AUDIT_PACKAGE.md" target="_blank" rel="noreferrer">Read audit package</a>
           </div>
         </section>
       </main>


### PR DESCRIPTION
## Summary
- Homepage footer no longer links to three URLs that don't resolve (docs.averray.com, status.averray.com, github.com/averray); repoints them at canonical surfaces (docs/ tree, public /trust/, averray-agent/agent)
- Replaces every \`github.com/depre-dev/agent\` reference across trust, builders, agent-tools manifest, and the schema.org sameAs with the current org \`averray-agent/agent\` (those still resolve via redirect, but the canonical name should be in the source)

## Test plan
- [x] \`npm run build:site\`
- [ ] After deploy: confirm footer links no longer 404 and the trust page links use the new org