### PR TITLE
Install ParaSpell core in backend image

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -20,6 +20,7 @@
     "bootstrap:upstream-status": "node src/jobs/bootstrap-upstream-status.js"
   },
   "dependencies": {
+    "@paraspell/sdk-core": "^13.4.0",
     "ethers": "^6.16.0",
     "redis": "^5.11.0"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -341,6 +341,7 @@
       "name": "@polkadot/agent-platform-server",
       "version": "0.1.0",
       "dependencies": {
+        "@paraspell/sdk-core": "^13.4.0",
         "ethers": "^6.16.0",
         "redis": "^5.11.0"
       }
@@ -2914,7 +2915,6 @@
       "version": "13.4.0",
       "resolved": "https://registry.npmjs.org/@paraspell/assets/-/assets-13.4.0.tgz",
       "integrity": "sha512-b4ty8a93PTkIrgzKEOFlaniSS8b61HERoV4rPjFDVlKzXdtends5VgZwnuIPcD2ODUJvPvWSsvpi+BLOl+sXng==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@paraspell/sdk-common": "13.4.0"
@@ -2924,7 +2924,6 @@
       "version": "13.4.0",
       "resolved": "https://registry.npmjs.org/@paraspell/pallets/-/pallets-13.4.0.tgz",
       "integrity": "sha512-tGu4a/MW067TnotQllN0HRj4f2rTlJVjB899qjOgmmwPNJtQbCLS3Kg0uQZbStRSB9VjeQYAOjSUPaUlRq+rDg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@paraspell/sdk-common": "13.4.0"
@@ -2951,14 +2950,12 @@
       "version": "13.4.0",
       "resolved": "https://registry.npmjs.org/@paraspell/sdk-common/-/sdk-common-13.4.0.tgz",
       "integrity": "sha512-QSOP4bWOVu/IUvvX9lYxIB6I0kQEdHFs6DIgjBqksLP2uk0li23a0t+JfZVdUc7nIrv2tK+z4+DTr54qjHzBBA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@paraspell/sdk-core": {
       "version": "13.4.0",
       "resolved": "https://registry.npmjs.org/@paraspell/sdk-core/-/sdk-core-13.4.0.tgz",
       "integrity": "sha512-w8raLw5FpDZVo71kf1buzHKRMIaDIw7FGyNka5qjWfkA6AEHHXkqQiIIpkY7f3L0OscUgiPNmP8ng1hevjf/Kg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.0.1",
@@ -2973,7 +2970,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
       "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -2986,7 +2982,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
       "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"


### PR DESCRIPTION
## Summary
- Move @paraspell/sdk-core into the backend workspace dependencies so the production backend Docker image installs it.
- Keep the change narrowly scoped to package metadata for the real vDOT XCM builder runtime import.

## Checks
- npm --workspace mcp-server test
- docker build -f mcp-server/Dockerfile .
- docker run --rm <built-image> node -e "import('./src/blockchain/xcm-message-builder.js').then(() => console.log('builder import ok'))"

## Impact
- Backend packaging only.
- No frontend, indexer, contracts, Caddy, or public site changes.
- No environment or VPS secret changes required.