### PR TITLE
Add native XCM capture preflight

### DIFF
--- a/docs/NATIVE_XCM_EVIDENCE_CAPTURE_RUNBOOK.md
+++ b/docs/NATIVE_XCM_EVIDENCE_CAPTURE_RUNBOOK.md
@@ -52,6 +52,27 @@ the production observer path is `request_id_in_message` or `remote_ref`.
 Do not use native observer output for automated settlement until this runbook
 has produced a passing evidence pack.
 
+Before queueing a live request, run the local capture preflight:
+
+```bash
+npm run preflight:native-xcm-capture
+```
+
+For an actual live staging capture, include the runtime environment check:
+
+```bash
+API_URL=https://api.averray.com \
+ADMIN_JWT="$ADMIN_JWT" \
+WALLET_JWT="$WALLET_JWT" \
+XCM_NATIVE_HUB_WS=wss://... \
+XCM_NATIVE_BIFROST_WS=wss://... \
+npm run preflight:native-xcm-capture -- --strict-env
+```
+
+The preflight must pass before treating captured files as real evidence. It
+checks that reproducible PAPI/Chopsticks tooling is declared and that the
+backend vDOT XCM builder is no longer on scaffold bytes.
+
 ## Artifact Layout
 
 Use one directory per capture date or deployment:

--- a/docs/RC1_IMPLEMENTATION_PLAN.md
+++ b/docs/RC1_IMPLEMENTATION_PLAN.md
@@ -67,12 +67,16 @@ Completed and deployed in this lane:
   `hub.json` / `bifrost.json` inputs required by the evidence assembler
 - testnet deploy wiring can now emit `XCM_WRAPPER_ADDRESS` plus an async
   `polkadot_vdot` strategy manifest for capture rehearsals
+- native XCM capture now has a preflight gate that rejects scaffolded vDOT
+  builder output and missing PAPI/Chopsticks tooling before evidence is promoted
 
 Still open in the broader rc1 path:
 
 - scheduler/email hardening for weekly reports after enough real jobs exist
 - real Chopsticks/PAPI native XCM evidence capture and selected fallback
   documentation if Bifrost does not preserve SetTopic
+- replacing the scaffolded vDOT XCM message prefixes with a real PAPI/ParaSpell
+  builder before sending staging capture transactions
 
 ## PR Slices
 
@@ -292,6 +296,10 @@ allocation.
   capture inputs from PAPI, Chopsticks, or block-explorer event JSON.
 - [x] Add testnet/staging deploy wiring for `XcmWrapper` plus
   `XcmVdotAdapter`; keep it blocked on mainnet until evidence passes.
+- [x] Add native capture preflight so scaffolded builder output cannot be
+  mistaken for real evidence.
+- [ ] Replace scaffolded vDOT XCM message prefixes with a real PAPI/ParaSpell
+  message builder for deposit, withdraw, and failure rehearsal.
 - [ ] Run Chopsticks experiment for Bifrost reply-leg topic preservation.
 - [ ] If preserved, match return leg by topic.
 - [ ] If not preserved but Hub credit events are unambiguous, use serialized

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "typecheck:indexer": "npm --workspace indexer run typecheck",
     "extract:native-xcm-event": "node scripts/ops/extract-native-xcm-event.mjs",
     "capture:native-xcm-evidence": "node scripts/ops/capture-native-xcm-evidence.mjs",
+    "preflight:native-xcm-capture": "node scripts/ops/preflight-native-xcm-capture.mjs",
     "check:native-xcm-evidence-pack": "node scripts/ops/check-native-xcm-evidence-pack.mjs",
     "validate:subscan-xcm": "node scripts/ops/validate-subscan-xcm-source.mjs",
     "validate:native-xcm-evidence": "node scripts/ops/validate-native-xcm-evidence.mjs",

--- a/scripts/ops/preflight-native-xcm-capture.mjs
+++ b/scripts/ops/preflight-native-xcm-capture.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+  buildXcmRequestPayload,
+  resolveDestinationParachainId
+} from "../../mcp-server/src/blockchain/xcm-message-builder.js";
+
+const REQUEST_ID = `0x${"11".repeat(32)}`;
+const STRATEGY_ID = `0x${"22".repeat(32)}`;
+const ACCOUNTING_ASSET = `0x${"33".repeat(20)}`;
+const PLACEHOLDER_WITHDRAW_BYTES = "010203040506070809";
+
+if (isMain()) {
+  await main();
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const checks = [
+    await checkDeclaredTooling(),
+    checkBuilderOutputs()
+  ];
+  if (options.strictEnv) checks.push(checkRuntimeEnv());
+
+  const failed = checks.filter((check) => !check.ok);
+  for (const check of checks) {
+    const marker = check.ok ? "[ok]" : "[fail]";
+    console.log(`${marker} ${check.name}`);
+    for (const detail of check.details) {
+      console.log(`  - ${detail}`);
+    }
+  }
+
+  if (failed.length > 0) {
+    console.error("");
+    console.error(`Native XCM capture preflight failed (${failed.length}/${checks.length} checks).`);
+    process.exit(1);
+  }
+
+  console.log("");
+  console.log("Native XCM capture preflight passed.");
+}
+
+function isMain() {
+  return import.meta.url === pathToFileURL(process.argv[1] ?? "").href;
+}
+
+function parseArgs(argv) {
+  const parsed = {};
+  for (const arg of argv) {
+    if (arg === "--help" || arg === "-h") {
+      parsed.help = true;
+    } else if (arg === "--strict-env") {
+      parsed.strictEnv = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return parsed;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/preflight-native-xcm-capture.mjs [options]
+
+Checks whether this checkout is ready to produce real native XCM evidence.
+This is intentionally stricter than validating already-captured JSON fixtures.
+
+Options:
+  --strict-env   Also require the live staging API/JWT and native endpoint env.
+  --help         Show this help.
+
+Environment checked with --strict-env:
+  API_URL
+  ADMIN_JWT
+  WALLET_JWT
+  XCM_NATIVE_HUB_WS
+  XCM_NATIVE_BIFROST_WS
+`);
+}
+
+async function checkDeclaredTooling() {
+  const rootPackage = await readPackageJson("package.json");
+  const workspacePackages = await Promise.all([
+    readPackageJson("mcp-server/package.json"),
+    readPackageJson("indexer/package.json")
+  ]);
+  const dependencyNames = new Set();
+  for (const packageJson of [rootPackage, ...workspacePackages]) {
+    for (const section of ["dependencies", "devDependencies", "optionalDependencies"]) {
+      for (const name of Object.keys(packageJson[section] ?? {})) {
+        dependencyNames.add(name);
+      }
+    }
+  }
+
+  const missing = [];
+  for (const required of ["polkadot-api", "@acala-network/chopsticks"]) {
+    if (!dependencyNames.has(required)) missing.push(required);
+  }
+
+  return {
+    name: "PAPI/Chopsticks tooling is declared in package manifests",
+    ok: missing.length === 0,
+    details: missing.length === 0
+      ? ["polkadot-api and @acala-network/chopsticks are declared."]
+      : [
+          `missing: ${missing.join(", ")}`,
+          "real capture needs reproducible PAPI/Chopsticks tooling, not ad hoc global installs"
+        ]
+  };
+}
+
+async function readPackageJson(relativePath) {
+  return JSON.parse(await readFile(path.resolve(relativePath), "utf8"));
+}
+
+function checkBuilderOutputs() {
+  const strategy = {
+    strategyId: STRATEGY_ID,
+    kind: "polkadot_vdot",
+    asset: ACCOUNTING_ASSET,
+    assetConfig: {
+      assetClass: "custom",
+      address: ACCOUNTING_ASSET,
+      symbol: "DOT",
+      decimals: 18
+    },
+    xcm: {
+      destinationParachain: 2030
+    }
+  };
+
+  const details = [];
+  let ok = true;
+  const destinationParaId = resolveDestinationParachainId(strategy);
+  details.push(`destination parachain resolves to ${destinationParaId}`);
+
+  const deposit = buildXcmRequestPayload({ strategy, direction: "deposit", requestId: REQUEST_ID });
+  const withdraw = buildXcmRequestPayload({ strategy, direction: "withdraw", requestId: REQUEST_ID });
+
+  for (const [label, payload] of [["deposit", deposit], ["withdraw", withdraw]]) {
+    const expectedSuffix = `2c${REQUEST_ID.slice(2)}`;
+    if (payload.message.toLowerCase().endsWith(expectedSuffix)) {
+      details.push(`${label} message ends with SetTopic(requestId)`);
+    } else {
+      ok = false;
+      details.push(`${label} message does not end with SetTopic(requestId)`);
+    }
+  }
+
+  if (withdraw.message.toLowerCase().includes(PLACEHOLDER_WITHDRAW_BYTES)) {
+    ok = false;
+    details.push("withdraw message still contains the scaffold byte sequence 0x010203040506070809");
+  } else {
+    details.push("withdraw message does not contain the known scaffold byte sequence");
+  }
+
+  if (deposit.message === withdraw.message) {
+    ok = false;
+    details.push("deposit and withdraw messages are identical");
+  } else {
+    details.push("deposit and withdraw messages are distinct");
+  }
+
+  return {
+    name: "backend vDOT XCM builder is capture-ready",
+    ok,
+    details
+  };
+}
+
+function checkRuntimeEnv() {
+  const required = [
+    "API_URL",
+    "ADMIN_JWT",
+    "WALLET_JWT",
+    "XCM_NATIVE_HUB_WS",
+    "XCM_NATIVE_BIFROST_WS"
+  ];
+  const missing = required.filter((name) => !String(process.env[name] ?? "").trim());
+  return {
+    name: "live capture environment is configured",
+    ok: missing.length === 0,
+    details: missing.length === 0
+      ? ["required live capture env vars are set"]
+      : [`missing: ${missing.join(", ")}`]
+  };
+}


### PR DESCRIPTION
## Summary
- add `npm run preflight:native-xcm-capture` to gate the real Chopsticks/PAPI evidence run
- fail loudly when reproducible PAPI/Chopsticks tooling is not declared
- fail loudly while the backend vDOT XCM builder still emits scaffolded withdraw bytes
- update the native XCM runbook and RC1 plan so real evidence is not promoted before the preflight passes

## What happened when running the requested capture
The real capture is currently blocked before chain interaction. The new preflight reports:

- missing package tooling: `polkadot-api`, `@acala-network/chopsticks`
- current withdraw XCM message still contains scaffold bytes: `0x010203040506070809`

That means producing deposit/withdraw/failure evidence now would be misleading, so this PR adds the hard gate first.

## Checks
- `node scripts/ops/preflight-native-xcm-capture.mjs --help`
- `npm run preflight:native-xcm-capture` (expected failure; documents current blockers)
- `git diff --check`
- `npm --workspace mcp-server test`

## Impact
- Scripts/docs only.
- No frontend, indexer runtime, contracts, generated static output, or production deploy behavior changed.
- No manual contract deployment or chain transaction performed.
