### PR TITLE
Surface active session state on /jobs and /admin/jobs

### DIFF
--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -108,6 +108,41 @@ export class PlatformService {
     return this.jobCatalogService.listJobs(options);
   }
 
+  /**
+   * Same as `listJobs`, but joins active-session state onto each row.
+   *
+   * Today the catalog stores immutable job documents — claiming a job
+   * only writes a Session into the state store, never mutates the job
+   * itself. That left the public `/jobs` feed with `state`,
+   * `claimedBy`, and `sessionId` permanently null even after a worker
+   * had locked a job in. The operator queue + ready-to-claim cards
+   * also rendered claimed jobs as still claimable.
+   *
+   * Joining sessions on read keeps the catalog clean and fixes the
+   * surface in one place: any list endpoint that wants run-state
+   * visibility calls this method instead of `listJobs`.
+   */
+  async listJobsWithSessions(options = {}) {
+    const jobs = this.jobCatalogService.listJobs(options);
+    return Promise.all(
+      jobs.map(async (job) => {
+        const session = await this.stateStore.findSessionByJobId?.(job.id);
+        if (!session) return job;
+        return {
+          ...job,
+          state: typeof session.status === "string" ? session.status : job.state ?? null,
+          claimedBy: typeof session.wallet === "string" ? session.wallet : job.claimedBy ?? null,
+          sessionId: typeof session.sessionId === "string"
+            ? session.sessionId
+            : job.sessionId ?? null,
+          claimedAt: typeof session.claimedAt === "string"
+            ? session.claimedAt
+            : job.claimedAt ?? undefined
+        };
+      })
+    );
+  }
+
   createJob(input) {
     return this.jobCatalogService.createJob(input);
   }

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -81,6 +81,31 @@ test("createSubJob links the child job to the active parent session", async () =
   assert.equal(subJobs[0].id, "child-job-001");
 });
 
+test("listJobsWithSessions joins active session state onto job rows", async () => {
+  const service = makePlatformService();
+
+  // Before any claim — listJobs and listJobsWithSessions agree.
+  const before = await service.listJobsWithSessions();
+  assert.equal(before.length, 1);
+  assert.equal(before[0].id, "parent-job-001");
+  assert.equal(before[0].claimedBy ?? null, null);
+  assert.equal(before[0].sessionId ?? null, null);
+  assert.equal(before[0].state ?? null, null);
+
+  // After a claim — the row carries claim state read live from the
+  // session store so the public /jobs feed and the operator queue
+  // stop showing the row as "ready / unclaimed" the moment a worker
+  // locks it in.
+  const session = await service.claimJob(WALLET, "parent-job-001", "http", "claim-state-test");
+  const after = await service.listJobsWithSessions();
+  assert.equal(after.length, 1);
+  assert.equal(after[0].id, "parent-job-001");
+  assert.equal(after[0].claimedBy, WALLET);
+  assert.equal(after[0].sessionId, session.sessionId);
+  assert.equal(typeof after[0].state, "string");
+  assert.equal(after[0].state, session.status);
+});
+
 test("getSessionTimeline includes transitions and verification state", async () => {
   const service = makePlatformService();
   const session = await service.claimJob(WALLET, "parent-job-001", "http", "timeline-claim");

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -1356,7 +1356,13 @@ const server = createServer(async (request, response) => {
     }
 
     if (request.method === "GET" && pathname === "/jobs") {
-      return respond(response, 200, buildPublicJobsResponse(service.listJobs(), url.searchParams));
+      // Use the session-joined variant so claimed jobs surface their
+      // state / claimedBy / sessionId. The public catalog stays
+      // immutable; this endpoint reads the live join. Without it
+      // browser agents would re-attempt already-claimed jobs and
+      // operator UIs would show "Ready" forever.
+      const jobs = await service.listJobsWithSessions();
+      return respond(response, 200, buildPublicJobsResponse(jobs, url.searchParams));
     }
 
     if (request.method === "GET" && pathname === "/admin/jobs") {
@@ -1366,7 +1372,7 @@ const server = createServer(async (request, response) => {
       // stale rows so the operator app can show lifecycle controls.
       // The public `/jobs` route filters those out by default.
       return respond(response, 200, {
-        jobs: service.listJobs({
+        jobs: await service.listJobsWithSessions({
           includePaused: true,
           includeArchived: true,
           includeStale: true


### PR DESCRIPTION
## Why
Diagnosed live: the catalog stores immutable job documents — claiming a job only writes a Session into the state store, never mutates the underlying job. Every row on \`/jobs\` and \`/admin/jobs\` came back with \`state: null\`, \`claimedBy: null\`, \`sessionId: null\` regardless of whether a worker had locked it in.

This made several recently-shipped frontend pieces look broken even when working as designed:
- Operator queue + ready-to-claim cards rendered claimed jobs as still \"Ready\" and offered them up for re-claim (which would then fail with \`job_already_claimed\`).
- Browser agents using \`/jobs\` for discovery had no way to tell which rows were already taken.
- The lifecycle pill (#67) and active-session block (#108) both read from a field the backend never populated.

## What
- \`PlatformService.listJobsWithSessions()\` — same shape as \`listJobs()\` but joins each row against \`stateStore.findSessionByJobId(job.id)\` and merges \`{ state, claimedBy, sessionId, claimedAt }\` onto the result.
- Both HTTP handlers (\`GET /jobs\`, \`GET /admin/jobs\`) call the joined variant.
- New \`listJobsWithSessions\` test in \`platform-service.test.js\` exercises both before-claim and after-claim shapes via the existing in-memory harness.

The catalog stays immutable; the join is read-side only, so a session that settles or expires naturally clears the row's claim state on the next listing.

## Test plan
- [x] \`npm --workspace mcp-server test\` — 329/333 pass; the 4 failures (\`gateway\`, \`xcm-message-builder\`, \`http-config\`, \`strategies-config\`) are pre-existing env-dependent failures present on \`main\` too.
- [ ] After deploy: trigger a claim from a test agent, then \`curl https://api.averray.com/jobs | jq '.[] | select(.claimedBy != null)'\` should show the row with state/claimedBy/sessionId populated, and the operator UI's existing lifecycle pill + active-session block should render that claim correctly.