### PR TITLE
Harden production deploy smoke routing

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -55,6 +55,24 @@ jobs:
           )
 
           ssh -p "${VPS_PORT:-22}" "$VPS_USER@$VPS_HOST" \
-            "set -e && \
-             cd /srv/agent-stack/app && \
-             ${remote_env} ./scripts/ops/deploy-production.sh"
+            "${remote_env} bash -s" <<'REMOTE'
+          set -e
+          cd /srv/agent-stack/app
+
+          old_sha=$(git rev-parse HEAD)
+          git fetch origin main
+          git checkout main
+          if ! git pull --ff-only origin main; then
+            if [ -z "$(git status --porcelain)" ]; then
+              echo "Pull failed without local changes to stash." >&2
+              exit 1
+            fi
+            stamp=$(date -u +"%Y%m%dT%H%M%SZ")
+            echo "Fast-forward pull failed with local changes; stashing and retrying ($stamp)."
+            git stash push -u -m "auto-stash before production deploy $stamp" >/dev/null
+            git pull --ff-only origin main
+          fi
+          new_sha=$(git rev-parse HEAD)
+
+          DEPLOY_OLD_SHA="$old_sha" DEPLOY_NEW_SHA="$new_sha" ./scripts/ops/deploy-production.sh
+          REMOTE

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -61,6 +61,10 @@ Run:
 
 # Optional: include the async XCM operator lane in the smoke check
 ADMIN_JWT='<admin-jwt>' ./scripts/ops/check-hosted-stack.sh
+
+# Component-scoped deploys can skip indexer checks when the indexer was not
+# touched, while scheduled/full-stack smoke should keep the default.
+CHECK_INDEXER=0 ./scripts/ops/check-hosted-stack.sh
 ```
 
 ---
@@ -80,7 +84,13 @@ What it does:
 3. Rebuilds the public Astro landing page and syncs it into `site/`.
 4. Typechecks the indexer workspace.
 5. Verifies the deployed contracts against the manifest for the selected profile.
-6. Runs the hosted-stack smoke check.
+6. Runs the hosted-stack smoke check. The deploy entrypoint keeps indexer
+   checks for indexer/Caddy changes and full smoke-only runs, but skips them
+   for unrelated component deploys so an existing indexer outage does not
+   falsely mark a backend or frontend deploy as failed.
+7. Preserves previously generated frontend/site output across unrelated
+   component deploys. Server-local changes are only stashed if the
+   fast-forward pull actually cannot proceed with them present.
 
 Useful overrides:
 

--- a/scripts/ops/check-hosted-stack.sh
+++ b/scripts/ops/check-hosted-stack.sh
@@ -14,6 +14,7 @@ INDEXER_STATUS_URL=${INDEXER_STATUS_URL:-https://index.averray.com/status}
 INDEXER_MAX_STALENESS_SEC=${INDEXER_MAX_STALENESS_SEC:-1800}
 INDEXER_RETRY_ATTEMPTS=${INDEXER_RETRY_ATTEMPTS:-12}
 INDEXER_RETRY_SLEEP_SEC=${INDEXER_RETRY_SLEEP_SEC:-5}
+CHECK_INDEXER=${CHECK_INDEXER:-1}
 TIMEOUT_SEC=${TIMEOUT_SEC:-20}
 APP_BASIC_AUTH_USER=${APP_BASIC_AUTH_USER:-}
 APP_BASIC_AUTH_PASSWORD=${APP_BASIC_AUTH_PASSWORD:-}
@@ -70,6 +71,13 @@ fetch_indexer_with_retries() {
   return 1
 }
 
+enabled() {
+  case "${1:-}" in
+    1|true|yes) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 echo "Checking public site"
 public_html="$(fetch "$PUBLIC_SITE_URL")"
 grep -q "<title>Averray" <<<"$public_html" || {
@@ -99,23 +107,27 @@ onboarding_json="$(fetch "$API_ONBOARDING_URL")"
 jq -e '.name | length > 0' >/dev/null <<<"$onboarding_json"
 jq -e '.protocols | index("http") != null' >/dev/null <<<"$onboarding_json"
 
-echo "Checking indexer root"
-indexer_json="$(fetch_indexer_with_retries "Indexer root" "$INDEXER_URL")"
-jq -e '.status == "ok"' >/dev/null <<<"$indexer_json"
+if enabled "$CHECK_INDEXER"; then
+  echo "Checking indexer root"
+  indexer_json="$(fetch_indexer_with_retries "Indexer root" "$INDEXER_URL")"
+  jq -e '.status == "ok"' >/dev/null <<<"$indexer_json"
 
-echo "Checking indexer readiness"
-fetch_indexer_with_retries "Indexer readiness" "$INDEXER_READY_URL" >/dev/null
+  echo "Checking indexer readiness"
+  fetch_indexer_with_retries "Indexer readiness" "$INDEXER_READY_URL" >/dev/null
 
-echo "Checking indexer status freshness"
-indexer_status_json="$(fetch_indexer_with_retries "Indexer status" "$INDEXER_STATUS_URL")"
-jq -e 'type == "object" and (keys | length) > 0' >/dev/null <<<"$indexer_status_json"
-jq -e 'to_entries[0].value.block.number > 0' >/dev/null <<<"$indexer_status_json"
-jq -e --argjson maxAge "$INDEXER_MAX_STALENESS_SEC" '
-  to_entries
-  | map(.value.block.timestamp)
-  | max as $latest
-  | (now - $latest) <= $maxAge
-' >/dev/null <<<"$indexer_status_json"
+  echo "Checking indexer status freshness"
+  indexer_status_json="$(fetch_indexer_with_retries "Indexer status" "$INDEXER_STATUS_URL")"
+  jq -e 'type == "object" and (keys | length) > 0' >/dev/null <<<"$indexer_status_json"
+  jq -e 'to_entries[0].value.block.number > 0' >/dev/null <<<"$indexer_status_json"
+  jq -e --argjson maxAge "$INDEXER_MAX_STALENESS_SEC" '
+    to_entries
+    | map(.value.block.timestamp)
+    | max as $latest
+    | (now - $latest) <= $maxAge
+  ' >/dev/null <<<"$indexer_status_json"
+else
+  echo "CHECK_INDEXER=$CHECK_INDEXER set; skipping indexer checks."
+fi
 
 if [[ -n "$ADMIN_JWT" ]]; then
   echo "Checking admin async XCM status"

--- a/scripts/ops/deploy-production.sh
+++ b/scripts/ops/deploy-production.sh
@@ -17,6 +17,8 @@ COMPOSE_FILE=${COMPOSE_FILE:-"$STACK_ROOT/docker-compose.yml"}
 BRANCH=${BRANCH:-main}
 DEPLOY_LOCK_FILE=${DEPLOY_LOCK_FILE:-/tmp/averray-production-deploy.lock}
 DEPLOY_AUTOSTASH=${DEPLOY_AUTOSTASH:-1}
+DEPLOY_OLD_SHA=${DEPLOY_OLD_SHA:-}
+DEPLOY_NEW_SHA=${DEPLOY_NEW_SHA:-}
 
 RUN_BACKEND=${RUN_BACKEND:-auto}
 RUN_FRONTEND=${RUN_FRONTEND:-auto}
@@ -24,6 +26,7 @@ RUN_INDEXER=${RUN_INDEXER:-auto}
 RUN_SITE=${RUN_SITE:-auto}
 RUN_CADDY=${RUN_CADDY:-auto}
 RUN_SMOKE=${RUN_SMOKE:-1}
+SMOKE_CHECK_INDEXER=${SMOKE_CHECK_INDEXER:-auto}
 
 SITE_BUILD_RUNNER=${SITE_BUILD_RUNNER:-auto}
 SITE_NODE_IMAGE=${SITE_NODE_IMAGE:-node:22-bookworm-slim}
@@ -58,21 +61,6 @@ with_lock() {
   deploy
 }
 
-autostash_if_needed() {
-  if [[ "$DEPLOY_AUTOSTASH" != "1" ]]; then
-    return 0
-  fi
-
-  if [[ -z "$(git -C "$APP_ROOT" status --porcelain)" ]]; then
-    return 0
-  fi
-
-  local stamp
-  stamp=$(date -u +"%Y%m%dT%H%M%SZ")
-  echo "Stashing local server changes before pulling ($stamp)."
-  git -C "$APP_ROOT" stash push -u -m "auto-stash before production deploy $stamp" >/dev/null
-}
-
 changed_matches() {
   local pattern="$1"
   if [[ "$OLD_SHA" == "$NEW_SHA" ]]; then
@@ -93,6 +81,28 @@ should_run() {
       exit 1
       ;;
   esac
+}
+
+pull_latest() {
+  if git -C "$APP_ROOT" pull --ff-only origin "$BRANCH"; then
+    return 0
+  fi
+
+  if [[ "$DEPLOY_AUTOSTASH" != "1" ]]; then
+    echo "Pull failed and DEPLOY_AUTOSTASH is disabled." >&2
+    exit 1
+  fi
+
+  if [[ -z "$(git -C "$APP_ROOT" status --porcelain)" ]]; then
+    echo "Pull failed without local changes to stash." >&2
+    exit 1
+  fi
+
+  local stamp
+  stamp=$(date -u +"%Y%m%dT%H%M%SZ")
+  echo "Fast-forward pull failed with local changes; stashing and retrying ($stamp)."
+  git -C "$APP_ROOT" stash push -u -m "auto-stash before production deploy $stamp" >/dev/null
+  git -C "$APP_ROOT" pull --ff-only origin "$BRANCH"
 }
 
 resolve_site_runner() {
@@ -151,19 +161,39 @@ apply_caddy() {
 deploy() {
   echo "Production deploy lock acquired: $DEPLOY_LOCK_FILE"
   echo "Updating repo in $APP_ROOT"
-  OLD_SHA=$(git -C "$APP_ROOT" rev-parse HEAD)
-  git -C "$APP_ROOT" fetch origin "$BRANCH"
-  git -C "$APP_ROOT" checkout "$BRANCH"
-  autostash_if_needed
-  git -C "$APP_ROOT" pull --ff-only origin "$BRANCH"
-  NEW_SHA=$(git -C "$APP_ROOT" rev-parse HEAD)
+  if [[ -n "$DEPLOY_OLD_SHA" || -n "$DEPLOY_NEW_SHA" ]]; then
+    if [[ -z "$DEPLOY_OLD_SHA" || -z "$DEPLOY_NEW_SHA" ]]; then
+      echo "DEPLOY_OLD_SHA and DEPLOY_NEW_SHA must be set together." >&2
+      exit 1
+    fi
+    OLD_SHA="$DEPLOY_OLD_SHA"
+    NEW_SHA=$(git -C "$APP_ROOT" rev-parse HEAD)
+    if [[ "$NEW_SHA" != "$DEPLOY_NEW_SHA" ]]; then
+      echo "Checkout SHA $NEW_SHA does not match DEPLOY_NEW_SHA $DEPLOY_NEW_SHA." >&2
+      exit 1
+    fi
+    echo "Using pre-updated checkout from workflow wrapper."
+  else
+    OLD_SHA=$(git -C "$APP_ROOT" rev-parse HEAD)
+    git -C "$APP_ROOT" fetch origin "$BRANCH"
+    git -C "$APP_ROOT" checkout "$BRANCH"
+    pull_latest
+    NEW_SHA=$(git -C "$APP_ROOT" rev-parse HEAD)
+  fi
   echo "Deploy range: $OLD_SHA -> $NEW_SHA"
 
   if [[ "$OLD_SHA" == "$NEW_SHA" ]]; then
     echo "No new commits. Running smoke check only."
   fi
 
+  local run_backend=0
+  local run_indexer=0
+  local run_frontend=0
+  local run_site=0
+  local run_caddy=0
+
   if should_run "$RUN_BACKEND" '^(mcp-server/|sdk/|examples/|docs/schemas/|package(-lock)?\.json|scripts/ops/redeploy-backend\.sh)'; then
+    run_backend=1
     echo "Deploying backend"
     SKIP_GIT_UPDATE=1 "$APP_ROOT/scripts/ops/redeploy-backend.sh"
   else
@@ -171,13 +201,15 @@ deploy() {
   fi
 
   if should_run "$RUN_INDEXER" '^(indexer/|package(-lock)?\.json|scripts/ops/redeploy-indexer\.sh)'; then
+    run_indexer=1
     echo "Deploying indexer"
     SKIP_GIT_UPDATE=1 "$APP_ROOT/scripts/ops/redeploy-indexer.sh"
   else
     echo "Skipping indexer deploy"
   fi
 
-  if should_run "$RUN_FRONTEND" '^(app/|frontend/|scripts/sync-operator-frontend\.mjs|scripts/ops/redeploy-frontend\.sh|package(-lock)?\.json)'; then
+  if should_run "$RUN_FRONTEND" '^(app/|frontend/|scripts/sync-operator-frontend\.mjs|scripts/ops/redeploy-frontend\.sh|scripts/ops/deploy-production\.sh|package(-lock)?\.json)'; then
+    run_frontend=1
     echo "Deploying operator frontend"
     SKIP_GIT_UPDATE=1 "$APP_ROOT/scripts/ops/redeploy-frontend.sh"
   else
@@ -185,6 +217,7 @@ deploy() {
   fi
 
   if should_run "$RUN_SITE" '^(marketing/|site/|scripts/sync-marketing-site\.mjs|package(-lock)?\.json)'; then
+    run_site=1
     echo "Building public site"
     build_site
   else
@@ -192,6 +225,7 @@ deploy() {
   fi
 
   if should_run "$RUN_CADDY" '^(deploy/Caddyfile\.averray|scripts/ops/render-caddyfile\.sh)'; then
+    run_caddy=1
     echo "Applying Caddy config"
     apply_caddy
   else
@@ -204,12 +238,37 @@ deploy() {
 
   if [[ "$RUN_SMOKE" == "1" ]]; then
     echo "Running hosted stack smoke check"
-    "$APP_ROOT/scripts/ops/check-hosted-stack.sh"
+    local check_indexer
+    check_indexer=$(resolve_smoke_check_indexer "$run_indexer" "$run_caddy")
+    if [[ "$check_indexer" != "1" ]]; then
+      echo "Skipping indexer smoke checks because this deploy did not change indexer or Caddy."
+    fi
+    CHECK_INDEXER="$check_indexer" "$APP_ROOT/scripts/ops/check-hosted-stack.sh"
   else
     echo "RUN_SMOKE=0 set; skipping hosted smoke check."
   fi
 
   echo "Production deploy completed."
+}
+
+resolve_smoke_check_indexer() {
+  local ran_indexer="$1"
+  local ran_caddy="$2"
+  case "$SMOKE_CHECK_INDEXER" in
+    1|true|yes) echo 1 ;;
+    0|false|no) echo 0 ;;
+    auto)
+      if [[ "$OLD_SHA" == "$NEW_SHA" || "$ran_indexer" == "1" || "$ran_caddy" == "1" ]]; then
+        echo 1
+      else
+        echo 0
+      fi
+      ;;
+    *)
+      echo "Invalid SMOKE_CHECK_INDEXER toggle: $SMOKE_CHECK_INDEXER" >&2
+      exit 1
+      ;;
+  esac
 }
 
 exec 9>"$DEPLOY_LOCK_FILE"


### PR DESCRIPTION
## Summary
- make hosted smoke checks component-scoped so backend/frontend deploys do not fail solely because the indexer is already unhealthy
- preserve generated frontend/site output during unrelated deploys by only stashing server-local changes when a fast-forward pull actually needs it
- update the workflow wrapper to run the freshly pulled deploy script with the old/new SHA range, so this deploy fix applies to itself and can rebuild the operator frontend

## Checks
- bash -n scripts/ops/check-hosted-stack.sh scripts/ops/deploy-production.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-production.yml"); puts "yaml ok"'
- git diff --check
- CHECK_INDEXER=0 APP_URL=https://averray.com/ APP_EXPECTED_MARKER=Averray ./scripts/ops/check-hosted-stack.sh

## Impact
- Deployment/workflow/docs only
- No backend, indexer, contract, or runtime app code changes
- No environment or VPS secret changes

Polkadot docs cross-check: indexer docs describe indexers as specialized query infrastructure, so separating indexer smoke from unrelated component deploy gates is consistent with that boundary.