### PR TITLE
Support old escrow job tuples in indexer

### DIFF
--- a/indexer/abis/contractsAbi.ts
+++ b/indexer/abis/contractsAbi.ts
@@ -23,6 +23,10 @@ export const EscrowCoreLegacyJobsAbi = parseAbi([
   "function jobs(bytes32 jobId) view returns ((address poster, address worker, address asset, bytes32 verifierMode, bytes32 category, bytes32 specHash, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 released, uint256 claimExpiry, uint256 claimStake, uint16 claimStakeBps, uint256 rejectedAt, uint256 disputedAt, uint8 payoutMode, uint8 state))"
 ]);
 
+export const EscrowCoreOldLegacyJobsAbi = parseAbi([
+  "function jobs(bytes32 jobId) view returns ((address poster, address worker, address asset, bytes32 verifierMode, bytes32 category, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 released, uint256 claimExpiry, uint256 claimStake, uint16 claimStakeBps, uint8 payoutMode, uint8 state))"
+]);
+
 export const ReputationSbtAbi = parseAbi([
   "event BadgeMinted(uint256 indexed tokenId, address indexed account, bytes32 indexed category, uint256 level, string metadataURI)",
   "event ReputationUpdated(address indexed account, uint256 skill, uint256 reliability, uint256 economic)",

--- a/indexer/src/index.ts
+++ b/indexer/src/index.ts
@@ -3,7 +3,7 @@ import { hexToString } from "viem";
 import { ponder } from "ponder:registry";
 import schema from "ponder:schema";
 
-import { EscrowCoreAbi, EscrowCoreLegacyJobsAbi } from "../abis/contractsAbi";
+import { EscrowCoreAbi, EscrowCoreLegacyJobsAbi, EscrowCoreOldLegacyJobsAbi } from "../abis/contractsAbi";
 
 const payoutModeLabels = ["single", "milestone"] as const;
 const jobStateLabels = ["none", "open", "claimed", "submitted", "rejected", "disputed", "closed"] as const;
@@ -144,7 +144,21 @@ const readLiveJob = async ({
       functionName: "jobs",
       args: [jobId]
     });
-  } catch (error) {
+  } catch {
+    return readLegacyJob({ context, event, jobId });
+  }
+};
+
+const readLegacyJob = async ({
+  context,
+  event,
+  jobId
+}: {
+  context: any;
+  event: any;
+  jobId: `0x${string}`;
+}) => {
+  try {
     const legacy = await context.client.readContract({
       abi: EscrowCoreLegacyJobsAbi,
       address: event.log.address,
@@ -190,6 +204,52 @@ const readLiveJob = async ({
       "0x0000000000000000000000000000000000000000",
       rejectedAt,
       disputedAt,
+      payoutMode,
+      state
+    ] as const;
+  } catch {
+    const oldLegacy = await context.client.readContract({
+      abi: EscrowCoreOldLegacyJobsAbi,
+      address: event.log.address,
+      functionName: "jobs",
+      args: [jobId]
+    });
+    const [
+      poster,
+      worker,
+      asset,
+      verifierMode,
+      category,
+      reward,
+      opsReserve,
+      contingencyReserve,
+      released,
+      claimExpiry,
+      claimStake,
+      claimStakeBps,
+      payoutMode,
+      state
+    ] = oldLegacy;
+    return [
+      poster,
+      worker,
+      asset,
+      verifierMode,
+      category,
+      zeroHash,
+      reward,
+      opsReserve,
+      contingencyReserve,
+      released,
+      claimExpiry,
+      claimStake,
+      claimStakeBps,
+      0n,
+      0,
+      false,
+      "0x0000000000000000000000000000000000000000",
+      0n,
+      0n,
       payoutMode,
       state
     ] as const;


### PR DESCRIPTION
## Summary
- add the older 14-field EscrowCore jobs(tuple) ABI used by the deployed contract
- make indexer job replay fall back current -> mid-legacy -> old-legacy instead of crash-looping on historical JobFunded events
- fill fields missing from the old tuple with zero/default values so the indexed schema remains stable

## Checks
- npm --workspace indexer run typecheck
- npm run test:indexer:api
- git diff --check

## Impact
- Indexer runtime only
- No backend, frontend, Caddy, contract, or secret changes

Polkadot docs cross-check: Polkadot Hub smart contracts expose Ethereum-style ABI/RPC behavior, so handling deployed Solidity ABI history at the indexer boundary is the correct fix.