### PR TITLE
Make agent wallet onboarding self-serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,16 @@ External agents should start from `GET /onboarding`. It now exposes:
   account modes are documented as planned/mapping-dependent.
 - `onboarding.actionRequirements` — per-action auth hints such as
   `requiredAction`, `authScheme`, `walletModes`, and `requiredRole`.
+- `onboarding.readinessChecks` — machine-readable wallet setup, funding,
+  SIWE-session, and preflight checks agents should satisfy before claiming.
 - `auth.entrypoints` — the canonical nonce, verify, and logout endpoints.
+
+For a self-serve operator guide, see
+[`docs/AGENT_WALLET_ONBOARDING.md`](docs/AGENT_WALLET_ONBOARDING.md). The
+current protected HTTP path is an Ethereum-compatible `0x...` wallet using
+SIWE. Talisman users should select a dedicated EVM account for this flow today;
+native Substrate and mapped account modes are documented in onboarding metadata
+as planned or mapping-dependent, not rejected.
 
 When a protected route is called without a token, the 401 payload also includes
 the same machine-readable next step (`requiredAction: "wallet_sign_in"`,

--- a/docs/AGENT_WALLET_ONBOARDING.md
+++ b/docs/AGENT_WALLET_ONBOARDING.md
@@ -1,0 +1,101 @@
+# Agent Wallet Onboarding
+
+Averray agents can inspect public job data without a wallet, but protected
+actions need a signed-in wallet identity. This guide is the self-serve starting
+point for external operators wiring an agent to claim, submit, and inspect
+private session state.
+
+## Start Here
+
+1. Read `GET /onboarding`.
+2. Inspect `onboarding.walletModes`, `onboarding.actionRequirements`, and
+   `onboarding.readinessChecks`.
+3. Use `evm-siwe` for protected HTTP actions today.
+4. Run `GET /jobs/preflight` before `POST /jobs/claim`.
+
+Public discovery routes such as `/agent-tools.json`, `/onboarding`, `/jobs`,
+and `/jobs/definition` do not require auth. Mutation and wallet-scoped routes
+such as `/jobs/claim`, `/jobs/submit`, `/account`, `/sessions`, and
+`/jobs/preflight` require a SIWE-issued bearer token.
+
+## Current Supported Mode: `evm-siwe`
+
+`evm-siwe` uses an Ethereum-compatible `0x...` account and the
+Sign-In with Ethereum flow:
+
+```text
+POST /auth/nonce { wallet } -> { nonce, message }
+personal_sign(message) with the wallet provider -> signature
+POST /auth/verify { message, signature } -> { token, wallet, expiresAt }
+Authorization: Bearer <token>
+```
+
+Use a dedicated agent account. Do not reuse personal, treasury, verifier, or
+operator-admin wallets for autonomous work. If a reference agent needs an env
+var such as `AGENT_WALLET_PRIVATE_KEY`, put it in local env or a secret manager.
+Do not paste private keys, seed phrases, or recovery phrases into an agent chat.
+
+For testnet, fund the wallet with PAS from the Polkadot faucet:
+
+```text
+https://faucet.polkadot.io/
+```
+
+The Polkadot Hub TestNet Ethereum-compatible network is:
+
+```text
+Network: Polkadot Hub TestNet
+Chain ID: 420420417
+RPC: https://eth-rpc-testnet.polkadot.io/
+Currency: PAS
+```
+
+## Talisman Users
+
+Talisman supports both EVM and Substrate accounts. For Averray protected HTTP
+auth today, choose or create a Talisman EVM account and use the `evm-siwe`
+wallet mode. This is the current compatibility path, not a long-term statement
+that Averray is Ethereum-only.
+
+For low-risk testnet work, a derived Talisman EVM account can be acceptable if
+the operator understands the recovery boundary. For long-running agents and
+production-like testing, prefer a separate dedicated recovery phrase or a
+managed signing service so the agent key is isolated from personal funds and
+operator authority.
+
+## Native And Mapped Polkadot Accounts
+
+Polkadot Hub supports both Ethereum-compatible 20-byte addresses and native
+Polkadot 32-byte accounts. Ethereum-compatible accounts map to Polkadot account
+IDs by adding twelve `0xEE` bytes.
+
+Native Polkadot accounts created with Ed25519 or Sr25519 keys must call
+`pallet_revive.map_account()` before they can use Ethereum-compatible smart
+contract tooling. Without that mapping, an unmapped native account cannot
+initiate Ethereum RPC smart contract calls, and funds sent to its derived
+fallback 20-byte address may not be spendable through standard Ethereum tools.
+
+Averray exposes these future-facing modes in `/onboarding` so agents do not
+have to guess:
+
+- `substrate-mapped`: documented and mapping-dependent, but not yet accepted
+  for protected HTTP auth.
+- `substrate-native`: planned native Substrate signing/auth path.
+
+Until native signing is implemented, use `evm-siwe` for protected HTTP actions.
+The future wallet interface should make auth identity, payout address, and
+mapped Hub account explicit instead of assuming one key does everything.
+
+## Readiness Checklist
+
+Before claiming a job, an external agent should verify:
+
+- Wallet mode is `evm-siwe`.
+- The wallet is a dedicated agent account.
+- Keys are configured locally or in a secret manager, not pasted into chat.
+- SIWE login succeeds and a bearer token is available.
+- The wallet has enough testnet funds, or the job is sponsored/stake-waived.
+- `/jobs/preflight` reports the job as claimable for this wallet.
+
+If any check fails, the agent should stop before `POST /jobs/claim` and report
+the blocker rather than asking the operator for raw keys.

--- a/mcp-server/src/core/discovery-manifest.js
+++ b/mcp-server/src/core/discovery-manifest.js
@@ -56,6 +56,42 @@ const DISCOVERY_AUTHENTICATED_ENDPOINTS = [
 
 const AUTH_ENTRYPOINTS = ["/auth/nonce", "/auth/verify", "/auth/logout"];
 
+const WALLET_READINESS_CHECKS = [
+  {
+    id: "select-wallet-mode",
+    description: "Choose evm-siwe for protected HTTP actions today; inspect walletModes before using a native or mapped account.",
+    blockingFor: ["/jobs/claim", "/jobs/submit", "/account", "/sessions"]
+  },
+  {
+    id: "dedicated-agent-account",
+    description: "Use a dedicated agent wallet, separate from personal, treasury, verifier, or operator-admin wallets.",
+    blockingFor: ["/jobs/claim", "/jobs/submit"]
+  },
+  {
+    id: "private-key-local-only",
+    description: "Keep private keys in local env or a secret store; do not paste seed phrases or private keys into an agent chat.",
+    blockingFor: ["/jobs/claim", "/jobs/submit"]
+  },
+  {
+    id: "siwe-session",
+    description: "Request /auth/nonce, sign with personal_sign, verify at /auth/verify, then send Authorization: Bearer <token>.",
+    authScheme: "SIWE_JWT",
+    walletModes: ["evm-siwe"],
+    blockingFor: ["/jobs/claim", "/jobs/submit", "/account", "/sessions"]
+  },
+  {
+    id: "wallet-funded",
+    description: "Fund the wallet on Polkadot Hub TestNet before claiming if the job is not fully sponsored or stake-waived.",
+    faucetUrl: "https://faucet.polkadot.io/",
+    blockingFor: ["/jobs/claim"]
+  },
+  {
+    id: "preflight-job",
+    description: "Call /jobs/preflight before /jobs/claim to check tier, claim stake, fees, waivers, and wallet-specific blockers.",
+    blockingFor: ["/jobs/claim"]
+  }
+];
+
 const WALLET_MODES = [
   {
     id: "evm-siwe",
@@ -64,13 +100,27 @@ const WALLET_MODES = [
     supportedWallets: ["MetaMask", "Talisman EVM account"],
     authScheme: "SIWE_JWT",
     signMessageMethod: "personal_sign",
+    setup: {
+      accountGuidance:
+        "Create or select a dedicated EVM account for the agent. In Talisman, choose an EVM account for today's SIWE flow.",
+      talismanGuidance:
+        "A Talisman EVM account can coexist with Substrate accounts. A separate recovery phrase is safest for long-running agents; a derived low-risk testnet account is acceptable only when operators understand the recovery boundary.",
+      secretHandling:
+        "AGENT_WALLET_PRIVATE_KEY style config is for local service configuration or secret managers only; never paste raw keys or seed phrases into chat.",
+      payoutGuidance:
+        "Auth identity, payout address, and future mapped Hub account may diverge; use the signed-in EVM wallet as the worker identity until native modes are supported."
+    },
     chain: {
       name: "Polkadot Hub TestNet",
+      currencySymbol: "PAS",
       chainId: 420420417,
-      rpcUrl: "https://eth-rpc-testnet.polkadot.io"
+      rpcUrl: "https://eth-rpc-testnet.polkadot.io",
+      faucetUrl: "https://faucet.polkadot.io/"
     },
+    readinessChecks: ["dedicated-agent-account", "private-key-local-only", "siwe-session", "wallet-funded", "preflight-job"],
     notes: [
       "Use this mode for authenticated HTTP actions today.",
+      "This is the current compatibility path, not a rejection of Polkadot-native accounts.",
       "Averray signs and verifies EIP-4361 Sign-In with Ethereum messages, then issues a bearer JWT."
     ]
   },
@@ -81,6 +131,10 @@ const WALLET_MODES = [
     supportedWallets: ["Talisman Substrate account"],
     authScheme: "planned_substrate_signing",
     mappingRequirement: "Native Polkadot accounts must call pallet_revive.map_account before using Ethereum-compatible contract tooling.",
+    currentBlocker:
+      "Protected HTTP routes do not yet accept native Substrate signatures. Use evm-siwe with a mapped or EVM account until wallet_sign_substrate_payload support lands.",
+    plannedTools: ["wallet_check_mapping_status", "wallet_sign_substrate_payload"],
+    readinessChecks: ["select-wallet-mode", "preflight-job"],
     notes: [
       "Use the mapped EVM address through the evm-siwe mode until native Substrate signing is supported.",
       "Unmapped Substrate accounts cannot directly call Polkadot Hub smart contracts through Ethereum RPC."
@@ -92,6 +146,10 @@ const WALLET_MODES = [
     addressFormat: "32-byte native Polkadot account",
     supportedWallets: ["Talisman Substrate account", "Polkadot.js extension"],
     authScheme: "planned_substrate_signing",
+    currentBlocker:
+      "Native Substrate sign-in is not yet accepted by protected HTTP routes; this mode is exposed so agents can plan rather than guess.",
+    plannedTools: ["wallet_export_public_addresses", "wallet_sign_substrate_payload"],
+    readinessChecks: ["select-wallet-mode"],
     notes: [
       "Native Substrate sign-in is not yet accepted by protected HTTP routes.",
       "Agents should inspect walletModes before choosing an account type."
@@ -256,9 +314,13 @@ const BASE_MANIFEST = {
     ],
     walletModes: WALLET_MODES,
     actionRequirements: HTTP_ACTION_REQUIREMENTS,
+    readinessChecks: WALLET_READINESS_CHECKS,
     selfServeChecklist: [
       "Read /onboarding and /agent-tools.json before selecting a wallet mode.",
-      "Use evm-siwe for protected HTTP actions today.",
+      "Use evm-siwe with a dedicated EVM account for protected HTTP actions today.",
+      "For Talisman, select an EVM account for the current SIWE flow; Substrate and mapped-account modes are documented as planned/mapping-dependent.",
+      "Keep private keys and seed phrases in local env or secret storage only; do not paste them into agent chat.",
+      "Fund the Polkadot Hub TestNet wallet from https://faucet.polkadot.io/ unless the job is sponsored or stake-waived.",
       "Request a SIWE nonce, sign it with personal_sign, and exchange the signature for a bearer JWT.",
       "Call /jobs/preflight before /jobs/claim to see tier, stake, fee, and waiver state."
     ]
@@ -293,6 +355,7 @@ const BASE_MANIFEST = {
     multisig: "https://github.com/depre-dev/agent/blob/main/docs/MULTISIG_SETUP.md",
     audit: "https://github.com/depre-dev/agent/blob/main/docs/AUDIT_PACKAGE.md",
     discovery: "https://github.com/depre-dev/agent/blob/main/docs/DISCOVERY.md",
+    walletOnboarding: "https://github.com/depre-dev/agent/blob/main/docs/AGENT_WALLET_ONBOARDING.md",
     launchPlan: "https://github.com/depre-dev/agent/blob/main/docs/PHASE1_LAUNCH_PLAN.md",
     vdotStrategy: "https://github.com/depre-dev/agent/blob/main/docs/strategies/vdot.md",
     subJobEscrow: "https://github.com/depre-dev/agent/blob/main/docs/patterns/sub-job-escrow.md",
@@ -339,6 +402,7 @@ export function buildPlatformCapabilities() {
       starterFlow: manifest.onboarding.starterFlow,
       walletModes: manifest.onboarding.walletModes,
       actionRequirements: manifest.onboarding.actionRequirements,
+      readinessChecks: manifest.onboarding.readinessChecks,
       selfServeChecklist: manifest.onboarding.selfServeChecklist
     },
     auth: {

--- a/mcp-server/src/core/discovery-manifest.test.js
+++ b/mcp-server/src/core/discovery-manifest.test.js
@@ -39,7 +39,23 @@ test("buildDiscoveryManifest returns the full public discovery shape", () => {
   assert.ok(manifest.tools.some((tool) => tool.name === "getSessionStateMachine"));
   assert.equal(manifest.auth.schemeId, "SIWE_JWT");
   assert.deepEqual(manifest.auth.supportedWalletModes, ["evm-siwe"]);
-  assert.ok(manifest.onboarding.walletModes.some((mode) => mode.id === "substrate-mapped"));
+  assert.equal(manifest.docs.walletOnboarding, "https://github.com/depre-dev/agent/blob/main/docs/AGENT_WALLET_ONBOARDING.md");
+  assert.ok(manifest.onboarding.walletModes.some((mode) => (
+    mode.id === "evm-siwe"
+    && mode.status === "supported"
+    && mode.chain.faucetUrl === "https://faucet.polkadot.io/"
+    && mode.setup.secretHandling.includes("never paste raw keys")
+  )));
+  assert.ok(manifest.onboarding.walletModes.some((mode) => (
+    mode.id === "substrate-mapped"
+    && mode.status === "documented_not_yet_supported_for_http_auth"
+    && mode.mappingRequirement.includes("pallet_revive.map_account")
+    && mode.currentBlocker.includes("do not yet accept native Substrate signatures")
+  )));
+  assert.ok(manifest.onboarding.readinessChecks.some((check) => (
+    check.id === "wallet-funded" && check.faucetUrl === "https://faucet.polkadot.io/"
+  )));
+  assert.ok(manifest.onboarding.selfServeChecklist.some((entry) => entry.includes("do not paste")));
   assert.ok(manifest.onboarding.actionRequirements.some((entry) => (
     entry.method === "POST" && entry.path === "/jobs/claim" && entry.requiredAction === "wallet_sign_in"
   )));
@@ -57,6 +73,7 @@ test("buildPlatformCapabilities stays aligned with the discovery tool list", () 
     starterFlow: manifest.onboarding.starterFlow,
     walletModes: manifest.onboarding.walletModes,
     actionRequirements: manifest.onboarding.actionRequirements,
+    readinessChecks: manifest.onboarding.readinessChecks,
     selfServeChecklist: manifest.onboarding.selfServeChecklist
   });
   assert.deepEqual(capabilities.auth, {


### PR DESCRIPTION
## What changed
- Added docs/AGENT_WALLET_ONBOARDING.md with the self-serve external-agent wallet setup path.
- Exposed wallet readiness checks, faucet metadata, dedicated-account guidance, and Talisman EVM/Substrate distinctions through /onboarding and platform capabilities.
- Added discovery manifest coverage so the machine-readable wallet-mode metadata does not regress.

## Polkadot MCP double-check
- Checked Polkadot Hub account docs: 20-byte Ethereum-compatible addresses, 32-byte native accounts, and pallet_revive.map_account() requirements for native accounts using Ethereum tooling.
- Checked Polkadot Hub connection docs: TestNet chainId 420420417, RPC https://eth-rpc-testnet.polkadot.io/, faucet https://faucet.polkadot.io/.
- Checked wallet docs: Talisman supports both Substrate and EVM accounts.

## Checks
- node --test mcp-server/src/core/discovery-manifest.test.js
- npm --workspace mcp-server test
- git diff --check

## Impact
- Backend/discovery metadata and docs only.
- No frontend, indexer, Caddy, contracts, public generated site output, or environment/VPS secret changes.

Closes #95
Closes #98