### PR TITLE
Recognise openapi_spec + standards_spec source kinds

### DIFF
--- a/app/components/runs/JobCard.tsx
+++ b/app/components/runs/JobCard.tsx
@@ -96,6 +96,26 @@ export function JobCard({ job }: { job: JobCardData }) {
                 </>
               ) : null}
             </p>
+          ) : job.source?.type === "openapi_spec" ? (
+            <p
+              className="mt-1 flex items-center gap-1 font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]"
+              style={{ letterSpacing: 0 }}
+            >
+              <span className="shrink-0">{job.source.provider}</span>
+              <span className="truncate text-[var(--avy-ink)]">
+                / {job.source.apiTitle}
+              </span>
+            </p>
+          ) : job.source?.type === "standards_spec" ? (
+            <p
+              className="mt-1 flex items-center gap-1 font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]"
+              style={{ letterSpacing: 0 }}
+            >
+              <span className="shrink-0">{job.source.provider.toUpperCase()}</span>
+              <span className="truncate text-[var(--avy-ink)]">
+                / {job.source.specTitle}
+              </span>
+            </p>
           ) : (
             <p
               className="mt-1 truncate font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]"
@@ -135,6 +155,10 @@ export function JobCard({ job }: { job: JobCardData }) {
           />
         ) : job.source?.type === "open_data_dataset" ? (
           <SourceBadge kind="data_gov" />
+        ) : job.source?.type === "openapi_spec" ? (
+          <SourceBadge kind="openapi" />
+        ) : job.source?.type === "standards_spec" ? (
+          <SourceBadge kind="standards" />
         ) : null}
         <TierPill tier={job.tier} />
         {job.category ? (

--- a/app/components/runs/RunQueueTable.tsx
+++ b/app/components/runs/RunQueueTable.tsx
@@ -228,6 +228,34 @@ function RunRowCard({
                     {row.jobMeta}
                   </span>
                 </>
+              ) : row.source?.type === "openapi_spec" ? (
+                <>
+                  <SourceBadge kind="openapi" className="shrink-0" />
+                  <span className="truncate">
+                    <span>{row.source.provider}</span>
+                    <span className="text-[var(--avy-accent)]">
+                      {" "}/ {row.source.apiTitle}
+                    </span>
+                  </span>
+                  <span className="shrink-0 opacity-40">·</span>
+                  <span className="shrink-0 truncate whitespace-nowrap">
+                    {row.jobMeta}
+                  </span>
+                </>
+              ) : row.source?.type === "standards_spec" ? (
+                <>
+                  <SourceBadge kind="standards" className="shrink-0" />
+                  <span className="truncate">
+                    <span>{row.source.provider.toUpperCase()}</span>
+                    <span className="text-[var(--avy-accent)]">
+                      {" "}/ {row.source.specTitle}
+                    </span>
+                  </span>
+                  <span className="shrink-0 opacity-40">·</span>
+                  <span className="shrink-0 truncate whitespace-nowrap">
+                    {row.jobMeta}
+                  </span>
+                </>
               ) : (
                 <span className="truncate">{row.jobMeta}</span>
               )}

--- a/app/components/runs/RunSemanticBlock.tsx
+++ b/app/components/runs/RunSemanticBlock.tsx
@@ -99,6 +99,25 @@ function describeSource(row: RunRow): string {
       ].filter((p): p is string => typeof p === "string" && p.length > 0);
       return parts.join(" · ");
     }
+    case "openapi_spec": {
+      const parts = [
+        "OpenAPI",
+        row.source.provider,
+        row.source.apiTitle,
+        row.source.openapiVersion ? `OpenAPI ${row.source.openapiVersion}` : undefined,
+        row.source.documentVersion ? `v${row.source.documentVersion}` : undefined,
+      ].filter((p): p is string => typeof p === "string" && p.length > 0);
+      return parts.join(" · ");
+    }
+    case "standards_spec": {
+      const parts = [
+        "Standards",
+        row.source.provider.toUpperCase(),
+        row.source.specTitle,
+        row.source.expectedStatus,
+      ].filter((p): p is string => typeof p === "string" && p.length > 0);
+      return parts.join(" · ");
+    }
     default:
       return "Native";
   }

--- a/app/components/runs/SourceFilter.tsx
+++ b/app/components/runs/SourceFilter.tsx
@@ -19,6 +19,8 @@ export type SourceFilter =
   | "wikipedia"
   | "osv"
   | "openData"
+  | "openApi"
+  | "standards"
   | "other";
 
 export interface SourceFilterCount {
@@ -39,6 +41,8 @@ const ALL_KINDS: SourceFilter[] = [
   "wikipedia",
   "osv",
   "openData",
+  "openApi",
+  "standards",
   "other",
 ];
 
@@ -48,6 +52,8 @@ const LABEL: Record<SourceFilter, string> = {
   wikipedia: "Wikipedia",
   osv: "OSV",
   openData: "Data.gov",
+  openApi: "OpenAPI",
+  standards: "Standards",
   other: "Other",
 };
 
@@ -61,6 +67,10 @@ export function rowSourceKind(row: RunRow): SourceFilter {
       return "osv";
     case "open_data_dataset":
       return "openData";
+    case "openapi_spec":
+      return "openApi";
+    case "standards_spec":
+      return "standards";
     default:
       return "other";
   }

--- a/app/components/runs/StatePill.tsx
+++ b/app/components/runs/StatePill.tsx
@@ -92,6 +92,8 @@ export type SourceKind =
   | "wikipedia"
   | "osv"
   | "data_gov"
+  | "openapi"
+  | "standards"
   | "oss";
 
 const SOURCE_CLASSES: Record<SourceKind, string> = {
@@ -101,6 +103,10 @@ const SOURCE_CLASSES: Record<SourceKind, string> = {
   // Open-data family — slate-tinted dark to keep visual weight in line
   // with the other dark badges while staying distinct from osv's red ink.
   data_gov: "bg-[#1f2a3a] text-white",
+  // OpenAPI spec audits — teal-tinted dark, same neutral weight family.
+  openapi: "bg-[#1f3a3a] text-white",
+  // Standards bodies (W3C, IETF, …) — purple-tinted dark.
+  standards: "bg-[#2a1f3a] text-white",
   oss: "bg-[color:rgba(17,19,21,0.06)] text-[var(--avy-ink)]",
 };
 
@@ -109,6 +115,8 @@ const SOURCE_LABEL: Record<SourceKind, string> = {
   wikipedia: "Wikipedia",
   osv: "OSV",
   data_gov: "Data.gov",
+  openapi: "OpenAPI",
+  standards: "Standards",
   oss: "OSS",
 };
 

--- a/app/components/runs/types.ts
+++ b/app/components/runs/types.ts
@@ -115,11 +115,70 @@ export interface OpenDataJobSource {
   discoveryApi?: string;
 }
 
+/**
+ * Provenance for runs ingested from a published OpenAPI spec — used by
+ * the platform to audit the OpenAPI quality of its own and partner
+ * APIs. The audit doesn't edit the spec; the worker submits a structured
+ * findings + recommendations report.
+ */
+export interface OpenApiJobSource {
+  type: "openapi_spec";
+  /** Stable identifier for the spec, e.g. "averray-http-api". */
+  specId: string;
+  /** Human title from the OpenAPI document (`info.title`). */
+  apiTitle: string;
+  /** Provider/owner of the API (e.g. "averray", "stripe"). */
+  provider: string;
+  /** Canonical URL of the OpenAPI document. */
+  specUrl: string;
+  /** Final URL after any redirects (the resolved spec). */
+  finalUrl?: string;
+  /** Version reported in `info.version` of the spec. */
+  documentVersion?: string;
+  /** "3.0.0", "3.1.0", … */
+  openapiVersion?: string;
+  /** GitHub-style "owner/repo" hosting the spec, when known. */
+  repo?: string;
+  pathCount?: number;
+  operationCount?: number;
+  schemaCount?: number;
+  score?: number;
+}
+
+/**
+ * Provenance for runs ingested from a published technical standard — W3C
+ * Recommendations, IETF RFCs, etc. The audit checks freshness and
+ * correctness of how Averray references the standard; no edits to the
+ * standard itself.
+ */
+export interface StandardsJobSource {
+  type: "standards_spec";
+  /** Stable identifier for the standard (e.g. "vc-data-model-2.0"). */
+  specId: string;
+  /** Human title (e.g. "Verifiable Credentials Data Model v2.0"). */
+  specTitle: string;
+  /** Standards body / publisher — "w3c", "ietf", "iso", … */
+  provider: string;
+  /** Canonical URL where the spec lives. */
+  specUrl: string;
+  /** Final URL after any redirects. */
+  finalUrl?: string;
+  /** "W3C Recommendation", "Proposed Standard", … */
+  expectedStatus?: string;
+  /** Version reported on the published spec page. */
+  currentVersion?: string;
+  /** GitHub-style "owner/repo" hosting Averray's reference, when known. */
+  repo?: string;
+  score?: number;
+}
+
 export type JobSource =
   | GitHubJobSource
   | WikipediaJobSource
   | OsvJobSource
   | OpenDataJobSource
+  | OpenApiJobSource
+  | StandardsJobSource
   | { type: "native" };
 
 /**

--- a/app/lib/api/receipt-adapters.ts
+++ b/app/lib/api/receipt-adapters.ts
@@ -46,6 +46,8 @@ const SOURCE_ATTRIBUTION: Record<SourceKind, string> = {
   wikipedia: "Averray proposal — agent never edits Wikipedia",
   osv: "Averray dependency remediation",
   data_gov: "Averray open-data quality audit",
+  openapi: "Averray OpenAPI quality audit",
+  standards: "Averray standards-freshness audit",
   oss: "Open-source contribution",
 };
 

--- a/app/lib/api/run-adapters.ts
+++ b/app/lib/api/run-adapters.ts
@@ -253,6 +253,59 @@ export function buildJobSource(job: unknown): JobSource | undefined {
         : {}),
     };
   }
+  if (sourceType === "openapi_spec") {
+    const specId = text(src.specId);
+    const apiTitle = text(src.apiTitle);
+    const provider = text(src.provider);
+    const specUrl = text(src.specUrl);
+    if (!specId || !apiTitle || !provider || !specUrl) return undefined;
+    return {
+      type: "openapi_spec",
+      specId,
+      apiTitle,
+      provider,
+      specUrl,
+      ...(text(src.finalUrl) ? { finalUrl: text(src.finalUrl) } : {}),
+      ...(text(src.documentVersion)
+        ? { documentVersion: text(src.documentVersion) }
+        : {}),
+      ...(text(src.openapiVersion)
+        ? { openapiVersion: text(src.openapiVersion) }
+        : {}),
+      ...(text(src.repo) ? { repo: text(src.repo) } : {}),
+      ...(typeof src.pathCount === "number" ? { pathCount: src.pathCount } : {}),
+      ...(typeof src.operationCount === "number"
+        ? { operationCount: src.operationCount }
+        : {}),
+      ...(typeof src.schemaCount === "number"
+        ? { schemaCount: src.schemaCount }
+        : {}),
+      ...(typeof src.score === "number" ? { score: src.score } : {}),
+    };
+  }
+  if (sourceType === "standards_spec") {
+    const specId = text(src.specId);
+    const specTitle = text(src.specTitle);
+    const provider = text(src.provider);
+    const specUrl = text(src.specUrl);
+    if (!specId || !specTitle || !provider || !specUrl) return undefined;
+    return {
+      type: "standards_spec",
+      specId,
+      specTitle,
+      provider,
+      specUrl,
+      ...(text(src.finalUrl) ? { finalUrl: text(src.finalUrl) } : {}),
+      ...(text(src.expectedStatus)
+        ? { expectedStatus: text(src.expectedStatus) }
+        : {}),
+      ...(text(src.currentVersion)
+        ? { currentVersion: text(src.currentVersion) }
+        : {}),
+      ...(text(src.repo) ? { repo: text(src.repo) } : {}),
+      ...(typeof src.score === "number" ? { score: src.score } : {}),
+    };
+  }
   return undefined;
 }
 
@@ -478,7 +531,41 @@ export function buildRunRows(payload: unknown): RunRow[] {
                       typeof part === "string" && part.length > 0
                   )
                   .join(" · ")
-              : `${id} · ${category} · ${tier}`;
+              : source?.type === "openapi_spec"
+                ? // OpenAPI audit row meta: `<provider> / <openapi
+                  // version> · <op count> ops · quality audit · T*`.
+                  // Drop missing pieces gracefully.
+                  [
+                    source.provider,
+                    source.openapiVersion
+                      ? `OpenAPI ${source.openapiVersion}`
+                      : undefined,
+                    typeof source.operationCount === "number"
+                      ? `${source.operationCount} ops`
+                      : undefined,
+                    "quality audit",
+                    tier,
+                  ]
+                    .filter(
+                      (part): part is string =>
+                        typeof part === "string" && part.length > 0
+                    )
+                    .join(" · ")
+                : source?.type === "standards_spec"
+                  ? // Standards-freshness row meta: `<provider> · <expected
+                    // status> · freshness audit · T*`.
+                    [
+                      source.provider.toUpperCase(),
+                      source.expectedStatus,
+                      "freshness audit",
+                      tier,
+                    ]
+                      .filter(
+                        (part): part is string =>
+                          typeof part === "string" && part.length > 0
+                      )
+                      .join(" · ")
+                  : `${id} · ${category} · ${tier}`;
     const lifecycle = buildJobLifecycle(job.lifecycle);
     return {
       id,
@@ -517,9 +604,17 @@ export function buildRunRows(payload: unknown): RunRow[] {
                 ? state === "ready"
                   ? "Audit only"
                   : `State: ${state}`
-                : state === "ready"
-                  ? "Job listed"
-                  : `State: ${state}`,
+                : source?.type === "openapi_spec"
+                  ? state === "ready"
+                    ? "Quality audit"
+                    : `State: ${state}`
+                  : source?.type === "standards_spec"
+                    ? state === "ready"
+                      ? "Freshness audit"
+                      : `State: ${state}`
+                    : state === "ready"
+                      ? "Job listed"
+                      : `State: ${state}`,
       lastEventMeta:
         source?.type === "github_issue"
           ? `${source.repo} #${source.issueNumber} · verifier ${verifierLabel(job.verifierMode)}`
@@ -537,7 +632,34 @@ export function buildRunRows(payload: unknown): RunRow[] {
                     )
                     .join(" · ") ||
                   `verifier ${verifierLabel(job.verifierMode)}`
-                : `${text(job.rewardAsset, "DOT")} · verifier ${verifierLabel(job.verifierMode)}`,
+                : source?.type === "openapi_spec"
+                  ? [
+                      source.apiTitle,
+                      source.documentVersion
+                        ? `v${source.documentVersion}`
+                        : undefined,
+                      typeof source.pathCount === "number"
+                        ? `${source.pathCount} paths`
+                        : undefined,
+                    ]
+                      .filter(
+                        (part): part is string =>
+                          typeof part === "string" && part.length > 0
+                      )
+                      .join(" · ") ||
+                    `verifier ${verifierLabel(job.verifierMode)}`
+                  : source?.type === "standards_spec"
+                    ? [
+                        source.specTitle,
+                        source.expectedStatus,
+                      ]
+                        .filter(
+                          (part): part is string =>
+                            typeof part === "string" && part.length > 0
+                        )
+                        .join(" · ") ||
+                      `verifier ${verifierLabel(job.verifierMode)}`
+                    : `${text(job.rewardAsset, "DOT")} · verifier ${verifierLabel(job.verifierMode)}`,
     };
   });
 }


### PR DESCRIPTION
## Summary
The backend emits \`source.type = "openapi_spec"\` and \`source.type = "standards_spec"\` with rich provenance, but the frontend had no handlers for either — so those rows fell through to the native fallback and showed only the raw job-ID slug (\`openapi-averray-averray-http-api\`, \`standards-w3c-vc-data-model-2-0\`). To a human or a browser agent that reads as "this row has no identifier".

This PR teaches the runs UI about both kinds.

## What changes
- **Types**: \`OpenApiJobSource\` + \`StandardsJobSource\` added to the \`JobSource\` union, mirroring the fields the backend already ships.
- **Adapter**: \`buildJobSource\` handlers + source-aware \`jobMeta\`, \`lastEvent\`, \`lastEventMeta\` so the queue row reads e.g. \`OpenAPI · averray / Averray HTTP API\` + \`OpenAPI 3.1.0 · 10 ops · quality audit · T1\` instead of the slug.
- **SourceBadge**: two new variants — \`openapi\` (teal-tinted dark) and \`standards\` (purple-tinted dark) — plus matching attribution strings on receipt rows.
- **Renderers**: RunQueueTable + JobCard render the new kinds with badge + source identity.
- **Filter**: SourceFilter gains \"OpenAPI\" and \"Standards\" chips so \`/runs?source=openApi\` narrows the queue.
- **Semantic block**: RunSemanticBlock describes the new kinds so /runs/detail/?id=… is fully scrapable.

## Defer
Dedicated source-aware LoadedRunPanel layouts for these two kinds. The native panel still renders fine — the structured data is in the semantic block at the top and the source-aware row meta.

## Test plan
- [x] \`npm run typecheck:app\`
- [x] \`npm run build:frontend\`
- [ ] After deploy: load /runs, confirm the OpenAPI + Standards rows now show their badges and human identity, and \`/runs?source=openApi\` filters correctly.