### PR TITLE
Expose agent-ready Wikipedia job details

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -256,7 +256,7 @@
         ],
         "operationId": "getJobDefinition",
         "summary": "Get one job definition",
-        "description": "Returns a single job definition by job id.",
+        "description": "Returns a single job definition by job id. Source-specific jobs may include an agentContext block with compact, explicit fields for autonomous agents; Wikipedia jobs expose page title, revision id, pinned revision URL, output schema URL, proposal-only status, and attribution policy.",
         "parameters": [
           {
             "name": "jobId",
@@ -837,6 +837,11 @@
           },
           "source": {
             "type": "object",
+            "additionalProperties": true
+          },
+          "agentContext": {
+            "type": "object",
+            "description": "Optional source-specific summary for autonomous agents. Wikipedia definitions include jobId, source, taskType, pageTitle, lang, revisionId, articleUrl, pinnedRevisionUrl, proposalOnly, attributionPolicy, outputSchemaRef, outputSchemaUrl, requiredOutputKeywords, and verificationSignals.",
             "additionalProperties": true
           },
           "lifecycle": {

--- a/mcp-server/src/core/job-catalog-metadata.test.js
+++ b/mcp-server/src/core/job-catalog-metadata.test.js
@@ -147,6 +147,66 @@ test("job lifecycle supports archival and claimability guardrails", () => {
   });
 });
 
+test("public Wikipedia definitions expose agent-ready detail affordances", () => {
+  const service = makeService();
+  service.createJob({
+    ...BASE_JOB,
+    id: "wiki-en-123-citation-repair-example",
+    title: "Wikipedia citation repair: Example article",
+    category: "wikipedia",
+    jobType: "review",
+    requiredRole: "worker",
+    inputSchemaRef: "schema://jobs/wikipedia-maintenance-input",
+    outputSchemaRef: "schema://jobs/wikipedia-citation-repair-output",
+    verifierTerms: ["page_title", "revision_id", "citation_findings", "proposed_changes", "review_notes"],
+    verifierMinimumMatches: 4,
+    acceptanceCriteria: ["Names the exact Wikipedia page title and revision id reviewed."],
+    verification: {
+      method: "reviewable_wikipedia_proposal",
+      signals: ["page_revision_cited", "source_urls_present", "proposal_only"]
+    },
+    source: {
+      type: "wikipedia_article",
+      project: "wikipedia",
+      language: "en",
+      pageId: 123,
+      pageTitle: "Example article",
+      pageUrl: "https://en.wikipedia.org/wiki/Example_article",
+      revisionId: "987654321",
+      taskType: "citation_repair"
+    }
+  });
+
+  const definition = service.getPublicJobDefinition("wiki-en-123-citation-repair-example");
+
+  assert.equal(definition.source.lang, "en");
+  assert.equal(definition.source.articleUrl, "https://en.wikipedia.org/wiki/Example_article");
+  assert.equal(
+    definition.source.pinnedRevisionUrl,
+    "https://en.wikipedia.org/w/index.php?title=Example+article&oldid=987654321"
+  );
+  assert.equal(definition.source.proposalOnly, true);
+  assert.match(definition.source.attributionPolicy, /do not edit Wikipedia directly/);
+  assert.deepEqual(definition.agentContext, {
+    jobId: "wiki-en-123-citation-repair-example",
+    source: "wikipedia",
+    sourceType: "wikipedia_article",
+    taskType: "citation_repair",
+    pageTitle: "Example article",
+    lang: "en",
+    revisionId: "987654321",
+    articleUrl: "https://en.wikipedia.org/wiki/Example_article",
+    pinnedRevisionUrl: "https://en.wikipedia.org/w/index.php?title=Example+article&oldid=987654321",
+    proposalOnly: true,
+    attributionPolicy: "Averray proposal only; do not edit Wikipedia directly from the agent account.",
+    acceptanceCriteria: ["Names the exact Wikipedia page title and revision id reviewed."],
+    outputSchemaRef: "schema://jobs/wikipedia-citation-repair-output",
+    outputSchemaUrl: "/schemas/jobs/wikipedia-citation-repair-output.json",
+    requiredOutputKeywords: ["page_title", "revision_id", "citation_findings", "proposed_changes", "review_notes"],
+    verificationSignals: ["page_revision_cited", "source_urls_present", "proposal_only"]
+  });
+});
+
 test("createJob accepts github_pr verifier configuration", () => {
   const service = makeService();
   const job = service.createJob({

--- a/mcp-server/src/core/job-catalog-service.js
+++ b/mcp-server/src/core/job-catalog-service.js
@@ -3,7 +3,7 @@ import {
   NotFoundError,
   ValidationError
 } from "./errors.js";
-import { isBuiltinJobSchemaRef } from "./job-schema-registry.js";
+import { isBuiltinJobSchemaRef, schemaRefToJobSchemaPath } from "./job-schema-registry.js";
 
 const DEFAULT_AGENT_PROFILE = {
   capabilities: ["claim_job", "submit_work", "allocate_idle_funds"],
@@ -344,7 +344,7 @@ export class JobCatalogService {
     if (!this.isVisibleJob(job)) {
       throw new NotFoundError(`Unknown job: ${jobId}`, "job_not_found");
     }
-    return this.withLifecycle(job);
+    return this.withAgentDefinitionContext(this.withLifecycle(job));
   }
 
   getClaimableJobDefinition(jobId) {
@@ -493,6 +493,48 @@ export class JobCatalogService {
     return {
       ...job,
       lifecycle: this.buildLifecycle(job, now)
+    };
+  }
+
+  withAgentDefinitionContext(job) {
+    if (job?.source?.type !== "wikipedia_article") {
+      return job;
+    }
+
+    const language = job.source.language ?? job.source.lang;
+    const articleUrl = job.source.pageUrl ?? job.source.articleUrl;
+    const source = {
+      ...job.source,
+      lang: language,
+      articleUrl,
+      pinnedRevisionUrl: job.source.pinnedRevisionUrl ?? buildWikipediaPinnedRevisionUrl(job.source),
+      proposalOnly: true,
+      attributionPolicy: job.source.attributionPolicy
+        ?? "Averray proposal only; do not edit Wikipedia directly from the agent account."
+    };
+
+    return {
+      ...job,
+      source,
+      agentContext: {
+        ...(job.agentContext ?? {}),
+        jobId: job.id,
+        source: "wikipedia",
+        sourceType: "wikipedia_article",
+        taskType: source.taskType,
+        pageTitle: source.pageTitle,
+        lang: source.language ?? source.lang,
+        revisionId: source.revisionId,
+        articleUrl: source.pageUrl ?? source.articleUrl,
+        pinnedRevisionUrl: source.pinnedRevisionUrl,
+        proposalOnly: true,
+        attributionPolicy: source.attributionPolicy,
+        acceptanceCriteria: job.acceptanceCriteria ?? [],
+        outputSchemaRef: job.outputSchemaRef,
+        outputSchemaUrl: schemaRefToJobSchemaPath(job.outputSchemaRef),
+        requiredOutputKeywords: job.verifierConfig?.requiredKeywords ?? [],
+        verificationSignals: job.verification?.signals ?? []
+      }
     };
   }
 
@@ -847,6 +889,24 @@ function normaliseSchedule(raw, recurring) {
 function normalizeJobType(value) {
   const normalised = String(value ?? "work").trim().toLowerCase();
   return VALID_JOB_TYPES.has(normalised) ? normalised : undefined;
+}
+
+function buildWikipediaPinnedRevisionUrl(source) {
+  const language = normalizeWikipediaLanguage(source?.language ?? source?.lang);
+  const pageTitle = String(source?.pageTitle ?? "").trim();
+  const revisionId = String(source?.revisionId ?? "").trim();
+  if (!pageTitle || !revisionId) {
+    return undefined;
+  }
+  const url = new URL(`https://${language}.wikipedia.org/w/index.php`);
+  url.searchParams.set("title", pageTitle);
+  url.searchParams.set("oldid", revisionId);
+  return url.toString();
+}
+
+function normalizeWikipediaLanguage(value) {
+  const language = String(value ?? "en").trim().toLowerCase();
+  return /^[a-z][a-z0-9-]{1,15}$/u.test(language) ? language : "en";
 }
 
 function normalizeAgentRole(value) {

--- a/mcp-server/src/jobs/ingest-wikipedia-maintenance.js
+++ b/mcp-server/src/jobs/ingest-wikipedia-maintenance.js
@@ -218,6 +218,9 @@ export function toPlatformJob(article, score = scoreArticle(article)) {
       pageId: article.pageId,
       pageTitle: article.title,
       pageUrl: article.pageUrl,
+      lang: article.language,
+      articleUrl: article.pageUrl,
+      pinnedRevisionUrl: wikipediaPinnedRevisionUrl(article),
       revisionId: article.revisionId,
       revisionTimestamp: article.revisionTimestamp,
       categoryTitle: article.categoryTitle,
@@ -226,6 +229,8 @@ export function toPlatformJob(article, score = scoreArticle(article)) {
       score,
       discoveryApi: `https://${article.language}.wikipedia.org/w/api.php`,
       writePolicy: "averray_company_reviewed_proposal_only",
+      proposalOnly: true,
+      attributionPolicy: "Averray proposal only; do not edit Wikipedia directly from the agent account.",
       attribution: {
         proposer: "Averray",
         directEdit: false,
@@ -332,6 +337,18 @@ function normalizeTaskType(value) {
 function normalizeLanguage(value) {
   const language = String(value ?? DEFAULT_LANGUAGE).trim().toLowerCase();
   return /^[a-z][a-z0-9-]{1,15}$/u.test(language) ? language : DEFAULT_LANGUAGE;
+}
+
+function wikipediaPinnedRevisionUrl(article) {
+  const title = String(article?.title ?? "").trim();
+  const revisionId = String(article?.revisionId ?? "").trim();
+  if (!title || !revisionId) {
+    return undefined;
+  }
+  const url = new URL(`https://${normalizeLanguage(article?.language)}.wikipedia.org/w/index.php`);
+  url.searchParams.set("title", title);
+  url.searchParams.set("oldid", revisionId);
+  return url.toString();
 }
 
 function mediaWikiActionUrl(language) {

--- a/mcp-server/src/jobs/ingest-wikipedia-maintenance.test.js
+++ b/mcp-server/src/jobs/ingest-wikipedia-maintenance.test.js
@@ -31,6 +31,14 @@ test("toPlatformJob produces an Averray-attributed Wikipedia proposal job", () =
   assert.equal(job.jobType, "review");
   assert.equal(job.source.type, "wikipedia_article");
   assert.equal(job.source.writePolicy, "averray_company_reviewed_proposal_only");
+  assert.equal(job.source.lang, "en");
+  assert.equal(job.source.articleUrl, "https://en.wikipedia.org/wiki/Example_article");
+  assert.equal(
+    job.source.pinnedRevisionUrl,
+    "https://en.wikipedia.org/w/index.php?title=Example+article&oldid=987654321"
+  );
+  assert.equal(job.source.proposalOnly, true);
+  assert.match(job.source.attributionPolicy, /do not edit Wikipedia directly/);
   assert.equal(job.source.attribution.proposer, "Averray");
   assert.equal(job.source.attribution.directEdit, false);
   assert.equal(job.inputSchemaRef, "schema://jobs/wikipedia-maintenance-input");


### PR DESCRIPTION
## What changed
- Adds an agentContext block to public Wikipedia job definitions with page title, language, revision id, pinned revision URL, schema URL, proposal-only status, attribution policy, verifier keywords, and verification signals.
- Stores explicit Wikipedia source aliases on newly ingested jobs: lang, articleUrl, pinnedRevisionUrl, proposalOnly, and attributionPolicy.
- Documents the agentContext affordance in the public OpenAPI spec.

Closes #78.

## Checks
- node --test mcp-server/src/core/job-catalog-metadata.test.js mcp-server/src/jobs/ingest-wikipedia-maintenance.test.js
- npm --workspace mcp-server test
- git diff --check

## Impact
- Backend/API: yes, public /jobs/definition response for Wikipedia jobs includes additive fields.
- Frontend: no direct UI changes.
- Indexer: no.
- Caddy: no.
- Contracts: no.
- Public site: no.

## Env / VPS changes
- None.