### PR TITLE
Expose expired claim state affordances

### DIFF
--- a/mcp-server/src/core/claim-state.js
+++ b/mcp-server/src/core/claim-state.js
@@ -1,0 +1,135 @@
+const TERMINAL_SESSION_STATUSES = new Set(["resolved", "rejected", "closed", "expired", "timed_out"]);
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+export function claimExpiresAt(session, job) {
+  if (!session?.claimedAt) return undefined;
+  const claimedAtMs = Date.parse(session.claimedAt);
+  const ttlSeconds = Number(job?.claimTtlSeconds ?? 0);
+  if (!Number.isFinite(claimedAtMs) || !Number.isFinite(ttlSeconds) || ttlSeconds <= 0) {
+    return undefined;
+  }
+  return new Date(claimedAtMs + ttlSeconds * 1000).toISOString();
+}
+
+export function isExpiredClaim(session, job, now = new Date()) {
+  if (session?.status !== "claimed") return false;
+  const expiresAt = claimExpiresAt(session, job);
+  return Boolean(expiresAt && Date.parse(expiresAt) <= now.getTime());
+}
+
+export function isTerminalSession(session) {
+  return TERMINAL_SESSION_STATUSES.has(session?.status);
+}
+
+export function summarizeJobClaimState({ job, session = undefined, wallet = undefined, now = new Date() } = {}) {
+  const lifecycle = job?.lifecycle ?? {};
+  const lifecycleState = lifecycle.state ?? lifecycle.status ?? "open";
+  const retryLimit = Number.isInteger(job?.retryLimit) ? job.retryLimit : 1;
+  const normalizedWallet = normalizeWallet(wallet);
+  const claimedBy = normalizeWallet(session?.wallet) ?? normalizeWallet(job?.claimedBy);
+  const walletMatchesClaim = Boolean(normalizedWallet && claimedBy && normalizedWallet === claimedBy);
+  const claimExpiresAtValue = claimExpiresAt(session, job);
+  const expired = isExpiredClaim(session, job, now) || session?.status === "expired";
+
+  if (!session) {
+    const claimable = lifecycleState === "open";
+    return compact({
+      claimState: claimable ? "open" : lifecycleState,
+      claimable,
+      currentWalletCanClaim: normalizedWallet ? claimable : null,
+      reason: claimable ? "claimable" : `job_${lifecycleState}`,
+      retryLimit,
+      claimedBy: null,
+      claimedAt: null,
+      claimExpiresAt: null,
+      claimNumber: null,
+      sessionId: null
+    });
+  }
+
+  if (expired) {
+    const retryLimitExhausted = walletMatchesClaim && retryLimit <= 1;
+    return compact({
+      claimState: "expired",
+      claimable: false,
+      currentWalletCanClaim: normalizedWallet ? false : null,
+      reason: retryLimitExhausted ? "retry_limit_exhausted" : "claim_expired_reopen_required",
+      retryLimit,
+      claimedBy,
+      claimedAt: session.claimedAt ?? null,
+      claimExpiresAt: claimExpiresAtValue ?? session.expiredAt ?? null,
+      claimNumber: session.claimNumber ?? 1,
+      sessionId: session.sessionId ?? null,
+      expiredAt: session.expiredAt ?? claimExpiresAtValue ?? null
+    });
+  }
+
+  if (session.status === "claimed") {
+    return compact({
+      claimState: "claimed",
+      claimable: false,
+      currentWalletCanClaim: normalizedWallet ? false : null,
+      reason: walletMatchesClaim ? "already_claimed_by_current_wallet" : "claimed_by_other_wallet",
+      retryLimit,
+      claimedBy,
+      claimedAt: session.claimedAt ?? null,
+      claimExpiresAt: claimExpiresAtValue ?? null,
+      claimNumber: session.claimNumber ?? 1,
+      sessionId: session.sessionId ?? null
+    });
+  }
+
+  const claimState = submittedLikeState(session.status);
+  return compact({
+    claimState,
+    claimable: false,
+    currentWalletCanClaim: normalizedWallet ? false : null,
+    reason: claimState === "exhausted" ? "job_session_completed" : `session_${claimState}`,
+    retryLimit,
+    claimedBy,
+    claimedAt: session.claimedAt ?? null,
+    claimExpiresAt: claimExpiresAtValue ?? null,
+    claimNumber: session.claimNumber ?? null,
+    sessionId: session.sessionId ?? null
+  });
+}
+
+export function claimStatusFields(claimStatus) {
+  return {
+    claimStatus,
+    claimState: claimStatus.claimState,
+    claimable: claimStatus.claimable,
+    currentWalletCanClaim: claimStatus.currentWalletCanClaim,
+    reason: claimStatus.reason,
+    retryLimit: claimStatus.retryLimit,
+    claimNumber: claimStatus.claimNumber ?? null,
+    claimedBy: claimStatus.claimedBy ?? null,
+    claimedAt: claimStatus.claimedAt ?? null,
+    claimExpiresAt: claimStatus.claimExpiresAt ?? null,
+    sessionId: claimStatus.sessionId ?? null,
+    state: claimStatus.claimState
+  };
+}
+
+function submittedLikeState(status) {
+  if (status === "submitted" || status === "disputed" || status === "rejected") {
+    return "submitted";
+  }
+  if (TERMINAL_SESSION_STATUSES.has(status)) {
+    return "exhausted";
+  }
+  return status ?? "open";
+}
+
+function normalizeWallet(wallet) {
+  if (typeof wallet !== "string" || !wallet.trim()) return undefined;
+  const trimmed = wallet.trim();
+  if (trimmed === ZERO_ADDRESS) return undefined;
+  return trimmed.toLowerCase();
+}
+
+function compact(value) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined)
+  );
+}

--- a/mcp-server/src/core/job-execution-service.js
+++ b/mcp-server/src/core/job-execution-service.js
@@ -17,6 +17,7 @@ import {
   DEFAULT_OPEN_PR_CAP_PER_REPO,
   countOpenGithubPullRequestsForRepo
 } from "./maintainer-surface-policy.js";
+import { claimExpiresAt, isExpiredClaim, isTerminalSession } from "./claim-state.js";
 
 export class JobExecutionService {
   constructor(
@@ -45,8 +46,12 @@ export class JobExecutionService {
 
   async claimJob(wallet, jobId, protocol, idempotencyKey) {
     const existing = await this.stateStore.findSessionByIdempotencyKey(idempotencyKey);
-    if (existing && !this.isTerminalSession(existing)) {
-      return existing;
+    if (existing) {
+      const existingJob = this.getJobDefinition(existing.jobId);
+      const refreshed = await this.materializeExpiredClaim(existing, existingJob);
+      if (!this.isTerminalSession(refreshed)) {
+        return refreshed;
+      }
     }
 
     const job = this.getClaimableJobDefinition(jobId);
@@ -69,24 +74,44 @@ export class JobExecutionService {
 
     try {
       const replay = await this.stateStore.findSessionByIdempotencyKey(idempotencyKey);
-      if (replay && !this.isTerminalSession(replay)) {
-        return replay;
+      if (replay) {
+        const replayJob = this.getJobDefinition(replay.jobId);
+        const refreshed = await this.materializeExpiredClaim(replay, replayJob);
+        if (!this.isTerminalSession(refreshed)) {
+          return refreshed;
+        }
       }
 
       const existingSession = await this.stateStore.getSession(sessionId);
       if (existingSession) {
-        if (this.isTerminalSession(existingSession)) {
+        const refreshed = await this.materializeExpiredClaim(existingSession, job);
+        if (this.isTerminalSession(refreshed)) {
           throw new ConflictError(
             `Job ${jobId} already has a completed session for this wallet. Create or select a different job to run again.`,
-            "job_session_completed"
+            refreshed.status === "expired" ? "retry_limit_exhausted" : "job_session_completed",
+            this.buildClaimExpiryDetails(refreshed, job)
           );
         }
-        return existingSession;
+        return refreshed;
       }
 
       const liveJobSession = await this.stateStore.findSessionByJobId(jobId);
       if (liveJobSession && liveJobSession.sessionId !== sessionId) {
-        throw new ConflictError(`Job ${jobId} is already claimed by another wallet.`, "job_already_claimed");
+        const refreshed = await this.materializeExpiredClaim(liveJobSession, job);
+        if (!this.isTerminalSession(refreshed)) {
+          throw new ConflictError(
+            `Job ${jobId} is already claimed by another wallet.`,
+            "job_already_claimed",
+            this.buildClaimExpiryDetails(refreshed, job)
+          );
+        }
+        if (refreshed.status === "expired") {
+          throw new ConflictError(
+            `Job ${jobId} has an expired claim that must be reopened before it can be claimed again.`,
+            "claim_expired_reopen_required",
+            this.buildClaimExpiryDetails(refreshed, job)
+          );
+        }
       }
 
       const chainJobId = this.blockchainGateway?.isEnabled()
@@ -150,6 +175,21 @@ export class JobExecutionService {
   async submitWork(sessionId, protocol, submissionInput = "submitted-via-service") {
     const session = await this.requireSession(sessionId);
     const job = this.getJobDefinition(session.jobId);
+    const refreshed = await this.materializeExpiredClaim(session, job);
+    if (refreshed.status === "expired") {
+      throw new ConflictError(
+        `Claim ${sessionId} expired before submission.`,
+        "claim_expired",
+        this.buildClaimExpiryDetails(refreshed, job)
+      );
+    }
+    if (this.isTerminalSession(refreshed)) {
+      throw new ConflictError(
+        `Session ${sessionId} is already complete and cannot be submitted.`,
+        "job_session_completed",
+        this.buildClaimExpiryDetails(refreshed, job)
+      );
+    }
     const submission = normalizeSubmission(normalizeSubmitPayloadShape(job.outputSchemaRef, submissionInput));
     if (submission.kind === "structured") {
       validateStructuredSubmission(job.outputSchemaRef, submission.structured, { path: "submission" });
@@ -158,9 +198,9 @@ export class JobExecutionService {
     if (this.blockchainGateway?.isEnabled()) {
       await this.blockchainGateway.submitWork(session.chainJobId ?? session.jobId, hashSubmission(submission));
     }
-    const protocolHistory = [...new Set([...session.protocolHistory, protocol])];
+    const protocolHistory = [...new Set([...refreshed.protocolHistory, protocol])];
     const transitioned = transitionSession({
-      ...session,
+      ...refreshed,
       protocolHistory,
       submission,
       outputSchemaBuiltin: Boolean(getBuiltinJobSchema(job.outputSchemaRef))
@@ -266,6 +306,40 @@ export class JobExecutionService {
     return session;
   }
 
+  async materializeExpiredClaim(session, job, now = new Date()) {
+    if (!isExpiredClaim(session, job, now)) {
+      return session;
+    }
+    const expiredAt = claimExpiresAt(session, job) ?? now.toISOString();
+    const transitioned = transitionSession(session, "expired", {
+      reason: "claim_ttl_expired",
+      timestamp: expiredAt,
+      metadata: {
+        claimExpiresAt: expiredAt,
+        claimTtlSeconds: job?.claimTtlSeconds
+      }
+    });
+    const persisted = await this.stateStore.upsertSession(transitioned);
+    const fundedJob = await this.stateStore.getFundedJob?.(persisted.jobId);
+    await this.stateStore.upsertFundedJob?.(updateFundedJobFromSession(fundedJob, { job, session: persisted }));
+    this.publishSessionEvent("session.expired", persisted, {
+      claimExpiresAt: expiredAt,
+      reason: "claim_ttl_expired"
+    });
+    return persisted;
+  }
+
+  buildClaimExpiryDetails(session, job) {
+    return {
+      sessionId: session?.sessionId,
+      jobId: session?.jobId,
+      claimedBy: session?.wallet,
+      claimedAt: session?.claimedAt,
+      claimExpiresAt: claimExpiresAt(session, job) ?? session?.expiredAt,
+      claimTtlSeconds: job?.claimTtlSeconds
+    };
+  }
+
   getClaimLockTtlSeconds(job) {
     return Math.max(60, Math.min(Number(job?.claimTtlSeconds ?? 300), 900));
   }
@@ -286,7 +360,7 @@ export class JobExecutionService {
   }
 
   isTerminalSession(session) {
-    return ["resolved", "rejected", "closed", "expired", "timed_out"].includes(session?.status);
+    return isTerminalSession(session);
   }
 
   publishSessionEvent(topic, session, data = {}) {

--- a/mcp-server/src/core/job-execution-service.test.js
+++ b/mcp-server/src/core/job-execution-service.test.js
@@ -142,6 +142,46 @@ test("submitWork rejects structured output when the schema ref is unknown", asyn
   );
 });
 
+test("submitWork rejects and materializes expired claims before mutation", async () => {
+  const stateStore = new MemoryStateStore();
+  const job = makeJob({
+    outputSchemaRef: "schema://jobs/coding-output",
+    claimTtlSeconds: 60
+  });
+  const service = new JobExecutionService(stateStore, undefined, () => job);
+
+  const claimed = await service.claimJob(WALLET, job.id, "http", "idemp-expired-submit");
+  await stateStore.upsertSession({
+    ...claimed,
+    claimedAt: "2026-05-01T10:00:00.000Z",
+    statusHistory: [
+      {
+        from: null,
+        to: "claimed",
+        reason: "job_claimed",
+        at: "2026-05-01T10:00:00.000Z"
+      }
+    ]
+  });
+
+  await assert.rejects(
+    () => service.submitWork(claimed.sessionId, "http", {
+      summary: "Parser fixed.",
+      output: "Added regression coverage.",
+      status: "complete"
+    }),
+    (error) => {
+      assert.equal(error.code, "claim_expired");
+      assert.equal(error.details.claimExpiresAt, "2026-05-01T10:01:00.000Z");
+      return true;
+    }
+  );
+
+  const stored = await stateStore.getSession(claimed.sessionId);
+  assert.equal(stored.status, "expired");
+  assert.equal(stored.expiredAt, "2026-05-01T10:01:00.000Z");
+});
+
 test("computeClaimEconomics waives first three claims and then applies stake plus fee", () => {
   const waived = computeClaimEconomics({
     rewardAmount: 5,

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -11,6 +11,7 @@ import {
   getSessionStateMachineDefinition
 } from "./session-state-machine.js";
 import { computeClaimEconomics, countClaimedSessions } from "./claim-economics.js";
+import { claimStatusFields, summarizeJobClaimState } from "./claim-state.js";
 
 const STARTER_REPUTATION = {
   skill: 0,
@@ -123,23 +124,10 @@ export class PlatformService {
    * visibility calls this method instead of `listJobs`.
    */
   async listJobsWithSessions(options = {}) {
-    const jobs = this.jobCatalogService.listJobs(options);
+    const { wallet, currentWallet, now = new Date(), ...catalogOptions } = options;
+    const jobs = this.jobCatalogService.listJobs({ ...catalogOptions, now });
     return Promise.all(
-      jobs.map(async (job) => {
-        const session = await this.stateStore.findSessionByJobId?.(job.id);
-        if (!session) return job;
-        return {
-          ...job,
-          state: typeof session.status === "string" ? session.status : job.state ?? null,
-          claimedBy: typeof session.wallet === "string" ? session.wallet : job.claimedBy ?? null,
-          sessionId: typeof session.sessionId === "string"
-            ? session.sessionId
-            : job.sessionId ?? null,
-          claimedAt: typeof session.claimedAt === "string"
-            ? session.claimedAt
-            : job.claimedAt ?? undefined
-        };
-      })
+      jobs.map((job) => this.attachClaimState(job, { wallet: currentWallet ?? wallet, now }))
     );
   }
 
@@ -423,8 +411,12 @@ export class PlatformService {
     return this.jobCatalogService.getJobDefinition(jobId);
   }
 
-  getPublicJobDefinition(jobId) {
-    return this.jobCatalogService.getPublicJobDefinition(jobId);
+  async getPublicJobDefinition(jobId, options = {}) {
+    const { wallet, currentWallet, now = new Date() } = options;
+    return this.attachClaimState(
+      this.jobCatalogService.getPublicJobDefinition(jobId),
+      { wallet: currentWallet ?? wallet, now }
+    );
   }
 
   getClaimableJobDefinition(jobId) {
@@ -440,7 +432,25 @@ export class PlatformService {
   }
 
   async preflightJob(wallet, jobId) {
-    return this.jobCatalogService.preflightJob(wallet, jobId);
+    const [preflight, job] = await Promise.all([
+      this.jobCatalogService.preflightJob(wallet, jobId),
+      this.getPublicJobDefinition(jobId, { wallet })
+    ]);
+    return {
+      ...preflight,
+      catalogEligible: preflight.eligible,
+      eligible: preflight.eligible && job.claimable === true && job.currentWalletCanClaim !== false,
+      claimStatus: job.claimStatus,
+      claimState: job.claimState,
+      claimable: job.claimable,
+      currentWalletCanClaim: job.currentWalletCanClaim,
+      reason: job.reason,
+      claimedBy: job.claimedBy,
+      claimedAt: job.claimedAt,
+      claimExpiresAt: job.claimExpiresAt,
+      retryLimit: job.retryLimit,
+      sessionId: job.sessionId
+    };
   }
 
   async explainEligibility(wallet, jobId) {
@@ -461,6 +471,23 @@ export class PlatformService {
 
   async resumeSession(sessionId) {
     return this.jobExecutionService.resumeSession(sessionId);
+  }
+
+  async attachClaimState(job, { wallet = undefined, now = new Date() } = {}) {
+    const session = await this.stateStore.findSessionByJobId?.(job.id);
+    const refreshedSession = session
+      ? await this.jobExecutionService.materializeExpiredClaim(session, job, now)
+      : undefined;
+    const claimStatus = summarizeJobClaimState({
+      job,
+      session: refreshedSession,
+      wallet,
+      now
+    });
+    return {
+      ...job,
+      ...claimStatusFields(claimStatus)
+    };
   }
 
   async listSessionHistory({ wallet = undefined, limit = 10, jobId = undefined } = {}) {

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -90,7 +90,9 @@ test("listJobsWithSessions joins active session state onto job rows", async () =
   assert.equal(before[0].id, "parent-job-001");
   assert.equal(before[0].claimedBy ?? null, null);
   assert.equal(before[0].sessionId ?? null, null);
-  assert.equal(before[0].state ?? null, null);
+  assert.equal(before[0].state, "open");
+  assert.equal(before[0].claimState, "open");
+  assert.equal(before[0].claimable, true);
 
   // After a claim — the row carries claim state read live from the
   // session store so the public /jobs feed and the operator queue
@@ -104,6 +106,51 @@ test("listJobsWithSessions joins active session state onto job rows", async () =
   assert.equal(after[0].sessionId, session.sessionId);
   assert.equal(typeof after[0].state, "string");
   assert.equal(after[0].state, session.status);
+  assert.equal(after[0].claimState, "claimed");
+  assert.equal(after[0].claimable, false);
+  assert.equal(after[0].currentWalletCanClaim, null);
+  assert.equal(after[0].claimExpiresAt, new Date(Date.parse(session.claimedAt) + 3600 * 1000).toISOString());
+});
+
+test("listJobsWithSessions and definition expose expired claim affordances", async () => {
+  const service = makePlatformService();
+  const session = await service.claimJob(WALLET, "parent-job-001", "http", "expired-claim-test");
+  await service.stateStore.upsertSession({
+    ...session,
+    claimedAt: "2026-05-01T11:18:03.973Z",
+    statusHistory: [
+      {
+        from: null,
+        to: "claimed",
+        reason: "job_claimed",
+        at: "2026-05-01T11:18:03.973Z"
+      }
+    ]
+  });
+
+  const now = new Date("2026-05-01T12:18:04.000Z");
+  const rows = await service.listJobsWithSessions({ wallet: WALLET, now });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].state, "expired");
+  assert.equal(rows[0].claimState, "expired");
+  assert.equal(rows[0].claimable, false);
+  assert.equal(rows[0].currentWalletCanClaim, false);
+  assert.equal(rows[0].reason, "retry_limit_exhausted");
+  assert.equal(rows[0].claimedBy, WALLET);
+  assert.equal(rows[0].claimedAt, "2026-05-01T11:18:03.973Z");
+  assert.equal(rows[0].claimExpiresAt, "2026-05-01T12:18:03.973Z");
+  assert.equal(rows[0].retryLimit, 1);
+  assert.equal(rows[0].sessionId, session.sessionId);
+
+  const stored = await service.resumeSession(session.sessionId);
+  assert.equal(stored.status, "expired");
+  assert.equal(stored.expiredAt, "2026-05-01T12:18:03.973Z");
+
+  const definition = await service.getPublicJobDefinition("parent-job-001", { wallet: WALLET, now });
+  assert.equal(definition.lifecycle.state, "open");
+  assert.equal(definition.claimState, "expired");
+  assert.equal(definition.claimStatus.claimExpiresAt, "2026-05-01T12:18:03.973Z");
+  assert.equal(definition.claimStatus.reason, "retry_limit_exhausted");
 });
 
 test("getSessionTimeline includes transitions and verification state", async () => {

--- a/mcp-server/src/protocols/http/jobs-response.js
+++ b/mcp-server/src/protocols/http/jobs-response.js
@@ -76,9 +76,7 @@ function matchesFilters(job, filters) {
     return false;
   }
   if (filters.state) {
-    const lifecycle = job.lifecycle ?? {};
-    const state = normalizeToken(lifecycle.state ?? lifecycle.status ?? "open");
-    const status = normalizeToken(lifecycle.status ?? state);
+    const { state, status } = effectiveJobState(job);
     if (filters.state !== state && filters.state !== status) {
       return false;
     }
@@ -88,12 +86,22 @@ function matchesFilters(job, filters) {
 
 function toCompactJobRow(job) {
   const lifecycle = job.lifecycle ?? {};
-  const state = lifecycle.state ?? lifecycle.status ?? "open";
+  const { state } = effectiveJobState(job);
   const sourceDetails = compactSourceDetails(job);
   return {
     id: job.id,
     title: job.title,
     state,
+    claimState: job.claimState ?? state,
+    claimable: job.claimable ?? state === "open",
+    currentWalletCanClaim: job.currentWalletCanClaim ?? null,
+    reason: job.reason ?? null,
+    claimedBy: job.claimedBy ?? null,
+    claimedAt: job.claimedAt ?? null,
+    claimExpiresAt: job.claimExpiresAt ?? null,
+    retryLimit: job.retryLimit ?? null,
+    claimNumber: job.claimNumber ?? null,
+    sessionId: job.sessionId ?? null,
     source: publicSourceLabel(job),
     sourceType: job.source?.type ?? null,
     category: job.category ?? null,
@@ -109,6 +117,13 @@ function toCompactJobRow(job) {
     definitionUrl: `/jobs/definition?jobId=${encodeURIComponent(job.id)}`,
     ...(sourceDetails ? { sourceDetails } : {})
   };
+}
+
+function effectiveJobState(job) {
+  const lifecycle = job.lifecycle ?? {};
+  const state = normalizeToken(job.claimState ?? job.state ?? lifecycle.state ?? lifecycle.status ?? "open");
+  const status = normalizeToken(job.claimStatus?.claimState ?? job.state ?? state);
+  return { state, status };
 }
 
 function compactSourceDetails(job) {

--- a/mcp-server/src/protocols/http/jobs-response.test.js
+++ b/mcp-server/src/protocols/http/jobs-response.test.js
@@ -80,6 +80,16 @@ test("public jobs response filters and compacts agent-friendly queries", () => {
     "id",
     "title",
     "state",
+    "claimState",
+    "claimable",
+    "currentWalletCanClaim",
+    "reason",
+    "claimedBy",
+    "claimedAt",
+    "claimExpiresAt",
+    "retryLimit",
+    "claimNumber",
+    "sessionId",
     "source",
     "sourceType",
     "category",
@@ -93,6 +103,9 @@ test("public jobs response filters and compacts agent-friendly queries", () => {
     "sourceDetails"
   ]);
   assert.equal(response.jobs[0].id, "wiki-en-123-citation-repair-example");
+  assert.equal(response.jobs[0].state, "open");
+  assert.equal(response.jobs[0].claimState, "open");
+  assert.equal(response.jobs[0].claimable, true);
   assert.equal(response.jobs[0].source, "wikipedia");
   assert.equal(response.jobs[0].sourceType, "wikipedia_article");
   assert.equal(response.jobs[0].definitionUrl, "/jobs/definition?jobId=wiki-en-123-citation-repair-example");
@@ -107,6 +120,46 @@ test("public jobs response filters and compacts agent-friendly queries", () => {
     attributionPolicy: "Averray proposal only / no direct Wikipedia edit",
     outputSchemaUrl: "/schemas/jobs/wikipedia-citation-repair-output.json"
   });
+});
+
+test("public jobs response filters compact rows by claim state", () => {
+  const response = buildPublicJobsResponse(
+    [
+      {
+        ...JOBS[0],
+        claimState: "expired",
+        claimable: false,
+        currentWalletCanClaim: false,
+        reason: "retry_limit_exhausted",
+        claimedBy: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        claimedAt: "2026-05-01T11:18:03.973Z",
+        claimExpiresAt: "2026-05-01T12:18:03.973Z",
+        retryLimit: 1,
+        claimNumber: 1,
+        sessionId: "wiki-en-123-citation-repair-example:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    ],
+    new URLSearchParams("state=expired&limit=25")
+  );
+
+  assert.equal(response.count, 1);
+  assert.equal(response.jobs[0].state, "expired");
+  assert.equal(response.jobs[0].claimState, "expired");
+  assert.equal(response.jobs[0].claimable, false);
+  assert.equal(response.jobs[0].currentWalletCanClaim, false);
+  assert.equal(response.jobs[0].reason, "retry_limit_exhausted");
+  assert.equal(response.jobs[0].claimExpiresAt, "2026-05-01T12:18:03.973Z");
+
+  const openResponse = buildPublicJobsResponse(
+    [
+      {
+        ...JOBS[0],
+        claimState: "expired"
+      }
+    ],
+    new URLSearchParams("state=open&limit=25")
+  );
+  assert.equal(openResponse.total, 0);
 });
 
 test("public jobs response supports category filters and pagination", () => {

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -1361,7 +1361,9 @@ const server = createServer(async (request, response) => {
       // immutable; this endpoint reads the live join. Without it
       // browser agents would re-attempt already-claimed jobs and
       // operator UIs would show "Ready" forever.
-      const jobs = await service.listJobsWithSessions();
+      const jobs = await service.listJobsWithSessions({
+        wallet: url.searchParams.get("wallet") ?? undefined
+      });
       return respond(response, 200, buildPublicJobsResponse(jobs, url.searchParams));
     }
 
@@ -1373,6 +1375,7 @@ const server = createServer(async (request, response) => {
       // The public `/jobs` route filters those out by default.
       return respond(response, 200, {
         jobs: await service.listJobsWithSessions({
+          wallet: auth.wallet,
           includePaused: true,
           includeArchived: true,
           includeStale: true
@@ -1451,7 +1454,9 @@ const server = createServer(async (request, response) => {
     }
 
     if (request.method === "GET" && pathname === "/jobs/definition") {
-      return respond(response, 200, service.getPublicJobDefinition(url.searchParams.get("jobId") ?? ""));
+      return respond(response, 200, await service.getPublicJobDefinition(url.searchParams.get("jobId") ?? "", {
+        wallet: url.searchParams.get("wallet") ?? undefined
+      }));
     }
 
     if (request.method === "GET" && pathname === "/gas/health") {


### PR DESCRIPTION
## Summary
- materialize claimed sessions as expired once their claim TTL has passed before read or submit paths continue
- expose claimState, claimable, claimExpiresAt, currentWalletCanClaim, retryLimit, claimNumber, and reason on /jobs and /jobs/definition
- make compact /jobs state filtering use the live claim state so expired claims do not also appear open

Closes #126.

## Checks
- npm --workspace mcp-server test
- git diff --check HEAD~1 HEAD

## Impact
- Backend/API only
- No environment or VPS secret changes required