### PR TITLE
Convert gateway asset amounts to base units

### DIFF
--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -5,8 +5,10 @@ import {
   Wallet,
   decodeBytes32String,
   encodeBytes32String,
+  formatUnits,
   id,
   keccak256,
+  parseUnits,
   toUtf8Bytes
 } from "ethers";
 import {
@@ -242,9 +244,12 @@ export class BlockchainGateway {
         optional(this.policyContract.onboardingWaiverClaimCount(), 0)
       ]);
       const minClaimFeeByAsset = {};
-      await Promise.all(this.config.supportedAssets.map(async (asset) => {
+      await Promise.all((this.config.supportedAssets ?? []).map(async (asset) => {
         const symbol = asset.symbol ?? this.resolveAssetSymbol(asset.address);
-        minClaimFeeByAsset[symbol] = Number(await optional(this.policyContract.minClaimFeeByAsset(asset.address), 0));
+        minClaimFeeByAsset[symbol] = this.toDisplayUnits(
+          await optional(this.policyContract.minClaimFeeByAsset(asset.address), 0),
+          asset
+        );
       }));
       return {
         claimFeeBps: Number(claimFeeBps),
@@ -327,8 +332,8 @@ export class BlockchainGateway {
     return this.withGatewayError("fundAccount", async () => {
       this.requireSigner("fundAccount");
       const asset = this.requireAsset(assetSymbol);
-      const parsedAmount = Number(amount);
-      if (!Number.isFinite(parsedAmount) || parsedAmount <= 0) {
+      const parsedAmount = this.toBaseUnits(amount, asset, "funding amount");
+      if (parsedAmount <= 0n) {
         throw new ValidationError("Funding amount must be greater than zero.");
       }
 
@@ -357,13 +362,14 @@ export class BlockchainGateway {
       }
       this.requireSigner("ensureClaimStakeLiquidity");
       const asset = this.requireAsset(assetSymbol);
+      const required = this.toBaseUnits(amount, asset, "claim lock amount");
       const signerAddress = await this.signer.getAddress();
       const position = await this.accountContract.positions(signerAddress, asset.address);
-      const available = Number(position.liquid);
-      if (available < amount) {
+      const available = BigInt(position.liquid);
+      if (available < required) {
         throw new InsufficientLiquidityError(assetSymbol, {
           required: amount,
-          available,
+          available: this.toDisplayUnits(available, asset),
           account: signerAddress
         });
       }
@@ -553,16 +559,20 @@ export class BlockchainGateway {
   async previewClaimEconomics(wallet, jobId) {
     return this.withGatewayError("previewClaimEconomics", async () => {
       const economics = await this.escrowContract.previewClaimEconomics(wallet, this.toJobId(jobId));
+      const live = await this.readEscrowJob(jobId);
+      const asset = this.assetForAddress(live.asset);
+      const claimStake = this.toDisplayUnits(economics.claimStake, asset);
+      const claimFee = this.toDisplayUnits(economics.claimFee, asset);
       return {
-        claimStake: Number(economics.claimStake),
+        claimStake,
         claimStakeRaw: economics.claimStake?.toString?.() ?? String(economics.claimStake),
         claimStakeBps: Number(economics.claimStakeBps),
-        claimFee: Number(economics.claimFee),
+        claimFee,
         claimFeeRaw: economics.claimFee?.toString?.() ?? String(economics.claimFee),
         claimFeeBps: Number(economics.claimFeeBps),
         claimEconomicsWaived: Boolean(economics.waived),
         claimNumber: Number(economics.claimNumber),
-        totalClaimLock: Number(economics.claimStake) + Number(economics.claimFee)
+        totalClaimLock: this.toDisplayUnits(BigInt(economics.claimStake) + BigInt(economics.claimFee), asset)
       };
     });
   }
@@ -576,18 +586,20 @@ export class BlockchainGateway {
         return this.publicEscrowJob(live);
       }
 
-      const totalRequired = Number(job.rewardAmount ?? 0) + Number(claimStakeAmount ?? 0);
-      if (totalRequired <= 0) {
+      const rewardAmount = this.toBaseUnits(job.rewardAmount ?? 0, asset, "job reward");
+      const claimStake = this.toBaseUnits(claimStakeAmount ?? 0, asset, "claim lock amount");
+      const totalRequired = rewardAmount + claimStake;
+      if (totalRequired <= 0n) {
         throw new ValidationError(`Job ${job.id} has no fundable reward`);
       }
 
       const token = new Contract(asset.address, ERC20_MOCK_ABI, this.signer);
       const signerAddress = await this.signer.getAddress();
       const signerPosition = await this.accountContract.positions(signerAddress, asset.address);
-      const liquid = Number(signerPosition.liquid);
-      const shortfall = Math.max(totalRequired - liquid, 0);
+      const liquid = BigInt(signerPosition.liquid);
+      const shortfall = totalRequired > liquid ? totalRequired - liquid : 0n;
 
-      if (shortfall > 0) {
+      if (shortfall > 0n) {
         const mintTx = await token.mint(signerAddress, shortfall);
         await mintTx.wait();
         const approveTx = await token.approve(this.config.agentAccountAddress, shortfall);
@@ -601,7 +613,7 @@ export class BlockchainGateway {
         live.contractLayout,
         this.toJobId(instanceJobId),
         asset.address,
-        job.rewardAmount,
+        rewardAmount,
         0,
         0,
         job.claimTtlSeconds,
@@ -704,23 +716,24 @@ export class BlockchainGateway {
   }
 
   normalizeEscrowJob(job, contractLayout) {
+    const asset = this.assetForAddress(job.asset);
     return {
       contractLayout,
       poster: job.poster,
       worker: job.worker,
       asset: job.asset,
       specHash: job.specHash ?? ZERO_BYTES32,
-      reward: Number(job.reward),
+      reward: this.toDisplayUnits(job.reward, asset),
       rewardRaw: job.reward?.toString?.() ?? String(job.reward),
-      claimStake: Number(job.claimStake),
+      claimStake: this.toDisplayUnits(job.claimStake, asset),
       claimStakeRaw: job.claimStake?.toString?.() ?? String(job.claimStake),
       claimStakeBps: Number(job.claimStakeBps),
-      claimFee: Number(job.claimFee ?? 0),
+      claimFee: this.toDisplayUnits(job.claimFee ?? 0, asset),
       claimFeeRaw: job.claimFee?.toString?.() ?? "0",
       claimFeeBps: Number(job.claimFeeBps ?? 0),
       claimEconomicsWaived: Boolean(job.claimEconomicsWaived ?? false),
       rejectingVerifier: job.rejectingVerifier ?? ZERO_ADDRESS,
-      released: Number(job.released),
+      released: this.toDisplayUnits(job.released, asset),
       releasedRaw: job.released?.toString?.() ?? String(job.released),
       state: Number(job.state),
       claimExpiry: Number(job.claimExpiry),
@@ -915,11 +928,63 @@ export class BlockchainGateway {
   }
 
   requireAsset(symbol) {
-    const asset = this.config.supportedAssets.find((candidate) => candidate.symbol === symbol);
+    const asset = (this.config.supportedAssets ?? []).find((candidate) => candidate.symbol === symbol);
     if (!asset) {
       throw new ValidationError(`Unsupported asset symbol: ${symbol}`);
     }
     return asset;
+  }
+
+  assetForAddress(assetAddress) {
+    const match = (this.config.supportedAssets ?? []).find(
+      (asset) => asset.address?.toLowerCase() === assetAddress?.toLowerCase?.()
+    );
+    return match ?? { symbol: this.resolveAssetSymbol(assetAddress), address: assetAddress, decimals: 18 };
+  }
+
+  assetDecimals(asset) {
+    const decimals = Number(asset?.decimals ?? 18);
+    if (!Number.isInteger(decimals) || decimals < 0 || decimals > 30) {
+      throw new ValidationError(`Asset ${asset?.symbol ?? asset?.address ?? "unknown"} decimals must be an integer in [0, 30].`);
+    }
+    return decimals;
+  }
+
+  toBaseUnits(amount, asset, label = "amount") {
+    if (typeof amount === "bigint") {
+      if (amount < 0n) throw new ValidationError(`${label} must be non-negative.`);
+      return amount;
+    }
+    const decimals = this.assetDecimals(asset);
+    const normalized = this.normalizeDecimalAmount(amount, decimals, label);
+    try {
+      return parseUnits(normalized, decimals);
+    } catch {
+      throw new ValidationError(`${label} must fit ${decimals} decimal places for ${asset?.symbol ?? "asset"}.`);
+    }
+  }
+
+  toDisplayUnits(amount, asset) {
+    return Number(formatUnits(amount ?? 0, this.assetDecimals(asset)));
+  }
+
+  normalizeDecimalAmount(amount, decimals, label) {
+    const value = typeof amount === "string" ? amount.trim() : String(amount ?? "");
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric) || numeric < 0) {
+      throw new ValidationError(`${label} must be a non-negative finite number.`);
+    }
+    if (!value || /e/i.test(value)) {
+      return numeric.toFixed(decimals).replace(/\.?0+$/u, "") || "0";
+    }
+    const [whole, fraction = ""] = value.split(".");
+    if (!/^\d+$/u.test(whole || "0") || !/^\d*$/u.test(fraction)) {
+      throw new ValidationError(`${label} must be a decimal number.`);
+    }
+    if (fraction.length <= decimals) {
+      return value;
+    }
+    return numeric.toFixed(decimals).replace(/\.?0+$/u, "") || "0";
   }
 
   requireAsyncStrategyConfig(strategy, operation) {
@@ -932,7 +997,7 @@ export class BlockchainGateway {
     if (!assetAddress) {
       return "DOT";
     }
-    const match = this.config.supportedAssets.find((asset) => asset.address?.toLowerCase() === assetAddress.toLowerCase());
+    const match = (this.config.supportedAssets ?? []).find((asset) => asset.address?.toLowerCase() === assetAddress.toLowerCase());
     return match?.symbol ?? "DOT";
   }
 

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -4,6 +4,16 @@ import { encodeBytes32String } from "ethers";
 
 import { BlockchainGateway } from "./gateway.js";
 
+const DOT_ASSET = {
+  symbol: "DOT",
+  address: "0x2222222222222222222222222222222222222222",
+  decimals: 18
+};
+
+function gatewayWithDot() {
+  return new BlockchainGateway({ enabled: false, supportedAssets: [DOT_ASSET] });
+}
+
 test("toDisputeReasonCode uses Solidity bytes32 string encoding", () => {
   const gateway = new BlockchainGateway({ enabled: false });
 
@@ -67,7 +77,7 @@ test("autoDiscloseContent skips when the contract already recorded the hash", as
 });
 
 test("getJob falls back to the legacy escrow struct when rc1 decoding fails", async () => {
-  const gateway = new BlockchainGateway({ enabled: false });
+  const gateway = gatewayWithDot();
   gateway.escrowContract = {
     async jobs() {
       const error = new Error("could not decode result data");
@@ -84,7 +94,7 @@ test("getJob falls back to the legacy escrow struct when rc1 decoding fails", as
         asset: "0x2222222222222222222222222222222222222222",
         verifierMode: encodeBytes32String("BENCH"),
         category: encodeBytes32String("WIKI"),
-        reward: 4n,
+        reward: 4_000_000_000_000_000_000n,
         opsReserve: 0n,
         contingencyReserve: 0n,
         released: 0n,
@@ -107,8 +117,125 @@ test("getJob falls back to the legacy escrow struct when rc1 decoding fails", as
   assert.equal("contractLayout" in job, false);
 });
 
+test("toBaseUnits converts display asset amounts before uint256 contract calls", () => {
+  const gateway = gatewayWithDot();
+
+  assert.equal(
+    gateway.toBaseUnits(4, DOT_ASSET, "job reward"),
+    4_000_000_000_000_000_000n
+  );
+  assert.equal(
+    gateway.toBaseUnits(0.4, DOT_ASSET, "claim lock amount"),
+    400_000_000_000_000_000n
+  );
+  assert.equal(
+    gateway.toBaseUnits(0.05, DOT_ASSET, "minimum claim fee"),
+    50_000_000_000_000_000n
+  );
+});
+
+test("getClaimEconomicsConfig converts chain min fees back to display units", async () => {
+  const gateway = gatewayWithDot();
+  gateway.policyContract = {
+    async claimFeeBps() {
+      return 200n;
+    },
+    async claimFeeVerifierBps() {
+      return 7000n;
+    },
+    async onboardingWaiverClaimCount() {
+      return 3n;
+    },
+    async minClaimFeeByAsset(asset) {
+      assert.equal(asset, DOT_ASSET.address);
+      return 50_000_000_000_000_000n;
+    }
+  };
+
+  assert.deepEqual(await gateway.getClaimEconomicsConfig(), {
+    claimFeeBps: 200,
+    claimFeeVerifierBps: 7000,
+    onboardingWaiverClaimCount: 3,
+    minClaimFeeByAsset: { DOT: 0.05 }
+  });
+});
+
+test("previewClaimEconomics returns display values while preserving raw chain amounts", async () => {
+  const gateway = gatewayWithDot();
+  gateway.escrowContract = {
+    async jobs() {
+      return {
+        poster: "0x1111111111111111111111111111111111111111",
+        worker: "0x0000000000000000000000000000000000000000",
+        asset: DOT_ASSET.address,
+        verifierMode: encodeBytes32String("BENCH"),
+        category: encodeBytes32String("WIKI"),
+        specHash: `0x${"0".repeat(64)}`,
+        reward: 4_000_000_000_000_000_000n,
+        opsReserve: 0n,
+        contingencyReserve: 0n,
+        released: 0n,
+        claimExpiry: 0n,
+        claimStake: 0n,
+        claimStakeBps: 0,
+        claimFee: 0n,
+        claimFeeBps: 0,
+        claimEconomicsWaived: false,
+        rejectingVerifier: "0x0000000000000000000000000000000000000000",
+        rejectedAt: 0n,
+        disputedAt: 0n,
+        payoutMode: 0,
+        state: 1
+      };
+    },
+    async previewClaimEconomics() {
+      return {
+        claimStake: 400_000_000_000_000_000n,
+        claimStakeBps: 1000,
+        claimFee: 80_000_000_000_000_000n,
+        claimFeeBps: 200,
+        waived: false,
+        claimNumber: 4n
+      };
+    }
+  };
+
+  assert.deepEqual(
+    await gateway.previewClaimEconomics("0x3333333333333333333333333333333333333333", "WIKI"),
+    {
+      claimStake: 0.4,
+      claimStakeRaw: "400000000000000000",
+      claimStakeBps: 1000,
+      claimFee: 0.08,
+      claimFeeRaw: "80000000000000000",
+      claimFeeBps: 200,
+      claimEconomicsWaived: false,
+      claimNumber: 4,
+      totalClaimLock: 0.48
+    }
+  );
+});
+
+test("ensureClaimStakeLiquidity checks fractional display locks against base-unit balances", async () => {
+  const gateway = gatewayWithDot();
+  gateway.signer = {
+    async getAddress() {
+      return "0x3333333333333333333333333333333333333333";
+    }
+  };
+  gateway.accountContract = {
+    async positions(account, asset) {
+      assert.equal(account, "0x3333333333333333333333333333333333333333");
+      assert.equal(asset, DOT_ASSET.address);
+      return { liquid: 480_000_000_000_000_000n };
+    }
+  };
+
+  assert.equal(await gateway.ensureClaimStakeLiquidity("DOT", 0.48), true);
+});
+
 test("createSinglePayoutJobForLayout uses the legacy signature for legacy escrow deployments", async () => {
-  const gateway = new BlockchainGateway({ enabled: false });
+  const gateway = gatewayWithDot();
   const calls = [];
   gateway.legacyEscrowContract = {
     async createSinglePayoutJob(...args) {
@@ -126,7 +253,7 @@ test("createSinglePayoutJobForLayout uses the legacy signature for legacy escrow
     "legacy",
     gateway.toJobId("WIKI"),
     "0x2222222222222222222222222222222222222222",
-    4,
+    4_000_000_000_000_000_000n,
     0,
     0,
     3600,
@@ -138,7 +265,7 @@ test("createSinglePayoutJobForLayout uses the legacy signature for legacy escrow
   assert.equal(calls.length, 1);
   assert.equal(calls[0].length, 8);
   assert.deepEqual(calls[0].slice(2), [
-    4,
+    4_000_000_000_000_000_000n,
     0,
     0,
     3600,


### PR DESCRIPTION
## Summary
- Convert display job rewards, claim locks, funding amounts, and min claim fees at the blockchain gateway boundary.
- Preserve raw chain amount fields while returning display-unit claim economics to the service/session layer.
- Add regression coverage for fractional claim locks so values like 0.48 DOT do not reach uint256 contract calls as fractional JS numbers.

## Root cause
Issue #105 showed /jobs/claim returning 502: `ensureJob failed: underflow`. The claim path mixed display DOT values with on-chain base units. Fractional display values such as the 10% stake on a 4 DOT job could be passed into ethers uint256 calls, which triggers an underflow; integer rewards could also be created on-chain as tiny raw-unit jobs.

Polkadot docs check: the ERC20 precompile uses raw token units and does not expose ERC20 metadata decimals, so the gateway must use configured asset decimals before contract calls.

Closes #105.

## Checks
- node --test mcp-server/src/blockchain/gateway.test.js mcp-server/src/core/job-execution-service.test.js
- npm --workspace mcp-server test
- git diff --check

## Impact
- Backend blockchain gateway only.
- No frontend, indexer, contracts, Caddy, or public site changes.
- No env or VPS secret changes required, assuming SUPPORTED_ASSETS_JSON includes the correct decimals for each configured asset.