### PR TITLE
Wikipedia titles + verifier-name wrapping

### DIFF
--- a/app/components/runs/JobCard.tsx
+++ b/app/components/runs/JobCard.tsx
@@ -66,7 +66,7 @@ export function JobCard({ job }: { job: JobCardData }) {
             >
               <span className="shrink-0">{job.source.language}.wikipedia</span>
               <span className="truncate text-[var(--avy-ink)]">
-                / {job.source.pageTitle}
+                / &ldquo;{job.source.pageTitle}&rdquo;
               </span>
             </p>
           ) : job.source?.type === "osv_advisory" ? (
@@ -149,7 +149,7 @@ export function JobCard({ job }: { job: JobCardData }) {
       </div>
 
       <dl
-        className="grid grid-cols-2 gap-x-2.5 gap-y-1 border-t border-[var(--avy-line-soft)] pt-2 font-[family-name:var(--font-mono)] text-[10.5px]"
+        className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-2.5 gap-y-1 border-t border-[var(--avy-line-soft)] pt-2 font-[family-name:var(--font-mono)] text-[10.5px]"
         style={{ letterSpacing: 0 }}
       >
         {job.meta.map((row) => (
@@ -157,7 +157,7 @@ export function JobCard({ job }: { job: JobCardData }) {
             <dt className="text-[var(--avy-muted)]">{row.label}</dt>
             <dd
               className={cn(
-                "m-0 font-medium",
+                "m-0 min-w-0 break-words font-medium",
                 row.accent ? "text-[var(--avy-accent)]" : "text-[var(--avy-ink)]"
               )}
             >

--- a/app/components/runs/LoadedRunPanel.tsx
+++ b/app/components/runs/LoadedRunPanel.tsx
@@ -732,10 +732,10 @@ function WikipediaEvidenceBlock({ ctx }: { ctx: WikipediaJobContext }) {
             rel="noreferrer noopener"
             className="truncate whitespace-nowrap font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-ink)] hover:text-[var(--avy-accent)]"
             style={{ letterSpacing: 0 }}
-            title={`${ctx.language}.wikipedia / ${ctx.pageTitle}`}
+            title={`${ctx.language}.wikipedia / "${ctx.pageTitle}"`}
           >
             <span className="text-[var(--avy-muted)]">{ctx.language}.wikipedia</span>
-            <span className="text-[var(--avy-accent)]"> / {ctx.pageTitle}</span>
+            <span className="text-[var(--avy-accent)]"> / &ldquo;{ctx.pageTitle}&rdquo;</span>
           </a>
           <span className="opacity-40">·</span>
           <span

--- a/app/components/runs/RunQueueTable.tsx
+++ b/app/components/runs/RunQueueTable.tsx
@@ -189,7 +189,7 @@ function RunRowCard({
                   <span className="truncate">
                     <span>{row.source.language}.wikipedia</span>
                     <span className="text-[var(--avy-accent)]">
-                      {" "}/ {row.source.pageTitle}
+                      {" "}/ &ldquo;{row.source.pageTitle}&rdquo;
                     </span>
                   </span>
                   <span className="shrink-0 opacity-40">·</span>


### PR DESCRIPTION
## Summary
Two readability fixes from another live look at /runs:

1. **Wikipedia source line read as junk for unusual page titles.** \`en.wikipedia / (+ +)\` (the actual page title for the \"+ +\" Wikipedia article) made the row look broken — the slash plus parens were indistinguishable from punctuation. Wrap pageTitle in curly quotes so the title segment is always delimited from the domain. Applied to RunQueueTable, JobCard, and LoadedRunPanel.
2. **Long verifier modes truncated mid-word in the \"ready to claim\" cards.** \`open_data_quality_audit\` rendered as \`open_data_quality_au...\` because the dl was a fixed 2-column grid with no min-width handling and underscore-separated tokens have no break opportunities. Switched the grid to \`[auto_minmax(0,1fr)]\` and added \`min-w-0 break-words\` to the dd so long values wrap cleanly to a second line.

## Test plan
- [x] \`npm run typecheck:app\`
- [x] \`npm run build:frontend\`
- [ ] After deploy: load /runs, confirm the Wikipedia rows show \`en.wikipedia / \"(+ +)\"\` and the ready-to-claim card for the open-data audit shows the full \`open_data_quality_audit\` verifier name