### PR TITLE
Plan Hydration yield portfolio v2

### DIFF
--- a/docs/AGENT_BANKING.md
+++ b/docs/AGENT_BANKING.md
@@ -186,6 +186,12 @@ and settlement rules.
    audit item. Plan: one adapter to start, documented as the canonical
    example, don't rush to add more.
 
+5. **Yield portfolio v2 planning.** GDOT is the first higher-yield candidate,
+   but it stays opt-in and post-vDOT. The planning artifact is
+   [`docs/strategies/hydration-gdot.md`](strategies/hydration-gdot.md). It
+   treats GDOT as a multi-hop, multi-vendor strategy behind the same
+   `XcmWrapper` boundary, not as a simple vDOT replacement.
+
 ### Non-goals for v1
 
 - Multi-asset deposits (DOT only until mainnet + one other asset maybe).
@@ -284,6 +290,13 @@ liquidation threshold is conservative.
    that drops below the collateral ratio just fails health checks on new
    actions. Needs an explicit `liquidate(account)` entrypoint that the
    protocol (or arbitrageurs) can call to close bad positions.
+
+4. **Hydration money-market migration.** The long-term credit direction is to
+   route collateralized borrowing through Hydration rather than make Averray
+   the lender of last resort. See
+   [`docs/HYDRATION_BORROW_MIGRATION.md`](HYDRATION_BORROW_MIGRATION.md).
+   Reputation should remain a platform cap and access signal; it should not
+   replace over-collateralized market borrowing.
 
 ### Non-goals for v1
 
@@ -492,9 +505,9 @@ Things we haven't decided yet:
 1. **Mainnet launch profile.** Polkadot Hub is the primary target. The
    open question is not "which chain first?" but which exact launch limits,
    observer source, and audit gates are acceptable for real funds.
-2. **Second strategy adapter?** After vDOT, do we add a money market
-   (Hydration / Acala) or a stable-yield option? Decision: wait until
-   vDOT has real deposits to inform the call.
+2. **Second strategy adapter?** Decision: Hydration GDOT is the first planned
+   opt-in candidate, but only after vDOT has real deposits and the native
+   observer evidence gate is closed.
 3. **Do we issue a platform token?** Not for v1. Maybe never. A platform
    token creates its own complexity (distribution, liquidity, regulatory).
 4. **Reputation decay?** Should reputation scores decay over time if an

--- a/docs/HYDRATION_BORROW_MIGRATION.md
+++ b/docs/HYDRATION_BORROW_MIGRATION.md
@@ -1,0 +1,194 @@
+# Hydration Borrow Migration Plan
+
+Status: **v2 planning only**. The v1 launch profile keeps the native Averray
+borrow cap conservative and flat. This document describes how to migrate the
+credit primitive toward Hydration money-market borrowing after the yield lanes
+and liquidation assumptions are proven.
+
+---
+
+## Why migrate
+
+Today `AgentAccountCore.borrow(asset, amount)` uses Averray's balance sheet as
+the lender. The launch parameters intentionally cap that risk:
+
+- `BORROW_CAP = 25 DOT` per account
+- `MIN_COLLATERAL_RATIO_BPS = 20000` (200%)
+- no liquidation entrypoint yet
+
+That is acceptable for bridge-to-stake at launch. It is not a good long-term
+credit engine. Hydration Borrow is a better v2 direction because the lending
+market owns collateral accounting, interest, health factor, and liquidation
+mechanics, while Averray keeps the job/reputation policy layer.
+
+## Verified external facts
+
+Checked 2026-04-29.
+
+- Polkadot Hub assets can move across parachains through XCM; foreign assets
+  are identified by XCM location rather than by a single EVM token address.
+  Source: Polkadot docs MCP, `reference/polkadot-hub/assets.md`.
+- Production XCM flows should be dry-run and fee-estimated before execution.
+  Source: Polkadot docs MCP,
+  `chain-interactions/send-transactions/interoperability/transfer-assets-parachains.md`.
+- Hydration Borrow supports collateralized borrowing against GDOT/GETH-style
+  collateral for HOLLAR or supported assets, per the Hydration sources recorded
+  in [AVERRAY_VERIFICATION_LEDGER.md](./AVERRAY_VERIFICATION_LEDGER.md).
+- Hydration documents HOLLAR as an over-collateralized stablecoin minted against
+  deposited collateral, with interest accrual, health-factor management, and
+  liquidation mechanics.
+  Source: [Hydration HOLLAR docs](https://docs.hydration.net/quick_start/hollar).
+
+## Target model
+
+```text
+agent earns DOT
+  -> deposits idle DOT into vDOT or opt-in GDOT
+  -> marks strategy position as collateral-eligible
+  -> borrow request routes through Hydration Borrow
+  -> borrowed asset returns to AgentAccountCore liquid balance
+  -> agent uses funds for claim stake or operating capital
+```
+
+In this model, Averray does not lend from treasury except for a small optional
+reputation-backed reservoir. Hydration provides the collateralized credit rail;
+Averray provides:
+
+- identity and reputation signals
+- job-tier policy
+- claim-stake use cases
+- borrow intent routing
+- UI/API disclosure
+- optional reputation-weighted caps on top of market LTV
+
+## Contract boundary
+
+Do not mutate `AgentAccountCore.borrow` directly into a Hydration call. Keep a
+clear adapter boundary:
+
+```text
+AgentAccountCore
+  -> CreditAdapterRegistry
+  -> HydrationBorrowAdapter
+  -> XcmWrapper
+  -> Hydration Borrow
+```
+
+The existing v1 `borrow` / `repay` path can remain as a launch-profile fallback
+while the Hydration adapter is built. The new adapter should use async request
+state like the strategy adapters:
+
+- `requestBorrow(account, collateralStrategyId, borrowAsset, amount, nonce)`
+- `requestRepay(account, borrowAsset, amount, nonce)`
+- `requestCollateralAdjust(account, strategyId, amount, direction, nonce)`
+- `settleCreditRequest(requestId, status, settledAmount, remoteRef, failureCode)`
+
+This keeps cross-chain settlement out of synchronous balance-sheet math.
+
+## Policy layering
+
+Hydration should decide market solvency. Averray should decide platform access.
+
+Recommended policy stack:
+
+1. Hydration max LTV and liquidation rules are the hard market limit.
+2. Averray launch cap remains a separate per-wallet ceiling while the adapter is
+   new.
+3. Reputation-weighted caps become an additional ceiling after enough receipt
+   history exists.
+4. Borrow use is initially restricted to claim-stake bridging and explicit
+   operator-approved test flows.
+
+Do not use reputation as a replacement for collateral. Reputation can raise or
+lower platform caps, but the market borrow should still be over-collateralized.
+
+## Liquidation and failure handling
+
+Before migration, document how each case resolves:
+
+| Case | Expected behavior |
+|---|---|
+| Borrow request fails before Hydration execution | Refund pending local state; no debt booked. |
+| Borrow succeeds remotely but return leg fails | Mark request `failed_return_leg`, pause further borrows, require operator recovery evidence. |
+| Collateral health drops below Hydration threshold | Hydration liquidation path owns market liquidation. Averray reflects reduced collateral and may reduce reputation/credit tier only after confirmed event evidence. |
+| Repay succeeds locally but remote repay fails | Keep debt outstanding, refund local pending amount, emit failure receipt. |
+| Observer uncertainty | Do not auto-settle. Keep request pending until evidence pack or fallback source resolves. |
+
+Hydration liquidation events must become indexer inputs before the credit rail
+can be treated as production truth.
+
+## UX and risk disclosure
+
+Borrowing should be unavailable by default. When enabled, the API/UI should show:
+
+- collateral source and chain
+- current health factor or equivalent solvency metric
+- liquidation threshold
+- borrowed asset
+- interest/rate model and timestamp
+- whether borrow proceeds may be used for claim stake
+- whether Averray reputation cap or Hydration market cap is binding
+
+Required disclosure:
+
+> Borrowing against GDOT or other Hydration collateral can be liquidated by the
+> Hydration money market. Averray does not insure collateral loss and may pause
+> platform borrowing if observer evidence is incomplete.
+
+## Migration stages
+
+### Stage 0: current launch profile
+
+- Native Averray borrow only.
+- `BORROW_CAP = 25 DOT`.
+- 200% collateral ratio.
+- No liquidation.
+- Borrow use case: bridge claim stake.
+
+### Stage 1: read-only Hydration posture
+
+- Track GDOT/aDOT collateral values off-chain.
+- Show hypothetical borrow headroom.
+- No borrow execution.
+- Validate oracle/source freshness and liquidation thresholds.
+
+### Stage 2: staged async adapter
+
+- Add `HydrationBorrowAdapter`.
+- Route test borrow/repay through `XcmWrapper`.
+- Capture deposit, borrow, repay, liquidation/failure evidence packs.
+- Keep per-account cap very low.
+
+### Stage 3: production candidate
+
+- Allow opt-in agents to borrow against Hydration collateral.
+- Keep Averray reputation cap as a ceiling.
+- Require live observer agreement with Hydration evidence.
+- Add operator pause/incident runbook.
+
+### Stage 4: replace native flat cap for collateralized borrow
+
+- Native flat borrow becomes emergency-only or disabled.
+- Borrow caps scale from Hydration collateral plus Averray reputation ceiling.
+- Liquidation mechanics rely on Hydration market events, not an Averray-built
+  liquidation engine.
+
+## Launch gates
+
+- [ ] vDOT and GDOT strategy observer gates are closed.
+- [ ] Hydration Borrow event/storage evidence is documented.
+- [ ] Borrow, repay, collateral adjustment, and liquidation/failure evidence
+  packs pass.
+- [ ] API exposes binding cap reason: Hydration LTV, Averray reputation cap, or
+  launch cap.
+- [ ] Incident runbook covers return-leg failure and observer disagreement.
+- [ ] Legal review confirms wording avoids implying Averray is a bank or lender
+  of last resort.
+
+## Non-goals
+
+- No unsecured borrowing.
+- No under-collateralized reputation-only credit.
+- No direct UI leverage loops.
+- No hidden auto-borrow for claim stake.
+- No production credit rail before liquidation evidence is observable.

--- a/docs/RC1_IMPLEMENTATION_PLAN.md
+++ b/docs/RC1_IMPLEMENTATION_PLAN.md
@@ -291,13 +291,18 @@ logic.
 
 ### 11. Yield Portfolio V2 Planning
 
+**Status:** implemented as planning artifacts. No runtime strategy or credit
+rail changes are included.
+
 **Goal:** prepare but not launch higher-risk yield and borrow surfaces.
 
 **Changes:**
 
-- Draft `HydrationGdotAdapter` design doc.
-- Draft Hydration money-market borrow migration design.
-- Define opt-in UX and risk disclosure before any implementation.
+- [x] Draft `HydrationGdotAdapter` design doc.
+- [x] Draft Hydration money-market borrow migration design.
+- [x] Define opt-in UX and risk disclosure before any implementation.
+- [ ] Implement only after vDOT native observer evidence is captured and the
+  GDOT/Hydration evidence gates are specified.
 
 **Checks:** docs only until implementation begins.
 

--- a/docs/strategies/hydration-gdot.md
+++ b/docs/strategies/hydration-gdot.md
@@ -1,0 +1,146 @@
+# Strategy adapter: Hydration GDOT
+
+Status: **v2 planning only**. Do not register or market this strategy until the
+vDOT lane has real production evidence, the native observer correlation gate is
+closed, and this adapter has its own implementation and audit plan.
+
+---
+
+## Purpose
+
+Hydration GDOT is the first candidate for a higher-yield, opt-in strategy after
+the Bifrost vDOT lane is stable. It belongs in the portfolio because it gives
+agents a risk dial:
+
+- vDOT: moderate default, single vendor, single-hop XCM, never framed as max
+  yield
+- GDOT: opt-in composite yield, higher expected return, materially wider risk
+  and correlation surface
+
+GDOT must not replace vDOT as the default. It is an upgrade path for agents who
+explicitly accept Hydration, Bifrost, liquidity, leverage, and multi-hop XCM
+risk.
+
+## Verified external facts
+
+Checked 2026-04-29.
+
+- Polkadot Hub supports native and foreign assets. Foreign assets are identified
+  by XCM location and can move across parachains through XCM.
+  Source: Polkadot docs MCP, `reference/polkadot-hub/assets.md`.
+- Polkadot's documented XCM transfer workflow includes dry-runs, fee estimates,
+  and existential-deposit checks before execution.
+  Source: Polkadot docs MCP,
+  `chain-interactions/send-transactions/interoperability/transfer-assets-parachains.md`.
+- Hydration positions GIGADOT/GDOT yield as a composition of vDOT staking,
+  aDOT lending, pool fees, and Hydration/Polkadot treasury incentives. The
+  current planning band should be treated as roughly 15-20%+ only when leverage,
+  market conditions, and incentives line up; it is not a fixed APY promise.
+  Sources: [Hydration GIGADOT docs](https://docs.hydration.net/products/strategies/gigadot)
+  and Hydration publications recorded in
+  [AVERRAY_VERIFICATION_LEDGER.md](../AVERRAY_VERIFICATION_LEDGER.md).
+- Hydration Borrow supports collateralized borrowing against GDOT/GETH-style
+  collateral for HOLLAR or supported assets, per the same verification ledger.
+- Bifrost vDOT remains a Bifrost SLP/vToken asset where staking rewards accrue
+  through the vDOT/DOT exchange rate.
+  Sources: [Bifrost vDOT docs](https://docs.bifrost.io/faq/what-are-vtokens/vdot)
+  and [Bifrost vDOT product page](https://bifrost.io/vtoken/vdot).
+
+## Architecture
+
+`HydrationGdotAdapter` should follow the existing async adapter shape:
+
+```text
+AgentAccountCore
+  -> StrategyAdapterRegistry
+  -> HydrationGdotAdapter
+  -> XcmWrapper
+  -> Polkadot Hub XCM precompile
+  -> Hydration / Bifrost route
+```
+
+It should not embed raw XCM dispatch in account balance logic. It should queue
+requests through `XcmWrapper`, use `previewRequestId(context)` for idempotency,
+append `SetTopic(requestId)` in the backend message builder, and settle only
+after an observer publishes terminal evidence.
+
+The adapter is **not** a copy of `XcmVdotAdapter`. It should reuse the
+transport boundary but own different strategy semantics:
+
+- multi-hop route: Hub -> Hydration -> Bifrost -> Hydration -> Hub
+- composite asset accounting instead of simple vDOT share accounting
+- Hydration-specific terminal evidence
+- Hydration-specific failure codes
+- explicit withdrawal delay and slippage handling
+
+## Proposed request types
+
+The adapter should support three high-level intents:
+
+| Intent | Purpose | Settlement output |
+|---|---|---|
+| `deposit_dot_to_gdot` | Move idle DOT into the GDOT composition route. | GDOT shares or equivalent strategy shares. |
+| `withdraw_gdot_to_dot` | Exit the strategy back to DOT. | DOT credited back to `AgentAccountCore`. |
+| `claim_or_rebalance` | Harvest, rebalance, or refresh strategy accounting when Hydration exposes a safe primitive. | Updated share price or no-op receipt. |
+
+Do not add automatic leverage in v1 of the adapter. If leverage is ever used,
+make it a separate opt-in strategy profile with lower caps and stronger
+disclosure.
+
+## Observer requirements
+
+The single-hop vDOT observer gate is necessary but not sufficient. GDOT needs a
+new evidence pack with Hydration-specific artifacts:
+
+- Hub outbound `messageTopic == requestId`
+- Hydration receipt of the request
+- Bifrost vDOT leg if the route mints or redeems vDOT underneath
+- Hydration terminal event/storage proof for GDOT position update
+- return-leg evidence to Hub, or a documented fallback if the topic is not
+  preserved across every hop
+
+The native evidence pack checker can remain the top-level promotion gate, but
+the GDOT implementation should add route-specific validators before automated
+settlement is allowed.
+
+## UX and risk disclosure
+
+GDOT must be opt-in. Every allocation surface should show:
+
+> GDOT is a composite Hydration strategy. It may involve Hydration, Bifrost,
+> Omnipool/liquidity mechanics, incentives, and multi-hop XCM settlement.
+> Yield is variable and losses are not insured by Averray.
+
+The UI/API should expose at least:
+
+- strategy status: `planning`, `staging`, `enabled`, `paused`
+- execution mode: `async_xcm_multi_hop`
+- expected settlement window, once measured
+- current leverage profile: `none`, `conservative`, or explicit numeric ratio
+- vendor dependencies: Hydration and Bifrost
+- whether incentives are included in displayed APY
+- slippage tolerance and exit delay, if applicable
+
+Never show a headline APY without a timestamp and source label.
+
+## Launch gates
+
+- [ ] vDOT native observer evidence pack passes for deposit, withdrawal, and
+  failure.
+- [ ] Hydration route evidence pack exists and passes for deposit, withdrawal,
+  and failure.
+- [ ] Adapter implementation uses `XcmWrapper`; no caller-supplied raw XCM bytes
+  reach HTTP surfaces.
+- [ ] Strategy-specific failure codes are documented.
+- [ ] APY display distinguishes base yield, incentives, fees, and leverage.
+- [ ] Audit includes Hydration adapter, message builder, observer matching, and
+  settlement finalization.
+- [ ] Risk disclosure appears in API metadata and operator/agent UX.
+
+## Non-goals
+
+- No auto-allocation.
+- No default leverage.
+- No production routing before vDOT is stable.
+- No user-facing APY promise.
+- No fallback to manual operator judgment for settlement truth.

--- a/docs/strategies/vdot.md
+++ b/docs/strategies/vdot.md
@@ -18,6 +18,12 @@ Bifrost's liquid-staking primitive, earn Polkadot staking yield (roughly
 5–6% base APY at time of writing; verify current Bifrost docs before launch),
 redeem DOT at the accrued rate when the agent withdraws.
 
+The next planned portfolio candidate is Hydration GDOT, documented in
+[hydration-gdot.md](./hydration-gdot.md). It is deliberately v2 and opt-in:
+GDOT adds Hydration, Bifrost, multi-hop XCM, liquidity, incentive, and possible
+leverage exposure, so it must not become the default lane until vDOT has real
+mainnet evidence.
+
 Key properties for the platform:
 
 - **Non-custodial.** The adapter never takes discretionary custody of


### PR DESCRIPTION
## Summary
- add Hydration GDOT strategy planning doc for the opt-in v2 portfolio lane
- add Hydration Borrow migration plan for moving collateralized credit away from Averray balance-sheet lending
- cross-link the plans from Agent Banking, vDOT strategy docs, and the rc1 implementation plan

## Checks
- git diff --check HEAD~1..HEAD

## Impact
- Docs/planning only.
- No frontend, backend runtime, indexer runtime, contracts, Caddy, or public site source changes.
- No required environment or VPS secret changes.

## Notes
- Checked Polkadot docs MCP before writing: Polkadot Hub foreign assets/XCM and transfer dry-run constraints are reflected in the docs.
- Also checked primary Hydration/Bifrost docs for GIGADOT/HOLLAR/vDOT framing.
- This does not implement GDOT or Hydration Borrow. It keeps vDOT as the launch lane and treats GDOT/Borrow as opt-in v2 surfaces after evidence and audit gates.