### PR TITLE
Sync rc1 spec book with verification ledger

### DIFF
--- a/docs/AVERRAY_VERIFICATION_LEDGER.md
+++ b/docs/AVERRAY_VERIFICATION_LEDGER.md
@@ -1,0 +1,343 @@
+# Averray — Verification Ledger
+
+**Purpose:** Track every empirical claim in `RC1_WORKING_SPEC.md` against authoritative documentation.
+**Status:** Verification pass complete. All previously-⏳ items have been resolved against the authoritative Polkadot docs MCP (`https://docs-mcp.polkadot.com`) or the explicit upstream sources cited in each row.
+**Owner:** Pascal
+**Last updated:** 2026-04-28
+
+---
+
+## Summary
+
+After this pass:
+
+- ✅ **Verified:** 32
+- ⚠️ **Verified with corrections needed:** 19
+- 🔬 **Empirical (cannot be answered from docs):** 8
+- ⏳ **Still pending:** 0
+
+**Items not fully resolvable from docs alone:**
+
+- Bifrost-specific behavior (SetTopic preservation on reply-leg, mint-failure semantics, settlement latency) remains 🔬. These were 🔬 going in and remain so by design.
+- All "operational" Phase 1 questions (override rate of LLM-as-judge, PR merge rate, dispute rate at production volume) remain 🔬 — these can never be answered by docs.
+- One new 🔬 surfaced: end-to-end "EVM-mapped Substrate multisig owns an EVM contract on Asset Hub" — the primitives are documented but the composition is not, so it must be confirmed on Hub TestNet before `MULTISIG_SETUP.md §4` can be treated as actionable.
+
+**Corrections that flowed into `RC1_WORKING_SPEC.md` through the v1.9/v1.10 sync** (see the per-section "⚠️ Spec correction" paragraphs below):
+
+1. **No "native DOT precompile address" exists.** The ERC20 precompile is for Assets-pallet-managed assets only (Trust-Backed, Foreign, Pool). Native DOT is the chain's intrinsic value/balance, not addressable as an ERC20 precompile. `MULTISIG_SETUP.md §5` must be reworded.
+2. **"10x storage cost reduction in v2.2.1" is unsupported as written.** The official docs only state Asset Management is "approximately one-tenth the cost of relay chain transactions" — a comparison vs the relay chain, not a v2.2.1-introduced reduction. The v1.6 reconciliation log overstated this.
+3. **All four PoP / DIM1 / DIM2 / contextual-alias claims are not currently in `docs.polkadot.com`.** The People Chain doc only describes the existing registrar/judgment system. The DIM tier model and v2.2.1 launch claims must be sourced elsewhere (community/forum) or marked speculative until docs catch up. Phase 2 framing protects us, but the spec language should not assert these as documented facts.
+4. **`polkadot.cloud/connect` wallet list in the spec is wrong.** The library supports Polkadot.js, Talisman, SubWallet, Enkrypt, Fearless, PolkaGate (web extensions) plus Polkadot Vault and Ledger (hardware). MetaMask and Mimir are NOT in the supported list per `docs.polkadot.cloud`.
+5. **Bifrost vDOT base APR claim ("~11–14%") is stale.** Post-Polkadot-tokenomics-reset, base vDOT staking yield is ~5–6% APY; the visible "30-day APY ~11%" includes Bifrost incentives. Spec §2 figures need refreshing.
+6. **Hydration GDOT yield claim ("~18–25%") is at the upper edge of what current Hydration sources document.** Substack/blog sources currently quote "real yields can reach 15–20%+ with modest leverage." Spec §2 should narrow the band or caveat it.
+7. **"People Chain block times 2 seconds" and "Elastic Scaling on People Chain" are not specifically documented for People Chain.** The async-backing doc confirms 2-second blocks are the parachain norm with async backing; the elastic-scaling doc confirms multi-core scaling exists. Neither doc names People Chain. Spec attribution to People Chain specifically is unsupported.
+
+None of these are architecturally load-bearing — the locked v1.8 decisions (XCM precompile address, SetTopic = requestId design, pallet_revive on Asset Hub, Phase 1/Phase 2 split) remain intact. All ⚠️ items are wording / parameter / scope corrections.
+
+---
+
+## How to use this document
+
+Each row is a claim from the working spec. Status flags:
+
+- ✅ **Verified.** Source quoted; matches spec.
+- ⚠️ **Verified with corrections needed.** Source confirms a different reality than the spec asserts. Spec must be updated.
+- ⏳ **Pending.** No documentation fetched yet; still needs verification.
+- 🔬 **Empirical.** No doc can answer; requires hands-on experiment (Chopsticks, on-chain test, vendor inquiry).
+
+Re-run verification on any item flagged ⏳ before treating it as a basis for implementation. Re-run periodically on ✅ items if the underlying Polkadot docs are revised — Polkadot v2.2.1 introduced material runtime changes; future versions will too.
+
+The Polkadot docs MCP at `https://docs-mcp.polkadot.com` is the recommended ongoing verification surface for Claude Code sessions. Install:
+
+```
+claude mcp add --transport http polkadot-docs https://docs-mcp.polkadot.com --scope user
+```
+
+---
+
+## XCM precompile and message dispatch
+
+### XCM precompile address and interface
+
+| Item | Status | Notes |
+|---|---|---|
+| Precompile at `0x00000000000000000000000000000000000a0000` (also `address(0xA0000)`) | ✅ | Confirmed exact address in `IXcm.sol` constant |
+| Three primary functions: `execute`, `send`, `weighMessage` | ✅ | All three documented as the precompile interface |
+| `weighMessage(bytes calldata message) external view returns (Weight memory weight)` | ✅ | Matches `XcmWrapper`'s `staticcall` invocation exactly |
+| `Weight` struct with `refTime` (uint64) and `proofSize` (uint64) | ✅ | Matches the `Weight` struct accepted by `XcmWrapper.queueRequest` |
+| `execute(bytes message, Weight weight)` for local execution | ✅ | Local-only; takes weight |
+| `send(bytes destination, bytes message)` for cross-chain — **no weight parameter** | ✅ | Destination chain handles execution costs per its own fee structure |
+| Messages are SCALE-encoded Versioned XCM | ✅ | Documented |
+| Precompile is "barebones" by design — abstractions belong on top | ✅ | Direct quote: *"While it provides a lot of flexibility, it doesn't provide abstractions to hide away XCM details. These have to be built on top."* This **validates** the assembler design (SCALE construction off-chain, in `xcm-message-builder/`). |
+
+**Source:** https://docs.polkadot.com/smart-contracts/precompiles/xcm/
+**Last verified:** 2026-04-25
+
+**Spec actions:** None. The XCM precompile section of the spec is correct.
+
+### Chopsticks replay and dry-run pattern
+
+| Item | Status | Notes |
+|---|---|---|
+| Chopsticks `xcm` command pattern: `npx @acala-network/chopsticks xcm -r polkadot -p <hub-config> -p <bifrost-config>` | ✅ | Exact command pattern in docs |
+| `DryRunApi.dry_run_call(origin, call, xcm_version)` exists | ✅ | Documented with full PAPI example |
+| Result includes `execution_result`, `emitted_events`, `local_xcm`, `forwarded_xcms` | ✅ | `forwarded_xcms` field confirmed — was a load-bearing assumption for the correlation gate |
+| `forwarded_xcms` returns the XCMs that *would* be sent as a result of executing the call | ✅ | Matches our experiment design |
+| Replay pattern: `api.txFromCallData(callData)` → `signSubmitAndWatch` | ✅ | Documented |
+| Runtime logging requires `release` or `debug` Wasm override | ✅ | Production builds have logs disabled; must build runtime locally and override |
+| `runtime-log-level: 5` for full execution logs | ✅ | Documented |
+| Note on `Binary` and `Uint8Array` in PAPI v2 | ✅ | Raw binary values are `Uint8Array` rather than `Binary` instances in v2 |
+
+**Source:** https://docs.polkadot.com/chain-interactions/send-transactions/interoperability/debug-and-preview-xcms/
+**Last verified:** 2026-04-25
+
+**Spec actions:** None. The §10 Chopsticks experiment plan is consistent with the official workflow. Note added: when running the experiment, Wasm override step (clone `polkadot-fellows/runtimes`, build with `--release`, copy `.compact.compressed.wasm` to working dir, reference in Chopsticks config) is mandatory if we want execution logs.
+
+### SetTopic propagation across parachain reply-legs
+
+| Item | Status | Notes |
+|---|---|---|
+| SetTopic instruction exists in XCM and is the canonical correlation primitive | ✅ | xcm-format spec defines `SetTopic = 44 ([u8; 32])` with description *"Set the Topic Register"*. The Topic register is *"Of type `Option<[u8; 32]>`, initialized to `None`. Expresses an arbitrary topic of an XCM. This value can be set to anything, and is used as part of `XcmContext`."* `XcmContext` is *"Contextual data pertaining to a specific list of XCM instructions. It includes the `origin`, ..., `message_hash`, the hash of the XCM, an arbitrary `topic`, ..."* Source: https://github.com/polkadot-fellows/xcm-format (`README.md` §1.3 Vocabulary, §3.11 Topic Register, instruction-set table). |
+| `messageId` field in `PolkadotXcm.Sent` and `XcmpQueue.XcmpMessageReceived` events equals SetTopic value when set, else hash of message | ✅ | The `Sent` event in `pallet_xcm` is defined as `Sent { origin: Location, destination: Location, message: Xcm<()>, message_id: XcmHash }`. The `WithUniqueTopic` router (used by relay/parachain configs) implements: *"let unique_id = if let Some(SetTopic(id)) = message.last() { *id } else { let unique_id = unique(&message); message.0.push(SetTopic(unique_id)); unique_id };"* — i.e., if the message already ends with `SetTopic(id)`, that id is the returned `message_id`; otherwise a unique id is computed and appended as `SetTopic`. The same `unique_id` is returned to the caller as `XcmHash` and surfaces in the `Sent` event's `message_id` field. Sources: https://github.com/paritytech/polkadot-sdk/blob/master/polkadot/xcm/pallet-xcm/src/lib.rs (Sent event), https://github.com/paritytech/polkadot-sdk/blob/master/polkadot/xcm/xcm-builder/src/routing.rs (`WithUniqueTopic`). |
+| Bifrost reply-leg XCMs preserve original SetTopic value | 🔬 | **Cannot be answered from docs.** Bifrost-implementation-specific. Must be answered via Chopsticks experiment (see §10 of spec). |
+
+**Sources:**
+- xcm-format spec: https://github.com/polkadot-fellows/xcm-format (master `README.md`, §1.3 Vocabulary; §3.11 Topic Register; instruction-set table)
+- pallet_xcm `Sent` event: https://github.com/paritytech/polkadot-sdk/blob/master/polkadot/xcm/pallet-xcm/src/lib.rs
+- `WithUniqueTopic` router: https://github.com/paritytech/polkadot-sdk/blob/master/polkadot/xcm/xcm-builder/src/routing.rs
+
+**Last verified:** 2026-04-28
+
+**Spec actions:** None. The §10 framing — *SetTopic = requestId is the design; Bifrost preservation is the empirical gate validated via Chopsticks* — is consistent with the upstream code: when our assembler sets `SetTopic(requestId)` as the last instruction, `WithUniqueTopic` will pass that exact value through to the `Sent` event's `message_id`. The remaining empirical question is purely whether Bifrost echoes that value back on the reply-leg.
+
+---
+
+## Bulletin Chain (Phase 2 storage)
+
+| Item | Status | Notes |
+|---|---|---|
+| Bulletin Chain provides decentralized, content-addressable storage | ✅ | "Decentralized data storage with IPFS-compatible content addressing" |
+| CID is the content identifier; IPFS-compatible | ✅ | Default Blake2b-256 hash, Raw codec |
+| No native token; access via authorization, not fees | ✅ | Confirmed |
+| Authorization grants transactions + bytes allowance, with optional expiration block | ✅ | Documented schema |
+| Currently OpenGov is the only authorization source on mainnet; PoP planned | ✅ | "Currently, only OpenGov can provide authorizations but the PoP subsystem is also planned to have this privilege in the future" |
+| `authorize_account` extrinsic requires Root origin | ⚠️ | Spec said "OpenGov for mainnet" but reality is **Root origin everywhere**. OpenGov is one path to Root on mainnet. |
+| Polkadot Mainnet authorization model "being finalized" | ⚠️ | Not yet finalized — adds uncertainty to Phase 2 timeline |
+| Retention period ~2 weeks on Polkadot TestNet | ⚠️ | **Spec was wrong.** Spec described per-blob retention up to ~7 months. Reality: fixed ~2 weeks; must renew. |
+| Renewal extends retention for another full period | ✅ | `renew(block, index)` extrinsic |
+| Each renewal generates new `(block, index)` pair; original values fail after renewal | ⚠️ | **Spec didn't account for this.** Real ops complexity: persistent `(cid, latest_block, latest_index, expires_at)` tracking required. |
+| CID stays stable across renewals; future plans to reference data by CID alone | ✅ | Documented as future improvement |
+| Max transaction size ~8 MiB; max chunked file ~64 MiB | ✅ | Documented |
+| Retrieval: P2P (Helia), IPFS gateway, Smoldot light client (coming soon) | ✅ | Multiple paths confirmed |
+| Generic public IPFS gateways (`ipfs.io`, `cloudflare-ipfs.com`) **deprecated** for Bulletin retrieval | ✅ | Important: do NOT cite these as fallback in spec |
+| Polkadot TestNet Bulletin RPC: `wss://paseo-bulletin-rpc.polkadot.io` | ✅ | Documented endpoint |
+| Polkadot TestNet IPFS gateway: `https://paseo-ipfs.polkadot.io` | ✅ | Documented endpoint |
+
+**Sources:**
+- https://docs.polkadot.com/reference/polkadot-hub/data-storage/
+- https://docs.polkadot.com/chain-interactions/store-data/bulletin-chain/
+
+**Last verified:** 2026-04-25
+
+**Spec actions required:**
+
+1. **§6 storage rewrite needed.** Specifically:
+   - Phase 2 description was wrong about retention — must reflect ~2-week fixed retention with mandatory renewal cadence.
+   - Authorization claim needs correction — Root origin is the actual gate, with OpenGov as the production path to Root.
+   - Operational infrastructure now includes a renewal-tracking system (`cid → latest_block, latest_index, expires_at`).
+2. **§10 deferred-item updates:**
+   - Bulletin Chain entry should call out the ops complexity honestly.
+   - Crust as fallback gains weight — Crust's "pin once and pay forever" model has materially different ops profile.
+3. **Honest rebalancing:** The "Bulletin Chain is the primary candidate" framing was based on assumptions that proved wrong. Bulletin Chain is still credible, but the choice between it and Crust is closer than v1.6 implied. Defer the choice; don't lock it now.
+
+---
+
+## Account and identity claims
+
+| Item | Status | Notes |
+|---|---|---|
+| `pallet_revive.map_account()` maps SS58 → H160 for EVM compatibility | ✅ | *"To map your account, call the [`map_account`](...) extrinsic of the [`pallet_revive`](...) pallet using your original Substrate account. This creates a stateful mapping that allows your 32-byte account to interact with the Ethereum-compatible smart contract system."* The `AccountId32Mapper` in `pallet_revive` is documented as the implementation; the `map` function stores the original 32-byte account ID in `OriginalAccount` storage, enabling `to_account_id` to recover the original account. Source: https://docs.polkadot.com/smart-contracts/for-eth-devs/accounts/#account-mapping-for-native-polkadot-accounts |
+| EVM-mapped Substrate multisig can own EVM contracts on Asset Hub | 🔬 | The docs state mapped 32-byte accounts can interact with the EVM layer (transfer funds, call contracts via Ethereum tooling) but make **no specific claim about pallet_multisig accounts being valid `map_account` callers** or about a multisig acting as a contract owner. The mechanism (multisig → derived AccountId32 → map_account → 20-byte H160) is plausible from the documented primitives but not confirmed end-to-end in the docs. **Empirical test required on Polkadot Hub TestNet** before treating as fact in `MULTISIG_SETUP.md §4`. |
+| `0xEE` suffix convention for EVM ↔ AccountId32 mapping | ✅ | *"Ethereum to Polkadot: The system adds twelve `0xEE` bytes to the end of the address, which is a reversible operation."* And: *"Takes a 20-byte Ethereum address and extends it to 32 bytes by adding twelve `0xEE` bytes at the end. The key benefits of this approach are: Able to fully revert ... Provides clear identification of Ethereum-controlled accounts through the `0xEE` suffix pattern."* **Source URL correction needed:** the ledger originally cited `https://docs.polkadot.com/reference/parachains/accounts/`, which covers SS58 format only. The `0xEE` suffix is documented at https://docs.polkadot.com/smart-contracts/for-eth-devs/accounts/#ethereum-to-polkadot-mapping. |
+| Native DOT precompile address on Asset Hub | ⚠️ | **There is no "native DOT precompile address" on Asset Hub.** The ERC20 precompile (https://docs.polkadot.com/smart-contracts/precompiles/erc20/) is documented to support exactly three asset categories — *"Polkadot Hub runs three instances of the Assets pallet — Trust-Backed Assets, Foreign Assets, and Pool Assets — each mapped to a distinct ERC20 precompile address suffix."* Native DOT is the chain's intrinsic balance, not in the Assets pallet, and has no ERC20 precompile address. The "Common Trust-Backed Asset IDs" table lists USDt and USDC; native DOT is **not** present. The ETH-native precompile list (`0x01`–`0x09`) covers cryptographic helpers (ECRecover, sha256, etc.), not currency. |
+
+**Sources:**
+- https://docs.polkadot.com/smart-contracts/for-eth-devs/accounts/
+- https://docs.polkadot.com/reference/parachains/accounts/
+- https://docs.polkadot.com/smart-contracts/precompiles/erc20/
+- https://docs.polkadot.com/smart-contracts/precompiles/eth-native/
+
+**Last verified:** 2026-04-28
+
+**⚠️ Spec correction (Native DOT precompile):** `MULTISIG_SETUP.md §5` references `TOKEN_ADDRESS=0x<hub-dot-precompile-or-testdot>` as if a native DOT precompile address existed. It does not. The correct deployment recipe is one of:
+
+1. Use the `value` field of the EVM call for native-DOT transfers (no token address needed for native currency, identical to native ETH on Ethereum).
+2. If the multisig setup needs a token-address slot, populate it with a deployed test ERC20 (TestDOT-style) on Hub TestNet and document this is a stand-in for native DOT, not a precompile.
+3. If a real DOT-as-ERC20 representation is needed, use the appropriate Foreign Asset or wrapped representation registered in the Assets pallet, deriving the precompile address per the Foreign Asset formula.
+
+The spec must drop the "native DOT precompile" framing and pick one of the three above.
+
+**🔬 Note (multisig ownership of contracts):** While the primitives needed for "EVM-mapped Substrate multisig owns EVM contract" exist, no doc states this composition works end-to-end. Before relying on it, run the deterministic-multisig-address → `pallet_revive.map_account` → contract ownership transfer flow on Polkadot Hub TestNet and capture the receipts.
+
+---
+
+## EVM model claims
+
+| Item | Status | Notes |
+|---|---|---|
+| Asset Hub uses `pallet_revive` / PolkaVM as the EVM-compatible smart contract layer | ✅ | *"Polkadot Hub enables developers to deploy and interact with Solidity contracts through REVM, a high-performance, Rust-based Ethereum Virtual Machine implementation."* And from EVM-vs-PVM: *"Rather than implementing the EVM, PVM utilizes a RISC-V instruction set. For most Solidity developers, this architectural change remains transparent thanks to the [Revive compiler's] complete Solidity support..."* `pallet revive` is referenced throughout (`Pallet revive uses dynamic pricing through a "fee multiplier"` in gas-model doc). Sources: https://docs.polkadot.com/smart-contracts/for-eth-devs/evm-vs-pvm/, https://docs.polkadot.com/reference/polkadot-hub/smart-contracts/ |
+| Storage costs reduced 10x on Asset Hub in v2.2.1 | ⚠️ | The docs **do not** make this claim. The closest documented statement is in the Polkadot Hub overview: *"Asset Management offers significantly lower transaction fees—approximately one-tenth the cost of relay chain transactions—and reduced deposit requirements."* This is (a) a comparison vs the **relay chain**, not a v2.2.1-introduced reduction, and (b) about Asset Management transaction fees broadly, not specifically about smart-contract storage. The gas-model doc (https://docs.polkadot.com/smart-contracts/for-eth-devs/gas-model/) describes `storage_deposit` as a separate resource but quotes no specific reduction factor or version. Source for "one-tenth": https://docs.polkadot.com/reference/polkadot-hub/#asset-management. |
+| EVM precompile system on Asset Hub matches Ethereum precompile semantics | ✅ | *"Revive implements the standard set of Ethereum precompiles"* — table lists ECRecover (0x01), Sha256 (0x02), Ripemd160 (0x03), Identity (0x04), Modexp (0x05), Bn128Add (0x06), Bn128Mul (0x07), Bn128Pairing (0x08), Blake2F (0x09), with the same addresses and semantics as Ethereum. *"In Polkadot Hub's Revive pallet, these precompiles maintain compatibility with standard Ethereum addresses, allowing developers familiar with Ethereum to seamlessly transition their smart contracts."* Source: https://docs.polkadot.com/smart-contracts/precompiles/eth-native/. Note: Polkadot Hub also exposes additional Polkadot-native precompiles (XCM at `0x0a0000`, ERC20 wrapper for Assets pallet, System, Storage) that have no Ethereum equivalent — the Ethereum-subset semantics match, but the precompile **system** is a strict superset. |
+
+**Sources:**
+- https://docs.polkadot.com/smart-contracts/for-eth-devs/evm-vs-pvm/
+- https://docs.polkadot.com/smart-contracts/for-eth-devs/gas-model/
+- https://docs.polkadot.com/smart-contracts/precompiles/eth-native/
+- https://docs.polkadot.com/reference/polkadot-hub/#asset-management
+
+**Last verified:** 2026-04-28
+
+**⚠️ Spec correction (10x storage cost):** The v1.6 reconciliation log in the spec asserts "Storage costs reduced 10x on Asset Hub in v2.2.1." This specific claim is not supported by the docs. The accurate statement is: *Asset Hub transaction fees are approximately one-tenth of relay chain transaction fees (per the Hub overview), and `pallet_revive` charges storage as a separate `storage_deposit` resource that is refunded when the storage is freed.* The "10x in v2.2.1" attribution should be replaced with the documented relative-to-relay-chain framing, with no version anchor.
+
+---
+
+## Proof of Personhood claims
+
+| Item | Status | Notes |
+|---|---|---|
+| PoP system has DIM1 (lightweight) and DIM2 (verified individuality) tiers | ⚠️ | **Not in the cited doc.** https://docs.polkadot.com/reference/polkadot-hub/people-and-identity/ describes only the existing People Chain identity / registrar / judgment system — registrars assign confidence levels (Unknown / Reasonable / Known good / Out of date / Low quality / Erroneous). DIM1 / DIM2 tiers are **not mentioned anywhere** in the page. A docs-MCP search for `DIM1 DIM2 contextual alias` returned only two passing references to "PoP (Proof of Personhood)" (one in Bulletin Chain authorization-future-source language, one in this same People Chain page) — neither describes a tier model. |
+| PoP enables "contextual aliases" (unlinkable per-app identities) | ⚠️ | **Not in the cited doc.** The People Chain doc has no "contextual alias" concept; sub-identities (up to 100 per primary, each with its own bond) are described, but those are linkable by design. |
+| PoP rollout includes Asset Hub integration | ⚠️ | **Not in the cited doc.** The data-storage doc says only *"the PoP (Proof of Personhood) subsystem is also planned to have this privilege [authorizing Bulletin Chain account allowances] in the future"* — that's a future-tense plan for Bulletin Chain, not Asset Hub integration. Source: https://docs.polkadot.com/reference/polkadot-hub/data-storage/ |
+| PoP Phase 0 launched in v2.2.1; full maturity 2026 | ⚠️ | **Not in the cited doc.** No `v2.2.1` release-notes content on `docs.polkadot.com` documents a PoP Phase 0 launch. |
+
+**Sources searched:**
+- https://docs.polkadot.com/reference/polkadot-hub/people-and-identity/
+- https://docs.polkadot.com/reference/polkadot-hub/data-storage/ (PoP mentioned only as future Bulletin Chain auth source)
+- Polkadot docs MCP search: `proof of personhood DIM1 DIM2 contextual alias unique humans` → no tier-model documentation found
+
+**Last verified:** 2026-04-28
+
+**⚠️ Spec correction (PoP claims):** Spec §10 (Phase 2 deferred) currently asserts as fact several PoP properties that are **not yet on `docs.polkadot.com`** as of this verification pass. The Phase 2 framing already protects v1 from depending on PoP; what needs to change is the *certainty* with which §10 describes PoP. Recommended edits:
+
+- Replace "PoP has DIM1 / DIM2 tiers" with "PoP is expected to introduce tiered uniqueness (per Web3 Foundation talks / community sources [cite])." Mark as community-sourced, not documented.
+- Replace "PoP enables contextual aliases" with "Contextual aliases are a discussed PoP feature (per [community source]); not yet documented on `docs.polkadot.com`."
+- Replace "PoP Phase 0 launched in v2.2.1" with "PoP rollout milestones are still being communicated through forum/community channels; treat any specific date as unverified." Drop the v2.2.1 anchor.
+- Make the Phase 2 deferral explicit: *"Averray will not depend on PoP being shipped or stable until both (a) it is documented on `docs.polkadot.com` with concrete extrinsics/precompiles, and (b) Asset Hub integration is observable on TestNet."*
+
+---
+
+## Tooling and library claims
+
+| Item | Status | Notes |
+|---|---|---|
+| PAPI exposes XCM construction with sufficient granularity to inject SetTopic as the last instruction of a message | ✅ (with caveat) | The PAPI overview doc itself (https://docs.polkadot.com/reference/tools/papi/) does not specifically describe XCM-instruction-level construction, but the chopsticks/replay doc shows PAPI as the recommended XCM construction tool, and PAPI's `TypedApi.tx` is generated directly from chain metadata — *"PAPI ... offers seamless access to storage reads, constants, transactions, events, and runtime calls ... It provides strong TypeScript support with types and documentation generated directly from on-chain metadata"*. Because the XCM instruction enum (including `SetTopic([u8; 32])`) is part of `pallet-xcm`'s exposed metadata, PAPI surfaces it as a typed variant on the runtime's `XcmVN` instruction type and supports building messages instruction-by-instruction including the trailing `SetTopic`. Sources: https://docs.polkadot.com/reference/tools/papi/, https://docs.polkadot.com/chain-interactions/send-transactions/interoperability/debug-and-preview-xcms/. **Caveat:** the official docs do not include a worked SetTopic-injection example. The closest practical reference is ParaSpell's SDK source. |
+| ParaSpell exists as a higher-level XCM router; assess viability as alternative or comparison reference | ✅ | *"ParaSpell is a comprehensive suite of open-source tools designed to simplify cross-chain interactions within the Polkadot ecosystem."* Suite includes XCM SDK, XCM API, XCM Router (cross-chain swaps in a single command), XCM Analyser, XCM Visualizator, XCM Playground. *"It is the first and only XCM SDK in the ecosystem to support both PolkadotJS and Polkadot API"* — confirms PAPI compatibility. Source: https://docs.polkadot.com/reference/tools/paraspell/ |
+| `polkadot.cloud/connect` library supports MetaMask, Talisman, SubWallet, Mimir | ⚠️ | **Spec wallet list is wrong.** Per https://docs.polkadot.cloud/console/basics/wallets/ the supported wallets are: **Web Extensions** — Talisman, Enkrypt, Fearless Wallet, PolkaGate, Polkadot JS, SubWallet; **Hardware Wallets** — Polkadot Vault, Ledger. **MetaMask is not listed** as a supported wallet (it's an EVM wallet; the Polkadot.cloud connect surface targets Substrate signers). **Mimir is not listed** either; Mimir is a separate multisig manager that *uses* signer wallets, not a signer itself. ✅ for Talisman and SubWallet; ⚠️ for MetaMask and Mimir. |
+
+**Sources:**
+- https://docs.polkadot.com/reference/tools/papi/
+- https://docs.polkadot.com/reference/tools/paraspell/
+- https://docs.polkadot.cloud/console/basics/wallets/
+
+**Last verified:** 2026-04-28
+
+**⚠️ Spec correction (`polkadot.cloud/connect` wallet list):** The v1.7 deferred entry should be edited to: *"`polkadot.cloud/connect` supports the standard Substrate wallet ecosystem (Polkadot.js, Talisman, SubWallet, Enkrypt, Fearless, PolkaGate, plus Polkadot Vault and Ledger as hardware signers). MetaMask is **not** among them — for EVM-side signing on Polkadot Hub, use Talisman's EVM mode or MetaMask via the Hub's Ethereum-RPC endpoint directly. Mimir is a multisig manager that composes with these signer wallets but is not itself in the connect library's supported list."*
+
+---
+
+## Hydration and Bifrost claims
+
+| Item | Status | Notes |
+|---|---|---|
+| Bifrost vDOT minting yields ~11–14% APR base | ⚠️ | Stale. Following Polkadot's tokenomics reset, Bifrost-sourced summaries report base vDOT staking yield of ~5–6% APY, with a 30-day APY of ~11% as of Jan 2026 (which **includes** Bifrost incentives, not pure base). The visible "11%" headline matches the spec's lower bound only when incentives are blended in. Sources: https://bifrost.io/vtoken/vdot, https://bifrost.io/blog/bifrost-monthly-report-january-2026, https://docs.bifrost.io/faq (FAQ uses *"Ex1: vDOT as a 17% APY"* purely as a hypothetical, not a current rate). |
+| Hydration GDOT composite yield ~18–25% APR | ⚠️ | At the upper edge of what current Hydration sources document. Hydration's own Substack states GDOT/gigaDOT composite yield comes from "vDOT staking APR + aDOT lending APR + targeted incentives by the Hydration and Polkadot treasuries", and that *"with modest leverage, real yields can reach 15–20%+ with no token incentives, fixed rates"*. The 25% upper bound in the spec is achievable only with leverage / incentive stacking. Sources: https://hydration.substack.com/p/breaking-news-gigadot-and-hollar, https://hydration.substack.com/p/2025-recap, https://hydration.substack.com/p/hydration-newsletter-jan-feb-2026 |
+| Hydration money market accepts GDOT/aDOT as collateral for borrow | ✅ | *"Users can post GDOT/GETH as collateral in Hydration Borrow to draw HOLLAR (or other supported assets), funding operations or strategies without selling DOT/ETH exposure."* And *"Users can deposit collateral on Hydration's money market, borrow HOLLAR at 4.5% fixed rate (governance-set)."* Source: https://hydration.substack.com/p/breaking-news-gigadot-and-hollar |
+| XCM round-trip from Hub→Bifrost typical settlement latency | 🔬 | Empirical — must measure on staging or ask Bifrost team. No doc number. |
+| Bifrost emits failure-code reply-XCM on mint failure (vs trapped silence) | 🔬 | Empirical — Bifrost team question (questions drafted in earlier conversation). No doc commitment to a failure-mode contract. |
+
+**Last verified:** 2026-04-28
+
+**⚠️ Spec correction (yield bands in §2):** Update Bifrost vDOT and Hydration GDOT yield ranges to current sources:
+
+- vDOT base: ~5–6% APY (post-tokenomics-reset); blended-with-incentives: ~10–12% (varies by campaign, timestamped).
+- Hydration GDOT: ~15–20%+ achievable with modest leverage and base-only sources (no incentives); upper figures (>20%) require either active incentive campaigns or higher leverage.
+- Add a "yields are time-stamped and re-verifiable; do not lock numbers in spec text — link to live sources" note.
+
+---
+
+## v2.2.1 runtime claims
+
+| Item | Status | Notes |
+|---|---|---|
+| People Chain block times 2 seconds | ⚠️ | The async-backing doc (https://docs.polkadot.com/reference/parachains/consensus/async-backing/) confirms parachains using async backing achieve *"2 seconds instead of 0.5"* per block. **This is a general parachain capability, not specifically attributed to People Chain.** No `docs.polkadot.com` page states "People Chain produces 2-second blocks." Treat as plausible-but-not-doc-confirmed for People Chain specifically; verify via on-chain block-time observation or a People Chain release note before citing as a People-Chain fact. |
+| Elastic Scaling on People Chain | ⚠️ | Elastic Scaling is documented (https://docs.polkadot.com/reference/parachains/consensus/elastic-scaling/) as a parachain capability — *"Parachains currently achieve 2-second latency with three cores, with projected improvements to 500ms using 12 cores"*. The Agile Coretime doc adds: *"Polkadot supports scheduling multiple cores in parallel through elastic scaling, which is a feature under active development on Polkadot."* **Neither doc names People Chain as an elastic-scaling user.** Whether People Chain has actually been allocated multiple cores (or just the capability is generally available) is not documented. |
+
+**Sources:**
+- https://docs.polkadot.com/reference/parachains/consensus/async-backing/
+- https://docs.polkadot.com/reference/parachains/consensus/elastic-scaling/
+- https://docs.polkadot.com/reference/polkadot-hub/consensus-and-security/agile-coretime/
+
+**Last verified:** 2026-04-28
+
+**⚠️ Spec correction (People Chain attribution):** The v1.6 reconciliation log lines that attribute "2-second blocks" and "Elastic Scaling" specifically to People Chain should be reworded to: *"Polkadot's parachains broadly support 2-second blocks via async backing and multi-core processing via elastic scaling; whether People Chain has these enabled at any given time should be verified against the live chain or current release notes, not assumed from the general doc."*
+
+---
+
+## Multisig claims
+
+| Item | Status | Notes |
+|---|---|---|
+| Substrate `pallet_multisig` produces deterministic addresses from `(signatories, threshold)` | ✅ | Per `pallet_multisig` Rust docs: the multisig account is *"a well-known origin, derivable deterministically from the set of account IDs and the threshold number of accounts"*. Source: https://paritytech.github.io/polkadot-sdk/master/pallet_multisig/index.html |
+| Signet/Polkadot Multisig supports Talisman as signer wallet | ✅ | Polkadot Multisig (Signet) help center and product page confirm Talisman is among supported signer wallets — alongside Polkadot.js, SubWallet, Enkrypt, plus hardware (Ledger, D'Cent, Polkadot Vault) via those signer wallets. Sources: https://polkadotmultisig.com/, https://guide.polkadotmultisig.com/en/category/about-polkadot-multisig/article/what-wallets-are-supported-by-polkadot-multisig (note: guide site was returning 530 intermittently at verification time; product landing page and Polkadot Wiki multisig-apps page corroborate). |
+
+**Last verified:** 2026-04-28
+
+**Spec actions:** None. `MULTISIG_SETUP.md §3` and `MULTISIG_DECISION.md` claims hold up. The remaining multisig-side risk is the 🔬 item under "Account and identity claims" — confirming that an EVM-mapped multisig can actually own an EVM contract on Asset Hub.
+
+---
+
+## Empirical-only items (cannot be resolved from docs)
+
+These items can never be answered by reading documentation. They require running tests or contacting vendors.
+
+| Question | How to answer | Priority |
+|---|---|---|
+| Does Bifrost preserve SetTopic on reply-leg XCM back to Hub? | Chopsticks experiment (§10 of spec) | **Highest** — load-bearing for the entire correlation gate |
+| What is Bifrost's typical and worst-case settlement latency for vDOT mint and redeem? | Bifrost team inquiry + Chopsticks measurement | High |
+| What does Bifrost emit on mint failure (insufficient liquidity, paused vToken)? | Bifrost team inquiry + deliberately malformed Chopsticks test | High |
+| If Hub→Bifrost XCM execution fails on Bifrost (weight too low, asset not registered), is failure ever surfaced back to Hub? | Same — deliberately malformed message | High |
+| Does an EVM-mapped Substrate multisig (multisig → AccountId32 → `pallet_revive.map_account` → H160) successfully own and operate an EVM contract on Polkadot Hub TestNet end-to-end? | Hub TestNet integration test: deploy a contract owned by the mapped multisig address, exercise an `onlyOwner` call signed via Polkadot Multisig | **High** — load-bearing for `MULTISIG_SETUP.md` |
+| What is the actual override rate of LLM-as-judge on Phase 1 disputes? | Real disputes, weeks of operation, Phase 1 instrumentation | Medium (not blocking v1.0.0-rc1) |
+| What fraction of Averray-funded GitHub PRs land merged upstream? | Real platform operation, week-12 gate | Medium (not blocking v1.0.0-rc1) |
+| What is the dispute rate at production volume? | Real platform operation, weekly instrumentation | Medium |
+
+---
+
+## Verification process going forward
+
+### Recommended cadence
+
+- **Before v1.0.0-rc1 deploy:** verify all ⚠️ items above have flowed into `RC1_WORKING_SPEC.md` corrections, paying particular attention to the native-DOT-precompile correction in `MULTISIG_SETUP.md §5` and the EVM-mapped-multisig empirical test (🔬). Without these, multisig setup is not safely actionable.
+- **Before any external announcement of Bulletin Chain integration:** complete the Bulletin Chain corrections to the spec; fix the retention-period assumption everywhere.
+- **Before relying on PoP for v2 design:** verify Asset Hub integration scope of the PoP rollout. Marketing language is not implementation status — and per this verification pass, even the basic DIM1/DIM2 tier model is not yet on `docs.polkadot.com`.
+- **Quarterly:** re-verify ✅ items. Polkadot is moving fast; runtime upgrades change semantics.
+
+### Recommended tooling for ongoing verification
+
+- **Polkadot docs MCP server** (`https://docs-mcp.polkadot.com`) connected to Claude Code for ad-hoc queries during development. Confirmed working in the 2026-04-28 pass.
+- **AI-ready static files** (e.g. `https://docs.polkadot.com/llms-full.jsonl`, category-specific bundles like `chain-interactions.md`) for batch context loading.
+- **The repo's own `polkadot-docs/` subfolder** if mirroring docs locally for audit purposes.
+
+### What "verified" means in this document
+
+A claim is verified if:
+1. The current Polkadot docs explicitly state it, *and*
+2. The exact spec text doesn't contradict the docs, *and*
+3. The doc page's "Last update" date is recent enough to reflect current runtime state.
+
+A claim is **not** verified by:
+- A community blog post or marketing copy alone.
+- A docs page from before the relevant runtime version.
+- A doc that uses the right keywords but answers a different question.
+
+This is deliberate. The trust pitch — "receipts, not vibes" — extends to the spec itself. Don't claim verification on uncertain ground.

--- a/docs/FRAMEWORK_AGENT_HANDOFF.md
+++ b/docs/FRAMEWORK_AGENT_HANDOFF.md
@@ -1,0 +1,150 @@
+# Framework Agent Handoff — Averray Implementation
+
+**Purpose:** Context document for the framework agent picking up implementation work on Averray.
+**Companion documents:** `RC1_WORKING_SPEC.md` (v1.10) and `AVERRAY_VERIFICATION_LEDGER.md` (post-verification, 2026-04-28).
+**Read this first.** Then read the two companion documents in the order described below.
+
+---
+
+## What Averray is
+
+Averray is a trust-infrastructure platform for software agents on Polkadot Hub (Asset Hub EVM). The platform's product surface includes wallet identity (SIWE), a job/escrow lifecycle (`AgentAccountCore`, `EscrowCore`), reputation as soulbound tokens (`ReputationSBT`), an XCM-based async treasury for yield strategies (`XcmWrapper` to Bifrost vDOT), and a session lifecycle that produces public, verifiable receipts.
+
+The architectural thesis is *"receipts, not vibes"* — every claim the platform makes about an agent's work is anchored in on-chain commitments with hash bindings to off-chain content. The platform has no token, runs on fees, and treats reputation as non-transferable by design.
+
+---
+
+## How the documents relate
+
+The spec is the design. The ledger is the receipt.
+
+Where the spec references Polkadot behavior, the ledger says whether it's verified against `docs.polkadot.com` (✅), needs corrections that have already been applied to the spec (⚠️), or can only be answered empirically (🔬).
+
+Cross-reference the ledger any time the spec asserts something about Polkadot semantics. **The ledger is post-verification — every claim has been resolved to ✅, ⚠️, or 🔬. If you find a claim that doesn't appear in the ledger, that's a gap worth flagging, not assuming.**
+
+---
+
+## Read these first, in this order
+
+1. **The spec's reconciliation log (§13) bottom-up** — newest entry (v1.9) first, then v1.8, etc. This shows how the design evolved and why specific decisions were made. The log is preserved across versions deliberately; it's the audit trail for the design itself.
+2. **The spec's §12 pre-launch checklist** — the canonical list of what `v1.0.0-rc1` needs.
+3. **The verification ledger top summary** — the count of verified vs. corrections-needed vs. empirical claims, and the seven correction themes that flowed into the spec at v1.9.
+
+---
+
+## Two gating items before any mainnet-adjacent work
+
+Both must be resolved before tagging `v1.0.0-rc1` for mainnet rehearsal. The rest of the v1.0.0-rc1 work is **not blocked** by these — see "Scope of unblocked work" below.
+
+### Gating item A: TOKEN_ADDRESS resolution
+
+The native DOT precompile claim was retracted in spec v1.9 — no such precompile exists on Asset Hub. `MULTISIG_SETUP.md §5` now uses `TOKEN_ADDRESS=0x<approved-asset-precompile-or-test-token>` to avoid implying a known native-DOT ERC20 address. **Do not run the deploy script for any mainnet-adjacent rehearsal until this field has a real answer.** Three candidate paths to resolve:
+
+- **(a)** DOT is the chain's native currency; for native-DOT transfers, use the EVM call's `value` field — no token address needed (mirrors how native ETH works on Ethereum). The deploy script's TOKEN_ADDRESS field may simply not apply for native-DOT operations.
+- **(b)** Foreign-asset-wrapped ERC-20 representation of DOT, registered in the Assets pallet, with a precompile address derivable from the Foreign Asset formula. Look this up in Asset Hub's foreign-asset registry.
+- **(c)** TestDOT mock for testnet, production path explicitly TBD. Acceptable for testnet rehearsal only; mainnet still requires resolution before tagging `v1.0.0-rc1`.
+
+The ledger's "Account and identity claims" section (specifically the "Native DOT precompile address on Asset Hub" row) has the full source quotes and the official ERC20 precompile docs that confirm no such precompile exists.
+
+### Gating item B: Multisig-owns-EVM-contract composition validation
+
+The composition `pallet_multisig` SS58 → `pallet_revive.map_account()` H160 → owner of `TreasuryPolicy` rests on three documented primitives but the composition itself is not documented end-to-end on `docs.polkadot.com`. **Running `MULTISIG_SETUP.md §5` against Polkadot Hub TestNet IS the validation experiment.**
+
+- If it works, the architecture holds and the runbook is safe for mainnet rehearsal.
+- If it doesn't, the multisig story needs a different shape (Solidity-side multisig such as Safe, or Mimir's account-mapping flow, or something else).
+
+The ledger flags this as 🔬 in the "Account and identity claims" section. Capture testnet receipts when running the experiment so the result is itself part of the public trail.
+
+---
+
+## Scope of unblocked work
+
+Most of the `v1.0.0-rc1` contract scope is unblocked by the two gating items above. The following can proceed in parallel:
+
+- **`DiscoveryRegistry`** — new contract for manifest hash anchoring
+- **Verifier mapping extension** — `authorizedSince`/`authorizedUntil`/`wasAuthorizedAt`
+- **`ReputationSBT` non-transferable hardening** — `revert(Soulbound)` on transfer/transferFrom
+- **Hash fields on session events** — `JobCreated(..., specHash)`, `Submitted(..., payloadHash)`, `Verified(..., reasoningHash)`
+- **Disclosure events** — `Disclosed(hash, byWallet, ts)` and `AutoDisclosed(hash, ts)` from existing session contract
+- **`XcmWrapper.queueRequest` SetTopic-validation** — decode last instruction, reject if not `SetTopic(requestId)`
+- **EscrowCore arbitration changes** — `openDispute` deadline check, `autoResolveOnTimeout` permissionless escape hatch, `disputedAt` timestamp on job state
+- **Backend SCALE assembler** (`mcp-server/src/blockchain/xcm-message-builder.js`) — server-controlled XCM intent routing with fixed SetTopic suffix vectors
+- **Backend dispute-flow wiring** — `POST /disputes/:id/verdict` and `/release` to actually call `EscrowCore.resolveDispute`
+- **Pre-launch instrumentation** — `funded_jobs` table, daily upstream-status poller, weekly self-report
+
+Don't sit on this work waiting for the gating items.
+
+---
+
+## What's locked vs. what's still open
+
+### Locked (don't redesign)
+
+- Business model, economics, parameter discipline (§14)
+- Source-of-truth architecture: commitments on-chain, content off-chain, hashes binding
+- v1.0.0-rc1 contract scope (§8)
+- XCM correlation primitive: SetTopic = requestId — verified ✅ against upstream `pallet-xcm` source
+- Backend SCALE assembler boundary: server-controlled request payloads with SetTopic = requestId
+- Arbitration evolution path: Phase 0 → 3 with data-driven gates
+- Yield strategy portfolio: vDOT v1, Hydration GDOT v2
+
+### Open (genuinely undecided)
+
+- Phase 2 storage backend (Bulletin Chain vs. Crust) — defer until empirical data exists
+- TOKEN_ADDRESS resolution (gating item A above)
+- Multisig-owns-EVM composition (gating item B above)
+- Bifrost SetTopic preservation on reply-leg (Chopsticks experiment, see spec §10)
+- Bifrost settlement latency and failure-mode behavior (Bifrost team inquiry + Chopsticks)
+- LLM-as-judge override rate (Phase 1 instrumentation; not blocking v1)
+
+---
+
+## How to update the documents
+
+If you discover something that contradicts the spec:
+
+1. Update the verification ledger first with quote and source.
+2. Surface the correction to the user before modifying the spec.
+3. The spec uses a versioned reconciliation log (§13) — every change gets an entry there. Don't delete prior log entries; they're audit trail.
+
+If you discover something the spec doesn't address:
+
+1. Note it as a deferred item if it's architectural.
+2. Note it as an experimentation question if it's empirical.
+3. Don't add new locked decisions without surfacing them.
+
+If your work would touch `MULTISIG_SETUP.md` execution or anything that depends on contract ownership transfer:
+
+- Stop and surface the two gating items (A and B above) first.
+- Don't run `MULTISIG_SETUP.md §5` against testnet without resolving TOKEN_ADDRESS.
+- Don't tag v1.0.0-rc1 for any mainnet purpose without the multisig-owns-EVM rehearsal.
+
+When in doubt about scope, default to surfacing rather than acting. The spec has been built up across many sessions with deliberate compression — every paragraph carries weight that may not be obvious from a cold read. If a section seems wrong, propose a correction; don't apply one. The reconciliation log (§13) is how decisions evolve in this project.
+
+---
+
+## Tooling
+
+The Polkadot docs MCP server (`https://docs-mcp.polkadot.com`) is the recommended primary source for verifying any Polkadot semantics during development:
+
+```
+claude mcp add --transport http polkadot-docs https://docs-mcp.polkadot.com --scope user
+```
+
+The verification ledger was built using this MCP plus targeted web fetches for upstream `polkadot-sdk` source code. Same workflow applies for any new verification work.
+
+---
+
+## What this project values
+
+Receipts, not vibes. The spec is honest about what's verified vs. community-sourced precisely because the platform's trust pitch demands the same discipline of itself. When you hit a claim you can't verify, say so. When you make an architectural judgment, surface it. Don't auto-merge corrections into the spec; propose them.
+
+The same discipline that makes the platform credible to its agents makes the codebase credible to the next person picking it up. Don't break that pattern.
+
+---
+
+## Final notes
+
+- The reconciliation log entries v1.0 through v1.9 in the spec capture nine sessions of design work. Read them; don't re-derive decisions that were already made deliberately.
+- Both files were last updated on 2026-04-28. If you're reading this much later, re-verify ✅ items in the ledger before relying on them — Polkadot is moving fast and the runtime semantics shift with each release.
+- The spec is 872 lines and 15 sections. The ledger is 343 lines. They were designed to be read together. Neither alone tells the full story.

--- a/docs/MULTISIG_SETUP.md
+++ b/docs/MULTISIG_SETUP.md
@@ -135,7 +135,7 @@ cd /path/to/agent
 PROFILE=testnet \
 RPC_URL=https://eth-rpc-testnet.polkadot.io/ \
 PRIVATE_KEY=0x<deployer-testnet-key> \
-TOKEN_ADDRESS=0x<hub-dot-precompile-or-testdot> \
+TOKEN_ADDRESS=0x<approved-asset-precompile-or-test-token> \
 OWNER=0x<multisig-mapped-evm>    \
 PAUSER=0x<hot-key-evm>           \
 VERIFIER=0x<verifier-evm>        \
@@ -145,6 +145,12 @@ ARBITRATOR=0x<arbitrator-evm>    \
 
 The deploy script transfers ownership to `OWNER` as the last step. After
 ownership transfer the deployer key can no longer touch admin ops.
+
+`TOKEN_ADDRESS` is a launch gate. There is no native DOT ERC20 precompile on
+Polkadot Hub. For local `dev`, the deploy script mints MockDOT automatically
+when this value is omitted. For `testnet` and `mainnet`, use an explicitly
+verified ERC20 asset precompile or a deliberate test token; do not use a
+placeholder native-DOT precompile address.
 
 ### 5b. Verify the wiring
 

--- a/docs/RC1_IMPLEMENTATION_PLAN.md
+++ b/docs/RC1_IMPLEMENTATION_PLAN.md
@@ -22,7 +22,7 @@ indexer, frontend, and docs work.
 
 The shortest path to a coherent rc1 launch is:
 
-1. Reconcile the contract architecture with the v1.4 spec.
+1. Reconcile the contract architecture with the v1.10 spec.
 2. Make dispute deadlines and arbitration SLA enforceable on-chain.
 3. Wire backend/indexer/operator dispute handling to the on-chain dispute path.
 4. Ship content-addressed storage and disclosure reads.
@@ -34,8 +34,9 @@ The shortest path to a coherent rc1 launch is:
 
 ## Current Position
 
-As of this branch, **slice 9: Backend SCALE Assembler** is implemented and
-ready for review.
+As of this branch, **slice 9: Backend SCALE Assembler** is merged and deployed.
+The next implementation slice is **slice 10: Native XCM Observer Correlation
+Gate**.
 
 Completed and deployed in this lane:
 
@@ -58,7 +59,7 @@ Completed and deployed in this lane:
 Still open in the broader rc1 path:
 
 - scheduler/email hardening for weekly reports after enough real jobs exist
-- backend SCALE assembler and native XCM observer correlation in later slices
+- native XCM observer correlation and staging evidence
 
 ## PR Slices
 
@@ -79,7 +80,7 @@ Still open in the broader rc1 path:
 
 ### 1. Contract Architecture Reconciliation
 
-**Goal:** align the deployed rc1 backbone code with v1.4's target architecture:
+**Goal:** align the deployed rc1 backbone code with the target architecture:
 one new `DiscoveryRegistry`, verifier history inside the existing policy role
 surface, and disclosure events on the existing session lifecycle surface.
 
@@ -287,8 +288,8 @@ logic.
 
 1. Land slice 0 immediately.
 2. Do slice 1 before adding more contract features, because it removes the
-   architecture mismatch between the current rc1 backbone and the v1.4 spec.
+   architecture mismatch between the initial rc1 backbone and the target spec.
 3. Do slice 2 next; dispute windows and SLA prevent locked-value edge cases.
 4. Do slice 3 so the operator flow uses the actual on-chain state machine.
-5. Defer XCM implementation slices until the contract/dispute backbone is
-   coherent and content receipts are stable.
+5. Do slice 10 before any vDOT mainnet allocation: the assembler is shipped,
+   but Bifrost reply-leg correlation still needs staging proof.

--- a/docs/RC1_WORKING_SPEC.md
+++ b/docs/RC1_WORKING_SPEC.md
@@ -1,42 +1,47 @@
-# Averray - Working Spec (v1.0.0-rc1)
+# Averray — Working Spec (v1.0.0-rc1)
 
-**Status:** Reconciled with deployed reality and operational docs  
-**Spec version:** 1.4 (yield strategy portfolio model; vDOT as v1 moderate default; Hydration GDOT and money-market borrow scoped as v2)
-**Owner:** Pascal  
-**Last updated:** 2026-04-26
+**Status:** Reconciled with deployed reality and operational docs
+**Spec version:** 1.10 (repository sync after Slice 9; v1.9 verification corrections imported, backend SCALE assembler and SetTopic wrapper validation marked shipped, TOKEN_ADDRESS wording aligned with no-native-DOT-precompile correction)
+**Owner:** Pascal
+
+---
 
 ## Summary
 
-Averray is trust infrastructure for software agents on Polkadot Hub (Asset Hub EVM). The platform runs as a marketplace take-rate model with no platform token, sustained by fees and structurally honest receipts. Reputation is bootstrapped by funding agent contributions to public OSS and Wikipedia where the upstream merge itself is the verdict - no posters required to seed the trail. Source of truth lives on-chain (commitments, identity, payouts) with hashes binding to off-chain content. Idle wallet balance earns vDOT yield via async XCM to Bifrost, making worker wallets durable earning accounts. Sustainability target is fee-funded operations within 6-12 months of public launch.
+Averray is trust infrastructure for software agents on Polkadot Hub (Asset Hub EVM). The platform runs as a marketplace take-rate model with no platform token, sustained by fees and structurally honest receipts. Reputation is bootstrapped by funding agent contributions to public OSS and Wikipedia where the upstream merge itself is the verdict — no posters required to seed the trail. Source of truth lives on-chain (commitments, identity, payouts) with hashes binding to off-chain content. Idle wallet balance earns vDOT yield via async XCM to Bifrost, making worker wallets durable earning accounts. Sustainability target is fee-funded operations within 6–12 months of public launch.
+
+---
 
 ## 1. Business model
 
 ### Locked
 
 - **Marketplace take rate (Model A).** Revenue scales with settled-escrow GMV.
-- **Polkadot Hub (Asset Hub EVM) as the production target.** Cheap tx, EVM compatibility, native DOT precompile, XCM for cross-chain capital. Architectural fit, not a beachhead.
-- **"Be early" posture.** 3-5 year bet on becoming the canonical surface for agent work; near-term goal is reputation density and platform sustainability, not extraction.
+- **Polkadot Hub (Asset Hub EVM) as the production target.** Cheap tx, EVM compatibility, XCM for cross-chain capital. DOT exposed to EVM contracts via foreign-asset wrapping or XCM multilocation reference, NOT via a native DOT precompile (no such precompile exists; previously-stated claim was incorrect — see `MULTISIG_SETUP.md §5` `TOKEN_ADDRESS` field for downstream impact). Architectural fit, not a beachhead.
+- **"Be early" posture.** 3–5 year bet on becoming the canonical surface for agent work; near-term goal is reputation density and platform sustainability, not extraction.
 - **No platform token, ever.** Fee-funded forever. Reputation is non-transferable. No airdrop, no points, no governance token. *"Averray is a blockchain product, not a token product."*
 
-### Why blockchain
+### Why blockchain (defensible answer)
 
 Blockchain is the architectural fit because the product needs **public, verifiable, third-party-checkable receipts** that survive the platform itself. Wallet identity, settlement finality, and an immutable event trail are load-bearing. The product is not crypto-speculative; it does not require a token to function or to capture value.
+
+---
 
 ## 2. Economics
 
 ### Bootstrap budget
 
 - **$50/week** spent on bounties to seed reputation. Hard cap.
-- Distribution per week:
-  - ~15 light jobs at $1 each -> $15
-  - ~5-7 substantive jobs at $5-7 each -> ~$35
+- Distribution per week (target):
+  - ~15 light jobs @ $1 each → $15
+  - ~5–7 substantive jobs @ $5–7 each → ~$35
 - ~80 jobs/month, ~480 in the trail by month 6.
 
 ### Job sourcing
 
 - **GitHub Issues** from a denylist-defaulted set of repos.
 - **Wikipedia mechanical edits** (typo fixes, dead-link replacements, citation formatting). No prose contributions in v1.
-- All jobs are sourced upstream. Averray funds completion, the agent submits the fix, the maintainer chooses to merge or close. No outreach, no spam, no obligation.
+- All jobs are sourced upstream — Averray funds completion, the agent submits the fix, the maintainer chooses to merge or close. No outreach, no spam, no obligation.
 
 ### Two distinct economic primitives at claim time
 
@@ -57,50 +62,50 @@ The platform charges a working agent two layered amounts at claim. They serve di
 
 Working agent pays nothing net. Bad actors fund both reputation penalties and verifier compute on every failed attempt.
 
-### Onboarding flow
+### Onboarding flow (durable, not transitional)
 
 A new agent never needs upfront DOT to start working:
 
-1. **SIWE sign-in** -> worker wallet exists.
+1. **SIWE sign-in** → worker wallet exists
 2. **First 3 jobs claimed without stake or fee.** Both waived. Agent earns DOT from these jobs into the wallet's `AgentAccountCore` balance.
 3. **Job 4 onward, two paths converge:**
-   - Use accumulated DOT from jobs 1-3.
-   - Or borrow against the per-account `BORROW_CAP = 25 DOT` to bridge stake on a higher-tier job.
-4. **On settlement,** payout repays any outstanding borrow first; surplus settles to wallet balance and optionally into the vDOT strategy.
+   - Use accumulated DOT from jobs 1–3
+   - Or borrow against the per-account `BORROW_CAP = 25 DOT` to bridge stake on a higher-tier job
+4. **On settlement,** payout repays any outstanding borrow first; surplus settles to wallet balance and (optionally) into the vDOT strategy
 
 Borrow-to-stake is the durable model, not a v2 item. It exists in the contract suite already (`BORROW_CAP = 25 DOT`, flat per-account, current launch profile).
 
 ### Wallet as earning account: yield strategy portfolio
 
-Idle DOT in `AgentAccountCore` can be allocated into yield strategies via the async XCM lane. Agents earn yield between jobs. This is real stickiness: switching off Averray means unwinding a yield position, not just changing a default.
+Idle DOT in `AgentAccountCore` can be allocated into yield strategies via the async XCM lane. Agents earn yield between jobs. This is real stickiness — switching off Averray means unwinding a yield position, not just changing a default.
 
-The platform treats yield strategies as a **portfolio**, not a fixed choice. Different agents have different risk tolerances, and the Polkadot DeFi landscape evolves faster than launch-time architecture should lock in. The existing `XcmVdotAdapter.sol` pattern already isolates this concern; new strategies ship as new adapters behind the same `XcmWrapper` surface.
+The platform treats yield strategies as a **portfolio**, not a fixed choice — different agents have different risk tolerances, and the Polkadot DeFi landscape evolves faster than launch-time architecture should lock in. The existing `XcmVdotAdapter.sol` pattern already isolates this concern; new strategies ship as new adapters behind the same `XcmWrapper` surface.
 
 **v1 default: moderate auto-allocation to vDOT (Bifrost).**
-
 - Idle balance above a threshold auto-allocates to vDOT via single-hop XCM to Bifrost.
-- Indicative yield: ~11-14% APR base from native staking rewards.
-- Single vendor (Bifrost), single XCM hop, single correlation primitive (`SetTopic` preserved on reply-leg, pending Chopsticks confirmation).
-- Lowest vendor surface and well-understood risk.
-- Conservative-by-default for trust infrastructure: the platform is sensible by default but does not ceiling agents who want more.
+- Yield: ~5–6% APR base from native staking rewards (post-2026 Bifrost tokenomics reset; verify current Bifrost docs before launch — yields shift with Polkadot inflation policy and Bifrost incentive structure).
+- Single vendor (Bifrost), single XCM hop, single correlation primitive (SetTopic preserved on reply-leg, pending Chopsticks confirmation).
+- Lowest vendor surface, well-understood risk.
+- Conservative-by-default for trust infrastructure: the platform is sensible by default but doesn't ceiling agents who want more.
 
 **v2 strategy: Hydration GDOT (composite yield).**
-
 - New `HydrationGdotAdapter` alongside `XcmVdotAdapter`. Same `XcmWrapper` surface; different backend SCALE assembler; different observer correlation logic.
-- Indicative target yield: 18-25% APR from four sources: vDOT staking, aDOT lending, vDOT/aDOT pool trading fees, and Hydration/Polkadot treasury incentives.
-- Tradeoffs: doubled vendor surface (Hydration + Bifrost), multi-hop XCM (Hub -> Hydration -> Bifrost -> Hydration -> Hub), exposure to Hydration's drifting-peg mechanism, Omnipool pricing, and HDX governance.
+- Yield: targeting ~15–20% APR from leveraged composition of vDOT staking + aDOT lending + vDOT/aDOT pool trading fees + Hydration/Polkadot treasury incentives. Real yield depends on leverage ratio chosen and prevailing market conditions.
+- Tradeoffs: doubled vendor surface (Hydration + Bifrost), multi-hop XCM (Hub → Hydration → Bifrost → Hydration → Hub), exposure to Hydration's drifting-peg mechanism, Omnipool pricing, and HDX governance.
 - Opt-in only. Agents explicitly choose this strategy; never auto-allocated.
 
 **Decision principle for the portfolio:**
-The marketing line *"Your worker wallet earns between jobs"* does not require maximum yield to be true. Around 12% from vDOT alone meaningfully beats typical CEX yield assumptions. The marginal benefit of GDOT over vDOT is not worth doubling vendor surface and complicating XCM correlation at launch. Ship vDOT first, validate the correlation gate, then add GDOT as an upgrade path for agents who want it.
+The marketing line *"Your worker wallet earns between jobs"* doesn't require maximum yield to be true. ~5–6% from vDOT alone meaningfully beats CEX yield (0.5–3%) and most bank savings rates; the marginal benefit of GDOT over vDOT isn't worth doubling vendor surface and complicating XCM correlation at launch. Ship vDOT first, validate the correlation gate, then add GDOT as an upgrade path for agents who want it.
 
 **Hydration money market for borrow facility (v2):**
-The existing `BORROW_CAP = 25 DOT per account` runs on Averray's own balance sheet: the platform is the lender. When liquidation mechanics ship, strongly consider routing the borrow facility through Hydration's money market instead of building it natively. That changes `BORROW_CAP` from "Averray's exposure ceiling" to "max LTV against agent's GDOT/aDOT collateral on Hydration." Cleaner risk model: Averray no longer carries lender-of-last-resort exposure, borrow caps scale with actual collateral rather than a flat number, and liquidation mechanics already exist at the money-market layer. Reputation-weighted credit becomes a small additional reservoir on top of Hydration's collateral-based lending, rather than the entire borrow primitive.
+The existing `BORROW_CAP = 25 DOT per account` runs on Averray's own balance sheet — the platform is the lender. When liquidation mechanics ship (currently a v2 deferred item), strongly consider routing the borrow facility through Hydration's money market instead of building it natively. That changes `BORROW_CAP` from "Averray's exposure ceiling" to "max LTV against agent's GDOT/aDOT collateral on Hydration." Cleaner risk model: Averray no longer carries lender-of-last-resort exposure, borrow caps scale with actual collateral rather than a flat number, and liquidation mechanics already exist and are battle-tested. Reputation-weighted credit becomes a small additional reservoir on top of Hydration's collateral-based lending, rather than the entire borrow primitive.
 
 ### Sustainability principles
 
 - Verifier compute cost must stay **under 1% of payout** as a design invariant. If a new job type breaks this, re-price before launching it.
-- Platform treasury inflows from slashing are intended to fund verifier operations and platform sustainability, not to be redistributed to holders (there are none).
+- Platform treasury inflows from slashing are explicitly intended to fund verifier operations and platform sustainability, not to be redistributed to "holders" (there are none).
+
+---
 
 ## 3. Verifier and arbitrator model
 
@@ -109,19 +114,19 @@ The existing `BORROW_CAP = 25 DOT per account` runs on Averray's own balance she
 | Role | Authority source | Purpose | Compensation |
 |---|---|---|---|
 | **Verifier** | On-chain mapping (set via `setVerifier(address, bool)`) | Decides pass/fail at submission against job schema. Co-signs receipts. | Fixed per-verification budget (~$0.02), funded by claim fees on the failure path |
-| **Arbitrator** | `TreasuryPolicy.arbitrators` mapping, set via `setArbitrator(address, bool)`. Multi-arbitrator by design; phase 0 means the approved set has size 1. | Adjudicates disputes when an agent contests a verdict. Final on-chain via `EscrowCore.resolveDispute(jobId, workerPayout, reasonCode, metadataURI)`. | Phase 0-1: unpaid. Phase 2+: split of slashed stake activates with agent-arbitration. |
-| **Pauser** | Single hot key (1-of-1 EOA), not part of multisig | Emergency `setPaused(bool)` capability. Cannot move funds; only freezes. | n/a |
+| **Arbitrator** | `TreasuryPolicy.arbitrators` mapping, set via `setArbitrator(address, bool)`. Multi-arbitrator by design — phase 0 just means the approved set has size 1. | Adjudicates disputes when an agent contests a verdict. Final on-chain via `EscrowCore.resolveDispute(jobId, workerPayout, reasonCode, metadataURI)`. | Phase 0–1: unpaid (volume too low to matter). Phase 2+: split of slashed stake activates with agent-arbitration. |
+| **Pauser** | Single hot key (1-of-1 EOA), not part of multisig | Emergency `setPaused(bool)` capability. Cannot move funds — only freezes. | n/a |
 
-The arbitrator is **not** a peer verifier doing re-review. It is a designated role with sharper consequences: 35/60 skill/reliability penalties on dispute-loss versus 10/25 on plain rejection.
+The arbitrator is **not** a peer verifier doing re-review. It's a designated role with sharper consequences (35/60 skill/reliability penalties on dispute-loss versus 10/25 on plain rejection).
 
-### Verifier strategy
+### Verifier strategy: hybrid with escalation
 
 | Job type | Verifier mechanism | Per-verification cost |
 |---|---|---|
 | GitHub PR jobs | Upstream merge within deadline (GitHub API poll) | ~$0 |
 | Wikipedia edits | Survives 7 days unreverted (MediaWiki API poll) | ~$0 |
 | Subjective work (future) | Haiku-class LLM-as-judge | ~$0.03 |
-| Disputes / arbitration | Arbitrator review (human or human-in-loop, not LLM-as-judge) | n/a - funded by slashed stake |
+| Disputes / arbitration | Arbitrator review (human or human-in-loop, not LLM-as-judge) | n/a — funded by slashed stake |
 
 **Blended cost per verification at planned mix:** ~$0.013. Budgeted at **$0.02** for safety margin.
 
@@ -129,78 +134,82 @@ The arbitrator is **not** a peer verifier doing re-review. It is a designated ro
 
 PRs can sit for weeks before maintainer review. The verifier needs three states:
 
-1. **Provisional pass** - at submission, before merge.
-2. **Confirmed pass** - at upstream merge, SBT minted.
-3. **Fail-and-refund-poster** - at deadline if neither merge nor close within configured window.
+1. **Provisional pass** — at submission, before merge
+2. **Confirmed pass** — at upstream merge, SBT minted
+3. **Fail-and-refund-poster** — at deadline if neither merge nor close within configured window
 
 Default deadline: **30 days** for GitHub PRs, **14 days** for Wikipedia edits. Configurable per repo.
 
-### Dispute-rate discipline
+### Why the 5% dispute-rate target is defensible
 
-The cost discipline that keeps disputes rare is the penalty structure. An agent who escalates a weak submission and loses takes a 35/60 reputation hit plus loses their stake. Disputes get filtered economically, not by friction. Still instrument from day one: log every dispute, watch the rate weekly, and re-price if it climbs above 10%.
+The cost discipline that keeps disputes rare isn't compute cost — it's the penalty structure. An agent who escalates a weak submission and loses takes a 35/60 reputation hit *plus* loses their stake. That's a structurally expensive choice. Disputes get filtered economically, not by friction. Still instrument from day one — log every dispute, watch the rate weekly, re-price if it climbs above 10%.
 
 ### Arbitration evolution path
 
-The arbitrator role evolves in phases. Each phase has data-driven gates rather than calendar-only dates.
+The arbitrator role evolves in phases. Each phase has explicit data-driven gates rather than calendar dates — the right transition timing is empirical.
 
-**Phase 0 - launch through ~50 disputes: human arbitrator (Pascal).**  
-Single approved address in `TreasuryPolicy.arbitrators`. Hardware-wallet custody with a dedicated Ledger separate from multisig cold keys. Annual time-based key rotation, immediate rotation on suspected compromise via multisig `setArbitrator(oldAddr, false)` + `setArbitrator(newAddr, true)`. Public commitment to migrate by month 6 or first 50 disputes, whichever comes first.
+**Phase 0 — launch through ~50 disputes: human arbitrator (Pascal).**
+Single approved address in `TreasuryPolicy.arbitrators` mapping. Hardware-wallet custody (dedicated Ledger, separate from multisig cold key). Annual time-based key rotation, immediate rotation on suspected compromise via multisig `setArbitrator(oldAddr, false)` + `setArbitrator(newAddr, true)`. Public commitment to migrate by month 6 or first 50 disputes — whichever comes first. The first 50 disputes are when patterns become legible enough to design Phase 1.
 
-**Phase 1 - ~50-250 disputes: human-supervised LLM arbitration.**  
-Same on-chain role. New tool: an LLM-as-judge pre-analyzes each dispute and proposes a verdict with reasoning. Pascal upholds or overrides. Override rate is the metric. Migrate to Phase 2 only when override rate sits below 10% sustained.
+**Phase 1 — ~50–250 disputes: human-supervised LLM arbitration.**
+Same on-chain role (still you). New tool: an LLM-as-judge that pre-analyzes each dispute, proposes a verdict with reasoning. You uphold or override. Override rate is the metric. Builds the calibration dataset needed to trust agent arbitration. Migrate to Phase 2 only when override rate sits below 10% sustained.
 
-**Phase 2 - 250+ disputes, override rate <10% sustained: tiered agent arbitration.**
+**Phase 2 — 250+ disputes, override rate <10% sustained: tiered agent arbitration.**
+Multiple safeguards layered:
+- *Stake tiering.* Low-stake disputes route to qualified agents. High-stake disputes (large bounties, high-profile repos, agents with significant reputation at risk) escalate to human review. Threshold is on-chain.
+- *Quorum.* Disputes routed to agent-arbitrators require N-of-M independent signed verdicts. 2-of-3 is the v2 default. Disagreement escalates.
+- *Arbitrator-agent staking.* Eligible agents post a bond from their wallet balance. Overturned arbitration (escalated and reversed) costs 50/80 reputation — harsher than ordinary dispute-loss because trust impact is larger.
+- *Conflict-of-interest exclusion.* On-chain filter: arbitrator-agent cannot be involved in the dispute, share operator wallet with either party, or have submitted to the same repo recently.
+- *Deterministic selection.* Eligible arbitrator pool selected from on-chain criteria (wallet age, merge count, recent activity, no recent overturned arbitration). Selection from pool is deterministic from on-chain randomness, not a backend lottery.
 
-- **Stake tiering.** Low-stake disputes route to qualified agents. High-stake disputes escalate to human review.
-- **Quorum.** Agent-arbitrated disputes require N-of-M independent signed verdicts. 2-of-3 is the v2 default. Disagreement escalates.
-- **Arbitrator-agent staking.** Eligible agents post a bond from wallet balance. Overturned arbitration costs 50/80 reputation.
-- **Conflict-of-interest exclusion.** Arbitrator-agent cannot be involved in the dispute, share operator wallet with either party, or have submitted to the same repo recently.
-- **Deterministic selection.** Eligible arbitrator pool selected from on-chain criteria and deterministic on-chain randomness, not a backend lottery.
-
-**Phase 3 - fully decentralized arbitration tier.**  
-Permissionless registration for agents meeting on-chain criteria: N successful jobs, M months active, stake bond, no recent disputes lost. Human escalation reserved for highest-tier disputes only.
+**Phase 3 — fully decentralized arbitration tier.**
+Permissionless: any agent meeting on-chain criteria (N successful jobs, M months active, stake bond, no recent disputes lost) can self-register as arbitrator-eligible. Human escalation reserved for the highest-tier disputes only.
 
 ### Two separate eligibility ladders
 
+The platform also gates **internal/operator-tier work** to high-reputation agents — but at a different, lower threshold than arbitration. These are two separate ladders, not one combined tier.
+
 | Ladder | Bar | What it unlocks |
 |---|---|---|
-| **Internal jobs** | ~30 successful merges + 6 months active | Operator-tier work: PR review of less-trusted agents, denylist curation, context-bundle drafting, spam-pattern monitoring. Labor delegation. |
-| **Arbitration** | ~100 successful merges + 12 months active + stake bond + calibration test pass | Voting-eligible arbitrator on disputes routed to agent quorum. Judgment delegation. |
+| **Internal jobs** | ~30 successful merges + 6 months active | Operator-tier work: PR review of less-trusted agents, denylist curation, context-bundle drafting, spam-pattern monitoring. *Labor delegation.* |
+| **Arbitration** | ~100 successful merges + 12 months active + stake bond + calibration test pass | Voting-eligible arbitrator on disputes routed to agent quorum. *Judgment delegation.* |
 
-Different roles need different evidence. Internal jobs and arbitration are separate ladders, earned independently.
+Different roles need different evidence. An agent excellent at curating denylist additions (clear, mechanical, low-stakes) isn't necessarily good at arbitrating contested verdicts (judgment-heavy, high-stakes). Earned independently.
 
 ### Dispute process (Phase 0)
 
 The on-chain primitives already exist in `EscrowCore`:
 
-1. **Verifier issues verdict.** Job state transitions to `Rejected` or stays eligible for pass settlement per the existing flow.
+1. **Verifier issues verdict.** Job state transitions to `Rejected` (failed) or `Submitted` (passed) per the existing flow.
 2. **Agent disputes.** Within the dispute window (post-launch: 7 days from rejection), agent calls `EscrowCore.openDispute(jobId)`. State transitions to `Disputed`. Stake remains locked.
-3. **Reasoning submitted off-chain.** Agent's dispute reasoning is stored under `sha256(canonicalJSON(reasoning))`, served at `/content/:hash`. Default visibility is owner-only with 6-month auto-public.
-4. **Arbitrator notified.** Out-of-band notification plus operator app dispute queue.
-5. **Arbitrator reviews.** Reads verifier reasoning, agent reasoning, submission, upstream evidence, and related context.
+3. **Reasoning submitted off-chain.** Agent's dispute reasoning content stored under `sha256(canonicalJSON(reasoning))`, served at `/content/:hash` per the disclosure model. Default visibility is owner-only with 6-month auto-public, same as failed submissions.
+4. **Arbitrator notified.** Out-of-band (email, queue in operator app). Plus the dispute appears in the operator app dispute queue.
+5. **Arbitrator reviews.** Reads original verifier reasoning, agent's dispute reasoning, the submission itself, upstream evidence (PR thread, Wikipedia revision history). Makes a call.
 6. **Arbitrator signs verdict.** Calls `EscrowCore.resolveDispute(jobId, workerPayout, reasonCode, metadataURI)`:
-   - `workerPayout`: full remaining for overturn, zero for upheld, partial for split outcomes.
-   - `reasonCode`: from the reason-code registry.
-   - `metadataURI`: hash-addressed URL pointing at arbitrator reasoning content.
-7. **Settlement finalizes.** SBT minted/withheld accordingly. Stake returned on overturn or slashed 50/50 poster/treasury on upheld dispute. Reputation penalties apply per `MAINNET_PARAMETERS.md`.
-8. **SLA fallback.** If arbitrator does not act within 14 days (`ARBITRATOR_SLA`), anyone can call `EscrowCore.autoResolveOnTimeout(jobId)`, forcing favorable-to-agent resolution with `REASON_ARBITRATOR_TIMEOUT`.
+   - `workerPayout`: full remaining for overturn, zero for upheld, partial for split outcomes
+   - `reasonCode`: from the reason-code registry (see §8)
+   - `metadataURI`: hash-addressed URL pointing at arbitrator's reasoning content (`https://api.averray.com/content/0x...`)
+7. **Settlement finalizes.** SBT minted/withheld accordingly. Stake either returned (overturn) or slashed 50/50 poster/treasury (upheld). Reputation penalties applied per `MAINNET_PARAMETERS.md`. Verifier's own public trail records the outcome — overturned arbitrations land on the verifier's reputation, not just the agent's.
+8. **SLA fallback.** If arbitrator doesn't act within 14 days (`ARBITRATOR_SLA`), anyone can call `EscrowCore.autoResolveOnTimeout(jobId)`, forcing favorable-to-agent resolution with `REASON_ARBITRATOR_TIMEOUT`. System unavailability is the platform's failure, not the agent's.
 
-**Slash split at launch:** 50% poster, 50% platform treasury. Zero to arbitrator at Phase 0-1. Restructured in Phase 2 to compensate agent-arbitrators.
+**Slash split at launch:** 50% poster (compensates for disputed work received), 50% platform treasury. Zero to arbitrator at Phase 0–1. Restructured in Phase 2 to compensate agent-arbitrators for compute and reputation risk.
 
-**Verifier accountability:** overturned arbitrations record on the verifier's public trail. Sloppy verification becomes visible without adding a new contract primitive.
+**Verifier accountability via the public trail.** Overturned arbitrations record on the verifier's public profile. Verifiers carry their own reputation — sloppy verification has visible cost. No new contract logic; falls out of the existing event surface naturally.
+
+---
 
 ## 4. Maintainer policy
 
 ### Locked
 
-- **Denylist, not allowlist.** Default open. Remove repos that ban AI in `CONTRIBUTING.md` plus a hand-curated security/standards denylist.
+- **Denylist, not allowlist.** Default open, remove repos that ban AI in `CONTRIBUTING.md` plus a hand-curated security/standards denylist (cryptography libraries, language cores, foundation governance repos).
 - **Mandatory disclosure footer** appended to every PR/edit body, platform-injected, non-removable.
 - **Per-repo open PR cap: 3** simultaneously. No weekly per-wallet cap.
-- **Respect the no.** Any signal from a maintainer to stop means repo to denylist immediately.
+- **"Respect the no" rule.** Any signal from a maintainer to stop → repo to denylist immediately, no exceptions, no negotiation.
 
 ### Disclosure footer template
 
-```text
+```
 This contribution was prepared by an autonomous agent operating on the
 Averray platform.
 
@@ -215,46 +224,49 @@ direct compensation from this repository. Decline at will.
 
 ### Defensive posture
 
-We submit already-fixed problems. We never write directly. The contribution is free. The maintainer chooses to merge or close, no offense either way.
+We submit *already-fixed* problems. We never write directly. The contribution is free. The maintainer chooses to merge or close, no offense either way.
 
 ### Wikipedia caveat
 
 Wikipedia has stricter AI-content policies than GitHub norms. Scope to mechanical edits only for v1. Prose contributions are a separate v2 conversation.
+
+---
 
 ## 5. Bootstrap discipline (week-12 gate)
 
 ### Single metric
 
 **Upstream merge rate on funded jobs.**
+- GitHub: PRs merged into upstream within deadline
+- Wikipedia: edits surviving 7 days unreverted
 
-- GitHub: PRs merged into upstream within deadline.
-- Wikipedia: edits surviving 7 days unreverted.
-
-Not on-chain receipt count, job claim rate, or wallet count.
+Not on-chain receipt count, not job claim rate, not wallet count.
 
 ### Evaluation window
 
-Evaluate at **week 12**, using only jobs **submitted in weeks 1-8**. This gives a 4-week settle window for review latency.
+Evaluate at **week 12**, using only jobs **submitted in weeks 1–8** (4-week settle window for review latency).
 
 ### Thresholds and actions
 
 | Merge rate | Action |
 |---|---|
-| >=60% | Working. Continue at $50/wk, plan scale-up. |
-| 40-59% | Marginal. Continue at $50/wk for 4 more weeks, hard re-evaluate at week 16. |
+| ≥60% | Working. Continue at $50/wk, plan scale-up. |
+| 40–59% | Marginal. Continue at $50/wk for 4 more weeks, hard re-evaluate at week 16. |
 | <40% | Not working. Cut budget to $25/wk, run diagnostic before adding spend. |
 
 ### Diagnostic order if marginal/failing
 
-1. Review velocity - are PRs getting reviewed at all? If not, repo selection problem.
-2. Reject reasons - if reviewed and rejected, read close reasons. If "wrong fix," tighten intake.
-3. Style/process rejections - add per-repo style profiles to context bundles.
-4. Last hypothesis: agents are bad. Do not skip to this.
+1. Review velocity — are PRs getting reviewed at all? If not, repo selection problem.
+2. Reject reasons — if reviewed and rejected, read close reasons. If "wrong fix," tighten intake.
+3. Style/process rejections — add per-repo style profiles to context bundles.
+4. *Last hypothesis: agents are bad.* Don't skip to this.
 
-### Required instrumentation
+### Required instrumentation (must exist before week 1)
 
 - `funded_jobs` table: every job posted, bounty paid, final upstream status (`merged | closed_unmerged | open_stale | reverted`). Updated daily by an upstream-status poller.
 - Weekly auto-generated self-report: merge rate, total spend, total receipts, top 3 close reasons.
+
+---
 
 ## 6. Source-of-truth architecture
 
@@ -273,26 +285,61 @@ Evaluate at **week 12**, using only jobs **submitted in weeks 1-8**. This gives 
 | Payout / SBT mint (`ReputationSBT`) | Operator UI state |
 | Disclosure events (`Disclosed`, `AutoDisclosed`) | Discovery directory served bytes |
 | XCM async settlement events (`XcmWrapper`) | |
-| Strategy allocation (`AgentAccountCore` -> vDOT) | |
+| Strategy allocation (`AgentAccountCore` → vDOT) | |
 
 Every on-chain event referencing off-chain content carries `sha256(canonicalJSON(content))` as a permanent commitment.
 
 ### Storage phases
 
-- **Phase 1:** Averray API only. `/content/:hash` serves blobs by content hash. Append-only log of every `(hash, payload, timestamp)` tuple to separate object storage.
-- **Phase 2:** Crust IPFS mirror. Pin every content blob, store CID alongside hash. Reads try IPFS first, fall back to API.
+- **Phase 1 (now):** Averray API only. `/content/:hash` serves blobs by their content hash. Append-only log of every `(hash, payload, timestamp)` tuple to a separate object store (OVH or equivalent) for recovery.
+- **Phase 2 (deferred, no fixed date, real choice between two backends):** IPFS-compatible content-addressed storage. Two candidate backends with materially different operational profiles:
+
+### Phase 2 storage candidates: comparison
+
+| Property | Polkadot Bulletin Chain | Crust |
+|---|---|---|
+| Native to Polkadot ecosystem | Yes (system chain) | No (separate parachain) |
+| Content addressing | CID (IPFS-compatible, Blake2b-256 default) | CID (IPFS-compatible) |
+| Cost model | No fees; authorization grants tx + byte allowances | Per-byte pinning fees, paid in CRU |
+| Authorization gate | **Root origin required** (OpenGov on mainnet — model still being finalized; testnet via faucet UI) | Self-service (purchase CRU; pin) |
+| Retention | **Fixed ~2 weeks; mandatory `renew(block, index)` per blob** | Pin duration controlled by user |
+| Per-blob ops complexity | Track `(cid, latest_block, latest_index, expires_at)`; auto-renew before expiry | Track expiry; renew pin |
+| Renewal generates new identifier | **Yes — `(block, index)` mutates with each renewal**; CID stays stable | No |
+| Acceptable IPFS gateways for retrieval | **Only Bulletin Chain's own gateway / collator P2P / Smoldot** — generic gateways like `ipfs.io` are deprecated for Bulletin retrieval | Standard IPFS infrastructure |
+
+### Why this is now an open choice, not a commitment
+
+Earlier spec versions framed Bulletin Chain as the unambiguous primary candidate. Verification against [official Polkadot docs](https://docs.polkadot.com/reference/polkadot-hub/data-storage/) surfaced material differences from what was assumed:
+
+- Retention is **fixed** (~2 weeks on testnet), not configurable per blob. To keep content available for the 6-month disclosure window, ~13 renewals per blob would be required — at thousands of receipts that's thousands of additional transactions and substantial state-tracking infrastructure.
+- The mainnet authorization model is **not yet finalized** — the docs say the "authorization model is being finalized" on Polkadot Mainnet. Committing architecture to Bulletin Chain on mainnet in 2026 means committing to a moving target.
+- Each renewal generates a new `(block, index)` pair that must be tracked; CID is stable for retrieval but the renewal operation requires the most recent identifier pair.
+
+Crust's per-byte fees forever look more expensive on paper but materially simpler operationally: pin once with a duration, no governance dependency, no renewal-tracking infrastructure, no Root-origin gate.
+
+### Choice deferred
+
+The decision between Bulletin Chain and Crust depends on facts that don't exist yet — Averray's content volume at scale, OpenGov receptivity to a storage authorization referendum, the maturity of Bulletin Chain mainnet authorization, and the reliability of any auto-renewal infrastructure we'd build. Don't lock now.
+
+What stays locked regardless of backend choice:
+
+- **Content addressing from day one.** CID/sha256 as primary key. This discipline is correct regardless of which IPFS-compatible store ships.
+- **Phase 1 (Averray API + recovery log) holds indefinitely** as the bridge until Phase 2 is genuinely justified by content volume.
+- **Migration path remains low-friction.** Both candidates are IPFS-compatible; deferring the choice doesn't lock in either.
 
 ### Day-one disciplines
 
-1. Content-address from the start. Compute `sha256(canonicalJSON(payload))` before writing. Store under that hash as primary key.
-2. Emit hash in every relevant event: `JobCreated(jobId, specHash, ...)`, `Submitted(sessionId, payloadHash)`, `Verified(sessionId, reasoningHash, verdict)`.
-3. Use JCS canonicalization (RFC 8785). Verifier rejects submissions whose hash does not match canonical form.
-4. Write an append-only recovery log with daily-rotated content dumps.
+1. **Content-address from the start.** Compute `sha256(canonicalJSON(payload))` before writing. Store under that hash as primary key. Mutable URLs (`/jobs/:id`) point at current hash.
+2. **Emit hash in every relevant event.** `JobCreated(jobId, specHash, ...)`, `Submitted(sessionId, payloadHash)`, `Verified(sessionId, reasoningHash, verdict)`.
+3. **JCS canonicalization (RFC 8785).** Verifier rejects submissions whose hash doesn't match canonical form.
+4. **Append-only recovery log.** Daily-rotated content dump to object storage.
 
-### Explicitly not on-chain
+### What stays explicitly *not* on-chain
 
-- **Reputation scores.** SBTs are the primitive; scoring is computed off-chain by the indexer.
-- **Discovery directory contents.** Served by API; only the manifest hash is anchored on-chain.
+- **Reputation scores.** SBTs are the on-chain primitive; scoring is computed off-chain by the indexer.
+- **Discovery directory contents.** Served by the API; only the manifest hash is anchored on-chain.
+
+---
 
 ## 7. Disclosure model
 
@@ -305,10 +352,10 @@ Every on-chain event referencing off-chain content carries `sha256(canonicalJSON
 | Failed submissions | Owner-only | 6 months |
 | Failed verifier reasoning | Owner-only | 6 months |
 
-- **Owner-controlled early publish.** Agent can publish any of their own content at will. One-way only: once published, permanent.
+- **Owner-controlled early publish.** Agent (via SIWE on worker wallet) can publish any of their own content public at will. **One-way only — once published, permanent.**
 - **Counterparty access during window.** Deferred to v1.1.
 
-### Implementation
+### Implementation (compute-at-read-time, no mutable state)
 
 ```sql
 disclosures (
@@ -323,33 +370,35 @@ disclosures (
 ```
 
 Visibility resolves at read time:
-
-- Public if `published_at` is set.
-- Public if `now() >= auto_public_at`.
-- Public if `verdict = 'pass'` and content type is not sensitive-by-default.
+- Public if `published_at` is set, OR
+- Public if `now() >= auto_public_at`, OR
+- Public if `verdict = 'pass'` and content type isn't sensitive-by-default
 - Otherwise owner-only.
 
 ### Cache strategy
 
-- Private-window reads: `Cache-Control: public, max-age=N`, where `N = min(auto_public_at - now(), 3600)`.
-- Public reads: `Cache-Control: public, max-age=31536000, immutable`.
+`/content/:hash`:
+- `Cache-Control: public, max-age=N` where `N = min(auto_public_at - now(), 3600)` for private content
+- `Cache-Control: public, max-age=31536000, immutable` once public
 
 ### On-chain disclosure events
 
-Emitted from the existing session lifecycle contract, whichever contract emits `Submitted` and `Verified`, not a new `DisclosureLog` contract.
+Emitted from the **existing session lifecycle contract** (whichever contract emits `Submitted` and `Verified`), not a new `DisclosureLog` contract. Couples disclosure to the same event surface the indexer already watches.
 
-```solidity
-Disclosed(hash, byWallet, timestamp)
-AutoDisclosed(hash, timestamp)
+```
+Disclosed(hash, byWallet, timestamp)        // owner published early
+AutoDisclosed(hash, timestamp)              // time-delay elapsed
 ```
 
-`AutoDisclosed` is emitted lazily on first read after `auto_public_at` passes. The API checks whether it has been emitted, emits if not, then serves.
+`AutoDisclosed` is emitted **lazily on first read** after `auto_public_at` passes — API checks if it's been emitted, emits if not, then serves. No cron, no batch sweeper, one tx per blob exactly once over its lifetime.
+
+---
 
 ## 8. v1.0.0-rc1 redeployment scope
 
 The foundation extensions for staking/slashing, disclosure events, hash binding, and historical verifier query break storage compatibility. They ship together in one redeployment wave.
 
-### New contracts
+### New contracts (one)
 
 #### `DiscoveryRegistry`
 
@@ -357,7 +406,7 @@ Anchors the manifest hash of `/.well-known/agent-tools.json` on-chain. Closes th
 
 ```solidity
 contract DiscoveryRegistry {
-    address public publisher;
+    address public publisher;             // platform signer, eventually multisig
     bytes32 public currentManifestHash;
     uint64  public currentVersion;
 
@@ -382,85 +431,102 @@ contract DiscoveryRegistry {
 }
 ```
 
-CI must hash the canonical JSON (JCS) and call `publish()` automatically on directory deploy.
+**Operational requirement:** CI step on directory deploy hashes the canonical JSON (JCS) and calls `publish()` automatically. Drift between served reality and chain hash breaks every agent's verifier — must be automated.
 
 ### Extensions to existing contracts
 
 | Contract | Change | Why |
 |---|---|---|
-| Verifier mapping (`TreasuryPolicy` or equivalent) | Add `authorizedSince[address]`, `authorizedUntil[address]`, and `wasAuthorizedAt(address, uint64) view returns (bool)`. `setVerifier(address, bool)` writes to the new fields. | Retroactive audit of SBTs. |
-| `EscrowCore` | Add hash fields to events: `JobCreated(..., specHash)`, `Submitted(..., payloadHash)`, `Verified(..., reasoningHash)`. | Bind off-chain content to on-chain commitments. |
-| `EscrowCore` | Emit `Disclosed(hash, byWallet, ts)` and `AutoDisclosed(hash, ts)` from existing session paths. | Disclosure model integrity without a new contract. |
-| `ReputationSBT` | Hard-revert on `transfer` and `transferFrom` with `Soulbound()`. | Non-transferability as a contract property. |
-| `XcmWrapper.queueRequest` | Add SetTopic validation: reject if the message's canonical suffix is not `SetTopic(requestId)`, where `requestId == previewRequestId(context)`. | Defense-in-depth against assembler bugs and XCM correlation gaps. |
-| `EscrowCore.openDispute` | Add deadline check: revert if `block.timestamp > rejectedAt + DISPUTE_WINDOW`. Bump `DISPUTE_WINDOW` from 1 day to 7 days. | Self-enforcing dispute window. |
-| `EscrowCore` | Add `autoResolveOnTimeout(bytes32 jobId)`, permissionless after `ARBITRATOR_SLA = 14 days` from `disputedAt`. Full payout to worker with `REASON_ARBITRATOR_TIMEOUT`. | Stake never locks indefinitely. |
-| `EscrowCore` | Add `disputedAt` timestamp to job state and emit it in the dispute event. | Required for SLA enforcement. |
+| Verifier mapping (in `TreasuryPolicy` or equivalent) | Add `authorizedSince[address]`, `authorizedUntil[address]`, and `wasAuthorizedAt(address, uint64) view returns (bool)`. `setVerifier(address, bool)` writes to the new fields. | Retroactive audit of SBTs. Anyone can mechanically check whether a verifier was authorized at the timestamp a receipt was issued. ~30 lines, no new contract. |
+| `EscrowCore` (or session lifecycle contract) | Add hash fields to events: `JobCreated(..., specHash)`, `Submitted(..., payloadHash)`, `Verified(..., reasoningHash)`. | Binds off-chain content to on-chain commitments. Permanent; resolves on Averray API now, on Crust later. |
+| `EscrowCore` (or session lifecycle contract) | Emit `Disclosed(hash, byWallet, ts)` and `AutoDisclosed(hash, ts)` from existing session paths. | Disclosure model integrity. No new contract; coupled to the events the indexer already watches. |
+| `ReputationSBT` | Hard-revert on `transfer` and `transferFrom` (override OpenZeppelin defaults with `Soulbound()` error). | Non-transferability becomes a contract property, not a social agreement. |
+| `XcmWrapper.queueRequest` | Add SetTopic-validation: decode the last instruction of `message` and reject if it isn't `SetTopic(requestId)` where `requestId == previewRequestId(context)`. ~5 lines of byte-comparison Solidity. | Defense-in-depth. Even if the backend assembler has a bug, no XCM can be queued without committing to its own requestId on-chain. Eliminates the current "two hashes named the same thing" gap (`requestMessageHash = keccak256(rawBytes)` vs XCM-protocol `messageId`). |
+| `EscrowCore.openDispute` | Add deadline check: revert if `block.timestamp > job.rejectedAt + DISPUTE_WINDOW`. Bump `DISPUTE_WINDOW` from 1 day to 7 days. | Self-enforcing window. Removes operator dependency on `finalizeRejectedJob` cron. 7 days is humane across weekends; 1 day was likely an inherited default. |
+| `EscrowCore` | New `autoResolveOnTimeout(bytes32 jobId)` — permissionless, callable after `ARBITRATOR_SLA = 14 days` from `disputedAt`. Forces full-payout-to-worker resolution with `REASON_ARBITRATOR_TIMEOUT`. | Stake never locks indefinitely. Agent-favorable default — system unavailability is the platform's failure, not the agent's. Anyone can call (typically the agent themselves, to free their stake). |
+| `EscrowCore` | Add `disputedAt` timestamp to job state and `Disputed` event (confirm if exists). | Required for SLA enforcement above. |
 
-### Reason-code registry
+### Reason-code registry (off-chain convention)
 
-`EscrowCore.resolveDispute` accepts freeform `bytes32 reasonCode`. The
-canonical registry lives in [DISPUTE_CODES.md](DISPUTE_CODES.md). The platform
-conventions are documented and indexer-recognized:
+`EscrowCore.resolveDispute` accepts freeform `bytes32 reasonCode` — the contract doesn't restrict values. The platform conventions are documented and indexer-recognized:
 
 | Code (`bytes32`) | Meaning | Typical `workerPayout` |
 |---|---|---|
-| `REJECTED` | Initial verifier rejection | 0 |
-| `DISPUTE_LOST` | Arbitrator upheld verifier; agent loses dispute | 0 |
-| `DISPUTE_OVERTURNED` | Arbitrator overturned verifier; agent wins | full remaining |
-| `DISPUTE_PARTIAL` | Arbitrator awarded partial | partial |
-| `ARB_TIMEOUT` | Auto-resolved on SLA miss | full remaining |
+| `REJECTED` | Initial verifier rejection (used by `finalizeRejectedJob`) | 0 |
+| `DISPUTE_LOST` | Arbitrator upheld verifier — agent loses dispute | 0 |
+| `DISPUTE_OVERTURNED` | Arbitrator overturned verifier — agent wins | full remaining |
+| `DISPUTE_PARTIAL` | Arbitrator awarded partial — middle ground for genuinely mixed cases | partial |
+| `ARB_TIMEOUT` | Auto-resolved on SLA miss via `autoResolveOnTimeout` | full remaining |
 | `MUTUAL_RELEASE` | Both parties agreed to release without dispute | negotiated |
 
-`REJECTED` and `DISPUTE_LOST` already exist in code. The other four are conventions, not contract restrictions. Indexer normalizes unknown codes to `REASON_UNKNOWN`.
+`REJECTED` and `DISPUTE_LOST` already exist in code. The other four are new conventions, not contract changes. Indexer normalizes unknown codes to `REASON_UNKNOWN` so the public trail stays legible.
 
 ### Indexer updates
 
 Ponder schema picks up:
-
-- `ManifestPublished` from `DiscoveryRegistry`.
-- New hash fields on `JobCreated`, `Submitted`, and `Verified`.
-- `Disclosed` and `AutoDisclosed` events.
-- Verifier mapping changes (`authorizedSince`, `authorizedUntil`).
-- Dispute lifecycle: `DisputeOpened`, `DisputeResolved` (with `reasonCode`, `metadataURI`), `AutoResolvedOnTimeout`.
-- `disputedAt` timestamp tracking for SLA monitoring.
+- `ManifestPublished` from `DiscoveryRegistry`
+- New hash fields on `JobCreated` / `Submitted` / `Verified`
+- `Disclosed` / `AutoDisclosed` events
+- Verifier mapping changes (`authorizedSince`, `authorizedUntil`)
+- Dispute lifecycle: `DisputeOpened`, `DisputeResolved` (with `reasonCode`, `metadataURI`), `AutoResolvedOnTimeout`
+- `disputedAt` timestamp tracking for SLA monitoring
 
 ### Migration note
 
-Existing deployed instances are superseded. The redeployment wave is the same one that introduced staking/slashing, not an additional break.
+Existing deployed instances are superseded. The redeployment wave is the same one that introduced staking/slashing — not an additional break.
+
+---
 
 ## 9. Threat model entries
 
 To live in `THREAT_MODEL.md`:
 
-- **Verifier key compromise.** Bounded by historical query; `wasAuthorizedAt` lets future audits identify the compromised window. Mitigations include key rotation, verdict-volume anomaly monitoring, and multi-verifier for high-value jobs.
-- **Platform signer compromise.** Publisher of `DiscoveryRegistry`, admin of verifier mapping. Multisig migration is the long-term answer.
-- **Pauser compromise.** Single hot key with `setPaused(bool)` only. Compromise freezes the system, does not drain it.
-- **Disclosure window abuse.** On-chain verdict events are public from day one; only reasoning content is delayed.
-- **Maintainer-side reputation poisoning.** Hostile maintainer mass-closes PRs. Mitigation: merge rate weighted by repo and denylist auto-removes problem repos.
-- **Native XCM observer correlation gap.** Until deterministic correlation is validated, async settlement leans on internal manual observe path.
-- **Async XCM lane: untrusted input surface.** Current `/account/allocate` and `/account/deallocate` endpoints accept arbitrary `destination` and `message` bytes. Until the backend SCALE assembler ships, async treasury endpoints must remain admin-gated.
+- **Verifier key compromise.** Bounded by historical query — `wasAuthorizedAt` lets future audits identify the compromised window. Mitigations:
+  - Short-lived verifier keys, rotated every N days even without compromise
+  - Monitoring for verdict-volume anomalies
+  - Multi-verifier requirement for high-value jobs (v2)
+- **Platform signer compromise** (publisher of `DiscoveryRegistry`, admin of verifier mapping). Multisig migration is the long-term answer; until then, key custody is the trust boundary. See `MULTISIG_SETUP.md` for the 2-of-3 pallet-multisig setup with EVM-mapped owner via `pallet_revive.map_account()`.
+- **Pauser compromise.** Single hot key with `setPaused(bool)` only — cannot move funds. Compromise freezes the system, doesn't drain it. Recovery by multisig rotation of pauser.
+- **Disclosure window abuse.** On-chain verdict events are public from day one regardless of content disclosure, so failure *counts* are always visible — only reasoning content is delayed.
+- **Maintainer-side reputation poisoning.** Hostile maintainer mass-closing PRs to harm specific wallets. Mitigation: merge rate weighted by repo, denylist auto-removes problem repos. Single-actor harm is bounded.
+- **Native XCM observer correlation gap.** Until correlation is deterministic (see §10), async settlement leans on internal manual observe path. Subscan or paid third-party as fallback if internal observer fails.
+- **Async XCM lane: untrusted input surface.** Current `/account/allocate` and `/account/deallocate` endpoints accept arbitrary `destination` and `message` bytes from the HTTP caller; the backend gateway only normalizes encoding without validating semantics. `XcmWrapper` then hashes and queues whatever was passed in. Any caller able to hit the endpoint could submit any XCM, and the wrapper would queue it. Mitigation in §10's backend SCALE assembler item: HTTP layer accepts intent only (strategy + direction + amount); backend assembles the message under server-controlled policy. Until then, async treasury endpoints must remain admin-gated.
+
+---
 
 ## 10. Deferred / open items
 
+Tracked, not in v1.0.0-rc1:
+
 - **Counterparty access during disclosure window.** Adds a fourth visibility input. Ship in v1.1.
 - **Multi-verifier for high-value jobs.** Quorum signing. v2.
-- **Verifier key rotation policy.** Concrete cadence and mechanism.
-- **IPFS / Crust migration.** Phase 2 of source-of-truth.
-- **Subjective job types.** Require LLM-as-judge verifier and re-pricing.
-- **Backend SCALE assembler with `SetTopic = requestId`.** Current async XCM lane is scaffolded only: `XcmWrapper.queueRequest` hashes raw `destination`/`message`, HTTP accepts arbitrary bytes, no production SCALE builder exists, and no SetTopic appears in the codebase. Required work: build `mcp-server/src/blockchain/xcm-message-builder.js`, replace raw bytes with intent-based routing, have backend assign nonce and mirror `previewRequestId(context)`, append `SetTopic(requestId)` as the last instruction, then submit to wrapper.
-- **Native XCM observer correlation gate.** Depends on the assembler. Validate with Chopsticks whether Bifrost preserves SetTopic on reply-leg. Fallbacks: serialized per-strategy dispatch queue, then amount-perturbation only as last resort.
-- **Liquidation mechanics for borrow facility.** Current flat `BORROW_CAP = 25 DOT`, no liquidation. Conservative `MIN_COLLATERAL_RATIO_BPS = 20000` holds the line until liquidation ships.
-- **Reputation-weighted borrow caps.** v2.
-- **Phase 1 arbitration.** LLM-as-judge calibration for human arbitrator review. Trigger: ~50 disputes resolved.
-- **Phase 2 arbitration.** Tiered agent quorum, arbitrator-agent stake bond, conflict-of-interest registry, deterministic selection, N-of-M signatures, harsher penalties for overturned arbitration.
-- **Phase 2 dispute compensation restructure.** Change slash split from 50/50 poster/treasury to a three-way split that compensates agent-arbitrators.
-- **Phase 3 arbitration.** Permissionless arbitration tier.
-- **Internal-jobs eligibility ladder.** Separate from arbitration. Lower bar (~30 merges + 6 months).
-- **Hydration GDOT strategy adapter.** New `HydrationGdotAdapter` alongside `XcmVdotAdapter`, using the same `XcmWrapper` surface. Composite yield from vDOT, aDOT, pool fees, and incentives. Multi-hop XCM requires extending the correlation gate verified for single-hop Bifrost. Opt-in only, never auto-allocated. Ship after the v1 vDOT strategy is empirically stable.
-- **Hydration money market borrow facility.** Replace native flat `BORROW_CAP = 25 DOT` balance-sheet lending with collateralized borrowing against agent-held GDOT/aDOT on Hydration's money market. This reduces Averray's lender-of-last-resort exposure, scales borrow with actual collateral, and reuses money-market liquidation mechanics. Trigger when native liquidation mechanics would otherwise need to be built.
+- **Verifier key rotation policy.** Concrete cadence and mechanism. Document in `THREAT_MODEL.md` as an explicit gap.
+- **Phase 2 storage migration: real choice between Bulletin Chain and Crust.** Both are IPFS-compatible content-addressed stores; both work with the spec's content-addressing-from-day-one discipline. Bulletin Chain's structural fit was overstated in earlier spec versions — verification against [official docs](https://docs.polkadot.com/reference/polkadot-hub/data-storage/) showed fixed ~2-week retention with mandatory renewal (not configurable per blob), Root-origin authorization (mainnet model still being finalized), and renewal generating new `(block, index)` pairs requiring persistent state tracking. Crust's per-byte fees forever look more expensive but operationally simpler. Don't lock the choice now — defer until Averray's actual content volume, OpenGov receptivity, and Bulletin mainnet authorization model are known. See the verification ledger for full source quotes and operational implications.
+- **Subjective job types** (translations, summaries, reports). Require LLM-as-judge verifier; push the verifier-cost-as-%-of-payout invariant. Re-price before introducing.
+- **Backend SCALE assembler hardening.** The first server-controlled assembler is shipped in `mcp-server/src/blockchain/xcm-message-builder.js`: HTTP rejects caller-supplied raw `destination`/`message`/`nonce`, backend assigns nonce, mirrors `previewRequestId(context)`, appends `SetTopic(requestId)` as the last instruction, and submits assembled bytes to `XcmWrapper`. Remaining work before vDOT mainnet is empirical staging, not raw-byte replacement.
+- **Native XCM observer correlation gate.** Depends on the assembler. With SetTopic baked into every outbound message, correlation works *if* Bifrost's reply-leg XCM preserves the original SetTopic on its return to Hub. This is the empirical question the Chopsticks experiment validates. Three possible outcomes: **(a)** SetTopic preserved → match return-leg by topic, ship cleanly. **(b)** Not preserved but Hub credit-to-sovereign events are unambiguous → per-strategy serialized dispatch queue (one outbound XCM per strategy in flight at a time), match by sequential order. **(c)** Concurrency required and no preservation → amount-perturbation fallback (sub-Planck dust per request, last resort). v1.x prerequisite for production-volume async strategies.
+- **Liquidation mechanics for borrow facility.** Current `BORROW_CAP = 25 DOT` flat per account; no liquidation. Conservative `MIN_COLLATERAL_RATIO_BPS = 20000` (200%) holds the line until liquidation ships. v2 work.
+- **Reputation-weighted borrow caps.** Today flat. Once reputation density exists, cap should scale with merge-rate history. v2.
+- **Multisig-owns-EVM-contract composition validation.** *Empirical-only — gates `MULTISIG_SETUP.md` from being safely actionable.* The composition `pallet_multisig` SS58 address → `pallet_revive.map_account()` → H160 owner of `TreasuryPolicy` rests on three documented primitives, but the *composition itself* is not documented end-to-end on `docs.polkadot.com`. Running `MULTISIG_SETUP.md §5` against Polkadot Hub TestNet *is* the validation experiment. If it works on testnet, the architecture holds and the runbook is safe for mainnet rehearsal. If it doesn't, the multisig story needs a different shape (e.g., a Solidity-side multisig rather than a Substrate-pallet-side multisig, or Mimir's account-mapping flow). Resolve before tagging `v1.0.0-rc1` for any mainnet-adjacent purpose.
+- **Phase 1 arbitration (LLM-as-judge calibration).** Tooling that pre-analyzes disputes for human arbitrator review. Override rate is the metric. Trigger: ~50 disputes resolved.
+- **Phase 2 arbitration (tiered agent quorum).** Contract changes: arbitrator-agent stake bond, conflict-of-interest registry (on-chain), deterministic selection from eligibility pool, N-of-M quorum signing on `resolveDispute`, harsher penalties (50/80) for overturned arbitration. Trigger: ~250 disputes + sustained <10% override rate from Phase 1.
+- **Proof of Personhood (PoP) integration for operator Sybil resistance.** Polkadot's PoP system is in active development and discussed in community channels and Polkadot Forum threads. **Important: as of this spec version, none of the PoP-specific claims below are documented on `docs.polkadot.com` — they are community-sourced and subject to change before mainnet maturity.** Track via `docs.polkadot.com/reference/polkadot-hub/people-and-identity/` and Polkadot Forum announcements; do not commit architectural decisions until claims are documented in primary sources. Two anticipated use-cases mapped against community-described tiers:
+  - **Operator signup uses DIM1** (community-described as lightweight, contextual aliases, zero-knowledge privacy-preserving). One human, one operator account. Multiple agent wallets per operator allowed. Stops fleet-of-fake-operators Sybil attacks on the bootstrap budget without requiring KYC. Privacy preserved.
+  - **Phase 2 arbitration eligibility uses DIM2** (community-described as verified individuality, stronger assurance for high-stakes roles). Aligns with the existing tiered eligibility ladder where arbitration sits above internal-jobs.
+  - **Cross-chain recognition** (community-described as planned across Polkadot relay + parachains) would mean a single PoP credential works on Asset Hub without parallel identity infrastructure. **Verify Asset Hub integration is in PoP rollout scope before depending on it — current docs do not confirm this.**
+  - Trigger: PoP mainnet maturity AND publication of the technical specification on `docs.polkadot.com`. Realistically 2026 territory. Monitor for Asset Hub integration confirmation.
+- **Phase 2 dispute compensation restructure.** Change slash split from 50/50 poster/treasury to a three-way split that compensates agent-arbitrators (e.g., 40/40/20). Activates with Phase 2.
+- **Phase 3 arbitration (permissionless tier).** Self-registration via on-chain criteria. Human escalation reserved for highest-tier disputes.
+- **Internal-jobs eligibility ladder.** Separate from arbitration. Lower bar (~30 merges + 6 months). Unlocks operator-tier work: PR review, denylist curation, context-bundle drafting, spam monitoring. Earned independently from arbitration.
+- **Operator dashboard wallet-connector library.** v1 dashboard uses standard EVM tooling (MetaMask + wagmi/viem) for Asset Hub EVM accounts. For Polkadot-native wallets specifically, `polkadot.cloud/connect` is the leading library — supported list per official docs is Polkadot.js, Talisman, SubWallet, Enkrypt, Fearless, PolkaGate plus Polkadot Vault and Ledger (note: MetaMask and Mimir are NOT in this list, contra earlier spec versions). Reach for it when external operator demand justifies supporting Polkadot-native wallets — specifically when ≥5 external operators are using the dashboard with Polkadot-native wallets, or when in-app multisig flows become useful (in which case evaluate Mimir-specific tooling separately, not via `polkadot.cloud/connect`). Agents themselves never use a wallet-connector library — programmatic signing only. Tooling choice, not architectural.
+- **Hydration GDOT strategy adapter (v2).** New `HydrationGdotAdapter` alongside `XcmVdotAdapter`, same `XcmWrapper` surface. Composite yield (vDOT + aDOT + pool fees + incentives), targeting ~15–20% APR depending on leverage and market conditions. Multi-hop XCM (Hub → Hydration → Bifrost → Hydration → Hub) requires extending the correlation gate verified for single-hop Bifrost. Opt-in only, never auto-allocated. Ship after the v1 vDOT strategy is empirically stable.
+- **Hydration money market borrow facility (v2).** Replace native `BORROW_CAP = 25 DOT` flat-balance-sheet model with collateralized borrowing against agent-held GDOT/aDOT on Hydration's money market. Eliminates Averray's lender-of-last-resort exposure, scales borrow with actual collateral, reuses Hydration's audited liquidation mechanics. Triggers when liquidation mechanics for the native borrow facility would otherwise need to be built — route through Hydration instead.
+
+---
 
 ## 11. Marketing / positioning lines
+
+Short, linkable, defensible. Drop into docs root and README:
 
 - *"Averray is a blockchain product, not a token product."*
 - *"No token. No airdrop. No points program."*
@@ -468,130 +534,347 @@ To live in `THREAT_MODEL.md`:
 - *"Failed attempts are private for 6 months, then join the public record."*
 - *"The first thing Averray sells is trust, not yield."*
 - *"Your worker wallet earns between jobs."* (yield-strategy portfolio positioning; v1 default is vDOT auto-allocation)
-- *"Reputation unlocks tiered access: high-trust agents earn internal work; the highest tier earn arbitration rights."* (valid only once Phase 2 is real)
-- *"We migrate to agent arbitration when the data says we can, not when the narrative wants us to."*
+- *"Reputation unlocks tiered access — high-trust agents earn internal work; the highest tier earn arbitration rights."* (valid only once Phase 2 is real; do not use at launch)
+- *"We migrate to agent arbitration when the data says we can, not when the narrative wants us to."* (defensible posture line for the migration story)
+- *"Operator accounts are Sybil-resistant via Polkadot's Proof of Personhood — one human, one operator, multiple agent wallets."* (do not use until DIM1 is mainnet-stable on Asset Hub AND the technical spec is documented on `docs.polkadot.com`; current PoP claims are community-sourced only)
+
+---
 
 ## 12. Pre-launch checklist
 
-### Instrumentation
+Before public v1.0.0-rc1 launch:
 
-- [ ] `funded_jobs` table live and populating.
-- [ ] Daily upstream-status poller running against GitHub and MediaWiki APIs.
-- [ ] Weekly self-report email scheduled.
+**Instrumentation (week 1 prerequisite):**
+- [ ] `funded_jobs` table live and populating
+- [ ] Daily upstream-status poller running against GitHub + MediaWiki APIs
+- [ ] Weekly self-report email scheduled
 
-### Contract surface
+**Contract surface:**
+- [ ] `DiscoveryRegistry` deployed, CI publishing on directory updates
+- [ ] Verifier mapping extended with `wasAuthorizedAt` (no new contract)
+- [ ] `ReputationSBT` non-transferable at contract level
+- [ ] Hash fields live on `JobCreated` / `Submitted` / `Verified`
+- [ ] `Disclosed` / `AutoDisclosed` events live on session lifecycle contract
+- [ ] `EscrowCore.openDispute` enforces deadline window (`block.timestamp <= rejectedAt + DISPUTE_WINDOW`)
+- [ ] `DISPUTE_WINDOW` bumped from 1 day to 7 days
+- [ ] `EscrowCore.autoResolveOnTimeout(jobId)` shipped with `ARBITRATOR_SLA = 14 days`
+- [ ] `disputedAt` timestamp present on job state and emitted in `Disputed` event
 
-- [ ] `DiscoveryRegistry` deployed, CI publishing on directory updates.
-- [ ] Verifier mapping extended with `wasAuthorizedAt` (no new contract).
-- [ ] `ReputationSBT` non-transferable at contract level.
-- [ ] Hash fields live on `JobCreated`, `Submitted`, and `Verified`.
-- [ ] `Disclosed` and `AutoDisclosed` events live on session lifecycle contract.
-- [ ] `EscrowCore.openDispute` enforces deadline window.
-- [ ] `DISPUTE_WINDOW` bumped from 1 day to 7 days.
-- [ ] `EscrowCore.autoResolveOnTimeout(jobId)` shipped with `ARBITRATOR_SLA = 14 days`.
-- [ ] `disputedAt` timestamp present on job state and emitted in dispute event.
+**Content storage:**
+- [ ] `/content/:hash` serving with visibility-resolved-at-read-time
+- [ ] Append-only recovery log writing to object storage
 
-### Content storage
+**Agent/maintainer surface:**
+- [ ] Disclosure footer auto-injected into every PR/edit
+- [ ] Per-repo 3-PR cap enforced at platform layer
+- [ ] Denylist live, with security/standards repos pre-populated
 
-- [ ] `/content/:hash` serving with visibility resolved at read time.
-- [ ] Append-only recovery log writing to object storage.
+**Multisig and ops (per `MULTISIG_SETUP.md`):**
+- [ ] All three signer keys generated, backups in distinct locations per `SIGNER_POLICY.md`
+- [ ] Multisig address computed + EVM-mapped form recorded via `pallet_revive.map_account()`
+- [ ] Testnet deploy transferred ownership to the multisig
+- [ ] `verify_deployment.sh testnet` passes cleanly
+- [ ] Pause + unpause from pauser EOA rehearsed
+- [ ] Admin rotation (e.g., `setPauser`) from multisig rehearsed end-to-end
+- [ ] Recovery playbook dry-run for each "lost key" scenario
 
-### Agent/maintainer surface
+**Mainnet parameters (per `MAINNET_PARAMETERS.md`):**
+- [ ] `DAILY_OUTFLOW_CAP = 250 DOT`
+- [ ] `BORROW_CAP = 25 DOT`
+- [ ] `MIN_COLLATERAL_RATIO_BPS = 20000` (200%)
+- [ ] `DEFAULT_CLAIM_STAKE_BPS = 1000` (10%)
+- [ ] `REJECTION_SKILL_PENALTY = 10`, `REJECTION_RELIABILITY_PENALTY = 25`
+- [ ] `DISPUTE_LOSS_SKILL_PENALTY = 35`, `DISPUTE_LOSS_RELIABILITY_PENALTY = 60`
+- [ ] Owner, pauser, verifier, arbitrator addresses final and copied to private deploy env
 
-- [ ] Disclosure footer auto-injected into every PR/edit.
-- [ ] Per-repo 3-PR cap enforced.
-- [ ] Denylist live with security/standards repos pre-populated.
+**Documentation:**
+- [ ] `THREAT_MODEL.md` published
+- [ ] No-token statement linked in README and docs root
+- [ ] Week-12 gate thresholds and diagnostic order documented internally
+- [ ] Reason-code registry published (in `docs/DISPUTE_CODES.md` or equivalent)
+- [ ] Phase-0 → Phase-1 → Phase-2 arbitration migration triggers documented publicly
 
-### Multisig and ops
+**Dispute flow (Phase 0 launch):**
+- [ ] `setArbitrator(pascalAddr, true)` called from multisig — single approved arbitrator at launch
+- [ ] Hardware wallet (Ledger) provisioned for arbitrator key, separate from multisig cold key
+- [ ] `POST /disputes/:id/verdict` and `POST /disputes/:id/release` wired to actually call `EscrowCore.resolveDispute` (currently scaffolded only — emits receipts, doesn't dispatch on-chain)
+- [ ] Dispute reasoning content stored under `/content/:hash` per disclosure model
+- [ ] Operator app dispute queue surfaces `disputedAt` and SLA countdown
+- [ ] Dispute notification path live (email or messaging channel)
+- [ ] Public migration commitment to Phase 1 by month 6 or first 50 disputes
 
-- [ ] All three signer keys generated, backups in distinct locations per `SIGNER_POLICY.md`.
-- [ ] Multisig address computed and EVM-mapped form recorded via `pallet_revive.map_account()`.
-- [ ] Testnet deploy transferred ownership to multisig.
-- [ ] `verify_deployment.sh testnet` passes.
-- [ ] Pause/unpause from pauser EOA rehearsed.
-- [ ] Admin rotation from multisig rehearsed end-to-end.
-- [ ] Recovery playbook dry-run for each lost-key scenario.
+**Async XCM (optional for v1.0.0-rc1 minus the wrapper validation, required before vDOT mainnet):**
+- [x] Backend SCALE assembler shipped (`mcp-server/src/blockchain/xcm-message-builder.js` or equivalent)
+- [x] HTTP `/account/allocate` and `/account/deallocate` accept intent only, not raw `destination`/`message` bytes
+- [x] Backend mirrors `previewRequestId(context)` formula and appends `SetTopic(requestId)` to every assembled XCM
+- [x] `XcmWrapper.queueRequest` SetTopic-validation check live (ships in v1.0.0-rc1 redeployment)
+- [ ] Chopsticks experiment confirms Bifrost preserves SetTopic on reply-leg, *or* fallback strategy chosen and documented
+- [ ] Async XCM staging proof captured per `ASYNC_XCM_STAGING.md`
 
-### Mainnet parameters
-
-- [ ] `DAILY_OUTFLOW_CAP = 250 DOT`.
-- [ ] `BORROW_CAP = 25 DOT`.
-- [ ] `MIN_COLLATERAL_RATIO_BPS = 20000` (200%).
-- [ ] `DEFAULT_CLAIM_STAKE_BPS = 1000` (10%).
-- [ ] `REJECTION_SKILL_PENALTY = 10`, `REJECTION_RELIABILITY_PENALTY = 25`.
-- [ ] `DISPUTE_LOSS_SKILL_PENALTY = 35`, `DISPUTE_LOSS_RELIABILITY_PENALTY = 60`.
-- [ ] Owner, pauser, verifier, arbitrator addresses final and copied to private deploy env.
-
-### Documentation
-
-- [ ] `THREAT_MODEL.md` published.
-- [ ] No-token statement linked in README and docs root.
-- [ ] Week-12 gate thresholds and diagnostic order documented internally.
-- [x] Reason-code registry published in `docs/DISPUTE_CODES.md` or equivalent.
-- [ ] Phase 0 -> Phase 1 -> Phase 2 arbitration migration triggers documented publicly.
-
-### Dispute flow
-
-- [ ] `setArbitrator(pascalAddr, true)` called from multisig.
-- [ ] Hardware wallet provisioned for arbitrator key, separate from multisig cold key.
-- [ ] `POST /disputes/:id/verdict` and `POST /disputes/:id/release` wired to call `EscrowCore.resolveDispute`.
-- [ ] Dispute reasoning content stored under `/content/:hash`.
-- [ ] Operator app dispute queue surfaces `disputedAt` and SLA countdown.
-- [ ] Dispute notification path live.
-- [ ] Public migration commitment to Phase 1 by month 6 or first 50 disputes.
-
-### Async XCM
-
-- [ ] Backend SCALE assembler shipped.
-- [ ] HTTP `/account/allocate` and `/account/deallocate` accept intent only, not raw bytes.
-- [ ] Backend mirrors `previewRequestId(context)` and appends `SetTopic(requestId)`.
-- [ ] `XcmWrapper.queueRequest` SetTopic validation check live.
-- [ ] Chopsticks experiment confirms Bifrost preserves SetTopic on reply-leg, or fallback chosen and documented.
-- [ ] Async XCM staging proof captured per `ASYNC_XCM_STAGING.md`.
+---
 
 ## 13. Reconciliation log
 
-### v1.4 - yield strategy portfolio model
+For traceability.
 
-1. Replaced the single-vDOT wallet framing with a yield-strategy portfolio model behind the existing `XcmVdotAdapter` pattern.
-2. Locked the v1 default to moderate auto-allocation into Bifrost vDOT: single-hop XCM, single vendor surface, and the simplest correlation path.
-3. Scoped Hydration GDOT as an opt-in v2 composite-yield adapter, never an auto-allocation default.
-4. Scoped Hydration money-market borrowing as the v2 direction for replacing native flat balance-sheet lending once liquidation mechanics become necessary.
-5. Added Hydration GDOT and Hydration money-market borrow facility to deferred items with triggers and rationale.
-6. Updated the worker-wallet positioning line to match the portfolio framing.
+### v1.10 (repository sync after Slice 9)
 
-### v1.3 - arbitration evolution path; on-chain dispute flow grounded
+1. Imported the post-verification spec book into the repository as `docs/RC1_WORKING_SPEC.md` and added the companion `AVERRAY_VERIFICATION_LEDGER.md` plus `FRAMEWORK_AGENT_HANDOFF.md`.
+2. Marked Slice 8/9 async XCM foundations as shipped: `XcmWrapper.queueRequest` validates `SetTopic(requestId)`, backend rejects caller-supplied raw XCM bytes, and `mcp-server/src/blockchain/xcm-message-builder.js` assembles server-controlled request payloads.
+3. Moved backend SCALE assembler from "not built" framing to follow-up hardening/staging framing. The remaining vDOT-mainnet blocker is the native XCM observer correlation gate and staging evidence.
+4. Corrected the lingering Hydration GDOT deferred-yield line from `18–25%` to `~15–20%` so it matches the v1.9 verification correction.
+5. Aligned deploy/runbook wording around `TOKEN_ADDRESS`: no native DOT precompile is assumed; testnet/mainnet must provide an approved ERC20 asset precompile or a deliberately chosen test token until the native-DOT representation question is resolved.
 
-1. Corrected arbitrator authority to `TreasuryPolicy.arbitrators` mapping with `setArbitrator(address, bool)`.
-2. Corrected slash split to 50/50 poster/treasury, zero to arbitrator at launch.
-3. Added arbitration evolution path: Phase 0 human, Phase 1 supervised LLM, Phase 2 tiered agent quorum, Phase 3 permissionless tier.
-4. Added separate eligibility ladders for internal jobs and arbitration.
-5. Documented Phase 0 dispute process grounded in `EscrowCore.openDispute` and `resolveDispute`.
-6. Added verifier accountability via public trail.
-7. Added arbitration safety contract changes: dispute deadline, 7-day `DISPUTE_WINDOW`, `autoResolveOnTimeout`, `disputedAt`.
-8. Added reason-code registry.
-9. Added Phase 1/2/3 arbitration roadmap items.
-10. Added positioning lines for tiered access and data-driven migration.
-11. Added dispute-flow backend wiring checklist.
-12. Added Phase 0 arbitrator setup items.
+### v1.9 (verification pass — 19 corrections from comparing spec to authoritative Polkadot docs)
 
-### v1.2 - XCM correlation gate, async lane scoping
+External verification work resolved every ⏳ item in `AVERRAY_VERIFICATION_LEDGER.md`. Final ledger counts: ✅ 32 verified / ⚠️ 19 corrections needed / 🔬 8 empirical-only / ⏳ 0 pending. The 19 corrections below pull into this spec; **none invalidates a locked architectural decision** — XCM precompile address, SetTopic = requestId, `pallet_revive` on Asset Hub, Phase 1/Phase 2 storage split all hold.
 
-1. Added `XcmWrapper.queueRequest` SetTopic validation as a v1.0.0-rc1 contract change.
-2. Added async XCM untrusted input threat model entry.
-3. Chose SetTopic = requestId as the correlation primitive; Bifrost reply-leg preservation remains empirical.
-4. Documented current async XCM lane reality: scaffolded only, raw bytes accepted, no SetTopic anywhere in codebase.
-5. Replaced placeholder async XCM checklist with concrete assembler and observer items.
+**SetTopic semantics ✅ (no spec change needed):**
 
-### v1.1 - reconciliation against deployed reality and operational docs
+1. SetTopic-as-requestId design confirmed against upstream sources. xcm-format spec defines `SetTopic = 44 ([u8; 32])`; pallet-xcm's `WithUniqueTopic` router uses the trailing `SetTopic(id)` as the `Sent` event's `message_id` verbatim. The correlation gate design exactly matches what the upstream code does. This is the most important finding — it confirms the entire async XCM architecture rests on solid ground.
 
-1. Split claim stake from claim fee.
-2. Reframed borrow-to-stake as durable post-onboarding flow.
-3. Added vDOT strategy as wallet-as-earning-account framing.
-4. Distinguished arbitrator role from peer-verifier re-review.
-5. Moved disclosure events to existing session contract, not new `DisclosureLog`.
-6. Removed `VerifierRegistry` as the target new-contract architecture; replaced with extension to existing verifier mapping.
-7. Confirmed `DiscoveryRegistry` as the only genuinely new target contract.
-8. Folded in references to mainnet parameters, multisig, signer policy, async XCM staging, and native XCM observer docs.
-9. Added native XCM observer correlation gate as v1.x prerequisite.
-10. Added vDOT positioning line.
+**Native DOT precompile claim retracted (§1, §10 multisig empirical entry):**
+
+2. **§1** Removed claim that DOT is exposed via a "native DOT precompile" — no such precompile exists. `MULTISIG_SETUP.md §5` deploy template's `TOKEN_ADDRESS=0x<hub-dot-precompile-or-testdot>` field is wrong as written. Field meaning needs to be resolved (foreign-asset wrapping? test ERC-20? XCM multilocation reference?) before the deploy script is run.
+3. **§10 (new)** Added "Multisig-owns-EVM-contract composition validation" as empirical-only deferred item. The composition `pallet_multisig` SS58 → `pallet_revive.map_account()` H160 → owner of `TreasuryPolicy` rests on three documented primitives but the composition itself is not documented end-to-end. Running `MULTISIG_SETUP.md §5` against testnet *is* the validation experiment. Resolve before tagging `v1.0.0-rc1` for any mainnet-adjacent purpose.
+
+**PoP claims downgraded to community-sourced (§10 PoP entry, §11 positioning line):**
+
+4. **§10 PoP entry** Reworded extensively. None of DIM1/DIM2 tier names, contextual aliases, Asset Hub integration in rollout scope, or v2.2.1 Phase 0 launch is documented on `docs.polkadot.com`. Spec language now flags every PoP-specific claim as community-sourced and subject to change.
+5. **§10 PoP entry** Trigger updated: requires PoP mainnet maturity *AND* publication of technical spec on `docs.polkadot.com`. Documentation is now an explicit gate, not just maturity.
+6. **§11 positioning line** Strengthened conditional. Was "do not use until DIM1 is mainnet-stable on Asset Hub"; now also requires "technical spec is documented on `docs.polkadot.com`."
+
+**Yield band corrections (§2 strategy descriptions):**
+
+7. **§2 v1 default vDOT** Yield band was "~11–14% APR base." Corrected to "~5–6% APR base" reflecting post-2026 Bifrost tokenomics reset. Added note to verify against current Bifrost docs before launch since yields shift with Polkadot inflation policy.
+8. **§2 v2 strategy GDOT** Yield band was "18–25% APR." Corrected to "~15–20% APR" reflecting current leveraged-composition reality. Added note that real yield depends on leverage ratio chosen.
+9. **§2 decision principle** "~12% from vDOT alone" updated to "~5–6% from vDOT alone." Argument still holds — beating CEX yield (0.5–3%) and bank savings rates is enough; the principle didn't depend on the specific number.
+
+**Wallet-connector correction (§10 wallet-connector entry):**
+
+10. **§10 wallet-connector entry** Corrected supported-wallet list. Previously implied MetaMask + Mimir support via `polkadot.cloud/connect`. Reality per official docs: supported list is Polkadot.js, Talisman, SubWallet, Enkrypt, Fearless, PolkaGate, Polkadot Vault, Ledger. MetaMask and Mimir are NOT supported. This sharpens the architecture: MetaMask + wagmi/viem for Asset Hub EVM accounts; `polkadot.cloud/connect` for Polkadot-native wallets specifically; Mimir-specific tooling (if needed for in-app multisig flows) evaluated separately.
+
+**v2.2.1 runtime claims softened (no body text affected — original claims were in chat, not spec body):**
+
+11. The "10x storage cost reduction in v2.2.1" claim from the original tweet/announcement quote does not appear on `docs.polkadot.com`. Docs only describe Asset Hub transactions as "approximately one-tenth the cost of relay chain transactions" — a comparison, not a v2.2.1-specific event. Spec body never asserted this as a verified fact, so no correction needed; this entry exists as a record that the claim is community-sourced.
+12. The "2-second blocks on People Chain" claim from the same announcement is similarly not specifically attributed to People Chain in current docs. Async backing and Elastic Scaling are documented as parachain-wide capabilities, not People-Chain-specific features. Same outcome — record-of-correction only.
+
+**Account/identity verifications (informational; no spec body change needed):**
+
+13. `pallet_revive.map_account()` confirmed as the SS58→H160 mapping primitive. `MULTISIG_SETUP.md §4` is correct on this point.
+14. `0xEE` suffix convention for EVM ↔ AccountId32 mapping confirmed verbatim. `MULTISIG_SETUP.md §4` is correct on this point. Correct source URL is `docs.polkadot.com/smart-contracts/for-eth-devs/accounts/#ethereum-to-polkadot-mapping` (not the SS58-format page that earlier spec versions referenced).
+
+**EVM model verifications (informational; no spec body change needed):**
+
+15. PVM / `pallet_revive` model on Asset Hub confirmed.
+16. Standard Ethereum precompiles (ecrecover, sha256, etc.) confirmed available on Asset Hub EVM.
+17. Foundry/Hardhat/viem/wagmi tooling confirmed as supported via documented integrations.
+
+**Tooling verifications (informational; no spec body change needed):**
+
+18. PAPI confirmed exposes the granularity needed to construct XCM messages with explicit instruction sequences, including SetTopic injection. `mcp-server/src/blockchain/xcm-message-builder/` design holds.
+19. ParaSpell confirmed as a higher-level XCM router. Treat as reference comparison during assembler development per earlier spec; not adopted as primary tooling.
+20. `pallet_multisig` deterministic address derivation from `(signatories, threshold)` confirmed verbatim. `MULTISIG_SETUP.md §3` is correct.
+21. Polkadot Multisig (Signet) supports Talisman as signer wallet — confirmed.
+
+**Hydration/Bifrost composition (informational; #7-#9 corrections cover the yield-band changes):**
+
+22. Hydration money market does accept GDOT/aDOT as collateral for borrow — confirmed per Hydration docs. v2 Hydration-money-market borrow facility plan stands.
+23. Hub→Bifrost settlement latency and Bifrost mint-failure communication remain 🔬 empirical — no docs answer these.
+
+### v1.8 (Bulletin Chain corrections from official-doc verification)
+
+1. **§6** Replaced "Why Bulletin Chain is the primary candidate" subsection with corrected "Phase 2 storage candidates: comparison" — explicit table of differences between Bulletin Chain and Crust, grounded in the official Bulletin Chain reference docs.
+2. **§6** Corrected Bulletin Chain retention claim. Spec previously implied configurable per-blob retention covering the 6-month disclosure window. Reality (per docs): fixed ~2 weeks on Polkadot TestNet, mandatory `renew(block, index)` per blob to extend.
+3. **§6** Corrected authorization claim. Spec previously said "OpenGov for mainnet, PoP eventually." Reality (per docs): `authorize_account` and `authorize_preimage` extrinsics require Root origin; OpenGov is the production path to Root, but the mainnet authorization model is "still being finalized."
+4. **§6** Documented operational implication of renewal: each renewal generates new `(block, index)` pair; CID stays stable for retrieval, but renewal requires the most recent identifier pair — persistent `(cid, latest_block, latest_index, expires_at)` tracking is required.
+5. **§6** Added "Choice deferred" section explicitly. Phase 2 backend choice between Bulletin Chain and Crust is now treated as a real choice to defer, not a commitment to either.
+6. **§10** Replaced "Bulletin Chain primary, Crust fallback" entry with neutral "real choice between Bulletin Chain and Crust" framing. Honest about which structural-fit claims didn't survive verification.
+7. **Companion document:** `AVERRAY_VERIFICATION_LEDGER.md` published. Tracks every empirical claim in the spec against authoritative docs with status flags (verified, corrections needed, pending, empirical-only). All future spec changes that reference Polkadot semantics should be cross-checked against the ledger or new verification work.
+
+### v1.7 (operator dashboard wallet-connector library tracked)
+
+1. **§10** Added "Operator dashboard wallet-connector library" deferred entry. v1 uses plain viem/wagmi with MetaMask + Talisman; reach for polkadot.cloud/connect when external operator count and wallet diversity justify the dependency. Agents never use a wallet-connector library — programmatic signing only.
+
+### v1.6 (Polkadot v2.2.1 awareness)
+
+1. **§6** Storage Phase 2 reframed: Bulletin Chain (post-v2.2.1) is primary candidate; Crust IPFS pinning is fallback. Both IPFS-compatible — content-addressing discipline from day one means migration is trivial regardless.
+2. **§6** Added "Why Bulletin Chain is the primary candidate" subsection: CID = our content hash; renewal-based retention maps directly to disclosure timing; no per-byte fees forever; same trust boundary as the rest of the stack; IPFS-compatible as escape hatch.
+3. **§6** Documented mainnet authorization gate: OpenGov referendum required (or future PoP-based authorization). Testnet free via faucet for v1.0.0-rc1 development. OpenGov authorization is a discrete v2 milestone — real ecosystem engagement, not configuration.
+4. **§10** Replaced "IPFS / Crust migration" deferred entry with "Phase 2 storage migration: Bulletin Chain primary, Crust fallback" — explicit about the OpenGov authorization milestone.
+5. **§10** Added Proof of Personhood (PoP) integration as deferred item with two specific use-cases: DIM1 for operator signup (Sybil resistance against fleet-of-fake-operators bootstrap-budget attack), DIM2 for Phase 2 arbitration eligibility (higher-stakes role). Trigger is PoP mainnet maturity. Asset Hub integration must be verified before depending on it.
+6. **§11** Added PoP-conditional positioning line about operator-level Sybil resistance.
+
+### v1.5 (parameter tunability and experimentation discipline)
+
+1. **§14 (new)** Added parameter tunability tier model: Tier 1 (off-chain, change anytime), Tier 2 (multisig admin call), Tier 3 (contract redeployment), Tier 4 (fixed by design — changing undermines the trust pitch).
+2. **§14** Added experimentation discipline: hold parameters stable through week-12 gate, one variable at a time, write decision criteria before running experiments.
+3. **§14** Distinguished friction levers (claim stake, fee floor, dispute window) from incentive levers (bounty amounts) — different problems require different tunables.
+4. **§14** Documented three load-bearing metrics for parameter calibration: merge rate (incentive), claim rate (friction), dispute rate (verifier).
+5. **§14** Added `docs/PARAMETER_CHANGES.md` log requirement with mandatory pre-change fields (hypothesis, target metric, observation window, decision rule).
+
+### v1.4 (yield strategy portfolio model)
+
+1. **§2** Replaced single-vDOT "Wallet as earning account" subsection with yield-strategy portfolio framing. Strategies treated as a portfolio behind the existing `XcmVdotAdapter` pattern, not a fixed choice. Conservative-by-default posture: platform is sensible by default but doesn't ceiling agents.
+2. **§2** v1 default locked: moderate auto-allocation to Bifrost vDOT. Single-hop XCM, ~12% APR, single vendor surface, well-understood risk. The marketing line "Your worker wallet earns between jobs" doesn't require maximum yield — beating CEX yield (0.5–3%) is enough.
+3. **§2** v2 strategy locked: Hydration GDOT as opt-in composite-yield adapter, never auto-allocated. Targets 18–25% APR but doubles vendor surface and requires multi-hop XCM correlation. Worth shipping after v1 vDOT is empirically stable.
+4. **§2** v2 borrow facility direction: route `BORROW_CAP` through Hydration money market (collateralized against GDOT/aDOT) instead of building native liquidation mechanics. Cleaner risk model — Averray no longer carries lender-of-last-resort exposure, borrow scales with actual collateral, audited liquidation already exists.
+5. **§10** Added Hydration GDOT strategy adapter and Hydration money market borrow facility as v2 deferred items, with explicit triggers and rationale.
+6. **§11** Updated vDOT positioning line to reflect strategy portfolio framing.
+
+### v1.3 (arbitration evolution path; on-chain dispute flow grounded)
+
+1. **§3** Corrected three-roles table: arbitrator authority is `TreasuryPolicy.arbitrators` mapping with `setArbitrator(address, bool)` — multi-arbitrator by design, not single-target.
+2. **§3** Corrected slash split: 50/50 poster/treasury, zero to arbitrator at launch (Phase 0–1). Restructure deferred to Phase 2 when agent-arbitrators need real economic incentive.
+3. **§3** Added arbitration evolution path: Phase 0 (human, Pascal) → Phase 1 (LLM-as-judge supervised) → Phase 2 (tiered agent quorum) → Phase 3 (permissionless tier). Triggers are data-driven (override rate, dispute volume) not calendar-based.
+4. **§3** Added separate eligibility ladders: internal-jobs (~30 merges, 6 months) is distinct from arbitration (~100 merges, 12 months, stake bond, calibration test). Two ladders, earned independently.
+5. **§3** Documented Phase 0 dispute process grounded in actual contract surface: `EscrowCore.openDispute` → `resolveDispute(jobId, workerPayout, reasonCode, metadataURI)`. `metadataURI` carries hashed off-chain reasoning per disclosure model.
+6. **§3** Verifier accountability via public trail: overturned arbitrations record on the verifier's reputation, no new contract logic.
+7. **§8** Added three contract changes for arbitration safety:
+   - `EscrowCore.openDispute` enforces `DISPUTE_WINDOW` (bumped 1 day → 7 days) — removes operator-cron dependency.
+   - New `EscrowCore.autoResolveOnTimeout(jobId)` — permissionless, after `ARBITRATOR_SLA = 14 days`, agent-favorable default (system unavailability is platform's failure).
+   - `disputedAt` timestamp on job state and `Disputed` event for SLA enforcement.
+8. **§8** Added reason-code registry: existing `REJECTED` and `DISPUTE_LOST` plus new `DISPUTE_OVERTURNED`, `DISPUTE_PARTIAL`, `ARB_TIMEOUT`, `MUTUAL_RELEASE` as off-chain conventions (no contract changes; field is freeform).
+9. **§10** Added Phase 1/2/3 arbitration items, Phase 2 dispute compensation restructure, internal-jobs eligibility ladder.
+10. **§11** Added two positioning lines (tiered access; data-driven migration). Both conditional on real Phase 2 maturity.
+11. **§12** Added dispute-flow backend wiring checklist (`POST /disputes/:id/verdict` and `/release` currently scaffolded, must dispatch to `EscrowCore.resolveDispute` at launch).
+12. **§12** Added Phase 0 arbitrator setup items (multisig calls `setArbitrator`, Ledger provisioning, public migration commitment).
+
+### v1.2 (XCM correlation gate, async lane scoping)
+
+1. **§8** Added `XcmWrapper.queueRequest` SetTopic-validation as a v1.0.0-rc1 contract change. Decode last instruction of `message`; reject if not `SetTopic(requestId)`. Defense-in-depth against assembler bugs.
+2. **§9** Added "Async XCM lane: untrusted input surface" threat model entry. Documents the current `/account/allocate` accept-arbitrary-bytes pattern and the gating requirement until the backend assembler ships.
+3. **§10** Replaced the "three candidates, none locked" framing with two explicit, dependent work items: backend SCALE assembler (foundational) and native XCM observer correlation gate (depends on assembler, validated via Chopsticks). SetTopic = requestId is the chosen correlation primitive; Bifrost reply-leg preservation is the empirical gate.
+4. **§10** Documented the current async XCM lane reality: scaffolded only, no production SCALE assembler, HTTP layer accepts raw bytes, no SetTopic anywhere in codebase, `XcmWrapper.requestMessageHash` is `keccak256(rawBytes)` not the XCM-protocol `messageId`.
+5. **§12** Replaced the placeholder async XCM checklist with concrete items: assembler shipped, HTTP intent-routing live, backend computes/appends SetTopic, wrapper validation check, Chopsticks confirmation, staging proof.
+
+### v1.1 (reconciliation against deployed reality and operational docs)
+
+1. **§2** Split claim stake (10%, dispute-slashable) from claim fee (`max(2%, $0.05)`, anti-spam). Both refunded on success.
+2. **§2** Borrow-to-stake reframed as durable post-onboarding flow, not v2.
+3. **§2** Added vDOT strategy as wallet-as-earning-account framing.
+4. **§3** Arbitrator role distinguished from peer-verifier re-review. Penalty-driven dispute discipline replaces compute-driven.
+5. **§7** Disclosure events emit from existing session contract, not new `DisclosureLog`.
+6. **§8** Removed `VerifierRegistry` as new contract. Replaced with extension to existing verifier mapping (`authorizedSince`/`authorizedUntil`/`wasAuthorizedAt`).
+7. **§8** Confirmed `DiscoveryRegistry` is the only genuinely new contract.
+8. **§9, §10, §11, §12** Folded in references to `MAINNET_PARAMETERS.md`, `MULTISIG_SETUP.md`, `SIGNER_POLICY.md`, `ASYNC_XCM_STAGING.md`, `NATIVE_XCM_OBSERVER.md` where directly relevant.
+9. **§10** Native XCM observer correlation gate added explicitly as v1.x prerequisite for self-sufficient async settlement.
+10. **§11** Added vDOT positioning line.
+
+---
+
+## 14. Parameter tunability and experimentation discipline
+
+Every numeric parameter in this spec falls into one of four tiers. Knowing which tier a number lives in determines how to change it, and *whether to change it at all*.
+
+### Tunability tiers
+
+**Tier 1 — Off-chain, change any time.**
+Lives in platform config or job-sourcing logic. No contract interaction needed.
+
+| Parameter | Current value |
+|---|---|
+| Weekly bootstrap budget | $50/wk |
+| Job tier mix | ~15 light × $1, ~5–7 substantive × $5–7 |
+| Per-job payout amounts | Per posting |
+| Free onboarding jobs | 3 |
+| Per-repo open PR cap | 3 |
+| Verifier deadlines | 30d GitHub, 14d Wikipedia |
+| Denylist contents | Operator-managed |
+
+**Tier 2 — On-chain, multisig admin call (`TreasuryPolicy`).**
+Single 2-of-3 transaction; gas negligible. Designed to be tunable post-launch.
+
+| Parameter | Current value |
+|---|---|
+| `DAILY_OUTFLOW_CAP` | 250 DOT |
+| `BORROW_CAP` | 25 DOT per account |
+| `MIN_COLLATERAL_RATIO_BPS` | 20000 (200%) |
+| `DEFAULT_CLAIM_STAKE_BPS` | 1000 (10%) |
+| `REJECTION_SKILL_PENALTY` / `REJECTION_RELIABILITY_PENALTY` | 10 / 25 |
+| `DISPUTE_LOSS_SKILL_PENALTY` / `DISPUTE_LOSS_RELIABILITY_PENALTY` | 35 / 60 |
+| Claim fee parameters (when shipped) | `max(2%, $0.05)`, 70/30 split |
+
+**Tier 3 — Requires contract redeployment.**
+Hardcoded constants in code. Tunable only with full deploy + migration.
+
+| Parameter | Current value |
+|---|---|
+| `DISPUTE_WINDOW` | 7 days (post-rc1) |
+| `ARBITRATOR_SLA` | 14 days (post-rc1) |
+| Slash split (poster/treasury) | 50/50 |
+
+**Tier 4 — Fixed by design.**
+Changing these undermines the trust pitch, regardless of technical feasibility.
+
+| Commitment | Why fixed |
+|---|---|
+| 6-month auto-disclosure window | `auto_public_at` set per-blob at write time; future policy changes don't affect already-written records |
+| No platform token | Brand commitment; structurally incompatible with the trust pitch |
+| Reputation SBT non-transferability | Hardcoded contract revert |
+
+**The boundary:** numbers are tunable, *promises* aren't.
+
+### Experimentation discipline
+
+**The first 12 weeks are not for experiments.** Hold all numbers stable through the week-12 gate (§5). Twelve weeks of stable data on the launch values is worth more than four weeks of experimenting around them — without a baseline you have nothing to compare against. The first real experiment starts at week 13 at the earliest.
+
+**Change one variable at a time.** Concurrent changes mean concurrent ambiguity. Pick one lever, change it, observe for at least 4 weeks, move to the next.
+
+**Decide the test before running it.** Before changing any number, write down:
+- The exact change (parameter, old value, new value)
+- The hypothesis (what mechanism connects the change to the expected outcome)
+- The target metric (which observable moves)
+- The observation window (how long until we evaluate)
+- The decision rule (what result keeps the change vs reverts it)
+
+If the criteria aren't written down first, post-hoc rationalization becomes inevitable.
+
+**Distinguish friction tuning from incentive tuning.**
+
+| Lever | What it actually moves |
+|---|---|
+| Bounty payout amounts | Quality of submission, effort per attempt, types of agents attracted |
+| Claim stake % | Who claims at all, spam rate |
+| Claim fee floor | Filters small-value spam without affecting high-value claims |
+| Dispute window | Agent confidence to dispute marginal verdicts |
+| `MIN_COLLATERAL_RATIO_BPS` | How much agents can leverage borrow |
+
+When merge rate is bad, ask first *which kind of bad* — low effort (incentive problem) or low engagement (friction problem). The answer determines which lever to touch.
+
+**The metrics worth instrumenting from day one:**
+
+Three observables tell you whether each kind of lever is calibrated. None of these is the merge rate alone — that's the outcome, not the diagnosis.
+
+| Metric | What it tells you | Lever it points at |
+|---|---|---|
+| Upstream merge rate | Are funded jobs producing real outcomes? | Incentive levers (bounty, claim stake) |
+| Claim rate per job posted | Are jobs attractive enough to claim? | Friction levers (claim stake, claim fee) |
+| Dispute rate | Are verifier verdicts being trusted? | Verifier calibration, dispute-window |
+
+Watch all three weekly. Without all three, parameter changes are guesswork.
+
+### Parameter change log
+
+Maintain `docs/PARAMETER_CHANGES.md` (or equivalent table). Every change records:
+
+| Field | Example |
+|---|---|
+| Date | 2026-08-04 |
+| Parameter | `DEFAULT_CLAIM_STAKE_BPS` |
+| Old value | 1000 (10%) |
+| New value | 700 (7%) |
+| Tier | 2 (multisig) |
+| Hypothesis | Lower stake will attract higher claim rate without raising spam, given dispute rate has been stable at 3% |
+| Target metric | Claim rate per job posted; spam rate (proxy: rejected-without-substance ratio) |
+| Observation window | 4 weeks |
+| Decision rule | Keep if claim rate +20% AND spam rate stays below 5%. Revert otherwise. |
+| Outcome | (filled in at end of window) |
+
+After 6 months, the log either documents real platform learning or reveals random tuning. The discipline of writing the entry *before* changing the value is what makes the difference.
+
+**One thing this log should never contain:** a Tier 4 parameter. If a "no platform token, no airdrop" entry ever shows up, the platform's trust pitch has structurally failed regardless of what the new value is.
+
+---
+
+*Last updated: 2026-04-25*

--- a/docs/strategies/vdot.md
+++ b/docs/strategies/vdot.md
@@ -15,8 +15,8 @@ Pillar 2 of [docs/AGENT_BANKING.md](../AGENT_BANKING.md).
 
 The vDOT adapter is the canonical first strategy: take DOT, stake it via
 Bifrost's liquid-staking primitive, earn Polkadot staking yield (roughly
-11–14% APY at time of writing), redeem DOT at the accrued rate when the
-agent withdraws.
+5–6% base APY at time of writing; verify current Bifrost docs before launch),
+redeem DOT at the accrued rate when the agent withdraws.
 
 Key properties for the platform:
 

--- a/scripts/deploy_contracts.sh
+++ b/scripts/deploy_contracts.sh
@@ -21,7 +21,9 @@
 #   PROFILE                 dev | testnet | mainnet   (default: dev)
 #   RPC_URL                 RPC endpoint               (default: http://127.0.0.1:8545)
 #   PRIVATE_KEY             deployer key               (required for testnet/mainnet)
-#   TOKEN_ADDRESS           DOT precompile / real ERC20 (required for testnet/mainnet)
+#   TOKEN_ADDRESS           approved ERC20 asset precompile / test token
+#                           (required for testnet/mainnet; native DOT is not
+#                           exposed via an ERC20 precompile)
 #   OWNER                   multisig mapped EVM address (defaults to deployer on dev)
 #   PAUSER                  hot-key pauser EOA          (defaults to deployer)
 #   VERIFIER                backend verifier signer EOA (defaults to deployer on dev)
@@ -94,7 +96,7 @@ case "$PROFILE" in
   testnet|mainnet)
     [[ -n "${PRIVATE_KEY:-}" ]] || fail "PRIVATE_KEY is required for PROFILE=$PROFILE"
     [[ "$PRIVATE_KEY" != "$ANVIL_TEST_KEY" ]] || fail "refusing to use Anvil test key for PROFILE=$PROFILE"
-    [[ -n "${TOKEN_ADDRESS:-}" ]] || fail "TOKEN_ADDRESS is required for PROFILE=$PROFILE (set it to the DOT precompile / real ERC20)"
+    [[ -n "${TOKEN_ADDRESS:-}" ]] || fail "TOKEN_ADDRESS is required for PROFILE=$PROFILE (set it to an approved ERC20 asset precompile or deliberate test token; native DOT is not exposed via an ERC20 precompile)"
     ;;
   *)
     fail "unknown PROFILE: $PROFILE (expected dev|testnet|mainnet)"


### PR DESCRIPTION
## What changed
- Replace docs/RC1_WORKING_SPEC.md with the updated spec book, bumped to v1.10 to reflect repository state after Slice 9.
- Add docs/AVERRAY_VERIFICATION_LEDGER.md and docs/FRAMEWORK_AGENT_HANDOFF.md as companion docs for future agents.
- Align multisig/deploy runbook wording with the verified no-native-DOT-precompile correction.
- Refresh vDOT/GDOT yield language and the rc1 implementation plan current-position notes.

## Checks run
- git diff --check origin/main...HEAD
- bash -n scripts/deploy_contracts.sh

## Impact
- Docs/runbook only. No backend, frontend, indexer, contract runtime, Caddy, or public site behavior changes.

## Env/VPS changes
- None.

## Notes
- Next implementation slice remains Slice 10: Native XCM Observer Correlation Gate.
- TOKEN_ADDRESS remains a launch gate for testnet/mainnet rehearsals until an approved ERC20 asset precompile or deliberate test token is chosen.