### PR TITLE
Runs source filter + URL params + semantic detail block (closes #77)

### DIFF
--- a/app/app/(authed)/runs/page.tsx
+++ b/app/app/(authed)/runs/page.tsx
@@ -1,12 +1,19 @@
 "use client";
 
-import { Suspense, useEffect, useMemo, useState } from "react";
-import { useSearchParams } from "next/navigation";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { RunsTopbar } from "@/components/runs/RunsTopbar";
 import {
   QueueBar,
   type QueueFilter,
 } from "@/components/runs/QueueBar";
+import {
+  buildSourceFilters,
+  parseSourceFilter,
+  rowSourceKind,
+  SourceFilterBar,
+  type SourceFilter,
+} from "@/components/runs/SourceFilter";
 import { RunQueueTable } from "@/components/runs/RunQueueTable";
 import { RecommendationRail } from "@/components/runs/RecommendationRail";
 import { LoadedRunView } from "@/components/runs/LoadedRunView";
@@ -49,12 +56,73 @@ export default function RunsPage() {
   );
 }
 
+// State filters that are valid as `?state=` URL params. Anything else
+// falls back to "all" so a malformed link doesn't surface a broken
+// filter chip.
+const STATE_VALUES: QueueFilter[] = [
+  "all",
+  "ready",
+  "claimed",
+  "submitted",
+  "disputed",
+  "settled",
+];
+
+function parseStateFilter(value: string | null | undefined): QueueFilter {
+  if (!value) return "all";
+  return STATE_VALUES.includes(value as QueueFilter)
+    ? (value as QueueFilter)
+    : "all";
+}
+
 function RunsPageInner() {
   const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
   const runParam = searchParams?.get("run") ?? null;
-  const [activeFilter, setActiveFilter] = useState<QueueFilter>("all");
+  const initialState = parseStateFilter(searchParams?.get("state"));
+  const initialSource = parseSourceFilter(searchParams?.get("source"));
+  const [activeFilter, setActiveFilter] = useState<QueueFilter>(initialState);
+  const [activeSource, setActiveSource] = useState<SourceFilter>(initialSource);
   const [showClosed, setShowClosed] = useState(false);
   const [selectedId, setSelectedId] = useState<string>(runParam ?? "run-2742");
+
+  // Sync filter state into the URL query string so links are
+  // shareable and a browser agent can deep-link to a narrowed
+  // marketplace view (e.g. `/runs?source=wikipedia&state=ready`).
+  // We use `replace` rather than `push` so toggling filters doesn't
+  // pollute the back stack.
+  const syncQuery = useCallback(
+    (next: { state?: QueueFilter; source?: SourceFilter }) => {
+      if (!pathname) return;
+      const params = new URLSearchParams(searchParams?.toString() ?? "");
+      const stateValue = next.state ?? activeFilter;
+      const sourceValue = next.source ?? activeSource;
+      if (stateValue === "all") params.delete("state");
+      else params.set("state", stateValue);
+      if (sourceValue === "all") params.delete("source");
+      else params.set("source", sourceValue);
+      const qs = params.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    },
+    [activeFilter, activeSource, pathname, router, searchParams]
+  );
+
+  const onStateChange = useCallback(
+    (next: QueueFilter) => {
+      setActiveFilter(next);
+      syncQuery({ state: next });
+    },
+    [syncQuery]
+  );
+
+  const onSourceChange = useCallback(
+    (next: SourceFilter) => {
+      setActiveSource(next);
+      syncQuery({ source: next });
+    },
+    [syncQuery]
+  );
 
   const jobs = useJobs();
   const adminJobs = useAdminJobs();
@@ -69,6 +137,7 @@ function RunsPageInner() {
   const liveRows = useMemo(() => buildRunRows(sourceForRows), [sourceForRows]);
   const rows = liveRows.length ? liveRows : FIXTURE_RUN_ROWS;
   const filters = useMemo(() => buildRunFilters(rows), [rows]);
+  const sourceFilters = useMemo(() => buildSourceFilters(rows), [rows]);
   const recommendationCards = useMemo(() => {
     const liveCards = buildRecommendationCards(recommendations.data, jobs.data);
     return liveCards.length ? liveCards : FIXTURE_RECOMMENDATIONS;
@@ -101,8 +170,11 @@ function RunsPageInner() {
     if (activeFilter !== "all") {
       next = next.filter((r) => r.state === activeFilter);
     }
+    if (activeSource !== "all") {
+      next = next.filter((r) => rowSourceKind(r) === activeSource);
+    }
     return next;
-  }, [activeFilter, rows, showClosed]);
+  }, [activeFilter, activeSource, rows, showClosed]);
 
   const closedRowCount = rows.filter(
     (r) => r.lifecycle && r.lifecycle.state !== "open"
@@ -205,7 +277,12 @@ function RunsPageInner() {
       <QueueBar
         filters={filters.length ? filters : FIXTURE_FILTERS}
         active={activeFilter}
-        onChange={setActiveFilter}
+        onChange={onStateChange}
+      />
+      <SourceFilterBar
+        filters={sourceFilters}
+        active={activeSource}
+        onChange={onSourceChange}
       />
       {closedRowCount > 0 || showClosed ? (
         <div className="flex items-center justify-between rounded-[10px] border border-[var(--avy-line-soft)] bg-[var(--avy-paper)] px-3.5 py-2 font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]">

--- a/app/components/runs/LoadedRunView.tsx
+++ b/app/components/runs/LoadedRunView.tsx
@@ -5,6 +5,7 @@ import { mutate } from "swr";
 import { LoadedRunPanel } from "./LoadedRunPanel";
 import { LifecycleRail } from "./LifecycleRail";
 import { LifecycleActionBar } from "./LifecycleActionBar";
+import { RunSemanticBlock } from "./RunSemanticBlock";
 import {
   ReceiptPreviewDrawer,
   type ReceiptPreviewDraft,
@@ -142,6 +143,16 @@ export function LoadedRunView({
 
   return (
     <div className="flex flex-col gap-3.5">
+      {/*
+       * The standalone detail page (showLifecycle === true) is the
+       * URL a browser-only agent receives when an upstream system
+       * links into Averray. Render the plain-HTML semantic block at
+       * the very top so the agent can scrape source / category /
+       * state / reward / job ID without OCRing the panel below. The
+       * queue page hides this block — it would just repeat the row
+       * the operator already clicked.
+       */}
+      {showLifecycle ? <RunSemanticBlock row={loadedRow} /> : null}
       <LifecycleActionBar
         jobId={loadedRow.id}
         lifecycle={loadedRow.lifecycle}

--- a/app/components/runs/RunSemanticBlock.tsx
+++ b/app/components/runs/RunSemanticBlock.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import type { RunRow } from "./RunQueueTable";
+
+/**
+ * Plain-HTML semantic block for `/runs/detail`. Lists source,
+ * category, state, reward, job ID, and (when available) the
+ * upstream identifier in a definition-list shape so a browser
+ * agent can scrape the row's identity without OCRing the screen.
+ *
+ * Intentionally text-heavy and visually quiet so it sits above the
+ * full LoadedRunPanel without competing for attention. The pretty
+ * panel still owns the visual story; this block exists for
+ * agent-readiness (issue #77) and for accessibility readers.
+ */
+export interface RunSemanticBlockProps {
+  row: RunRow;
+}
+
+export function RunSemanticBlock({ row }: RunSemanticBlockProps) {
+  const fields = describeRow(row);
+  return (
+    <section
+      aria-label="Run summary"
+      className="rounded-[10px] border border-[var(--avy-line)] bg-[var(--avy-paper)] p-[0.85rem_1.05rem] shadow-[var(--shadow-card)]"
+    >
+      <h2
+        className="mb-2 font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase text-[var(--avy-muted)]"
+        style={{ letterSpacing: "0.14em" }}
+      >
+        Run summary
+      </h2>
+      <dl className="grid grid-cols-1 gap-x-4 gap-y-1.5 font-[family-name:var(--font-mono)] text-[12.5px] text-[var(--avy-ink)] sm:grid-cols-[auto_minmax(0,1fr)]">
+        {fields.map((field) => (
+          <div key={field.label} className="contents">
+            <dt
+              className="font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase text-[var(--avy-muted)]"
+              style={{ letterSpacing: "0.12em" }}
+            >
+              {field.label}
+            </dt>
+            <dd
+              className="m-0 min-w-0 break-words"
+              data-field={field.id}
+            >
+              {field.value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
+
+interface Field {
+  id: string;
+  label: string;
+  value: string;
+}
+
+function describeRow(row: RunRow): Field[] {
+  const fields: Field[] = [
+    { id: "job-id", label: "Job ID", value: row.id },
+    { id: "title", label: "Title", value: row.title },
+    { id: "source", label: "Source", value: describeSource(row) },
+    { id: "category", label: "Category", value: row.jobMeta },
+    { id: "state", label: "State", value: row.state },
+    { id: "reward", label: "Reward", value: `${row.stake} DOT` },
+    { id: "worker", label: "Worker", value: row.worker.label },
+    { id: "window", label: "Claim window", value: row.age },
+  ];
+  if (row.lifecycle) {
+    fields.push({
+      id: "lifecycle",
+      label: "Lifecycle",
+      value: `${row.lifecycle.status} (${row.lifecycle.state})`,
+    });
+  }
+  if (row.sessionId) {
+    fields.push({ id: "session", label: "Session", value: row.sessionId });
+  }
+  return fields;
+}
+
+function describeSource(row: RunRow): string {
+  switch (row.source?.type) {
+    case "github_issue":
+      return `GitHub · ${row.source.repo} #${row.source.issueNumber}`;
+    case "wikipedia_article":
+      return `Wikipedia · ${row.source.language}.wikipedia / "${row.source.pageTitle}" (rev ${row.source.revisionId})`;
+    case "osv_advisory":
+      return `OSV · ${row.source.ecosystem}/${row.source.packageName} · ${row.source.advisoryId}`;
+    case "open_data_dataset": {
+      const parts = [
+        "Data.gov",
+        row.source.agency,
+        row.source.datasetTitle,
+        row.source.resourceFormat,
+      ].filter((p): p is string => typeof p === "string" && p.length > 0);
+      return parts.join(" · ");
+    }
+    default:
+      return "Native";
+  }
+}

--- a/app/components/runs/SourceFilter.tsx
+++ b/app/components/runs/SourceFilter.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { cn } from "@/lib/utils/cn";
+import type { RunRow } from "./RunQueueTable";
+
+/**
+ * Source-kind filter for the runs queue. Sister to QueueBar's
+ * state-filter row, but operates on `row.source.type`.
+ *
+ * Browser agents want to narrow the marketplace to a single upstream
+ * (e.g. "show me only Wikipedia citation-repair jobs"); the public job
+ * feed already carries the source kind on every row, so this is a
+ * pure-frontend filter — no extra fetch.
+ */
+
+export type SourceFilter =
+  | "all"
+  | "github"
+  | "wikipedia"
+  | "osv"
+  | "openData"
+  | "other";
+
+export interface SourceFilterCount {
+  id: SourceFilter;
+  label: string;
+  count: number;
+}
+
+export interface SourceFilterBarProps {
+  filters: SourceFilterCount[];
+  active: SourceFilter;
+  onChange: (id: SourceFilter) => void;
+}
+
+const ALL_KINDS: SourceFilter[] = [
+  "all",
+  "github",
+  "wikipedia",
+  "osv",
+  "openData",
+  "other",
+];
+
+const LABEL: Record<SourceFilter, string> = {
+  all: "All sources",
+  github: "GitHub",
+  wikipedia: "Wikipedia",
+  osv: "OSV",
+  openData: "Data.gov",
+  other: "Other",
+};
+
+export function rowSourceKind(row: RunRow): SourceFilter {
+  switch (row.source?.type) {
+    case "github_issue":
+      return "github";
+    case "wikipedia_article":
+      return "wikipedia";
+    case "osv_advisory":
+      return "osv";
+    case "open_data_dataset":
+      return "openData";
+    default:
+      return "other";
+  }
+}
+
+/** Build the filter chip set with live row counts. */
+export function buildSourceFilters(rows: RunRow[]): SourceFilterCount[] {
+  const counts = new Map<SourceFilter, number>();
+  for (const row of rows) {
+    const kind = rowSourceKind(row);
+    counts.set(kind, (counts.get(kind) ?? 0) + 1);
+  }
+  return ALL_KINDS.map((id) => ({
+    id,
+    label: LABEL[id],
+    count: id === "all" ? rows.length : counts.get(id) ?? 0,
+  }));
+}
+
+/** Type guard for parsing `?source=` URL params. */
+export function parseSourceFilter(value: string | null | undefined): SourceFilter {
+  if (!value) return "all";
+  return ALL_KINDS.includes(value as SourceFilter)
+    ? (value as SourceFilter)
+    : "all";
+}
+
+export function SourceFilterBar({
+  filters,
+  active,
+  onChange,
+}: SourceFilterBarProps) {
+  return (
+    <div
+      className="flex flex-wrap items-center gap-2 rounded-[10px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-3.5 py-2"
+      role="tablist"
+      aria-label="Filter runs by source"
+    >
+      <span
+        className="font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase text-[var(--avy-muted)]"
+        style={{ letterSpacing: "0.14em" }}
+      >
+        Source
+      </span>
+      <div className="inline-flex flex-wrap items-center gap-0.5 rounded-[8px] bg-[color:rgba(17,19,21,0.04)] p-0.5">
+        {filters.map((f) => {
+          const isActive = active === f.id;
+          // Hide kinds that have zero rows in the current data set,
+          // except "All" which is always shown so the operator can
+          // reset the filter.
+          if (f.id !== "all" && f.count === 0) return null;
+          return (
+            <button
+              key={f.id}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => onChange(f.id)}
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded-[6px] border border-transparent px-2.5 py-1 font-[family-name:var(--font-display)] text-[11px] font-bold uppercase text-[var(--avy-muted)] transition-colors hover:text-[var(--avy-ink)]",
+                isActive &&
+                  "border-[var(--avy-line)] bg-[var(--avy-paper-solid)] text-[var(--avy-ink)] shadow-[0_1px_0_rgba(17,19,21,0.04)]"
+              )}
+              style={{ letterSpacing: "0.06em" }}
+            >
+              {f.label}
+              <span
+                className={cn(
+                  "rounded-[4px] px-1.5 py-px font-[family-name:var(--font-mono)] text-[10.5px] font-medium",
+                  isActive
+                    ? "bg-[var(--avy-accent-soft)] text-[var(--avy-accent)]"
+                    : "bg-[color:rgba(17,19,21,0.05)] text-[var(--avy-muted)]"
+                )}
+                style={{ letterSpacing: 0 }}
+              >
+                {f.count}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #77.

## Summary
Three additions to make /runs navigable for a browser-only agent:

1. **\`SourceFilterBar\` on /runs** — sister row to QueueBar, buckets rows by source kind (GitHub / Wikipedia / OSV / Data.gov / Other) with live counts. Composes with the existing state filter and show-closed toggle.
2. **URL-param sync** — both filters read \`?state=\` and \`?source=\` on mount and write them back as they change (router.replace, no scroll, no history pollution). \`/runs?source=wikipedia&state=ready\` becomes a shareable deep link.
3. **\`RunSemanticBlock\` on /runs/detail/** — plain-HTML \`<dl>\` listing job ID / title / source (with upstream identifier) / category / state / reward / worker / claim window / lifecycle / session. Lets a browser agent scrape the row's identity without OCRing the panel. Suppressed on the queue page (would just duplicate the clicked row).

## Acceptance criteria from the issue
- *Browser-only agent can find an open Wikipedia job without API access* — yes via \`?source=wikipedia\`, plain-text pageTitle on each row, and the semantic block on the detail page.
- *Page exposes enough text/semantic information that the agent does not need screenshot-only interpretation* — yes via the semantic block.

## Test plan
- [x] \`npm run typecheck:app\`
- [x] \`npm run build:frontend\`
- [ ] After deploy: load \`/runs?source=wikipedia&state=ready\`, confirm only Wikipedia ready rows render and the URL persists across reload
- [ ] Click into a Wikipedia row → \`/runs/detail/?id=…\` shows the Run summary block at the top with all fields populated