### PR TITLE
Add native XCM evidence capture runbook

### DIFF
--- a/docs/ASYNC_XCM_STAGING.md
+++ b/docs/ASYNC_XCM_STAGING.md
@@ -191,10 +191,11 @@ This is the current-lane proof we can run before paying for Subscan or
 before building the native Polkadot/Bifrost observer.
 
 For the next native-observer lane, see
-[NATIVE_XCM_OBSERVER.md](./NATIVE_XCM_OBSERVER.md). That design keeps the
-existing `/xcm/outcomes` producer contract and focuses first on proving a
-deterministic correlation path from an Averray `requestId` to native
-Hub/Bifrost settlement evidence.
+[NATIVE_XCM_OBSERVER.md](./NATIVE_XCM_OBSERVER.md) and the operator
+[NATIVE_XCM_EVIDENCE_CAPTURE_RUNBOOK.md](./NATIVE_XCM_EVIDENCE_CAPTURE_RUNBOOK.md).
+That design keeps the existing `/xcm/outcomes` producer contract and focuses
+first on proving a deterministic correlation path from an Averray `requestId`
+to native Hub/Bifrost settlement evidence.
 
 The native evidence validator now enforces the correlation gate:
 
@@ -214,8 +215,11 @@ gate before promoting the native observer:
 npm run check:native-xcm-evidence-pack -- \
   --deposit artifacts/xcm/native-deposit-evidence.json \
   --withdraw artifacts/xcm/native-withdraw-evidence.json \
-  --failure artifacts/xcm/native-failure-evidence.json
+  --failure artifacts/xcm/native-failure-evidence.json \
+  --decision-output artifacts/xcm/native-evidence-decision.md
 ```
 
 The pack gate rejects staging-only `ledger_join` evidence and requires a single
-production-candidate correlation method across all three captures.
+production-candidate correlation method across all three captures. The
+decision output records whether the pack supports SetTopic/request-id
+correlation or the `remote_ref` fallback.

--- a/docs/NATIVE_XCM_EVIDENCE_CAPTURE_RUNBOOK.md
+++ b/docs/NATIVE_XCM_EVIDENCE_CAPTURE_RUNBOOK.md
@@ -1,0 +1,265 @@
+# Native XCM Evidence Capture Runbook
+
+Status: **operator runbook for Slice 10 evidence capture**. This is the
+procedure for producing the three artifacts required before the native
+Polkadot/Bifrost observer can become settlement truth for vDOT requests.
+
+This runbook uses the tools described in the official Polkadot docs:
+
+- Chopsticks replay/dry-run for tracing XCM execution on forked chains.
+- PAPI for typed chain reads from Polkadot Hub and Bifrost.
+- Fee and dry-run checks before treating a message shape as production-ready.
+
+Source docs checked through the Polkadot docs MCP:
+
+- `chain-interactions/send-transactions/interoperability/debug-and-preview-xcms.md`
+- `chain-interactions/send-transactions/interoperability/estimate-xcm-fees.md`
+- `smart-contracts/precompiles/xcm.md`
+
+## Goal
+
+Produce a validated evidence pack with:
+
+1. one successful vDOT deposit
+2. one successful vDOT withdrawal
+3. one failed request with a stable `failureCode`
+
+The pack must pass:
+
+```bash
+npm run check:native-xcm-evidence-pack -- \
+  --deposit artifacts/xcm/native-deposit-evidence.json \
+  --withdraw artifacts/xcm/native-withdraw-evidence.json \
+  --failure artifacts/xcm/native-failure-evidence.json \
+  --decision-output artifacts/xcm/native-evidence-decision.md
+```
+
+The generated decision record is the artifact reviewers use to decide whether
+the production observer path is `request_id_in_message` or `remote_ref`.
+
+## Preconditions
+
+- `XcmWrapper.queueRequest` SetTopic validation is deployed in the target
+  environment.
+- Backend async XCM requests are generated from intent, not caller-supplied raw
+  bytes.
+- The request being captured uses the same `XcmVdotAdapter` and backend message
+  builder that mainnet would use.
+- Hub and Bifrost endpoints are pinned for the capture.
+- The capture uses finalized blocks, or records the exact confirmation window
+  used by the operator.
+
+Do not use native observer output for automated settlement until this runbook
+has produced a passing evidence pack.
+
+## Artifact Layout
+
+Use one directory per capture date or deployment:
+
+```text
+artifacts/xcm/2026-04-29-vdot-correlation/
+  deposit/
+    request.json
+    hub.json
+    bifrost.json
+    evidence.json
+  withdraw/
+    request.json
+    hub.json
+    bifrost.json
+    evidence.json
+  failure/
+    request.json
+    hub.json
+    bifrost.json
+    evidence.json
+  native-evidence-decision.md
+```
+
+The committed repo contains sample fixtures only. Real capture artifacts should
+be stored in the operator artifact store unless Pascal explicitly asks to
+commit a sanitized evidence pack.
+
+## Capture Procedure
+
+### 1. Queue The Request
+
+Queue a real staging request through the normal backend path. Do not call
+`XcmWrapper.queueRequest` directly unless the direct call is the thing being
+tested.
+
+Save the backend request payload:
+
+```bash
+curl -sS "https://api.averray.com/xcm/request?requestId=$REQUEST_ID" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  > artifacts/xcm/2026-04-29-vdot-correlation/deposit/request.json
+```
+
+The request JSON must contain or be paired with:
+
+- `requestId`
+- direction: `deposit`, `withdraw`, or failure scenario direction
+- expected asset/share amounts
+- queued transaction or remote reference, if known
+
+### 2. Capture Hub Evidence
+
+Use PAPI, block explorers, or Chopsticks replay to capture the Hub-side
+transaction and message evidence. The JSON must include:
+
+```json
+{
+  "chain": "polkadot-hub",
+  "blockNumber": "123",
+  "blockHash": "0x...",
+  "extrinsicHash": "0x...",
+  "messageHash": "0x...",
+  "messageTopic": "0x...",
+  "eventIndex": "123-7"
+}
+```
+
+For `request_id_in_message`, `messageTopic` must equal `requestId`.
+
+If the Hub topic does not equal the request id, stop. That means the backend
+assembler, `previewRequestId(context)` mirror, or wrapper validation path is not
+the one we think it is.
+
+### 3. Capture Bifrost Evidence
+
+Capture the Bifrost-side terminal event or storage proof. The JSON must include:
+
+```json
+{
+  "chain": "bifrost-polkadot",
+  "blockNumber": "456",
+  "blockHash": "0x...",
+  "eventIndex": "456-12",
+  "messageTopic": "0x...",
+  "assetLocation": {
+    "parents": 1,
+    "interior": "Here"
+  },
+  "amount": "5000000000000"
+}
+```
+
+If Bifrost preserves the original SetTopic on the reply leg, set
+`messageTopic` to the observed topic and use `--method request_id_in_message`
+with `--confidence production_candidate`.
+
+If Bifrost does not preserve the topic, use `--method remote_ref` only if the
+capture includes a durable remote reference that can be found again from chain
+evidence without operator judgement.
+
+Do not promote `ledger_join`. It is staging-only.
+
+### 4. Assemble One Evidence Envelope
+
+For a successful deposit:
+
+```bash
+npm run capture:native-xcm-evidence -- \
+  --request-json artifacts/xcm/2026-04-29-vdot-correlation/deposit/request.json \
+  --direction deposit \
+  --status succeeded \
+  --settled-assets 5000000000000 \
+  --settled-shares 4900000000000 \
+  --method request_id_in_message \
+  --confidence production_candidate \
+  --hub-json artifacts/xcm/2026-04-29-vdot-correlation/deposit/hub.json \
+  --bifrost-json artifacts/xcm/2026-04-29-vdot-correlation/deposit/bifrost.json \
+  --output artifacts/xcm/2026-04-29-vdot-correlation/deposit/evidence.json
+```
+
+For a successful withdrawal, use `--direction withdraw`.
+
+For the failure capture, use `--status failed`, `--settled-assets 0`,
+`--settled-shares 0`, and a stable `--failure-code 0x...`.
+
+### 5. Validate Each Envelope
+
+```bash
+npm run validate:native-xcm-evidence -- \
+  --file artifacts/xcm/2026-04-29-vdot-correlation/deposit/evidence.json
+```
+
+Repeat for withdraw and failure.
+
+### 6. Validate The Pack
+
+```bash
+npm run check:native-xcm-evidence-pack -- \
+  --deposit artifacts/xcm/2026-04-29-vdot-correlation/deposit/evidence.json \
+  --withdraw artifacts/xcm/2026-04-29-vdot-correlation/withdraw/evidence.json \
+  --failure artifacts/xcm/2026-04-29-vdot-correlation/failure/evidence.json \
+  --decision-output artifacts/xcm/2026-04-29-vdot-correlation/native-evidence-decision.md
+```
+
+The pack passes only if:
+
+- deposit is `direction=deposit`, `status=succeeded`
+- withdrawal is `direction=withdraw`, `status=succeeded`
+- failure is `status=failed` and has a `failureCode`
+- every artifact is `production_candidate` or `production`
+- all three artifacts use the same production correlation method
+- no artifact uses `ledger_join`
+
+## Decision Rules
+
+### SetTopic Preserved
+
+If all three captures pass with `method=request_id_in_message`, the native
+observer may use:
+
+```text
+requestId == Hub messageTopic == Bifrost messageTopic
+```
+
+as the production-candidate correlation contract.
+
+### SetTopic Not Preserved
+
+If Hub has `messageTopic == requestId` but Bifrost does not preserve the topic,
+try `remote_ref` only if the remote reference is deterministic and recoverable
+from chain evidence.
+
+If no durable `remoteRef` exists, do not implement live native reads yet. Choose
+one of the documented fallbacks in [NATIVE_XCM_OBSERVER.md](./NATIVE_XCM_OBSERVER.md)
+and add a new spec slice before production volume:
+
+- serialized per-strategy dispatch, if Hub credit events are unambiguous
+- amount perturbation, only as a last resort
+
+## Failure Capture
+
+The failure case should prove that a bad or underfunded request remains
+correlatable. Prefer a controlled staging failure such as an intentionally
+insufficient remote execution fee, invalid destination in a fork, or blocked
+asset route.
+
+The failure evidence must include a stable `failureCode`. The code can be a
+hash of the observed chain error if the runtime does not expose a compact enum,
+but the mapping must be documented before live reads are enabled.
+
+## Promotion Checklist
+
+- [ ] Deposit evidence validates.
+- [ ] Withdrawal evidence validates.
+- [ ] Failure evidence validates.
+- [ ] Pack gate validates.
+- [ ] Decision record generated.
+- [ ] Decision record reviewed against [NATIVE_XCM_OBSERVER.md](./NATIVE_XCM_OBSERVER.md).
+- [ ] If `remote_ref` was selected, fallback rationale is documented before
+      native live reads are enabled.
+- [ ] Operator artifact store contains raw Hub/Bifrost captures and assembled
+      evidence envelopes.
+
+## What This Does Not Do
+
+- It does not implement live PAPI reads.
+- It does not enable native observer settlement.
+- It does not prove Hydration GDOT, multi-hop XCM, or money-market borrow flows.
+- It does not replace the internal staging observe/finalize path until the pack
+  passes and the operator explicitly promotes the observer source.

--- a/docs/NATIVE_XCM_OBSERVER.md
+++ b/docs/NATIVE_XCM_OBSERVER.md
@@ -7,6 +7,7 @@ publishes terminal outcomes into the existing `/xcm/outcomes` feed.
 This doc sits after:
 
 - [ASYNC_XCM_STAGING.md](./ASYNC_XCM_STAGING.md)
+- [NATIVE_XCM_EVIDENCE_CAPTURE_RUNBOOK.md](./NATIVE_XCM_EVIDENCE_CAPTURE_RUNBOOK.md)
 - [POLKADOT_EXECUTION_PLAN.md](./POLKADOT_EXECUTION_PLAN.md)
 - [strategies/vdot.md](./strategies/vdot.md)
 
@@ -336,7 +337,8 @@ Validate the whole pack:
 npm run check:native-xcm-evidence-pack -- \
   --deposit artifacts/xcm/native-deposit-evidence.json \
   --withdraw artifacts/xcm/native-withdraw-evidence.json \
-  --failure artifacts/xcm/native-failure-evidence.json
+  --failure artifacts/xcm/native-failure-evidence.json \
+  --decision-output artifacts/xcm/native-evidence-decision.md
 ```
 
 The pack checker runs the single-envelope validator for each file, then applies
@@ -352,6 +354,7 @@ the launch gate across all three captures:
 If all three use `request_id_in_message`, the pack supports the SetTopic
 preservation path. If they all use `remote_ref`, the pack supports the fallback
 path and the fallback must be documented here before live reads are enabled.
+The optional `--decision-output` file is the review artifact for that decision.
 
 ---
 
@@ -373,9 +376,9 @@ path and the fallback must be documented here before live reads are enabled.
 
 ## Recommended next implementation slice
 
-1. Capture one real staging evidence envelope with Chopsticks/PAPI using
-  `npm run capture:native-xcm-evidence`, then make it pass
-  `npm run validate:native-xcm-evidence`.
+1. Follow
+   [NATIVE_XCM_EVIDENCE_CAPTURE_RUNBOOK.md](./NATIVE_XCM_EVIDENCE_CAPTURE_RUNBOOK.md)
+   to capture one real staging evidence pack with Chopsticks/PAPI.
 2. If Bifrost does not preserve SetTopic on the reply leg, document the chosen
    fallback (`remote_ref`, serialized dispatch, or amount perturbation) before
    implementing live reads.

--- a/docs/RC1_IMPLEMENTATION_PLAN.md
+++ b/docs/RC1_IMPLEMENTATION_PLAN.md
@@ -36,9 +36,9 @@ The shortest path to a coherent rc1 launch is:
 
 As of this branch, **slice 10: Native XCM Observer Correlation Gate** is
 implemented as a machine-checkable staging gate. The three-artifact
-deposit/withdraw/failure evidence-pack checker is in place; the next
-operational step is running the real Chopsticks/PAPI capture and saving the
-artifacts before any vDOT mainnet allocation.
+deposit/withdraw/failure evidence-pack checker and operator capture runbook are
+in place; the next operational step is running the real Chopsticks/PAPI capture
+and saving the artifacts before any vDOT mainnet allocation.
 
 Completed and deployed in this lane:
 
@@ -61,6 +61,8 @@ Completed and deployed in this lane:
   remote-ref correlation, and staging-only ledger joins
 - deposit, withdraw, and failure evidence packs can be checked together before
   promoting the native observer
+- native XCM evidence capture now has an operator runbook and can emit a
+  decision record from the evidence-pack checker
 
 Still open in the broader rc1 path:
 
@@ -280,6 +282,8 @@ allocation.
   `messageTopic == requestId` for production-candidate SetTopic evidence.
 - [x] Add a three-artifact pack gate for deposit, withdraw, and failure
   evidence.
+- [x] Add an operator runbook for capturing Hub/Bifrost evidence and producing
+  the promotion decision record.
 - [ ] Run Chopsticks experiment for Bifrost reply-leg topic preservation.
 - [ ] If preserved, match return leg by topic.
 - [ ] If not preserved but Hub credit events are unambiguous, use serialized

--- a/scripts/ops/check-native-xcm-evidence-pack.mjs
+++ b/scripts/ops/check-native-xcm-evidence-pack.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { validateEvidence } from "./validate-native-xcm-evidence.mjs";
@@ -68,6 +68,13 @@ if (method === "request_id_in_message") {
   fail(`unsupported production correlation method: ${method}.`);
 }
 
+if (options.decisionOutput) {
+  const outputPath = path.resolve(options.decisionOutput);
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, renderDecisionRecord({ method, captures }), "utf8");
+  console.log(`Decision record written to ${outputPath}`);
+}
+
 function parseArgs(argv) {
   const parsed = {};
   for (let index = 0; index < argv.length; index += 1) {
@@ -97,6 +104,8 @@ Required:
   --deposit <path>    Successful deposit evidence JSON.
   --withdraw <path>   Successful withdraw evidence JSON.
   --failure <path>    Failed request evidence JSON.
+  --decision-output <path>
+                      Write a Markdown decision record for the validated pack.
 
 Rules:
   - each file must pass validate-native-xcm-evidence
@@ -123,6 +132,54 @@ function assertExpectedCapture({ evidence, outcome }, { label, direction, status
   if (outcome.status !== status) {
     fail(`${label} evidence must have status=${status}; got ${outcome.status}.`);
   }
+}
+
+function renderDecisionRecord({ method, captures }) {
+  const now = new Date().toISOString();
+  const decision = method === "request_id_in_message"
+    ? "SetTopic/request-id correlation is supported."
+    : "remote_ref fallback correlation is supported.";
+  const productionPath = method === "request_id_in_message"
+    ? "Match native Hub and Bifrost evidence by `messageTopic == requestId`."
+    : "Match native Hub and Bifrost evidence by durable `remoteRef`; document why SetTopic was not preserved before enabling live reads.";
+
+  const rows = captures.map(({ label, filePath, evidence, outcome }) =>
+    `| ${label} | ${evidence.direction} | ${outcome.status} | ${outcome.requestId} | ${evidence.correlation.confidence} | ${outcome.remoteRef ?? "n/a"} | ${formatPath(filePath)} |`
+  ).join("\n");
+
+  return `# Native XCM Evidence Pack Decision
+
+Generated: ${now}
+
+## Decision
+
+${decision}
+
+Production observer path:
+
+${productionPath}
+
+## Evidence Pack
+
+Correlation method: \`${method}\`
+
+| Capture | Direction | Status | Request ID | Confidence | Remote Ref | Source File |
+|---|---|---|---|---|---|---|
+${rows}
+
+## Gate Result
+
+This pack passed \`scripts/ops/check-native-xcm-evidence-pack.mjs\`.
+
+The gate proves only the captured strategy path and request shape. Re-run it
+after changing the XCM assembler, \`XcmWrapper\`, \`XcmVdotAdapter\`, Bifrost
+destination semantics, observer extraction logic, or finality assumptions.
+`;
+}
+
+function formatPath(filePath) {
+  const relativePath = path.relative(process.cwd(), filePath);
+  return relativePath && !relativePath.startsWith("..") ? relativePath : filePath;
 }
 
 function fail(message) {


### PR DESCRIPTION
## Summary
- Add an operator runbook for capturing the real Native XCM deposit/withdraw/failure evidence pack.
- Extend the native evidence pack checker with `--decision-output` so a passing pack emits a Markdown promotion/fallback decision record.
- Cross-link the runbook from the native observer, async staging, and rc1 implementation plan docs.

## Checks
- `git diff --cached --check`
- `npm run check:native-xcm-evidence-pack -- --deposit docs/fixtures/xcm/native-observer-evidence.sample.json --withdraw docs/fixtures/xcm/native-observer-evidence-withdraw.sample.json --failure docs/fixtures/xcm/native-observer-evidence-failure.sample.json --decision-output /private/tmp/native-evidence-decision.md`

## Impact
- Docs and ops script only.
- No backend, frontend, indexer runtime, contracts, Caddy, public site, VPS secret, or deployment changes.
- Polkadot assumptions checked against the Polkadot docs MCP: Chopsticks replay/dry-run, XCM fee/dry-run guidance, and XCM precompile context.