### PR TITLE
Keep deploy SSH session alive across long npm ci steps

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -117,7 +117,17 @@ jobs:
               "$DEPLOY_INDEXER_FRESH_SCHEMA"
           )
 
-          ssh -p "${VPS_PORT:-22}" "$VPS_USER@$VPS_HOST" \
+          # ServerAliveInterval=30 + ServerAliveCountMax=120 keeps the session
+          # alive for up to 60 minutes of remote silence. Long-running steps —
+          # in particular `npm ci` for the operator frontend — produce no SSH
+          # traffic for several minutes at a stretch, and a default-keepalive
+          # session times out partway through the build with `client_loop: send
+          # disconnect: Broken pipe` (exit 255). The build itself is not slow
+          # enough to be a problem; the *idle* session is.
+          ssh -p "${VPS_PORT:-22}" \
+            -o ServerAliveInterval=30 \
+            -o ServerAliveCountMax=120 \
+            "$VPS_USER@$VPS_HOST" \
             "${remote_env} bash -s" <<'REMOTE'
           set -e
           cd /srv/agent-stack/app


### PR DESCRIPTION
## Summary

Adds `-o ServerAliveInterval=30 -o ServerAliveCountMax=120` to the SSH command in the production deploy workflow, so the session survives long stretches of remote silence during `npm ci` and similar build steps.

## Why

The post-merge auto-deploy of #122 ([run 25229407481](https://github.com/averray-agent/agent/actions/runs/25229407481)) reported:

```
agent-indexer: Indexer redeployed successfully.
Deploying *** frontend
Building and syncing *** frontend
... ~4.5 minutes of npm install warnings ...
client_loop: send disconnect: Broken pipe
##[error]Process completed with exit code 255.
```

Backend and indexer had already redeployed successfully. The failure was purely the SSH client tearing down a session that had been idle (no stdout traffic) for a few minutes during `npm ci`. The keepalive probe interval at default values isn't enough to keep the session alive across the longest quiet windows in a fresh node_modules install.

This same pattern is the root cause for several earlier "cosmetic red" deploys the team has been seeing — runs that complete the work but exit 255 because the SSH dies before the wrapper can finish. PR #122's structural fixes (rollback target, schema visibility, fatal-error surfacing) all worked correctly in run 25229407481 and are unaffected by this change.

## Why these specific values

- `ServerAliveInterval=30` — every 30s of remote silence the client sends a no-op keepalive. Cheap; 30s is well below any reasonable TCP/firewall timeout.
- `ServerAliveCountMax=120` — tolerate up to 120 missed responses (= 60 minutes of remote unresponsiveness) before declaring the connection dead. 60 minutes is a generous ceiling; no realistic single component step takes that long.

The build itself is not slow. The *idle session during the build* is what was timing out.

## Test plan

- [x] `bash -n` on the workflow's bash heredoc would not catch this (it's an SSH client flag, not script content). Manual review of the diff is the actual gate.
- [ ] Post-merge auto-deploy completes without `client_loop: send disconnect`. Will be visible in the next deploy run that touches `app/` or `frontend/`.
- [ ] Backend, indexer, and frontend deploy steps all log "redeployed successfully" before the workflow exits 0.

## Out of scope

- Switching component builds to run on the GitHub runner (build-then-rsync-only) instead of remote bash. That's a structurally cleaner fix and would also avoid the SSH session covering the build window — but it's a much bigger PR (Docker image hosting, secret routing, network from runner to VPS) and the keepalive fix is enough to close the visible incident.
- Adding a per-component timeout. Not warranted while we're not seeing real builds run away.