### PR TITLE
Track per-component deploy pointers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
         working-directory: mcp-server
         run: node --test --test-timeout=30000 src/protocols/http/server.smoke.test.js
 
+      - name: Ops script regression tests
+        run: npm run test:ops
+
   frontend:
     name: Operator app — static export
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:sdk": "node --test sdk/agent-platform-client.test.mjs",
     "test:examples": "node --test examples/**/*.test.mjs",
     "test:indexer:api": "npm --workspace indexer run test:api",
+    "test:ops": "node --test scripts/ops/*.test.mjs",
     "test:contracts": "forge test",
     "dev:app": "npm --workspace averray-app run dev",
     "build:app": "npm --workspace averray-app run build",

--- a/scripts/ops/deploy-production.sh
+++ b/scripts/ops/deploy-production.sh
@@ -19,6 +19,7 @@ DEPLOY_LOCK_FILE=${DEPLOY_LOCK_FILE:-/tmp/averray-production-deploy.lock}
 DEPLOY_AUTOSTASH=${DEPLOY_AUTOSTASH:-1}
 DEPLOY_OLD_SHA=${DEPLOY_OLD_SHA:-}
 DEPLOY_NEW_SHA=${DEPLOY_NEW_SHA:-}
+DEPLOY_STATE_DIR=${DEPLOY_STATE_DIR:-"$STACK_ROOT/.deploy-state"}
 
 RUN_BACKEND=${RUN_BACKEND:-auto}
 RUN_FRONTEND=${RUN_FRONTEND:-auto}
@@ -72,13 +73,79 @@ changed_matches() {
   git -C "$APP_ROOT" diff --name-only "$OLD_SHA" "$NEW_SHA" | grep -Eq "$pattern"
 }
 
-should_run() {
-  local setting="$1"
+component_state_file() {
+  local component="$1"
+  printf '%s/%s.last-good\n' "$DEPLOY_STATE_DIR" "$component"
+}
+
+write_component_sha() {
+  local component="$1"
+  local sha="$2"
+  local file
+  file=$(component_state_file "$component")
+  mkdir -p "$DEPLOY_STATE_DIR"
+  local tmp="${file}.tmp.$$"
+  printf '%s\n' "$sha" > "$tmp"
+  mv "$tmp" "$file"
+}
+
+read_component_sha() {
+  local component="$1"
+  local file
+  file=$(component_state_file "$component")
+  if [[ ! -f "$file" ]]; then
+    echo "$OLD_SHA"
+    return
+  fi
+
+  local sha
+  sha=$(head -n 1 "$file" | tr -d '[:space:]')
+  if git -C "$APP_ROOT" cat-file -e "${sha}^{commit}" >/dev/null 2>&1; then
+    echo "$sha"
+    return
+  fi
+
+  echo "Ignoring invalid deploy state for $component: $sha" >&2
+  echo "$OLD_SHA"
+}
+
+initialize_component_state() {
+  local component
+  for component in backend indexer frontend site caddy; do
+    local file
+    file=$(component_state_file "$component")
+    if [[ ! -f "$file" ]]; then
+      write_component_sha "$component" "$OLD_SHA"
+      echo "Initialized $component deploy pointer at $OLD_SHA"
+    fi
+  done
+}
+
+component_changed_matches() {
+  local component="$1"
   local pattern="$2"
+  local base_sha
+  base_sha=$(read_component_sha "$component")
+  if [[ "$base_sha" == "$NEW_SHA" ]]; then
+    return 1
+  fi
+  git -C "$APP_ROOT" diff --name-only "$base_sha" "$NEW_SHA" | grep -Eq "$pattern"
+}
+
+mark_component_deployed() {
+  local component="$1"
+  write_component_sha "$component" "$NEW_SHA"
+  echo "Recorded $component deploy pointer: $NEW_SHA"
+}
+
+should_run() {
+  local component="$1"
+  local setting="$2"
+  local pattern="$3"
   case "$setting" in
     1|true|yes) return 0 ;;
     0|false|no) return 1 ;;
-    auto) changed_matches "$pattern" ;;
+    auto) component_changed_matches "$component" "$pattern" ;;
     *)
       echo "Invalid deploy toggle: $setting" >&2
       exit 1
@@ -266,6 +333,7 @@ deploy() {
     echo "No new commits. Running smoke check only."
   fi
 
+  initialize_component_state
   apply_indexer_database_schema
 
   local run_backend=0
@@ -274,44 +342,64 @@ deploy() {
   local run_site=0
   local run_caddy=0
 
-  if should_run "$RUN_BACKEND" '^(mcp-server/|sdk/|examples/|docs/schemas/|package(-lock)?\.json|scripts/ops/redeploy-backend\.sh)'; then
+  if should_run backend "$RUN_BACKEND" '^(mcp-server/|sdk/|examples/|docs/schemas/|package(-lock)?\.json|scripts/ops/redeploy-backend\.sh)'; then
     run_backend=1
     echo "Deploying backend"
     SKIP_GIT_UPDATE=1 PRE_DEPLOY_SHA="$OLD_SHA" "$APP_ROOT/scripts/ops/redeploy-backend.sh"
+    mark_component_deployed backend
   else
     echo "Skipping backend deploy"
+    if [[ "$RUN_BACKEND" == "auto" ]]; then
+      mark_component_deployed backend
+    fi
   fi
 
-  if should_run "$RUN_INDEXER" '^(indexer/|package(-lock)?\.json|scripts/ops/redeploy-indexer\.sh)'; then
+  if should_run indexer "$RUN_INDEXER" '^(indexer/|package(-lock)?\.json|scripts/ops/redeploy-indexer\.sh)'; then
     run_indexer=1
     echo "Deploying indexer"
     SKIP_GIT_UPDATE=1 PRE_DEPLOY_SHA="$OLD_SHA" "$APP_ROOT/scripts/ops/redeploy-indexer.sh"
+    mark_component_deployed indexer
   else
     echo "Skipping indexer deploy"
+    if [[ "$RUN_INDEXER" == "auto" ]]; then
+      mark_component_deployed indexer
+    fi
   fi
 
-  if should_run "$RUN_FRONTEND" '^(app/|frontend/|scripts/sync-operator-frontend\.mjs|scripts/ops/redeploy-frontend\.sh|scripts/ops/deploy-production\.sh|package(-lock)?\.json)'; then
+  if should_run frontend "$RUN_FRONTEND" '^(app/|frontend/|scripts/sync-operator-frontend\.mjs|scripts/ops/redeploy-frontend\.sh|scripts/ops/deploy-production\.sh|package(-lock)?\.json)'; then
     run_frontend=1
     echo "Deploying operator frontend"
     SKIP_GIT_UPDATE=1 PRE_DEPLOY_SHA="$OLD_SHA" "$APP_ROOT/scripts/ops/redeploy-frontend.sh"
+    mark_component_deployed frontend
   else
     echo "Skipping operator frontend deploy"
+    if [[ "$RUN_FRONTEND" == "auto" ]]; then
+      mark_component_deployed frontend
+    fi
   fi
 
-  if should_run "$RUN_SITE" '^(marketing/|site/|scripts/sync-marketing-site\.mjs|package(-lock)?\.json)'; then
+  if should_run site "$RUN_SITE" '^(marketing/|site/|scripts/sync-marketing-site\.mjs|package(-lock)?\.json)'; then
     run_site=1
     echo "Building public site"
     build_site
+    mark_component_deployed site
   else
     echo "Skipping public site build"
+    if [[ "$RUN_SITE" == "auto" ]]; then
+      mark_component_deployed site
+    fi
   fi
 
-  if should_run "$RUN_CADDY" '^(deploy/Caddyfile\.averray|scripts/ops/render-caddyfile\.sh)'; then
+  if should_run caddy "$RUN_CADDY" '^(deploy/Caddyfile\.averray|scripts/ops/render-caddyfile\.sh)'; then
     run_caddy=1
     echo "Applying Caddy config"
     apply_caddy
+    mark_component_deployed caddy
   else
     echo "Skipping Caddy config"
+    if [[ "$RUN_CADDY" == "auto" ]]; then
+      mark_component_deployed caddy
+    fi
   fi
 
   if changed_matches '^(contracts/|script/|foundry\.toml|remappings\.txt)'; then

--- a/scripts/ops/deploy-production.test.mjs
+++ b/scripts/ops/deploy-production.test.mjs
@@ -1,0 +1,143 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, writeFile, copyFile, chmod } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync, spawnSync } from "node:child_process";
+
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const DEPLOY_SCRIPT = join(REPO_ROOT, "scripts/ops/deploy-production.sh");
+
+test("deploy wrapper retries frontend after an earlier failed indexer deploy", async () => {
+  const root = await mkdtemp(join(tmpdir(), "deploy-production-"));
+  const appRoot = join(root, "app");
+  const stackRoot = join(root, "stack");
+  const fakeBin = join(root, "bin");
+  const stateDir = join(root, "state");
+  const deployLog = join(root, "deploy.log");
+
+  await mkdir(join(appRoot, "scripts/ops"), { recursive: true });
+  await mkdir(join(appRoot, "app"), { recursive: true });
+  await mkdir(join(appRoot, "indexer"), { recursive: true });
+  await mkdir(stackRoot, { recursive: true });
+  await mkdir(fakeBin, { recursive: true });
+  await writeFile(join(stackRoot, "docker-compose.yml"), "services: {}\n");
+  await copyFile(DEPLOY_SCRIPT, join(appRoot, "scripts/ops/deploy-production.sh"));
+  await chmod(join(appRoot, "scripts/ops/deploy-production.sh"), 0o755);
+
+  await writeExecutable(join(appRoot, "scripts/ops/redeploy-indexer.sh"), [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    "echo indexer >> \"$DEPLOY_LOG\"",
+    "if [[ \"${FAIL_INDEXER:-0}\" == \"1\" ]]; then exit 1; fi"
+  ].join("\n"));
+  await writeExecutable(join(appRoot, "scripts/ops/redeploy-frontend.sh"), [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    "echo frontend >> \"$DEPLOY_LOG\""
+  ].join("\n"));
+  await writeExecutable(join(appRoot, "scripts/ops/redeploy-backend.sh"), [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    "echo backend >> \"$DEPLOY_LOG\""
+  ].join("\n"));
+  await writeExecutable(join(appRoot, "scripts/ops/check-hosted-stack.sh"), [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    "echo smoke >> \"$DEPLOY_LOG\""
+  ].join("\n"));
+  await writeExecutable(join(appRoot, "scripts/ops/render-caddyfile.sh"), [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    "echo caddy-render >> \"$DEPLOY_LOG\""
+  ].join("\n"));
+
+  for (const command of ["docker", "curl", "npm", "flock"]) {
+    await writeExecutable(join(fakeBin, command), "#!/usr/bin/env bash\nexit 0\n");
+  }
+
+  git(appRoot, "init");
+  git(appRoot, "config", "user.email", "test@example.com");
+  git(appRoot, "config", "user.name", "Deploy Test");
+  await writeFile(join(appRoot, "README.md"), "base\n");
+  await writeFile(join(appRoot, "app/README.md"), "base app\n");
+  await writeFile(join(appRoot, "indexer/README.md"), "base indexer\n");
+  git(appRoot, "add", ".");
+  git(appRoot, "commit", "-m", "base");
+  const baseSha = revParse(appRoot, "HEAD");
+
+  await writeFile(join(appRoot, "app/page.tsx"), "export default function Page() { return null; }\n");
+  git(appRoot, "add", ".");
+  git(appRoot, "commit", "-m", "frontend change");
+  const frontendSha = revParse(appRoot, "HEAD");
+
+  const firstRun = runDeploy(appRoot, {
+    PATH: `${fakeBin}:${process.env.PATH}`,
+    STACK_ROOT: stackRoot,
+    COMPOSE_FILE: join(stackRoot, "docker-compose.yml"),
+    DEPLOY_LOCK_FILE: join(root, "deploy.lock"),
+    DEPLOY_STATE_DIR: stateDir,
+    DEPLOY_OLD_SHA: baseSha,
+    DEPLOY_NEW_SHA: frontendSha,
+    DEPLOY_LOG: deployLog,
+    FAIL_INDEXER: "1",
+    RUN_INDEXER: "1",
+    RUN_SITE: "0",
+    RUN_CADDY: "0",
+    RUN_SMOKE: "0"
+  });
+  assert.equal(firstRun.status, 1);
+  assert.match(await readFile(deployLog, "utf8"), /^indexer$/m);
+  assert.doesNotMatch(await readFile(deployLog, "utf8"), /^frontend$/m);
+  assert.equal((await readFile(join(stateDir, "frontend.last-good"), "utf8")).trim(), baseSha);
+
+  await writeFile(join(appRoot, "indexer/fix.ts"), "export const fixed = true;\n");
+  git(appRoot, "add", ".");
+  git(appRoot, "commit", "-m", "indexer fix");
+  const indexerFixSha = revParse(appRoot, "HEAD");
+  await writeFile(deployLog, "");
+
+  const secondRun = runDeploy(appRoot, {
+    PATH: `${fakeBin}:${process.env.PATH}`,
+    STACK_ROOT: stackRoot,
+    COMPOSE_FILE: join(stackRoot, "docker-compose.yml"),
+    DEPLOY_LOCK_FILE: join(root, "deploy.lock"),
+    DEPLOY_STATE_DIR: stateDir,
+    DEPLOY_OLD_SHA: frontendSha,
+    DEPLOY_NEW_SHA: indexerFixSha,
+    DEPLOY_LOG: deployLog,
+    RUN_BACKEND: "0",
+    RUN_INDEXER: "0",
+    RUN_SITE: "0",
+    RUN_CADDY: "0",
+    RUN_SMOKE: "0"
+  });
+  assert.equal(secondRun.status, 0, secondRun.stderr);
+  assert.match(await readFile(deployLog, "utf8"), /^frontend$/m);
+  assert.equal((await readFile(join(stateDir, "frontend.last-good"), "utf8")).trim(), indexerFixSha);
+});
+
+async function writeExecutable(path, content) {
+  await writeFile(path, `${content}\n`);
+  await chmod(path, 0o755);
+}
+
+function git(cwd, ...args) {
+  execFileSync("git", args, { cwd, stdio: "pipe" });
+}
+
+function revParse(cwd, revision) {
+  return execFileSync("git", ["rev-parse", revision], { cwd, encoding: "utf8" }).trim();
+}
+
+function runDeploy(cwd, env) {
+  return spawnSync("bash", ["scripts/ops/deploy-production.sh"], {
+    cwd,
+    env: {
+      ...process.env,
+      ...env
+    },
+    encoding: "utf8"
+  });
+}


### PR DESCRIPTION
## Summary
- add per-component last-good deploy pointers for backend, indexer, frontend, site, and Caddy
- route auto deploy decisions from each component pointer to the new SHA instead of only wrapper OLD_SHA..NEW_SHA
- initialize missing pointers to the pre-deploy SHA so a failed first deploy does not lose pending component changes
- add an ops regression test for the issue #124 failure shape and run ops tests in CI

Closes #124.

## Checks
- npm run test:ops
- bash -n scripts/ops/deploy-production.sh
- git diff --cached --check

## Impact
- Deployment wrapper / GitHub Actions only
- No app, backend, indexer, contracts, or public-site runtime code changes
- Creates/updates component pointer files under DEPLOY_STATE_DIR (default: $STACK_ROOT/.deploy-state) on production deploys