### PR TITLE
Handle legacy escrow job reads

### DIFF
--- a/mcp-server/src/blockchain/abis.js
+++ b/mcp-server/src/blockchain/abis.js
@@ -61,6 +61,11 @@ export const ESCROW_CORE_ABI = [
   "event AutoDisclosed(bytes32 indexed hash, uint64 timestamp)"
 ];
 
+export const ESCROW_CORE_LEGACY_ABI = [
+  "function createSinglePayoutJob(bytes32 jobId, address asset, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 claimTtl, bytes32 verifierMode, bytes32 category)",
+  "function jobs(bytes32 jobId) view returns ((address poster, address worker, address asset, bytes32 verifierMode, bytes32 category, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 released, uint256 claimExpiry, uint256 claimStake, uint16 claimStakeBps, uint8 payoutMode, uint8 state))"
+];
+
 export const REPUTATION_SBT_ABI = [
   "function balanceOf(address account) view returns (uint256)",
   "function reputations(address account) view returns (uint256 skill, uint256 reliability, uint256 economic)",

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -13,6 +13,7 @@ import {
   AGENT_ACCOUNT_ABI,
   ERC20_MOCK_ABI,
   ESCROW_CORE_ABI,
+  ESCROW_CORE_LEGACY_ABI,
   REPUTATION_SBT_ABI,
   STRATEGY_ADAPTER_ABI,
   TREASURY_POLICY_ABI,
@@ -34,6 +35,7 @@ import {
 const REQUEST_KIND_LABELS = ["deposit", "withdraw", "claim"];
 const REQUEST_STATUS_LABELS = ["unknown", "pending", "succeeded", "failed", "cancelled"];
 const abiCoder = AbiCoder.defaultAbiCoder();
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 export class BlockchainGateway {
   constructor(config = loadBlockchainConfig()) {
@@ -44,6 +46,7 @@ export class BlockchainGateway {
       this.policyContract = undefined;
       this.accountContract = undefined;
       this.escrowContract = undefined;
+      this.legacyEscrowContract = undefined;
       this.reputationContract = undefined;
       this.xcmWrapperContract = undefined;
       return;
@@ -66,6 +69,11 @@ export class BlockchainGateway {
     this.escrowContract = new Contract(
       config.escrowCoreAddress,
       ESCROW_CORE_ABI,
+      this.signer ?? this.provider
+    );
+    this.legacyEscrowContract = new Contract(
+      config.escrowCoreAddress,
+      ESCROW_CORE_LEGACY_ABI,
       this.signer ?? this.provider
     );
     this.reputationContract = new Contract(
@@ -563,9 +571,9 @@ export class BlockchainGateway {
     return this.withGatewayError("ensureJob", async () => {
       this.requireSigner("ensureJob");
       const asset = this.requireAsset(job.rewardAsset);
-      const live = await this.getJob(instanceJobId);
+      const live = await this.readEscrowJob(instanceJobId);
       if (live.state !== 0) {
-        return live;
+        return this.publicEscrowJob(live);
       }
 
       const totalRequired = Number(job.rewardAmount ?? 0) + Number(claimStakeAmount ?? 0);
@@ -589,7 +597,8 @@ export class BlockchainGateway {
       }
 
       const specHash = hashCanonicalContent(job);
-      const createTx = await this.escrowContract.createSinglePayoutJob(
+      const createTx = await this.createSinglePayoutJobForLayout(
+        live.contractLayout,
         this.toJobId(instanceJobId),
         asset.address,
         job.rewardAmount,
@@ -682,31 +691,95 @@ export class BlockchainGateway {
     });
   }
 
+  async readEscrowJob(jobId) {
+    const normalizedJobId = this.toJobId(jobId);
+    try {
+      return this.normalizeEscrowJob(await this.escrowContract.jobs(normalizedJobId), "rc1");
+    } catch (error) {
+      if (!this.isEscrowJobDecodeError(error) || !this.legacyEscrowContract) {
+        throw error;
+      }
+      return this.normalizeEscrowJob(await this.legacyEscrowContract.jobs(normalizedJobId), "legacy");
+    }
+  }
+
+  normalizeEscrowJob(job, contractLayout) {
+    return {
+      contractLayout,
+      poster: job.poster,
+      worker: job.worker,
+      asset: job.asset,
+      specHash: job.specHash ?? ZERO_BYTES32,
+      reward: Number(job.reward),
+      rewardRaw: job.reward?.toString?.() ?? String(job.reward),
+      claimStake: Number(job.claimStake),
+      claimStakeRaw: job.claimStake?.toString?.() ?? String(job.claimStake),
+      claimStakeBps: Number(job.claimStakeBps),
+      claimFee: Number(job.claimFee ?? 0),
+      claimFeeRaw: job.claimFee?.toString?.() ?? "0",
+      claimFeeBps: Number(job.claimFeeBps ?? 0),
+      claimEconomicsWaived: Boolean(job.claimEconomicsWaived ?? false),
+      rejectingVerifier: job.rejectingVerifier ?? ZERO_ADDRESS,
+      released: Number(job.released),
+      releasedRaw: job.released?.toString?.() ?? String(job.released),
+      state: Number(job.state),
+      claimExpiry: Number(job.claimExpiry),
+      rejectedAt: Number(job.rejectedAt ?? 0),
+      disputedAt: Number(job.disputedAt ?? 0)
+    };
+  }
+
+  publicEscrowJob(job) {
+    const { contractLayout: _contractLayout, ...publicJob } = job;
+    return publicJob;
+  }
+
+  async createSinglePayoutJobForLayout(
+    contractLayout,
+    jobId,
+    assetAddress,
+    reward,
+    opsReserve,
+    contingencyReserve,
+    claimTtl,
+    verifierMode,
+    category,
+    specHash
+  ) {
+    if (contractLayout === "legacy") {
+      return this.legacyEscrowContract.createSinglePayoutJob(
+        jobId,
+        assetAddress,
+        reward,
+        opsReserve,
+        contingencyReserve,
+        claimTtl,
+        verifierMode,
+        category
+      );
+    }
+    return this.escrowContract.createSinglePayoutJob(
+      jobId,
+      assetAddress,
+      reward,
+      opsReserve,
+      contingencyReserve,
+      claimTtl,
+      verifierMode,
+      category,
+      specHash
+    );
+  }
+
+  isEscrowJobDecodeError(error) {
+    const code = String(error?.code ?? "");
+    const message = `${error?.shortMessage ?? ""} ${error?.message ?? ""}`;
+    return code === "BAD_DATA" || /could not decode result data|decode result data|invalid length/u.test(message);
+  }
+
   async getJob(jobId) {
     return this.withGatewayError("getJob", async () => {
-      const job = await this.escrowContract.jobs(this.toJobId(jobId));
-      return {
-        poster: job.poster,
-        worker: job.worker,
-        asset: job.asset,
-        specHash: job.specHash,
-        reward: Number(job.reward),
-        rewardRaw: job.reward?.toString?.() ?? String(job.reward),
-        claimStake: Number(job.claimStake),
-        claimStakeRaw: job.claimStake?.toString?.() ?? String(job.claimStake),
-        claimStakeBps: Number(job.claimStakeBps),
-        claimFee: Number(job.claimFee),
-        claimFeeRaw: job.claimFee?.toString?.() ?? String(job.claimFee),
-        claimFeeBps: Number(job.claimFeeBps),
-        claimEconomicsWaived: Boolean(job.claimEconomicsWaived),
-        rejectingVerifier: job.rejectingVerifier,
-        released: Number(job.released),
-        releasedRaw: job.released?.toString?.() ?? String(job.released),
-        state: Number(job.state),
-        claimExpiry: Number(job.claimExpiry),
-        rejectedAt: Number(job.rejectedAt),
-        disputedAt: Number(job.disputedAt)
-      };
+      return this.publicEscrowJob(await this.readEscrowJob(jobId));
     });
   }
 

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -65,3 +65,84 @@ test("autoDiscloseContent skips when the contract already recorded the hash", as
     { skipped: true, reason: "already_auto_disclosed" }
   );
 });
+
+test("getJob falls back to the legacy escrow struct when rc1 decoding fails", async () => {
+  const gateway = new BlockchainGateway({ enabled: false });
+  gateway.escrowContract = {
+    async jobs() {
+      const error = new Error("could not decode result data");
+      error.code = "BAD_DATA";
+      throw error;
+    }
+  };
+  gateway.legacyEscrowContract = {
+    async jobs(jobId) {
+      assert.equal(jobId, gateway.toJobId("WIKI"));
+      return {
+        poster: "0x1111111111111111111111111111111111111111",
+        worker: "0x0000000000000000000000000000000000000000",
+        asset: "0x2222222222222222222222222222222222222222",
+        verifierMode: encodeBytes32String("BENCH"),
+        category: encodeBytes32String("WIKI"),
+        reward: 4n,
+        opsReserve: 0n,
+        contingencyReserve: 0n,
+        released: 0n,
+        claimExpiry: 0n,
+        claimStake: 0n,
+        claimStakeBps: 0,
+        payoutMode: 0,
+        state: 1
+      };
+    }
+  };
+
+  const job = await gateway.getJob("WIKI");
+
+  assert.equal(job.state, 1);
+  assert.equal(job.reward, 4);
+  assert.equal(job.specHash, `0x${"0".repeat(64)}`);
+  assert.equal(job.claimFee, 0);
+  assert.equal(job.claimEconomicsWaived, false);
+  assert.equal("contractLayout" in job, false);
+});
+
+test("createSinglePayoutJobForLayout uses the legacy signature for legacy escrow deployments", async () => {
+  const gateway = new BlockchainGateway({ enabled: false });
+  const calls = [];
+  gateway.legacyEscrowContract = {
+    async createSinglePayoutJob(...args) {
+      calls.push(args);
+      return { async wait() {} };
+    }
+  };
+  gateway.escrowContract = {
+    async createSinglePayoutJob() {
+      throw new Error("rc1 signature should not be used");
+    }
+  };
+
+  await gateway.createSinglePayoutJobForLayout(
+    "legacy",
+    gateway.toJobId("WIKI"),
+    "0x2222222222222222222222222222222222222222",
+    4,
+    0,
+    0,
+    3600,
+    encodeBytes32String("BENCH"),
+    encodeBytes32String("WIKI"),
+    `0x${"1".repeat(64)}`
+  );
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].length, 8);
+  assert.deepEqual(calls[0].slice(2), [
+    4,
+    0,
+    0,
+    3600,
+    encodeBytes32String("BENCH"),
+    encodeBytes32String("WIKI")
+  ]);
+});


### PR DESCRIPTION
## Summary
- Add a legacy EscrowCore ABI for the pre-rc1 job struct and createSinglePayoutJob signature.
- Fall back to the legacy jobs(bytes32) decoder only when the rc1 decoder hits an ethers result-shape decode failure.
- Use the matching legacy create-job signature when a legacy escrow layout is detected, so dynamic Wikipedia jobs can be seeded and claimed on the current staging contract set.

## Root cause
Issue #103 showed /jobs/claim returning a 502: `getJob failed: could not decode result data`. The hosted backend was reading the disposable pre-rc1 escrow deployment with the newer rc1 job struct ABI before it had a chance to seed/claim the Wikipedia job.

Closes #103.

## Checks
- node --test mcp-server/src/blockchain/gateway.test.js mcp-server/src/core/job-execution-service.test.js
- npm --workspace mcp-server test

## Impact
- Backend blockchain gateway only.
- No frontend, indexer, contracts, Caddy, or public site changes.
- No env or VPS secret changes required.