### PR TITLE
Fix deploy rollback target, indexer schema reuse, and fatal-error visibility

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -44,9 +44,17 @@ on:
           - "1"
           - "0"
       indexer_database_schema:
-        description: Optional fresh Ponder DATABASE_SCHEMA for indexer recovery.
+        description: Optional explicit Ponder DATABASE_SCHEMA. Mutually exclusive with indexer_fresh_schema.
         required: false
         type: string
+      indexer_fresh_schema:
+        description: Auto-mint a timestamped DATABASE_SCHEMA for one-shot recovery (convenience over indexer_database_schema).
+        required: false
+        default: "0"
+        type: choice
+        options:
+          - "0"
+          - "1"
 
 concurrency:
   group: production
@@ -73,6 +81,7 @@ jobs:
       DEPLOY_INDEXER_LOG_TAIL: ${{ github.event_name == 'workflow_dispatch' && inputs.indexer_log_tail || '120' }}
       DEPLOY_SMOKE_CHECK_INDEXER: ${{ github.event_name == 'workflow_dispatch' && inputs.smoke_check_indexer || 'auto' }}
       DEPLOY_INDEXER_DATABASE_SCHEMA: ${{ github.event_name == 'workflow_dispatch' && inputs.indexer_database_schema || '' }}
+      DEPLOY_INDEXER_FRESH_SCHEMA: ${{ github.event_name == 'workflow_dispatch' && inputs.indexer_fresh_schema || '0' }}
     steps:
       - name: Validate required secrets
         run: |
@@ -94,7 +103,7 @@ jobs:
       - name: Deploy production
         run: |
           remote_env=$(
-            printf 'APP_BASIC_AUTH_USER=%q APP_BASIC_AUTH_PASSWORD=%q APP_BASIC_AUTH_PASSWORD_HASH=%q ADMIN_JWT=%q RUN_INDEXER=%q WAIT_FOR_READY=%q HEALTH_STABILITY_SEC=%q INDEXER_LOG_TAIL=%q SMOKE_CHECK_INDEXER=%q INDEXER_DATABASE_SCHEMA=%q ' \
+            printf 'APP_BASIC_AUTH_USER=%q APP_BASIC_AUTH_PASSWORD=%q APP_BASIC_AUTH_PASSWORD_HASH=%q ADMIN_JWT=%q RUN_INDEXER=%q WAIT_FOR_READY=%q HEALTH_STABILITY_SEC=%q INDEXER_LOG_TAIL=%q SMOKE_CHECK_INDEXER=%q INDEXER_DATABASE_SCHEMA=%q INDEXER_FRESH_SCHEMA=%q ' \
               "$APP_BASIC_AUTH_USER" \
               "$APP_BASIC_AUTH_PASSWORD" \
               "$APP_BASIC_AUTH_PASSWORD_HASH" \
@@ -104,7 +113,8 @@ jobs:
               "$DEPLOY_HEALTH_STABILITY_SEC" \
               "$DEPLOY_INDEXER_LOG_TAIL" \
               "$DEPLOY_SMOKE_CHECK_INDEXER" \
-              "$DEPLOY_INDEXER_DATABASE_SCHEMA"
+              "$DEPLOY_INDEXER_DATABASE_SCHEMA" \
+              "$DEPLOY_INDEXER_FRESH_SCHEMA"
           )
 
           ssh -p "${VPS_PORT:-22}" "$VPS_USER@$VPS_HOST" \

--- a/scripts/ops/deploy-production.sh
+++ b/scripts/ops/deploy-production.sh
@@ -28,6 +28,7 @@ RUN_CADDY=${RUN_CADDY:-auto}
 RUN_SMOKE=${RUN_SMOKE:-1}
 SMOKE_CHECK_INDEXER=${SMOKE_CHECK_INDEXER:-auto}
 INDEXER_DATABASE_SCHEMA=${INDEXER_DATABASE_SCHEMA:-}
+INDEXER_FRESH_SCHEMA=${INDEXER_FRESH_SCHEMA:-0}
 INDEXER_ENV_FILE=${INDEXER_ENV_FILE:-"$STACK_ROOT/indexer.env"}
 
 SITE_BUILD_RUNNER=${SITE_BUILD_RUNNER:-auto}
@@ -160,16 +161,22 @@ apply_caddy() {
     restart caddy
 }
 
-apply_indexer_database_schema() {
-  local schema="$INDEXER_DATABASE_SCHEMA"
-  if [[ -z "$schema" ]]; then
-    return 0
+read_current_indexer_schema() {
+  if [[ -f "$INDEXER_ENV_FILE" ]]; then
+    awk -F= '/^DATABASE_SCHEMA=/{ sub(/^DATABASE_SCHEMA=/, ""); print; exit }' "$INDEXER_ENV_FILE" | tr -d '"'
   fi
+}
 
+validate_indexer_schema() {
+  local schema="$1"
   if [[ ${#schema} -gt 63 || ! "$schema" =~ ^[a-z_][a-z0-9_]*$ ]]; then
-    echo "INDEXER_DATABASE_SCHEMA must be a lowercase PostgreSQL identifier up to 63 characters." >&2
+    echo "Indexer DATABASE_SCHEMA must be a lowercase PostgreSQL identifier up to 63 characters: $schema" >&2
     exit 1
   fi
+}
+
+write_indexer_schema() {
+  local schema="$1"
 
   if [[ ! -f "$INDEXER_ENV_FILE" ]]; then
     echo "Missing indexer env file at $INDEXER_ENV_FILE; cannot set DATABASE_SCHEMA." >&2
@@ -183,8 +190,52 @@ apply_indexer_database_schema() {
   chmod 600 "$tmp"
   mv "$tmp" "$INDEXER_ENV_FILE"
 
-  echo "Updated indexer DATABASE_SCHEMA in $INDEXER_ENV_FILE."
+  echo "Updated indexer DATABASE_SCHEMA in $INDEXER_ENV_FILE: $schema"
   RUN_INDEXER=1
+}
+
+apply_indexer_database_schema() {
+  local current_schema=""
+  current_schema=$(read_current_indexer_schema)
+  if [[ -n "$current_schema" ]]; then
+    echo "Current indexer DATABASE_SCHEMA in $INDEXER_ENV_FILE: $current_schema"
+  else
+    echo "No DATABASE_SCHEMA set in $INDEXER_ENV_FILE; indexer will use Ponder's default."
+  fi
+
+  case "$INDEXER_FRESH_SCHEMA" in
+    1|true|yes) ;;
+    0|false|no|"") INDEXER_FRESH_SCHEMA=0 ;;
+    *)
+      echo "Invalid INDEXER_FRESH_SCHEMA toggle: $INDEXER_FRESH_SCHEMA (expected 0 or 1)" >&2
+      exit 1
+      ;;
+  esac
+
+  if [[ -n "$INDEXER_DATABASE_SCHEMA" && "$INDEXER_FRESH_SCHEMA" == "1" ]]; then
+    echo "INDEXER_DATABASE_SCHEMA and INDEXER_FRESH_SCHEMA=1 are mutually exclusive." >&2
+    echo "Pass either an explicit schema name OR set INDEXER_FRESH_SCHEMA=1, not both." >&2
+    exit 1
+  fi
+
+  local target_schema=""
+  if [[ -n "$INDEXER_DATABASE_SCHEMA" ]]; then
+    validate_indexer_schema "$INDEXER_DATABASE_SCHEMA"
+    target_schema="$INDEXER_DATABASE_SCHEMA"
+    echo "Operator pinned indexer DATABASE_SCHEMA: $target_schema"
+  elif [[ "$INDEXER_FRESH_SCHEMA" == "1" ]]; then
+    target_schema="agent_indexer_$(date -u +%Y%m%d%H%M%S)"
+    validate_indexer_schema "$target_schema"
+    echo "INDEXER_FRESH_SCHEMA=1 — minting fresh DATABASE_SCHEMA: $target_schema"
+  else
+    return 0
+  fi
+
+  if [[ -n "$current_schema" && "$current_schema" != "$target_schema" ]]; then
+    echo "Replacing existing DATABASE_SCHEMA ($current_schema) with $target_schema."
+  fi
+
+  write_indexer_schema "$target_schema"
 }
 
 deploy() {
@@ -226,7 +277,7 @@ deploy() {
   if should_run "$RUN_BACKEND" '^(mcp-server/|sdk/|examples/|docs/schemas/|package(-lock)?\.json|scripts/ops/redeploy-backend\.sh)'; then
     run_backend=1
     echo "Deploying backend"
-    SKIP_GIT_UPDATE=1 "$APP_ROOT/scripts/ops/redeploy-backend.sh"
+    SKIP_GIT_UPDATE=1 PRE_DEPLOY_SHA="$OLD_SHA" "$APP_ROOT/scripts/ops/redeploy-backend.sh"
   else
     echo "Skipping backend deploy"
   fi
@@ -234,7 +285,7 @@ deploy() {
   if should_run "$RUN_INDEXER" '^(indexer/|package(-lock)?\.json|scripts/ops/redeploy-indexer\.sh)'; then
     run_indexer=1
     echo "Deploying indexer"
-    SKIP_GIT_UPDATE=1 "$APP_ROOT/scripts/ops/redeploy-indexer.sh"
+    SKIP_GIT_UPDATE=1 PRE_DEPLOY_SHA="$OLD_SHA" "$APP_ROOT/scripts/ops/redeploy-indexer.sh"
   else
     echo "Skipping indexer deploy"
   fi
@@ -242,7 +293,7 @@ deploy() {
   if should_run "$RUN_FRONTEND" '^(app/|frontend/|scripts/sync-operator-frontend\.mjs|scripts/ops/redeploy-frontend\.sh|scripts/ops/deploy-production\.sh|package(-lock)?\.json)'; then
     run_frontend=1
     echo "Deploying operator frontend"
-    SKIP_GIT_UPDATE=1 "$APP_ROOT/scripts/ops/redeploy-frontend.sh"
+    SKIP_GIT_UPDATE=1 PRE_DEPLOY_SHA="$OLD_SHA" "$APP_ROOT/scripts/ops/redeploy-frontend.sh"
   else
     echo "Skipping operator frontend deploy"
   fi

--- a/scripts/ops/redeploy-backend.sh
+++ b/scripts/ops/redeploy-backend.sh
@@ -19,6 +19,10 @@
 #   HEALTH_TIMEOUT_SEC max seconds to wait for health (default: 120)
 #   HEALTH_INTERVAL_SEC seconds between health polls (default: 5)
 #   SKIP_GIT_UPDATE=1  skip fetch/checkout/pull because caller already pinned the repo
+#   PRE_DEPLOY_SHA     rollback target SHA when SKIP_GIT_UPDATE=1 — supplied by
+#                      deploy-production.sh from the wrapper's pre-pull HEAD so
+#                      rollback() doesn't checkout the SAME commit that just
+#                      failed. Falls back to current HEAD if unset.
 #   SKIP_ROLLBACK=1    disable auto-rollback (useful for staged canary tests)
 set -euo pipefail
 
@@ -50,9 +54,15 @@ for cmd in git docker curl; do
 done
 
 # Pin the pre-deploy SHA before changing anything so rollback has a concrete
-# target. `rev-parse HEAD` works even in detached-HEAD setups.
-PREVIOUS_SHA=$(git -C "$APP_ROOT" rev-parse HEAD)
+# target. When the wrapper has already pulled origin/main, `rev-parse HEAD`
+# is the NEW SHA — making rollback a no-op. Honour PRE_DEPLOY_SHA from the
+# wrapper, fall back to HEAD when invoked directly.
+CURRENT_HEAD=$(git -C "$APP_ROOT" rev-parse HEAD)
+PREVIOUS_SHA=${PRE_DEPLOY_SHA:-$CURRENT_HEAD}
 echo "Pre-deploy SHA: $PREVIOUS_SHA"
+if [[ "$PREVIOUS_SHA" == "$CURRENT_HEAD" && "${SKIP_GIT_UPDATE:-0}" == "1" ]]; then
+  echo "Note: PRE_DEPLOY_SHA matches current HEAD; rollback would re-deploy the same SHA." >&2
+fi
 
 compose_up() {
   docker compose \
@@ -82,6 +92,15 @@ rollback() {
     echo "SKIP_ROLLBACK=1 set; leaving the unhealthy deploy in place for inspection." >&2
     exit 1
   fi
+
+  local now_head
+  now_head=$(git -C "$APP_ROOT" rev-parse HEAD)
+  if [[ "$PREVIOUS_SHA" == "$now_head" ]]; then
+    echo "No usable rollback target: PREVIOUS_SHA ($PREVIOUS_SHA) matches current HEAD." >&2
+    echo "Leaving the unhealthy backend in place for inspection. Manual intervention required." >&2
+    exit 1
+  fi
+
   echo "Health check failed; rolling back to $PREVIOUS_SHA" >&2
   git -C "$APP_ROOT" checkout --quiet "$PREVIOUS_SHA"
   compose_up

--- a/scripts/ops/redeploy-frontend.sh
+++ b/scripts/ops/redeploy-frontend.sh
@@ -24,6 +24,10 @@
 #   STACK_ROOT                parent dir containing docker-compose.yml (default: repo parent)
 #   COMPOSE_FILE              path to docker-compose.yml
 #   SKIP_GIT_UPDATE=1         skip fetch/checkout/pull because caller already pinned the repo
+#   PRE_DEPLOY_SHA            rollback target SHA when SKIP_GIT_UPDATE=1 — supplied by
+#                             deploy-production.sh from the wrapper's pre-pull HEAD so
+#                             rollback() doesn't checkout the SAME commit that just
+#                             failed. Falls back to current HEAD if unset.
 #   SKIP_ROLLBACK=1           disable auto-rollback
 set -euo pipefail
 
@@ -93,8 +97,15 @@ if [[ "$RESTART_CADDY" == "1" ]]; then
   fi
 fi
 
-PREVIOUS_SHA=$(git -C "$APP_ROOT" rev-parse HEAD)
+# Pin the pre-deploy SHA. When the wrapper has already pulled origin/main,
+# `rev-parse HEAD` is the NEW SHA, so rollback would re-deploy the same code
+# that just failed. Honour PRE_DEPLOY_SHA from the wrapper.
+CURRENT_HEAD=$(git -C "$APP_ROOT" rev-parse HEAD)
+PREVIOUS_SHA=${PRE_DEPLOY_SHA:-$CURRENT_HEAD}
 echo "Pre-deploy SHA: $PREVIOUS_SHA"
+if [[ "$PREVIOUS_SHA" == "$CURRENT_HEAD" && "${SKIP_GIT_UPDATE:-0}" == "1" ]]; then
+  echo "Note: PRE_DEPLOY_SHA matches current HEAD; rollback would re-deploy the same SHA." >&2
+fi
 
 autostash_if_needed() {
   if [[ "$DEPLOY_AUTOSTASH" != "1" ]]; then
@@ -163,6 +174,15 @@ rollback() {
     echo "SKIP_ROLLBACK=1 set; leaving the failed frontend deploy in place for inspection." >&2
     exit 1
   fi
+
+  local now_head
+  now_head=$(git -C "$APP_ROOT" rev-parse HEAD)
+  if [[ "$PREVIOUS_SHA" == "$now_head" ]]; then
+    echo "No usable rollback target: PREVIOUS_SHA ($PREVIOUS_SHA) matches current HEAD." >&2
+    echo "Leaving the failed frontend in place for inspection. Manual intervention required." >&2
+    exit 1
+  fi
+
   echo "Operator app check failed; rolling back to $PREVIOUS_SHA" >&2
   git -C "$APP_ROOT" checkout --quiet "$PREVIOUS_SHA"
   build_frontend

--- a/scripts/ops/redeploy-indexer.sh
+++ b/scripts/ops/redeploy-indexer.sh
@@ -26,6 +26,10 @@
 #   ROLLBACK_WAIT_FOR_READY=1
 #                         also wait for /ready after rollback (default: 0)
 #   SKIP_GIT_UPDATE=1     skip fetch/checkout/pull because caller already pinned the repo
+#   PRE_DEPLOY_SHA        rollback target SHA when SKIP_GIT_UPDATE=1 — provided by
+#                         deploy-production.sh from the wrapper's pre-pull HEAD so
+#                         that rollback() doesn't checkout the SAME commit that just
+#                         failed. Falls back to current HEAD if unset.
 #   SKIP_ROLLBACK=1       disable auto-rollback
 set -euo pipefail
 
@@ -69,8 +73,16 @@ for cmd in git docker curl; do
   fi
 done
 
-PREVIOUS_SHA=$(git -C "$APP_ROOT" rev-parse HEAD)
+# When the wrapper has already pulled origin/main, `git rev-parse HEAD` is the
+# NEW SHA, not the pre-deploy one — making rollback a structural no-op. The
+# wrapper passes the real pre-deploy SHA via PRE_DEPLOY_SHA. Fall back to HEAD
+# only when this script is invoked directly without the wrapper.
+CURRENT_HEAD=$(git -C "$APP_ROOT" rev-parse HEAD)
+PREVIOUS_SHA=${PRE_DEPLOY_SHA:-$CURRENT_HEAD}
 echo "Pre-deploy SHA: $PREVIOUS_SHA"
+if [[ "$PREVIOUS_SHA" == "$CURRENT_HEAD" && "${SKIP_GIT_UPDATE:-0}" == "1" ]]; then
+  echo "Note: PRE_DEPLOY_SHA matches current HEAD; rollback would re-deploy the same SHA." >&2
+fi
 
 compose_up() {
   docker compose \
@@ -87,16 +99,47 @@ dump_indexer_diagnostics() {
     ps indexer || true
 
   echo "Indexer diagnostics: last ${INDEXER_LOG_TAIL} indexer log lines"
-  docker compose \
-    --project-directory "$STACK_ROOT" \
-    -f "$COMPOSE_FILE" \
-    logs --tail="$INDEXER_LOG_TAIL" indexer || true
+  local indexer_log
+  indexer_log=$(
+    docker compose \
+      --project-directory "$STACK_ROOT" \
+      -f "$COMPOSE_FILE" \
+      logs --tail="$INDEXER_LOG_TAIL" indexer 2>&1 || true
+  )
+  printf '%s\n' "$indexer_log"
 
   echo "Indexer diagnostics: last ${INDEXER_LOG_TAIL} Caddy log lines"
   docker compose \
     --project-directory "$STACK_ROOT" \
     -f "$COMPOSE_FILE" \
     logs --tail="$INDEXER_LOG_TAIL" caddy || true
+
+  # Skim the indexer log for known fatal-startup patterns and surface a one-line
+  # summary. This is the user-visible answer to "why didn't /health bind?" so it
+  # belongs ahead of the raw log dump in scrollback. Patterns are derived from
+  # incidents that have actually wedged this stack:
+  #   MigrationError       — Ponder schema build_id mismatch (issue #120)
+  #   TypeError            — indexing-function bug (e.g. oldLegacy iterable family)
+  #   uncaughtException    — generic Node fatal that exits the process
+  #   unhandledRejection   — async fatal Ponder treats as unrecoverable
+  #   ECONNREFUSED.*postgres / postgres.*ECONNREFUSED — Postgres unreachable
+  #   Cannot find module   — image built without expected dep
+  #   start_block.*greater than head — config/RPC drift
+  echo "::group::Indexer fatal-pattern summary"
+  local matches
+  matches=$(
+    printf '%s\n' "$indexer_log" \
+      | grep -E 'MigrationError|TypeError|uncaughtException|unhandledRejection|FATAL|Cannot find module|ECONNREFUSED.*postgres|postgres.*ECONNREFUSED|start_block.*greater than head' \
+      | head -20 \
+      || true
+  )
+  if [[ -n "$matches" ]]; then
+    printf '%s\n' "$matches"
+    echo "(scroll up for full context)"
+  else
+    echo "(no known fatal-startup patterns matched in the last ${INDEXER_LOG_TAIL} indexer log lines)"
+  fi
+  echo "::endgroup::"
 }
 
 wait_for_ok() {
@@ -129,6 +172,18 @@ rollback() {
     echo "SKIP_ROLLBACK=1 set; leaving the unhealthy indexer deploy in place for inspection." >&2
     exit 1
   fi
+
+  local now_head
+  now_head=$(git -C "$APP_ROOT" rev-parse HEAD)
+  if [[ "$PREVIOUS_SHA" == "$now_head" ]]; then
+    # Nothing earlier to roll back to — checking out the same SHA and rebuilding
+    # would just waste another 120s health-wait on the same broken code. Bail
+    # explicitly so the operator sees the right next step.
+    echo "No usable rollback target: PREVIOUS_SHA ($PREVIOUS_SHA) matches current HEAD." >&2
+    echo "Leaving the unhealthy indexer in place for inspection. Manual intervention required." >&2
+    exit 1
+  fi
+
   echo "Indexer gate failed; rolling back to $PREVIOUS_SHA" >&2
   git -C "$APP_ROOT" checkout --quiet "$PREVIOUS_SHA"
   compose_up


### PR DESCRIPTION
## Summary

Fixes the three structural deploy-pipeline problems tracked in #120 that
together caused the 2026-05-01 indexer wedge.

- **Rollback target.** `redeploy-{backend,indexer,frontend}.sh` now honour
  `PRE_DEPLOY_SHA` from the wrapper instead of capturing `git rev-parse HEAD`
  *after* the wrapper has already pulled — which made every rollback a
  structural no-op (`rolling back to <new SHA>` against the SAME commit that
  just failed). Wrapper exports `OLD_SHA` as `PRE_DEPLOY_SHA` on every
  component invocation. `rollback()` also short-circuits when there's no
  usable target, so we stop burning extra 120s health-wait windows after
  failures.
- **Indexer schema reuse.** Add `indexer_fresh_schema` workflow input as a
  one-shot recovery convenience that auto-mints `agent_indexer_<UTC-timestamp>`
  in the wrapper. Mutually exclusive with `indexer_database_schema`; both
  validated. The wrapper also prints the *current* `DATABASE_SCHEMA` value
  at the start of every deploy so the foot-gun (a stale operator-pinned
  schema with a now-mismatched Ponder build_id) is visible at a glance
  rather than hidden in `indexer.env`.
- **Fatal-error visibility.** `dump_indexer_diagnostics` greps the indexer
  log tail for known fatal-startup patterns (`MigrationError`, `TypeError`,
  `uncaughtException`, `unhandledRejection`, `FATAL`, `Cannot find module`,
  `ECONNREFUSED.*postgres`, `start_block.*greater than head`) and surfaces
  them in a `::group::Indexer fatal-pattern summary` block alongside the
  raw dumps. The next time `/health` won't bind, the workflow log answers
  *why* in the first screen of output instead of buried 200 lines deep.

## Why it matters

In the 2026-05-01 incident, the surface error (`MigrationError: Schema
agent_indexer_20260501165300 was previously used by a different Ponder app`)
existed in the indexer log tail of every failed deploy from 18:06 UTC
onward but wasn't surfaced — the workflow's final user-visible message was
the generic `Rollback failed to restore indexer health. Manual intervention
required.` It took an SSH-free deep-dive through three GitHub Actions runs
to find the actual cause. With this PR's fix-3, the fatal-pattern summary
would have shown the `MigrationError` line in the first failed-deploy log,
and the operator could have run the recovery workflow_dispatch immediately
instead of after an hour of debugging.

## Test plan

- [x] `bash -n` passes on all four scripts.
- [x] `shellcheck -x` passes (pre-existing SC2034 warnings only, no new
      warnings).
- [x] Manual fixture tests of `apply_indexer_database_schema`:
      - no input → existing schema unchanged, just printed for visibility
      - explicit `INDEXER_DATABASE_SCHEMA=name` → replaced, log shows old→new
      - `INDEXER_FRESH_SCHEMA=1` → auto-minted timestamped name
      - both inputs set → rejected
      - invalid identifier (uppercase/dashes/leading-digit) → rejected
        before mutating state
- [ ] CI on main with this PR merged: a no-op deploy run should print
      the new "Current indexer DATABASE_SCHEMA in /srv/agent-stack/indexer.env: ..."
      line for the first time, confirming visibility.
- [ ] First indexer-touching deploy after this PR: the `Pre-deploy SHA`
      logged inside `redeploy-indexer.sh` should now be the wrapper's
      `OLD_SHA` (different from `Deploying SHA`), confirming the rollback
      target propagation fix.

## Out of scope

- The "wrapper short-circuits before reaching frontend/site/caddy when
  indexer fails" risk that the audit flagged. None of #110–#119 actually
  hit it (those PRs were all indexer-only or scripts-only), but it's a
  real foot-gun. Architecturally bigger because of `git checkout` state
  spillover between component scripts; deserves its own PR with its own
  test plan. Will spin out as a follow-up issue.

Closes #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)