### PR TITLE
Keep indexer compatible with legacy job tuple

### DIFF
--- a/indexer/abis/contractsAbi.ts
+++ b/indexer/abis/contractsAbi.ts
@@ -19,6 +19,10 @@ export const EscrowCoreAbi = parseAbi([
   "function jobs(bytes32 jobId) view returns ((address poster, address worker, address asset, bytes32 verifierMode, bytes32 category, bytes32 specHash, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 released, uint256 claimExpiry, uint256 claimStake, uint16 claimStakeBps, uint256 claimFee, uint16 claimFeeBps, bool claimEconomicsWaived, address rejectingVerifier, uint256 rejectedAt, uint256 disputedAt, uint8 payoutMode, uint8 state))"
 ]);
 
+export const EscrowCoreLegacyJobsAbi = parseAbi([
+  "function jobs(bytes32 jobId) view returns ((address poster, address worker, address asset, bytes32 verifierMode, bytes32 category, bytes32 specHash, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 released, uint256 claimExpiry, uint256 claimStake, uint16 claimStakeBps, uint256 rejectedAt, uint256 disputedAt, uint8 payoutMode, uint8 state))"
+]);
+
 export const ReputationSbtAbi = parseAbi([
   "event BadgeMinted(uint256 indexed tokenId, address indexed account, bytes32 indexed category, uint256 level, string metadataURI)",
   "event ReputationUpdated(address indexed account, uint256 skill, uint256 reliability, uint256 economic)",

--- a/indexer/src/index.ts
+++ b/indexer/src/index.ts
@@ -3,7 +3,7 @@ import { hexToString } from "viem";
 import { ponder } from "ponder:registry";
 import schema from "ponder:schema";
 
-import { EscrowCoreAbi } from "../abis/contractsAbi";
+import { EscrowCoreAbi, EscrowCoreLegacyJobsAbi } from "../abis/contractsAbi";
 
 const payoutModeLabels = ["single", "milestone"] as const;
 const jobStateLabels = ["none", "open", "claimed", "submitted", "rejected", "disputed", "closed"] as const;
@@ -44,12 +44,7 @@ const syncJob = async ({
   event: any;
   jobId: `0x${string}`;
 }) => {
-  const live = await context.client.readContract({
-    abi: EscrowCoreAbi,
-    address: event.log.address,
-    functionName: "jobs",
-    args: [jobId]
-  });
+  const live = await readLiveJob({ context, event, jobId });
 
   const [
     poster,
@@ -131,6 +126,74 @@ const syncJob = async ({
       updatedAtTimestamp: row.updatedAtTimestamp,
       lastTxHash: row.lastTxHash
     }));
+};
+
+const readLiveJob = async ({
+  context,
+  event,
+  jobId
+}: {
+  context: any;
+  event: any;
+  jobId: `0x${string}`;
+}) => {
+  try {
+    return await context.client.readContract({
+      abi: EscrowCoreAbi,
+      address: event.log.address,
+      functionName: "jobs",
+      args: [jobId]
+    });
+  } catch (error) {
+    const legacy = await context.client.readContract({
+      abi: EscrowCoreLegacyJobsAbi,
+      address: event.log.address,
+      functionName: "jobs",
+      args: [jobId]
+    });
+    const [
+      poster,
+      worker,
+      asset,
+      verifierMode,
+      category,
+      specHash,
+      reward,
+      opsReserve,
+      contingencyReserve,
+      released,
+      claimExpiry,
+      claimStake,
+      claimStakeBps,
+      rejectedAt,
+      disputedAt,
+      payoutMode,
+      state
+    ] = legacy;
+    return [
+      poster,
+      worker,
+      asset,
+      verifierMode,
+      category,
+      specHash,
+      reward,
+      opsReserve,
+      contingencyReserve,
+      released,
+      claimExpiry,
+      claimStake,
+      claimStakeBps,
+      0n,
+      0,
+      false,
+      "0x0000000000000000000000000000000000000000",
+      rejectedAt,
+      disputedAt,
+      payoutMode,
+      state
+    ] as const;
+  }
 };
 
 ponder.on("EscrowCore:JobFunded", async ({ event, context }) => {


### PR DESCRIPTION
## What changed
- Add a legacy `EscrowCore.jobs` ABI shape for the currently deployed pre-claim-fee contract tuple.
- Make indexer job sync try the rc1 claim-fee tuple first, then fall back to legacy tuple values with claim-fee fields defaulted to zero/null.

## Checks
- `npm --workspace indexer run typecheck`
- `git diff --check`

## Impact
- Affects indexer only.
- No frontend, backend, contracts, Caddy, or public-site changes.
- No environment or VPS secret changes required.

## Notes
This is a production safety bridge until the rc1 contract redeploy lands. Normal production deploys do not deploy smart contracts, so the indexer must remain compatible with the currently deployed contract surface.