### PR TITLE
Agents UI: lifecycle states, active session, scope-labelled cards

### DIFF
--- a/app/components/agents/AgentDirectoryTable.tsx
+++ b/app/components/agents/AgentDirectoryTable.tsx
@@ -13,9 +13,34 @@ export interface AgentDirectoryTableProps {
   onSelect: (agent: AgentRecord) => void;
 }
 
-const STATE_PILL: Record<AgentRecord["state"], { cls: string; label: string }> = {
-  active: { cls: "bg-[var(--avy-accent-soft)] text-[var(--avy-accent)]", label: "Active" },
+// State pill palette. Lifecycle-position tones:
+//   - idle: neutral parchment, "no claim, no work in flight"
+//   - claimed/working/active: green family — currently producing or has
+//     a verified history
+//   - submitted: amber — produced something, awaiting verification
+//   - disputed/slashed: red family — operator action wanted
+const STATE_PILL: Record<
+  AgentRecord["state"],
+  { cls: string; label: string }
+> = {
   idle: { cls: "bg-[#ebe7da] text-[#756d58]", label: "Idle" },
+  claimed: {
+    cls: "bg-[var(--avy-accent-soft)] text-[var(--avy-accent)]",
+    label: "Claimed",
+  },
+  working: {
+    cls: "bg-[var(--avy-accent-soft)] text-[var(--avy-accent)]",
+    label: "Working",
+  },
+  submitted: {
+    cls: "bg-[var(--avy-warn-soft)] text-[var(--avy-warn)]",
+    label: "Submitted",
+  },
+  disputed: { cls: "bg-[#f3d9d9] text-[#8a2a2a]", label: "Disputed" },
+  active: {
+    cls: "bg-[var(--avy-accent-soft)] text-[var(--avy-accent)]",
+    label: "Active",
+  },
   slashed: { cls: "bg-[#f3d9d9] text-[#8a2a2a]", label: "Slashed" },
 };
 
@@ -98,7 +123,16 @@ export function AgentDirectoryTable({
                         >
                           {a.score}
                         </span>
-                        <Sparkline points={a.sparkline} width={72} height={20} />
+                        {/* Suppress a flat-zero spark on first-agent rows;
+                            it read as fake against a 0 score. */}
+                        {a.sparkline.some((v) => v > 0) ? (
+                          <Sparkline points={a.sparkline} width={72} height={20} />
+                        ) : (
+                          <span
+                            aria-hidden="true"
+                            className="block h-[2px] w-[72px] rounded-full bg-[color:rgba(17,19,21,0.08)]"
+                          />
+                        )}
                       </div>
                     </Td>
                     <Td>

--- a/app/components/agents/AgentDrawerBody.tsx
+++ b/app/components/agents/AgentDrawerBody.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { cn } from "@/lib/utils/cn";
 import { Sparkline } from "@/components/overview/Sparkline";
 import { BadgeChip } from "./BadgeStrip";
@@ -8,6 +9,7 @@ import {
   BADGES,
   tierFor,
   nextThreshold,
+  type AgentActiveSession,
   type AgentRecord,
   type AgentTier,
 } from "./types";
@@ -22,36 +24,31 @@ export function AgentDrawerBody({ agent }: { agent: AgentRecord }) {
   const lockPct = agent.stake.deposited > 0 ? agent.stake.locked / agent.stake.deposited : 0;
   const curTier = tierFor(agent.score);
   const next = nextThreshold(agent.score);
-  const profileUrl = `averray.com/agents/${agent.walletFull}`;
+  const profileUrl = `https://averray.com/agents/${agent.walletFull}`;
+  const showSparkline = agent.sparkline.some((v) => v > 0);
+  // Badge section copy depends on whether any badge represents a
+  // verified-receipt outcome. Capability markers granted on registration
+  // (e.g. "Coding L1" assigned to every fresh wallet) shouldn't be
+  // labelled "earned" — that conflates "the agent did something" with
+  // "the agent has the right to do something".
+  const badgeSectionTitle = agent.hasVerifiedBadges
+    ? `Badges earned · ${agent.badges.length}`
+    : `Capabilities · ${agent.badges.length}`;
+  const badgeNote = agent.hasVerifiedBadges
+    ? null
+    : "starter capability — not from a verified receipt";
 
   return (
     <>
-      <Section title="Signature header">
-        <div className="flex flex-col gap-1.5 rounded-[10px] border border-[color:rgba(30,102,66,0.24)] bg-[color:rgba(30,102,66,0.06)] px-4 py-3">
-          <span
-            className="font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase text-[var(--avy-accent)]"
-            style={{ letterSpacing: "0.12em" }}
-          >
-            Public identity
-          </span>
-          <span
-            className="break-all font-[family-name:var(--font-mono)] text-[13px] text-[var(--avy-accent)]"
-            style={{ letterSpacing: 0 }}
-          >
-            {agent.walletFull}
-          </span>
-          <a
-            href={`https://${profileUrl}`}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center gap-1.5 self-start rounded-[6px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-2.5 py-1.5 font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-ink)] hover:border-[color:rgba(30,102,66,0.35)] hover:text-[var(--avy-accent)]"
-            style={{ letterSpacing: 0 }}
-          >
-            <span>↗</span>
-            <span>{profileUrl}</span>
-          </a>
-        </div>
+      <Section title="Public identity">
+        <PublicIdentityCard wallet={agent.walletFull} profileUrl={profileUrl} />
       </Section>
+
+      {agent.activeSession ? (
+        <Section title="Active session">
+          <ActiveSessionCard session={agent.activeSession} />
+        </Section>
+      ) : null}
 
       <Section title="Reputation · 30d">
         <div className="grid gap-3 rounded-[10px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-4 py-3.5">
@@ -69,7 +66,14 @@ export function AgentDrawerBody({ agent }: { agent: AgentRecord }) {
                   : "top tier — no further ladder"}
               </div>
             </div>
-            <Sparkline points={agent.sparkline} width={160} height={34} />
+            {showSparkline ? (
+              <Sparkline points={agent.sparkline} width={160} height={34} />
+            ) : (
+              <span
+                aria-hidden="true"
+                className="block h-[2px] w-[160px] rounded-full bg-[color:rgba(17,19,21,0.08)]"
+              />
+            )}
           </div>
           <div className="grid gap-1.5">
             {TIERS.map((t) => {
@@ -110,80 +114,58 @@ export function AgentDrawerBody({ agent }: { agent: AgentRecord }) {
         </div>
       </Section>
 
-      <Section title={`Badges earned · ${agent.badges.length}`}>
-        <div className="grid grid-cols-2 gap-2">
-          {agent.badges.map((b) => {
-            const def = BADGES[b];
-            return (
-              <div
-                key={b}
-                className="grid items-center gap-2.5 rounded-[8px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-3 py-2.5"
-                style={{ gridTemplateColumns: "28px 1fr" }}
-              >
-                <BadgeChip badgeId={b} size="md" />
-                <div>
-                  <div className="font-[family-name:var(--font-display)] text-[12.5px] font-bold text-[var(--avy-ink)]">
-                    {def?.name}
-                  </div>
-                  <div
-                    className="mt-px font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
-                    style={{ letterSpacing: 0 }}
-                  >
-                    issued {agent.badgeDates[b] ?? "—"}
+      <Section title={badgeSectionTitle}>
+        {badgeNote ? (
+          <p
+            className="font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]"
+            style={{ letterSpacing: 0 }}
+          >
+            {badgeNote}
+          </p>
+        ) : null}
+        {agent.badges.length === 0 ? (
+          <div
+            className="rounded-[8px] border border-dashed border-[var(--avy-line)] bg-[rgba(255,253,247,0.5)] px-3.5 py-2.5 font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-muted)]"
+            style={{ letterSpacing: 0 }}
+          >
+            No capabilities recorded yet.
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-2">
+            {agent.badges.map((b) => {
+              const def = BADGES[b];
+              const issued = agent.badgeDates[b];
+              return (
+                <div
+                  key={b}
+                  className="grid items-center gap-2.5 rounded-[8px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-3 py-2.5"
+                  style={{ gridTemplateColumns: "28px 1fr" }}
+                >
+                  <BadgeChip badgeId={b} size="md" />
+                  <div>
+                    <div className="font-[family-name:var(--font-display)] text-[12.5px] font-bold text-[var(--avy-ink)]">
+                      {def?.name}
+                    </div>
+                    <div
+                      className="mt-px font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
+                      style={{ letterSpacing: 0 }}
+                    >
+                      {agent.hasVerifiedBadges
+                        ? issued
+                          ? `issued ${issued}`
+                          : "issued —"
+                        : "starter capability"}
+                    </div>
                   </div>
                 </div>
-              </div>
-            );
-          })}
-        </div>
+              );
+            })}
+          </div>
+        )}
       </Section>
 
       <Section title="Recent runs · last 8">
-        <div className="grid gap-1.5">
-          {agent.recentRuns.map((r) => {
-            const pillCls =
-              r.state === "Verified"
-                ? "bg-[var(--avy-accent-soft)] text-[var(--avy-accent)]"
-                : r.state === "Disputed"
-                  ? "bg-[var(--avy-warn-soft)] text-[var(--avy-warn)]"
-                  : "bg-[#ebe7da] text-[#756d58]";
-            return (
-              <div
-                key={r.id}
-                className="grid items-center gap-3 rounded-[8px] border border-[var(--avy-line-soft)] bg-[var(--avy-paper-solid)] px-3 py-2"
-                style={{ gridTemplateColumns: "1fr auto auto" }}
-              >
-                <div>
-                  <div className="text-[13px] leading-tight text-[var(--avy-ink)]">
-                    {r.title}
-                  </div>
-                  <span
-                    className="mt-0.5 block font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
-                    style={{ letterSpacing: 0 }}
-                  >
-                    {r.id}
-                  </span>
-                </div>
-                <span
-                  className="font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-accent)]"
-                  style={{ letterSpacing: 0 }}
-                >
-                  {r.receipt}
-                </span>
-                <span
-                  className={cn(
-                    "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase",
-                    pillCls
-                  )}
-                  style={{ letterSpacing: "0.08em" }}
-                >
-                  <span className="h-1.5 w-1.5 rounded-full bg-current opacity-70" />
-                  {r.state}
-                </span>
-              </div>
-            );
-          })}
-        </div>
+        <RecentRunsBlock agent={agent} />
       </Section>
 
       <Section title="Stake">
@@ -209,7 +191,7 @@ export function AgentDrawerBody({ agent }: { agent: AgentRecord }) {
             className="rounded-[8px] border border-dashed border-[var(--avy-line)] bg-[rgba(255,253,247,0.5)] px-3.5 py-2.5 font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-muted)]"
             style={{ letterSpacing: 0 }}
           >
-            No slashes on record — clean history since claim-open.
+            No slashes on record — clean history since first seen.
           </div>
         ) : (
           <div className="grid gap-2">
@@ -242,21 +224,252 @@ export function AgentDrawerBody({ agent }: { agent: AgentRecord }) {
           </div>
         )}
       </Section>
+    </>
+  );
+}
 
-      <Section title="Public profile">
+/**
+ * Public-identity header. Wallet + profile URL never overflow horizontally —
+ * we render the long string in a wrapping container, then offer
+ * middle-truncated buttons for `Open` and `Copy` so the full address is
+ * always one click away without ever creating a horizontal scrollbar.
+ */
+function PublicIdentityCard({
+  wallet,
+  profileUrl,
+}: {
+  wallet: string;
+  profileUrl: string;
+}) {
+  const [copied, setCopied] = useState<"wallet" | "url" | null>(null);
+
+  const copy = async (which: "wallet" | "url", value: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(which);
+      setTimeout(() => setCopied(null), 1500);
+    } catch {
+      // Fall through silently — the wallet text is already on screen.
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2 overflow-hidden rounded-[10px] border border-[color:rgba(30,102,66,0.24)] bg-[color:rgba(30,102,66,0.06)] px-4 py-3">
+      <span
+        className="font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase text-[var(--avy-accent)]"
+        style={{ letterSpacing: "0.12em" }}
+      >
+        Public identity
+      </span>
+      <span
+        className="break-all font-[family-name:var(--font-mono)] text-[13px] text-[var(--avy-accent)]"
+        style={{ letterSpacing: 0 }}
+      >
+        {wallet}
+      </span>
+      <div className="flex flex-wrap items-center gap-1.5">
         <a
-          href={`https://${profileUrl}`}
+          href={profileUrl}
           target="_blank"
           rel="noreferrer"
-          className="inline-flex items-center gap-2 rounded-[8px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-3 py-2 font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-ink)] hover:border-[color:rgba(30,102,66,0.35)] hover:text-[var(--avy-accent)]"
+          title={profileUrl}
+          className="inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-[6px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-2.5 py-1.5 font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-ink)] hover:border-[color:rgba(30,102,66,0.35)] hover:text-[var(--avy-accent)]"
           style={{ letterSpacing: 0 }}
         >
-          <span>↗</span>
-          <span>https://{profileUrl}</span>
-          <span className="opacity-60">open</span>
+          <span className="shrink-0">↗</span>
+          <span className="min-w-0 truncate">
+            averray.com/agents/{middleTruncate(wallet, 14)}
+          </span>
         </a>
-      </Section>
-    </>
+        <button
+          type="button"
+          onClick={() => copy("url", profileUrl)}
+          className="inline-flex shrink-0 items-center rounded-[6px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-2 py-1.5 font-[family-name:var(--font-display)] text-[10.5px] font-bold uppercase text-[var(--avy-ink)] transition-colors hover:border-[color:rgba(30,102,66,0.35)] hover:text-[var(--avy-accent)]"
+          style={{ letterSpacing: "0.06em" }}
+        >
+          {copied === "url" ? "Copied" : "Copy URL"}
+        </button>
+        <button
+          type="button"
+          onClick={() => copy("wallet", wallet)}
+          className="inline-flex shrink-0 items-center rounded-[6px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-2 py-1.5 font-[family-name:var(--font-display)] text-[10.5px] font-bold uppercase text-[var(--avy-ink)] transition-colors hover:border-[color:rgba(30,102,66,0.35)] hover:text-[var(--avy-accent)]"
+          style={{ letterSpacing: "0.06em" }}
+        >
+          {copied === "wallet" ? "Copied" : "Copy wallet"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const STATUS_PILL: Record<
+  AgentActiveSession["status"],
+  { label: string; cls: string }
+> = {
+  claimed: {
+    label: "Claimed",
+    cls: "bg-[var(--avy-accent-soft)] text-[var(--avy-accent)]",
+  },
+  working: {
+    label: "Working",
+    cls: "bg-[var(--avy-accent-soft)] text-[var(--avy-accent)]",
+  },
+  submitted: {
+    label: "Submitted · pending verification",
+    cls: "bg-[var(--avy-warn-soft)] text-[var(--avy-warn)]",
+  },
+  disputed: {
+    label: "Disputed",
+    cls: "bg-[#f3d9d9] text-[#8a2a2a]",
+  },
+};
+
+function ActiveSessionCard({ session }: { session: AgentActiveSession }) {
+  const pill = STATUS_PILL[session.status];
+  return (
+    <div className="grid gap-2 rounded-[10px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-4 py-3.5">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase",
+            pill.cls
+          )}
+          style={{ letterSpacing: "0.08em" }}
+        >
+          <span className="h-1.5 w-1.5 rounded-full bg-current opacity-70" />
+          {pill.label}
+        </span>
+        {session.deadlineAt ? (
+          <span
+            className="font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]"
+            style={{ letterSpacing: 0 }}
+          >
+            deadline {formatDeadline(session.deadlineAt)}
+          </span>
+        ) : null}
+      </div>
+      {session.title ? (
+        <p className="m-0 text-[14px] font-semibold leading-tight text-[var(--avy-ink)]">
+          {session.title}
+        </p>
+      ) : null}
+      <dl
+        className="grid grid-cols-1 gap-x-3 gap-y-1 font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-ink)] sm:grid-cols-[auto_minmax(0,1fr)]"
+        style={{ letterSpacing: 0 }}
+      >
+        <SessionField label="Job" value={session.jobId} />
+        <SessionField label="Run" value={session.runId} />
+        <SessionField label="Session" value={session.sessionId} />
+        {session.lastEvent ? (
+          <SessionField
+            label="Last event"
+            value={
+              session.lastEventAt
+                ? `${session.lastEvent} · ${formatRelative(session.lastEventAt)}`
+                : session.lastEvent
+            }
+          />
+        ) : null}
+      </dl>
+    </div>
+  );
+}
+
+function SessionField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="contents">
+      <dt
+        className="font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-muted)]"
+        style={{ letterSpacing: "0.12em" }}
+      >
+        {label}
+      </dt>
+      <dd className="m-0 min-w-0 break-words">{value}</dd>
+    </div>
+  );
+}
+
+/**
+ * Recent runs section. The previous version always listed the static
+ * fixture; with first-agent state we need an explicit empty/active
+ * vocabulary so an operator immediately knows what they're looking at.
+ */
+function RecentRunsBlock({ agent }: { agent: AgentRecord }) {
+  const verified = agent.recentRuns;
+  const session = agent.activeSession;
+
+  if (verified.length === 0) {
+    const copy = !session
+      ? "No verified runs yet."
+      : session.status === "submitted"
+        ? "1 active run · submitted, awaiting verification."
+        : session.status === "disputed"
+          ? "1 active run · in dispute."
+          : `1 active run · ${session.status}.`;
+    return (
+      <div
+        className="rounded-[8px] border border-dashed border-[var(--avy-line)] bg-[rgba(255,253,247,0.5)] px-3.5 py-2.5 font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-muted)]"
+        style={{ letterSpacing: 0 }}
+      >
+        {copy}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-1.5">
+      {session ? (
+        <div
+          className="rounded-[8px] border border-dashed border-[color:rgba(30,102,66,0.35)] bg-[color:rgba(30,102,66,0.04)] px-3.5 py-2 font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-accent)]"
+          style={{ letterSpacing: 0 }}
+        >
+          1 active run · {session.status} · {session.jobId}
+        </div>
+      ) : null}
+      {verified.map((r) => {
+        const pillCls =
+          r.state === "Verified"
+            ? "bg-[var(--avy-accent-soft)] text-[var(--avy-accent)]"
+            : r.state === "Disputed"
+              ? "bg-[var(--avy-warn-soft)] text-[var(--avy-warn)]"
+              : "bg-[#ebe7da] text-[#756d58]";
+        return (
+          <div
+            key={r.id}
+            className="grid items-center gap-3 rounded-[8px] border border-[var(--avy-line-soft)] bg-[var(--avy-paper-solid)] px-3 py-2"
+            style={{ gridTemplateColumns: "1fr auto auto" }}
+          >
+            <div>
+              <div className="text-[13px] leading-tight text-[var(--avy-ink)]">
+                {r.title}
+              </div>
+              <span
+                className="mt-0.5 block font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
+                style={{ letterSpacing: 0 }}
+              >
+                {r.id}
+              </span>
+            </div>
+            <span
+              className="font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-accent)]"
+              style={{ letterSpacing: 0 }}
+            >
+              {r.receipt}
+            </span>
+            <span
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase",
+                pillCls
+              )}
+              style={{ letterSpacing: "0.08em" }}
+            >
+              <span className="h-1.5 w-1.5 rounded-full bg-current opacity-70" />
+              {r.state}
+            </span>
+          </div>
+        );
+      })}
+    </div>
   );
 }
 
@@ -310,4 +523,36 @@ function StakeCell({
       </span>
     </div>
   );
+}
+
+function middleTruncate(value: string, keep: number): string {
+  if (value.length <= keep + 3) return value;
+  const head = Math.ceil(keep / 2);
+  const tail = keep - head;
+  return `${value.slice(0, head)}…${value.slice(-tail)}`;
+}
+
+function formatRelative(iso: string): string {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return iso;
+  const deltaSec = Math.max(0, Math.round((Date.now() - t) / 1000));
+  if (deltaSec < 60) return `${deltaSec}s ago`;
+  const deltaMin = Math.round(deltaSec / 60);
+  if (deltaMin < 60) return `${deltaMin}m ago`;
+  const deltaHr = Math.round(deltaMin / 60);
+  if (deltaHr < 24) return `${deltaHr}h ago`;
+  return `${Math.round(deltaHr / 24)}d ago`;
+}
+
+function formatDeadline(iso: string): string {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return iso;
+  const deltaSec = Math.round((t - Date.now()) / 1000);
+  if (deltaSec <= 0) return "expired";
+  if (deltaSec < 60) return `in ${deltaSec}s`;
+  const deltaMin = Math.round(deltaSec / 60);
+  if (deltaMin < 60) return `in ${deltaMin}m`;
+  const deltaHr = Math.round(deltaMin / 60);
+  if (deltaHr < 24) return `in ${deltaHr}h`;
+  return `in ${Math.round(deltaHr / 24)}d`;
 }

--- a/app/components/agents/AgentsAggregateStrip.tsx
+++ b/app/components/agents/AgentsAggregateStrip.tsx
@@ -7,52 +7,106 @@ export interface AgentsAggregateStripProps {
   agents: AgentRecord[];
 }
 
+const PLATFORM_CLAIMED_24H = 23;
+const PLATFORM_CLAIM_SPARK = [1, 2, 0, 3, 2, 4, 3, 2, 5, 1, 0, 0];
+
+/**
+ * Top-of-page summary cards on /agents. Each card is explicitly scoped —
+ * "Working now / Roster" against the visible roster, "Platform 24h"
+ * against the platform-wide ledger — so the operator never reads two
+ * numbers as if they referred to the same population. (The previous
+ * version mixed `Active 0/1` with `Avg reputation 0 across 8 agents` and
+ * `Claimed 24h 23 runs` without a scope label, which read as broken at
+ * first-agent state.)
+ */
 export function AgentsAggregateStrip({ agents }: AgentsAggregateStripProps) {
-  const active = agents.filter((a) => a.state === "active").length;
-  const claimed24h = 23;
-  const claim24Spark = [1, 2, 0, 3, 2, 4, 3, 2, 5, 1, 0, 0];
-  const avgRep = Math.round(
-    agents.reduce((s, a) => s + a.score, 0) / agents.length
-  );
-  const slashed30 = agents.filter((a) => a.state === "slashed").length;
+  const rosterCount = agents.length;
+  const workingNow = agents.filter((a) => isWorking(a.state)).length;
+  const slashed = agents.filter((a) => a.state === "slashed").length;
+
+  const repPoints = agents.map((a) => a.score);
+  const avgRep =
+    rosterCount > 0
+      ? Math.round(repPoints.reduce((s, n) => s + n, 0) / rosterCount)
+      : 0;
+  const allRepsZero = repPoints.every((p) => p === 0);
+
+  // Working / Roster meta uses the actual roster size so the copy stays
+  // honest at small N: "1 visible agent" reads better than "below
+  // healthy floor" when the roster is just one wallet.
+  const workingMeta =
+    rosterCount === 0
+      ? "no agents visible"
+      : workingNow === 0
+        ? rosterCount === 1
+          ? "1 visible agent · idle"
+          : `${rosterCount} visible · all idle`
+        : `${workingNow} working · ${rosterCount} visible`;
 
   return (
     <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
       <AggCard
-        label="Active agents"
-        value={`${active}`}
-        unit={`/ ${agents.length}`}
-        meta={active < 3 ? "below healthy floor" : "healthy roster"}
-        metaTone={active < 3 ? "warn" : "ok"}
+        scope="visible roster"
+        label="Working now"
+        value={`${workingNow}`}
+        unit={`/ ${rosterCount}`}
+        meta={workingMeta}
+        metaTone={workingNow > 0 ? "ok" : "muted"}
       />
       <AggCard
-        label="Claimed 24h"
-        value={`${claimed24h}`}
+        scope="platform · 24h"
+        label="Claimed runs"
+        value={`${PLATFORM_CLAIMED_24H}`}
         unit="runs"
         meta="+4 vs prior 24h"
         metaTone="ok"
-        rightSlot={<Sparkline points={claim24Spark} width={72} height={20} />}
+        rightSlot={
+          <Sparkline points={PLATFORM_CLAIM_SPARK} width={72} height={20} />
+        }
       />
       <AggCard
+        scope="visible roster"
         label="Avg reputation"
         value={`${avgRep}`}
         mono
-        meta="across 8 agents · 14d trend up"
-        metaTone="ok"
-        rightSlot={<TierChip tier={tierFor(avgRep)} />}
+        meta={
+          rosterCount === 0
+            ? "no agents visible"
+            : `across ${rosterCount} visible agent${rosterCount === 1 ? "" : "s"}`
+        }
+        metaTone={avgRep > 0 ? "ok" : "muted"}
+        rightSlot={avgRep > 0 ? <TierChip tier={tierFor(avgRep)} /> : undefined}
+        // Suppress the empty trend bar when every visible agent has a
+        // 0 score — a flat-zero line read as a fake spark on the
+        // first-agent screenshot.
+        sparkline={allRepsZero ? null : repPoints}
       />
       <AggCard
-        label="Slashed 30d"
-        value={`${slashed30}`}
-        valueAccent={slashed30 > 0 ? "bad" : undefined}
-        meta={slashed30 > 0 ? `${slashed30} event · 45 DOT total` : "clean record"}
-        metaTone={slashed30 > 0 ? "bad" : "ok"}
+        scope="visible roster · 30d"
+        label="Slashed"
+        value={`${slashed}`}
+        valueAccent={slashed > 0 ? "bad" : undefined}
+        meta={
+          slashed > 0
+            ? `${slashed} event · stake recovery pending`
+            : "clean record"
+        }
+        metaTone={slashed > 0 ? "bad" : "ok"}
       />
     </div>
   );
 }
 
+function isWorking(state: AgentRecord["state"]): boolean {
+  // "Working now" for the strip means: holds an open claim or has work
+  // in some pre-verify lifecycle stage. `active` is the legacy umbrella
+  // for "has a verified history", which is *not* the same as "currently
+  // doing work" — we don't count those.
+  return state === "claimed" || state === "working" || state === "submitted";
+}
+
 interface AggCardProps {
+  scope: string;
   label: string;
   value: string;
   unit?: string;
@@ -61,9 +115,16 @@ interface AggCardProps {
   metaTone?: "muted" | "ok" | "warn" | "bad";
   rightSlot?: React.ReactNode;
   valueAccent?: "bad";
+  /**
+   * When provided, render a small sparkline next to the value. Pass
+   * `null` to *suppress* a trend slot on cards whose data doesn't have
+   * any meaningful variation — flat-zero sparks read as fake.
+   */
+  sparkline?: number[] | null;
 }
 
 function AggCard({
+  scope,
   label,
   value,
   unit,
@@ -72,31 +133,48 @@ function AggCard({
   metaTone = "muted",
   rightSlot,
   valueAccent,
+  sparkline,
 }: AggCardProps) {
+  const showSpark = Array.isArray(sparkline) && sparkline.length > 0;
   return (
     <article className="flex min-h-[96px] flex-col gap-1.5 rounded-[10px] border border-[var(--avy-line)] bg-[var(--avy-paper)] p-4 shadow-[var(--shadow-card)] backdrop-blur-[8px]">
-      <div className="flex items-baseline justify-between">
-        <span
-          className="font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase text-[var(--avy-muted)]"
-          style={{ letterSpacing: "0.12em" }}
-        >
-          {label}
-        </span>
-        {rightSlot}
+      <div className="flex items-baseline justify-between gap-2">
+        <div className="flex flex-col gap-px">
+          <span
+            className="font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase text-[var(--avy-muted)]"
+            style={{ letterSpacing: "0.12em" }}
+          >
+            {label}
+          </span>
+          <span
+            className="font-[family-name:var(--font-mono)] text-[9.5px] uppercase text-[var(--avy-muted)] opacity-80"
+            style={{ letterSpacing: "0.1em" }}
+          >
+            {scope}
+          </span>
+        </div>
+        {rightSlot ? <div className="shrink-0">{rightSlot}</div> : null}
       </div>
-      <span
-        className={cn(
-          "font-[family-name:var(--font-display)] font-bold text-[2rem] leading-none tabular-nums flex items-baseline gap-1.5",
-          mono && "!font-[family-name:var(--font-mono)]",
-          valueAccent === "bad" && "text-[#8a2a2a]",
-          !valueAccent && "text-[var(--avy-ink)]"
-        )}
-      >
-        {value}
-        {unit ? (
-          <span className="text-[13px] font-semibold text-[var(--avy-muted)]">{unit}</span>
+      <div className="flex items-end justify-between gap-2">
+        <span
+          className={cn(
+            "flex items-baseline gap-1.5 font-[family-name:var(--font-display)] font-bold text-[2rem] leading-none tabular-nums",
+            mono && "!font-[family-name:var(--font-mono)]",
+            valueAccent === "bad" && "text-[#8a2a2a]",
+            !valueAccent && "text-[var(--avy-ink)]"
+          )}
+        >
+          {value}
+          {unit ? (
+            <span className="text-[13px] font-semibold text-[var(--avy-muted)]">
+              {unit}
+            </span>
+          ) : null}
+        </span>
+        {showSpark ? (
+          <Sparkline points={sparkline as number[]} width={72} height={20} />
         ) : null}
-      </span>
+      </div>
       <span
         className={cn(
           "flex items-center gap-1.5 font-[family-name:var(--font-mono)] text-[11.5px]",

--- a/app/components/agents/types.ts
+++ b/app/components/agents/types.ts
@@ -1,5 +1,26 @@
 export type AgentTier = "T1" | "T2" | "T3";
-export type AgentState = "active" | "idle" | "slashed";
+/**
+ * Agent operational state, ordered by when it can occur in the work loop:
+ *   - `idle`: no current claim, no verified run yet, OR caught up
+ *   - `claimed`: holds a claim, hasn't started work
+ *   - `working`: claim is open and the agent is producing the artefact
+ *   - `submitted`: artefact submitted, verifier hasn't ruled yet
+ *   - `disputed`: a claim went into dispute
+ *   - `slashed`: a slash event landed against this wallet
+ *
+ * `active` is a legacy umbrella for "has at least one verified run" — kept
+ * so older fixture data still works, but new code should use the granular
+ * states above. `stateFromAgent` collapses the live signal into one of
+ * these per-render.
+ */
+export type AgentState =
+  | "idle"
+  | "claimed"
+  | "working"
+  | "submitted"
+  | "disputed"
+  | "active"
+  | "slashed";
 export type AgentSpecialty = "coding" | "writer-gov" | "ops" | "gov-review";
 export type BadgeSpecialtyColor = "code" | "write" | "ops" | "gov";
 
@@ -14,6 +35,34 @@ export interface AgentRecentRun {
   title: string;
   receipt: string;
   state: "Verified" | "Disputed" | "Pending";
+}
+
+/**
+ * Active claim/session info for the agent, when known. Populated from the
+ * backend's session payload (or from the agent payload if it ships an
+ * `activeSession` block); undefined when the agent isn't currently working.
+ *
+ * The drawer renders an "Active session" block above the historical
+ * sections when this is set, and the directory pill flips to the matching
+ * lifecycle state (claimed / working / submitted / disputed).
+ */
+export interface AgentActiveSession {
+  /** Run identifier for the session-level audit trail. */
+  runId: string;
+  /** The job the run was claimed against. */
+  jobId: string;
+  /** Session id (matches `/session?sessionId=<id>` on the API). */
+  sessionId: string;
+  /** Lifecycle status surfaced from the backend. */
+  status: "claimed" | "working" | "submitted" | "disputed";
+  /** Human title (so the drawer doesn't have to refetch the job). */
+  title?: string;
+  /** ISO timestamp. Used to compute the relative "claim deadline" copy. */
+  deadlineAt?: string;
+  /** ISO timestamp of the last event the operator should care about. */
+  lastEventAt?: string;
+  /** Optional human label for the last event ("PR submitted", …). */
+  lastEvent?: string;
 }
 
 export interface AgentSlash {
@@ -50,6 +99,20 @@ export interface AgentRecord {
    */
   activity: { msg: string; ref: string; when: string };
   state: AgentState;
+  /**
+   * Set when the agent currently holds a claim/session. The directory pill
+   * promotes the row out of "idle" and the drawer renders the dedicated
+   * Active session block above Recent runs.
+   */
+  activeSession?: AgentActiveSession;
+  /**
+   * True when this agent has not yet earned any verified-receipt badges —
+   * i.e. the badges list (when populated) holds **capability markers**
+   * granted on registration, not "earned" outputs of completed work. The
+   * drawer relabels its badge section accordingly so the operator doesn't
+   * confuse a starter capability with a verified receipt.
+   */
+  hasVerifiedBadges?: boolean;
   recentRuns: AgentRecentRun[];
   slashes: AgentSlash[];
 }

--- a/app/lib/api/agent-adapters.ts
+++ b/app/lib/api/agent-adapters.ts
@@ -1,6 +1,7 @@
 import {
   BADGES,
   tierFor,
+  type AgentActiveSession,
   type AgentRecord,
   type AgentSpecialty,
   type AgentState,
@@ -36,6 +37,8 @@ export function extractAgent(data: unknown): AgentRecord | null {
     ? number(stats?.completionRate, 0)
     : number(record.successRate, 0);
 
+  const activeSession = activeSessionFor(record);
+  const verifiedBadgeCount = badgesRaw.length;
   return {
     handle: text(record.handle, handleForWallet(walletFull)),
     wallet: shortAddress(walletFull),
@@ -47,8 +50,10 @@ export function extractAgent(data: unknown): AgentRecord | null {
     badgeDates: badgeDatesFor(badgesRaw, badgeIds),
     specialty,
     stake: stakeFor(record),
-    activity: activityFor(record, badgesRaw, totalJobs),
-    state: stateFor(record, totalJobs),
+    activity: activityFor(record, badgesRaw, totalJobs, activeSession),
+    state: stateFor(record, totalJobs, activeSession),
+    ...(activeSession ? { activeSession } : {}),
+    hasVerifiedBadges: verifiedBadgeCount > 0,
     recentRuns: recentRunsFor(badgesRaw),
     slashes: slashEvents(record.slashEvents),
   };
@@ -134,7 +139,29 @@ function stakeFor(record: RawRecord): AgentRecord["stake"] {
   };
 }
 
-function activityFor(record: RawRecord, badges: unknown[], totalJobs: number): AgentRecord["activity"] {
+function activityFor(
+  record: RawRecord,
+  badges: unknown[],
+  totalJobs: number,
+  activeSession: AgentActiveSession | undefined
+): AgentRecord["activity"] {
+  // Priority: live claim > most recent badge > fallback to the
+  // "no runs yet" empty-state copy.
+  if (activeSession) {
+    const verb =
+      activeSession.status === "claimed"
+        ? "Claimed"
+        : activeSession.status === "working"
+          ? "Working on"
+          : activeSession.status === "submitted"
+            ? "Submitted"
+            : "Disputed";
+    return {
+      msg: `${verb} ${activeSession.jobId}`,
+      ref: activeSession.jobId,
+      when: relativeTime(activeSession.lastEventAt ?? record.fetchedAt),
+    };
+  }
   const latest = badges[0] && typeof badges[0] === "object" ? (badges[0] as RawRecord) : null;
   const jobId = text(latest?.jobId, "");
   if (jobId) {
@@ -151,9 +178,51 @@ function activityFor(record: RawRecord, badges: unknown[], totalJobs: number): A
   };
 }
 
-function stateFor(record: RawRecord, totalJobs: number): AgentState {
+function stateFor(
+  record: RawRecord,
+  totalJobs: number,
+  activeSession: AgentActiveSession | undefined
+): AgentState {
   if (Array.isArray(record.slashEvents) && record.slashEvents.length) return "slashed";
+  if (activeSession) return activeSession.status;
   return totalJobs > 0 ? "active" : "idle";
+}
+
+function activeSessionFor(record: RawRecord): AgentActiveSession | undefined {
+  // The backend may attach an `activeSession` block directly on the agent
+  // payload, or split it across `currentSession` / `currentJob`. Tolerate
+  // either shape — if neither is present we just leave the agent in
+  // `idle`/`active` and the directory + drawer fall back to history.
+  const block =
+    objectField(record, "activeSession") ??
+    objectField(record, "currentSession") ??
+    null;
+  if (!block) return undefined;
+  const runId = text(block.runId, "");
+  const jobId = text(block.jobId, "");
+  const sessionId = text(block.sessionId, "");
+  if (!runId || !jobId || !sessionId) return undefined;
+  const status = activeStatus(block.status);
+  if (!status) return undefined;
+  return {
+    runId,
+    jobId,
+    sessionId,
+    status,
+    ...(text(block.title) ? { title: text(block.title) } : {}),
+    ...(text(block.deadlineAt) ? { deadlineAt: text(block.deadlineAt) } : {}),
+    ...(text(block.lastEventAt) ? { lastEventAt: text(block.lastEventAt) } : {}),
+    ...(text(block.lastEvent) ? { lastEvent: text(block.lastEvent) } : {}),
+  };
+}
+
+function activeStatus(value: unknown): AgentActiveSession["status"] | null {
+  const raw = text(value, "").toLowerCase();
+  if (raw === "claimed") return "claimed";
+  if (raw === "working" || raw === "in_progress") return "working";
+  if (raw === "submitted" || raw === "pending" || raw === "pending_verification") return "submitted";
+  if (raw === "disputed" || raw === "rejected") return "disputed";
+  return null;
 }
 
 function recentRunsFor(badges: unknown[]): AgentRecord["recentRuns"] {


### PR DESCRIPTION
## Summary
The /agents page was reputation/receipt-only. With the first real wallet now visible (\`agent-30bc-ee05\`, 0 score, 0 jobs) it gave contradictory readouts: \`Active 0/1\` next to \`Avg reputation 0 across 8 agents\` next to a fixture sparkline trending up at score 0. This PR aligns the page with the agent lifecycle and the actual visible roster.

### State model
\`AgentState\` now has \`idle | claimed | working | submitted | disputed | active | slashed\`. \`active\` stays as the legacy umbrella for "has verified history" so existing fixtures still render. New states drive the directory pill colour:
- idle → neutral
- claimed/working → green
- submitted → amber
- disputed/slashed → red

A new \`AgentActiveSession\` type carries \`{ runId, jobId, sessionId, status, deadlineAt?, lastEvent?, ... }\`. The adapter reads it off the agent payload (\`activeSession\` or \`currentSession\`) and tolerates status synonyms.

### Aggregate strip
Each card is explicitly scoped — \"visible roster\", \"platform · 24h\", \"visible roster · 30d\" — so two numbers can't be read against the same population. \"Working now / Roster N\" replaces \"Active 0/1\". \"Avg reputation\" counts the visible roster honestly. Trend sparks suppress when all values are 0.

### Drawer
- New **Active session** block above Reputation when the agent currently holds a claim. Renders job / run / session / status pill / deadline / last event.
- **Recent runs** has empty/active states: \"No verified runs yet\" or \"1 active run · submitted, awaiting verification\", with an accent-bordered banner above verified history when both exist.
- **Badges** section is \"Capabilities · N\" with a \"starter capability\" note when the agent has no verified-receipt badges yet, so a registration capability marker isn't misframed as earned work.
- **Public identity** card uses middle-truncated link text + Copy URL / Copy wallet buttons inside an \`overflow-hidden\` panel — no more horizontal scrollbar at the bottom of the drawer on long Polkadot wallets.

### Other fixes
- Directory sparkline suppressed at flat-zero (falls back to a thin bar so the row keeps a horizontal anchor).
- Drawer reputation sparkline gets the same suppression.
- Slash empty-state: \"clean history since first seen\" (not \"since claim-open\").

## Test plan
- [x] \`npm run typecheck:app\`
- [x] \`npm run build:frontend\`
- [ ] After deploy: open /agents on the live API. Confirm the strip reads \`Working now 0 / 1\` + \`Avg reputation 0 across 1 visible agent\` and the only row's pill stays \"Idle\". Once \`activeSession\` lands on the backend, the row pill flips to Claimed/Working/Submitted and the drawer renders the Active session block.