### PR TITLE
Add native XCM decoded event extractor

### DIFF
--- a/docs/NATIVE_XCM_EVIDENCE_CAPTURE_RUNBOOK.md
+++ b/docs/NATIVE_XCM_EVIDENCE_CAPTURE_RUNBOOK.md
@@ -126,6 +126,21 @@ If the Hub topic does not equal the request id, stop. That means the backend
 assembler, `previewRequestId(context)` mirror, or wrapper validation path is not
 the one we think it is.
 
+If the capture source is decoded PAPI, Chopsticks, Polkadot.js, or
+block-explorer event JSON, normalize it into the required shape with:
+
+```bash
+npm run extract:native-xcm-event -- \
+  --chain hub \
+  --events-json artifacts/xcm/2026-04-29-vdot-correlation/deposit/hub-decoded-events.json \
+  --request-id "$REQUEST_ID" \
+  --output artifacts/xcm/2026-04-29-vdot-correlation/deposit/hub.json
+```
+
+Use `--block-number`, `--block-hash`, `--event-index`,
+`--extrinsic-hash`, or `--message-hash` when the decoded source separates
+block metadata from event records.
+
 ### 3. Capture Bifrost Evidence
 
 Capture the Bifrost-side terminal event or storage proof. The JSON must include:
@@ -154,6 +169,20 @@ capture includes a durable remote reference that can be found again from chain
 evidence without operator judgement.
 
 Do not promote `ledger_join`. It is staging-only.
+
+Normalize decoded Bifrost evidence with:
+
+```bash
+npm run extract:native-xcm-event -- \
+  --chain bifrost \
+  --events-json artifacts/xcm/2026-04-29-vdot-correlation/deposit/bifrost-decoded-events.json \
+  --request-id "$REQUEST_ID" \
+  --output artifacts/xcm/2026-04-29-vdot-correlation/deposit/bifrost.json
+```
+
+If Bifrost does not preserve the topic and the capture is investigating the
+`remote_ref` fallback, add `--allow-missing-topic` and provide the durable
+remote reference later to `capture-native-xcm-evidence`.
 
 ### 4. Assemble One Evidence Envelope
 

--- a/docs/NATIVE_XCM_OBSERVER.md
+++ b/docs/NATIVE_XCM_OBSERVER.md
@@ -173,6 +173,9 @@ Current implementation status:
 - evidence-to-`PublishedOutcome` normalization exists
 - captured evidence is now correlation-gated: SetTopic/request-id evidence,
   remote-ref evidence, and staging-only ledger joins are validated differently
+- decoded PAPI/Chopsticks/block-explorer events can be normalized into
+  `hub.json` / `bifrost.json` capture inputs with
+  `npm run extract:native-xcm-event`
 - live PAPI reads intentionally fail until the correlation gate is proven
 
 Adapter responsibilities:

--- a/docs/RC1_IMPLEMENTATION_PLAN.md
+++ b/docs/RC1_IMPLEMENTATION_PLAN.md
@@ -63,6 +63,8 @@ Completed and deployed in this lane:
   promoting the native observer
 - native XCM evidence capture now has an operator runbook and can emit a
   decision record from the evidence-pack checker
+- decoded PAPI/Chopsticks/block-explorer events can be normalized into the raw
+  `hub.json` / `bifrost.json` inputs required by the evidence assembler
 
 Still open in the broader rc1 path:
 
@@ -284,6 +286,8 @@ allocation.
   evidence.
 - [x] Add an operator runbook for capturing Hub/Bifrost evidence and producing
   the promotion decision record.
+- [x] Add a decoded-event extractor for producing `hub.json` / `bifrost.json`
+  capture inputs from PAPI, Chopsticks, or block-explorer event JSON.
 - [ ] Run Chopsticks experiment for Bifrost reply-leg topic preservation.
 - [ ] If preserved, match return leg by topic.
 - [ ] If not preserved but Hub credit events are unambiguous, use serialized

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dev:indexer": "npm --workspace indexer run dev",
     "start:indexer": "npm --workspace indexer run start",
     "typecheck:indexer": "npm --workspace indexer run typecheck",
+    "extract:native-xcm-event": "node scripts/ops/extract-native-xcm-event.mjs",
     "capture:native-xcm-evidence": "node scripts/ops/capture-native-xcm-evidence.mjs",
     "check:native-xcm-evidence-pack": "node scripts/ops/check-native-xcm-evidence-pack.mjs",
     "validate:subscan-xcm": "node scripts/ops/validate-subscan-xcm-source.mjs",

--- a/scripts/ops/extract-native-xcm-event.mjs
+++ b/scripts/ops/extract-native-xcm-event.mjs
@@ -1,0 +1,317 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  if (options.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  if (!options.chain) fail("missing --chain <hub|bifrost>.");
+  if (!options.eventsJson) fail("missing --events-json <path>.");
+  if (!options.requestId) fail("missing --request-id <0x...>.");
+
+  const chain = normalizeChain(options.chain);
+  const requestId = assertHex32(options.requestId, "requestId");
+  const inputPath = path.resolve(options.eventsJson);
+  const input = JSON.parse(await readFile(inputPath, "utf8"));
+  const extraction = extractEventEvidence({
+    input,
+    chain,
+    requestId,
+    overrides: options
+  });
+
+  if (options.output) {
+    const outputPath = path.resolve(options.output);
+    await mkdir(path.dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, `${JSON.stringify(extraction, null, 2)}\n`, "utf8");
+    console.log(`Saved ${chain} native XCM evidence input to ${outputPath}`);
+  } else {
+    console.log(JSON.stringify(extraction, null, 2));
+  }
+}
+
+function isMain() {
+  return import.meta.url === pathToFileURL(process.argv[1] ?? "").href;
+}
+
+export function extractEventEvidence({ input, chain, requestId, overrides = {} }) {
+  const normalizedChain = normalizeChain(chain);
+  const normalizedRequestId = assertHex32(requestId, "requestId");
+  const allowMissingTopic = Boolean(overrides.allowMissingTopic);
+  const root = normalizeRoot(input);
+  const events = collectEventCandidates(root);
+  const matched = findMatchingEvent(events, normalizedRequestId);
+
+  if (!matched && !allowMissingTopic) {
+    fail(`No decoded event in ${overrides.eventsJson ?? "input"} contains requestId ${normalizedRequestId}.`);
+  }
+
+  const source = matched?.event ?? root;
+  const blockNumber = pickString(
+    overrides.blockNumber,
+    pickDeep(source, BLOCK_NUMBER_KEYS),
+    pickDeep(root, BLOCK_NUMBER_KEYS)
+  );
+  const blockHash = pickString(
+    overrides.blockHash,
+    pickDeep(source, BLOCK_HASH_KEYS),
+    pickDeep(root, BLOCK_HASH_KEYS)
+  );
+  const eventIndex = pickString(
+    overrides.eventIndex,
+    pickDeep(source, EVENT_INDEX_KEYS),
+    matched ? `${blockNumber || "block"}-${matched.index}` : ""
+  );
+
+  if (!blockNumber) fail("blockNumber is required; pass --block-number or include it in the decoded event JSON.");
+  if (!blockHash) fail("blockHash is required; pass --block-hash or include it in the decoded event JSON.");
+  if (!eventIndex) fail("eventIndex is required; pass --event-index or include it in the decoded event JSON.");
+
+  const messageTopic = pickTopic(source, normalizedRequestId) || (matched ? normalizedRequestId : "");
+  if (!messageTopic && !allowMissingTopic) {
+    fail("messageTopic is required unless --allow-missing-topic is set.");
+  }
+
+  if (normalizedChain === "hub") {
+    return stripUndefined({
+      chain: "polkadot-hub",
+      blockNumber: String(blockNumber),
+      blockHash: assertHex32(blockHash, "blockHash"),
+      extrinsicHash: normalizeOptionalHex32(pickString(
+        overrides.extrinsicHash,
+        pickDeep(source, EXTRINSIC_HASH_KEYS),
+        pickDeep(root, EXTRINSIC_HASH_KEYS)
+      ), "extrinsicHash"),
+      messageHash: normalizeOptionalHex32(pickString(
+        overrides.messageHash,
+        pickDeep(source, MESSAGE_HASH_KEYS),
+        pickDeep(root, MESSAGE_HASH_KEYS)
+      ), "messageHash"),
+      messageTopic: messageTopic ? assertHex32(messageTopic, "messageTopic") : undefined,
+      eventIndex: String(eventIndex)
+    });
+  }
+
+  const assetLocation = parseJsonOption(overrides.assetLocationJson)
+    ?? pickDeep(source, ASSET_LOCATION_KEYS)
+    ?? pickDeep(root, ASSET_LOCATION_KEYS)
+    ?? null;
+
+  return stripUndefined({
+    chain: "bifrost-polkadot",
+    blockNumber: String(blockNumber),
+    blockHash: assertHex32(blockHash, "blockHash"),
+    eventIndex: String(eventIndex),
+    messageTopic: messageTopic ? assertHex32(messageTopic, "messageTopic") : undefined,
+    assetLocation,
+    amount: pickString(
+      overrides.amount,
+      pickDeep(source, AMOUNT_KEYS),
+      pickDeep(root, AMOUNT_KEYS),
+      "0"
+    )
+  });
+}
+
+function parseArgs(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      parsed.help = true;
+      continue;
+    }
+    if (arg === "--allow-missing-topic") {
+      parsed.allowMissingTopic = true;
+      continue;
+    }
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2).replace(/-([a-z])/gu, (_, char) => char.toUpperCase());
+      parsed[key] = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return parsed;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/extract-native-xcm-event.mjs [options]
+
+Normalizes decoded PAPI, Chopsticks, Polkadot.js, or block-explorer event JSON
+into the raw hub.json / bifrost.json files consumed by
+capture-native-xcm-evidence.mjs.
+
+Required:
+  --chain <hub|bifrost>       Which evidence input to emit.
+  --events-json <path>        Decoded event/block JSON from PAPI or replay.
+  --request-id <0x...>        Averray request id / expected SetTopic value.
+
+Common options:
+  --block-number <n>          Override block number.
+  --block-hash <0x...>        Override block hash.
+  --event-index <n-m>         Override event index.
+  --extrinsic-hash <0x...>    Hub extrinsic hash override.
+  --message-hash <0x...>      Hub message hash override.
+  --amount <integer>          Bifrost amount override.
+  --asset-location-json <json>
+                              Bifrost asset location override.
+  --allow-missing-topic       Allow emitting evidence without a Bifrost topic
+                              for remote_ref fallback investigation.
+  --output <path>             Write JSON to path. Prints to stdout if omitted.
+  --help
+`);
+}
+
+function normalizeRoot(input) {
+  if (input && typeof input === "object") return input;
+  fail("events JSON must decode to an object or array.");
+}
+
+function collectEventCandidates(root) {
+  const candidates = [];
+  const seen = new WeakSet();
+
+  function visit(value, keyHint = "", indexHint = undefined) {
+    if (!value || typeof value !== "object") return;
+    if (seen.has(value)) return;
+    seen.add(value);
+
+    if (Array.isArray(value)) {
+      value.forEach((entry, index) => visit(entry, keyHint, index));
+      return;
+    }
+
+    if (looksLikeEvent(value) || keyHint.toLowerCase().includes("event")) {
+      candidates.push({ event: value, index: indexHint ?? candidates.length });
+    }
+
+    for (const [key, child] of Object.entries(value)) {
+      visit(child, key, Array.isArray(child) ? undefined : indexHint);
+    }
+  }
+
+  visit(root);
+  return candidates.length ? candidates : [{ event: root, index: 0 }];
+}
+
+function looksLikeEvent(value) {
+  return Boolean(
+    value.event ||
+    value.phase ||
+    value.section ||
+    value.method ||
+    value.pallet ||
+    value.eventIndex ||
+    value.event_index ||
+    value.messageTopic ||
+    value.topic ||
+    value.setTopic
+  );
+}
+
+function findMatchingEvent(events, requestId) {
+  return events.find(({ event }) => containsString(event, requestId));
+}
+
+function containsString(value, needle) {
+  const normalizedNeedle = String(needle).toLowerCase();
+  if (typeof value === "string") {
+    return value.toLowerCase().includes(normalizedNeedle);
+  }
+  if (!value || typeof value !== "object") return false;
+  if (Array.isArray(value)) return value.some((entry) => containsString(entry, needle));
+  return Object.values(value).some((entry) => containsString(entry, needle));
+}
+
+const BLOCK_NUMBER_KEYS = ["blockNumber", "block_number", "number", "height"];
+const BLOCK_HASH_KEYS = ["blockHash", "block_hash"];
+const EVENT_INDEX_KEYS = ["eventIndex", "event_index", "index"];
+const EXTRINSIC_HASH_KEYS = ["extrinsicHash", "extrinsic_hash", "txHash", "transactionHash"];
+const MESSAGE_HASH_KEYS = ["messageHash", "message_hash"];
+const TOPIC_KEYS = ["messageTopic", "message_topic", "topic", "setTopic", "set_topic"];
+const ASSET_LOCATION_KEYS = ["assetLocation", "asset_location", "location", "asset"];
+const AMOUNT_KEYS = ["amount", "settledAssets", "settled_assets", "assets", "value"];
+
+function pickTopic(source, requestId) {
+  const explicit = pickDeep(source, TOPIC_KEYS);
+  if (explicit) return explicit;
+  return containsString(source, requestId) ? requestId : "";
+}
+
+function pickDeep(value, keys) {
+  if (!value || typeof value !== "object") return "";
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const found = pickDeep(entry, keys);
+      if (found) return found;
+    }
+    return "";
+  }
+
+  for (const key of keys) {
+    if (value[key] !== undefined && value[key] !== null && value[key] !== "") {
+      return value[key];
+    }
+  }
+  for (const child of Object.values(value)) {
+    const found = pickDeep(child, keys);
+    if (found) return found;
+  }
+  return "";
+}
+
+function pickString(...values) {
+  for (const value of values) {
+    if (value === undefined || value === null || value === "") continue;
+    if (typeof value === "object") continue;
+    return String(value).trim();
+  }
+  return "";
+}
+
+function parseJsonOption(value) {
+  if (!value) return undefined;
+  return JSON.parse(value);
+}
+
+function normalizeChain(value) {
+  const normalized = String(value).trim().toLowerCase();
+  if (["hub", "polkadot-hub", "polkadothub"].includes(normalized)) return "hub";
+  if (["bifrost", "bifrost-polkadot", "bifrostpolkadot"].includes(normalized)) return "bifrost";
+  fail(`chain must be hub or bifrost; got ${JSON.stringify(value)}.`);
+}
+
+function assertHex32(value, label) {
+  const normalized = pickString(value);
+  if (!/^0x[a-fA-F0-9]{64}$/u.test(normalized)) {
+    fail(`${label} must be a 0x-prefixed 32-byte hex string.`);
+  }
+  return normalized;
+}
+
+function normalizeOptionalHex32(value, label) {
+  const normalized = pickString(value);
+  if (!normalized) return undefined;
+  return assertHex32(normalized, label);
+}
+
+function stripUndefined(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+if (isMain()) {
+  await main();
+}
+
+function fail(message) {
+  throw new Error(message);
+}

--- a/scripts/ops/extract-native-xcm-event.test.mjs
+++ b/scripts/ops/extract-native-xcm-event.test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { extractEventEvidence } from "./extract-native-xcm-event.mjs";
+
+const REQUEST_ID = `0x${"11".repeat(32)}`;
+const BLOCK_HASH = `0x${"22".repeat(32)}`;
+const EXTRINSIC_HASH = `0x${"33".repeat(32)}`;
+const MESSAGE_HASH = `0x${"44".repeat(32)}`;
+
+test("extracts Hub evidence from decoded event JSON", () => {
+  const evidence = extractEventEvidence({
+    chain: "hub",
+    requestId: REQUEST_ID,
+    input: {
+      blockNumber: "123",
+      blockHash: BLOCK_HASH,
+      events: [
+        {
+          eventIndex: "123-0",
+          event: {
+            section: "System",
+            method: "ExtrinsicSuccess"
+          }
+        },
+        {
+          eventIndex: "123-7",
+          extrinsicHash: EXTRINSIC_HASH,
+          messageHash: MESSAGE_HASH,
+          event: {
+            section: "XcmPallet",
+            method: "Sent",
+            data: {
+              messageTopic: REQUEST_ID
+            }
+          }
+        }
+      ]
+    }
+  });
+
+  assert.deepEqual(evidence, {
+    chain: "polkadot-hub",
+    blockNumber: "123",
+    blockHash: BLOCK_HASH,
+    extrinsicHash: EXTRINSIC_HASH,
+    messageHash: MESSAGE_HASH,
+    messageTopic: REQUEST_ID,
+    eventIndex: "123-7"
+  });
+});
+
+test("extracts Bifrost evidence and amount from decoded event JSON", () => {
+  const evidence = extractEventEvidence({
+    chain: "bifrost",
+    requestId: REQUEST_ID,
+    input: {
+      blockNumber: "456",
+      blockHash: BLOCK_HASH,
+      records: [
+        {
+          eventIndex: "456-12",
+          event: {
+            section: "XTokens",
+            method: "Transferred",
+            data: {
+              topic: REQUEST_ID,
+              amount: "5000000000000",
+              assetLocation: {
+                parents: 1,
+                interior: "Here"
+              }
+            }
+          }
+        }
+      ]
+    }
+  });
+
+  assert.deepEqual(evidence, {
+    chain: "bifrost-polkadot",
+    blockNumber: "456",
+    blockHash: BLOCK_HASH,
+    eventIndex: "456-12",
+    messageTopic: REQUEST_ID,
+    assetLocation: {
+      parents: 1,
+      interior: "Here"
+    },
+    amount: "5000000000000"
+  });
+});
+
+test("allows missing Bifrost topic for remote_ref fallback investigation", () => {
+  const evidence = extractEventEvidence({
+    chain: "bifrost",
+    requestId: REQUEST_ID,
+    input: {
+      blockNumber: "456",
+      blockHash: BLOCK_HASH,
+      events: [
+        {
+          eventIndex: "456-4",
+          event: {
+            section: "Balances",
+            method: "Deposit",
+            data: {
+              amount: "7"
+            }
+          }
+        }
+      ]
+    },
+    overrides: {
+      allowMissingTopic: true,
+      eventIndex: "456-4"
+    }
+  });
+
+  assert.equal(evidence.messageTopic, undefined);
+  assert.equal(evidence.amount, "7");
+});


### PR DESCRIPTION
## Summary
- Add `npm run extract:native-xcm-event` to normalize decoded PAPI, Chopsticks, Polkadot.js, or block-explorer event JSON into the `hub.json` / `bifrost.json` inputs consumed by the native XCM evidence assembler.
- Add focused extractor tests for Hub evidence, Bifrost evidence, and missing-topic `remote_ref` fallback investigation.
- Update the native XCM capture runbook, observer design, and rc1 plan to reference the extractor.

## Checks
- `git diff --cached --check`
- `node --test scripts/ops/extract-native-xcm-event.test.mjs`
- `npm run extract:native-xcm-event -- --chain hub --events-json docs/fixtures/xcm/native-hub-event.sample.json --request-id 0x1111111111111111111111111111111111111111111111111111111111111111 --output /private/tmp/native-hub.json`
- `npm run extract:native-xcm-event -- --chain bifrost --events-json docs/fixtures/xcm/native-bifrost-event.sample.json --request-id 0x1111111111111111111111111111111111111111111111111111111111111111 --output /private/tmp/native-bifrost.json`
- `npm run capture:native-xcm-evidence -- --request-id 0x1111111111111111111111111111111111111111111111111111111111111111 --direction deposit --status succeeded --settled-assets 5000000000000 --settled-shares 4900000000000 --method request_id_in_message --confidence production_candidate --hub-json /private/tmp/native-hub.json --bifrost-json /private/tmp/native-bifrost.json --output /private/tmp/native-evidence.json`
- `npm run validate:native-xcm-evidence -- --file /private/tmp/native-evidence.json`

## Impact
- Ops tooling and docs only.
- No backend, frontend, indexer runtime, contracts, Caddy, public site, VPS secret, or deployment changes.
- Polkadot assumptions checked against the Polkadot docs MCP: PAPI typed reads plus Chopsticks replay/dry-run guidance.