### PR TITLE
Expose active agent session state

### DIFF
--- a/docs/schemas/agent-profile-v1.json
+++ b/docs/schemas/agent-profile-v1.json
@@ -106,6 +106,39 @@
         "maximum": 255
       }
     },
+    "currentActivity": {
+      "type": ["object", "null"],
+      "description": "Most recent non-terminal claimed/submitted/disputed session for this wallet, if any. Lets operator UIs distinguish an active claimed run from an agent with no verified receipts yet.",
+      "additionalProperties": false,
+      "required": ["sessionId", "jobId", "status", "label", "phase", "outcome", "canSubmit", "awaitingVerification"],
+      "properties": {
+        "sessionId": { "type": "string" },
+        "jobId": { "type": "string" },
+        "status": {
+          "type": "string",
+          "enum": ["claimed", "submitted", "disputed"]
+        },
+        "label": { "type": "string" },
+        "phase": {
+          "type": "string",
+          "enum": ["work", "verification"]
+        },
+        "outcome": {
+          "type": "string",
+          "enum": ["in_progress", "awaiting_verification", "operator_attention"]
+        },
+        "claimedAt": { "type": "string", "format": "date-time" },
+        "submittedAt": { "type": "string", "format": "date-time" },
+        "updatedAt": { "type": "string", "format": "date-time" },
+        "deadlineAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Claim deadline derived from claimedAt + job claimTtlSeconds when available."
+        },
+        "canSubmit": { "type": "boolean" },
+        "awaitingVerification": { "type": "boolean" }
+      }
+    },
     "badges": {
       "type": "array",
       "description": "List of earned badges, ordered most-recent first. Each entry links back to the canonical per-badge document via `badgeUrl`.",

--- a/docs/schemas/agent-profile-v1.md
+++ b/docs/schemas/agent-profile-v1.md
@@ -47,6 +47,18 @@ badge list.
     "coding": 2,
     "governance": 1
   },
+  "currentActivity": {
+    "sessionId": "wiki-en-62871101-citation-repair-hash:0x1234567890123456789012345678901234567890",
+    "jobId": "wiki-en-62871101-citation-repair-hash",
+    "status": "claimed",
+    "label": "Claimed",
+    "phase": "work",
+    "outcome": "in_progress",
+    "claimedAt": "2026-05-01T12:18:03.973Z",
+    "deadlineAt": "2026-05-01T13:18:03.973Z",
+    "canSubmit": true,
+    "awaitingVerification": false
+  },
   "badges": [
     {
       "sessionId": "session-0x1234-starter-coding-001-1700000000000",
@@ -78,6 +90,10 @@ Same trust posture as the badge schema:
 4. **Missing vs zero**. `categoryLevels` is sparse — a category the agent
    hasn't touched is absent, not `0`. `badges` is an empty array when the
    agent has none.
+5. **Current activity is not a badge.** `currentActivity` is the latest
+   non-terminal session, such as a claimed job inside its work window or a
+   submitted job awaiting verification. Use it to render working/submitted
+   states even when `badges` is still empty.
 
 ---
 
@@ -94,6 +110,8 @@ Averray data):
 - Preferred categories SHOULD be ordered by count DESC.
 - `badgeUrl` SHOULD be omitted if you don't host the canonical badge docs.
   Don't invent a URL that won't resolve.
+- `currentActivity` SHOULD be omitted or null when the wallet has no
+  non-terminal sessions. Do not synthesize it from reputation or badge counts.
 
 ---
 
@@ -120,6 +138,9 @@ per-session verification records. That means:
   identical.
 - `categoryLevels` tracks the highest `level` across approved sessions
   (single-payout = 1, milestone = 2).
+- `currentActivity` is derived from the most recent non-terminal session and
+  can be present before the agent has any approved receipt. This is how UIs
+  distinguish "working now" from "no verified runs yet".
 
 When the agent-profile endpoint is rewritten on top of the Ponder
 indexer, these derivations switch to chain-event sources and become the

--- a/mcp-server/src/core/agent-profile.js
+++ b/mcp-server/src/core/agent-profile.js
@@ -1,4 +1,5 @@
 import { ValidationError } from "./errors.js";
+import { describeSessionStatus } from "./session-state-machine.js";
 
 /**
  * Build a v1 agent profile document from in-memory platform state.
@@ -97,6 +98,7 @@ export function buildAgentProfile({ wallet, reputation, sessions, getJobDefiniti
   }
 
   const githubSignals = aggregateGithubSignals(safeSessions);
+  const currentActivity = buildCurrentActivity(safeSessions, definitionOf);
 
   const preferredCategories = Array.from(categoryCounts.entries())
     .sort((a, b) => b[1] - a[1])
@@ -127,9 +129,38 @@ export function buildAgentProfile({ wallet, reputation, sessions, getJobDefiniti
       lastActive: lastActiveMs ? new Date(lastActiveMs).toISOString() : null,
       preferredCategories
     },
+    ...(currentActivity ? { currentActivity } : {}),
     categoryLevels,
     badges
   };
+}
+
+function buildCurrentActivity(sessions, definitionOf) {
+  const active = sessions
+    .filter((session) => {
+      const status = describeSessionStatus(session?.status);
+      return !status.terminal && status.status !== "__new__";
+    })
+    .sort((a, b) => timestampOf(b) - timestampOf(a))[0];
+  if (!active) return null;
+
+  const status = describeSessionStatus(active.status);
+  const job = definitionOf(active.jobId);
+  const deadlineAt = computeDeadlineAt(active, job);
+  return compact({
+    sessionId: active.sessionId,
+    jobId: active.jobId,
+    status: status.status,
+    label: status.label,
+    phase: status.phase,
+    outcome: status.outcome,
+    claimedAt: isoOrUndefined(active.claimedAt),
+    submittedAt: isoOrUndefined(active.submittedAt),
+    updatedAt: isoOrUndefined(active.updatedAt),
+    deadlineAt,
+    canSubmit: status.status === "claimed",
+    awaitingVerification: status.status === "submitted" || status.status === "disputed"
+  });
 }
 
 function aggregateGithubSignals(sessions) {
@@ -190,6 +221,19 @@ function maxTimestamp(sessions) {
   return max;
 }
 
+function computeDeadlineAt(session, job) {
+  const claimed = Date.parse(session?.claimedAt ?? "");
+  if (!Number.isFinite(claimed)) return undefined;
+  const ttl = Number(job?.claimTtlSeconds);
+  if (!Number.isFinite(ttl) || ttl <= 0) return undefined;
+  return new Date(claimed + ttl * 1000).toISOString();
+}
+
+function isoOrUndefined(value) {
+  const parsed = Date.parse(value ?? "");
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : undefined;
+}
+
 function toBaseUnits(amount, decimals) {
   if (amount === undefined || amount === null || amount === "") {
     return 0n;
@@ -212,4 +256,10 @@ function requireAddress(raw, label) {
   if (typeof raw !== "string" || !/^0x[a-fA-F0-9]{40}$/u.test(raw)) {
     throw new ValidationError(`${label} must be a 0x-prefixed 20-byte EVM address`);
   }
+}
+
+function compact(value) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined)
+  );
 }

--- a/mcp-server/src/core/agent-profile.test.js
+++ b/mcp-server/src/core/agent-profile.test.js
@@ -8,7 +8,7 @@ const WALLET = "0x1234567890123456789012345678901234567890";
 
 function jobCatalog() {
   return new Map([
-    ["starter-coding-001", { id: "starter-coding-001", category: "coding", rewardAsset: "DOT", rewardAmount: 5 }],
+    ["starter-coding-001", { id: "starter-coding-001", category: "coding", rewardAsset: "DOT", rewardAmount: 5, claimTtlSeconds: 3600 }],
     ["governance-pro-001", { id: "governance-pro-001", category: "governance", rewardAsset: "DOT", rewardAmount: 25, payoutMode: "milestone" }]
   ]);
 }
@@ -139,6 +139,7 @@ test("buildAgentProfile ignores sessions that are pending verification", () => {
       wallet: WALLET,
       jobId: "starter-coding-001",
       status: "submitted",
+      submittedAt: "2026-04-15T10:00:00Z",
       updatedAt: "2026-04-15T10:00:00Z",
       verification: undefined
     }
@@ -157,6 +158,54 @@ test("buildAgentProfile ignores sessions that are pending verification", () => {
   // latest session update including pending ones.
   assert.equal(profile.stats.activeSince, "2026-04-10T10:00:00.000Z");
   assert.equal(profile.stats.lastActive, "2026-04-15T10:00:00.000Z");
+  assert.deepEqual(profile.currentActivity, {
+    sessionId: "s-pending",
+    jobId: "starter-coding-001",
+    status: "submitted",
+    label: "Submitted",
+    phase: "verification",
+    outcome: "awaiting_verification",
+    submittedAt: "2026-04-15T10:00:00.000Z",
+    updatedAt: "2026-04-15T10:00:00.000Z",
+    canSubmit: false,
+    awaitingVerification: true
+  });
+});
+
+test("buildAgentProfile exposes the latest claimed session as current activity", () => {
+  const profile = buildAgentProfile({
+    wallet: WALLET,
+    reputation: { skill: 0, reliability: 0, economic: 0, tier: "starter" },
+    sessions: [
+      {
+        sessionId: "wiki-en-62871101-citation-repair-hash:0x1234567890123456789012345678901234567890",
+        wallet: WALLET,
+        jobId: "starter-coding-001",
+        status: "claimed",
+        claimedAt: "2026-05-01T12:18:03.973Z",
+        updatedAt: "2026-05-01T12:18:03.973Z",
+        verification: undefined
+      }
+    ],
+    getJobDefinition: makeGetJob()
+  });
+
+  assert.equal(profile.stats.totalBadges, 0);
+  assert.equal(profile.stats.completionRate, null);
+  assert.deepEqual(profile.badges, []);
+  assert.deepEqual(profile.currentActivity, {
+    sessionId: "wiki-en-62871101-citation-repair-hash:0x1234567890123456789012345678901234567890",
+    jobId: "starter-coding-001",
+    status: "claimed",
+    label: "Claimed",
+    phase: "work",
+    outcome: "in_progress",
+    claimedAt: "2026-05-01T12:18:03.973Z",
+    updatedAt: "2026-05-01T12:18:03.973Z",
+    deadlineAt: "2026-05-01T13:18:03.973Z",
+    canSubmit: true,
+    awaitingVerification: false
+  });
 });
 
 test("buildAgentProfile aggregates GitHub reputation signals", () => {

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -246,6 +246,7 @@ function buildAgentDirectoryRow(profile) {
       Number(reputation.economic ?? 0),
     successRate: profile.stats?.completionRate ?? null,
     totalJobs,
+    currentActivity: profile.currentActivity ?? null,
     activeStake: 0,
     badges: profile.badges ?? [],
     slashEvents: []

--- a/mcp-server/src/protocols/http/server.smoke.test.js
+++ b/mcp-server/src/protocols/http/server.smoke.test.js
@@ -502,6 +502,64 @@ test("http smoke: /agents/:wallet aggregates approved sessions into badges", { s
   });
 });
 
+test("http smoke: /agents exposes a claimed session as current activity", { skip: !RUN }, async () => {
+  await runWithServer(async (base) => {
+    const adminToken = issueToken(ADMIN_WALLET, { roles: ["admin"] });
+
+    const createJob = await fetch(`${base}/admin/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${adminToken}` },
+      body: JSON.stringify({
+        id: "profile-active-smoke-job-001",
+        category: "coding",
+        tier: "starter",
+        rewardAmount: 4,
+        claimTtlSeconds: 3600,
+        verifierMode: "benchmark",
+        verifierTerms: ["complete", "verified", "output"],
+        verifierMinimumMatches: 2,
+        outputSchemaRef: "schema://jobs/profile-active-smoke"
+      })
+    });
+    assert.equal(createJob.status, 201);
+
+    await fetch(`${base}/account/fund?asset=DOT&amount=10`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${adminToken}` }
+    });
+
+    const claim = await fetch(
+      `${base}/jobs/claim?jobId=profile-active-smoke-job-001&idempotencyKey=profile-active-smoke-claim`,
+      { method: "POST", headers: { authorization: `Bearer ${adminToken}` } }
+    );
+    assert.equal(claim.status, 200);
+    const { sessionId } = await claim.json();
+
+    const response = await fetch(`${base}/agents/${ADMIN_WALLET}`);
+    assert.equal(response.status, 200);
+    const profile = await response.json();
+    assert.equal(profile.stats.totalBadges, 0);
+    assert.equal(profile.stats.completionRate, null);
+    assert.deepEqual(profile.badges, []);
+    assert.equal(profile.currentActivity.sessionId, sessionId);
+    assert.equal(profile.currentActivity.jobId, "profile-active-smoke-job-001");
+    assert.equal(profile.currentActivity.status, "claimed");
+    assert.equal(profile.currentActivity.phase, "work");
+    assert.equal(profile.currentActivity.canSubmit, true);
+    assert.equal(profile.currentActivity.awaitingVerification, false);
+    assert.match(profile.currentActivity.deadlineAt, /^\d{4}-\d{2}-\d{2}T/u);
+
+    const listResponse = await fetch(`${base}/agents`);
+    assert.equal(listResponse.status, 200);
+    const agents = await listResponse.json();
+    const row = agents.find((agent) => agent.wallet === ADMIN_WALLET.toLowerCase());
+    assert.ok(row);
+    assert.equal(row.totalJobs, 0);
+    assert.equal(row.currentActivity.sessionId, sessionId);
+    assert.equal(row.currentActivity.status, "claimed");
+  });
+});
+
 test("http smoke: /disputes exposes human-review sessions and records verdict/release receipts", { skip: !RUN }, async () => {
   await runWithServer(async (base) => {
     const adminToken = issueToken(ADMIN_WALLET, { roles: ["admin"] });


### PR DESCRIPTION
## What changed
- Added optional `currentActivity` to the agent profile schema and docs.
- Derived `currentActivity` from the latest non-terminal claimed/submitted/disputed session.
- Included the same field in `GET /agents` directory rows so the operator UI can render working/submitted states before an agent earns any badges.
- Added unit and HTTP smoke coverage for a newly claimed agent with zero badges.

## Checks run
- `node --test mcp-server/src/core/agent-profile.test.js mcp-server/src/core/session-state-machine.test.js`
- `npm --workspace mcp-server test`
- `RUN_HTTP_SMOKE=1 node --test mcp-server/src/protocols/http/server.smoke.test.js` (requires local port bind outside sandbox)
- `git diff --check`

## Impact
- Backend: yes, public `/agents` and `/agents/:wallet` response shape gains optional `currentActivity`.
- Frontend/indexer/Caddy/contracts/public site: no direct changes.
- Generated `frontend/` and `site/` output: untouched.

## Env / VPS
- No environment or VPS secret changes required.

## Polkadot MCP check
- Checked Polkadot Hub account docs via MCP: EVM-style 20-byte wallet addresses are valid public smart-contract-layer identities and map into native accounts behind the scenes, so this API keeps the wallet identity as the 0x address and only exposes Averray session state.