### PR TITLE
Add indexer deploy failure diagnostics

### DIFF
--- a/VPS_RUNBOOK.md
+++ b/VPS_RUNBOOK.md
@@ -325,6 +325,8 @@ The script:
 4. Polls `https://index.averray.com/health` until the process is listening.
 5. Polls `https://index.averray.com/ready` until historical indexing is complete.
 6. Automatically rolls back to the previous SHA if either gate fails.
+7. Prints `docker compose ps indexer` plus recent indexer and Caddy logs before
+   rollback when a gate fails.
 
 Useful overrides:
 
@@ -334,6 +336,9 @@ WAIT_FOR_READY=0 ./scripts/ops/redeploy-indexer.sh
 
 # Give a heavy backfill more time before rollback.
 READY_TIMEOUT_SEC=3600 ./scripts/ops/redeploy-indexer.sh
+
+# Include more log context in a failed deploy report.
+INDEXER_LOG_TAIL=300 ./scripts/ops/redeploy-indexer.sh
 ```
 
 ### Remote hosted-stack smoke test

--- a/scripts/ops/redeploy-indexer.sh
+++ b/scripts/ops/redeploy-indexer.sh
@@ -20,6 +20,7 @@
 #   HEALTH_TIMEOUT_SEC    max seconds to wait for /health (default: 120)
 #   READY_TIMEOUT_SEC     max seconds to wait for /ready (default: 900)
 #   POLL_INTERVAL_SEC     seconds between polls (default: 5)
+#   INDEXER_LOG_TAIL      lines of indexer/Caddy logs to print on failure (default: 120)
 #   WAIT_FOR_READY=0      skip the /ready gate (useful during long backfills)
 #   SKIP_GIT_UPDATE=1     skip fetch/checkout/pull because caller already pinned the repo
 #   SKIP_ROLLBACK=1       disable auto-rollback
@@ -35,6 +36,7 @@ READY_URL=${READY_URL:-https://index.averray.com/ready}
 HEALTH_TIMEOUT_SEC=${HEALTH_TIMEOUT_SEC:-120}
 READY_TIMEOUT_SEC=${READY_TIMEOUT_SEC:-900}
 POLL_INTERVAL_SEC=${POLL_INTERVAL_SEC:-5}
+INDEXER_LOG_TAIL=${INDEXER_LOG_TAIL:-120}
 WAIT_FOR_READY=${WAIT_FOR_READY:-1}
 SKIP_GIT_UPDATE=${SKIP_GIT_UPDATE:-0}
 
@@ -63,6 +65,26 @@ compose_up() {
     --project-directory "$STACK_ROOT" \
     -f "$COMPOSE_FILE" \
     up -d --build indexer
+}
+
+dump_indexer_diagnostics() {
+  echo "Indexer diagnostics: docker compose ps indexer"
+  docker compose \
+    --project-directory "$STACK_ROOT" \
+    -f "$COMPOSE_FILE" \
+    ps indexer || true
+
+  echo "Indexer diagnostics: last ${INDEXER_LOG_TAIL} indexer log lines"
+  docker compose \
+    --project-directory "$STACK_ROOT" \
+    -f "$COMPOSE_FILE" \
+    logs --tail="$INDEXER_LOG_TAIL" indexer || true
+
+  echo "Indexer diagnostics: last ${INDEXER_LOG_TAIL} Caddy log lines"
+  docker compose \
+    --project-directory "$STACK_ROOT" \
+    -f "$COMPOSE_FILE" \
+    logs --tail="$INDEXER_LOG_TAIL" caddy || true
 }
 
 wait_for_ok() {
@@ -120,12 +142,14 @@ compose_up
 
 echo "Waiting for indexer health at $HEALTH_URL (timeout ${HEALTH_TIMEOUT_SEC}s)"
 if ! wait_for_ok "$HEALTH_URL" "$HEALTH_TIMEOUT_SEC" "Health check"; then
+  dump_indexer_diagnostics
   rollback
 fi
 
 if [[ "$WAIT_FOR_READY" == "1" ]]; then
   echo "Waiting for indexer readiness at $READY_URL (timeout ${READY_TIMEOUT_SEC}s)"
   if ! wait_for_ok "$READY_URL" "$READY_TIMEOUT_SEC" "Readiness check"; then
+    dump_indexer_diagnostics
     rollback
   fi
 else


### PR DESCRIPTION
## Summary
- print indexer container status and recent indexer/Caddy logs when indexer health or readiness gates fail
- document INDEXER_LOG_TAIL for larger deploy-failure reports

## Checks
- bash -n scripts/ops/redeploy-indexer.sh
- git diff --check

## Impact
- Deployment/runbook only
- Touches scripts/ops/redeploy-indexer.sh, so the production deploy router will rebuild the indexer after this lands
- No env or secret changes

Polkadot docs cross-check: indexers are specialized query infrastructure with their own process/API health, so surfacing indexer-specific container and proxy logs at the indexer deploy gate is the right boundary.