### PR TITLE
Clarify and normalize submit payload shape

### DIFF
--- a/mcp-server/src/core/errors.js
+++ b/mcp-server/src/core/errors.js
@@ -14,6 +14,12 @@ export class ValidationError extends AppError {
   }
 }
 
+export class InvalidSubmissionShapeError extends AppError {
+  constructor(message, details = undefined) {
+    super(message, { name: "InvalidSubmissionShapeError", code: "invalid_submission_shape", statusCode: 400, details });
+  }
+}
+
 export class NotFoundError extends AppError {
   constructor(message, code = "not_found", details = undefined) {
     super(message, { name: "NotFoundError", code, statusCode: 404, details });

--- a/mcp-server/src/core/job-catalog-metadata.test.js
+++ b/mcp-server/src/core/job-catalog-metadata.test.js
@@ -205,6 +205,20 @@ test("public Wikipedia definitions include direct agent affordances", () => {
     proposalOnly: true,
     attributionPolicy: "Averray proposal only / no direct Wikipedia edit"
   });
+  assert.equal(job.submissionContract.endpoint, "POST /jobs/submit");
+  assert.equal(job.submissionContract.submissionShape, "direct_schema_object");
+  assert.equal(job.submissionContract.schemaValidates, "payload.submission");
+  assert.equal(job.submissionContract.doNotWrapInOutput, true);
+  assert.deepEqual(job.submissionContract.compatibilityAliases, ["payload.submission.output"]);
+  assert.equal(job.submissionContract.submitPayloadExample.sessionId, "<session-id>");
+  assert.deepEqual(Object.keys(job.submissionContract.submitPayloadExample.submission), [
+    "page_title",
+    "revision_id",
+    "citation_findings",
+    "proposed_changes",
+    "review_notes"
+  ]);
+  assert.equal(job.submissionContract.submitPayloadExample.submission.page_title, "Example article");
 });
 
 test("reviewer role gate blocks low-score agents", async () => {

--- a/mcp-server/src/core/job-catalog-service.js
+++ b/mcp-server/src/core/job-catalog-service.js
@@ -3,7 +3,7 @@ import {
   NotFoundError,
   ValidationError
 } from "./errors.js";
-import { isBuiltinJobSchemaRef, schemaRefToJobSchemaPath } from "./job-schema-registry.js";
+import { getBuiltinJobSchema, isBuiltinJobSchemaRef, schemaRefToJobSchemaPath } from "./job-schema-registry.js";
 
 const DEFAULT_AGENT_PROFILE = {
   capabilities: ["claim_job", "submit_work", "allocate_idle_funds"],
@@ -491,9 +491,11 @@ export class JobCatalogService {
 
   withLifecycle(job, now = new Date()) {
     const publicDetails = buildPublicJobDetails(job);
+    const submissionContract = buildSubmissionContract(job);
     return {
       ...job,
       ...(publicDetails ? { publicDetails } : {}),
+      ...(submissionContract ? { submissionContract } : {}),
       lifecycle: this.buildLifecycle(job, now)
     };
   }
@@ -955,6 +957,73 @@ function buildPublicJobDetails(job) {
     proposalOnly: source.proposalOnly ?? source.attribution?.directEdit === false,
     attributionPolicy: source.attributionPolicy ?? "Averray proposal only / no direct Wikipedia edit"
   };
+}
+
+function buildSubmissionContract(job) {
+  const schema = getBuiltinJobSchema(job?.outputSchemaRef);
+  if (!schema) {
+    return undefined;
+  }
+
+  return {
+    endpoint: "POST /jobs/submit",
+    submissionShape: "direct_schema_object",
+    schemaValidates: "payload.submission",
+    doNotWrapInOutput: true,
+    compatibilityAliases: ["payload.submission.output"],
+    outputSchemaRef: job.outputSchemaRef,
+    outputSchemaUrl: schemaRefToJobSchemaPath(job.outputSchemaRef),
+    submitPayloadExample: {
+      sessionId: "<session-id>",
+      submission: buildSchemaExample(schema)
+    },
+    invalidWrappedOutputHint: "Send the schema object directly as payload.submission. Do not wrap it under payload.submission.output."
+  };
+}
+
+function buildSchemaExample(schema, fieldName = "value") {
+  if (!schema || typeof schema !== "object") {
+    return "...";
+  }
+  if (Array.isArray(schema.enum) && schema.enum.length) {
+    return schema.enum[0];
+  }
+  if (schema.type === "object") {
+    const properties = schema.properties ?? {};
+    const keys = schema.required?.length ? schema.required : Object.keys(properties).slice(0, 3);
+    return Object.fromEntries(keys.map((key) => [key, buildSchemaExample(properties[key], key)]));
+  }
+  if (schema.type === "array") {
+    const item = buildSchemaExample(schema.items, singularizeFieldName(fieldName));
+    return Number.isInteger(schema.minItems) && schema.minItems > 0 ? [item] : [];
+  }
+  if (schema.type === "integer") {
+    return 1;
+  }
+  if (schema.type === "number") {
+    return 1;
+  }
+  if (schema.type === "boolean") {
+    return true;
+  }
+  if (schema.type === "string") {
+    return sampleStringForField(fieldName);
+  }
+  return "...";
+}
+
+function sampleStringForField(fieldName) {
+  const normalized = String(fieldName ?? "").toLowerCase();
+  if (normalized.includes("url")) return "https://example.com/source";
+  if (normalized.includes("revision")) return "123456789";
+  if (normalized.includes("page_title") || normalized.includes("pagetitle")) return "Example article";
+  if (normalized.includes("risk")) return "low";
+  if (normalized.includes("status")) return "complete";
+  return "...";
+}
+
+function singularizeFieldName(fieldName) {
+  return String(fieldName ?? "item").replace(/s$/u, "");
 }
 
 function buildWikipediaPinnedRevisionUrl(source) {

--- a/mcp-server/src/core/job-execution-service.js
+++ b/mcp-server/src/core/job-execution-service.js
@@ -1,11 +1,12 @@
 import { randomUUID } from "node:crypto";
 import {
   ConflictError,
+  InvalidSubmissionShapeError,
   NotFoundError
 } from "./errors.js";
 import { buildSessionLifecycle, describeSessionStatus, transitionSession } from "./session-state-machine.js";
-import { hashSubmission, normalizeSubmission } from "./submission.js";
-import { getBuiltinJobSchema, validateStructuredSubmission } from "./job-schema-registry.js";
+import { hashSubmission, isStructuredSubmission, normalizeSubmission } from "./submission.js";
+import { getBuiltinJobSchema, validateAgainstSchema, validateStructuredSubmission } from "./job-schema-registry.js";
 import {
   buildFundedJobFromClaim,
   parseGithubPullRequestUrl,
@@ -149,7 +150,7 @@ export class JobExecutionService {
   async submitWork(sessionId, protocol, submissionInput = "submitted-via-service") {
     const session = await this.requireSession(sessionId);
     const job = this.getJobDefinition(session.jobId);
-    const submission = normalizeSubmission(submissionInput);
+    const submission = normalizeSubmission(normalizeSubmitPayloadShape(job.outputSchemaRef, submissionInput));
     if (submission.kind === "structured") {
       validateStructuredSubmission(job.outputSchemaRef, submission.structured, { path: "submission" });
     }
@@ -314,4 +315,55 @@ export class JobExecutionService {
       }
     });
   }
+}
+
+function normalizeSubmitPayloadShape(schemaRef, submissionInput) {
+  if (!isPlainObject(submissionInput) || !isStructuredSubmission(submissionInput.output)) {
+    return submissionInput;
+  }
+
+  const schema = getBuiltinJobSchema(schemaRef);
+  if (!schema) {
+    return submissionInput;
+  }
+
+  const directValidation = tryValidateAgainstSchema(submissionInput, schema, "submission");
+  if (directValidation.ok) {
+    return submissionInput;
+  }
+
+  const outputValidation = tryValidateAgainstSchema(submissionInput.output, schema, "submission.output");
+  if (outputValidation.ok) {
+    return submissionInput.output;
+  }
+
+  throw new InvalidSubmissionShapeError(
+    "Send the structured proposal object directly as submission, not under submission.output.",
+    {
+      expected: firstRequiredSubmissionPath(schema),
+      schemaValidates: "payload.submission",
+      received: "payload.submission.output",
+      hint: "Move the object currently under submission.output up to submission. Do not wrap the job output under an output key.",
+      directError: directValidation.message,
+      outputError: outputValidation.message
+    }
+  );
+}
+
+function tryValidateAgainstSchema(value, schema, path) {
+  try {
+    validateAgainstSchema(value, schema, path);
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, message: error?.message ?? "invalid submission" };
+  }
+}
+
+function firstRequiredSubmissionPath(schema) {
+  const [firstRequired] = schema?.required ?? [];
+  return firstRequired ? `payload.submission.${firstRequired}` : "payload.submission";
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }

--- a/mcp-server/src/core/job-execution-service.test.js
+++ b/mcp-server/src/core/job-execution-service.test.js
@@ -55,6 +55,80 @@ test("submitWork accepts structured output for built-in schemas", async () => {
   assert.equal(submitted.statusHistory[1].metadata.schemaRef, "schema://jobs/pr-review-findings-output");
 });
 
+test("submitWork unwraps submission.output compatibility alias before storing structured output", async () => {
+  const stateStore = new MemoryStateStore();
+  const job = makeJob();
+  const service = new JobExecutionService(stateStore, undefined, () => job);
+
+  const output = {
+    summary: "Auth flow has one blocker.",
+    findings: [
+      {
+        severity: "high",
+        file: "frontend/auth.js",
+        issue: "Session refresh is hidden behind retry logic.",
+        recommendation: "Show a visible sign-in refresh path."
+      }
+    ],
+    risk_level: "high",
+    files_touched: ["frontend/auth.js"],
+    recommended_next_step: "request_changes"
+  };
+
+  const claimed = await service.claimJob(WALLET, job.id, "http", "idemp-output-alias");
+  const submitted = await service.submitWork(claimed.sessionId, "http", {
+    jobId: job.id,
+    output
+  });
+
+  assert.equal(submitted.status, "submitted");
+  assert.equal(submitted.submission.kind, "structured");
+  assert.deepEqual(submitted.submission.structured, output);
+});
+
+test("submitWork keeps direct structured submissions that legitimately include an output field", async () => {
+  const stateStore = new MemoryStateStore();
+  const job = makeJob({ outputSchemaRef: "schema://jobs/coding-output" });
+  const service = new JobExecutionService(stateStore, undefined, () => job);
+
+  const output = {
+    summary: "Parser fixed.",
+    output: "Added regression coverage.",
+    status: "complete",
+    filesChanged: ["src/parser.js"]
+  };
+
+  const claimed = await service.claimJob(WALLET, job.id, "http", "idemp-direct-output");
+  const submitted = await service.submitWork(claimed.sessionId, "http", output);
+
+  assert.equal(submitted.submission.kind, "structured");
+  assert.deepEqual(submitted.submission.structured, output);
+});
+
+test("submitWork explains wrapped output shape when the alias payload is still invalid", async () => {
+  const stateStore = new MemoryStateStore();
+  const job = makeJob({ outputSchemaRef: "schema://jobs/wikipedia-citation-repair-output" });
+  const service = new JobExecutionService(stateStore, undefined, () => job);
+
+  const claimed = await service.claimJob(WALLET, job.id, "http", "idemp-bad-output-alias");
+
+  await assert.rejects(
+    () => service.submitWork(claimed.sessionId, "http", {
+      jobId: job.id,
+      output: {
+        page_title: "Example article",
+        revision_id: "123456789"
+      }
+    }),
+    (error) => {
+      assert.equal(error.code, "invalid_submission_shape");
+      assert.equal(error.details.expected, "payload.submission.page_title");
+      assert.match(error.details.hint, /Do not wrap/u);
+      return true;
+    }
+  );
+});
+
 test("submitWork rejects structured output when the schema ref is unknown", async () => {
   const stateStore = new MemoryStateStore();
   const job = makeJob({ outputSchemaRef: "schema://jobs/custom-output" });


### PR DESCRIPTION
## What changed
- Adds a machine-readable submissionContract to public job definitions with the exact POST /jobs/submit payload example.
- Documents that output schemas validate payload.submission directly and that agents should not wrap under submission.output.
- Accepts payload.submission.output as a compatibility alias when it validates against the job output schema, while preserving legitimate direct schemas that include an output field.
- Returns invalid_submission_shape with expected path and hint when a wrapped output is still invalid.

## Checks
- node --test mcp-server/src/core/job-execution-service.test.js mcp-server/src/core/job-catalog-metadata.test.js
- npm --workspace mcp-server test
- git diff --check

## Impact
- Backend/API ergonomics only. No frontend, indexer, contracts, Caddy, or public-site changes.

## Polkadot MCP check
- Rechecked Polkadot docs for JSON-RPC/API and indexer context; this is an Averray API contract normalization change, not a Polkadot RPC behavior change.

Closes #113