### PR TITLE
Add agent-friendly jobs listing filters

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -106,17 +106,92 @@
         ],
         "operationId": "listJobs",
         "summary": "List available jobs",
-        "description": "Returns all currently available platform jobs.",
+        "description": "Returns all currently available platform jobs. With no query parameters this preserves the legacy full-array response. Query parameters enable an agent-friendly compact, filtered, paginated envelope; use /jobs/definition for the full payload of one job.",
+        "parameters": [
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "description": "Filter by public source label or source type, for example wikipedia, open_data, osv, openapi, standards, or github.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "wikipedia"
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "required": false,
+            "description": "Filter by job category.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "wikipedia"
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "Filter by lifecycle state or status.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "open"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum compact rows to return when using agent-friendly query parameters.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Zero-based compact row offset for pagination.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "description": "Set to full to force the legacy full-array response even when query parameters are present.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "compact",
+                "full"
+              ]
+            }
+          }
+        ],
         "responses": {
           "200": {
-            "description": "A list of job definitions.",
+            "description": "A legacy list of full job definitions, or a compact paginated envelope when query filters are used.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Job"
-                  }
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Job"
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/CompactJobListResponse"
+                    }
+                  ]
                 },
                 "examples": {
                   "jobs": {
@@ -132,6 +207,40 @@
                         "rewardAmount": 3
                       }
                     ]
+                  },
+                  "compactWikipediaJobs": {
+                    "value": {
+                      "jobs": [
+                        {
+                          "id": "wiki-en-123-citation-repair-example",
+                          "title": "Repair Wikipedia citations: Example",
+                          "state": "open",
+                          "source": "wikipedia",
+                          "sourceType": "wikipedia_article",
+                          "category": "wikipedia",
+                          "jobType": "review",
+                          "tier": "starter",
+                          "stake": null,
+                          "reward": {
+                            "asset": "DOT",
+                            "amount": 3
+                          },
+                          "createdAt": "2026-04-28T10:00:00.000Z",
+                          "summary": "Review the article and return an editor-ready citation repair proposal.",
+                          "definitionUrl": "/jobs/definition?jobId=wiki-en-123-citation-repair-example"
+                        }
+                      ],
+                      "count": 1,
+                      "total": 1,
+                      "limit": 25,
+                      "offset": 0,
+                      "nextOffset": null,
+                      "filters": {
+                        "source": "wikipedia",
+                        "state": "open"
+                      },
+                      "compact": true
+                    }
                   }
                 }
               }
@@ -735,6 +844,152 @@
           }
         },
         "additionalProperties": true
+      },
+      "CompactJobListResponse": {
+        "type": "object",
+        "required": [
+          "jobs",
+          "count",
+          "total",
+          "limit",
+          "offset",
+          "nextOffset",
+          "filters",
+          "compact"
+        ],
+        "properties": {
+          "jobs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CompactJobRow"
+            }
+          },
+          "count": {
+            "type": "integer"
+          },
+          "total": {
+            "type": "integer"
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "offset": {
+            "type": "integer"
+          },
+          "nextOffset": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "filters": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "compact": {
+            "type": "boolean",
+            "const": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CompactJobRow": {
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "state",
+          "source",
+          "sourceType",
+          "category",
+          "jobType",
+          "tier",
+          "stake",
+          "reward",
+          "createdAt",
+          "summary",
+          "definitionUrl"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "sourceType": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "category": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "jobType": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "tier": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "stake": {
+            "type": [
+              "number",
+              "string",
+              "null"
+            ]
+          },
+          "reward": {
+            "type": "object",
+            "required": [
+              "asset",
+              "amount"
+            ],
+            "properties": {
+              "asset": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "amount": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          "createdAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "summary": {
+            "type": "string"
+          },
+          "definitionUrl": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
       },
       "JobLifecycle": {
         "type": "object",

--- a/mcp-server/src/protocols/http/jobs-response.js
+++ b/mcp-server/src/protocols/http/jobs-response.js
@@ -1,0 +1,164 @@
+const DEFAULT_AGENT_LIMIT = 25;
+const MAX_AGENT_LIMIT = 100;
+
+const SOURCE_LABELS = new Map([
+  ["github_issue", "github"],
+  ["open_data_dataset", "open_data"],
+  ["openapi_spec", "openapi"],
+  ["osv_advisory", "osv"],
+  ["standards_spec", "standards"],
+  ["wikipedia_article", "wikipedia"]
+]);
+
+const SOURCE_ALIASES = new Map([
+  ["wiki", "wikipedia"],
+  ["wikipedia_article", "wikipedia"],
+  ["open_data", "open_data"],
+  ["open_data_dataset", "open_data"],
+  ["data_gov", "open_data"],
+  ["datagov", "open_data"],
+  ["open_api", "openapi"],
+  ["openapi", "openapi"],
+  ["openapi_spec", "openapi"],
+  ["osv", "osv"],
+  ["osv_advisory", "osv"],
+  ["standards", "standards"],
+  ["standards_spec", "standards"],
+  ["github", "github"],
+  ["github_issue", "github"]
+]);
+
+export function buildPublicJobsResponse(jobs, searchParams) {
+  if (!usesAgentFriendlyQuery(searchParams)) {
+    return jobs;
+  }
+
+  const limit = parseLimit(searchParams.get("limit"), DEFAULT_AGENT_LIMIT, MAX_AGENT_LIMIT);
+  const offset = parseOffset(searchParams.get("offset"));
+  const filters = parseJobFilters(searchParams);
+  const filteredJobs = jobs.filter((job) => matchesFilters(job, filters));
+  const page = filteredJobs.slice(offset, offset + limit);
+
+  return {
+    jobs: page.map(toCompactJobRow),
+    count: page.length,
+    total: filteredJobs.length,
+    limit,
+    offset,
+    nextOffset: offset + limit < filteredJobs.length ? offset + limit : null,
+    filters,
+    compact: true
+  };
+}
+
+function usesAgentFriendlyQuery(searchParams) {
+  if (!searchParams || [...searchParams.keys()].length === 0) {
+    return false;
+  }
+  return normalizeToken(searchParams.get("format") ?? searchParams.get("shape")) !== "full";
+}
+
+function parseJobFilters(searchParams) {
+  return {
+    source: normalizeSourceFilter(searchParams.get("source")),
+    category: normalizeToken(searchParams.get("category")),
+    state: normalizeToken(searchParams.get("state"))
+  };
+}
+
+function matchesFilters(job, filters) {
+  if (filters.source && !sourceCandidates(job).has(filters.source)) {
+    return false;
+  }
+  if (filters.category && normalizeToken(job.category) !== filters.category) {
+    return false;
+  }
+  if (filters.state) {
+    const lifecycle = job.lifecycle ?? {};
+    const state = normalizeToken(lifecycle.state ?? lifecycle.status ?? "open");
+    const status = normalizeToken(lifecycle.status ?? state);
+    if (filters.state !== state && filters.state !== status) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function toCompactJobRow(job) {
+  const lifecycle = job.lifecycle ?? {};
+  const state = lifecycle.state ?? lifecycle.status ?? "open";
+  return {
+    id: job.id,
+    title: job.title,
+    state,
+    source: publicSourceLabel(job),
+    sourceType: job.source?.type ?? null,
+    category: job.category ?? null,
+    jobType: job.jobType ?? null,
+    tier: job.tier ?? null,
+    stake: job.claimStake ?? job.stake ?? null,
+    reward: {
+      asset: job.rewardAsset ?? null,
+      amount: job.rewardAmount ?? null
+    },
+    createdAt: lifecycle.createdAt ?? null,
+    summary: summarizeJob(job),
+    definitionUrl: `/jobs/definition?jobId=${encodeURIComponent(job.id)}`
+  };
+}
+
+function summarizeJob(job) {
+  const description = String(job.description ?? "").replace(/\s+/gu, " ").trim();
+  if (!description) {
+    return "";
+  }
+  return description.length > 180 ? `${description.slice(0, 177)}...` : description;
+}
+
+function sourceCandidates(job) {
+  const source = job.source ?? {};
+  return new Set([
+    publicSourceLabel(job),
+    normalizeSourceFilter(source.type),
+    normalizeSourceFilter(source.provider),
+    normalizeSourceFilter(source.project)
+  ].filter(Boolean));
+}
+
+function publicSourceLabel(job) {
+  const rawType = normalizeToken(job.source?.type);
+  if (SOURCE_LABELS.has(rawType)) {
+    return SOURCE_LABELS.get(rawType);
+  }
+  return normalizeSourceFilter(job.source?.provider)
+    ?? normalizeSourceFilter(job.source?.project)
+    ?? rawType
+    ?? normalizeToken(job.category)
+    ?? "unknown";
+}
+
+function normalizeSourceFilter(value) {
+  const token = normalizeToken(value);
+  return token ? SOURCE_ALIASES.get(token) ?? token : undefined;
+}
+
+function normalizeToken(value) {
+  const token = String(value ?? "").trim().toLowerCase().replace(/[-\s]+/gu, "_");
+  return token || undefined;
+}
+
+function parseLimit(value, fallback, max) {
+  const raw = Number(value ?? fallback);
+  if (!Number.isFinite(raw) || raw <= 0) {
+    return fallback;
+  }
+  return Math.min(Math.trunc(raw), max);
+}
+
+function parseOffset(value) {
+  const raw = Number(value ?? 0);
+  if (!Number.isFinite(raw) || raw < 0) {
+    return 0;
+  }
+  return Math.trunc(raw);
+}

--- a/mcp-server/src/protocols/http/jobs-response.test.js
+++ b/mcp-server/src/protocols/http/jobs-response.test.js
@@ -1,0 +1,108 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildPublicJobsResponse } from "./jobs-response.js";
+
+const JOBS = [
+  {
+    id: "wiki-en-123-citation-repair-example",
+    title: "Repair Wikipedia citations: Example",
+    description: "Review the article and return an editor-ready citation repair proposal.",
+    category: "wikipedia",
+    jobType: "review",
+    tier: "starter",
+    rewardAsset: "DOT",
+    rewardAmount: 3,
+    lifecycle: {
+      status: "open",
+      state: "open",
+      createdAt: "2026-04-28T10:00:00.000Z"
+    },
+    source: {
+      type: "wikipedia_article",
+      project: "wikipedia",
+      taskType: "citation_repair"
+    }
+  },
+  {
+    id: "openapi-averray-http-api",
+    title: "Audit OpenAPI quality: Averray HTTP API",
+    description: "Validate the public OpenAPI document.",
+    category: "api",
+    jobType: "review",
+    tier: "starter",
+    rewardAsset: "DOT",
+    rewardAmount: 3,
+    lifecycle: {
+      status: "open",
+      state: "open",
+      createdAt: "2026-04-28T11:00:00.000Z"
+    },
+    source: {
+      type: "openapi_spec",
+      provider: "averray"
+    }
+  }
+];
+
+test("public jobs response keeps bare array for legacy callers", () => {
+  const response = buildPublicJobsResponse(JOBS, new URLSearchParams());
+
+  assert.equal(response, JOBS);
+});
+
+test("public jobs response filters and compacts agent-friendly queries", () => {
+  const response = buildPublicJobsResponse(
+    JOBS,
+    new URLSearchParams("source=wikipedia&state=open&limit=25")
+  );
+
+  assert.equal(response.compact, true);
+  assert.equal(response.count, 1);
+  assert.equal(response.total, 1);
+  assert.equal(response.limit, 25);
+  assert.equal(response.nextOffset, null);
+  assert.deepEqual(response.filters, {
+    source: "wikipedia",
+    category: undefined,
+    state: "open"
+  });
+  assert.deepEqual(Object.keys(response.jobs[0]), [
+    "id",
+    "title",
+    "state",
+    "source",
+    "sourceType",
+    "category",
+    "jobType",
+    "tier",
+    "stake",
+    "reward",
+    "createdAt",
+    "summary",
+    "definitionUrl"
+  ]);
+  assert.equal(response.jobs[0].id, "wiki-en-123-citation-repair-example");
+  assert.equal(response.jobs[0].source, "wikipedia");
+  assert.equal(response.jobs[0].sourceType, "wikipedia_article");
+  assert.equal(response.jobs[0].definitionUrl, "/jobs/definition?jobId=wiki-en-123-citation-repair-example");
+});
+
+test("public jobs response supports category filters and pagination", () => {
+  const response = buildPublicJobsResponse(
+    JOBS,
+    new URLSearchParams("source=open-api&category=api&limit=1&offset=0")
+  );
+
+  assert.equal(response.count, 1);
+  assert.equal(response.total, 1);
+  assert.equal(response.jobs[0].id, "openapi-averray-http-api");
+  assert.equal(response.jobs[0].source, "openapi");
+  assert.equal(response.jobs[0].summary, "Validate the public OpenAPI document.");
+});
+
+test("public jobs response allows explicit full format with query params", () => {
+  const response = buildPublicJobsResponse(JOBS, new URLSearchParams("source=wikipedia&format=full"));
+
+  assert.equal(response, JOBS);
+});

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -45,6 +45,7 @@ import {
 } from "../../jobs/ingest-osv-advisories.js";
 import { ingestStandardsSpecs, parseSpecs as parseStandardsSpecs } from "../../jobs/ingest-standards-specs.js";
 import { ingestWikipediaMaintenance, parseCategories } from "../../jobs/ingest-wikipedia-maintenance.js";
+import { buildPublicJobsResponse } from "./jobs-response.js";
 
 const {
   platformService: service,
@@ -1338,7 +1339,7 @@ const server = createServer(async (request, response) => {
     }
 
     if (request.method === "GET" && pathname === "/jobs") {
-      return respond(response, 200, service.listJobs());
+      return respond(response, 200, buildPublicJobsResponse(service.listJobs(), url.searchParams));
     }
 
     if (request.method === "GET" && pathname === "/admin/jobs") {


### PR DESCRIPTION
## What changed
- Keep plain `GET /jobs` backward compatible as the existing full job array.
- Add compact, filtered, paginated responses when `/jobs` is called with query params such as `source=wikipedia&state=open&limit=25`.
- Include compact row fields for `id`, `title`, `state`, `source`, `category`, reward, summary, and `definitionUrl`.
- Document the compact response shape in OpenAPI.

Closes #79.

## Checks run
- node --test mcp-server/src/protocols/http/jobs-response.test.js
- node -e 'JSON.parse(require("fs").readFileSync("docs/api/openapi.json", "utf8")); console.log("openapi json ok")'\n- git diff --check\n- npm --workspace mcp-server test\n\n## Impact\n- Backend public jobs API adds optional query behavior.\n- Existing frontend callers of `/jobs` are unchanged because the no-query response remains a full array.\n- No indexer, Caddy, contracts, or public site behavior changes.\n\n## Frontend adaptation\n- No required frontend change for current screens.\n- Browser-agent UI can opt into `/jobs?source=wikipedia&state=open&limit=25` and handle `{ jobs, count, total, limit, offset, nextOffset, compact }`.\n\n## Env/VPS changes\n- None.