### PR TITLE
Add maintainer-surface controls

### DIFF
--- a/docs/RC1_IMPLEMENTATION_PLAN.md
+++ b/docs/RC1_IMPLEMENTATION_PLAN.md
@@ -203,15 +203,18 @@ if new events are indexed.
 
 ### 7. Maintainer-Surface Controls
 
+**Status:** in progress; backend intake/submission/verifier foundations are
+implemented in this slice.
+
 **Goal:** reduce external ecosystem risk before public job sourcing scales.
 
 **Changes:**
 
-- Add denylist with security/standards seeds.
-- Add CONTRIBUTING/AI-policy scanner for repo intake.
-- Enforce per-repo open PR cap of 3.
-- Inject non-removable disclosure footer into PR/edit bodies.
-- Implement "respect the no" denylist workflow.
+- [x] Add denylist with security/standards seeds.
+- [x] Add CONTRIBUTING/AI-policy scanner for repo intake.
+- [x] Enforce per-repo open PR cap of 3.
+- [x] Inject non-removable disclosure footer into PR/edit bodies.
+- [x] Implement "respect the no" denylist workflow.
 
 **Checks:** `npm --workspace mcp-server test`, frontend checks if operator UI
 surfaces controls.

--- a/mcp-server/src/core/funded-jobs.js
+++ b/mcp-server/src/core/funded-jobs.js
@@ -245,7 +245,7 @@ function findGithubPullRequestUrl(text) {
   return String(text ?? "").match(/https:\/\/github\.com\/[a-z0-9_.-]+\/[a-z0-9_.-]+\/pull\/\d+/iu)?.[0] ?? "";
 }
 
-function parseGithubPullRequestUrl(url) {
+export function parseGithubPullRequestUrl(url) {
   const match = String(url ?? "").trim().match(/^https:\/\/github\.com\/([a-z0-9_.-]+)\/([a-z0-9_.-]+)\/pull\/(\d+)(?:[/?#].*)?$/iu);
   if (!match) return undefined;
   return {

--- a/mcp-server/src/core/job-execution-service.js
+++ b/mcp-server/src/core/job-execution-service.js
@@ -8,9 +8,14 @@ import { hashSubmission, normalizeSubmission } from "./submission.js";
 import { getBuiltinJobSchema, validateStructuredSubmission } from "./job-schema-registry.js";
 import {
   buildFundedJobFromClaim,
+  parseGithubPullRequestUrl,
   updateFundedJobFromSession
 } from "./funded-jobs.js";
 import { computeClaimEconomics, countClaimedSessions } from "./claim-economics.js";
+import {
+  DEFAULT_OPEN_PR_CAP_PER_REPO,
+  countOpenGithubPullRequestsForRepo
+} from "./maintainer-surface-policy.js";
 
 export class JobExecutionService {
   constructor(
@@ -21,7 +26,8 @@ export class JobExecutionService {
     accountMutationService = undefined,
     getDefaultClaimStakeBps = async () => 500,
     getClaimableJobDefinition = getJobDefinition,
-    getClaimEconomicsConfig = async () => ({})
+    getClaimEconomicsConfig = async () => ({}),
+    maintainerSurfaceConfig = {}
   ) {
     this.stateStore = stateStore;
     this.blockchainGateway = blockchainGateway;
@@ -31,6 +37,9 @@ export class JobExecutionService {
     this.accountMutationService = accountMutationService;
     this.getDefaultClaimStakeBps = getDefaultClaimStakeBps;
     this.getClaimEconomicsConfig = getClaimEconomicsConfig;
+    this.openPrCap = Number.isInteger(maintainerSurfaceConfig.openPrCap) && maintainerSurfaceConfig.openPrCap > 0
+      ? maintainerSurfaceConfig.openPrCap
+      : DEFAULT_OPEN_PR_CAP_PER_REPO;
   }
 
   async claimJob(wallet, jobId, protocol, idempotencyKey) {
@@ -144,6 +153,7 @@ export class JobExecutionService {
     if (submission.kind === "structured") {
       validateStructuredSubmission(job.outputSchemaRef, submission.structured, { path: "submission" });
     }
+    await this.enforceMaintainerOpenPrCap(job, submission);
     if (this.blockchainGateway?.isEnabled()) {
       await this.blockchainGateway.submitWork(session.chainJobId ?? session.jobId, hashSubmission(submission));
     }
@@ -257,6 +267,21 @@ export class JobExecutionService {
 
   getClaimLockTtlSeconds(job) {
     return Math.max(60, Math.min(Number(job?.claimTtlSeconds ?? 300), 900));
+  }
+
+  async enforceMaintainerOpenPrCap(job, submission) {
+    if (job?.source?.type !== "github_issue" || submission.kind !== "structured") return;
+    const parsed = parseGithubPullRequestUrl(submission.structured?.prUrl ?? submission.structured?.pullRequestUrl);
+    if (!parsed) return;
+    const repo = job.source.repo ?? parsed.repo;
+    const openCount = await countOpenGithubPullRequestsForRepo(this.stateStore, repo);
+    if (openCount >= this.openPrCap) {
+      throw new ConflictError(
+        `Repository ${repo} already has ${openCount} open Averray pull request submissions.`,
+        "maintainer_open_pr_cap_reached",
+        { repo, openCount, openPrCap: this.openPrCap }
+      );
+    }
   }
 
   isTerminalSession(session) {

--- a/mcp-server/src/core/job-execution-service.test.js
+++ b/mcp-server/src/core/job-execution-service.test.js
@@ -134,3 +134,38 @@ test("claimJob records onboarding waiver and claim fee economics on sessions", a
   assert.equal(paid.claimFee, 0.1);
   assert.equal(paid.totalClaimLock, 0.6);
 });
+
+test("submitWork enforces per-repo open PR cap for GitHub issue jobs", async () => {
+  const stateStore = new MemoryStateStore();
+  for (let index = 0; index < 3; index++) {
+    await stateStore.upsertFundedJob({
+      jobId: `existing-${index}`,
+      finalStatus: "open",
+      upstream: {
+        kind: "github_pull_request",
+        repo: "example/project",
+        pullNumber: index + 1
+      }
+    });
+  }
+  const job = makeJob({
+    id: "github-issue-job-001",
+    outputSchemaRef: "schema://jobs/github-pr-evidence-output",
+    source: {
+      type: "github_issue",
+      repo: "example/project",
+      issueNumber: 42
+    }
+  });
+  const service = new JobExecutionService(stateStore, undefined, () => job);
+  const claimed = await service.claimJob(WALLET, job.id, "http", "idemp-cap");
+
+  await assert.rejects(
+    () => service.submitWork(claimed.sessionId, "http", {
+      prUrl: "https://github.com/example/project/pull/4",
+      summary: "Adds the requested parser regression test.",
+      tests: "npm test"
+    }),
+    (error) => error.code === "maintainer_open_pr_cap_reached"
+  );
+});

--- a/mcp-server/src/core/job-schema-registry.js
+++ b/mcp-server/src/core/job-schema-registry.js
@@ -32,6 +32,7 @@ const BUILTIN_JOB_SCHEMAS = new Map([
       summary: stringSchema({ minLength: 1 }),
       tests: stringSchema({ minLength: 1 }),
       notes: stringSchema(),
+      prBody: stringSchema(),
       issueNumber: integerSchema({ minimum: 1 }),
       issueUrl: stringSchema(),
       commitUrl: stringSchema(),

--- a/mcp-server/src/core/maintainer-surface-policy.js
+++ b/mcp-server/src/core/maintainer-surface-policy.js
@@ -1,0 +1,214 @@
+export const DEFAULT_OPEN_PR_CAP_PER_REPO = 3;
+
+export const DEFAULT_SECURITY_STANDARDS_DENYLIST = Object.freeze([
+  "bitcoin/bitcoin",
+  "ethereum/go-ethereum",
+  "openssl/openssl",
+  "python/cpython",
+  "rust-lang/rust",
+  "nodejs/node",
+  "golang/go",
+  "paritytech/polkadot-sdk",
+  "w3c/*",
+  "tc39/*"
+]);
+
+export const DEFAULT_POLICY_FILE_PATHS = Object.freeze([
+  "CONTRIBUTING.md",
+  "CONTRIBUTING",
+  ".github/CONTRIBUTING.md",
+  "docs/CONTRIBUTING.md",
+  "CODE_OF_CONDUCT.md",
+  ".github/CODE_OF_CONDUCT.md"
+]);
+
+const DENY_AI_PATTERNS = [
+  /\b(no|not|never)\s+(ai|llm|chatgpt|copilot|bot|automated|autonomous)\b/u,
+  /\b(ai|llm|chatgpt|copilot|bot|automated|autonomous)[-\s]*(generated|assisted)?\s*(contributions?|pull requests?|prs?|patches?)\s+(are\s+)?(not\s+)?(allowed|accepted|permitted)/u,
+  /\b(do\s+not|don't)\s+(submit|send|open)\s+(ai|llm|chatgpt|copilot|bot|automated|autonomous)/u,
+  /\b(ai|llm|chatgpt|copilot|bot|automated|autonomous)\s+(contributions?|pull requests?|prs?|patches?)\s+(will\s+be\s+)?(rejected|closed)/u
+];
+
+const STOP_SIGNAL_PATTERNS = [
+  /\b(stop|cease)\s+(submitting|opening|sending)\b/u,
+  /\b(do\s+not|don't)\s+(submit|open|send)\s+(more|any)\b/u,
+  /\b(no\s+more)\s+(averray|agent|ai|bot|automated)\b/u,
+  /\b(averray|agent|ai|bot|automated)\s+(prs?|pull requests?|contributions?)\s+(are\s+)?(not\s+welcome|banned|prohibited)/u
+];
+
+const FOOTER_HEADER = "This contribution was prepared by an autonomous agent operating on the";
+
+export function normalizeRepo(repo) {
+  const value = String(repo ?? "").trim().replace(/^https:\/\/github\.com\//u, "");
+  const [owner, name] = value.split("/").filter(Boolean);
+  if (!owner || !name) return "";
+  return `${owner.toLowerCase()}/${name.toLowerCase().replace(/\.git$/u, "")}`;
+}
+
+export function parseRepoList(raw) {
+  if (!raw) return [];
+  if (Array.isArray(raw)) return raw.map(normalizeRepoPattern).filter(Boolean);
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed.map(normalizeRepoPattern).filter(Boolean);
+  } catch {
+    // Fall through to comma/newline parsing.
+  }
+  return String(raw)
+    .split(/\n|,/u)
+    .map(normalizeRepoPattern)
+    .filter(Boolean);
+}
+
+export function isRepoDenied(repo, denylist = DEFAULT_SECURITY_STANDARDS_DENYLIST) {
+  const normalized = normalizeRepo(repo);
+  if (!normalized) return false;
+  return denylist.some((entry) => repoMatchesPattern(normalized, entry));
+}
+
+export function scanPolicyText(text) {
+  const normalized = String(text ?? "").toLowerCase();
+  const aiPolicyMatch = DENY_AI_PATTERNS.find((pattern) => pattern.test(normalized));
+  if (aiPolicyMatch) {
+    return { allowed: false, reason: "repo_ai_policy_denies_agent_contributions" };
+  }
+  const stopSignalMatch = STOP_SIGNAL_PATTERNS.find((pattern) => pattern.test(normalized));
+  if (stopSignalMatch) {
+    return { allowed: false, reason: "maintainer_stop_signal" };
+  }
+  return { allowed: true };
+}
+
+export async function scanGithubRepoPolicyFiles({
+  repo,
+  githubToken = undefined,
+  fetchImpl = fetch,
+  paths = DEFAULT_POLICY_FILE_PATHS
+} = {}) {
+  const normalizedRepo = normalizeRepo(repo);
+  if (!normalizedRepo) {
+    return { allowed: true, scannedPaths: [], matches: [] };
+  }
+
+  const headers = {
+    accept: "application/vnd.github.raw",
+    "user-agent": "averray-maintainer-policy-scanner"
+  };
+  if (githubToken) headers.authorization = `Bearer ${githubToken}`;
+
+  const scannedPaths = [];
+  const matches = [];
+  for (const path of paths) {
+    const url = `https://api.github.com/repos/${encodeURIComponent(normalizedRepo.split("/")[0])}/${encodeURIComponent(normalizedRepo.split("/")[1])}/contents/${encodeURIComponent(path).replace(/%2F/gu, "/")}`;
+    const response = await fetchImpl(url, { headers });
+    if (response.status === 404) continue;
+    if (!response.ok) continue;
+    const text = await response.text();
+    scannedPaths.push(path);
+    const result = scanPolicyText(text);
+    if (!result.allowed) {
+      matches.push({ path, reason: result.reason });
+    }
+  }
+
+  return {
+    allowed: matches.length === 0,
+    reason: matches[0]?.reason,
+    scannedPaths,
+    matches
+  };
+}
+
+export async function evaluateMaintainerSurfaceForIssue(issue, {
+  denylistRepos = DEFAULT_SECURITY_STANDARDS_DENYLIST,
+  scanRepoPolicies = false,
+  githubToken = undefined,
+  fetchImpl = fetch
+} = {}) {
+  const repo = repoFromIssue(issue);
+  if (isRepoDenied(repo, denylistRepos)) {
+    return { allowed: false, repo, reason: "repo_denylisted", denylistHit: true };
+  }
+
+  const issuePolicy = scanPolicyText(`${issue?.title ?? ""}\n${issue?.body ?? ""}`);
+  if (!issuePolicy.allowed) {
+    return { allowed: false, repo, reason: issuePolicy.reason, issueBodyHit: true };
+  }
+
+  if (scanRepoPolicies) {
+    const scan = await scanGithubRepoPolicyFiles({ repo, githubToken, fetchImpl });
+    if (!scan.allowed) {
+      return { allowed: false, repo, reason: scan.reason, policyScan: scan };
+    }
+    return { allowed: true, repo, policyScan: scan };
+  }
+
+  return { allowed: true, repo };
+}
+
+export function buildAverrayDisclosureFooter({
+  agentWallet = "0x...",
+  jobSpecUrl = "https://api.averray.com/jobs/{id}",
+  submissionHash = "0x{hash}"
+} = {}) {
+  return [
+    "This contribution was prepared by an autonomous agent operating on the",
+    "Averray platform.",
+    "",
+    `Agent identity: ${agentWallet}`,
+    `Job spec:       ${jobSpecUrl}`,
+    `Submission:     ${submissionHash}`,
+    "",
+    "Maintainer review of the substance is requested before merge.",
+    "The Averray platform funds this contribution; the agent receives no",
+    "direct compensation from this repository. Decline at will."
+  ].join("\n");
+}
+
+export function hasAverrayDisclosureFooter(text) {
+  return String(text ?? "").includes(FOOTER_HEADER) && String(text ?? "").includes("Averray platform.");
+}
+
+export function appendAverrayDisclosureFooter(body, footerOptions = {}) {
+  const value = String(body ?? "").trimEnd();
+  if (hasAverrayDisclosureFooter(value)) return value;
+  return `${value}${value ? "\n\n" : ""}${buildAverrayDisclosureFooter(footerOptions)}`;
+}
+
+export async function countOpenGithubPullRequestsForRepo(stateStore, repo, { limit = 10_000 } = {}) {
+  if (!stateStore?.listFundedJobs) return 0;
+  const normalizedRepo = normalizeRepo(repo);
+  if (!normalizedRepo) return 0;
+  const records = await stateStore.listFundedJobs({ limit });
+  return records.filter((record) =>
+    normalizeRepo(record?.upstream?.repo) === normalizedRepo
+    && record?.upstream?.kind === "github_pull_request"
+    && !["merged", "closed_unmerged", "open_stale", "reverted"].includes(record?.finalStatus)
+  ).length;
+}
+
+export function repoFromIssue(issue) {
+  const fromApiUrl = String(issue?.repository_url ?? "").split("/repos/").at(-1);
+  if (fromApiUrl) return normalizeRepo(fromApiUrl);
+  const match = String(issue?.html_url ?? "").match(/github\.com\/([^/]+\/[^/]+)\/issues\//u);
+  return normalizeRepo(match?.[1]);
+}
+
+function normalizeRepoPattern(value) {
+  const pattern = String(value ?? "").trim().toLowerCase();
+  if (!pattern) return "";
+  if (pattern.endsWith("/*")) {
+    const owner = pattern.slice(0, -2).replace(/^https:\/\/github\.com\//u, "");
+    return owner ? `${owner}/*` : "";
+  }
+  return normalizeRepo(pattern);
+}
+
+function repoMatchesPattern(repo, pattern) {
+  const normalizedPattern = normalizeRepoPattern(pattern);
+  if (!normalizedPattern) return false;
+  if (normalizedPattern.endsWith("/*")) {
+    return repo.startsWith(`${normalizedPattern.slice(0, -2)}/`);
+  }
+  return repo === normalizedPattern;
+}

--- a/mcp-server/src/core/maintainer-surface-policy.test.js
+++ b/mcp-server/src/core/maintainer-surface-policy.test.js
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  appendAverrayDisclosureFooter,
+  buildAverrayDisclosureFooter,
+  countOpenGithubPullRequestsForRepo,
+  evaluateMaintainerSurfaceForIssue,
+  hasAverrayDisclosureFooter,
+  isRepoDenied,
+  scanPolicyText
+} from "./maintainer-surface-policy.js";
+import { MemoryStateStore } from "./state-store.js";
+
+test("denylist blocks seeded security and standards repositories", () => {
+  assert.equal(isRepoDenied("openssl/openssl"), true);
+  assert.equal(isRepoDenied("w3c/csswg-drafts"), true);
+  assert.equal(isRepoDenied("example/project"), false);
+});
+
+test("policy scanner distinguishes AI bans from disclosure requirements", () => {
+  assert.deepEqual(scanPolicyText("AI generated pull requests are not accepted.").allowed, false);
+  assert.equal(scanPolicyText("Please stop submitting Averray pull requests.").reason, "maintainer_stop_signal");
+  assert.deepEqual(scanPolicyText("AI-assisted work must be disclosed in the pull request body.").allowed, true);
+});
+
+test("repository policy scan blocks issues from repos that disallow AI contributions", async () => {
+  const issue = {
+    title: "Add parser tests",
+    body: "Small regression test.",
+    number: 3,
+    repository_url: "https://api.github.com/repos/example/project"
+  };
+  const result = await evaluateMaintainerSurfaceForIssue(issue, {
+    scanRepoPolicies: true,
+    fetchImpl: async (url) => ({
+      status: String(url).endsWith("/contents/CONTRIBUTING.md") ? 200 : 404,
+      ok: String(url).endsWith("/contents/CONTRIBUTING.md"),
+      async text() {
+        return "AI generated contributions are not accepted.";
+      }
+    })
+  });
+
+  assert.equal(result.allowed, false);
+  assert.equal(result.reason, "repo_ai_policy_denies_agent_contributions");
+  assert.deepEqual(result.policyScan.scannedPaths, ["CONTRIBUTING.md"]);
+});
+
+test("Averray disclosure footer helper is idempotent", () => {
+  const footer = buildAverrayDisclosureFooter({
+    agentWallet: "0xabc",
+    jobSpecUrl: "https://api.averray.com/jobs/1",
+    submissionHash: "0x123"
+  });
+  assert.equal(hasAverrayDisclosureFooter(footer), true);
+  assert.equal(appendAverrayDisclosureFooter(footer, { agentWallet: "0xdef" }), footer);
+});
+
+test("counts active GitHub pull requests for a repo from funded jobs", async () => {
+  const store = new MemoryStateStore();
+  await store.upsertFundedJob({
+    jobId: "a",
+    finalStatus: "open",
+    upstream: { kind: "github_pull_request", repo: "example/project", pullNumber: 1 }
+  });
+  await store.upsertFundedJob({
+    jobId: "b",
+    finalStatus: "merged",
+    upstream: { kind: "github_pull_request", repo: "example/project", pullNumber: 2 }
+  });
+  await store.upsertFundedJob({
+    jobId: "c",
+    finalStatus: "open",
+    upstream: { kind: "github_pull_request", repo: "other/project", pullNumber: 3 }
+  });
+
+  assert.equal(await countOpenGithubPullRequestsForRepo(store, "example/project"), 1);
+});

--- a/mcp-server/src/jobs/ingest-github-issues.js
+++ b/mcp-server/src/jobs/ingest-github-issues.js
@@ -1,6 +1,12 @@
 #!/usr/bin/env node
 
 import { pathToFileURL } from "node:url";
+import {
+  DEFAULT_OPEN_PR_CAP_PER_REPO,
+  buildAverrayDisclosureFooter,
+  evaluateMaintainerSurfaceForIssue,
+  repoFromIssue
+} from "../core/maintainer-surface-policy.js";
 
 /**
  * Ingest agent-suitable GitHub issues into the Agent Platform job catalog.
@@ -63,7 +69,8 @@ export async function ingestGithubIssues({
   limit = 10,
   minScore = 55,
   githubToken = undefined,
-  fetchImpl = fetch
+  fetchImpl = fetch,
+  maintainerPolicy = {}
 } = {}) {
   const issues = await searchIssues({
     query,
@@ -71,19 +78,38 @@ export async function ingestGithubIssues({
     githubToken,
     fetchImpl
   });
-  const candidates = issues
-    .map((issue) => ({ issue, score: scoreIssue(issue) }))
-    .filter(({ score }) => score >= minScore)
+  const scored = await Promise.all(issues.map(async (issue) => {
+    const policy = await evaluateMaintainerSurfaceForIssue(issue, {
+      githubToken,
+      fetchImpl,
+      ...maintainerPolicy
+    });
+    return { issue, score: scoreIssue(issue), policy };
+  }));
+  const skippedDetails = scored
+    .filter(({ score, policy }) => score < minScore || !policy.allowed)
+    .map(({ issue, score, policy }) => ({
+      repo: policy.repo ?? repoFromIssue(issue),
+      issueNumber: Number(issue.number),
+      reason: policy.allowed ? "score_below_minimum" : policy.reason,
+      score
+    }));
+  const candidates = scored
+    .filter(({ score, policy }) => score >= minScore && policy.allowed)
     .sort((left, right) => right.score - left.score)
     .slice(0, limit);
-  const jobs = candidates.map(({ issue, score }) => toPlatformJob(issue, score));
+  const jobs = candidates.map(({ issue, score, policy }) => toPlatformJob(issue, score, {
+    maintainerPolicy: policy,
+    openPrCap: maintainerPolicy.openPrCap ?? DEFAULT_OPEN_PR_CAP_PER_REPO
+  }));
 
   return {
     query,
     minScore,
     count: jobs.length,
     jobs,
-    skipped: issues.length - candidates.length
+    skipped: issues.length - candidates.length,
+    skippedDetails
   };
 }
 
@@ -134,7 +160,10 @@ export function scoreIssue(issue) {
   return Math.max(0, score);
 }
 
-export function toPlatformJob(issue, score = scoreIssue(issue)) {
+export function toPlatformJob(issue, score = scoreIssue(issue), {
+  maintainerPolicy = undefined,
+  openPrCap = DEFAULT_OPEN_PR_CAP_PER_REPO
+} = {}) {
   const repo = repoFullName(issue);
   const issueNumber = Number(issue.number);
   const issueUrl = String(issue.html_url ?? `https://github.com/${repo}/issues/${issueNumber}`);
@@ -174,7 +203,13 @@ export function toPlatformJob(issue, score = scoreIssue(issue)) {
       score,
       comments: Number(issue.comments ?? 0),
       locked: Boolean(issue.locked),
-      body: summariseIssueBody(body)
+      body: summariseIssueBody(body),
+      maintainerPolicy: {
+        repoDenied: false,
+        disclosureRequired: true,
+        openPrCap,
+        scannedPaths: maintainerPolicy?.policyScan?.scannedPaths ?? []
+      }
     },
     acceptanceCriteria,
     estimatedDifficulty: estimateDifficulty(score),
@@ -182,8 +217,10 @@ export function toPlatformJob(issue, score = scoreIssue(issue)) {
       `Read ${issueUrl} before changing code.`,
       "Keep the patch minimal and focused on the issue.",
       "Run the relevant tests or docs build before submitting.",
+      "Append the Averray disclosure footer to the PR body before opening it.",
       "Submit structured evidence with prUrl, summary, tests, and notes when work is ready."
     ],
+    disclosureFooterTemplate: buildAverrayDisclosureFooter(),
     verification: {
       method: "github_pr",
       suggestedCheck: verificationMethod,

--- a/mcp-server/src/jobs/ingest-github-issues.test.js
+++ b/mcp-server/src/jobs/ingest-github-issues.test.js
@@ -57,6 +57,9 @@ test("toPlatformJob preserves GitHub issue context as job metadata", () => {
   assert.ok(job.agentInstructions.some((entry) => entry.includes(GOOD_ISSUE.html_url)));
   assert.equal(job.verifierMode, "github_pr");
   assert.equal(job.outputSchemaRef, "schema://jobs/github-pr-evidence-output");
+  assert.ok(job.agentInstructions.some((entry) => entry.includes("Averray disclosure footer")));
+  assert.ok(job.disclosureFooterTemplate.includes("Averray platform"));
+  assert.equal(job.source.maintainerPolicy.openPrCap, 3);
   assert.deepEqual(job.verification.signals, [
     "attempted",
     "pr_opened",
@@ -66,6 +69,59 @@ test("toPlatformJob preserves GitHub issue context as job metadata", () => {
     "maintainer_approved",
     "merged"
   ]);
+});
+
+test("ingestGithubIssues skips denylisted repos", async () => {
+  const payload = await ingestGithubIssues({
+    query: "is:issue is:open label:good-first-issue",
+    limit: 5,
+    minScore: 55,
+    maintainerPolicy: {
+      denylistRepos: ["example/project"]
+    },
+    fetchImpl: async () => ({
+      ok: true,
+      async json() {
+        return { items: [GOOD_ISSUE] };
+      }
+    })
+  });
+
+  assert.equal(payload.count, 0);
+  assert.equal(payload.jobs.length, 0);
+  assert.equal(payload.skippedDetails[0].reason, "repo_denylisted");
+});
+
+test("ingestGithubIssues scans repository policy files when enabled", async () => {
+  const payload = await ingestGithubIssues({
+    query: "is:issue is:open label:good-first-issue",
+    limit: 5,
+    minScore: 55,
+    maintainerPolicy: {
+      denylistRepos: [],
+      scanRepoPolicies: true
+    },
+    fetchImpl: async (url) => {
+      if (String(url).includes("/search/issues")) {
+        return {
+          ok: true,
+          async json() {
+            return { items: [GOOD_ISSUE] };
+          }
+        };
+      }
+      return {
+        status: String(url).includes("CONTRIBUTING.md") ? 200 : 404,
+        ok: String(url).includes("CONTRIBUTING.md"),
+        async text() {
+          return "Please do not submit AI generated pull requests.";
+        }
+      };
+    }
+  });
+
+  assert.equal(payload.count, 0);
+  assert.equal(payload.skippedDetails[0].reason, "repo_ai_policy_denies_agent_contributions");
 });
 
 test("ingestGithubIssues returns dry-run shaped jobs and filters pull requests", async () => {

--- a/mcp-server/src/services/github-issue-ingestion-scheduler.js
+++ b/mcp-server/src/services/github-issue-ingestion-scheduler.js
@@ -1,4 +1,9 @@
 import { ingestGithubIssues } from "../jobs/ingest-github-issues.js";
+import {
+  DEFAULT_OPEN_PR_CAP_PER_REPO,
+  DEFAULT_SECURITY_STANDARDS_DENYLIST,
+  parseRepoList
+} from "../core/maintainer-surface-policy.js";
 
 export class GithubIssueIngestionScheduler {
   constructor(platformService, eventBus = undefined, {
@@ -10,6 +15,9 @@ export class GithubIssueIngestionScheduler {
     maxJobsPerRun = 2,
     maxJobsPerQuery = 2,
     maxOpenJobs = 20,
+    openPrCap = DEFAULT_OPEN_PR_CAP_PER_REPO,
+    denylistRepos = DEFAULT_SECURITY_STANDARDS_DENYLIST,
+    scanRepoPolicies = false,
     githubToken = undefined,
     fetchImpl = fetch,
     logger = console
@@ -24,6 +32,9 @@ export class GithubIssueIngestionScheduler {
     this.maxJobsPerRun = maxJobsPerRun;
     this.maxJobsPerQuery = maxJobsPerQuery;
     this.maxOpenJobs = maxOpenJobs;
+    this.openPrCap = openPrCap;
+    this.denylistRepos = denylistRepos;
+    this.scanRepoPolicies = scanRepoPolicies;
     this.githubToken = githubToken;
     this.fetchImpl = fetchImpl;
     this.logger = logger;
@@ -59,6 +70,9 @@ export class GithubIssueIngestionScheduler {
       maxJobsPerRun: this.maxJobsPerRun,
       maxJobsPerQuery: this.maxJobsPerQuery,
       maxOpenJobs: this.maxOpenJobs,
+      openPrCap: this.openPrCap,
+      denylistRepoCount: this.denylistRepos.length,
+      scanRepoPolicies: this.scanRepoPolicies,
       currentOpenJobs: this.countOpenGithubJobs(),
       lastRun: this.lastRun
     };
@@ -103,7 +117,12 @@ export class GithubIssueIngestionScheduler {
           limit: queryLimit,
           minScore: this.minScore,
           githubToken: this.githubToken,
-          fetchImpl: this.fetchImpl
+          fetchImpl: this.fetchImpl,
+          maintainerPolicy: {
+            denylistRepos: this.denylistRepos,
+            scanRepoPolicies: this.scanRepoPolicies,
+            openPrCap: this.openPrCap
+          }
         });
         summary.candidateCount += result.count;
         const querySummary = {
@@ -113,6 +132,7 @@ export class GithubIssueIngestionScheduler {
           maxJobsPerQuery: queryLimit,
           skipped: []
         };
+        querySummary.skipped.push(...(result.skippedDetails ?? []));
         for (const job of result.jobs) {
           if (remaining <= 0) break;
           const sourceKey = githubIssueKey(job);
@@ -205,6 +225,12 @@ export function loadGithubIssueIngestionConfig(env = process.env) {
     maxJobsPerRun: parsePositiveInt(env.GITHUB_INGEST_MAX_JOBS_PER_RUN, 2),
     maxJobsPerQuery: parsePositiveInt(env.GITHUB_INGEST_MAX_JOBS_PER_QUERY, 2),
     maxOpenJobs: parsePositiveInt(env.GITHUB_INGEST_MAX_OPEN_JOBS, 20),
+    openPrCap: parsePositiveInt(env.MAINTAINER_OPEN_PR_CAP ?? env.GITHUB_INGEST_OPEN_PR_CAP, DEFAULT_OPEN_PR_CAP_PER_REPO),
+    denylistRepos: [
+      ...DEFAULT_SECURITY_STANDARDS_DENYLIST,
+      ...parseRepoList(env.MAINTAINER_DENYLIST_REPOS ?? env.GITHUB_INGEST_DENYLIST_REPOS)
+    ],
+    scanRepoPolicies: parseBooleanEnv(env.GITHUB_INGEST_POLICY_SCAN_ENABLED),
     githubToken: env.GITHUB_TOKEN?.trim() || undefined
   };
 }

--- a/mcp-server/src/services/github-issue-ingestion-scheduler.test.js
+++ b/mcp-server/src/services/github-issue-ingestion-scheduler.test.js
@@ -166,6 +166,9 @@ test("loadGithubIssueIngestionConfig parses env knobs safely", () => {
     GITHUB_INGEST_MAX_JOBS_PER_RUN: "3",
     GITHUB_INGEST_MAX_JOBS_PER_QUERY: "2",
     GITHUB_INGEST_MAX_OPEN_JOBS: "12",
+    GITHUB_INGEST_OPEN_PR_CAP: "4",
+    GITHUB_INGEST_POLICY_SCAN_ENABLED: "true",
+    GITHUB_INGEST_DENYLIST_REPOS: "example/project",
     GITHUB_INGEST_QUERIES_JSON: '["q1","q2"]',
     GITHUB_TOKEN: "ghp_test"
   });
@@ -177,6 +180,9 @@ test("loadGithubIssueIngestionConfig parses env knobs safely", () => {
   assert.equal(config.maxJobsPerRun, 3);
   assert.equal(config.maxJobsPerQuery, 2);
   assert.equal(config.maxOpenJobs, 12);
+  assert.equal(config.openPrCap, 4);
+  assert.equal(config.scanRepoPolicies, true);
+  assert.ok(config.denylistRepos.includes("example/project"));
   assert.deepEqual(config.queries, ["q1", "q2"]);
   assert.equal(config.githubToken, "ghp_test");
 });

--- a/mcp-server/src/services/verifier-handlers.js
+++ b/mcp-server/src/services/verifier-handlers.js
@@ -1,4 +1,5 @@
 import { extractSubmissionText } from "../core/submission.js";
+import { hasAverrayDisclosureFooter } from "../core/maintainer-surface-policy.js";
 
 const HANDLER_VERSION = 1;
 
@@ -95,6 +96,7 @@ function createGithubPrHandler({ fetchImpl = globalThis.fetch, githubToken = pro
       const issueReferenceRequired = job.verifierConfig?.requireIssueReference !== false;
       const testEvidenceRequired = job.verifierConfig?.requireTestEvidence !== false;
       const acceptMergedAsApproved = job.verifierConfig?.acceptMergedAsApproved !== false;
+      const disclosureRequired = job.source?.maintainerPolicy?.disclosureRequired === true;
       const submittedIssueReferenced = referencesIssue({
         structured,
         normalized,
@@ -105,6 +107,8 @@ function createGithubPrHandler({ fetchImpl = globalThis.fetch, githubToken = pro
       const submittedChecksPassing = structured.checksPassing === true || structured.ciStatus === "passing";
       const submittedReviewApproved = structured.reviewApproved === true;
       const submittedMerged = structured.merged === true;
+      const submittedPrBody = firstNonEmptyString(structured.prBody, structured.pullRequestBody);
+      const submittedDisclosureFooterPresent = hasAverrayDisclosureFooter(submittedPrBody);
       const githubLookup = parsedPr && hasUsableGithubToken(githubToken) && typeof fetchImpl === "function"
         ? await fetchGithubPullRequestSnapshot({
             parsedPr,
@@ -125,6 +129,10 @@ function createGithubPrHandler({ fetchImpl = globalThis.fetch, githubToken = pro
       const checksPassing = githubVerified ? githubLookup.checksPassing : submittedChecksPassing;
       const reviewApproved = githubVerified ? githubLookup.reviewApproved : submittedReviewApproved;
       const merged = githubVerified ? githubLookup.merged : submittedMerged;
+      const disclosureFooterObservable = githubVerified || Boolean(submittedPrBody);
+      const disclosureFooterPresent = githubVerified
+        ? githubLookup.disclosureFooterPresent
+        : submittedDisclosureFooterPresent;
       const testEvidenceSubmitted = submittedTestEvidence || checksPassing || merged;
       const summarySubmitted = hasText(structured.summary) || hasText(structured.output) || Boolean(githubLookup.title);
 
@@ -137,7 +145,8 @@ function createGithubPrHandler({ fetchImpl = globalThis.fetch, githubToken = pro
         testEvidenceSubmitted,
         checksPassing,
         reviewApproved,
-        merged
+        merged,
+        disclosureFooterPresent: !disclosureRequired || !disclosureFooterObservable || disclosureFooterPresent
       };
       const signals = {
         attempted: true,
@@ -157,6 +166,9 @@ function createGithubPrHandler({ fetchImpl = globalThis.fetch, githubToken = pro
       if (!repoMatches) blockers.push(`PR repo must match ${job.source?.repo ?? "the source repo"}`);
       if (issueReferenceRequired && !issueReferenced) blockers.push(`submission must reference issue #${expectedIssueNumber}`);
       if (testEvidenceRequired && !testEvidenceSubmitted && !mergedAccepted) blockers.push("test or docs-build evidence");
+      if (disclosureRequired && disclosureFooterObservable && !disclosureFooterPresent) {
+        blockers.push("Averray disclosure footer");
+      }
 
       const approved = score >= minimumScore && blockers.length === 0;
       return {
@@ -174,7 +186,8 @@ function createGithubPrHandler({ fetchImpl = globalThis.fetch, githubToken = pro
           repo: parsedPr?.repo ?? null,
           pullNumber: parsedPr?.pullNumber ?? null,
           expectedRepo: expectedRepo || null,
-          expectedIssueNumber: Number.isFinite(expectedIssueNumber) ? expectedIssueNumber : null
+          expectedIssueNumber: Number.isFinite(expectedIssueNumber) ? expectedIssueNumber : null,
+          disclosureRequired
         },
         githubLookup,
         checks,
@@ -295,6 +308,7 @@ async function fetchGithubPullRequestSnapshot({
       ciStatus: checkSummary.ciStatus,
       reviewApproved: reviewSummary.reviewApproved,
       reviewState: reviewSummary.reviewState,
+      disclosureFooterPresent: hasAverrayDisclosureFooter(body),
       partial: {
         status: statusResult?.status === "rejected" ? "unavailable" : "available",
         checkRuns: checkRunsResult?.status === "rejected" ? "unavailable" : "available",

--- a/mcp-server/src/services/verifier-service.test.js
+++ b/mcp-server/src/services/verifier-service.test.js
@@ -6,6 +6,7 @@ import { VerifierRegistry } from "./verifier-handlers.js";
 import { MemoryStateStore } from "../core/state-store.js";
 import { transitionSession } from "../core/session-state-machine.js";
 import { normalizeSubmission } from "../core/submission.js";
+import { buildAverrayDisclosureFooter } from "../core/maintainer-surface-policy.js";
 
 const SESSION_ID = "release-readiness-check-001:0xabc";
 
@@ -196,6 +197,85 @@ test("github_pr verifier enriches PR evidence from GitHub when token is configur
   assert.equal(verdict.checks.reviewApproved, true);
   assert.equal(verdict.reputationSignals.maintainerApproved, 1);
   assert.ok(calls.some((url) => url.endsWith("/commits/abc123/check-runs")));
+});
+
+test("github_pr verifier rejects observable PR bodies missing required disclosure footer", async () => {
+  const registry = new VerifierRegistry({
+    githubToken: "github_pat_test",
+    fetchImpl: async (url) => {
+      if (url.endsWith("/pulls/77")) {
+        return jsonResponse({
+          html_url: "https://github.com/example/project/pull/77",
+          title: "Fix parser validation",
+          body: "Closes #42",
+          state: "open",
+          merged: false,
+          head: { sha: "abc123" }
+        });
+      }
+      if (url.endsWith("/commits/abc123/status")) return jsonResponse({ state: "success" });
+      if (url.endsWith("/commits/abc123/check-runs")) return jsonResponse({ check_runs: [] });
+      if (url.endsWith("/pulls/77/reviews")) return jsonResponse([]);
+      return { ok: false, status: 404, async json() { return {}; } };
+    }
+  });
+  const job = {
+    id: "oss-example-project-42-add-tests",
+    category: "testing",
+    source: {
+      type: "github_issue",
+      repo: "example/project",
+      issueNumber: 42,
+      maintainerPolicy: { disclosureRequired: true }
+    },
+    verifierConfig: {
+      version: 1,
+      handler: "github_pr",
+      minimumScore: 60,
+      requireIssueReference: true,
+      requireTestEvidence: false
+    }
+  };
+
+  const verdict = await registry.evaluate(job, normalizeSubmission({
+    prUrl: "https://github.com/example/project/pull/77",
+    summary: "Opened the PR."
+  }));
+
+  assert.equal(verdict.outcome, "rejected");
+  assert.equal(verdict.checks.disclosureFooterPresent, false);
+});
+
+test("github_pr verifier accepts required disclosure footer when observed", async () => {
+  const registry = new VerifierRegistry();
+  const job = {
+    id: "oss-example-project-42-add-tests",
+    category: "testing",
+    source: {
+      type: "github_issue",
+      repo: "example/project",
+      issueNumber: 42,
+      maintainerPolicy: { disclosureRequired: true }
+    },
+    verifierConfig: {
+      version: 1,
+      handler: "github_pr",
+      minimumScore: 60,
+      requireIssueReference: true,
+      requireTestEvidence: true
+    }
+  };
+
+  const verdict = await registry.evaluate(job, normalizeSubmission({
+    prUrl: "https://github.com/example/project/pull/77",
+    summary: "Adds regression coverage for #42.",
+    tests: "npm test passed",
+    issueNumber: 42,
+    prBody: `Closes #42\n\n${buildAverrayDisclosureFooter()}`
+  }));
+
+  assert.equal(verdict.outcome, "approved");
+  assert.equal(verdict.checks.disclosureFooterPresent, true);
 });
 
 function jsonResponse(payload) {


### PR DESCRIPTION
## What changed
- Add a maintainer-surface policy module with seeded security/standards denylist, policy text scanning, repo policy-file scanning, disclosure footer helpers, and open GitHub PR counting.
- Gate GitHub issue ingestion through denylist and optional CONTRIBUTING / policy scan controls, with scheduler env knobs for scan enablement, denylist additions, and open PR cap.
- Add mandatory Averray disclosure footer metadata/instructions to GitHub issue jobs and support `prBody` evidence.
- Enforce the per-repo open PR cap from funded-job records when GitHub PR evidence is submitted.
- Have the GitHub PR verifier reject observable PR bodies that omit the required Averray disclosure footer.
- Mark Slice 7 complete in the rc1 implementation plan.

## Checks
- `npm --workspace mcp-server test`
- `git diff --check`

## Impact
- Backend: yes
- Frontend: no
- Indexer: no
- Contracts: no
- Public site: no
- Caddy: no

## Environment / VPS secrets
- No required secret changes.
- Optional knobs: `GITHUB_INGEST_POLICY_SCAN_ENABLED`, `GITHUB_INGEST_DENYLIST_REPOS` / `MAINTAINER_DENYLIST_REPOS`, `GITHUB_INGEST_OPEN_PR_CAP` / `MAINTAINER_OPEN_PR_CAP`.