### PR TITLE
Runs page polish: source-aware rail, readable rows, freshness pill

### DIFF
--- a/app/app/(authed)/runs/page.tsx
+++ b/app/app/(authed)/runs/page.tsx
@@ -14,6 +14,9 @@ import { LifecycleRail } from "@/components/runs/LifecycleRail";
 import {
   FIXTURE_FILTERS,
   FIXTURE_LIFECYCLE,
+  FIXTURE_LIFECYCLE_OPEN_DATA,
+  FIXTURE_LIFECYCLE_OSV,
+  FIXTURE_LIFECYCLE_WIKIPEDIA,
   FIXTURE_RECOMMENDATIONS,
   FIXTURE_RUN_ROWS,
 } from "@/components/runs/fixtures";
@@ -255,7 +258,15 @@ function RunsPageInner() {
       <LifecycleRail
         runId={selectedId}
         contextNote={lifecycleContextNote}
-        stages={FIXTURE_LIFECYCLE}
+        stages={
+          selectedSource?.type === "wikipedia_article"
+            ? FIXTURE_LIFECYCLE_WIKIPEDIA
+            : selectedSource?.type === "osv_advisory"
+              ? FIXTURE_LIFECYCLE_OSV
+              : selectedSource?.type === "open_data_dataset"
+                ? FIXTURE_LIFECYCLE_OPEN_DATA
+                : FIXTURE_LIFECYCLE
+        }
         next={lifecycleNext}
       />
 

--- a/app/components/runs/LoadedRunPanel.tsx
+++ b/app/components/runs/LoadedRunPanel.tsx
@@ -612,7 +612,7 @@ function GitHubEvidenceBlock({ ctx }: { ctx: GitHubJobContext }) {
             {ctx.category}
           </span>
           {typeof ctx.score === "number" ? (
-            <span className="ml-auto inline-flex items-center gap-1 whitespace-nowrap font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]">
+            <span className="ml-auto whitespace-nowrap font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]">
               Fit score{" "}
               <b className="font-semibold text-[var(--avy-ink)]">{ctx.score}</b>
               <span className="text-[var(--avy-muted)]">/100</span>
@@ -752,7 +752,7 @@ function WikipediaEvidenceBlock({ ctx }: { ctx: WikipediaJobContext }) {
             rev {ctx.revisionId}
           </span>
           {typeof ctx.score === "number" ? (
-            <span className="ml-auto inline-flex items-center gap-1 whitespace-nowrap font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]">
+            <span className="ml-auto whitespace-nowrap font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]">
               Fit score{" "}
               <b className="font-semibold text-[var(--avy-ink)]">{ctx.score}</b>
               <span className="text-[var(--avy-muted)]">/100</span>
@@ -1063,7 +1063,7 @@ function OsvEvidenceBlock({ ctx }: { ctx: OsvJobContext }) {
             {ctx.vulnerableVersion} → {ctx.fixedVersion}
           </span>
           {typeof ctx.score === "number" ? (
-            <span className="ml-auto inline-flex items-center gap-1 whitespace-nowrap font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]">
+            <span className="ml-auto whitespace-nowrap font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]">
               Fit score{" "}
               <b className="font-semibold text-[var(--avy-ink)]">{ctx.score}</b>
               <span className="text-[var(--avy-muted)]">/100</span>
@@ -1460,7 +1460,7 @@ function OpenDataEvidenceBlock({ ctx }: { ctx: OpenDataJobContext }) {
             </>
           ) : null}
           {typeof ctx.score === "number" ? (
-            <span className="ml-auto inline-flex items-center gap-1 whitespace-nowrap font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]">
+            <span className="ml-auto whitespace-nowrap font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]">
               Fit score{" "}
               <b className="font-semibold text-[var(--avy-ink)]">{ctx.score}</b>
               <span className="text-[var(--avy-muted)]">/100</span>

--- a/app/components/runs/LoadedRunView.tsx
+++ b/app/components/runs/LoadedRunView.tsx
@@ -12,6 +12,9 @@ import {
 import {
   FIXTURE_JOB_DEFINITIONS,
   FIXTURE_LIFECYCLE,
+  FIXTURE_LIFECYCLE_OPEN_DATA,
+  FIXTURE_LIFECYCLE_OSV,
+  FIXTURE_LIFECYCLE_WIKIPEDIA,
   FIXTURE_RUN_ROWS,
 } from "./fixtures";
 import type { RunRow } from "./RunQueueTable";
@@ -614,7 +617,15 @@ export function LoadedRunView({
               </>
             )
           }
-          stages={FIXTURE_LIFECYCLE}
+          stages={
+            loadedWikipedia
+              ? FIXTURE_LIFECYCLE_WIKIPEDIA
+              : loadedOsv
+                ? FIXTURE_LIFECYCLE_OSV
+                : loadedOpenData
+                  ? FIXTURE_LIFECYCLE_OPEN_DATA
+                  : FIXTURE_LIFECYCLE
+          }
           next={{
             label: "Next",
             value: loadedWikipedia

--- a/app/components/runs/fixtures.ts
+++ b/app/components/runs/fixtures.ts
@@ -650,10 +650,9 @@ Repro: run \`cargo test --test claim_race -- --test-threads=1 --ignored\` in a l
   },
 ];
 
-// Lifecycle for GitHub-ingested jobs. For MVP we keep the same 5-stage
-// shape but relabel for the OSS flow: Ready → Claimed → PR submitted →
-// Verified → Paid. Future revisions can add an explicit "Working"
-// intermediate stage once the runner reports keep-alive signals.
+// Lifecycle for GitHub-ingested jobs (the platform's original flow):
+// Ready → Claimed → PR submitted → Verified → Paid. Default fixture
+// when no source-specific override applies.
 export const FIXTURE_LIFECYCLE: LifecycleStage[] = [
   { index: 1, label: "Ready", meta: "14:20:25", state: "done" },
   { index: 2, label: "Claimed", meta: "14:23:53 · by you", state: "done" },
@@ -667,6 +666,70 @@ export const FIXTURE_LIFECYCLE: LifecycleStage[] = [
     index: 4,
     label: "Verified",
     meta: "2/3 signals · maintainer review pending",
+    state: "current",
+  },
+  { index: 5, label: "Paid", meta: "—", state: "pending" },
+];
+
+// Wikipedia flow: the platform never edits Wikipedia directly, so the
+// stage between "claimed" and "verified" is "Proposal submitted" to
+// Averray (not a public PR), and review is by an Averray-approved
+// editor.
+export const FIXTURE_LIFECYCLE_WIKIPEDIA: LifecycleStage[] = [
+  { index: 1, label: "Ready", meta: "14:20:25", state: "done" },
+  { index: 2, label: "Claimed", meta: "14:23:53 · by you", state: "done" },
+  {
+    index: 3,
+    label: "Proposal submitted",
+    meta: "14:27:45 · structured proposal + citations",
+    state: "done",
+  },
+  {
+    index: 4,
+    label: "Verified",
+    meta: "1/2 signals · Averray editor review pending",
+    state: "current",
+  },
+  { index: 5, label: "Paid", meta: "—", state: "pending" },
+];
+
+// OSV flow: the worker opens a focused dependency-bump PR in the
+// consumer repo, not the upstream package. The PR submission stage is
+// real but the maintainer who reviews it is the consumer's, not the
+// package author.
+export const FIXTURE_LIFECYCLE_OSV: LifecycleStage[] = [
+  { index: 1, label: "Ready", meta: "14:20:25", state: "done" },
+  { index: 2, label: "Claimed", meta: "14:23:53 · by you", state: "done" },
+  {
+    index: 3,
+    label: "PR submitted",
+    meta: "14:27:45 · dependency bump + lockfile",
+    state: "done",
+  },
+  {
+    index: 4,
+    label: "Verified",
+    meta: "3/4 signals · maintainer merge pending",
+    state: "current",
+  },
+  { index: 5, label: "Paid", meta: "—", state: "pending" },
+];
+
+// Open data flow: the worker submits an audit report (no edits to the
+// source dataset). Verification is automated against the catalog.
+export const FIXTURE_LIFECYCLE_OPEN_DATA: LifecycleStage[] = [
+  { index: 1, label: "Ready", meta: "14:20:25", state: "done" },
+  { index: 2, label: "Claimed", meta: "14:23:53 · by you", state: "done" },
+  {
+    index: 3,
+    label: "Audit submitted",
+    meta: "14:27:45 · checks + findings + recommendations",
+    state: "done",
+  },
+  {
+    index: 4,
+    label: "Verified",
+    meta: "4/5 signals · audit verifier check pending",
     state: "current",
   },
   { index: 5, label: "Paid", meta: "—", state: "pending" },

--- a/app/components/shell/DataFreshnessPill.tsx
+++ b/app/components/shell/DataFreshnessPill.tsx
@@ -88,19 +88,33 @@ export function DataFreshnessPill({
 /**
  * Derive a single freshness state from one or more SWR-style requests.
  *
- *   - if any request errored → `fallback`
+ *   - if any request errored with a non-auth status → `fallback`
  *   - else if all requests are still loading and have no data → `loading`
  *   - else → `live`
  *
- * The "error" branch comes first because once any request has failed,
- * the page is definitely rendering against the fallback path — even if
- * other requests are still in flight or have already resolved live.
+ * 401/403 errors are treated as "this surface is unauthenticated" rather
+ * than a fallback signal — when the operator app calls a public route
+ * and an admin route in parallel, the admin route 401s for signed-out
+ * viewers but the public route still returns live data, so the pill
+ * should not falsely advertise "FIXTURE DATA".
  */
 export function freshnessFromRequests(
   ...requests: { data?: unknown; error?: unknown; isLoading?: boolean }[]
 ): FreshnessState {
   if (requests.length === 0) return "fallback";
-  if (requests.some((r) => Boolean(r.error))) return "fallback";
+  const realError = requests.some((r) => isRealError(r.error));
+  if (realError) return "fallback";
   if (requests.every((r) => !r.data && r.isLoading)) return "loading";
   return "live";
+}
+
+function isRealError(err: unknown): boolean {
+  if (!err) return false;
+  // ApiError surfaces an HTTP status; treat 401/403 as expected
+  // unauth-mode behavior rather than a freshness fault.
+  const status = (err as { status?: unknown }).status;
+  if (typeof status === "number" && (status === 401 || status === 403)) {
+    return false;
+  }
+  return true;
 }

--- a/app/lib/api/run-adapters.ts
+++ b/app/lib/api/run-adapters.ts
@@ -495,22 +495,27 @@ export function buildRunRows(payload: unknown): RunRow[] {
       state,
       stake: formatReward(job.stake ?? job.rewardAmount),
       age: formatWindow(job.claimTtlSeconds),
+      // The SourceBadge already shows where the row came from, so the
+      // lastEvent line carries the work *kind* instead of restating the
+      // source. The previous "Ingested from Wikipedia · proposal-only"
+      // truncated to "Inge…" in narrow queue columns and lost all
+      // signal.
       lastEvent:
         source?.type === "github_issue"
           ? state === "ready"
-            ? "Ingested from GitHub"
+            ? "Issue triage"
             : `State: ${state}`
           : source?.type === "wikipedia_article"
             ? state === "ready"
-              ? "Ingested from Wikipedia · proposal-only"
+              ? "Proposal-only"
               : `State: ${state}`
             : source?.type === "osv_advisory"
               ? state === "ready"
-                ? "Ingested from OSV · dependency remediation"
+                ? "Dependency remediation"
                 : `State: ${state}`
               : source?.type === "open_data_dataset"
                 ? state === "ready"
-                  ? "Ingested from Data.gov · audit only"
+                  ? "Audit only"
                   : `State: ${state}`
                 : state === "ready"
                   ? "Job listed"


### PR DESCRIPTION
## Summary
Four polish fixes from a live look at /runs:

1. **Lifecycle rail was hardcoded to the GitHub flow.** A loaded Wikipedia article still showed \"PR submitted · #4931 on paritytech/polkadot-sdk\" in the session lifecycle. Adds three source-specific stage fixtures (Wikipedia / OSV / OpenData) and switches by loaded source.
2. **Queue rows truncated to \"Inge…\".** Each row's lastEvent was \"Ingested from Wikipedia · proposal-only\" etc.; the \"Ingested from X\" prefix repeated the SourceBadge and squeezed the rest into a meaningless ellipsis. Now leads with the work kind (\"Proposal-only\", \"Dependency remediation\", \"Audit only\", \"Issue triage\").
3. **DataFreshnessPill falsely showed FIXTURE DATA.** /runs polls /admin/jobs in parallel which 401s when signed-out, tipping the pill to fallback even though the public /jobs feed was live. \`freshnessFromRequests\` now ignores 401/403 errors (real failures still trip).
4. **\"Fit score 85 /100\"** had a stray space from an inline-flex \`gap-1\` between the number and the suffix. Removed the gap.

## Test plan
- [x] \`npm run typecheck:app\`
- [x] \`npm run build:frontend\`
- [ ] After deploy: load /runs, click a Wikipedia row → lifecycle rail reads \"Proposal submitted\", not \"PR submitted #4931\"
- [ ] Signed-out load → freshness pill stays on \"LIVE DATA\" if /jobs returns 200, even though /admin/jobs 401s