### PR TITLE
Clarify claimability and reopen expired claims

### DIFF
--- a/docs/EXTERNAL_AGENT_WALLET_ONBOARDING.md
+++ b/docs/EXTERNAL_AGENT_WALLET_ONBOARDING.md
@@ -126,6 +126,11 @@ curl -s 'https://api.averray.com/jobs?source=wikipedia&state=open&limit=5'
 curl -s 'https://api.averray.com/jobs/definition?jobId=<job-id>'
 ```
 
+Use `claimStatus.claimable` and `claimStatus.reason` as the authoritative
+claimability signal before attempting `/jobs/claim`. `lifecycle.status`
+describes the content/job lifecycle and may remain `open` for a job whose
+current claim state is `claimed`, `submitted`, or `exhausted`.
+
 After SIWE login, check readiness before claiming:
 
 ```bash

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -132,7 +132,7 @@
             "name": "state",
             "in": "query",
             "required": false,
-            "description": "Filter by lifecycle state or status.",
+            "description": "Filter by effective claim state/status. Agents should use claimStatus.claimable and claimStatus.reason before attempting /jobs/claim.",
             "schema": {
               "type": "string"
             },
@@ -215,6 +215,14 @@
                           "id": "wiki-en-123-citation-repair-example",
                           "title": "Repair Wikipedia citations: Example",
                           "state": "open",
+                          "claimState": "open",
+                          "effectiveState": "claimable",
+                          "claimable": true,
+                          "currentWalletCanClaim": null,
+                          "reason": "claimable",
+                          "retryLimit": 1,
+                          "claimAttemptCount": 0,
+                          "remainingClaimAttempts": 1,
                           "source": "wikipedia",
                           "sourceType": "wikipedia_article",
                           "category": "wikipedia",
@@ -267,7 +275,7 @@
         ],
         "operationId": "getJobDefinition",
         "summary": "Get one job definition",
-        "description": "Returns a single job definition by job id. Wikipedia jobs include publicDetails with article, pinned revision, proposal-only, attribution, acceptance, and schema affordances for generic agents.",
+        "description": "Returns a single job definition by job id. Wikipedia jobs include publicDetails with article, pinned revision, proposal-only, attribution, acceptance, and schema affordances for generic agents. claimStatus.claimable and claimStatus.reason are the authoritative current claimability decision; lifecycle.status describes the content/job lifecycle and may remain open when a job is claimed, submitted, or exhausted.",
         "parameters": [
           {
             "name": "jobId",
@@ -855,6 +863,95 @@
           },
           "lifecycle": {
             "$ref": "#/components/schemas/JobLifecycle"
+          },
+          "claimStatus": {
+            "$ref": "#/components/schemas/JobClaimStatus"
+          },
+          "claimabilitySource": {
+            "type": "string",
+            "const": "claimStatus"
+          },
+          "lifecycleStatusMeaning": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "JobClaimStatus": {
+        "type": "object",
+        "description": "Authoritative current claimability state for agents. Use this before mutating /jobs/claim; lifecycle.status is content/job lifecycle metadata.",
+        "properties": {
+          "claimState": {
+            "type": "string",
+            "enum": [
+              "open",
+              "claimed",
+              "expired",
+              "submitted",
+              "exhausted"
+            ]
+          },
+          "state": {
+            "type": "string"
+          },
+          "effectiveState": {
+            "type": "string",
+            "enum": [
+              "claimable",
+              "claimed",
+              "expired",
+              "submitted",
+              "exhausted"
+            ]
+          },
+          "claimable": {
+            "type": "boolean"
+          },
+          "currentWalletCanClaim": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "reason": {
+            "type": "string"
+          },
+          "retryLimit": {
+            "type": "integer"
+          },
+          "claimAttemptCount": {
+            "type": "integer"
+          },
+          "remainingClaimAttempts": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "claimedBy": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "claimedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "claimExpiresAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "claimabilitySource": {
+            "type": "string",
+            "const": "claimStatus"
+          },
+          "lifecycleStatusMeaning": {
+            "type": "string"
           }
         },
         "additionalProperties": true
@@ -933,6 +1030,75 @@
           },
           "state": {
             "type": "string"
+          },
+          "claimState": {
+            "type": "string"
+          },
+          "effectiveState": {
+            "type": "string"
+          },
+          "claimable": {
+            "type": "boolean"
+          },
+          "currentWalletCanClaim": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "retryLimit": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "claimAttemptCount": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "remainingClaimAttempts": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "claimNumber": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "claimedBy": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "claimedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "claimExpiresAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sessionId": {
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "source": {
             "type": "string"

--- a/mcp-server/src/blockchain/abis.js
+++ b/mcp-server/src/blockchain/abis.js
@@ -32,6 +32,7 @@ export const AGENT_ACCOUNT_ABI = [
 export const ESCROW_CORE_ABI = [
   "function createSinglePayoutJob(bytes32 jobId, address asset, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 claimTtl, bytes32 verifierMode, bytes32 category, bytes32 specHash)",
   "function claimJob(bytes32 jobId)",
+  "function handleClaimTimeout(bytes32 jobId)",
   "function submitWork(bytes32 jobId, bytes32 evidenceHash)",
   "function resolveSinglePayout(bytes32 jobId, bool approved, bytes32 reasonCode, string metadataURI, bytes32 reasoningHash)",
   "function finalizeRejectedJob(bytes32 jobId)",

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -556,6 +556,14 @@ export class BlockchainGateway {
     });
   }
 
+  async handleClaimTimeout(jobId) {
+    return this.withGatewayError("handleClaimTimeout", async () => {
+      this.requireSigner("handleClaimTimeout");
+      const tx = await this.escrowContract.handleClaimTimeout(this.toJobId(jobId));
+      await tx.wait();
+    });
+  }
+
   async previewClaimEconomics(wallet, jobId) {
     return this.withGatewayError("previewClaimEconomics", async () => {
       const economics = await this.escrowContract.previewClaimEconomics(wallet, this.toJobId(jobId));

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -76,6 +76,24 @@ test("autoDiscloseContent skips when the contract already recorded the hash", as
   );
 });
 
+test("handleClaimTimeout reopens the canonical chain job id", async () => {
+  const gateway = new BlockchainGateway({ enabled: false });
+  const calls = [];
+  gateway.signer = {};
+  gateway.escrowContract = {
+    async handleClaimTimeout(...args) {
+      calls.push(args);
+      return {
+        async wait() {}
+      };
+    }
+  };
+
+  await gateway.handleClaimTimeout("wiki-job");
+
+  assert.deepEqual(calls, [[gateway.toJobId("wiki-job")]]);
+});
+
 test("getJob falls back to the legacy escrow struct when rc1 decoding fails", async () => {
   const gateway = gatewayWithDot();
   gateway.escrowContract = {

--- a/mcp-server/src/core/claim-state.js
+++ b/mcp-server/src/core/claim-state.js
@@ -21,10 +21,21 @@ export function isTerminalSession(session) {
   return TERMINAL_SESSION_STATUSES.has(session?.status);
 }
 
-export function summarizeJobClaimState({ job, session = undefined, wallet = undefined, now = new Date() } = {}) {
+export function summarizeJobClaimState({
+  job,
+  session = undefined,
+  sessions = undefined,
+  wallet = undefined,
+  now = new Date()
+} = {}) {
   const lifecycle = job?.lifecycle ?? {};
   const lifecycleState = lifecycle.state ?? lifecycle.status ?? "open";
   const retryLimit = Number.isInteger(job?.retryLimit) ? job.retryLimit : 1;
+  const claimAttemptCount = countClaimAttempts(sessions, session);
+  const retryExhausted = retryLimit > 0 && claimAttemptCount >= retryLimit;
+  const remainingClaimAttempts = retryLimit > 0
+    ? Math.max(0, retryLimit - claimAttemptCount)
+    : null;
   const normalizedWallet = normalizeWallet(wallet);
   const claimedBy = normalizeWallet(session?.wallet) ?? normalizeWallet(job?.claimedBy);
   const walletMatchesClaim = Boolean(normalizedWallet && claimedBy && normalizedWallet === claimedBy);
@@ -32,13 +43,18 @@ export function summarizeJobClaimState({ job, session = undefined, wallet = unde
   const expired = isExpiredClaim(session, job, now) || session?.status === "expired";
 
   if (!session) {
-    const claimable = lifecycleState === "open";
+    const claimable = lifecycleState === "open" && !retryExhausted;
+    const claimState = retryExhausted ? "exhausted" : claimable ? "open" : lifecycleState;
     return compact({
-      claimState: claimable ? "open" : lifecycleState,
+      claimState,
+      state: claimState,
+      effectiveState: claimable ? "claimable" : claimState,
       claimable,
       currentWalletCanClaim: normalizedWallet ? claimable : null,
-      reason: claimable ? "claimable" : `job_${lifecycleState}`,
+      reason: retryExhausted ? "retry_limit_exhausted" : claimable ? "claimable" : `job_${lifecycleState}`,
       retryLimit,
+      claimAttemptCount,
+      remainingClaimAttempts,
       claimedBy: null,
       claimedAt: null,
       claimExpiresAt: null,
@@ -48,13 +64,18 @@ export function summarizeJobClaimState({ job, session = undefined, wallet = unde
   }
 
   if (expired) {
-    const retryLimitExhausted = walletMatchesClaim && retryLimit <= 1;
+    const claimable = lifecycleState === "open" && !retryExhausted;
+    const claimState = retryExhausted ? "exhausted" : "expired";
     return compact({
-      claimState: "expired",
-      claimable: false,
-      currentWalletCanClaim: normalizedWallet ? false : null,
-      reason: retryLimitExhausted ? "retry_limit_exhausted" : "claim_expired_reopen_required",
+      claimState,
+      state: claimState,
+      effectiveState: claimable ? "claimable" : claimState,
+      claimable,
+      currentWalletCanClaim: normalizedWallet ? claimable : null,
+      reason: retryExhausted ? "retry_limit_exhausted" : "claim_ttl_expired_reopen_available",
       retryLimit,
+      claimAttemptCount,
+      remainingClaimAttempts,
       claimedBy,
       claimedAt: session.claimedAt ?? null,
       claimExpiresAt: claimExpiresAtValue ?? session.expiredAt ?? null,
@@ -67,10 +88,14 @@ export function summarizeJobClaimState({ job, session = undefined, wallet = unde
   if (session.status === "claimed") {
     return compact({
       claimState: "claimed",
+      state: "claimed",
+      effectiveState: "claimed",
       claimable: false,
       currentWalletCanClaim: normalizedWallet ? false : null,
       reason: walletMatchesClaim ? "already_claimed_by_current_wallet" : "claimed_by_other_wallet",
       retryLimit,
+      claimAttemptCount,
+      remainingClaimAttempts,
       claimedBy,
       claimedAt: session.claimedAt ?? null,
       claimExpiresAt: claimExpiresAtValue ?? null,
@@ -82,10 +107,14 @@ export function summarizeJobClaimState({ job, session = undefined, wallet = unde
   const claimState = submittedLikeState(session.status);
   return compact({
     claimState,
+    state: claimState,
+    effectiveState: claimState,
     claimable: false,
     currentWalletCanClaim: normalizedWallet ? false : null,
     reason: claimState === "exhausted" ? "job_session_completed" : `session_${claimState}`,
     retryLimit,
+    claimAttemptCount,
+    remainingClaimAttempts,
     claimedBy,
     claimedAt: session.claimedAt ?? null,
     claimExpiresAt: claimExpiresAtValue ?? null,
@@ -96,19 +125,47 @@ export function summarizeJobClaimState({ job, session = undefined, wallet = unde
 
 export function claimStatusFields(claimStatus) {
   return {
-    claimStatus,
+    claimStatus: {
+      ...claimStatus,
+      state: claimStatus.state ?? claimStatus.claimState,
+      claimabilitySource: "claimStatus",
+      lifecycleStatusMeaning: "content/job lifecycle; check claimStatus.claimable and claimStatus.reason before claiming"
+    },
     claimState: claimStatus.claimState,
+    effectiveState: claimStatus.effectiveState ?? claimStatus.claimState,
     claimable: claimStatus.claimable,
     currentWalletCanClaim: claimStatus.currentWalletCanClaim,
     reason: claimStatus.reason,
     retryLimit: claimStatus.retryLimit,
+    claimAttemptCount: claimStatus.claimAttemptCount ?? null,
+    remainingClaimAttempts: claimStatus.remainingClaimAttempts ?? null,
     claimNumber: claimStatus.claimNumber ?? null,
     claimedBy: claimStatus.claimedBy ?? null,
     claimedAt: claimStatus.claimedAt ?? null,
     claimExpiresAt: claimStatus.claimExpiresAt ?? null,
     sessionId: claimStatus.sessionId ?? null,
-    state: claimStatus.claimState
+    state: claimStatus.state ?? claimStatus.claimState,
+    claimabilitySource: "claimStatus",
+    lifecycleStatusMeaning: "content/job lifecycle; check claimStatus.claimable and claimStatus.reason before claiming"
   };
+}
+
+export function countClaimAttempts(sessions = undefined, session = undefined) {
+  const candidates = Array.isArray(sessions)
+    ? sessions
+    : session
+      ? [session]
+      : [];
+  const seen = new Set();
+  let count = 0;
+  for (const candidate of candidates) {
+    if (!candidate?.sessionId || seen.has(candidate.sessionId)) continue;
+    seen.add(candidate.sessionId);
+    if (candidate.claimedAt || candidate.status) {
+      count += 1;
+    }
+  }
+  return count;
 }
 
 function submittedLikeState(status) {

--- a/mcp-server/src/core/discovery-manifest.js
+++ b/mcp-server/src/core/discovery-manifest.js
@@ -322,7 +322,8 @@ const BASE_MANIFEST = {
       "Keep private keys and seed phrases in local env or secret storage only; do not paste them into agent chat.",
       "Fund the Polkadot Hub TestNet wallet from https://faucet.polkadot.io/ unless the job is sponsored or stake-waived.",
       "Request a SIWE nonce, sign it with personal_sign, and exchange the signature for a bearer JWT.",
-      "Call /jobs/preflight before /jobs/claim to see tier, stake, fee, and waiver state."
+      "Call /jobs/preflight before /jobs/claim to see tier, stake, fee, and waiver state.",
+      "Treat claimStatus.claimable and claimStatus.reason as authoritative for whether a job may be claimed now; lifecycle.status describes the content/job lifecycle and can remain open when claimStatus says exhausted, claimed, or submitted."
     ]
   },
   auth: {

--- a/mcp-server/src/core/job-execution-service.js
+++ b/mcp-server/src/core/job-execution-service.js
@@ -17,7 +17,7 @@ import {
   DEFAULT_OPEN_PR_CAP_PER_REPO,
   countOpenGithubPullRequestsForRepo
 } from "./maintainer-surface-policy.js";
-import { claimExpiresAt, isExpiredClaim, isTerminalSession } from "./claim-state.js";
+import { claimExpiresAt, countClaimAttempts, isExpiredClaim, isTerminalSession } from "./claim-state.js";
 
 export class JobExecutionService {
   constructor(
@@ -52,10 +52,28 @@ export class JobExecutionService {
       if (!this.isTerminalSession(refreshed)) {
         return refreshed;
       }
+      throw new ConflictError(
+        "Idempotency key already belongs to a terminal claim session.",
+        "idempotency_key_already_used",
+        { sessionId: refreshed.sessionId, jobId: refreshed.jobId, status: refreshed.status }
+      );
     }
 
     const job = this.getClaimableJobDefinition(jobId);
-    const sessionId = `${jobId}:${wallet}`;
+    const activeJobSession = await this.stateStore.findSessionByJobId(jobId);
+    const refreshedActiveJobSession = activeJobSession
+      ? await this.materializeExpiredClaim(activeJobSession, job)
+      : undefined;
+    const jobSessions = await this.listJobSessions(jobId);
+    const claimAttemptCount = countClaimAttempts(jobSessions);
+    if (this.isRetryExhausted(job, claimAttemptCount)) {
+      throw new ConflictError(
+        `Job ${jobId} exhausted its claim retry budget.`,
+        "retry_limit_exhausted",
+        { jobId, retryLimit: job.retryLimit, claimAttemptCount }
+      );
+    }
+    const sessionId = this.nextSessionId(jobId, wallet, jobSessions);
     const sessionLockId = sessionId;
     const lockOwner = randomUUID();
     const lockAcquired = await this.stateStore.acquireClaimLock?.(
@@ -80,22 +98,34 @@ export class JobExecutionService {
         if (!this.isTerminalSession(refreshed)) {
           return refreshed;
         }
+        throw new ConflictError(
+          "Idempotency key already belongs to a terminal claim session.",
+          "idempotency_key_already_used",
+          { sessionId: refreshed.sessionId, jobId: refreshed.jobId, status: refreshed.status }
+        );
       }
 
       const existingSession = await this.stateStore.getSession(sessionId);
       if (existingSession) {
         const refreshed = await this.materializeExpiredClaim(existingSession, job);
         if (this.isTerminalSession(refreshed)) {
-          throw new ConflictError(
-            `Job ${jobId} already has a completed session for this wallet. Create or select a different job to run again.`,
-            refreshed.status === "expired" ? "retry_limit_exhausted" : "job_session_completed",
-            this.buildClaimExpiryDetails(refreshed, job)
-          );
+          const refreshedSessions = await this.listJobSessions(jobId);
+          if (refreshed.status === "expired" && !this.isRetryExhausted(job, countClaimAttempts(refreshedSessions))) {
+            await this.reopenExpiredClaim(jobId);
+          } else {
+            throw new ConflictError(
+              `Job ${jobId} already has a completed session for this wallet. Create or select a different job to run again.`,
+              refreshed.status === "expired" ? "retry_limit_exhausted" : "job_session_completed",
+              this.buildClaimExpiryDetails(refreshed, job)
+            );
+          }
         }
-        return refreshed;
+        if (!this.isTerminalSession(refreshed)) {
+          return refreshed;
+        }
       }
 
-      const liveJobSession = await this.stateStore.findSessionByJobId(jobId);
+      const liveJobSession = refreshedActiveJobSession ?? await this.stateStore.findSessionByJobId(jobId);
       if (liveJobSession && liveJobSession.sessionId !== sessionId) {
         const refreshed = await this.materializeExpiredClaim(liveJobSession, job);
         if (!this.isTerminalSession(refreshed)) {
@@ -106,11 +136,16 @@ export class JobExecutionService {
           );
         }
         if (refreshed.status === "expired") {
-          throw new ConflictError(
-            `Job ${jobId} has an expired claim that must be reopened before it can be claimed again.`,
-            "claim_expired_reopen_required",
-            this.buildClaimExpiryDetails(refreshed, job)
-          );
+          const refreshedSessions = await this.listJobSessions(jobId);
+          if (!this.isRetryExhausted(job, countClaimAttempts(refreshedSessions))) {
+            await this.reopenExpiredClaim(jobId);
+          } else {
+            throw new ConflictError(
+              `Job ${jobId} exhausted its claim retry budget.`,
+              "retry_limit_exhausted",
+              this.buildClaimExpiryDetails(refreshed, job)
+            );
+          }
         }
       }
 
@@ -327,6 +362,36 @@ export class JobExecutionService {
       reason: "claim_ttl_expired"
     });
     return persisted;
+  }
+
+  async reopenExpiredClaim(jobId) {
+    if (this.blockchainGateway?.isEnabled() && typeof this.blockchainGateway.handleClaimTimeout === "function") {
+      await this.blockchainGateway.handleClaimTimeout(jobId);
+    }
+  }
+
+  async listJobSessions(jobId, limit = 100) {
+    return await this.stateStore.listSessionsByJob?.(jobId, limit) ?? [];
+  }
+
+  isRetryExhausted(job, claimAttemptCount) {
+    const retryLimit = Number.isInteger(job?.retryLimit) ? job.retryLimit : 1;
+    return retryLimit > 0 && claimAttemptCount >= retryLimit;
+  }
+
+  nextSessionId(jobId, wallet, sessions = []) {
+    const baseSessionId = `${jobId}:${wallet}`;
+    const existingIds = new Set(sessions.map((session) => session?.sessionId).filter(Boolean));
+    if (!existingIds.has(baseSessionId)) {
+      return baseSessionId;
+    }
+    let attempt = existingIds.size + 1;
+    let candidate = `${baseSessionId}:${attempt}`;
+    while (existingIds.has(candidate)) {
+      attempt += 1;
+      candidate = `${baseSessionId}:${attempt}`;
+    }
+    return candidate;
   }
 
   buildClaimExpiryDetails(session, job) {

--- a/mcp-server/src/core/job-execution-service.test.js
+++ b/mcp-server/src/core/job-execution-service.test.js
@@ -7,6 +7,7 @@ import { MemoryStateStore } from "./state-store.js";
 import { computeClaimEconomics } from "./claim-economics.js";
 
 const WALLET = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const WALLET_2 = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 
 function makeJob(overrides = {}) {
   return {
@@ -180,6 +181,70 @@ test("submitWork rejects and materializes expired claims before mutation", async
   const stored = await stateStore.getSession(claimed.sessionId);
   assert.equal(stored.status, "expired");
   assert.equal(stored.expiredAt, "2026-05-01T10:01:00.000Z");
+});
+
+test("claimJob reopens an expired claim when retry budget remains", async () => {
+  const stateStore = new MemoryStateStore();
+  const job = makeJob({
+    claimTtlSeconds: 60,
+    retryLimit: 2
+  });
+  const service = new JobExecutionService(stateStore, undefined, () => job);
+
+  const first = await service.claimJob(WALLET, job.id, "http", "idemp-expired-retry-1");
+  await stateStore.upsertSession({
+    ...first,
+    claimedAt: "2026-05-01T10:00:00.000Z",
+    statusHistory: [
+      {
+        from: null,
+        to: "claimed",
+        reason: "job_claimed",
+        at: "2026-05-01T10:00:00.000Z"
+      }
+    ]
+  });
+
+  const second = await service.claimJob(WALLET_2, job.id, "http", "idemp-expired-retry-2");
+
+  assert.equal(second.status, "claimed");
+  assert.equal(second.wallet, WALLET_2);
+  assert.notEqual(second.sessionId, first.sessionId);
+  assert.equal((await stateStore.getSession(first.sessionId)).status, "expired");
+  assert.equal((await stateStore.findSessionByJobId(job.id)).sessionId, second.sessionId);
+});
+
+test("claimJob reports exhausted retry budget after an expired single-attempt job", async () => {
+  const stateStore = new MemoryStateStore();
+  const job = makeJob({
+    claimTtlSeconds: 60,
+    retryLimit: 1
+  });
+  const service = new JobExecutionService(stateStore, undefined, () => job);
+
+  const first = await service.claimJob(WALLET, job.id, "http", "idemp-expired-exhausted-1");
+  await stateStore.upsertSession({
+    ...first,
+    claimedAt: "2026-05-01T10:00:00.000Z",
+    statusHistory: [
+      {
+        from: null,
+        to: "claimed",
+        reason: "job_claimed",
+        at: "2026-05-01T10:00:00.000Z"
+      }
+    ]
+  });
+
+  await assert.rejects(
+    () => service.claimJob(WALLET_2, job.id, "http", "idemp-expired-exhausted-2"),
+    (error) => {
+      assert.equal(error.code, "retry_limit_exhausted");
+      assert.equal(error.details.claimAttemptCount, 1);
+      return true;
+    }
+  );
+  assert.equal((await stateStore.getSession(first.sessionId)).status, "expired");
 });
 
 test("computeClaimEconomics waives first three claims and then applies stake plus fee", () => {

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -478,9 +478,13 @@ export class PlatformService {
     const refreshedSession = session
       ? await this.jobExecutionService.materializeExpiredClaim(session, job, now)
       : undefined;
+    const sessions = await this.stateStore.listSessionsByJob?.(job.id, 100) ?? (
+      refreshedSession ? [refreshedSession] : []
+    );
     const claimStatus = summarizeJobClaimState({
       job,
       session: refreshedSession,
+      sessions,
       wallet,
       now
     });

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -131,11 +131,14 @@ test("listJobsWithSessions and definition expose expired claim affordances", asy
   const now = new Date("2026-05-01T12:18:04.000Z");
   const rows = await service.listJobsWithSessions({ wallet: WALLET, now });
   assert.equal(rows.length, 1);
-  assert.equal(rows[0].state, "expired");
-  assert.equal(rows[0].claimState, "expired");
+  assert.equal(rows[0].state, "exhausted");
+  assert.equal(rows[0].claimState, "exhausted");
+  assert.equal(rows[0].effectiveState, "exhausted");
   assert.equal(rows[0].claimable, false);
   assert.equal(rows[0].currentWalletCanClaim, false);
   assert.equal(rows[0].reason, "retry_limit_exhausted");
+  assert.equal(rows[0].claimAttemptCount, 1);
+  assert.equal(rows[0].remainingClaimAttempts, 0);
   assert.equal(rows[0].claimedBy, WALLET);
   assert.equal(rows[0].claimedAt, "2026-05-01T11:18:03.973Z");
   assert.equal(rows[0].claimExpiresAt, "2026-05-01T12:18:03.973Z");
@@ -148,9 +151,14 @@ test("listJobsWithSessions and definition expose expired claim affordances", asy
 
   const definition = await service.getPublicJobDefinition("parent-job-001", { wallet: WALLET, now });
   assert.equal(definition.lifecycle.state, "open");
-  assert.equal(definition.claimState, "expired");
+  assert.equal(definition.claimabilitySource, "claimStatus");
+  assert.match(definition.lifecycleStatusMeaning, /check claimStatus/u);
+  assert.equal(definition.claimState, "exhausted");
+  assert.equal(definition.effectiveState, "exhausted");
   assert.equal(definition.claimStatus.claimExpiresAt, "2026-05-01T12:18:03.973Z");
   assert.equal(definition.claimStatus.reason, "retry_limit_exhausted");
+  assert.equal(definition.claimStatus.claimabilitySource, "claimStatus");
+  assert.match(definition.claimStatus.lifecycleStatusMeaning, /check claimStatus/u);
 });
 
 test("getSessionTimeline includes transitions and verification state", async () => {

--- a/mcp-server/src/protocols/http/jobs-response.js
+++ b/mcp-server/src/protocols/http/jobs-response.js
@@ -76,8 +76,12 @@ function matchesFilters(job, filters) {
     return false;
   }
   if (filters.state) {
-    const { state, status } = effectiveJobState(job);
-    if (filters.state !== state && filters.state !== status) {
+    const { state, status, effectiveState } = effectiveJobState(job);
+    const wantsClaimable = ["open", "available", "claimable"].includes(filters.state);
+    if (wantsClaimable && effectiveState === "claimable") {
+      return true;
+    }
+    if (filters.state !== state && filters.state !== status && filters.state !== effectiveState) {
       return false;
     }
   }
@@ -87,19 +91,23 @@ function matchesFilters(job, filters) {
 function toCompactJobRow(job) {
   const lifecycle = job.lifecycle ?? {};
   const { state } = effectiveJobState(job);
+  const claimable = job.claimable ?? state === "open";
   const sourceDetails = compactSourceDetails(job);
   return {
     id: job.id,
     title: job.title,
     state,
     claimState: job.claimState ?? state,
-    claimable: job.claimable ?? state === "open",
+    effectiveState: job.effectiveState ?? (claimable ? "claimable" : job.claimState ?? state),
+    claimable,
     currentWalletCanClaim: job.currentWalletCanClaim ?? null,
     reason: job.reason ?? null,
     claimedBy: job.claimedBy ?? null,
     claimedAt: job.claimedAt ?? null,
     claimExpiresAt: job.claimExpiresAt ?? null,
     retryLimit: job.retryLimit ?? null,
+    claimAttemptCount: job.claimAttemptCount ?? null,
+    remainingClaimAttempts: job.remainingClaimAttempts ?? null,
     claimNumber: job.claimNumber ?? null,
     sessionId: job.sessionId ?? null,
     source: publicSourceLabel(job),
@@ -123,7 +131,8 @@ function effectiveJobState(job) {
   const lifecycle = job.lifecycle ?? {};
   const state = normalizeToken(job.claimState ?? job.state ?? lifecycle.state ?? lifecycle.status ?? "open");
   const status = normalizeToken(job.claimStatus?.claimState ?? job.state ?? state);
-  return { state, status };
+  const effectiveState = normalizeToken(job.effectiveState ?? (job.claimable ? "claimable" : state));
+  return { state, status, effectiveState };
 }
 
 function compactSourceDetails(job) {

--- a/mcp-server/src/protocols/http/jobs-response.test.js
+++ b/mcp-server/src/protocols/http/jobs-response.test.js
@@ -81,6 +81,7 @@ test("public jobs response filters and compacts agent-friendly queries", () => {
     "title",
     "state",
     "claimState",
+    "effectiveState",
     "claimable",
     "currentWalletCanClaim",
     "reason",
@@ -88,6 +89,8 @@ test("public jobs response filters and compacts agent-friendly queries", () => {
     "claimedAt",
     "claimExpiresAt",
     "retryLimit",
+    "claimAttemptCount",
+    "remainingClaimAttempts",
     "claimNumber",
     "sessionId",
     "source",
@@ -105,6 +108,7 @@ test("public jobs response filters and compacts agent-friendly queries", () => {
   assert.equal(response.jobs[0].id, "wiki-en-123-citation-repair-example");
   assert.equal(response.jobs[0].state, "open");
   assert.equal(response.jobs[0].claimState, "open");
+  assert.equal(response.jobs[0].effectiveState, "claimable");
   assert.equal(response.jobs[0].claimable, true);
   assert.equal(response.jobs[0].source, "wikipedia");
   assert.equal(response.jobs[0].sourceType, "wikipedia_article");
@@ -128,6 +132,7 @@ test("public jobs response filters compact rows by claim state", () => {
       {
         ...JOBS[0],
         claimState: "expired",
+        effectiveState: "expired",
         claimable: false,
         currentWalletCanClaim: false,
         reason: "retry_limit_exhausted",
@@ -135,6 +140,8 @@ test("public jobs response filters compact rows by claim state", () => {
         claimedAt: "2026-05-01T11:18:03.973Z",
         claimExpiresAt: "2026-05-01T12:18:03.973Z",
         retryLimit: 1,
+        claimAttemptCount: 1,
+        remainingClaimAttempts: 0,
         claimNumber: 1,
         sessionId: "wiki-en-123-citation-repair-example:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       }
@@ -150,16 +157,48 @@ test("public jobs response filters compact rows by claim state", () => {
   assert.equal(response.jobs[0].reason, "retry_limit_exhausted");
   assert.equal(response.jobs[0].claimExpiresAt, "2026-05-01T12:18:03.973Z");
 
-  const openResponse = buildPublicJobsResponse(
+  const exhaustedOpenResponse = buildPublicJobsResponse(
     [
       {
         ...JOBS[0],
-        claimState: "expired"
+        claimState: "expired",
+        effectiveState: "expired",
+        claimable: false
       }
     ],
     new URLSearchParams("state=open&limit=25")
   );
-  assert.equal(openResponse.total, 0);
+  assert.equal(exhaustedOpenResponse.total, 0);
+
+  const claimableOpenResponse = buildPublicJobsResponse(
+    [
+      {
+        ...JOBS[0],
+        claimState: "expired",
+        effectiveState: "claimable",
+        claimable: true,
+        reason: "claim_ttl_expired_reopen_available"
+      }
+    ],
+    new URLSearchParams("state=open&limit=25")
+  );
+  assert.equal(claimableOpenResponse.total, 1);
+  assert.equal(claimableOpenResponse.jobs[0].claimState, "expired");
+  assert.equal(claimableOpenResponse.jobs[0].effectiveState, "claimable");
+
+  const claimableResponse = buildPublicJobsResponse(
+    [
+      {
+        ...JOBS[0],
+        claimState: "expired",
+        effectiveState: "claimable",
+        claimable: true,
+        reason: "claim_ttl_expired_reopen_available"
+      }
+    ],
+    new URLSearchParams("state=claimable&limit=25")
+  );
+  assert.equal(claimableResponse.total, 1);
 });
 
 test("public jobs response supports category filters and pagination", () => {


### PR DESCRIPTION
## Summary
- make claimStatus.claimable/reason first-class in job definitions, compact /jobs rows, onboarding docs, and OpenAPI docs
- track claim attempts/remaining retry budget so expired sessions become claimable again when budget remains and exhausted when it does not
- lazily reopen expired on-chain claims through handleClaimTimeout before allowing the next claim attempt

## Checks
- npm --workspace mcp-server test
- node --test mcp-server/src/core/job-execution-service.test.js mcp-server/src/core/platform-service.test.js mcp-server/src/protocols/http/jobs-response.test.js mcp-server/src/core/discovery-manifest.test.js mcp-server/src/blockchain/gateway.test.js
- git diff --check
- OpenAPI JSON parse check

## Impact
- Backend/API docs only; no frontend, indexer, Caddy, contracts, or public site source changes
- No environment or VPS secret changes required

Closes #131
Closes #132