### PR TITLE
Keep admin status available when policy status fails

### DIFF
--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -28,6 +28,15 @@ const INGESTION_PROVIDER_DEFINITIONS = [
   ["openApi", "openApiIngestion", "OpenAPI quality", "specCount"]
 ];
 
+const DEFAULT_TREASURY_POLICY_STATUS = {
+  enabled: false,
+  policyAddress: undefined,
+  paused: undefined,
+  owner: undefined,
+  pauser: undefined,
+  risk: {}
+};
+
 export class PlatformService {
   constructor(
     jobs,
@@ -142,14 +151,7 @@ export class PlatformService {
       jobStaleSweeper,
       recentSessions
     ] = await Promise.all([
-      this.blockchainGateway?.getTreasuryPolicyStatus?.() ?? {
-        enabled: false,
-        policyAddress: undefined,
-        paused: undefined,
-        owner: undefined,
-        pauser: undefined,
-        risk: {}
-      },
+      getTreasuryPolicyStatusSafely(this.blockchainGateway),
       this.jobCatalogService.getRecurringTemplateStatus(),
       this.recurringScheduler?.getStatus?.() ?? { enabled: false, running: false, templates: [] },
       this.githubIssueIngestionScheduler?.getStatus?.() ?? {
@@ -280,6 +282,14 @@ export class PlatformService {
         severity: "high",
         code: "policy_paused",
         message: "Treasury policy is paused."
+      });
+    }
+    if (policy?.error) {
+      anomalies.push({
+        severity: "medium",
+        code: "policy_status_unavailable",
+        message: "Treasury policy status is unavailable.",
+        details: policy.error
       });
     }
     for (const template of scheduler.templates ?? []) {
@@ -787,6 +797,27 @@ function sanitizeProviderOperationStatus(status) {
       errors: []
     }
   };
+}
+
+async function getTreasuryPolicyStatusSafely(blockchainGateway) {
+  if (!blockchainGateway?.getTreasuryPolicyStatus) {
+    return { ...DEFAULT_TREASURY_POLICY_STATUS };
+  }
+
+  try {
+    return await blockchainGateway.getTreasuryPolicyStatus();
+  } catch (error) {
+    return {
+      ...DEFAULT_TREASURY_POLICY_STATUS,
+      enabled: Boolean(blockchainGateway.isEnabled?.()),
+      policyAddress: blockchainGateway.config?.treasuryPolicyAddress || undefined,
+      error: {
+        code: error?.code ?? "policy_status_error",
+        message: error?.message ?? "Treasury policy status failed.",
+        details: error?.details
+      }
+    };
+  }
 }
 
 function buildProviderOperations(statuses) {

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -144,6 +144,36 @@ test("getAdminStatus surfaces recurring scheduler anomalies", async () => {
   assert.equal(status.jobStaleSweeper.enabled, false);
 });
 
+test("getAdminStatus reports treasury policy failures without failing the status response", async () => {
+  const service = makePlatformService({
+    config: {
+      treasuryPolicyAddress: "0x1111111111111111111111111111111111111111"
+    },
+    isEnabled() {
+      return true;
+    },
+    async getTreasuryPolicyStatus() {
+      const error = new Error("getTreasuryPolicyStatus failed: require(false)");
+      error.code = "blockchain_revert";
+      error.details = {
+        operation: "getTreasuryPolicyStatus",
+        rawCode: "CALL_EXCEPTION",
+        rawReason: "require(false)"
+      };
+      throw error;
+    }
+  });
+
+  const status = await service.getAdminStatus();
+
+  assert.equal(status.maintenance.policy.enabled, true);
+  assert.equal(status.maintenance.policy.policyAddress, "0x1111111111111111111111111111111111111111");
+  assert.equal(status.maintenance.policy.error.code, "blockchain_revert");
+  assert.equal(status.maintenance.policy.error.details.rawReason, "require(false)");
+  assert.ok(status.anomalies.some((entry) => entry.code === "policy_status_unavailable"));
+  assert.equal(status.jobStaleSweeper.enabled, false);
+});
+
 test("getAdminStatus surfaces public source ingestion scheduler status", async () => {
   const service = makePlatformService();
   service.githubIssueIngestionScheduler = {


### PR DESCRIPTION
## Summary
- make /admin/status tolerate treasury policy status failures
- report the failure under maintenance.policy.error and add a policy_status_unavailable anomaly
- cover the observed getTreasuryPolicyStatus failed: require(false) path with a regression test

## Verification
- npm --workspace mcp-server test -- platform-service.test.js
- node -e 'JSON.parse(require("node:fs").readFileSync("docs/api/openapi.json","utf8")); console.log("openapi ok")'
- git diff --check