### PR TITLE
Job lifecycle UI: counts, filter, per-job actions

### DIFF
--- a/app/app/(authed)/overview/page.tsx
+++ b/app/app/(authed)/overview/page.tsx
@@ -20,10 +20,15 @@ import {
   ProviderOperationsCard,
   PROVIDER_OPERATIONS_FIXTURE,
 } from "@/components/overview/ProviderOperationsCard";
+import { JobLifecycleStrip } from "@/components/overview/JobLifecycleStrip";
 import { useAccount, useAlerts, useHealth, useJobs, useProviderOperations, useSessions, useStrategyPositions } from "@/lib/api/hooks";
 import { freshnessFromRequests } from "@/components/shell/DataFreshnessPill";
 import { extractRunJobs } from "@/lib/api/run-adapters";
 import { buildProviderOperations } from "@/lib/api/provider-operations";
+import {
+  buildJobLifecycleSummary,
+  EMPTY_JOB_LIFECYCLE_SUMMARY,
+} from "@/lib/api/job-lifecycle";
 import {
   buildLaneCards,
   buildOverviewAlerts,
@@ -371,6 +376,11 @@ export default function OverviewPage() {
     [jobs.data, sessions.data, strategyPositions.data]
   );
   const liveJobs = extractRunJobs(jobs.data);
+  const lifecycleSummary = useMemo(
+    () => buildJobLifecycleSummary(providerOps.data),
+    [providerOps.data]
+  );
+  const hasLifecycleData = lifecycleSummary.total > 0;
   const liveProviderOps = useMemo(
     () => buildProviderOperations(providerOps.data),
     [providerOps.data]
@@ -411,6 +421,10 @@ export default function OverviewPage() {
         policiesAppliedToday={hasLiveOverview ? liveLanes.length : 22}
       />
       <RoomVitals vitals={vitals} comparedTo={hasLiveOverview ? "live API" : "14:08 UTC yesterday"} />
+      <JobLifecycleStrip
+        summary={hasLifecycleData ? lifecycleSummary : EMPTY_JOB_LIFECYCLE_SUMMARY}
+        meta={hasLifecycleData ? "live API · /admin/status" : "no jobs yet"}
+      />
       <NeedsActionList alerts={alerts} meta={`${alerts.length} open`} />
       <LaneStatusGrid lanes={lanes} meta={hasLiveOverview ? "live API snapshot" : undefined} />
       <ProviderOperationsCard

--- a/app/app/(authed)/runs/page.tsx
+++ b/app/app/(authed)/runs/page.tsx
@@ -17,7 +17,7 @@ import {
   FIXTURE_RECOMMENDATIONS,
   FIXTURE_RUN_ROWS,
 } from "@/components/runs/fixtures";
-import { useJobs, useRecommendations } from "@/lib/api/hooks";
+import { useAdminJobs, useJobs, useRecommendations } from "@/lib/api/hooks";
 import { freshnessFromRequests } from "@/components/shell/DataFreshnessPill";
 import {
   buildRecommendationCards,
@@ -25,6 +25,7 @@ import {
   buildRunRows,
   sumReadyStake,
 } from "@/lib/api/run-adapters";
+import { extractAdminJobs } from "@/lib/api/job-lifecycle";
 
 /**
  * Runs — the operator's primary work surface.
@@ -49,12 +50,20 @@ function RunsPageInner() {
   const searchParams = useSearchParams();
   const runParam = searchParams?.get("run") ?? null;
   const [activeFilter, setActiveFilter] = useState<QueueFilter>("all");
+  const [showClosed, setShowClosed] = useState(false);
   const [selectedId, setSelectedId] = useState<string>(runParam ?? "run-2742");
 
   const jobs = useJobs();
+  const adminJobs = useAdminJobs();
   const recommendations = useRecommendations();
 
-  const liveRows = useMemo(() => buildRunRows(jobs.data), [jobs.data]);
+  // Operator app uses /admin/jobs (which carries lifecycle metadata and
+  // includes paused/archived/stale rows). Falls back to public /jobs
+  // until the admin payload arrives so the queue isn't empty on first
+  // hydration.
+  const adminPayload = adminJobs.data ? extractAdminJobs(adminJobs.data) : [];
+  const sourceForRows = adminPayload.length ? adminPayload : jobs.data;
+  const liveRows = useMemo(() => buildRunRows(sourceForRows), [sourceForRows]);
   const rows = liveRows.length ? liveRows : FIXTURE_RUN_ROWS;
   const filters = useMemo(() => buildRunFilters(rows), [rows]);
   const recommendationCards = useMemo(() => {
@@ -77,9 +86,24 @@ function RunsPageInner() {
   }, [rows, selectedId]);
 
   const visibleRows = useMemo(() => {
-    if (activeFilter === "all") return rows;
-    return rows.filter((r) => r.state === activeFilter);
-  }, [activeFilter, rows]);
+    let next = rows;
+    // Default-hide stale, paused, and archived rows so the queue stays
+    // focused on actionable runs. Operators can flip the toggle to see
+    // the full lifecycle picture (or to reopen something they paused).
+    if (!showClosed) {
+      next = next.filter(
+        (r) => !r.lifecycle || r.lifecycle.state === "open"
+      );
+    }
+    if (activeFilter !== "all") {
+      next = next.filter((r) => r.state === activeFilter);
+    }
+    return next;
+  }, [activeFilter, rows, showClosed]);
+
+  const closedRowCount = rows.filter(
+    (r) => r.lifecycle && r.lifecycle.state !== "open"
+  ).length;
 
   // Lifecycle rail at the page level mirrors the loaded run, so its
   // copy has to follow the selected row's source — otherwise selecting
@@ -170,7 +194,7 @@ function RunsPageInner() {
     : jobs.isLoading
       ? "loading live jobs"
       : "live API";
-  const freshness = freshnessFromRequests(jobs, recommendations);
+  const freshness = freshnessFromRequests(jobs, adminJobs, recommendations);
 
   return (
     <div className="flex w-full max-w-[1440px] flex-col gap-3.5">
@@ -180,6 +204,23 @@ function RunsPageInner() {
         active={activeFilter}
         onChange={setActiveFilter}
       />
+      {closedRowCount > 0 || showClosed ? (
+        <div className="flex items-center justify-between rounded-[10px] border border-[var(--avy-line-soft)] bg-[var(--avy-paper)] px-3.5 py-2 font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]">
+          <span>
+            {showClosed
+              ? `Showing all jobs including ${closedRowCount} paused/archived/stale.`
+              : `${closedRowCount} paused/archived/stale ${closedRowCount === 1 ? "job is" : "jobs are"} hidden.`}
+          </span>
+          <button
+            type="button"
+            onClick={() => setShowClosed((v) => !v)}
+            className="rounded-full border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-2.5 py-1 font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase text-[var(--avy-ink)] transition-colors hover:border-[color:rgba(30,102,66,0.35)] hover:text-[var(--avy-accent)]"
+            style={{ letterSpacing: "0.08em" }}
+          >
+            {showClosed ? "Hide closed" : "Show closed"}
+          </button>
+        </div>
+      ) : null}
 
       {/*
        * Email-client layout: queue left, loaded-run detail right. The

--- a/app/components/overview/JobLifecycleStrip.tsx
+++ b/app/components/overview/JobLifecycleStrip.tsx
@@ -1,0 +1,62 @@
+import { SectionHead } from "./SectionHead";
+import type { JobLifecycleSummary } from "@/lib/api/job-lifecycle";
+
+export interface JobLifecycleStripProps {
+  summary: JobLifecycleSummary;
+  meta?: string;
+}
+
+interface Slot {
+  label: string;
+  value: number;
+  tone: "ink" | "accent" | "warn" | "muted";
+}
+
+export function JobLifecycleStrip({ summary, meta }: JobLifecycleStripProps) {
+  const slots: Slot[] = [
+    { label: "total", value: summary.total, tone: "ink" },
+    { label: "claimable", value: summary.claimable, tone: "accent" },
+    { label: "open", value: summary.open, tone: "ink" },
+    { label: "stale", value: summary.stale, tone: "warn" },
+    { label: "paused", value: summary.paused, tone: "muted" },
+    { label: "archived", value: summary.archived, tone: "muted" },
+  ];
+  return (
+    <section>
+      <SectionHead
+        title="Job lifecycle"
+        meta={meta ?? "/admin/jobs/lifecycle"}
+      />
+      <div className="grid grid-cols-2 gap-2 rounded-[10px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] p-[0.85rem_1.05rem] shadow-[var(--shadow-card)] sm:grid-cols-3 md:grid-cols-6">
+        {slots.map((slot) => (
+          <div
+            key={slot.label}
+            className="flex flex-col gap-0.5 font-[family-name:var(--font-mono)]"
+          >
+            <span
+              className="font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase text-[var(--avy-muted)]"
+              style={{ letterSpacing: "0.14em" }}
+            >
+              {slot.label}
+            </span>
+            <span
+              className="font-[family-name:var(--font-display)] text-[1.7rem] font-bold leading-none"
+              style={{
+                color:
+                  slot.tone === "accent"
+                    ? "var(--avy-accent)"
+                    : slot.tone === "warn"
+                      ? "var(--avy-warn)"
+                      : slot.tone === "muted"
+                        ? "var(--avy-muted)"
+                        : "var(--avy-ink)",
+              }}
+            >
+              {slot.value}
+            </span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/app/components/runs/LifecycleActionBar.tsx
+++ b/app/components/runs/LifecycleActionBar.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState } from "react";
+import { mutate } from "swr";
+import { swrFetcher } from "@/lib/api/client";
+import {
+  availableActions,
+  formatLifecycleLabel,
+  LIFECYCLE_ACTION_LABEL,
+  postJobLifecycleAction,
+  type JobLifecycle,
+  type JobLifecycleAction,
+} from "@/lib/api/job-lifecycle";
+import { cn } from "@/lib/utils/cn";
+
+export interface LifecycleActionBarProps {
+  jobId: string;
+  lifecycle?: JobLifecycle;
+}
+
+/**
+ * Operator action bar for the loaded run. Issues `POST
+ * /admin/jobs/lifecycle` and revalidates the admin job feed +
+ * `/admin/status` so the counts strip and lifecycle pills refresh.
+ *
+ * Hidden when the row carries no `lifecycle` block — that means the
+ * row was loaded from the public `/jobs` feed and the operator
+ * doesn't have admin auth for this surface.
+ */
+export function LifecycleActionBar({ jobId, lifecycle }: LifecycleActionBarProps) {
+  const [pending, setPending] = useState<JobLifecycleAction | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!lifecycle) return null;
+
+  const actions = availableActions(lifecycle.state);
+
+  const onClick = async (action: JobLifecycleAction) => {
+    setError(null);
+    setPending(action);
+    try {
+      await postJobLifecycleAction(swrFetcher, jobId, action);
+      await Promise.all([mutate("/admin/jobs"), mutate("/admin/status")]);
+    } catch {
+      setError(
+        `Could not ${LIFECYCLE_ACTION_LABEL[action].toLowerCase()} this job. Try again.`
+      );
+    } finally {
+      setPending(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-[10px] border border-[var(--avy-line)] bg-[var(--avy-paper)] p-[0.7rem_0.95rem] shadow-[var(--shadow-card)]">
+      <span
+        className="font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase text-[var(--avy-muted)]"
+        style={{ letterSpacing: "0.14em" }}
+      >
+        Lifecycle
+      </span>
+      <span
+        className={cn(
+          "inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase",
+          lifecycle.state === "open" &&
+            "bg-[var(--avy-accent-soft)] text-[var(--avy-accent)]",
+          lifecycle.state === "stale" &&
+            "bg-[var(--avy-warn-soft)] text-[var(--avy-warn)]",
+          (lifecycle.state === "paused" || lifecycle.state === "archived") &&
+            "bg-[color:rgba(17,19,21,0.06)] text-[var(--avy-muted)]"
+        )}
+        style={{ letterSpacing: "0.1em" }}
+      >
+        {formatLifecycleLabel(lifecycle.state)}
+      </span>
+
+      <div className="ml-auto flex flex-wrap items-center gap-1.5">
+        {actions.map((action) => (
+          <button
+            key={action}
+            type="button"
+            onClick={() => onClick(action)}
+            disabled={pending !== null}
+            className={cn(
+              "rounded-full border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-2.5 py-1 font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase transition-colors",
+              "hover:border-[color:rgba(30,102,66,0.35)] hover:text-[var(--avy-accent)]",
+              "disabled:opacity-50 disabled:cursor-not-allowed",
+              pending === action && "text-[var(--avy-accent)]"
+            )}
+            style={{ letterSpacing: "0.08em" }}
+          >
+            {pending === action ? "…" : LIFECYCLE_ACTION_LABEL[action]}
+          </button>
+        ))}
+      </div>
+
+      {error ? (
+        <span className="basis-full font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-warn)]">
+          {error}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/app/components/runs/LoadedRunView.tsx
+++ b/app/components/runs/LoadedRunView.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { mutate } from "swr";
 import { LoadedRunPanel } from "./LoadedRunPanel";
 import { LifecycleRail } from "./LifecycleRail";
+import { LifecycleActionBar } from "./LifecycleActionBar";
 import {
   ReceiptPreviewDrawer,
   type ReceiptPreviewDraft,
@@ -15,7 +16,7 @@ import {
 } from "./fixtures";
 import type { RunRow } from "./RunQueueTable";
 import { swrFetcher } from "@/lib/api/client";
-import { useJobDefinition, useJobs } from "@/lib/api/hooks";
+import { useAdminJobs, useJobDefinition, useJobs } from "@/lib/api/hooks";
 import {
   buildGitHubContext,
   buildOpenDataContext,
@@ -24,6 +25,7 @@ import {
   buildWikipediaContext,
   extractRunJobs,
 } from "@/lib/api/run-adapters";
+import { extractAdminJobs } from "@/lib/api/job-lifecycle";
 
 /**
  * Self-contained detail view for a single run.
@@ -59,9 +61,15 @@ export function LoadedRunView({
   showLifecycle = true,
 }: LoadedRunViewProps) {
   const jobs = useJobs();
-  const liveRows = useMemo(() => buildRunRows(jobs.data), [jobs.data]);
+  const adminJobs = useAdminJobs();
+  // Prefer the admin job feed (carries lifecycle metadata + paused/
+  // archived/stale rows). Fall back to the public feed until the admin
+  // payload arrives so we don't render an empty panel on first paint.
+  const adminPayload = adminJobs.data ? extractAdminJobs(adminJobs.data) : [];
+  const sourceForRows = adminPayload.length ? adminPayload : jobs.data;
+  const liveRows = useMemo(() => buildRunRows(sourceForRows), [sourceForRows]);
   const rows = liveRows.length ? liveRows : FIXTURE_RUN_ROWS;
-  const rawJobs = useMemo(() => extractRunJobs(jobs.data), [jobs.data]);
+  const rawJobs = useMemo(() => extractRunJobs(sourceForRows), [sourceForRows]);
   const loadedRow =
     rows.find((row) => row.id === runId) ?? rows[0] ?? FIXTURE_RUN_ROWS[0];
 
@@ -131,6 +139,10 @@ export function LoadedRunView({
 
   return (
     <div className="flex flex-col gap-3.5">
+      <LifecycleActionBar
+        jobId={loadedRow.id}
+        lifecycle={loadedRow.lifecycle}
+      />
       <LoadedRunPanel
         kicker={kicker}
         title={loadedRow.title}

--- a/app/components/runs/RunQueueTable.tsx
+++ b/app/components/runs/RunQueueTable.tsx
@@ -5,6 +5,11 @@ import { cn } from "@/lib/utils/cn";
 import { StatePill, SourceBadge, type RunState } from "./StatePill";
 import { WorkerChip, type WorkerVariant } from "./WorkerChip";
 import type { JobSource } from "./types";
+import {
+  formatLifecycleLabel,
+  type JobLifecycle,
+  type JobLifecycleState,
+} from "@/lib/api/job-lifecycle";
 
 export interface RunRow {
   id: string;
@@ -17,6 +22,12 @@ export interface RunRow {
    * internal job id.
    */
   source?: JobSource;
+  /**
+   * Lifecycle metadata from PR #64. Present when the row was loaded
+   * from `/admin/jobs` (operator). Drives the lifecycle pill and the
+   * action bar in the loaded-run panel.
+   */
+  lifecycle?: JobLifecycle;
   worker: {
     variant: WorkerVariant;
     initials: string;
@@ -224,7 +235,12 @@ function RunRowCard({
           </div>
 
           <div className="flex shrink-0 flex-col items-end gap-0.5">
-            <StatePill state={row.state} />
+            <div className="flex items-center gap-1.5">
+              {row.lifecycle && row.lifecycle.state !== "open" ? (
+                <LifecyclePill state={row.lifecycle.state} />
+              ) : null}
+              <StatePill state={row.state} />
+            </div>
             <span className="font-[family-name:var(--font-mono)] text-[12.5px] leading-tight text-[var(--avy-ink)]">
               {row.stake}
               <small className="font-normal text-[var(--avy-muted)]"> DOT</small>
@@ -256,5 +272,26 @@ function RunRowCard({
         </div>
       </button>
     </li>
+  );
+}
+
+function LifecyclePill({ state }: { state: JobLifecycleState }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-[family-name:var(--font-display)] text-[9.5px] font-extrabold uppercase",
+        state === "stale" &&
+          "bg-[var(--avy-warn-soft)] text-[var(--avy-warn)]",
+        state === "paused" &&
+          "bg-[color:rgba(17,19,21,0.06)] text-[var(--avy-muted)]",
+        state === "archived" &&
+          "bg-[color:rgba(17,19,21,0.06)] text-[var(--avy-muted)]",
+        state === "open" && "bg-[var(--avy-accent-soft)] text-[var(--avy-accent)]"
+      )}
+      style={{ letterSpacing: "0.1em" }}
+      title={`Lifecycle: ${state}`}
+    >
+      {formatLifecycleLabel(state)}
+    </span>
   );
 }

--- a/app/lib/api/hooks.ts
+++ b/app/lib/api/hooks.ts
@@ -64,6 +64,13 @@ export const useHealth = () => useApi("/health");
  */
 export const useProviderOperations = () =>
   useApi("/admin/status", { refreshInterval: 30_000 });
+/**
+ * Operator-side full job listing including paused, archived, and stale
+ * rows so the operator app can show lifecycle controls. The public
+ * `/jobs` feed filters those out by default.
+ */
+export const useAdminJobs = () =>
+  useApi("/admin/jobs", { refreshInterval: 15_000 });
 export const useOnboarding = () => useApi("/onboarding");
 export const useVerifierHandlers = () => useApi("/verifier/handlers");
 export const useSessionStateMachine = () => useApi("/session/state-machine");

--- a/app/lib/api/job-lifecycle.ts
+++ b/app/lib/api/job-lifecycle.ts
@@ -1,0 +1,198 @@
+/**
+ * Adapters and types for the job-lifecycle slice introduced in PR #64.
+ *
+ * Two surfaces: the operator `/overview` page reads `jobLifecycle` from
+ * `/admin/status` (counts only — total, open, claimable, stale, paused,
+ * archived), and the `/runs` page reads the full job list from
+ * `/admin/jobs` so it can show paused/archived/stale rows that the
+ * public `/jobs` feed filters out.
+ */
+
+export type JobLifecycleStatus = "open" | "paused" | "archived";
+/**
+ * Computed state derived from status + age. "stale" means the job is
+ * status: open but past its automatic stale-after window. "open" means
+ * status: open and within the window. Paused/archived statuses surface
+ * as the same string here.
+ */
+export type JobLifecycleState =
+  | "open"
+  | "stale"
+  | "paused"
+  | "archived";
+
+export type JobLifecycleAction =
+  | "pause"
+  | "archive"
+  | "reopen"
+  | "mark_stale";
+
+export interface JobLifecycle {
+  status: JobLifecycleStatus;
+  state: JobLifecycleState;
+  reason?: string;
+  staleAt?: string;
+  staleReason?: string;
+  pausedAt?: string;
+  archivedAt?: string;
+  reopenedAt?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface JobLifecycleSummary {
+  total: number;
+  open: number;
+  claimable: number;
+  stale: number;
+  paused: number;
+  archived: number;
+}
+
+export const EMPTY_JOB_LIFECYCLE_SUMMARY: JobLifecycleSummary = {
+  total: 0,
+  open: 0,
+  claimable: 0,
+  stale: 0,
+  paused: 0,
+  archived: 0,
+};
+
+/** Read `jobLifecycle` from either `/admin/status` or `/admin/jobs` payload. */
+export function buildJobLifecycleSummary(payload: unknown): JobLifecycleSummary {
+  const root = asRecord(payload);
+  if (!root) return EMPTY_JOB_LIFECYCLE_SUMMARY;
+  const slice = asRecord(root.jobLifecycle);
+  if (!slice) return EMPTY_JOB_LIFECYCLE_SUMMARY;
+  return {
+    total: nonNegInt(slice.total),
+    open: nonNegInt(slice.open),
+    claimable: nonNegInt(slice.claimable),
+    stale: nonNegInt(slice.stale),
+    paused: nonNegInt(slice.paused),
+    archived: nonNegInt(slice.archived),
+  };
+}
+
+/** Pull a single job's lifecycle block off a raw job object. */
+export function buildJobLifecycle(raw: unknown): JobLifecycle | undefined {
+  const record = asRecord(raw);
+  if (!record) return undefined;
+  const status = isStatus(record.status) ? record.status : undefined;
+  const state = isState(record.state) ? record.state : undefined;
+  if (!status || !state) return undefined;
+  return {
+    status,
+    state,
+    ...(text(record.reason) ? { reason: text(record.reason) } : {}),
+    ...(text(record.staleAt) ? { staleAt: text(record.staleAt) } : {}),
+    ...(text(record.staleReason) ? { staleReason: text(record.staleReason) } : {}),
+    ...(text(record.pausedAt) ? { pausedAt: text(record.pausedAt) } : {}),
+    ...(text(record.archivedAt) ? { archivedAt: text(record.archivedAt) } : {}),
+    ...(text(record.reopenedAt) ? { reopenedAt: text(record.reopenedAt) } : {}),
+    ...(text(record.createdAt) ? { createdAt: text(record.createdAt) } : {}),
+    ...(text(record.updatedAt) ? { updatedAt: text(record.updatedAt) } : {}),
+  };
+}
+
+/** Pretty label for the lifecycle pill. */
+export function formatLifecycleLabel(state: JobLifecycleState): string {
+  switch (state) {
+    case "open":
+      return "Open";
+    case "stale":
+      return "Stale";
+    case "paused":
+      return "Paused";
+    case "archived":
+      return "Archived";
+  }
+}
+
+/**
+ * Which actions are valid for a given current state. The backend is the
+ * source of truth for what's allowed; this is a UI hint to disable
+ * obviously-wrong transitions before the click round-trips.
+ */
+export function availableActions(state: JobLifecycleState): JobLifecycleAction[] {
+  switch (state) {
+    case "open":
+      return ["pause", "archive", "mark_stale"];
+    case "stale":
+      return ["reopen", "pause", "archive"];
+    case "paused":
+      return ["reopen", "archive"];
+    case "archived":
+      return ["reopen"];
+  }
+}
+
+export const LIFECYCLE_ACTION_LABEL: Record<JobLifecycleAction, string> = {
+  pause: "Pause",
+  archive: "Archive",
+  reopen: "Reopen",
+  mark_stale: "Mark stale",
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function nonNegInt(value: unknown): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.floor(n);
+}
+
+function text(value: unknown): string | "" {
+  return typeof value === "string" && value.trim() ? value.trim() : "";
+}
+
+function isStatus(value: unknown): value is JobLifecycleStatus {
+  return value === "open" || value === "paused" || value === "archived";
+}
+
+function isState(value: unknown): value is JobLifecycleState {
+  return value === "open" || value === "stale" || value === "paused" || value === "archived";
+}
+
+/**
+ * Extract the array of jobs from `/admin/jobs` (`{ jobs: [...] }`) or
+ * any payload that's already a bare array. Used by the runs page to
+ * choose between the public and admin job feeds.
+ */
+export function extractAdminJobs(payload: unknown): unknown[] {
+  if (Array.isArray(payload)) return payload;
+  const root = asRecord(payload);
+  if (!root) return [];
+  if (Array.isArray(root.jobs)) return root.jobs;
+  return [];
+}
+
+/**
+ * POST a lifecycle action against `/admin/jobs/lifecycle`. The caller
+ * is responsible for triggering an SWR revalidate after success — this
+ * helper is intentionally thin so the runs page owns the optimistic /
+ * pessimistic strategy.
+ */
+export async function postJobLifecycleAction(
+  fetcher: <T = unknown>(key: string | [string, RequestInit?]) => Promise<T>,
+  jobId: string,
+  action: JobLifecycleAction,
+  reason?: string
+): Promise<unknown> {
+  return fetcher([
+    "/admin/jobs/lifecycle",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jobId,
+        action,
+        ...(reason ? { reason } : {}),
+      }),
+    },
+  ]);
+}

--- a/app/lib/api/run-adapters.ts
+++ b/app/lib/api/run-adapters.ts
@@ -9,6 +9,7 @@ import type {
   OsvJobContext,
   WikipediaJobContext,
 } from "@/components/runs/types";
+import { buildJobLifecycle } from "@/lib/api/job-lifecycle";
 
 type RawRecord = Record<string, unknown>;
 
@@ -478,12 +479,14 @@ export function buildRunRows(payload: unknown): RunRow[] {
                   )
                   .join(" · ")
               : `${id} · ${category} · ${tier}`;
+    const lifecycle = buildJobLifecycle(job.lifecycle);
     return {
       id,
       sessionId: text(job.sessionId),
       title,
       jobMeta,
       ...(source ? { source } : {}),
+      ...(lifecycle ? { lifecycle } : {}),
       worker: {
         variant: worker ? "a" : "unclaimed",
         initials: worker ? "AG" : "-",

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -91,8 +91,8 @@ export class PlatformService {
     };
   }
 
-  listJobs() {
-    return this.jobCatalogService.listJobs();
+  listJobs(options) {
+    return this.jobCatalogService.listJobs(options);
   }
 
   createJob(input) {

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -1337,6 +1337,22 @@ const server = createServer(async (request, response) => {
       return respond(response, 200, service.listJobs());
     }
 
+    if (request.method === "GET" && pathname === "/admin/jobs") {
+      const auth = await authMiddleware(request, url, { requireRole: "admin" });
+      await enforceLimit("admin_jobs", auth.wallet, rateLimitConfig.adminJobs);
+      // Operator-side full job listing including paused, archived, and
+      // stale rows so the operator app can show lifecycle controls.
+      // The public `/jobs` route filters those out by default.
+      return respond(response, 200, {
+        jobs: service.listJobs({
+          includePaused: true,
+          includeArchived: true,
+          includeStale: true
+        }),
+        jobLifecycle: service.getJobLifecycleSummary()
+      });
+    }
+
     if (request.method === "GET" && pathname === "/strategies") {
       // Public read: which yield/strategy adapters are registered for
       // this deployment. Populated from STRATEGIES_JSON env (copied from


### PR DESCRIPTION
## Summary
PR #64 added job-lifecycle plumbing server-side and called out a frontend contract. This is that frontend, plus a small backend addition to expose paused/archived/stale rows to the operator app.

**Backend**
- New \`GET /admin/jobs\` route returning the full job list (includes paused/archived/stale + lifecycle metadata). Public \`/jobs\` continues to filter those out.

**Operator app**
- Adapter at \`app/lib/api/job-lifecycle.ts\` (types, summary builder, per-row parser, action helper)
- \`RunRow\` gains an optional \`lifecycle\` field
- \`/overview\` gets a JobLifecycleStrip between RoomVitals and NeedsActionList (total / claimable / open / stale / paused / archived from \`/admin/status.jobLifecycle\`)
- \`/runs\` queue switches to \`/admin/jobs\` when authed; small lifecycle pill on each non-open row; \"Show closed / Hide closed\" toggle that only appears when closed rows exist
- LoadedRunView gets a LifecycleActionBar above the panel with Pause / Archive / Mark stale / Reopen buttons gated by available transitions; posts \`/admin/jobs/lifecycle\` and revalidates \`/admin/jobs\` + \`/admin/status\` on success

**Defer**: confirmation dialog with a reason field. Action bar fires immediately for now.

## Test plan
- [x] \`npm --workspace mcp-server test\` — 328/328 pass
- [x] \`npm run typecheck:app\`
- [x] \`npm run build:frontend\`
- [ ] After deploy: confirm overview strip populates from live API, /runs shows the lifecycle pill on a paused/archived/stale row when toggled, and the action bar transitions a job