### PR TITLE
Add automatic stale job sweeper

### DIFF
--- a/docs/PUBLIC_JOB_SOURCES.md
+++ b/docs/PUBLIC_JOB_SOURCES.md
@@ -198,6 +198,12 @@ without leaving stale work on the public board forever.
   `archive`, `reopen`, or `mark_stale` plus an optional `reason`.
 - `/admin/status.jobLifecycle` reports total, open, claimable, stale, paused,
   and archived counts for the provider operations UI.
+- The automatic stale sweeper is controlled by `JOB_STALE_SWEEPER_ENABLED`,
+  `JOB_STALE_SWEEPER_DRY_RUN`, `JOB_STALE_SWEEPER_ACTION` (`mark_stale`,
+  `pause`, or `archive`), `JOB_STALE_SWEEPER_INTERVAL_MS`, and
+  `JOB_STALE_SWEEPER_MAX_JOBS_PER_RUN`. It skips recurring templates and jobs
+  with active sessions, and reports its last pass at
+  `/admin/status.jobStaleSweeper`.
 
 ### Public status endpoint
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -911,6 +911,11 @@
             "description": "Counts for open, stale, paused, archived, and claimable jobs.",
             "additionalProperties": true
           },
+          "jobStaleSweeper": {
+            "type": "object",
+            "description": "Automatic stale-job sweeper status, including dry-run/live mode, action, limits, and lastRun summary.",
+            "additionalProperties": true
+          },
           "githubIngestion": {
             "type": [
               "object",

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -52,6 +52,7 @@ export class PlatformService {
     this.openDataIngestionScheduler = undefined;
     this.standardsSpecIngestionScheduler = undefined;
     this.openApiSpecIngestionScheduler = undefined;
+    this.jobStaleSweeper = undefined;
     this.xcmSettlementWatcher = undefined;
     this.xcmObservationRelay = undefined;
     this.upstreamStatusPoller = undefined;
@@ -91,7 +92,7 @@ export class PlatformService {
     };
   }
 
-  listJobs(options) {
+  listJobs(options = {}) {
     return this.jobCatalogService.listJobs(options);
   }
 
@@ -135,6 +136,7 @@ export class PlatformService {
       standardsIngestion,
       openApiIngestion,
       upstreamStatus,
+      jobStaleSweeper,
       recentSessions
     ] = await Promise.all([
       this.blockchainGateway?.getTreasuryPolicyStatus?.() ?? {
@@ -226,6 +228,16 @@ export class PlatformService {
         running: false,
         intervalMs: 0,
         batchSize: 0,
+        lastRun: undefined
+      },
+      this.jobStaleSweeper?.getStatus?.() ?? {
+        enabled: false,
+        running: false,
+        dryRun: true,
+        mode: "dry_run",
+        intervalMs: 0,
+        action: "archive",
+        maxJobsPerRun: 0,
         lastRun: undefined
       },
       this.jobExecutionService.listRecentSessions(14)
@@ -325,6 +337,7 @@ export class PlatformService {
       },
       recurring: recurring,
       jobLifecycle: this.jobCatalogService.getJobLifecycleSummary(),
+      jobStaleSweeper,
       scheduler,
       providerOperations,
       githubIngestion: githubIngestion,

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -141,6 +141,7 @@ test("getAdminStatus surfaces recurring scheduler anomalies", async () => {
   assert.equal(status.jobLifecycle.total, 1);
   assert.equal(status.jobLifecycle.paused, 1);
   assert.equal(status.jobLifecycle.claimable, 0);
+  assert.equal(status.jobStaleSweeper.enabled, false);
 });
 
 test("getAdminStatus surfaces public source ingestion scheduler status", async () => {
@@ -262,6 +263,25 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
       };
     }
   };
+  service.jobStaleSweeper = {
+    getStatus() {
+      return {
+        enabled: true,
+        running: true,
+        dryRun: false,
+        mode: "live",
+        intervalMs: 3600000,
+        action: "archive",
+        maxJobsPerRun: 25,
+        lastRun: {
+          candidateCount: 3,
+          updatedCount: 2,
+          skipped: [{ id: "active", reason: "active_session" }],
+          errors: []
+        }
+      };
+    }
+  };
 
   const status = await service.getAdminStatus();
   assert.equal(status.osvIngestion.packageCount, 0);
@@ -294,6 +314,8 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
   assert.equal(status.providerOperations.github.nextQuery, undefined);
   assert.equal(status.providerOperations.openApi.health, "error");
   assert.equal(status.providerOperations.openApi.lastRun.errorCount, 1);
+  assert.equal(status.jobStaleSweeper.mode, "live");
+  assert.equal(status.jobStaleSweeper.lastRun.updatedCount, 2);
 
   // Public sanitized counterpart preserves health / mode / counts but
   // strips lastRun.skipped[] and lastRun.errors[] (which can carry

--- a/mcp-server/src/services/bootstrap.js
+++ b/mcp-server/src/services/bootstrap.js
@@ -45,6 +45,10 @@ import {
   UpstreamStatusPollerService,
   loadUpstreamStatusPollerConfig
 } from "./upstream-status-poller.js";
+import {
+  JobStaleSweeperService,
+  loadJobStaleSweeperConfig
+} from "./job-stale-sweeper.js";
 import { normaliseStrategyAssetConfig } from "./strategy-asset-config.js";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -234,6 +238,12 @@ export async function createPlatformRuntime() {
       logger
     })
   );
+  const jobStaleSweeper = initStep("init-job-stale-sweeper", logger, () =>
+    new JobStaleSweeperService(platformService, stateStore, eventBus, {
+      ...loadJobStaleSweeperConfig(process.env),
+      logger
+    })
+  );
   platformService.recurringScheduler = recurringScheduler;
   platformService.githubIssueIngestionScheduler = githubIssueIngestionScheduler;
   platformService.wikipediaMaintenanceIngestionScheduler = wikipediaMaintenanceIngestionScheduler;
@@ -244,6 +254,7 @@ export async function createPlatformRuntime() {
   platformService.xcmSettlementWatcher = xcmSettlementWatcher;
   platformService.xcmObservationRelay = xcmObservationRelay;
   platformService.upstreamStatusPoller = upstreamStatusPoller;
+  platformService.jobStaleSweeper = jobStaleSweeper;
   recurringScheduler.start();
   githubIssueIngestionScheduler.start();
   wikipediaMaintenanceIngestionScheduler.start();
@@ -254,6 +265,7 @@ export async function createPlatformRuntime() {
   xcmSettlementWatcher.start();
   xcmObservationRelay.start();
   upstreamStatusPoller.start();
+  jobStaleSweeper.start();
 
   const authMiddleware = createAuthMiddleware({ authConfig, stateStore, logger });
   const rateLimiter = createRateLimiter({ stateStore, logger });
@@ -286,6 +298,7 @@ export async function createPlatformRuntime() {
     xcmSettlementWatcher,
     xcmObservationRelay,
     upstreamStatusPoller,
+    jobStaleSweeper,
     authConfig,
     authMiddleware,
     authCapabilities: {

--- a/mcp-server/src/services/job-stale-sweeper.js
+++ b/mcp-server/src/services/job-stale-sweeper.js
@@ -1,0 +1,185 @@
+const DEFAULT_INTERVAL_MS = 60 * 60 * 1000;
+const DEFAULT_MAX_JOBS_PER_RUN = 25;
+const VALID_SWEEP_ACTIONS = new Set(["mark_stale", "pause", "archive"]);
+const TERMINAL_SESSION_STATUSES = new Set(["resolved", "rejected", "closed", "expired", "timed_out"]);
+
+export class JobStaleSweeperService {
+  constructor(platformService, stateStore, eventBus = undefined, {
+    enabled = false,
+    dryRun = true,
+    intervalMs = DEFAULT_INTERVAL_MS,
+    action = "archive",
+    maxJobsPerRun = DEFAULT_MAX_JOBS_PER_RUN,
+    reason = "automatic stale job cleanup",
+    logger = console
+  } = {}) {
+    this.platformService = platformService;
+    this.stateStore = stateStore;
+    this.eventBus = eventBus;
+    this.enabled = enabled;
+    this.dryRun = dryRun;
+    this.intervalMs = intervalMs;
+    this.action = normalizeSweepAction(action);
+    this.maxJobsPerRun = maxJobsPerRun;
+    this.reason = String(reason || "automatic stale job cleanup").trim();
+    this.logger = logger;
+    this.running = false;
+    this.timer = undefined;
+    this.lastRun = undefined;
+  }
+
+  start() {
+    if (!this.enabled || this.running) return;
+    this.running = true;
+    void this.runOnceAndSchedule();
+  }
+
+  stop() {
+    this.running = false;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  async getStatus() {
+    return {
+      enabled: this.enabled,
+      running: this.running,
+      dryRun: this.dryRun,
+      mode: this.dryRun ? "dry_run" : "live",
+      intervalMs: this.intervalMs,
+      action: this.action,
+      maxJobsPerRun: this.maxJobsPerRun,
+      lastRun: this.lastRun
+    };
+  }
+
+  async runOnce(now = new Date()) {
+    const summary = {
+      startedAt: now.toISOString(),
+      finishedAt: undefined,
+      dryRun: this.dryRun,
+      action: this.action,
+      candidateCount: 0,
+      updatedCount: 0,
+      skipped: [],
+      errors: []
+    };
+
+    if (!this.enabled) {
+      summary.skipped.push({ reason: "disabled" });
+      return this.finishRun(summary);
+    }
+
+    const candidates = this.findStaleJobs(now).slice(0, this.maxJobsPerRun);
+    summary.candidateCount = candidates.length;
+    for (const job of candidates) {
+      try {
+        const activeSession = await this.findActiveSession(job.id);
+        if (activeSession) {
+          summary.skipped.push({
+            id: job.id,
+            reason: "active_session",
+            sessionId: activeSession.sessionId,
+            status: activeSession.status
+          });
+          continue;
+        }
+        if (!this.dryRun) {
+          this.platformService.updateJobLifecycle(job.id, {
+            action: this.action,
+            reason: this.reason
+          });
+        }
+        summary.updatedCount += 1;
+        this.eventBus?.publish?.({
+          id: `job-stale-sweeper-${job.id}-${Date.now()}`,
+          topic: "jobs.lifecycle.swept",
+          jobId: job.id,
+          timestamp: new Date().toISOString(),
+          data: {
+            dryRun: this.dryRun,
+            action: this.action,
+            jobId: job.id,
+            lifecycle: job.lifecycle
+          }
+        });
+      } catch (error) {
+        summary.errors.push({ id: job.id, message: error?.message ?? String(error) });
+        this.logger.warn?.({ jobId: job.id, err: error }, "job_stale_sweeper.update_failed");
+      }
+    }
+
+    return this.finishRun(summary);
+  }
+
+  findStaleJobs(now = new Date()) {
+    return this.platformService.listJobs({
+      includeStale: true,
+      includePaused: false,
+      includeArchived: false,
+      now
+    }).filter((job) => !job.recurring && job.lifecycle?.status === "open" && job.lifecycle?.state === "stale");
+  }
+
+  async findActiveSession(jobId) {
+    const sessions = await this.stateStore?.listSessionsByJob?.(jobId, 10) ?? [];
+    const activeFromHistory = sessions.find((session) => session && !TERMINAL_SESSION_STATUSES.has(session.status));
+    if (activeFromHistory) return activeFromHistory;
+    const current = await this.stateStore?.findSessionByJobId?.(jobId);
+    if (current && !TERMINAL_SESSION_STATUSES.has(current.status)) return current;
+    return undefined;
+  }
+
+  async runOnceAndSchedule() {
+    await this.runOnce(new Date());
+    if (!this.running) return;
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      void this.runOnceAndSchedule();
+    }, this.intervalMs);
+  }
+
+  finishRun(summary) {
+    summary.finishedAt = new Date().toISOString();
+    this.lastRun = summary;
+    return summary;
+  }
+}
+
+export function loadJobStaleSweeperConfig(env = process.env) {
+  return {
+    enabled: parseBooleanEnv(env.JOB_STALE_SWEEPER_ENABLED),
+    dryRun: env.JOB_STALE_SWEEPER_DRY_RUN === undefined
+      ? true
+      : parseBooleanEnv(env.JOB_STALE_SWEEPER_DRY_RUN),
+    intervalMs: parsePositiveInt(env.JOB_STALE_SWEEPER_INTERVAL_MS, DEFAULT_INTERVAL_MS),
+    action: normalizeSweepAction(env.JOB_STALE_SWEEPER_ACTION ?? "archive"),
+    maxJobsPerRun: parsePositiveInt(env.JOB_STALE_SWEEPER_MAX_JOBS_PER_RUN, DEFAULT_MAX_JOBS_PER_RUN),
+    reason: env.JOB_STALE_SWEEPER_REASON?.trim() || "automatic stale job cleanup"
+  };
+}
+
+function normalizeSweepAction(value) {
+  const action = String(value ?? "archive").trim().toLowerCase();
+  return VALID_SWEEP_ACTIONS.has(action) ? action : "archive";
+}
+
+function parsePositiveInt(raw, fallback) {
+  if (raw === undefined || raw === null || raw === "") {
+    return fallback;
+  }
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    return fallback;
+  }
+  return value;
+}
+
+function parseBooleanEnv(raw) {
+  if (raw === undefined || raw === null || raw === "") {
+    return false;
+  }
+  return ["1", "true", "yes", "on"].includes(String(raw).trim().toLowerCase());
+}

--- a/mcp-server/src/services/job-stale-sweeper.test.js
+++ b/mcp-server/src/services/job-stale-sweeper.test.js
@@ -1,0 +1,158 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { MemoryStateStore } from "../core/state-store.js";
+import { JobStaleSweeperService, loadJobStaleSweeperConfig } from "./job-stale-sweeper.js";
+
+const STALE_JOB = {
+  id: "stale-open-001",
+  source: { type: "open_data_dataset" },
+  lifecycle: {
+    status: "open",
+    state: "stale",
+    staleAt: "2026-04-01T00:00:00.000Z"
+  }
+};
+
+function makePlatformService(initialJobs = [STALE_JOB]) {
+  const jobs = initialJobs.map((job) => ({ ...job, lifecycle: { ...job.lifecycle } }));
+  return {
+    jobs,
+    listJobs(options = {}) {
+      return jobs.filter((job) => {
+        if (job.lifecycle.status === "archived" && !options.includeArchived) return false;
+        if (job.lifecycle.status === "paused" && !options.includePaused) return false;
+        if (job.lifecycle.state === "stale" && !options.includeStale) return false;
+        return true;
+      });
+    },
+    updateJobLifecycle(jobId, patch = {}) {
+      const job = jobs.find((candidate) => candidate.id === jobId);
+      if (!job) throw new Error(`Unknown job: ${jobId}`);
+      const status = patch.action === "pause"
+        ? "paused"
+        : patch.action === "archive"
+          ? "archived"
+          : "open";
+      job.lifecycle = {
+        ...job.lifecycle,
+        status,
+        state: status,
+        reason: patch.reason
+      };
+      return job;
+    }
+  };
+}
+
+test("JobStaleSweeperService dry-run reports stale candidates without mutating", async () => {
+  const platform = makePlatformService();
+  const sweeper = new JobStaleSweeperService(platform, new MemoryStateStore(), undefined, {
+    enabled: true,
+    dryRun: true,
+    action: "archive"
+  });
+
+  const run = await sweeper.runOnce(new Date("2026-04-27T10:00:00.000Z"));
+  assert.equal(run.candidateCount, 1);
+  assert.equal(run.updatedCount, 1);
+  assert.equal(platform.jobs[0].lifecycle.status, "open");
+  assert.equal((await sweeper.getStatus()).lastRun.dryRun, true);
+});
+
+test("JobStaleSweeperService archives stale jobs when live", async () => {
+  const platform = makePlatformService();
+  const sweeper = new JobStaleSweeperService(platform, new MemoryStateStore(), undefined, {
+    enabled: true,
+    dryRun: false,
+    action: "archive",
+    reason: "aged out"
+  });
+
+  const run = await sweeper.runOnce(new Date("2026-04-27T10:00:00.000Z"));
+  assert.equal(run.updatedCount, 1);
+  assert.equal(platform.jobs[0].lifecycle.status, "archived");
+  assert.equal(platform.jobs[0].lifecycle.reason, "aged out");
+});
+
+test("JobStaleSweeperService skips jobs with active sessions", async () => {
+  const platform = makePlatformService();
+  const stateStore = new MemoryStateStore();
+  await stateStore.upsertSession({
+    sessionId: "stale-open-001:0xagent",
+    jobId: "stale-open-001",
+    wallet: "0xagent",
+    status: "claimed",
+    idempotencyKey: "claim-1"
+  });
+  const sweeper = new JobStaleSweeperService(platform, stateStore, undefined, {
+    enabled: true,
+    dryRun: false,
+    action: "archive"
+  });
+
+  const run = await sweeper.runOnce(new Date("2026-04-27T10:00:00.000Z"));
+  assert.equal(run.updatedCount, 0);
+  assert.equal(run.skipped[0].reason, "active_session");
+  assert.equal(platform.jobs[0].lifecycle.status, "open");
+});
+
+test("JobStaleSweeperService only sweeps open stale non-recurring jobs", async () => {
+  const platform = makePlatformService([
+    STALE_JOB,
+    {
+      ...STALE_JOB,
+      id: "paused-stale-001",
+      lifecycle: { ...STALE_JOB.lifecycle, status: "paused", state: "paused" }
+    },
+    {
+      ...STALE_JOB,
+      id: "recurring-stale-001",
+      recurring: true
+    },
+    {
+      ...STALE_JOB,
+      id: "fresh-open-001",
+      lifecycle: { ...STALE_JOB.lifecycle, state: "open" }
+    }
+  ]);
+  const sweeper = new JobStaleSweeperService(platform, new MemoryStateStore(), undefined, {
+    enabled: true,
+    dryRun: false,
+    action: "pause"
+  });
+
+  const run = await sweeper.runOnce(new Date("2026-04-27T10:00:00.000Z"));
+  assert.equal(run.candidateCount, 1);
+  assert.equal(platform.jobs.find((job) => job.id === "stale-open-001").lifecycle.status, "paused");
+  assert.equal(platform.jobs.find((job) => job.id === "paused-stale-001").lifecycle.status, "paused");
+  assert.equal(platform.jobs.find((job) => job.id === "recurring-stale-001").lifecycle.status, "open");
+  assert.equal(platform.jobs.find((job) => job.id === "fresh-open-001").lifecycle.status, "open");
+});
+
+test("loadJobStaleSweeperConfig parses safe defaults and live action", () => {
+  assert.deepEqual(loadJobStaleSweeperConfig({}), {
+    enabled: false,
+    dryRun: true,
+    intervalMs: 60 * 60 * 1000,
+    action: "archive",
+    maxJobsPerRun: 25,
+    reason: "automatic stale job cleanup"
+  });
+
+  assert.deepEqual(loadJobStaleSweeperConfig({
+    JOB_STALE_SWEEPER_ENABLED: "true",
+    JOB_STALE_SWEEPER_DRY_RUN: "false",
+    JOB_STALE_SWEEPER_INTERVAL_MS: "300000",
+    JOB_STALE_SWEEPER_ACTION: "pause",
+    JOB_STALE_SWEEPER_MAX_JOBS_PER_RUN: "5",
+    JOB_STALE_SWEEPER_REASON: "ops rotation"
+  }), {
+    enabled: true,
+    dryRun: false,
+    intervalMs: 300000,
+    action: "pause",
+    maxJobsPerRun: 5,
+    reason: "ops rotation"
+  });
+});


### PR DESCRIPTION
## Summary
- add a scheduled stale-job sweeper service with dry-run/live modes
- support mark_stale, pause, and archive actions with max-jobs-per-run limits
- skip recurring templates and jobs with active sessions
- expose sweeper status through /admin/status.jobStaleSweeper
- document JOB_STALE_SWEEPER_* env knobs and update OpenAPI

## Verification
- npm --workspace mcp-server test -- job-stale-sweeper.test.js platform-service.test.js job-catalog-metadata.test.js
- node -e 'JSON.parse(require("node:fs").readFileSync("docs/api/openapi.json", "utf8")); console.log("openapi ok")'
- git diff --check

## Ops notes
- defaults are safe: disabled and dry-run
- enable with JOB_STALE_SWEEPER_ENABLED=true
- live action requires JOB_STALE_SWEEPER_DRY_RUN=false
- action is JOB_STALE_SWEEPER_ACTION=archive|pause|mark_stale