### PR TITLE
Validate XCM SetTopic request topics

### DIFF
--- a/contracts/XcmWrapper.sol
+++ b/contracts/XcmWrapper.sol
@@ -23,6 +23,8 @@ import {ReentrancyGuard} from "./lib/ReentrancyGuard.sol";
  */
 contract XcmWrapper is IXcmWrapper, ReentrancyGuard {
     address public constant DEFAULT_XCM_PRECOMPILE = 0x00000000000000000000000000000000000a0000;
+    bytes1 internal constant XCM_SET_TOPIC_INSTRUCTION = 0x2c;
+    uint256 internal constant XCM_SET_TOPIC_SUFFIX_LENGTH = 33;
 
     TreasuryPolicy public immutable policy;
     address public immutable override xcmPrecompile;
@@ -32,11 +34,7 @@ contract XcmWrapper is IXcmWrapper, ReentrancyGuard {
     mapping(bytes32 => bytes32) public requestMessageHash;
 
     event RequestPayloadStored(
-        bytes32 indexed requestId,
-        bytes32 destinationHash,
-        bytes32 messageHash,
-        uint64 refTime,
-        uint64 proofSize
+        bytes32 indexed requestId, bytes32 destinationHash, bytes32 messageHash, uint64 refTime, uint64 proofSize
     );
 
     error Unauthorized();
@@ -45,6 +43,7 @@ contract XcmWrapper is IXcmWrapper, ReentrancyGuard {
     error InvalidRequest();
     error InvalidStatus();
     error InvalidTransition();
+    error InvalidSetTopic();
     error PayloadMismatch();
 
     constructor(TreasuryPolicy policy_, address xcmPrecompile_) {
@@ -82,9 +81,7 @@ contract XcmWrapper is IXcmWrapper, ReentrancyGuard {
             return Weight({refTime: 0, proofSize: 0});
         }
 
-        (bool ok, bytes memory data) = xcmPrecompile.staticcall(
-            abi.encodeWithSignature("weighMessage(bytes)", message)
-        );
+        (bool ok, bytes memory data) = xcmPrecompile.staticcall(abi.encodeWithSignature("weighMessage(bytes)", message));
         if (!ok || data.length == 0) {
             return Weight({refTime: 0, proofSize: 0});
         }
@@ -101,6 +98,8 @@ contract XcmWrapper is IXcmWrapper, ReentrancyGuard {
         _validateRequestContext(context);
 
         requestId = previewRequestId(context);
+        _validateSetTopic(message, requestId);
+
         bytes32 destinationHash = keccak256(destination);
         bytes32 messageHash = keccak256(message);
 
@@ -145,10 +144,9 @@ contract XcmWrapper is IXcmWrapper, ReentrancyGuard {
         bytes32 remoteRef,
         bytes32 failureCode
     ) external override nonReentrant whenNotPaused onlyOwnerOrOperator {
-        if (
-            status == RequestStatus.Unknown ||
-            status == RequestStatus.Pending
-        ) revert InvalidStatus();
+        if (status == RequestStatus.Unknown || status == RequestStatus.Pending) {
+            revert InvalidStatus();
+        }
 
         RequestRecord storage record = requests[requestId];
         if (record.context.account == address(0)) revert UnknownRequest();
@@ -165,11 +163,8 @@ contract XcmWrapper is IXcmWrapper, ReentrancyGuard {
         }
 
         if (
-            record.status == status &&
-            record.settledAssets == settledAssets &&
-            record.settledShares == settledShares &&
-            record.remoteRef == remoteRef &&
-            record.failureCode == failureCode
+            record.status == status && record.settledAssets == settledAssets && record.settledShares == settledShares
+                && record.remoteRef == remoteRef && record.failureCode == failureCode
         ) {
             return;
         }
@@ -199,22 +194,27 @@ contract XcmWrapper is IXcmWrapper, ReentrancyGuard {
             context.shares,
             context.nonce
         );
-        emit RequestPayloadStored(
-            requestId,
-            destinationHash,
-            messageHash,
-            maxWeight.refTime,
-            maxWeight.proofSize
-        );
+        emit RequestPayloadStored(requestId, destinationHash, messageHash, maxWeight.refTime, maxWeight.proofSize);
     }
 
     function _validateRequestContext(RequestContext calldata context) internal pure {
         if (
-            context.strategyId == bytes32(0) ||
-            context.account == address(0) ||
-            context.asset == address(0) ||
-            context.recipient == address(0)
+            context.strategyId == bytes32(0) || context.account == address(0) || context.asset == address(0)
+                || context.recipient == address(0)
         ) revert InvalidRequest();
         if (context.assets == 0 && context.shares == 0) revert InvalidRequest();
+    }
+
+    function _validateSetTopic(bytes calldata message, bytes32 requestId) internal pure {
+        if (message.length < XCM_SET_TOPIC_SUFFIX_LENGTH) revert InvalidSetTopic();
+        if (message[message.length - XCM_SET_TOPIC_SUFFIX_LENGTH] != XCM_SET_TOPIC_INSTRUCTION) {
+            revert InvalidSetTopic();
+        }
+
+        bytes32 topic;
+        assembly {
+            topic := calldataload(add(message.offset, sub(message.length, 32)))
+        }
+        if (topic != requestId) revert InvalidSetTopic();
     }
 }

--- a/contracts/interfaces/IXcmWrapper.sol
+++ b/contracts/interfaces/IXcmWrapper.sol
@@ -112,8 +112,9 @@ interface IXcmWrapper {
      *
      * `destination` and `message` are kept as raw bytes because the
      * transport wrapper may evolve independently from strategy-specific
-     * message builders. Strategy adapters should still construct these at
-     * a higher abstraction layer than vault accounting.
+     * message builders. The message must still end with the canonical
+     * SCALE-encoded `SetTopic(requestId)` instruction so async outcomes can
+     * be correlated back to this request.
      */
     function queueRequest(
         RequestContext calldata context,

--- a/docs/RC1_IMPLEMENTATION_PLAN.md
+++ b/docs/RC1_IMPLEMENTATION_PLAN.md
@@ -34,8 +34,8 @@ The shortest path to a coherent rc1 launch is:
 
 ## Current Position
 
-As of the claim economics work, **slice 6: Claim Economics And Onboarding
-Waivers** is in progress.
+As of this branch, **slice 8: XCM SetTopic Validation** is implemented and
+ready for review.
 
 Completed and deployed in this lane:
 
@@ -58,7 +58,7 @@ Completed and deployed in this lane:
 Still open in the broader rc1 path:
 
 - scheduler/email hardening for weekly reports after enough real jobs exist
-- maintainer controls and XCM work in later slices
+- backend SCALE assembler and native XCM observer correlation in later slices
 
 ## PR Slices
 
@@ -182,7 +182,7 @@ generation are implemented as backend foundations.
 
 ### 6. Claim Economics And Onboarding Waivers
 
-**Status:** in progress; contract, backend, indexer, and session-surface
+**Status:** implemented; contract, backend, indexer, and session-surface
 foundations are implemented in this slice.
 
 **Goal:** implement the two claim-time primitives from the spec without
@@ -203,7 +203,7 @@ if new events are indexed.
 
 ### 7. Maintainer-Surface Controls
 
-**Status:** in progress; backend intake/submission/verifier foundations are
+**Status:** implemented; backend intake/submission/verifier foundations are
 implemented in this slice.
 
 **Goal:** reduce external ecosystem risk before public job sourcing scales.
@@ -221,17 +221,19 @@ surfaces controls.
 
 ### 8. XCM SetTopic Validation
 
+**Status:** implemented in this branch.
+
 **Goal:** prevent queuing XCM payloads that cannot be correlated to the local
 request.
 
 **Changes:**
 
-- Define the exact canonical SCALE message suffix produced by the backend
+- [x] Define the exact canonical SCALE message suffix produced by the backend
   assembler.
-- Add `XcmWrapper.queueRequest` validation that the message commits to
+- [x] Add `XcmWrapper.queueRequest` validation that the message commits to
   `SetTopic(requestId)`.
-- Add fixed test vectors for deposit and withdraw messages.
-- Keep async treasury endpoints admin-gated until the backend assembler exists.
+- [x] Add fixed test vectors for deposit and withdraw messages.
+- [x] Keep async treasury endpoints admin-gated until the backend assembler exists.
 
 **Checks:** `forge test`.
 

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -179,6 +179,16 @@ function ensureXcmRequestOwnership(record, auth) {
   }
 }
 
+function ensureAsyncXcmTreasuryAdmin(auth) {
+  if (hasRole(auth.claims, "admin")) {
+    return;
+  }
+  throw new AuthorizationError(
+    "Async XCM treasury actions require an admin role until the server-side XCM assembler is enabled.",
+    "async_xcm_admin_required"
+  );
+}
+
 function clientIp(request) {
   return extractClientKey(request, { trustProxy });
 }
@@ -2082,6 +2092,7 @@ const server = createServer(async (request, response) => {
       const amount = Number(payload?.amount ?? url.searchParams.get("amount") ?? "0");
       const strategy = findStrategyConfig(strategyId);
       if (strategy?.executionMode === "async_xcm") {
+        ensureAsyncXcmTreasuryAdmin(auth);
         const strategyAsset = resolveStrategyAssetSymbol(strategy);
         const options = parseAsyncTreasuryOptions(payload, url);
         const mutationKey = options.idempotencyKey
@@ -2120,6 +2131,7 @@ const server = createServer(async (request, response) => {
       const amount = Number(payload?.amount ?? url.searchParams.get("amount") ?? "0");
       const strategy = findStrategyConfig(strategyId);
       if (strategy?.executionMode === "async_xcm") {
+        ensureAsyncXcmTreasuryAdmin(auth);
         const strategyAsset = resolveStrategyAssetSymbol(strategy);
         const options = parseAsyncTreasuryOptions(payload, url, {
           defaultRecipient: gateway?.config?.agentAccountAddress

--- a/mcp-server/src/protocols/http/server.smoke.test.js
+++ b/mcp-server/src/protocols/http/server.smoke.test.js
@@ -24,7 +24,7 @@ const ADMIN_WALLET = "0x1111111111111111111111111111111111111111";
 const VERIFIER_WALLET = "0x2222222222222222222222222222222222222222";
 const STRANGER_WALLET = "0x3333333333333333333333333333333333333333";
 
-async function startServer(port) {
+async function startServer(port, envOverrides = {}) {
   const child = spawn(process.execPath, [serverPath], {
     env: {
       ...process.env,
@@ -39,7 +39,8 @@ async function startServer(port) {
       STATE_STORE_ALLOW_MEMORY: "1",
       LOG_LEVEL: "silent",
       RATE_LIMIT_AUTH_NONCE_LIMIT: "3",
-      RATE_LIMIT_AUTH_NONCE_WINDOW_SECONDS: "60"
+      RATE_LIMIT_AUTH_NONCE_WINDOW_SECONDS: "60",
+      ...envOverrides
     },
     stdio: "ignore",
     detached: false
@@ -97,6 +98,16 @@ function issueToken(wallet, { roles = [] } = {}) {
 async function runWithServer(fn) {
   const port = 19_000 + Math.floor(Math.random() * 1_000);
   const child = await startServer(port);
+  try {
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await stop(child);
+  }
+}
+
+async function runWithServerEnv(envOverrides, fn) {
+  const port = 19_000 + Math.floor(Math.random() * 1_000);
+  const child = await startServer(port, envOverrides);
   try {
     await fn(`http://127.0.0.1:${port}`);
   } finally {
@@ -179,6 +190,62 @@ test("http smoke: /admin/status returns recurring + maintenance data for admin t
     assert.equal(payload.recurring.templates[0].templateId, "weekly-digest");
     assert.equal(typeof payload.maintenance.release.checklistDoc, "string");
   });
+});
+
+test("http smoke: async XCM allocation requires admin role until assembler ships", { skip: !RUN }, async () => {
+  const asyncStrategyId = "0x56444f545f56315f4d4f434b0000000000000000000000000000000000000000";
+  await runWithServerEnv(
+    {
+      STRATEGIES_JSON: JSON.stringify([
+        {
+          strategyId: asyncStrategyId,
+          adapter: "0x1234567890123456789012345678901234567890",
+          kind: "polkadot_vdot",
+          executionMode: "async_xcm",
+          asset: "0xABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD"
+        }
+      ])
+    },
+    async (base) => {
+      const token = issueToken(STRANGER_WALLET, { roles: [] });
+      const response = await fetch(`${base}/account/allocate`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+        body: JSON.stringify({ strategyId: asyncStrategyId, amount: 1 })
+      });
+      assert.equal(response.status, 403);
+      const payload = await response.json();
+      assert.equal(payload.error, "async_xcm_admin_required");
+    }
+  );
+});
+
+test("http smoke: async XCM deallocation requires admin role until assembler ships", { skip: !RUN }, async () => {
+  const asyncStrategyId = "0x56444f545f56315f4d4f434b0000000000000000000000000000000000000000";
+  await runWithServerEnv(
+    {
+      STRATEGIES_JSON: JSON.stringify([
+        {
+          strategyId: asyncStrategyId,
+          adapter: "0x1234567890123456789012345678901234567890",
+          kind: "polkadot_vdot",
+          executionMode: "async_xcm",
+          asset: "0xABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD"
+        }
+      ])
+    },
+    async (base) => {
+      const token = issueToken(STRANGER_WALLET, { roles: [] });
+      const response = await fetch(`${base}/account/deallocate`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+        body: JSON.stringify({ strategyId: asyncStrategyId, amount: 1 })
+      });
+      assert.equal(response.status, 403);
+      const payload = await response.json();
+      assert.equal(payload.error, "async_xcm_admin_required");
+    }
+  );
 });
 
 test("http smoke: /auth/nonce returns 429 once the window limit is crossed", { skip: !RUN }, async () => {

--- a/test/AgentAccountAsyncStrategy.t.sol
+++ b/test/AgentAccountAsyncStrategy.t.sol
@@ -48,6 +48,7 @@ contract AgentAccountAsyncStrategyTest is Test {
 
     function testRequestStrategyDepositMovesFundsIntoPendingAsyncLane() public {
         IXcmWrapper.Weight memory maxWeight = IXcmWrapper.Weight({refTime: 10, proofSize: 5});
+        bytes32 requestId = _previewDepositRequestId(worker, 20 ether, 1);
 
         vm.prank(worker);
         accounts.requestStrategyDeposit(
@@ -56,7 +57,7 @@ contract AgentAccountAsyncStrategyTest is Test {
                 strategyId: STRATEGY_ID,
                 amount: 20 ether,
                 destination: hex"0102",
-                message: hex"0304",
+                message: _depositMessage(requestId),
                 maxWeight: maxWeight,
                 nonce: 1
             })
@@ -76,12 +77,7 @@ contract AgentAccountAsyncStrategyTest is Test {
         bytes32 requestId = _requestDeposit(20 ether, 1);
 
         accounts.settleStrategyRequest(
-            requestId,
-            IXcmWrapper.RequestStatus.Succeeded,
-            20 ether,
-            20 ether,
-            bytes32("REMOTE"),
-            bytes32(0)
+            requestId, IXcmWrapper.RequestStatus.Succeeded, 20 ether, 20 ether, bytes32("REMOTE"), bytes32(0)
         );
 
         (uint256 liquid,, uint256 strategyAllocated,,,) = accounts.positions(worker, address(dot));
@@ -96,14 +92,7 @@ contract AgentAccountAsyncStrategyTest is Test {
     function testStrategyDepositFailureRefundsLiquidBalance() public {
         bytes32 requestId = _requestDeposit(20 ether, 2);
 
-        accounts.settleStrategyRequest(
-            requestId,
-            IXcmWrapper.RequestStatus.Failed,
-            0,
-            0,
-            bytes32(0),
-            bytes32("FAILED")
-        );
+        accounts.settleStrategyRequest(requestId, IXcmWrapper.RequestStatus.Failed, 0, 0, bytes32(0), bytes32("FAILED"));
 
         (uint256 liquid,, uint256 strategyAllocated,,,) = accounts.positions(worker, address(dot));
         assertEq(liquid, WORKER_DEPOSIT);
@@ -118,6 +107,7 @@ contract AgentAccountAsyncStrategyTest is Test {
         _seedSettledDeposit(40 ether, 3);
 
         IXcmWrapper.Weight memory maxWeight = IXcmWrapper.Weight({refTime: 10, proofSize: 5});
+        bytes32 previewId = _previewWithdrawRequestId(worker, 15 ether, address(accounts), 4);
         vm.prank(worker);
         bytes32 requestId = accounts.requestStrategyWithdraw(
             worker,
@@ -126,22 +116,18 @@ contract AgentAccountAsyncStrategyTest is Test {
                 shares: 15 ether,
                 recipient: address(accounts),
                 destination: hex"0a",
-                message: hex"0b",
+                message: _withdrawMessage(previewId),
                 maxWeight: maxWeight,
                 nonce: 4
             })
         );
 
+        require(requestId == previewId, "WRONG_REQUEST_ID");
         assertEq(accounts.pendingStrategyWithdrawalShares(worker, STRATEGY_ID), 15 ether);
         assertEq(accounts.strategyShares(worker, STRATEGY_ID), 40 ether);
 
         accounts.settleStrategyRequest(
-            requestId,
-            IXcmWrapper.RequestStatus.Succeeded,
-            15 ether,
-            0,
-            bytes32("WITHDRAW"),
-            bytes32(0)
+            requestId, IXcmWrapper.RequestStatus.Succeeded, 15 ether, 0, bytes32("WITHDRAW"), bytes32(0)
         );
 
         (uint256 liquid,, uint256 strategyAllocated,,,) = accounts.positions(worker, address(dot));
@@ -157,6 +143,7 @@ contract AgentAccountAsyncStrategyTest is Test {
         _seedSettledDeposit(40 ether, 5);
 
         IXcmWrapper.Weight memory maxWeight = IXcmWrapper.Weight({refTime: 10, proofSize: 5});
+        bytes32 previewId = _previewWithdrawRequestId(worker, 10 ether, address(accounts), 6);
         vm.prank(worker);
         bytes32 requestId = accounts.requestStrategyWithdraw(
             worker,
@@ -165,19 +152,14 @@ contract AgentAccountAsyncStrategyTest is Test {
                 shares: 10 ether,
                 recipient: address(accounts),
                 destination: hex"0c",
-                message: hex"0d",
+                message: _withdrawMessage(previewId),
                 maxWeight: maxWeight,
                 nonce: 6
             })
         );
 
         accounts.settleStrategyRequest(
-            requestId,
-            IXcmWrapper.RequestStatus.Failed,
-            0,
-            0,
-            bytes32(0),
-            bytes32("WITHDRAW_FAILED")
+            requestId, IXcmWrapper.RequestStatus.Failed, 0, 0, bytes32(0), bytes32("WITHDRAW_FAILED")
         );
 
         (uint256 liquid,, uint256 strategyAllocated,,,) = accounts.positions(worker, address(dot));
@@ -192,17 +174,13 @@ contract AgentAccountAsyncStrategyTest is Test {
     function _seedSettledDeposit(uint256 amount, uint64 nonce) internal returns (bytes32 requestId) {
         requestId = _requestDeposit(amount, nonce);
         accounts.settleStrategyRequest(
-            requestId,
-            IXcmWrapper.RequestStatus.Succeeded,
-            amount,
-            amount,
-            bytes32("REMOTE"),
-            bytes32(0)
+            requestId, IXcmWrapper.RequestStatus.Succeeded, amount, amount, bytes32("REMOTE"), bytes32(0)
         );
     }
 
     function _requestDeposit(uint256 amount, uint64 nonce) internal returns (bytes32 requestId) {
         IXcmWrapper.Weight memory maxWeight = IXcmWrapper.Weight({refTime: 10, proofSize: 5});
+        bytes32 previewId = _previewDepositRequestId(worker, amount, nonce);
         vm.prank(worker);
         requestId = accounts.requestStrategyDeposit(
             worker,
@@ -210,10 +188,57 @@ contract AgentAccountAsyncStrategyTest is Test {
                 strategyId: STRATEGY_ID,
                 amount: amount,
                 destination: hex"0102",
-                message: hex"0304",
+                message: _depositMessage(previewId),
                 maxWeight: maxWeight,
                 nonce: nonce
             })
         );
+        require(requestId == previewId, "WRONG_REQUEST_ID");
+    }
+
+    function _previewDepositRequestId(address account, uint256 amount, uint64 nonce) internal view returns (bytes32) {
+        return wrapper.previewRequestId(
+            IXcmWrapper.RequestContext({
+                strategyId: STRATEGY_ID,
+                kind: IXcmWrapper.RequestKind.Deposit,
+                account: account,
+                asset: address(dot),
+                recipient: account,
+                assets: amount,
+                shares: 0,
+                nonce: nonce
+            })
+        );
+    }
+
+    function _previewWithdrawRequestId(address account, uint256 shares, address recipient, uint64 nonce)
+        internal
+        view
+        returns (bytes32)
+    {
+        return wrapper.previewRequestId(
+            IXcmWrapper.RequestContext({
+                strategyId: STRATEGY_ID,
+                kind: IXcmWrapper.RequestKind.Withdraw,
+                account: account,
+                asset: address(dot),
+                recipient: recipient,
+                assets: 0,
+                shares: shares,
+                nonce: nonce
+            })
+        );
+    }
+
+    function _depositMessage(bytes32 requestId) internal pure returns (bytes memory) {
+        return abi.encodePacked(
+            hex"0510000401000003008c86471301000003008c8647000d010101000000010100368e8759910dab756d344995f1d3c79374ca8f70066d3a709e48029f6bf0ee7e",
+            bytes1(0x2c),
+            requestId
+        );
+    }
+
+    function _withdrawMessage(bytes32 requestId) internal pure returns (bytes memory) {
+        return abi.encodePacked(hex"050800010203040506070809", bytes1(0x2c), requestId);
     }
 }

--- a/test/XcmVdotAdapter.t.sol
+++ b/test/XcmVdotAdapter.t.sol
@@ -37,16 +37,15 @@ contract XcmVdotAdapterTest is Test {
     }
 
     function testRequestDepositQueuesWrapperAndEscrowsAssets() public {
+        bytes32 previewId = _previewDepositRequestId(worker, 25 ether, 1);
+        bytes memory message = _depositMessage(previewId);
+
         vm.prank(operator);
         bytes32 requestId = adapter.requestDeposit(
-            worker,
-            25 ether,
-            hex"0102",
-            hex"aabbccdd",
-            IXcmWrapper.Weight({refTime: 11, proofSize: 22}),
-            1
+            worker, 25 ether, hex"0102", message, IXcmWrapper.Weight({refTime: 11, proofSize: 22}), 1
         );
 
+        require(requestId == previewId, "WRONG_REQUEST_ID");
         IXcmStrategyAdapter.AdapterRequest memory request = adapter.getAdapterRequest(requestId);
         IXcmWrapper.RequestRecord memory wrapperRequest = wrapper.getRequest(requestId);
 
@@ -63,22 +62,14 @@ contract XcmVdotAdapterTest is Test {
     }
 
     function testRequestDepositIsIdempotentForSamePayload() public {
+        bytes memory message = _depositMessage(_previewDepositRequestId(worker, 25 ether, 1));
+
         vm.startPrank(operator);
         bytes32 first = adapter.requestDeposit(
-            worker,
-            25 ether,
-            hex"0102",
-            hex"aabbccdd",
-            IXcmWrapper.Weight({refTime: 11, proofSize: 22}),
-            1
+            worker, 25 ether, hex"0102", message, IXcmWrapper.Weight({refTime: 11, proofSize: 22}), 1
         );
         bytes32 second = adapter.requestDeposit(
-            worker,
-            25 ether,
-            hex"0102",
-            hex"aabbccdd",
-            IXcmWrapper.Weight({refTime: 11, proofSize: 22}),
-            1
+            worker, 25 ether, hex"0102", message, IXcmWrapper.Weight({refTime: 11, proofSize: 22}), 1
         );
         vm.stopPrank();
 
@@ -88,24 +79,16 @@ contract XcmVdotAdapterTest is Test {
     }
 
     function testSettleDepositBooksSharesAndAssets() public {
+        bytes memory message = _depositMessage(_previewDepositRequestId(worker, 25 ether, 1));
+
         vm.prank(operator);
         bytes32 requestId = adapter.requestDeposit(
-            worker,
-            25 ether,
-            hex"0102",
-            hex"aabbccdd",
-            IXcmWrapper.Weight({refTime: 11, proofSize: 22}),
-            1
+            worker, 25 ether, hex"0102", message, IXcmWrapper.Weight({refTime: 11, proofSize: 22}), 1
         );
 
         vm.prank(operator);
         adapter.settleRequest(
-            requestId,
-            IXcmWrapper.RequestStatus.Succeeded,
-            25 ether,
-            23 ether,
-            keccak256("remote-deposit"),
-            bytes32(0)
+            requestId, IXcmWrapper.RequestStatus.Succeeded, 25 ether, 23 ether, keccak256("remote-deposit"), bytes32(0)
         );
 
         IXcmStrategyAdapter.AdapterRequest memory request = adapter.getAdapterRequest(requestId);
@@ -124,6 +107,7 @@ contract XcmVdotAdapterTest is Test {
 
     function testRequestWithdrawQueuesAndReservesShares() public {
         bytes32 depositRequestId = _seedSettledDeposit();
+        bytes32 previewId = _previewWithdrawRequestId(worker, 10 ether, recipient, 2);
 
         vm.prank(operator);
         bytes32 withdrawRequestId = adapter.requestWithdraw(
@@ -131,11 +115,12 @@ contract XcmVdotAdapterTest is Test {
             10 ether,
             recipient,
             hex"0304",
-            hex"deadbeef",
+            _withdrawMessage(previewId),
             IXcmWrapper.Weight({refTime: 5, proofSize: 6}),
             2
         );
 
+        require(withdrawRequestId == previewId, "WRONG_REQUEST_ID");
         IXcmStrategyAdapter.AdapterRequest memory request = adapter.getAdapterRequest(withdrawRequestId);
         IXcmWrapper.RequestRecord memory wrapperRequest = wrapper.getRequest(withdrawRequestId);
 
@@ -150,6 +135,7 @@ contract XcmVdotAdapterTest is Test {
 
     function testSettleWithdrawBurnsSharesAndPaysRecipient() public {
         _seedSettledDeposit();
+        bytes32 previewId = _previewWithdrawRequestId(worker, 10 ether, recipient, 2);
 
         vm.prank(operator);
         bytes32 withdrawRequestId = adapter.requestWithdraw(
@@ -157,7 +143,7 @@ contract XcmVdotAdapterTest is Test {
             10 ether,
             recipient,
             hex"0304",
-            hex"deadbeef",
+            _withdrawMessage(previewId),
             IXcmWrapper.Weight({refTime: 5, proofSize: 6}),
             2
         );
@@ -183,24 +169,62 @@ contract XcmVdotAdapterTest is Test {
     }
 
     function _seedSettledDeposit() internal returns (bytes32 requestId) {
+        bytes32 previewId = _previewDepositRequestId(worker, 25 ether, 1);
+
         vm.prank(operator);
         requestId = adapter.requestDeposit(
-            worker,
-            25 ether,
-            hex"0102",
-            hex"aabbccdd",
-            IXcmWrapper.Weight({refTime: 11, proofSize: 22}),
-            1
+            worker, 25 ether, hex"0102", _depositMessage(previewId), IXcmWrapper.Weight({refTime: 11, proofSize: 22}), 1
         );
 
         vm.prank(operator);
         adapter.settleRequest(
-            requestId,
-            IXcmWrapper.RequestStatus.Succeeded,
-            25 ether,
-            23 ether,
-            keccak256("remote-deposit"),
-            bytes32(0)
+            requestId, IXcmWrapper.RequestStatus.Succeeded, 25 ether, 23 ether, keccak256("remote-deposit"), bytes32(0)
         );
+    }
+
+    function _previewDepositRequestId(address account, uint256 assets, uint64 nonce) internal view returns (bytes32) {
+        return wrapper.previewRequestId(
+            IXcmWrapper.RequestContext({
+                strategyId: STRATEGY_ID,
+                kind: IXcmWrapper.RequestKind.Deposit,
+                account: account,
+                asset: address(asset),
+                recipient: account,
+                assets: assets,
+                shares: 0,
+                nonce: nonce
+            })
+        );
+    }
+
+    function _previewWithdrawRequestId(address account, uint256 shares, address withdrawRecipient, uint64 nonce)
+        internal
+        view
+        returns (bytes32)
+    {
+        return wrapper.previewRequestId(
+            IXcmWrapper.RequestContext({
+                strategyId: STRATEGY_ID,
+                kind: IXcmWrapper.RequestKind.Withdraw,
+                account: account,
+                asset: address(asset),
+                recipient: withdrawRecipient,
+                assets: 0,
+                shares: shares,
+                nonce: nonce
+            })
+        );
+    }
+
+    function _depositMessage(bytes32 requestId) internal pure returns (bytes memory) {
+        return abi.encodePacked(
+            hex"0510000401000003008c86471301000003008c8647000d010101000000010100368e8759910dab756d344995f1d3c79374ca8f70066d3a709e48029f6bf0ee7e",
+            bytes1(0x2c),
+            requestId
+        );
+    }
+
+    function _withdrawMessage(bytes32 requestId) internal pure returns (bytes memory) {
+        return abi.encodePacked(hex"050800010203040506070809", bytes1(0x2c), requestId);
     }
 }

--- a/test/XcmWrapper.t.sol
+++ b/test/XcmWrapper.t.sol
@@ -9,10 +9,7 @@ import {XcmWrapper} from "../contracts/XcmWrapper.sol";
 
 contract MockXcmPrecompile {
     function weighMessage(bytes calldata message) external pure returns (IXcmWrapper.Weight memory) {
-        return IXcmWrapper.Weight({
-            refTime: uint64(message.length * 10),
-            proofSize: uint64(message.length)
-        });
+        return IXcmWrapper.Weight({refTime: uint64(message.length * 10), proofSize: uint64(message.length)});
     }
 }
 
@@ -38,15 +35,14 @@ contract XcmWrapperTest is Test {
 
     function testQueueRequestPersistsPendingRecord() public {
         IXcmWrapper.RequestContext memory context = _context(25 ether, 0, 1);
+        bytes32 previewId = wrapper.previewRequestId(context);
+        bytes memory message = _depositMessage(previewId);
 
         vm.prank(operator);
-        bytes32 requestId = wrapper.queueRequest(
-            context,
-            hex"0102",
-            hex"aabbccdd",
-            IXcmWrapper.Weight({refTime: 111, proofSize: 222})
-        );
+        bytes32 requestId =
+            wrapper.queueRequest(context, hex"0102", message, IXcmWrapper.Weight({refTime: 111, proofSize: 222}));
 
+        require(requestId == previewId, "WRONG_REQUEST_ID");
         IXcmWrapper.RequestRecord memory record = wrapper.getRequest(requestId);
         assertEq(uint256(record.status), uint256(IXcmWrapper.RequestStatus.Pending));
         require(record.context.strategyId == STRATEGY_ID, "WRONG_STRATEGY_ID");
@@ -57,25 +53,18 @@ contract XcmWrapperTest is Test {
         assertEq(record.context.shares, 0);
         assertEq(record.context.nonce, 1);
         require(wrapper.requestDestinationHash(requestId) == keccak256(hex"0102"), "WRONG_DEST_HASH");
-        require(wrapper.requestMessageHash(requestId) == keccak256(hex"aabbccdd"), "WRONG_MESSAGE_HASH");
+        require(wrapper.requestMessageHash(requestId) == keccak256(message), "WRONG_MESSAGE_HASH");
     }
 
     function testQueueRequestIsIdempotentForSamePayload() public {
         IXcmWrapper.RequestContext memory context = _context(25 ether, 0, 1);
+        bytes memory message = _depositMessage(wrapper.previewRequestId(context));
 
         vm.startPrank(operator);
-        bytes32 first = wrapper.queueRequest(
-            context,
-            hex"0102",
-            hex"aabbccdd",
-            IXcmWrapper.Weight({refTime: 1, proofSize: 2})
-        );
-        bytes32 second = wrapper.queueRequest(
-            context,
-            hex"0102",
-            hex"aabbccdd",
-            IXcmWrapper.Weight({refTime: 1, proofSize: 2})
-        );
+        bytes32 first =
+            wrapper.queueRequest(context, hex"0102", message, IXcmWrapper.Weight({refTime: 1, proofSize: 2}));
+        bytes32 second =
+            wrapper.queueRequest(context, hex"0102", message, IXcmWrapper.Weight({refTime: 1, proofSize: 2}));
         vm.stopPrank();
 
         require(first == second, "request id mismatch");
@@ -85,43 +74,68 @@ contract XcmWrapperTest is Test {
 
     function testQueueRequestRejectsPayloadMismatchForSameContext() public {
         IXcmWrapper.RequestContext memory context = _context(25 ether, 0, 1);
+        bytes32 requestId = wrapper.previewRequestId(context);
 
         vm.prank(operator);
         wrapper.queueRequest(
-            context,
-            hex"0102",
-            hex"aabbccdd",
-            IXcmWrapper.Weight({refTime: 1, proofSize: 2})
+            context, hex"0102", _depositMessage(requestId), IXcmWrapper.Weight({refTime: 1, proofSize: 2})
         );
         vm.prank(operator);
-        (bool ok, bytes memory data) = address(wrapper).call(
-            abi.encodeCall(
-                wrapper.queueRequest,
-                (context, hex"0102", hex"deadbeef", IXcmWrapper.Weight({refTime: 1, proofSize: 2}))
-            )
-        );
+        (bool ok, bytes memory data) = address(wrapper)
+            .call(
+                abi.encodeCall(
+                    wrapper.queueRequest,
+                    (context, hex"0102", _withdrawMessage(requestId), IXcmWrapper.Weight({refTime: 1, proofSize: 2}))
+                )
+            );
         _assertCustomError(ok, data, XcmWrapper.PayloadMismatch.selector);
+    }
+
+    function testQueueRequestRejectsMissingSetTopic() public {
+        IXcmWrapper.RequestContext memory context = _context(25 ether, 0, 1);
+
+        vm.prank(operator);
+        (bool ok, bytes memory data) = address(wrapper)
+            .call(
+                abi.encodeCall(
+                    wrapper.queueRequest,
+                    (context, hex"0102", hex"aabbccdd", IXcmWrapper.Weight({refTime: 1, proofSize: 2}))
+                )
+            );
+        _assertCustomError(ok, data, XcmWrapper.InvalidSetTopic.selector);
+    }
+
+    function testQueueRequestRejectsSetTopicForDifferentRequest() public {
+        IXcmWrapper.RequestContext memory context = _context(25 ether, 0, 1);
+        IXcmWrapper.RequestContext memory otherContext = _context(25 ether, 0, 2);
+
+        vm.prank(operator);
+        (bool ok, bytes memory data) = address(wrapper)
+            .call(
+                abi.encodeCall(
+                    wrapper.queueRequest,
+                    (
+                        context,
+                        hex"0102",
+                        _depositMessage(wrapper.previewRequestId(otherContext)),
+                        IXcmWrapper.Weight({refTime: 1, proofSize: 2})
+                    )
+                )
+            );
+        _assertCustomError(ok, data, XcmWrapper.InvalidSetTopic.selector);
     }
 
     function testFinalizeRequestStoresTerminalOutcome() public {
         IXcmWrapper.RequestContext memory context = _context(25 ether, 0, 1);
+        bytes memory message = _depositMessage(wrapper.previewRequestId(context));
 
         vm.prank(operator);
-        bytes32 requestId = wrapper.queueRequest(
-            context,
-            hex"0102",
-            hex"aabbccdd",
-            IXcmWrapper.Weight({refTime: 1, proofSize: 2})
-        );
+        bytes32 requestId =
+            wrapper.queueRequest(context, hex"0102", message, IXcmWrapper.Weight({refTime: 1, proofSize: 2}));
 
         vm.prank(operator);
         wrapper.finalizeRequest(
-            requestId,
-            IXcmWrapper.RequestStatus.Succeeded,
-            25 ether,
-            23 ether,
-            keccak256("remote-ref"),
-            bytes32(0)
+            requestId, IXcmWrapper.RequestStatus.Succeeded, 25 ether, 23 ether, keccak256("remote-ref"), bytes32(0)
         );
 
         IXcmWrapper.RequestRecord memory record = wrapper.getRequest(requestId);
@@ -133,32 +147,15 @@ contract XcmWrapperTest is Test {
 
     function testFinalizeIsIdempotentForRepeatedSameSettlement() public {
         IXcmWrapper.RequestContext memory context = _context(25 ether, 0, 1);
+        bytes memory message = _depositMessage(wrapper.previewRequestId(context));
 
         vm.prank(operator);
-        bytes32 requestId = wrapper.queueRequest(
-            context,
-            hex"0102",
-            hex"aabbccdd",
-            IXcmWrapper.Weight({refTime: 1, proofSize: 2})
-        );
+        bytes32 requestId =
+            wrapper.queueRequest(context, hex"0102", message, IXcmWrapper.Weight({refTime: 1, proofSize: 2}));
 
         vm.startPrank(operator);
-        wrapper.finalizeRequest(
-            requestId,
-            IXcmWrapper.RequestStatus.Failed,
-            0,
-            0,
-            bytes32(0),
-            bytes32("XCM_FAIL")
-        );
-        wrapper.finalizeRequest(
-            requestId,
-            IXcmWrapper.RequestStatus.Failed,
-            0,
-            0,
-            bytes32(0),
-            bytes32("XCM_FAIL")
-        );
+        wrapper.finalizeRequest(requestId, IXcmWrapper.RequestStatus.Failed, 0, 0, bytes32(0), bytes32("XCM_FAIL"));
+        wrapper.finalizeRequest(requestId, IXcmWrapper.RequestStatus.Failed, 0, 0, bytes32(0), bytes32("XCM_FAIL"));
         vm.stopPrank();
 
         IXcmWrapper.RequestRecord memory record = wrapper.getRequest(requestId);
@@ -168,52 +165,51 @@ contract XcmWrapperTest is Test {
 
     function testOnlyOwnerOrOperatorCanQueueOrFinalize() public {
         IXcmWrapper.RequestContext memory context = _context(25 ether, 0, 1);
+        bytes memory message = _depositMessage(wrapper.previewRequestId(context));
 
         vm.prank(stranger);
-        (bool queueOk, bytes memory queueData) = address(wrapper).call(
-            abi.encodeCall(
-                wrapper.queueRequest,
-                (context, hex"0102", hex"aabbccdd", IXcmWrapper.Weight({refTime: 1, proofSize: 2}))
-            )
-        );
+        (bool queueOk, bytes memory queueData) = address(wrapper)
+            .call(
+                abi.encodeCall(
+                    wrapper.queueRequest, (context, hex"0102", message, IXcmWrapper.Weight({refTime: 1, proofSize: 2}))
+                )
+            );
         _assertCustomError(queueOk, queueData, XcmWrapper.Unauthorized.selector);
 
         vm.prank(operator);
-        bytes32 requestId = wrapper.queueRequest(
-            context,
-            hex"0102",
-            hex"aabbccdd",
-            IXcmWrapper.Weight({refTime: 1, proofSize: 2})
-        );
+        bytes32 requestId =
+            wrapper.queueRequest(context, hex"0102", message, IXcmWrapper.Weight({refTime: 1, proofSize: 2}));
 
         vm.prank(stranger);
-        (bool finalizeOk, bytes memory finalizeData) = address(wrapper).call(
-            abi.encodeCall(
-                wrapper.finalizeRequest,
-                (
-                    requestId,
-                    IXcmWrapper.RequestStatus.Succeeded,
-                    25 ether,
-                    23 ether,
-                    keccak256("remote-ref"),
-                    bytes32(0)
+        (bool finalizeOk, bytes memory finalizeData) = address(wrapper)
+            .call(
+                abi.encodeCall(
+                    wrapper.finalizeRequest,
+                    (
+                        requestId,
+                        IXcmWrapper.RequestStatus.Succeeded,
+                        25 ether,
+                        23 ether,
+                        keccak256("remote-ref"),
+                        bytes32(0)
+                    )
                 )
-            )
-        );
+            );
         _assertCustomError(finalizeOk, finalizeData, XcmWrapper.Unauthorized.selector);
     }
 
     function testPauseBlocksQueueAndFinalize() public {
         IXcmWrapper.RequestContext memory context = _context(25 ether, 0, 1);
+        bytes memory message = _depositMessage(wrapper.previewRequestId(context));
         policy.setPaused(true);
 
         vm.prank(operator);
-        (bool ok, bytes memory data) = address(wrapper).call(
-            abi.encodeCall(
-                wrapper.queueRequest,
-                (context, hex"0102", hex"aabbccdd", IXcmWrapper.Weight({refTime: 1, proofSize: 2}))
-            )
-        );
+        (bool ok, bytes memory data) = address(wrapper)
+            .call(
+                abi.encodeCall(
+                    wrapper.queueRequest, (context, hex"0102", message, IXcmWrapper.Weight({refTime: 1, proofSize: 2}))
+                )
+            );
         _assertCustomError(ok, data, XcmWrapper.ProtocolPaused.selector);
     }
 
@@ -238,6 +234,18 @@ contract XcmWrapperTest is Test {
             shares: shares,
             nonce: nonce
         });
+    }
+
+    function _depositMessage(bytes32 requestId) internal pure returns (bytes memory) {
+        return abi.encodePacked(
+            hex"0510000401000003008c86471301000003008c8647000d010101000000010100368e8759910dab756d344995f1d3c79374ca8f70066d3a709e48029f6bf0ee7e",
+            bytes1(0x2c),
+            requestId
+        );
+    }
+
+    function _withdrawMessage(bytes32 requestId) internal pure returns (bytes memory) {
+        return abi.encodePacked(hex"050800010203040506070809", bytes1(0x2c), requestId);
     }
 
     function _assertCustomError(bool ok, bytes memory data, bytes4 selector) internal pure {


### PR DESCRIPTION
## What changed
- Add `XcmWrapper.queueRequest` validation that queued XCM messages end with the canonical `SetTopic(requestId)` suffix.
- Update async XCM contract tests and adapter/account tests to use deterministic request-id topics for deposit and withdraw messages.
- Keep async XCM treasury allocation/deallocation admin-only until the backend assembler exists, with HTTP smoke coverage.
- Mark Slice 8 as implemented in `docs/RC1_IMPLEMENTATION_PLAN.md`.

## Checks run
- `forge test -vv`
- `npm --workspace mcp-server test`
- `RPC_URL= DWELLER_RPC_URL= POLKADOT_RPC_URL= SIGNER_PRIVATE_KEY= AGENT_ACCOUNT_ADDRESS= ESCROW_CORE_ADDRESS= REPUTATION_SBT_ADDRESS= SUPPORTED_ASSETS= SUPPORTED_ASSETS_JSON= TREASURY_POLICY_ADDRESS= REDIS_URL= RUN_HTTP_SMOKE=1 node --test mcp-server/src/protocols/http/server.smoke.test.js`
- `git diff --check`

## Impact
- Affects contracts and backend HTTP authorization for async XCM treasury paths.
- No frontend, indexer, Caddy, generated static output, or public site changes.
- Contract behavior only takes effect after the rc1 contract redeploy; normal production deploy does not deploy smart contracts.

## Env / deploy notes
- No new env vars or VPS secret changes.
- Async XCM `/account/allocate` and `/account/deallocate` remain admin-gated for `executionMode: "async_xcm"` until the server-side assembler replaces raw caller-supplied XCM bytes.
