### PR TITLE
Add indexer schema rotation deploy input

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -6,6 +6,37 @@ on:
     branches: [main]
     types: [completed]
   workflow_dispatch:
+    inputs:
+      run_indexer:
+        description: Force indexer deploy for operational recovery.
+        required: false
+        default: auto
+        type: choice
+        options:
+          - auto
+          - "1"
+          - "0"
+      wait_for_ready:
+        description: Wait for indexer historical readiness after health passes.
+        required: false
+        default: "1"
+        type: choice
+        options:
+          - "1"
+          - "0"
+      smoke_check_indexer:
+        description: Include indexer in hosted smoke checks.
+        required: false
+        default: auto
+        type: choice
+        options:
+          - auto
+          - "1"
+          - "0"
+      indexer_database_schema:
+        description: Optional fresh Ponder DATABASE_SCHEMA for indexer recovery.
+        required: false
+        type: string
 
 concurrency:
   group: production
@@ -26,6 +57,10 @@ jobs:
       APP_BASIC_AUTH_PASSWORD: ${{ secrets.APP_BASIC_AUTH_PASSWORD }}
       APP_BASIC_AUTH_PASSWORD_HASH: ${{ secrets.APP_BASIC_AUTH_PASSWORD_HASH }}
       ADMIN_JWT: ${{ secrets.ADMIN_JWT }}
+      DEPLOY_RUN_INDEXER: ${{ github.event_name == 'workflow_dispatch' && inputs.run_indexer || 'auto' }}
+      DEPLOY_WAIT_FOR_READY: ${{ github.event_name == 'workflow_dispatch' && inputs.wait_for_ready || '1' }}
+      DEPLOY_SMOKE_CHECK_INDEXER: ${{ github.event_name == 'workflow_dispatch' && inputs.smoke_check_indexer || 'auto' }}
+      DEPLOY_INDEXER_DATABASE_SCHEMA: ${{ github.event_name == 'workflow_dispatch' && inputs.indexer_database_schema || '' }}
     steps:
       - name: Validate required secrets
         run: |
@@ -47,11 +82,15 @@ jobs:
       - name: Deploy production
         run: |
           remote_env=$(
-            printf 'APP_BASIC_AUTH_USER=%q APP_BASIC_AUTH_PASSWORD=%q APP_BASIC_AUTH_PASSWORD_HASH=%q ADMIN_JWT=%q ' \
+            printf 'APP_BASIC_AUTH_USER=%q APP_BASIC_AUTH_PASSWORD=%q APP_BASIC_AUTH_PASSWORD_HASH=%q ADMIN_JWT=%q RUN_INDEXER=%q WAIT_FOR_READY=%q SMOKE_CHECK_INDEXER=%q INDEXER_DATABASE_SCHEMA=%q ' \
               "$APP_BASIC_AUTH_USER" \
               "$APP_BASIC_AUTH_PASSWORD" \
               "$APP_BASIC_AUTH_PASSWORD_HASH" \
-              "$ADMIN_JWT"
+              "$ADMIN_JWT" \
+              "$DEPLOY_RUN_INDEXER" \
+              "$DEPLOY_WAIT_FOR_READY" \
+              "$DEPLOY_SMOKE_CHECK_INDEXER" \
+              "$DEPLOY_INDEXER_DATABASE_SCHEMA"
           )
 
           ssh -p "${VPS_PORT:-22}" "$VPS_USER@$VPS_HOST" \

--- a/VPS_RUNBOOK.md
+++ b/VPS_RUNBOOK.md
@@ -613,6 +613,19 @@ Do not commit server secrets back into the repository.
    - RPC reachable (`DWELLER_RPC_URL`, `POLKADOT_RPC_URL`, or `PONDER_RPC_URL_<chainId>`)
    - `DATABASE_URL` and `DATABASE_SCHEMA` correct
 
+If logs contain `Schema "..." was previously used by a different Ponder app`,
+rotate to a fresh Ponder schema instead of dropping the old one:
+
+1. Use a lowercase PostgreSQL-safe schema name, for example
+   `agent_indexer_20260501153000`.
+2. Dispatch the `Deploy Production` workflow with:
+   - `indexer_database_schema=<new schema>`
+   - `run_indexer=1`
+   - `wait_for_ready=0` if a long historical backfill is expected
+   - `smoke_check_indexer=0` only while the fresh schema is backfilling
+3. After `/ready` is healthy, re-run the hosted smoke check with indexer checks
+   enabled.
+
 ### TLS / domain issues
 
 1. Check DNS records in Cloudflare

--- a/scripts/ops/deploy-production.sh
+++ b/scripts/ops/deploy-production.sh
@@ -27,6 +27,8 @@ RUN_SITE=${RUN_SITE:-auto}
 RUN_CADDY=${RUN_CADDY:-auto}
 RUN_SMOKE=${RUN_SMOKE:-1}
 SMOKE_CHECK_INDEXER=${SMOKE_CHECK_INDEXER:-auto}
+INDEXER_DATABASE_SCHEMA=${INDEXER_DATABASE_SCHEMA:-}
+INDEXER_ENV_FILE=${INDEXER_ENV_FILE:-"$STACK_ROOT/indexer.env"}
 
 SITE_BUILD_RUNNER=${SITE_BUILD_RUNNER:-auto}
 SITE_NODE_IMAGE=${SITE_NODE_IMAGE:-node:22-bookworm-slim}
@@ -158,6 +160,33 @@ apply_caddy() {
     restart caddy
 }
 
+apply_indexer_database_schema() {
+  local schema="$INDEXER_DATABASE_SCHEMA"
+  if [[ -z "$schema" ]]; then
+    return 0
+  fi
+
+  if [[ ${#schema} -gt 63 || ! "$schema" =~ ^[a-z_][a-z0-9_]*$ ]]; then
+    echo "INDEXER_DATABASE_SCHEMA must be a lowercase PostgreSQL identifier up to 63 characters." >&2
+    exit 1
+  fi
+
+  if [[ ! -f "$INDEXER_ENV_FILE" ]]; then
+    echo "Missing indexer env file at $INDEXER_ENV_FILE; cannot set DATABASE_SCHEMA." >&2
+    exit 1
+  fi
+
+  local tmp
+  tmp=$(mktemp)
+  awk '!/^DATABASE_SCHEMA=/' "$INDEXER_ENV_FILE" > "$tmp"
+  printf 'DATABASE_SCHEMA=%s\n' "$schema" >> "$tmp"
+  chmod 600 "$tmp"
+  mv "$tmp" "$INDEXER_ENV_FILE"
+
+  echo "Updated indexer DATABASE_SCHEMA in $INDEXER_ENV_FILE."
+  RUN_INDEXER=1
+}
+
 deploy() {
   echo "Production deploy lock acquired: $DEPLOY_LOCK_FILE"
   echo "Updating repo in $APP_ROOT"
@@ -185,6 +214,8 @@ deploy() {
   if [[ "$OLD_SHA" == "$NEW_SHA" ]]; then
     echo "No new commits. Running smoke check only."
   fi
+
+  apply_indexer_database_schema
 
   local run_backend=0
   local run_indexer=0


### PR DESCRIPTION
## What changed
- Added guarded workflow_dispatch inputs for indexer recovery: run_indexer, wait_for_ready, smoke_check_indexer, and indexer_database_schema.
- Added deploy script support to validate a fresh lowercase PostgreSQL schema, update /srv/agent-stack/indexer.env with DATABASE_SCHEMA, and force only the indexer redeploy.
- Documented the Ponder schema-mismatch recovery flow in the VPS runbook.

## Checks
- bash -n scripts/ops/deploy-production.sh
- git diff --check
- ruby YAML parse for .github/workflows/deploy-production.yml

## Impact
- Production deploy workflow and VPS deploy script only.
- Enables non-destructive indexer recovery by rotating to a new Ponder schema instead of dropping the old schema.
- No backend, frontend, contracts, indexer code, Caddy, or public site runtime changes until the manual workflow input is used.