### PR TITLE
Expose Wikipedia job detail affordances

### DIFF
--- a/docs/PUBLIC_JOB_SOURCES.md
+++ b/docs/PUBLIC_JOB_SOURCES.md
@@ -50,6 +50,15 @@ Wikipedia. If a proposal is later sent to Wikipedia, it must be attributed to
 Averray or an approved Averray editor/bot account and follow Wikipedia
 disclosure and bot rules.
 
+Public Wikipedia job definitions expose a small agent-ready detail block at
+`publicDetails` so generic agents do not need to infer the task from UI state or
+schema conventions. The block repeats the stable fields a worker needs before
+claiming: `jobId`, `source: "wikipedia"`, `taskType`, `pageTitle`, `lang`,
+`revisionId`, `articleUrl`, `pinnedRevisionUrl`, `acceptanceCriteria`,
+`outputSchemaUrl`, `proposalOnly: true`, and the attribution policy. Compact
+`GET /jobs?source=wikipedia...` rows include the same source affordances under
+`sourceDetails`, plus `definitionUrl` for the full canonical payload.
+
 In production, this crawler is enabled by default and creates jobs
 autonomously with conservative caps: two jobs per run, twenty open Wikipedia
 jobs maximum, and a thirty-minute interval. Set

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -227,7 +227,18 @@
                           },
                           "createdAt": "2026-04-28T10:00:00.000Z",
                           "summary": "Review the article and return an editor-ready citation repair proposal.",
-                          "definitionUrl": "/jobs/definition?jobId=wiki-en-123-citation-repair-example"
+                          "definitionUrl": "/jobs/definition?jobId=wiki-en-123-citation-repair-example",
+                          "sourceDetails": {
+                            "taskType": "citation_repair",
+                            "pageTitle": "Example",
+                            "lang": "en",
+                            "revisionId": "123456789",
+                            "articleUrl": "https://en.wikipedia.org/wiki/Example",
+                            "pinnedRevisionUrl": "https://en.wikipedia.org/w/index.php?title=Example&oldid=123456789",
+                            "proposalOnly": true,
+                            "attributionPolicy": "Averray proposal only / no direct Wikipedia edit",
+                            "outputSchemaUrl": "/schemas/jobs/wikipedia-citation-repair-output.json"
+                          }
                         }
                       ],
                       "count": 1,
@@ -256,7 +267,7 @@
         ],
         "operationId": "getJobDefinition",
         "summary": "Get one job definition",
-        "description": "Returns a single job definition by job id.",
+        "description": "Returns a single job definition by job id. Wikipedia jobs include publicDetails with article, pinned revision, proposal-only, attribution, acceptance, and schema affordances for generic agents.",
         "parameters": [
           {
             "name": "jobId",
@@ -839,6 +850,9 @@
             "type": "object",
             "additionalProperties": true
           },
+          "publicDetails": {
+            "$ref": "#/components/schemas/WikipediaPublicJobDetails"
+          },
           "lifecycle": {
             "$ref": "#/components/schemas/JobLifecycle"
           }
@@ -986,6 +1000,115 @@
             "type": "string"
           },
           "definitionUrl": {
+            "type": "string"
+          },
+          "sourceDetails": {
+            "$ref": "#/components/schemas/WikipediaCompactSourceDetails"
+          }
+        },
+        "additionalProperties": false
+      },
+      "WikipediaCompactSourceDetails": {
+        "type": "object",
+        "properties": {
+          "taskType": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "pageTitle": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "lang": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "revisionId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "articleUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "pinnedRevisionUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "proposalOnly": {
+            "type": "boolean"
+          },
+          "attributionPolicy": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "outputSchemaUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "WikipediaPublicJobDetails": {
+        "type": "object",
+        "properties": {
+          "jobId": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string",
+            "const": "wikipedia"
+          },
+          "taskType": {
+            "type": "string"
+          },
+          "pageTitle": {
+            "type": "string"
+          },
+          "lang": {
+            "type": "string"
+          },
+          "revisionId": {
+            "type": "string"
+          },
+          "articleUrl": {
+            "type": "string"
+          },
+          "pinnedRevisionUrl": {
+            "type": "string"
+          },
+          "acceptanceCriteria": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "outputSchemaRef": {
+            "type": "string"
+          },
+          "outputSchemaUrl": {
+            "type": "string"
+          },
+          "proposalOnly": {
+            "type": "boolean"
+          },
+          "attributionPolicy": {
             "type": "string"
           }
         },

--- a/mcp-server/src/core/job-catalog-metadata.test.js
+++ b/mcp-server/src/core/job-catalog-metadata.test.js
@@ -163,6 +163,50 @@ test("createJob accepts github_pr verifier configuration", () => {
   assert.equal(job.verifierConfig.minimumScore, 70);
 });
 
+test("public Wikipedia definitions include direct agent affordances", () => {
+  const service = makeService();
+  service.createJob({
+    ...BASE_JOB,
+    id: "wiki-en-123-citation-repair-example",
+    title: "Wikipedia citation repair: Example article",
+    category: "wikipedia",
+    jobType: "review",
+    outputSchemaRef: "schema://jobs/wikipedia-citation-repair-output",
+    acceptanceCriteria: ["Names the page and revision.", "Does not edit Wikipedia directly."],
+    source: {
+      type: "wikipedia_article",
+      project: "wikipedia",
+      language: "en",
+      pageId: 123,
+      pageTitle: "Example article",
+      pageUrl: "https://en.wikipedia.org/wiki/Example_article",
+      revisionId: "987654321",
+      taskType: "citation_repair",
+      attribution: {
+        directEdit: false
+      }
+    }
+  });
+
+  const job = service.getPublicJobDefinition("wiki-en-123-citation-repair-example");
+
+  assert.deepEqual(job.publicDetails, {
+    jobId: "wiki-en-123-citation-repair-example",
+    source: "wikipedia",
+    taskType: "citation_repair",
+    pageTitle: "Example article",
+    lang: "en",
+    revisionId: "987654321",
+    articleUrl: "https://en.wikipedia.org/wiki/Example_article",
+    pinnedRevisionUrl: "https://en.wikipedia.org/w/index.php?title=Example_article&oldid=987654321",
+    acceptanceCriteria: ["Names the page and revision.", "Does not edit Wikipedia directly."],
+    outputSchemaRef: "schema://jobs/wikipedia-citation-repair-output",
+    outputSchemaUrl: "/schemas/jobs/wikipedia-citation-repair-output.json",
+    proposalOnly: true,
+    attributionPolicy: "Averray proposal only / no direct Wikipedia edit"
+  });
+});
+
 test("reviewer role gate blocks low-score agents", async () => {
   const service = makeService({ skill: 60, reliability: 0, economic: 0, tier: "starter" });
   service.createJob({

--- a/mcp-server/src/core/job-catalog-service.js
+++ b/mcp-server/src/core/job-catalog-service.js
@@ -3,7 +3,7 @@ import {
   NotFoundError,
   ValidationError
 } from "./errors.js";
-import { isBuiltinJobSchemaRef } from "./job-schema-registry.js";
+import { isBuiltinJobSchemaRef, schemaRefToJobSchemaPath } from "./job-schema-registry.js";
 
 const DEFAULT_AGENT_PROFILE = {
   capabilities: ["claim_job", "submit_work", "allocate_idle_funds"],
@@ -490,8 +490,10 @@ export class JobCatalogService {
   }
 
   withLifecycle(job, now = new Date()) {
+    const publicDetails = buildPublicJobDetails(job);
     return {
       ...job,
+      ...(publicDetails ? { publicDetails } : {}),
       lifecycle: this.buildLifecycle(job, now)
     };
   }
@@ -929,6 +931,44 @@ function normalizeIsoTimestamp(value, field) {
     throw new ValidationError(`${field} must be ISO-8601 if provided.`);
   }
   return new Date(parsed).toISOString();
+}
+
+function buildPublicJobDetails(job) {
+  if (job?.source?.type !== "wikipedia_article") {
+    return undefined;
+  }
+  const source = job.source;
+  const articleUrl = source.articleUrl ?? source.pageUrl;
+  const pinnedRevisionUrl = source.pinnedRevisionUrl ?? buildWikipediaPinnedRevisionUrl(source);
+  return {
+    jobId: job.id,
+    source: "wikipedia",
+    taskType: source.taskType,
+    pageTitle: source.pageTitle,
+    lang: source.lang ?? source.language,
+    revisionId: source.revisionId,
+    articleUrl,
+    pinnedRevisionUrl,
+    acceptanceCriteria: Array.isArray(job.acceptanceCriteria) ? job.acceptanceCriteria : [],
+    outputSchemaRef: job.outputSchemaRef,
+    outputSchemaUrl: source.outputSchemaUrl ?? schemaRefToJobSchemaPath(job.outputSchemaRef),
+    proposalOnly: source.proposalOnly ?? source.attribution?.directEdit === false,
+    attributionPolicy: source.attributionPolicy ?? "Averray proposal only / no direct Wikipedia edit"
+  };
+}
+
+function buildWikipediaPinnedRevisionUrl(source) {
+  const lang = String(source?.lang ?? source?.language ?? "en").trim() || "en";
+  const title = String(source?.pageTitle ?? "").trim();
+  const revisionId = String(source?.revisionId ?? "").trim();
+  const url = new URL(`https://${lang}.wikipedia.org/w/index.php`);
+  if (title) {
+    url.searchParams.set("title", title.replace(/\s+/gu, "_"));
+  }
+  if (revisionId) {
+    url.searchParams.set("oldid", revisionId);
+  }
+  return String(url);
 }
 
 function buildRecommendationExplanation({ job, eligible, tierGate, roleGate, profile }) {

--- a/mcp-server/src/core/job-schema-registry.js
+++ b/mcp-server/src/core/job-schema-registry.js
@@ -336,10 +336,16 @@ const BUILTIN_JOB_SCHEMAS = new Map([
     properties: {
       project: enumString(["wikipedia"]),
       language: stringSchema(),
+      lang: stringSchema(),
       pageTitle: stringSchema({ minLength: 1 }),
       pageUrl: stringSchema({ minLength: 1 }),
+      articleUrl: stringSchema({ minLength: 1 }),
       revisionId: stringSchema({ minLength: 1 }),
+      pinnedRevisionUrl: stringSchema({ minLength: 1 }),
       taskType: enumString(["citation_repair", "freshness_check", "infobox_consistency"]),
+      proposalOnly: booleanSchema(),
+      attributionPolicy: stringSchema({ minLength: 1 }),
+      outputSchemaUrl: stringSchema({ minLength: 1 }),
       sourceUrls: arrayOfStrings(),
       instructions: arrayOfStrings({ minItems: 1 })
     }

--- a/mcp-server/src/jobs/ingest-wikipedia-maintenance.js
+++ b/mcp-server/src/jobs/ingest-wikipedia-maintenance.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { pathToFileURL } from "node:url";
+import { schemaRefToJobSchemaPath } from "../core/job-schema-registry.js";
 
 export const DEFAULT_LANGUAGE = "en";
 export const DEFAULT_BASE_URL = "http://localhost:8787";
@@ -191,6 +192,9 @@ export function toPlatformJob(article, score = scoreArticle(article)) {
   const task = TASK_CONFIG[article.taskType] ?? TASK_CONFIG.citation_repair;
   const slug = slugify(article.title).slice(0, 48);
   const id = `wiki-${article.language}-${article.pageId}-${article.taskType}-${slug}`.slice(0, 120);
+  const articleUrl = article.articleUrl ?? article.pageUrl;
+  const pinnedRevisionUrl = article.pinnedRevisionUrl ?? wikipediaPinnedRevisionUrl(article);
+  const outputSchemaUrl = schemaRefToJobSchemaPath(task.outputSchemaRef);
 
   return {
     id,
@@ -215,17 +219,24 @@ export function toPlatformJob(article, score = scoreArticle(article)) {
       type: "wikipedia_article",
       project: "wikipedia",
       language: article.language,
+      lang: article.language,
       pageId: article.pageId,
       pageTitle: article.title,
       pageUrl: article.pageUrl,
+      articleUrl,
       revisionId: article.revisionId,
+      pinnedRevisionUrl,
+      proposalOnly: true,
       revisionTimestamp: article.revisionTimestamp,
       categoryTitle: article.categoryTitle,
       taskType: article.taskType,
       templates: article.templates,
       score,
+      outputSchemaRef: task.outputSchemaRef,
+      outputSchemaUrl,
       discoveryApi: `https://${article.language}.wikipedia.org/w/api.php`,
       writePolicy: "averray_company_reviewed_proposal_only",
+      attributionPolicy: "Averray proposal only / no direct Wikipedia edit",
       attribution: {
         proposer: "Averray",
         directEdit: false,
@@ -242,7 +253,7 @@ export function toPlatformJob(article, score = scoreArticle(article)) {
     ],
     estimatedDifficulty: estimateDifficulty(score),
     agentInstructions: [
-      `Review the fixed revision at ${article.pageUrl}.`,
+      `Review the fixed revision at ${pinnedRevisionUrl}.`,
       "Do not edit Wikipedia directly from the agent account.",
       "Submit the correction or review notes back to Averray as structured evidence.",
       "Any later public Wikipedia communication must come from Averray or an approved Averray editor/bot account, with required disclosures.",
@@ -254,6 +265,20 @@ export function toPlatformJob(article, score = scoreArticle(article)) {
       signals: ["page_revision_cited", "source_urls_present", "proposal_only", "averray_attribution", "human_review_ready"]
     }
   };
+}
+
+export function wikipediaPinnedRevisionUrl(article) {
+  const language = normalizeLanguage(article?.language ?? DEFAULT_LANGUAGE);
+  const revisionId = String(article?.revisionId ?? "").trim();
+  const title = String(article?.title ?? article?.pageTitle ?? "").trim();
+  const url = new URL(`https://${language}.wikipedia.org/w/index.php`);
+  if (title) {
+    url.searchParams.set("title", title.replace(/\s+/gu, "_"));
+  }
+  if (revisionId) {
+    url.searchParams.set("oldid", revisionId);
+  }
+  return String(url);
 }
 
 export async function postJobs({ baseUrl, adminToken, jobs, fetchImpl = fetch }) {

--- a/mcp-server/src/jobs/ingest-wikipedia-maintenance.test.js
+++ b/mcp-server/src/jobs/ingest-wikipedia-maintenance.test.js
@@ -30,6 +30,15 @@ test("toPlatformJob produces an Averray-attributed Wikipedia proposal job", () =
   assert.equal(job.category, "wikipedia");
   assert.equal(job.jobType, "review");
   assert.equal(job.source.type, "wikipedia_article");
+  assert.equal(job.source.lang, "en");
+  assert.equal(job.source.articleUrl, "https://en.wikipedia.org/wiki/Example_article");
+  assert.equal(
+    job.source.pinnedRevisionUrl,
+    "https://en.wikipedia.org/w/index.php?title=Example_article&oldid=987654321"
+  );
+  assert.equal(job.source.proposalOnly, true);
+  assert.equal(job.source.outputSchemaUrl, "/schemas/jobs/wikipedia-citation-repair-output.json");
+  assert.equal(job.source.attributionPolicy, "Averray proposal only / no direct Wikipedia edit");
   assert.equal(job.source.writePolicy, "averray_company_reviewed_proposal_only");
   assert.equal(job.source.attribution.proposer, "Averray");
   assert.equal(job.source.attribution.directEdit, false);

--- a/mcp-server/src/protocols/http/jobs-response.js
+++ b/mcp-server/src/protocols/http/jobs-response.js
@@ -1,3 +1,5 @@
+import { schemaRefToJobSchemaPath } from "../../core/job-schema-registry.js";
+
 const DEFAULT_AGENT_LIMIT = 25;
 const MAX_AGENT_LIMIT = 100;
 
@@ -87,6 +89,7 @@ function matchesFilters(job, filters) {
 function toCompactJobRow(job) {
   const lifecycle = job.lifecycle ?? {};
   const state = lifecycle.state ?? lifecycle.status ?? "open";
+  const sourceDetails = compactSourceDetails(job);
   return {
     id: job.id,
     title: job.title,
@@ -103,8 +106,41 @@ function toCompactJobRow(job) {
     },
     createdAt: lifecycle.createdAt ?? null,
     summary: summarizeJob(job),
-    definitionUrl: `/jobs/definition?jobId=${encodeURIComponent(job.id)}`
+    definitionUrl: `/jobs/definition?jobId=${encodeURIComponent(job.id)}`,
+    ...(sourceDetails ? { sourceDetails } : {})
   };
+}
+
+function compactSourceDetails(job) {
+  if (job?.source?.type !== "wikipedia_article") {
+    return undefined;
+  }
+  const source = job.source;
+  return {
+    taskType: source.taskType ?? null,
+    pageTitle: source.pageTitle ?? null,
+    lang: source.lang ?? source.language ?? null,
+    revisionId: source.revisionId ?? null,
+    articleUrl: source.articleUrl ?? source.pageUrl ?? null,
+    pinnedRevisionUrl: source.pinnedRevisionUrl ?? buildWikipediaPinnedRevisionUrl(source),
+    proposalOnly: source.proposalOnly ?? source.attribution?.directEdit === false,
+    attributionPolicy: source.attributionPolicy ?? null,
+    outputSchemaUrl: source.outputSchemaUrl ?? schemaRefToJobSchemaPath(job.outputSchemaRef) ?? null
+  };
+}
+
+function buildWikipediaPinnedRevisionUrl(source) {
+  const lang = String(source?.lang ?? source?.language ?? "en").trim() || "en";
+  const title = String(source?.pageTitle ?? "").trim();
+  const revisionId = String(source?.revisionId ?? "").trim();
+  const url = new URL(`https://${lang}.wikipedia.org/w/index.php`);
+  if (title) {
+    url.searchParams.set("title", title.replace(/\s+/gu, "_"));
+  }
+  if (revisionId) {
+    url.searchParams.set("oldid", revisionId);
+  }
+  return String(url);
 }
 
 function summarizeJob(job) {

--- a/mcp-server/src/protocols/http/jobs-response.test.js
+++ b/mcp-server/src/protocols/http/jobs-response.test.js
@@ -21,7 +21,16 @@ const JOBS = [
     source: {
       type: "wikipedia_article",
       project: "wikipedia",
-      taskType: "citation_repair"
+      taskType: "citation_repair",
+      language: "en",
+      pageTitle: "Example",
+      pageUrl: "https://en.wikipedia.org/wiki/Example",
+      articleUrl: "https://en.wikipedia.org/wiki/Example",
+      revisionId: "123456789",
+      pinnedRevisionUrl: "https://en.wikipedia.org/w/index.php?title=Example&oldid=123456789",
+      proposalOnly: true,
+      attributionPolicy: "Averray proposal only / no direct Wikipedia edit",
+      outputSchemaUrl: "/schemas/jobs/wikipedia-citation-repair-output.json"
     }
   },
   {
@@ -80,12 +89,24 @@ test("public jobs response filters and compacts agent-friendly queries", () => {
     "reward",
     "createdAt",
     "summary",
-    "definitionUrl"
+    "definitionUrl",
+    "sourceDetails"
   ]);
   assert.equal(response.jobs[0].id, "wiki-en-123-citation-repair-example");
   assert.equal(response.jobs[0].source, "wikipedia");
   assert.equal(response.jobs[0].sourceType, "wikipedia_article");
   assert.equal(response.jobs[0].definitionUrl, "/jobs/definition?jobId=wiki-en-123-citation-repair-example");
+  assert.deepEqual(response.jobs[0].sourceDetails, {
+    taskType: "citation_repair",
+    pageTitle: "Example",
+    lang: "en",
+    revisionId: "123456789",
+    articleUrl: "https://en.wikipedia.org/wiki/Example",
+    pinnedRevisionUrl: "https://en.wikipedia.org/w/index.php?title=Example&oldid=123456789",
+    proposalOnly: true,
+    attributionPolicy: "Averray proposal only / no direct Wikipedia edit",
+    outputSchemaUrl: "/schemas/jobs/wikipedia-citation-repair-output.json"
+  });
 });
 
 test("public jobs response supports category filters and pagination", () => {


### PR DESCRIPTION
## Summary
- add explicit Wikipedia article aliases and pinned revision URLs during ingestion
- expose `publicDetails` on full Wikipedia job definitions and `sourceDetails` on compact `/jobs` rows
- document the public API/schema affordances for generic agents

Closes #78.

## Checks
- npm --workspace mcp-server test
- jq empty docs/api/openapi.json
- git diff --check

## Affected surfaces
- Backend: yes, public job response shape for Wikipedia jobs
- Frontend/operator app: no required changes
- Public API docs: yes
- Public site/static discovery: no
- Indexer: no
- Contracts: no
- VPS/env changes: none