### PR TITLE
Add native XCM evidence pack gate

### DIFF
--- a/docs/ASYNC_XCM_STAGING.md
+++ b/docs/ASYNC_XCM_STAGING.md
@@ -206,3 +206,16 @@ The native evidence validator now enforces the correlation gate:
 
 Until a real Chopsticks/PAPI capture passes those rules, use the internal
 observe/finalize path above for staging settlement.
+
+Once deposit, withdraw, and failure captures exist, validate the three-artifact
+gate before promoting the native observer:
+
+```bash
+npm run check:native-xcm-evidence-pack -- \
+  --deposit artifacts/xcm/native-deposit-evidence.json \
+  --withdraw artifacts/xcm/native-withdraw-evidence.json \
+  --failure artifacts/xcm/native-failure-evidence.json
+```
+
+The pack gate rejects staging-only `ledger_join` evidence and requires a single
+production-candidate correlation method across all three captures.

--- a/docs/NATIVE_XCM_OBSERVER.md
+++ b/docs/NATIVE_XCM_OBSERVER.md
@@ -271,6 +271,8 @@ Native observer output is acceptable for automated settlement only after:
 The repo includes a sample evidence envelope:
 
 - [docs/fixtures/xcm/native-observer-evidence.sample.json](./fixtures/xcm/native-observer-evidence.sample.json)
+- [docs/fixtures/xcm/native-observer-evidence-withdraw.sample.json](./fixtures/xcm/native-observer-evidence-withdraw.sample.json)
+- [docs/fixtures/xcm/native-observer-evidence-failure.sample.json](./fixtures/xcm/native-observer-evidence-failure.sample.json)
 - [docs/fixtures/xcm/native-hub-event.sample.json](./fixtures/xcm/native-hub-event.sample.json)
 - [docs/fixtures/xcm/native-bifrost-event.sample.json](./fixtures/xcm/native-bifrost-event.sample.json)
 
@@ -318,6 +320,38 @@ The validator checks:
 This is intentionally stricter than the public `/xcm/outcomes` item. The
 compact feed is for automated settlement; the evidence envelope is for
 debugging, audit, and proving the native observer is not guessing.
+
+### Evidence pack gate
+
+Before the native observer can become settlement truth, collect three separate
+captures:
+
+1. successful vDOT deposit
+2. successful vDOT withdrawal
+3. one failed request with a stable `failureCode`
+
+Validate the whole pack:
+
+```bash
+npm run check:native-xcm-evidence-pack -- \
+  --deposit artifacts/xcm/native-deposit-evidence.json \
+  --withdraw artifacts/xcm/native-withdraw-evidence.json \
+  --failure artifacts/xcm/native-failure-evidence.json
+```
+
+The pack checker runs the single-envelope validator for each file, then applies
+the launch gate across all three captures:
+
+- deposit must be `direction=deposit` and `status=succeeded`
+- withdraw must be `direction=withdraw` and `status=succeeded`
+- failure must be `status=failed` and include a `failureCode`
+- every capture must be `production_candidate` or `production`
+- all captures must use the same production correlation method
+- `ledger_join` is rejected because it is staging-only
+
+If all three use `request_id_in_message`, the pack supports the SetTopic
+preservation path. If they all use `remote_ref`, the pack supports the fallback
+path and the fallback must be documented here before live reads are enabled.
 
 ---
 

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -200,6 +200,8 @@ npm run validate:subscan-xcm -- --require-published
   evidence linked back to the Averray `requestId`.
 - [ ] Captured evidence passes
   `npm run validate:native-xcm-evidence -- --file <capture.json>`.
+- [ ] Deposit, withdrawal, and failure captures pass
+  `npm run check:native-xcm-evidence-pack -- --deposit <deposit.json> --withdraw <withdraw.json> --failure <failure.json>`.
 - [ ] Captured evidence was assembled with
   `npm run capture:native-xcm-evidence` or contains the same
   `native-xcm-observer-evidence-v1` fields.

--- a/docs/RC1_IMPLEMENTATION_PLAN.md
+++ b/docs/RC1_IMPLEMENTATION_PLAN.md
@@ -35,9 +35,10 @@ The shortest path to a coherent rc1 launch is:
 ## Current Position
 
 As of this branch, **slice 10: Native XCM Observer Correlation Gate** is
-implemented as a machine-checkable staging gate. The next operational step is
-capturing real Chopsticks/PAPI evidence for deposit, withdraw, and one failure
-case before any vDOT mainnet allocation.
+implemented as a machine-checkable staging gate. The three-artifact
+deposit/withdraw/failure evidence-pack checker is in place; the next
+operational step is running the real Chopsticks/PAPI capture and saving the
+artifacts before any vDOT mainnet allocation.
 
 Completed and deployed in this lane:
 
@@ -58,6 +59,8 @@ Completed and deployed in this lane:
 - weekly bootstrap self-report generation exists as a backend service/CLI
 - native XCM evidence now distinguishes SetTopic/request-id correlation,
   remote-ref correlation, and staging-only ledger joins
+- deposit, withdraw, and failure evidence packs can be checked together before
+  promoting the native observer
 
 Still open in the broader rc1 path:
 
@@ -275,6 +278,8 @@ allocation.
   remote-ref correlation, and staging-only ledger joins.
 - [x] Reject promoted `ledger_join` evidence and require
   `messageTopic == requestId` for production-candidate SetTopic evidence.
+- [x] Add a three-artifact pack gate for deposit, withdraw, and failure
+  evidence.
 - [ ] Run Chopsticks experiment for Bifrost reply-leg topic preservation.
 - [ ] If preserved, match return leg by topic.
 - [ ] If not preserved but Hub credit events are unambiguous, use serialized

--- a/docs/fixtures/xcm/native-observer-evidence-failure.sample.json
+++ b/docs/fixtures/xcm/native-observer-evidence-failure.sample.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": "native-xcm-observer-evidence-v1",
+  "requestId": "0x7777777777777777777777777777777777777777777777777777777777777777",
+  "direction": "deposit",
+  "status": "failed",
+  "settledAssets": "0",
+  "settledShares": "0",
+  "remoteRef": null,
+  "failureCode": "0x9999999999999999999999999999999999999999999999999999999999999999",
+  "observedAt": "2026-04-23T12:10:00.000Z",
+  "correlation": {
+    "method": "request_id_in_message",
+    "confidence": "production_candidate",
+    "notes": "Sample only. Replace with evidence captured from a Chopsticks/PAPI replay proving the failure path remains correlated to the original SetTopic."
+  },
+  "hub": {
+    "chain": "polkadot-hub",
+    "blockNumber": "323",
+    "blockHash": "0x8888888888888888888888888888888888888888888888888888888888888888",
+    "extrinsicHash": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "messageHash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "messageTopic": "0x7777777777777777777777777777777777777777777777777777777777777777",
+    "eventIndex": "323-7"
+  },
+  "bifrost": {
+    "chain": "bifrost-polkadot",
+    "blockNumber": "656",
+    "blockHash": "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "eventIndex": "656-12",
+    "messageTopic": "0x7777777777777777777777777777777777777777777777777777777777777777",
+    "assetLocation": {
+      "parents": 1,
+      "interior": "Here"
+    },
+    "amount": "0"
+  },
+  "decision": {
+    "status": "failed",
+    "settledAssets": "0",
+    "settledShares": "0",
+    "remoteRef": null,
+    "failureCode": "0x9999999999999999999999999999999999999999999999999999999999999999",
+    "reason": "matched_terminal_failure_event"
+  }
+}

--- a/docs/fixtures/xcm/native-observer-evidence-withdraw.sample.json
+++ b/docs/fixtures/xcm/native-observer-evidence-withdraw.sample.json
@@ -1,0 +1,44 @@
+{
+  "schemaVersion": "native-xcm-observer-evidence-v1",
+  "requestId": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "direction": "withdraw",
+  "status": "succeeded",
+  "settledAssets": "5000000000000",
+  "settledShares": "4900000000000",
+  "remoteRef": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "failureCode": null,
+  "observedAt": "2026-04-23T12:05:00.000Z",
+  "correlation": {
+    "method": "request_id_in_message",
+    "confidence": "production_candidate",
+    "notes": "Sample only. Replace with evidence captured from a Chopsticks/PAPI replay proving Bifrost preserves SetTopic on the withdraw reply leg."
+  },
+  "hub": {
+    "chain": "polkadot-hub",
+    "blockNumber": "223",
+    "blockHash": "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "extrinsicHash": "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "messageHash": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "messageTopic": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "eventIndex": "223-7"
+  },
+  "bifrost": {
+    "chain": "bifrost-polkadot",
+    "blockNumber": "556",
+    "blockHash": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "eventIndex": "556-12",
+    "messageTopic": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "assetLocation": {
+      "parents": 1,
+      "interior": "Here"
+    },
+    "amount": "5000000000000"
+  },
+  "decision": {
+    "status": "succeeded",
+    "settledAssets": "5000000000000",
+    "settledShares": "4900000000000",
+    "remoteRef": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "reason": "matched_terminal_bifrost_event"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "start:indexer": "npm --workspace indexer run start",
     "typecheck:indexer": "npm --workspace indexer run typecheck",
     "capture:native-xcm-evidence": "node scripts/ops/capture-native-xcm-evidence.mjs",
+    "check:native-xcm-evidence-pack": "node scripts/ops/check-native-xcm-evidence-pack.mjs",
     "validate:subscan-xcm": "node scripts/ops/validate-subscan-xcm-source.mjs",
     "validate:native-xcm-evidence": "node scripts/ops/validate-native-xcm-evidence.mjs",
     "exercise:async-xcm": "node scripts/ops/exercise-async-xcm-request.mjs",

--- a/scripts/ops/check-native-xcm-evidence-pack.mjs
+++ b/scripts/ops/check-native-xcm-evidence-pack.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { validateEvidence } from "./validate-native-xcm-evidence.mjs";
+
+const options = parseArgs(process.argv.slice(2));
+
+if (options.help) {
+  printHelp();
+  process.exit(0);
+}
+
+const required = ["deposit", "withdraw", "failure"];
+for (const key of required) {
+  if (!options[key]) {
+    fail(`missing --${key} <path>.`);
+  }
+}
+
+const captures = [
+  await loadCapture("deposit", options.deposit),
+  await loadCapture("withdraw", options.withdraw),
+  await loadCapture("failure", options.failure)
+];
+
+assertExpectedCapture(captures[0], { label: "deposit", direction: "deposit", status: "succeeded" });
+assertExpectedCapture(captures[1], { label: "withdraw", direction: "withdraw", status: "succeeded" });
+assertExpectedCapture(captures[2], { label: "failure", status: "failed" });
+
+const methods = new Set(captures.map(({ evidence }) => evidence.correlation.method));
+if (methods.has("ledger_join")) {
+  fail("ledger_join evidence is staging-only and cannot satisfy the native observer launch gate.");
+}
+if (methods.size > 1) {
+  fail(`all captures must use the same production correlation method; got ${[...methods].join(", ")}.`);
+}
+
+const [method] = methods;
+const confidenceOrder = new Map([
+  ["staging", 0],
+  ["production_candidate", 1],
+  ["production", 2]
+]);
+
+for (const { label, evidence } of captures) {
+  const confidence = evidence.correlation.confidence;
+  if ((confidenceOrder.get(confidence) ?? -1) < confidenceOrder.get("production_candidate")) {
+    fail(`${label} evidence must be production_candidate or production; got ${confidence}.`);
+  }
+}
+
+console.log("Native XCM evidence pack validated.");
+console.log(`Correlation method: ${method}`);
+for (const { label, outcome, evidence } of captures) {
+  console.log(
+    `${label}: ${outcome.requestId} ${evidence.direction}/${outcome.status} ` +
+      `confidence=${evidence.correlation.confidence} remoteRef=${outcome.remoteRef ?? "none"}`
+  );
+}
+
+if (method === "request_id_in_message") {
+  console.log("Decision: SetTopic/request-id correlation is supported by this evidence pack.");
+} else if (method === "remote_ref") {
+  console.log("Decision: remote_ref fallback is supported by this evidence pack.");
+} else {
+  fail(`unsupported production correlation method: ${method}.`);
+}
+
+function parseArgs(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      parsed.help = true;
+      continue;
+    }
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2).replace(/-([a-z])/gu, (_, char) => char.toUpperCase());
+      parsed[key] = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return parsed;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/check-native-xcm-evidence-pack.mjs [options]
+
+Validates the three native XCM captures required before promoting the native
+observer toward production settlement truth.
+
+Required:
+  --deposit <path>    Successful deposit evidence JSON.
+  --withdraw <path>   Successful withdraw evidence JSON.
+  --failure <path>    Failed request evidence JSON.
+
+Rules:
+  - each file must pass validate-native-xcm-evidence
+  - deposit must be direction=deposit and status=succeeded
+  - withdraw must be direction=withdraw and status=succeeded
+  - failure must be status=failed and include a failureCode
+  - confidence must be production_candidate or production
+  - ledger_join is rejected because it is staging-only
+  - all three captures must use the same production correlation method
+`);
+}
+
+async function loadCapture(label, filePath) {
+  const absolutePath = path.resolve(filePath);
+  const evidence = JSON.parse(await readFile(absolutePath, "utf8"));
+  const outcome = validateEvidence(evidence);
+  return { label, filePath: absolutePath, evidence, outcome };
+}
+
+function assertExpectedCapture({ evidence, outcome }, { label, direction, status }) {
+  if (direction && evidence.direction !== direction) {
+    fail(`${label} evidence must have direction=${direction}; got ${evidence.direction}.`);
+  }
+  if (outcome.status !== status) {
+    fail(`${label} evidence must have status=${status}; got ${outcome.status}.`);
+  }
+}
+
+function fail(message) {
+  throw new Error(message);
+}


### PR DESCRIPTION
## Summary
- add a three-artifact native XCM evidence pack checker for deposit, withdraw, and failure captures
- add withdraw and failure sample evidence envelopes so the full pack gate is executable
- document the pack gate in native observer, staging, production checklist, and rc1 plan docs

## Checks
- npm run check:native-xcm-evidence-pack -- --deposit docs/fixtures/xcm/native-observer-evidence.sample.json --withdraw docs/fixtures/xcm/native-observer-evidence-withdraw.sample.json --failure docs/fixtures/xcm/native-observer-evidence-failure.sample.json
- npm run validate:native-xcm-evidence -- --file docs/fixtures/xcm/native-observer-evidence-withdraw.sample.json
- npm run validate:native-xcm-evidence -- --file docs/fixtures/xcm/native-observer-evidence-failure.sample.json
- git diff --check HEAD~1..HEAD

## Impact
- Affects XCM evidence tooling, fixtures, and docs only.
- No frontend, backend runtime, indexer runtime, contracts, Caddy, or public site changes.
- No required environment or VPS secret changes.

## Notes
- Polkadot docs MCP confirms Chopsticks replay/dry-run is the right validation loop, but Bifrost reply-leg SetTopic preservation remains empirical.
- This PR does not fabricate the empirical answer. It makes the three required real captures mechanically checkable before vDOT mainnet allocation.