### PR TITLE
Handle object-shaped legacy job tuples

### DIFF
--- a/indexer/src/index.ts
+++ b/indexer/src/index.ts
@@ -29,6 +29,41 @@ const toEventId = (txHash: string, logIndex: number | bigint) => `${txHash}-${lo
 const nullIfZeroHash = (value: `0x${string}`): `0x${string}` | null =>
   value.toLowerCase() === zeroHash ? null : value;
 const hexByteLength = (value: `0x${string}`) => (value.length - 2) / 2;
+const legacyJobFields = [
+  "poster",
+  "worker",
+  "asset",
+  "verifierMode",
+  "category",
+  "specHash",
+  "reward",
+  "opsReserve",
+  "contingencyReserve",
+  "released",
+  "claimExpiry",
+  "claimStake",
+  "claimStakeBps",
+  "rejectedAt",
+  "disputedAt",
+  "payoutMode",
+  "state"
+] as const;
+const oldLegacyJobFields = [
+  "poster",
+  "worker",
+  "asset",
+  "verifierMode",
+  "category",
+  "reward",
+  "opsReserve",
+  "contingencyReserve",
+  "released",
+  "claimExpiry",
+  "claimStake",
+  "claimStakeBps",
+  "payoutMode",
+  "state"
+] as const;
 
 const toTier = (skill: bigint) => {
   if (skill >= 200n) return "elite";
@@ -185,6 +220,21 @@ const decodeLiveJob = (data: `0x${string}`) => {
   );
 };
 
+const tupleValues = (value: any, fields: readonly string[]) => {
+  if (Array.isArray(value)) return value;
+  if (!value || typeof value !== "object") {
+    throw new Error("EscrowCore.jobs returned an unsupported tuple shape");
+  }
+
+  return fields.map((field, index) => {
+    const item = value[field] ?? value[index];
+    if (item === undefined) {
+      throw new Error(`EscrowCore.jobs decoded tuple is missing ${field}`);
+    }
+    return item;
+  });
+};
+
 const normalizeLegacyJob = (legacy: any) => {
   const [
     poster,
@@ -204,7 +254,7 @@ const normalizeLegacyJob = (legacy: any) => {
     disputedAt,
     payoutMode,
     state
-  ] = legacy;
+  ] = tupleValues(legacy, legacyJobFields);
   return [
     poster,
     worker,
@@ -246,7 +296,7 @@ const normalizeOldLegacyJob = (oldLegacy: any) => {
     claimStakeBps,
     payoutMode,
     state
-  ] = oldLegacy;
+  ] = tupleValues(oldLegacy, oldLegacyJobFields);
   return [
     poster,
     worker,


### PR DESCRIPTION
## What changed
- Accept both array-shaped and object-shaped decoded legacy EscrowCore.jobs tuples in the indexer.
- Fixes the production indexer crash seen during backfill: TypeError: oldLegacy is not iterable at block 8298659.

## Checks
- npm --workspace indexer run typecheck
- git diff --check

## Impact
- Indexer only. No frontend, backend, contract, Caddy, or public site changes.

## Notes
- Rechecked against Polkadot docs: Polkadot Hub supports Ethereum-compatible JSON-RPC contract reads via eth_call; this patch only normalizes the local decoded return shape.