### PR TITLE
Read currentActivity + submissionContract on the runs / agents pages

### DIFF
--- a/app/components/runs/LoadedRunView.tsx
+++ b/app/components/runs/LoadedRunView.tsx
@@ -19,7 +19,7 @@ import {
   FIXTURE_RUN_ROWS,
 } from "./fixtures";
 import type { RunRow } from "./RunQueueTable";
-import { swrFetcher } from "@/lib/api/client";
+import { ApiError, swrFetcher } from "@/lib/api/client";
 import { useAdminJobs, useJobDefinition, useJobs } from "@/lib/api/hooks";
 import {
   buildGitHubContext,
@@ -91,6 +91,25 @@ export function LoadedRunView({
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [receiptOpen, setReceiptOpen] = useState(false);
 
+  // PR #123 added a per-job `submissionContract` block on /jobs that
+  // tells callers exactly what shape `payload.submission` should take
+  // (including a `submitPayloadExample.submission` skeleton).
+  // Surfacing it on the operator panel turns the previously-stubbed
+  // textarea into a useful template editor: the operator sees the
+  // schema-shaped example pre-filled, edits the placeholder values,
+  // and submits something the verifier can actually validate.
+  const submissionContract = asRecord(selectedJob?.submissionContract);
+  const submissionExample = asRecord(
+    asRecord(submissionContract?.submitPayloadExample)?.submission
+  );
+  const submissionSample = submissionExample
+    ? JSON.stringify(submissionExample, null, 2)
+    : "";
+  const outputSchemaUrl =
+    typeof submissionContract?.outputSchemaUrl === "string"
+      ? submissionContract.outputSchemaUrl
+      : undefined;
+
   const handleSubmit = async (evidence: string) => {
     setSubmitError(null);
     if (!loadedRow.sessionId) {
@@ -99,6 +118,13 @@ export function LoadedRunView({
     }
     setSubmitting(true);
     try {
+      // The backend validates `payload.submission` directly against the
+      // job's output schema (PR #123). If the operator typed a JSON
+      // object that matches the schema, send it as-is. Otherwise fall
+      // back to the legacy text-evidence wrapping so older fixtures
+      // and free-text smoke tests still get a 4xx that says what's
+      // wrong instead of failing silently here.
+      const submission = parseSubmissionInput(evidence, loadedRow.id);
       await swrFetcher([
         "/jobs/submit",
         {
@@ -106,19 +132,21 @@ export function LoadedRunView({
           headers: { "content-type": "application/json" },
           body: JSON.stringify({
             sessionId: loadedRow.sessionId,
-            submission: {
-              evidence,
-              jobId: loadedRow.id,
-              submittedAt: new Date().toISOString(),
-            },
+            submission,
           }),
         },
       ]);
       mutate("/jobs");
       mutate("/sessions");
-    } catch {
+    } catch (err) {
+      // Surface the verifier's own message when it's an
+      // `invalid_submission_shape` 422 — that's the new error code
+      // PR #123 introduced and it carries an `expectedPath` hint that
+      // tells the operator exactly which field is missing.
+      const apiMessage = extractApiErrorMessage(err);
       setSubmitError(
-        "Could not submit this run. Check session ownership and try again."
+        apiMessage ??
+          "Could not submit this run. Check session ownership and the submission shape."
       );
     } finally {
       setSubmitting(false);
@@ -187,9 +215,12 @@ export function LoadedRunView({
         evidence={{
           tabs: [{ id: "brief", label: "Brief" }],
           activeTab: "brief",
-          metaRight: "",
-          metaFoot: "",
-          sample: "",
+          // Hint the operator that the textarea expects schema-shaped
+          // JSON; the per-source SubmissionTabs override these labels
+          // when a richer source-aware UI takes over.
+          metaRight: outputSchemaUrl ? "schema-shaped JSON" : "",
+          metaFoot: outputSchemaUrl ? `output schema · ${outputSchemaUrl}` : "",
+          sample: submissionSample,
         }}
         submission={{
           note: loadedWikipedia ? (
@@ -670,6 +701,67 @@ export function LoadedRunView({
       />
     </div>
   );
+}
+
+/**
+ * Read an operator's textarea content as a submission body. Two paths:
+ *   - JSON-object input → forward verbatim as `payload.submission`. This
+ *     is the supported shape after PR #123: the verifier validates this
+ *     object directly against the job's output schema.
+ *   - Anything else → wrap in the legacy `{ evidence, jobId, submittedAt }`
+ *     shape so older smoke tests and free-text scratch input get a
+ *     useful 4xx from the verifier (with `expectedPath`) rather than
+ *     failing silently in the client.
+ */
+function parseSubmissionInput(evidence: string, jobId: string): unknown {
+  const trimmed = evidence.trim();
+  if (trimmed.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed;
+      }
+    } catch {
+      // Fall through to the wrapped form below.
+    }
+  }
+  return {
+    evidence,
+    jobId,
+    submittedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Lift the human-friendly verifier message off an ApiError 4xx body so
+ * the operator sees `invalid_submission_shape · expectedPath ...`
+ * instead of a generic "could not submit" string. Returns undefined for
+ * non-API errors so the caller can substitute its own copy.
+ */
+function extractApiErrorMessage(err: unknown): string | undefined {
+  if (!(err instanceof ApiError)) return undefined;
+  const body = err.body;
+  if (body && typeof body === "object" && !Array.isArray(body)) {
+    const record = body as Record<string, unknown>;
+    const code = typeof record.code === "string" ? record.code : undefined;
+    const message =
+      typeof record.message === "string" ? record.message : undefined;
+    const expected =
+      typeof record.expectedPath === "string"
+        ? record.expectedPath
+        : typeof (record.details as Record<string, unknown> | undefined)?.expectedPath ===
+            "string"
+          ? ((record.details as Record<string, unknown>).expectedPath as string)
+          : undefined;
+    if (message || code) {
+      const parts = [code, message].filter(
+        (p): p is string => typeof p === "string" && p.length > 0
+      );
+      const combined = parts.join(" · ");
+      return expected ? `${combined} · expected ${expected}` : combined;
+    }
+  }
+  return err.message;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {

--- a/app/lib/api/agent-adapters.ts
+++ b/app/lib/api/agent-adapters.ts
@@ -189,21 +189,38 @@ function stateFor(
 }
 
 function activeSessionFor(record: RawRecord): AgentActiveSession | undefined {
-  // The backend may attach an `activeSession` block directly on the agent
-  // payload, or split it across `currentSession` / `currentJob`. Tolerate
-  // either shape — if neither is present we just leave the agent in
-  // `idle`/`active` and the directory + drawer fall back to history.
+  // The backend has shipped this block under three names across the
+  // recent indexer/deploy churns:
+  //   - `currentActivity` (live shape, see GET /agents/<wallet>):
+  //       { sessionId, jobId, status, label, phase, outcome,
+  //         claimedAt, updatedAt, deadlineAt, canSubmit,
+  //         awaitingVerification }
+  //     The session id doubles as the run id in this scheme — there's
+  //     no separate `runId` field today.
+  //   - `activeSession` / `currentSession` (older / fallback names that
+  //     PR #108 originally targeted)
+  // Tolerate any of the three so the drawer keeps rendering through
+  // schema rotations.
   const block =
+    objectField(record, "currentActivity") ??
     objectField(record, "activeSession") ??
     objectField(record, "currentSession") ??
     null;
   if (!block) return undefined;
-  const runId = text(block.runId, "");
   const jobId = text(block.jobId, "");
   const sessionId = text(block.sessionId, "");
+  // `runId` is optional on the backend; fall back to sessionId so the
+  // drawer always has a value to display.
+  const runId = text(block.runId, "") || sessionId;
   if (!runId || !jobId || !sessionId) return undefined;
   const status = activeStatus(block.status);
   if (!status) return undefined;
+  // `currentActivity` uses `updatedAt` and `label`; older `activeSession`
+  // shapes used `lastEventAt` / `lastEvent`. Fall through both so the
+  // drawer's "Last event" line is populated regardless of which key
+  // the backend emits today.
+  const lastEventAt = text(block.lastEventAt, "") || text(block.updatedAt, "");
+  const lastEvent = text(block.lastEvent, "") || text(block.label, "");
   return {
     runId,
     jobId,
@@ -211,8 +228,8 @@ function activeSessionFor(record: RawRecord): AgentActiveSession | undefined {
     status,
     ...(text(block.title) ? { title: text(block.title) } : {}),
     ...(text(block.deadlineAt) ? { deadlineAt: text(block.deadlineAt) } : {}),
-    ...(text(block.lastEventAt) ? { lastEventAt: text(block.lastEventAt) } : {}),
-    ...(text(block.lastEvent) ? { lastEvent: text(block.lastEvent) } : {}),
+    ...(lastEventAt ? { lastEventAt } : {}),
+    ...(lastEvent ? { lastEvent } : {}),
   };
 }
 


### PR DESCRIPTION
## Why
The user pointed out that a real claim landed on prod (\`agent-30bc-ee05\` claimed Wikipedia citation repair (Hash)) but the operator UI was still showing the agent as Idle and the row as Ready. Two backend fields had shipped during the indexer-deploy churn that the frontend wasn't reading yet:

1. **\`/agents/<wallet>.currentActivity\`** is the live shape for the active claim. PR [#108](https://github.com/averray-agent/agent/pull/108) wired the drawer to read \`activeSession\` / \`currentSession\` — slightly different keys, so the drawer never populated.
2. **\`job.submissionContract\`** (PR [#123](https://github.com/averray-agent/agent/pull/123)) tells callers exactly what shape \`payload.submission\` should take, including a \`submitPayloadExample.submission\` skeleton + schema URL. The submit handler was still wrapping operator input as \`{ evidence, jobId, submittedAt }\` which fails schema validation on every job kind.

I also checked the Polkadot docs MCP for any session/claim-state guidance — only validator-staking content, nothing applicable.

## What changes

### Agent drawer (\`agent-adapters.ts\`)
- \`activeSessionFor\` reads \`currentActivity\` first, then falls back to \`activeSession\` / \`currentSession\` for older fixtures.
- Maps \`updatedAt\` → \`lastEventAt\` and \`label\` → \`lastEvent\` so the drawer's \"Last event\" line keeps rendering.
- \`runId\` falls back to \`sessionId\` since the live shape doesn't separate them.

### Submit handler (\`LoadedRunView.tsx\`)
- Pre-fills the textarea from \`job.submissionContract.submitPayloadExample.submission\` so the operator sees the schema-shaped object and can edit placeholder values.
- New \`parseSubmissionInput\` helper: JSON-parses the textarea — object input forwards verbatim as \`payload.submission\`; anything else falls back to the legacy wrapping so free-text smoke tests still get a useful 4xx.
- New \`extractApiErrorMessage\` lifts the verifier's \`invalid_submission_shape · expectedPath ...\` body off the ApiError so the operator sees what's wrong, not a generic \"could not submit\".

## Other tabs audit
\`/sessions\`, \`/policies\`, \`/disputes\`, \`/audit\`, \`/alerts\`, \`/badges\` — all return 401 without auth and the existing hooks already cover them. No new backend endpoints landed during the recent indexer-deploy work that the operator app needs to consume. Nothing to ship there.

## Test plan
- [x] \`npm run typecheck:app\`
- [x] \`npm run build:frontend\`
- [ ] After deploy: open \`/agents\` signed-in. The 30BC wallet's row should show the Claimed pill and the drawer should render the Active session block with jobId \`wiki-en-62871101-citation-repair-hash\`, deadline countdown, and the \"Claimed\" last-event copy.
- [ ] Open \`/runs/detail/?id=wiki-en-62871101-citation-repair-hash\`. Submit textarea should pre-fill with the schema-shaped JSON example.