### PR TITLE
Assemble async XCM request payloads server-side

### DIFF
--- a/docs/RC1_IMPLEMENTATION_PLAN.md
+++ b/docs/RC1_IMPLEMENTATION_PLAN.md
@@ -34,7 +34,7 @@ The shortest path to a coherent rc1 launch is:
 
 ## Current Position
 
-As of this branch, **slice 8: XCM SetTopic Validation** is implemented and
+As of this branch, **slice 9: Backend SCALE Assembler** is implemented and
 ready for review.
 
 Completed and deployed in this lane:
@@ -239,17 +239,19 @@ request.
 
 ### 9. Backend SCALE Assembler
 
+**Status:** implemented in this branch.
+
 **Goal:** replace caller-supplied raw XCM bytes with server-controlled intent
 routing.
 
 **Changes:**
 
-- Add `mcp-server/src/blockchain/xcm-message-builder.js` or equivalent.
-- Replace HTTP `destination` / `message` inputs with intent:
+- [x] Add `mcp-server/src/blockchain/xcm-message-builder.js` or equivalent.
+- [x] Replace HTTP `destination` / `message` inputs with intent:
   `{ strategyId, direction, amount }`.
-- Backend assigns nonce, mirrors `previewRequestId(context)`, appends
+- [x] Backend assigns nonce, mirrors `previewRequestId(context)`, appends
   `SetTopic(requestId)`, and submits assembled bytes.
-- Add builder test vectors and staging smoke scripts.
+- [x] Add builder test vectors and HTTP smoke coverage for rejecting raw XCM bytes.
 
 **Checks:** `npm --workspace mcp-server test`, `forge test` if vectors touch
 contract validation.

--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -91,7 +91,7 @@ AUTH_CHAIN_ID=420420417
 # Preferred explicit asset metadata form:
 # STRATEGIES_JSON=[{"strategyId":"0x...","adapter":"0x...","kind":"mock_vdot","riskLabel":"Mock vDOT liquid staking (testnet). Not a real yield source.","asset":{"assetClass":"foreign","foreignAssetIndex":5,"symbol":"vDOT","decimals":10,"xcmLocation":"{ parents: 1, interior: X1(Parachain(2030)) }"}}]
 # Async XCM lane example:
-# STRATEGIES_JSON=[{"strategyId":"0x...","adapter":"0x...","kind":"polkadot_vdot","executionMode":"async_xcm","riskLabel":"Async XCM-backed vDOT lane.","asset":{"assetClass":"foreign","foreignAssetIndex":5,"symbol":"vDOT","decimals":10,"xcmLocation":"{ parents: 1, interior: X1(Parachain(2030)) }"}}]
+# STRATEGIES_JSON=[{"strategyId":"0x...","adapter":"0x...","kind":"polkadot_vdot","executionMode":"async_xcm","riskLabel":"Async XCM-backed vDOT lane.","asset":{"assetClass":"foreign","foreignAssetIndex":5,"symbol":"vDOT","decimals":10,"xcmLocation":"{ parents: 1, interior: X1(Parachain(2030)) }"},"xcm":{"destinationParachain":2030}}]
 # Async watcher controls. Defaults to on when blockchain mode is enabled.
 # XCM_SETTLEMENT_WATCHER_ENABLED=true
 # XCM_SETTLEMENT_WATCHER_POLL_MS=15000

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -20,6 +20,7 @@ import {
   ZERO_BYTES32
 } from "./abis.js";
 import { loadBlockchainConfig } from "./config.js";
+import { buildXcmRequestPayload } from "./xcm-message-builder.js";
 import { hashCanonicalContent } from "../core/canonical-content.js";
 import {
   BlockchainRevertError,
@@ -407,12 +408,7 @@ export class BlockchainGateway {
     });
   }
 
-  async requestStrategyDeposit(wallet, strategy, amount, {
-    destination = "0x",
-    message = "0x",
-    maxWeight = undefined,
-    nonce = Date.now()
-  } = {}) {
+  async requestStrategyDeposit(wallet, strategy, amount, { maxWeight = undefined, nonce = Date.now() } = {}) {
     return this.withGatewayError("requestStrategyDeposit", async () => {
       this.requireSigner("requestStrategyDeposit");
       this.requireAsyncStrategyConfig(strategy, "requestStrategyDeposit");
@@ -426,12 +422,17 @@ export class BlockchainGateway {
         shares: 0,
         nonce
       });
+      const payload = buildXcmRequestPayload({
+        strategy,
+        direction: "deposit",
+        requestId
+      });
       const tx = await this.accountContract.requestStrategyDeposit(wallet, {
         strategyId: this.normalizeStrategyId(strategy.strategyId),
         amount,
-        destination: this.toBytesPayload(destination, "destination"),
-        message: this.toBytesPayload(message, "message"),
-        maxWeight: this.normalizeWeight(maxWeight),
+        destination: payload.destination,
+        message: payload.message,
+        maxWeight: this.normalizeWeight(maxWeight ?? payload.maxWeight),
         nonce
       });
       await tx.wait();
@@ -446,8 +447,6 @@ export class BlockchainGateway {
 
   async requestStrategyWithdraw(wallet, strategy, amount, {
     recipient = this.config.agentAccountAddress,
-    destination = "0x",
-    message = "0x",
     maxWeight = undefined,
     nonce = Date.now(),
     requestedShares = undefined
@@ -468,13 +467,18 @@ export class BlockchainGateway {
         shares,
         nonce
       });
+      const payload = buildXcmRequestPayload({
+        strategy,
+        direction: "withdraw",
+        requestId
+      });
       const tx = await this.accountContract.requestStrategyWithdraw(wallet, {
         strategyId: this.normalizeStrategyId(strategy.strategyId),
         shares,
         recipient,
-        destination: this.toBytesPayload(destination, "destination"),
-        message: this.toBytesPayload(message, "message"),
-        maxWeight: this.normalizeWeight(maxWeight),
+        destination: payload.destination,
+        message: payload.message,
+        maxWeight: this.normalizeWeight(maxWeight ?? payload.maxWeight),
         nonce
       });
       await tx.wait();

--- a/mcp-server/src/blockchain/xcm-message-builder.js
+++ b/mcp-server/src/blockchain/xcm-message-builder.js
@@ -1,0 +1,97 @@
+import { ValidationError } from "../core/errors.js";
+
+export const XCM_VERSION_V5 = 0x05;
+export const XCM_SET_TOPIC_INSTRUCTION = 0x2c;
+
+const HEX_RE = /^0x[a-fA-F0-9]*$/u;
+const BYTES32_RE = /^0x[a-fA-F0-9]{64}$/u;
+const PARACHAIN_RE = /Parachain\((\d+)\)/iu;
+
+const BIFROST_VDOT_DEPOSIT_XCM_V5_PREFIX =
+  "0x0510000401000003008c86471301000003008c8647000d010101000000010100368e8759910dab756d344995f1d3c79374ca8f70066d3a709e48029f6bf0ee7e";
+const BIFROST_VDOT_WITHDRAW_XCM_V5_PREFIX = "0x050c00010203040506070809";
+
+export function buildXcmRequestPayload({ strategy, direction, requestId }) {
+  const normalizedDirection = normalizeDirection(direction);
+  const kind = String(strategy?.kind ?? "").trim().toLowerCase();
+  if (kind !== "polkadot_vdot") {
+    throw new ValidationError(`Unsupported async XCM strategy kind "${strategy?.kind ?? "unknown"}".`);
+  }
+
+  const destinationParaId = resolveDestinationParachainId(strategy);
+  const messagePrefix = normalizedDirection === "deposit"
+    ? BIFROST_VDOT_DEPOSIT_XCM_V5_PREFIX
+    : BIFROST_VDOT_WITHDRAW_XCM_V5_PREFIX;
+
+  return {
+    destination: encodeVersionedParachainLocation(destinationParaId),
+    message: appendSetTopic(messagePrefix, requestId),
+    maxWeight: { refTime: 0, proofSize: 0 }
+  };
+}
+
+export function appendSetTopic(messagePrefix, requestId) {
+  const prefix = normalizeHex(messagePrefix, "messagePrefix");
+  const topic = normalizeBytes32(requestId, "requestId").slice(2);
+  return `${prefix}${XCM_SET_TOPIC_INSTRUCTION.toString(16).padStart(2, "0")}${topic}`.toLowerCase();
+}
+
+export function encodeVersionedParachainLocation(paraId) {
+  return `0x${toU8Hex(XCM_VERSION_V5)}01${toU8Hex(1)}00${encodeU32LeHex(paraId)}`;
+}
+
+export function resolveDestinationParachainId(strategy) {
+  const explicit = strategy?.xcm?.destinationParachain ?? strategy?.xcm?.destinationParaId;
+  if (explicit !== undefined && explicit !== null && explicit !== "") {
+    return normalizeParaId(explicit, "strategy.xcm.destinationParachain");
+  }
+
+  const location = strategy?.assetConfig?.xcmLocation;
+  if (typeof location === "string") {
+    const match = PARACHAIN_RE.exec(location);
+    if (match) {
+      return normalizeParaId(match[1], "strategy.asset.xcmLocation");
+    }
+  }
+
+  throw new ValidationError("Async XCM strategy requires a destination parachain in xcmLocation or strategy.xcm.");
+}
+
+function normalizeDirection(direction) {
+  const normalized = String(direction ?? "").trim().toLowerCase();
+  if (normalized === "deposit" || normalized === "withdraw") {
+    return normalized;
+  }
+  throw new ValidationError('direction must be "deposit" or "withdraw".');
+}
+
+function normalizeHex(value, label) {
+  if (typeof value !== "string" || !HEX_RE.test(value) || value.length % 2 !== 0) {
+    throw new ValidationError(`${label} must be an even-length 0x-prefixed hex string.`);
+  }
+  return value.toLowerCase();
+}
+
+function normalizeBytes32(value, label) {
+  if (typeof value !== "string" || !BYTES32_RE.test(value)) {
+    throw new ValidationError(`${label} must be a 0x-prefixed 32-byte hex string.`);
+  }
+  return value.toLowerCase();
+}
+
+function normalizeParaId(value, label) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > 0xffffffff) {
+    throw new ValidationError(`${label} must be a uint32 parachain id.`);
+  }
+  return parsed;
+}
+
+function toU8Hex(value) {
+  return value.toString(16).padStart(2, "0");
+}
+
+function encodeU32LeHex(value) {
+  const hex = value.toString(16).padStart(8, "0");
+  return `${hex.slice(6, 8)}${hex.slice(4, 6)}${hex.slice(2, 4)}${hex.slice(0, 2)}`;
+}

--- a/mcp-server/src/blockchain/xcm-message-builder.test.js
+++ b/mcp-server/src/blockchain/xcm-message-builder.test.js
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  appendSetTopic,
+  buildXcmRequestPayload,
+  encodeVersionedParachainLocation,
+  resolveDestinationParachainId,
+  XCM_SET_TOPIC_INSTRUCTION
+} from "./xcm-message-builder.js";
+
+const REQUEST_ID = `0x${"11".repeat(32)}`;
+
+function vdotStrategy(overrides = {}) {
+  return {
+    strategyId: `0x${"22".repeat(32)}`,
+    kind: "polkadot_vdot",
+    assetConfig: {
+      assetClass: "foreign",
+      foreignAssetIndex: 5,
+      symbol: "vDOT",
+      xcmLocation: "{ parents: 1, interior: X1(Parachain(2030)) }"
+    },
+    ...overrides
+  };
+}
+
+test("encodeVersionedParachainLocation builds the Bifrost destination location", () => {
+  assert.equal(encodeVersionedParachainLocation(2030), "0x05010100ee070000");
+});
+
+test("resolveDestinationParachainId reads the strategy asset XCM location", () => {
+  assert.equal(resolveDestinationParachainId(vdotStrategy()), 2030);
+});
+
+test("resolveDestinationParachainId allows an explicit strategy XCM override", () => {
+  assert.equal(resolveDestinationParachainId(vdotStrategy({ xcm: { destinationParachain: 2001 } })), 2001);
+});
+
+test("appendSetTopic appends the request id as the final XCM instruction", () => {
+  const message = appendSetTopic("0x050c000102", REQUEST_ID);
+  assert.equal(message, `0x050c000102${XCM_SET_TOPIC_INSTRUCTION.toString(16)}${"11".repeat(32)}`);
+});
+
+test("buildXcmRequestPayload creates deterministic deposit and withdraw payloads", () => {
+  const deposit = buildXcmRequestPayload({
+    strategy: vdotStrategy(),
+    direction: "deposit",
+    requestId: REQUEST_ID
+  });
+  const withdraw = buildXcmRequestPayload({
+    strategy: vdotStrategy(),
+    direction: "withdraw",
+    requestId: REQUEST_ID
+  });
+
+  assert.equal(deposit.destination, "0x05010100ee070000");
+  assert.equal(withdraw.destination, "0x05010100ee070000");
+  assert.match(deposit.message, /^0x0510/u);
+  assert.match(withdraw.message, /^0x050c/u);
+  assert.ok(deposit.message.endsWith(`2c${"11".repeat(32)}`));
+  assert.ok(withdraw.message.endsWith(`2c${"11".repeat(32)}`));
+  assert.deepEqual(deposit.maxWeight, { refTime: 0, proofSize: 0 });
+});
+
+test("buildXcmRequestPayload rejects unsupported strategy kinds", () => {
+  assert.throws(
+    () => buildXcmRequestPayload({ strategy: vdotStrategy({ kind: "mock_vdot" }), direction: "deposit", requestId: REQUEST_ID }),
+    /Unsupported async XCM strategy kind/u
+  );
+});
+
+test("buildXcmRequestPayload rejects missing or malformed request ids", () => {
+  assert.throws(
+    () => buildXcmRequestPayload({ strategy: vdotStrategy(), direction: "deposit", requestId: "0x1234" }),
+    /requestId must be/u
+  );
+});

--- a/mcp-server/src/core/agent-transfer.test.js
+++ b/mcp-server/src/core/agent-transfer.test.js
@@ -185,7 +185,7 @@ test("requestStrategyDeposit delegates async lanes to the blockchain gateway and
     6,
     "0xstrategy",
     { strategyId: "0xstrategy", executionMode: "async_xcm", asset: "0xdot" },
-    { destination: "0x01", message: "0x02", nonce: 7 }
+    { nonce: 7 }
   );
 
   assert.equal(calls.length, 1);
@@ -284,7 +284,7 @@ test("requestStrategyWithdraw delegates async lanes to the blockchain gateway an
     3,
     "0xstrategy",
     { strategyId: "0xstrategy", executionMode: "async_xcm", asset: "0xdot" },
-    { destination: "0x01", message: "0x02", nonce: 8, recipient: "0xReceiver" }
+    { nonce: 8, recipient: "0xReceiver" }
   );
 
   assert.equal(updated.requestId, "0xwithdraw");

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -1075,7 +1075,20 @@ function deriveAsyncNonce(seed) {
   return Number.parseInt(hash.slice(2, 14), 16);
 }
 
+function rejectCallerSuppliedAsyncXcmField(payload, url, field) {
+  if (payload && Object.prototype.hasOwnProperty.call(payload, field)) {
+    throw new ValidationError(`Async XCM ${field} is assembled by the server and cannot be supplied by the caller.`);
+  }
+  if (url.searchParams.has(field)) {
+    throw new ValidationError(`Async XCM ${field} is assembled by the server and cannot be supplied by the caller.`);
+  }
+}
+
 function parseAsyncTreasuryOptions(payload = {}, url, { defaultRecipient = undefined } = {}) {
+  rejectCallerSuppliedAsyncXcmField(payload, url, "destination");
+  rejectCallerSuppliedAsyncXcmField(payload, url, "message");
+  rejectCallerSuppliedAsyncXcmField(payload, url, "nonce");
+
   const queryWeight = {
     refTime: url.searchParams.get("maxWeightRefTime"),
     proofSize: url.searchParams.get("maxWeightProofSize")
@@ -1088,10 +1101,6 @@ function parseAsyncTreasuryOptions(payload = {}, url, { defaultRecipient = undef
   const idempotencyKey = typeof payload?.idempotencyKey === "string" && payload.idempotencyKey.trim()
     ? payload.idempotencyKey.trim()
     : undefined;
-  const nonceRaw = payload?.nonce ?? url.searchParams.get("nonce");
-  const nonce = Number.isFinite(Number(nonceRaw)) && Number(nonceRaw) >= 0
-    ? Math.trunc(Number(nonceRaw))
-    : undefined;
   const recipient = typeof payload?.recipient === "string" && payload.recipient.trim()
     ? payload.recipient.trim()
     : (url.searchParams.get("recipient")?.trim() || defaultRecipient);
@@ -1100,11 +1109,8 @@ function parseAsyncTreasuryOptions(payload = {}, url, { defaultRecipient = undef
     ? Number(requestedSharesRaw)
     : undefined;
   return {
-    destination: payload?.destination ?? url.searchParams.get("destination") ?? "0x",
-    message: payload?.message ?? url.searchParams.get("message") ?? "0x",
     maxWeight,
     idempotencyKey,
-    nonce,
     recipient,
     requestedShares
   };

--- a/mcp-server/src/protocols/http/server.smoke.test.js
+++ b/mcp-server/src/protocols/http/server.smoke.test.js
@@ -248,6 +248,35 @@ test("http smoke: async XCM deallocation requires admin role until assembler shi
   );
 });
 
+test("http smoke: async XCM routes reject caller-supplied raw message bytes", { skip: !RUN }, async () => {
+  const asyncStrategyId = "0x56444f545f56315f4d4f434b0000000000000000000000000000000000000000";
+  await runWithServerEnv(
+    {
+      STRATEGIES_JSON: JSON.stringify([
+        {
+          strategyId: asyncStrategyId,
+          adapter: "0x1234567890123456789012345678901234567890",
+          kind: "polkadot_vdot",
+          executionMode: "async_xcm",
+          asset: "0xABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD"
+        }
+      ])
+    },
+    async (base) => {
+      const token = issueToken(ADMIN_WALLET, { roles: ["admin"] });
+      const response = await fetch(`${base}/account/allocate`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+        body: JSON.stringify({ strategyId: asyncStrategyId, amount: 1, message: "0xdeadbeef" })
+      });
+      assert.equal(response.status, 400);
+      const payload = await response.json();
+      assert.equal(payload.error, "invalid_request");
+      assert.match(payload.message, /message is assembled by the server/u);
+    }
+  );
+});
+
 test("http smoke: /auth/nonce returns 429 once the window limit is crossed", { skip: !RUN }, async () => {
   await runWithServer(async (base) => {
     const body = JSON.stringify({ wallet: Wallet.createRandom().address });

--- a/mcp-server/src/services/bootstrap.js
+++ b/mcp-server/src/services/bootstrap.js
@@ -421,7 +421,7 @@ function normaliseStrategyEntry(entry, idx) {
   if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
     throw new Error(`strategies[${idx}] must be an object`);
   }
-  const { strategyId, adapter, kind, riskLabel, asset, executionMode } = entry;
+  const { strategyId, adapter, kind, riskLabel, asset, executionMode, xcm } = entry;
   const assetConfig = normaliseStrategyAssetConfig(asset, idx);
   if (typeof strategyId !== "string" || !/^0x[a-fA-F0-9]{64}$/u.test(strategyId)) {
     throw new Error(`strategies[${idx}].strategyId must be 0x + 32-byte hex`);
@@ -436,8 +436,27 @@ function normaliseStrategyEntry(entry, idx) {
     executionMode: normaliseStrategyExecutionMode(executionMode, typeof kind === "string" ? kind : "unknown", idx),
     riskLabel: typeof riskLabel === "string" ? riskLabel : "",
     asset: assetConfig?.address,
-    assetConfig
+    assetConfig,
+    xcm: normaliseStrategyXcmConfig(xcm, idx)
   };
+}
+
+function normaliseStrategyXcmConfig(xcm, idx) {
+  if (xcm === undefined || xcm === null) {
+    return undefined;
+  }
+  if (typeof xcm !== "object" || Array.isArray(xcm)) {
+    throw new Error(`strategies[${idx}].xcm must be an object`);
+  }
+  const destinationParachain = xcm.destinationParachain ?? xcm.destinationParaId;
+  if (destinationParachain === undefined || destinationParachain === null || destinationParachain === "") {
+    return {};
+  }
+  const parsed = Number(destinationParachain);
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > 0xffffffff) {
+    throw new Error(`strategies[${idx}].xcm.destinationParachain must be a uint32`);
+  }
+  return { destinationParachain: parsed };
 }
 
 function normaliseStrategyExecutionMode(rawExecutionMode, kind, idx) {

--- a/mcp-server/src/services/strategies-config.test.js
+++ b/mcp-server/src/services/strategies-config.test.js
@@ -84,6 +84,22 @@ test("loadStrategiesConfig honours explicit executionMode overrides", () => {
   assert.equal(result[0].executionMode, "async_xcm");
 });
 
+test("loadStrategiesConfig preserves server-controlled XCM destination policy", () => {
+  const env = {
+    STRATEGIES_JSON: JSON.stringify([
+      {
+        strategyId: "0x56444f545f56315f4d4f434b0000000000000000000000000000000000000000",
+        adapter: "0x1234567890123456789012345678901234567890",
+        kind: "polkadot_vdot",
+        executionMode: "async_xcm",
+        xcm: { destinationParachain: "2030" }
+      }
+    ])
+  };
+  const result = loadStrategiesConfig(env, { logger: silentLogger() });
+  assert.deepEqual(result[0].xcm, { destinationParachain: 2030 });
+});
+
 test("loadStrategiesConfig parses foreign asset metadata when the runtime index is known", () => {
   const env = {
     STRATEGIES_JSON: JSON.stringify([


### PR DESCRIPTION
## What changed
- Add `mcp-server/src/blockchain/xcm-message-builder.js` for server-controlled async XCM destination/message construction.
- Wire async strategy deposit/withdraw gateway calls through the builder so queued messages append `SetTopic(requestId)` after mirroring the contract request-id formula.
- Reject caller-supplied raw async XCM `destination`, `message`, and `nonce` fields at the HTTP layer.
- Preserve optional server-side `xcm.destinationParachain` strategy policy from `STRATEGIES_JSON`.
- Mark Slice 9 as implemented in `docs/RC1_IMPLEMENTATION_PLAN.md`.

## Checks run
- `npm --workspace mcp-server test`
- `RPC_URL= DWELLER_RPC_URL= POLKADOT_RPC_URL= SIGNER_PRIVATE_KEY= AGENT_ACCOUNT_ADDRESS= ESCROW_CORE_ADDRESS= REPUTATION_SBT_ADDRESS= SUPPORTED_ASSETS= SUPPORTED_ASSETS_JSON= TREASURY_POLICY_ADDRESS= REDIS_URL= RUN_HTTP_SMOKE=1 node --test mcp-server/src/protocols/http/server.smoke.test.js`
- `forge test -vv`
- `git diff --check`

## Impact
- Affects backend async XCM request assembly and HTTP validation.
- Affects docs/env example for async XCM strategy configuration.
- No frontend, indexer, Caddy, generated static output, or public site changes.
- No smart contract changes in this PR.

## Env / deploy notes
- No new required env vars or VPS secrets.
- Optional strategy config can now include `"xcm":{"destinationParachain":2030}`; if omitted, the builder reads `Parachain(2030)` from `asset.xcmLocation`.
