### PR TITLE
Harden indexer job tuple decoding

### DIFF
--- a/indexer/src/index.ts
+++ b/indexer/src/index.ts
@@ -29,6 +29,29 @@ const toEventId = (txHash: string, logIndex: number | bigint) => `${txHash}-${lo
 const nullIfZeroHash = (value: `0x${string}`): `0x${string}` | null =>
   value.toLowerCase() === zeroHash ? null : value;
 const hexByteLength = (value: `0x${string}`) => (value.length - 2) / 2;
+const currentJobFields = [
+  "poster",
+  "worker",
+  "asset",
+  "verifierMode",
+  "category",
+  "specHash",
+  "reward",
+  "opsReserve",
+  "contingencyReserve",
+  "released",
+  "claimExpiry",
+  "claimStake",
+  "claimStakeBps",
+  "claimFee",
+  "claimFeeBps",
+  "claimEconomicsWaived",
+  "rejectingVerifier",
+  "rejectedAt",
+  "disputedAt",
+  "payoutMode",
+  "state"
+] as const;
 const legacyJobFields = [
   "poster",
   "worker",
@@ -194,11 +217,14 @@ const decodeLiveJob = (data: `0x${string}`) => {
   const byteLength = hexByteLength(data);
 
   if (byteLength >= 672) {
-    return decodeFunctionResult({
-      abi: EscrowCoreAbi,
-      functionName: "jobs",
-      data
-    }) as any;
+    return tupleValues(
+      decodeFunctionResult({
+        abi: EscrowCoreAbi,
+        functionName: "jobs",
+        data
+      }) as any,
+      currentJobFields
+    );
   }
 
   if (byteLength >= 544) {
@@ -221,7 +247,14 @@ const decodeLiveJob = (data: `0x${string}`) => {
 };
 
 const tupleValues = (value: any, fields: readonly string[]) => {
-  if (Array.isArray(value)) return value;
+  if (Array.isArray(value)) {
+    if (value.length === 1 && value[0] && typeof value[0] === "object" && !Array.isArray(value[0])) {
+      return tupleValues(value[0], fields);
+    }
+
+    return value;
+  }
+
   if (!value || typeof value !== "object") {
     throw new Error("EscrowCore.jobs returned an unsupported tuple shape");
   }


### PR DESCRIPTION
## What changed
- Normalize current EscrowCore.jobs decoded tuples before syncJob destructures them.
- Accept wrapped single-tuple decode results like [{ poster, worker, ... }] in addition to flat arrays and bare named objects.
- Keeps the legacy and old-legacy paths using the same field-order normalization.

## Why
- Follow-up to #118. Production still failed to bring the indexer healthy after #118, and review of the ABI shape showed the primary current-job path had the same possible object-shaped tuple issue.

## Checks
- npm --workspace indexer run typecheck
- git diff --check

## Impact
- Indexer only. No frontend, backend, Caddy, contract, or public-site changes.

## Polkadot docs check
- Rechecked Polkadot docs: Hub TestNet supports Ethereum-compatible JSON-RPC contract reads via eth_call, and indexers are expected to process chain data into queryable APIs. This patch is local decode-shape handling after RPC bytes are returned.