### PR TITLE
Use claimStatus as source of truth for claimability in /runs

### DIFF
--- a/app/components/runs/JobCard.tsx
+++ b/app/components/runs/JobCard.tsx
@@ -7,6 +7,11 @@ import {
   type RunState,
 } from "./StatePill";
 import type { JobSource } from "./types";
+import {
+  CLAIM_STATE_LABEL,
+  formatClaimReason,
+  type ClaimSummary,
+} from "@/lib/api/claim-status";
 
 export interface JobCardData {
   id: string;
@@ -28,6 +33,12 @@ export interface JobCardData {
   meta: { label: string; value: string; accent?: boolean }[];
   fit: number; // 0..5
   hot?: boolean;
+  /**
+   * Claim contract surfaced from the job feed. Drives the Claim button
+   * (disabled unless `claimable === true`) and replaces the legacy
+   * "always claimable" assumption that used to live on this card.
+   */
+  claim?: ClaimSummary;
 }
 
 export function JobCard({ job }: { job: JobCardData }) {
@@ -191,11 +202,60 @@ export function JobCard({ job }: { job: JobCardData }) {
         ))}
       </dl>
 
+      {/*
+       * When the row carries the new claim contract, surface
+       * `effectiveState` + the human reason so an operator scanning
+       * the rail can immediately tell why an "open" job isn't
+       * actually grabbable. Hidden when the row predates the
+       * contract, so older fixtures still render normally.
+       */}
+      {job.claim ? (
+        <p
+          className="font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]"
+          style={{ letterSpacing: 0 }}
+          title={`reason: ${job.claim.reason}`}
+        >
+          <b
+            className={cn(
+              "font-semibold",
+              job.claim.claimable
+                ? "text-[var(--avy-accent)]"
+                : "text-[var(--avy-ink)]"
+            )}
+          >
+            {CLAIM_STATE_LABEL[job.claim.state]}
+          </b>
+          {" · "}
+          {formatClaimReason(job.claim.reason)}
+          {job.claim.retryLimit > 0
+            ? ` · ${job.claim.remainingClaimAttempts}/${job.claim.retryLimit} attempts left`
+            : null}
+        </p>
+      ) : null}
+
       <div className="mt-0.5 flex items-center justify-between gap-2">
         <FitMeter fit={job.fit} />
+        {/*
+         * Brief: "Disable claim/start buttons unless claimable === true."
+         * When the row doesn't carry a claim contract yet (older
+         * fixtures), default to enabled — that's the legacy behaviour
+         * and we don't want to silently disable everything during
+         * rollout.
+         */}
         <button
           type="button"
-          className="inline-flex h-6 items-center gap-1.5 rounded-[8px] bg-[var(--avy-accent)] px-2.5 font-[family-name:var(--font-display)] text-[10.5px] font-bold uppercase text-[var(--fg-invert)] transition-transform hover:-translate-y-px hover:bg-[var(--avy-accent-2)]"
+          disabled={job.claim ? !job.claim.claimable : false}
+          title={
+            job.claim && !job.claim.claimable
+              ? formatClaimReason(job.claim.reason)
+              : undefined
+          }
+          className={cn(
+            "inline-flex h-6 items-center gap-1.5 rounded-[8px] px-2.5 font-[family-name:var(--font-display)] text-[10.5px] font-bold uppercase transition-transform",
+            job.claim && !job.claim.claimable
+              ? "cursor-not-allowed bg-[color:rgba(17,19,21,0.08)] text-[var(--avy-muted)]"
+              : "bg-[var(--avy-accent)] text-[var(--fg-invert)] hover:-translate-y-px hover:bg-[var(--avy-accent-2)]"
+          )}
           style={{ letterSpacing: "0.06em" }}
         >
           Claim

--- a/app/components/runs/RunQueueTable.tsx
+++ b/app/components/runs/RunQueueTable.tsx
@@ -10,6 +10,11 @@ import {
   type JobLifecycle,
   type JobLifecycleState,
 } from "@/lib/api/job-lifecycle";
+import {
+  CLAIM_STATE_LABEL,
+  type ClaimEffectiveState,
+  type ClaimSummary,
+} from "@/lib/api/claim-status";
 
 export interface RunRow {
   id: string;
@@ -28,6 +33,15 @@ export interface RunRow {
    * action bar in the loaded-run panel.
    */
   lifecycle?: JobLifecycle;
+  /**
+   * Claim-state block from `/jobs[]` and `/admin/jobs[]`. Present on
+   * every row the backend has rolled out the new claim contract for;
+   * absent on older fixtures. When present the row pill renders the
+   * claim `effectiveState` (which reflects retry-budget exhaustion)
+   * instead of the legacy `state` field, and recommendation / claim
+   * buttons gate on `claim.claimable`.
+   */
+  claim?: ClaimSummary;
   worker: {
     variant: WorkerVariant;
     initials: string;
@@ -267,7 +281,19 @@ function RunRowCard({
               {row.lifecycle && row.lifecycle.state !== "open" ? (
                 <LifecyclePill state={row.lifecycle.state} />
               ) : null}
-              <StatePill state={row.state} />
+              {/*
+               * Prefer the claim `effectiveState` pill when the row
+               * carries the new claim contract — it tells the operator
+               * whether the job can actually be claimed (an "open" row
+               * can still be `exhausted` after every retry was used).
+               * Fall back to the legacy run-state pill for older
+               * fixtures and any backend that hasn't rolled out yet.
+               */}
+              {row.claim ? (
+                <EffectiveStatePill state={row.claim.state} />
+              ) : (
+                <StatePill state={row.state} />
+              )}
             </div>
             <span className="font-[family-name:var(--font-mono)] text-[12.5px] leading-tight text-[var(--avy-ink)]">
               {row.stake}
@@ -320,6 +346,43 @@ function LifecyclePill({ state }: { state: JobLifecycleState }) {
       title={`Lifecycle: ${state}`}
     >
       {formatLifecycleLabel(state)}
+    </span>
+  );
+}
+
+/**
+ * Pill for `claim.effectiveState`. Five buckets, one tone each:
+ *   - claimable → green (matches the existing "ready" affordance)
+ *   - claimed → blue-tinted (a worker holds it; not red)
+ *   - submitted → amber (awaiting verification)
+ *   - expired → amber (a prior claim TTL'd; reopen is implicit)
+ *   - exhausted → muted (retry budget gone)
+ *
+ * Brief explicitly calls out `lifecycle.status: "open"` +
+ * `claim.exhausted` rendering as Exhausted, not Open. This pill is the
+ * single place that decides that.
+ */
+function EffectiveStatePill({ state }: { state: ClaimEffectiveState }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase",
+        state === "claimable" &&
+          "bg-[var(--avy-accent-soft)] text-[var(--avy-accent)]",
+        state === "claimed" &&
+          "bg-[color:rgba(37,78,154,0.14)] text-[#254e9a]",
+        state === "submitted" &&
+          "bg-[var(--avy-warn-soft)] text-[var(--avy-warn)]",
+        state === "expired" &&
+          "bg-[var(--avy-warn-soft)] text-[var(--avy-warn)]",
+        state === "exhausted" &&
+          "bg-[color:rgba(17,19,21,0.06)] text-[var(--avy-muted)]"
+      )}
+      style={{ letterSpacing: "0.08em" }}
+      title={`Claim state: ${state}`}
+    >
+      <span className="h-1.5 w-1.5 rounded-full bg-current opacity-80" />
+      {CLAIM_STATE_LABEL[state]}
     </span>
   );
 }

--- a/app/components/runs/RunSemanticBlock.tsx
+++ b/app/components/runs/RunSemanticBlock.tsx
@@ -64,11 +64,39 @@ function describeRow(row: RunRow): Field[] {
     { id: "title", label: "Title", value: row.title },
     { id: "source", label: "Source", value: describeSource(row) },
     { id: "category", label: "Category", value: row.jobMeta },
-    { id: "state", label: "State", value: row.state },
-    { id: "reward", label: "Reward", value: `${row.stake} DOT` },
-    { id: "worker", label: "Worker", value: row.worker.label },
-    { id: "window", label: "Claim window", value: row.age },
   ];
+  // Claim block is the source of truth for "is this row currently
+  // grabbable" — render it before the legacy state/lifecycle pair so
+  // a browser agent reading top-down sees the operational answer
+  // first.
+  if (row.claim) {
+    fields.push({
+      id: "claim-state",
+      label: "Claim state",
+      value: row.claim.state,
+    });
+    fields.push({
+      id: "claimable",
+      label: "Claimable",
+      value: row.claim.claimable ? "yes" : "no",
+    });
+    fields.push({
+      id: "claim-reason",
+      label: "Reason",
+      value: row.claim.reason,
+    });
+    if (row.claim.retryLimit > 0) {
+      fields.push({
+        id: "claim-attempts",
+        label: "Attempts",
+        value: `${row.claim.claimAttemptCount}/${row.claim.retryLimit} used · ${row.claim.remainingClaimAttempts} left`,
+      });
+    }
+  }
+  fields.push({ id: "state", label: "State", value: row.state });
+  fields.push({ id: "reward", label: "Reward", value: `${row.stake} DOT` });
+  fields.push({ id: "worker", label: "Worker", value: row.worker.label });
+  fields.push({ id: "window", label: "Claim window", value: row.age });
   if (row.lifecycle) {
     fields.push({
       id: "lifecycle",

--- a/app/lib/api/claim-status.ts
+++ b/app/lib/api/claim-status.ts
@@ -1,0 +1,219 @@
+/**
+ * Claim-state model for the runs surface.
+ *
+ * The backend emits two layers of "state" on every job:
+ *   - `lifecycle.{status,state}` — content/job lifecycle (open / paused /
+ *     archived / stale). Tells the operator whether the row is in the
+ *     catalog at all.
+ *   - `claimStatus` — claim lifecycle (claimable / claimed / expired /
+ *     submitted / exhausted). Tells the operator (and any worker) whether
+ *     the row can currently be acted on.
+ *
+ * A row can be `lifecycle.status: "open"` AND `claimStatus.claimable:
+ * false` — for example after every retry has been used up. The UI must
+ * never decide claimability from `lifecycle` alone; that's the failure
+ * mode the new `claimabilitySource` hint warns about.
+ *
+ * This module is the single source of truth for parsing/labelling the
+ * claim block. Both the queue rows (which carry the compact top-level
+ * fields) and the detail panel (which carries the full `claimStatus`
+ * object) feed through it.
+ */
+
+export type ClaimEffectiveState =
+  | "claimable"
+  | "claimed"
+  | "expired"
+  | "submitted"
+  | "exhausted";
+
+export type ClaimRawState =
+  | "open"
+  | "claimed"
+  | "expired"
+  | "submitted"
+  | "exhausted";
+
+/**
+ * Free-form reason code attached to the claim block. The backend may
+ * emit codes we don't have a label for yet — `formatClaimReason`
+ * falls back to the raw code rather than swallowing it.
+ */
+export type ClaimReason = string;
+
+export interface ClaimSummary {
+  /** Compact `effectiveState` from the row payload. */
+  state: ClaimEffectiveState;
+  /** True when the current viewer (or any worker, for the public feed)
+   *  can claim. The UI gates Claim/Start buttons on this. */
+  claimable: boolean;
+  /** Machine reason code; pair with `formatClaimReason` for display. */
+  reason: ClaimReason;
+  /** Total attempts allowed across the whole job (including the
+   *  current one when claimed). */
+  retryLimit: number;
+  /** Attempts used so far. */
+  claimAttemptCount: number;
+  /** What's left in the retry budget. 0 means exhausted. */
+  remainingClaimAttempts: number;
+}
+
+export interface ClaimStatusDetail extends ClaimSummary {
+  /** Per-viewer hint: even if `claimable` is true on the row, this
+   *  flag flips false when the viewer's wallet has already claimed.
+   *  Null when no viewer is signed in (public feed). */
+  currentWalletCanClaim: boolean | null;
+  /** Wallet that currently holds the claim, if any. */
+  claimedBy?: string;
+  /** ISO timestamp of when the active claim opened. */
+  claimedAt?: string;
+  /** ISO timestamp of when the active claim's TTL expires. */
+  claimExpiresAt?: string;
+  /** Sequence number of the active claim attempt (1-indexed). */
+  claimNumber?: number;
+  /** Active session id when the row is in `claimed` / `submitted`. */
+  sessionId?: string;
+  /** ISO timestamp of when a prior claim expired (drives the
+   *  "claim_ttl_expired_reopen_available" affordance). */
+  expiredAt?: string;
+}
+
+const ALLOWED_EFFECTIVE: ClaimEffectiveState[] = [
+  "claimable",
+  "claimed",
+  "expired",
+  "submitted",
+  "exhausted",
+];
+
+/**
+ * Compact-row claim block builder. Reads the top-level fields the
+ * backend now emits on every `/jobs[]` row (and `/admin/jobs[]`).
+ * Returns `undefined` when the row is missing the contract entirely
+ * — the caller falls back to the legacy `state`-based render so we
+ * don't break older fixtures.
+ */
+export function buildClaimSummary(raw: unknown): ClaimSummary | undefined {
+  const record = asRecord(raw);
+  if (!record) return undefined;
+  const state = parseEffectiveState(record.effectiveState);
+  if (!state) return undefined;
+  return {
+    state,
+    claimable: record.claimable === true,
+    reason: typeof record.reason === "string" && record.reason.trim()
+      ? record.reason.trim()
+      : "claimable",
+    retryLimit: nonNegInt(record.retryLimit),
+    claimAttemptCount: nonNegInt(record.claimAttemptCount),
+    remainingClaimAttempts: nonNegInt(record.remainingClaimAttempts),
+  };
+}
+
+/**
+ * Detail-page builder. Reads from `/jobs/definition`'s `claimStatus`
+ * block. Returns undefined for the same legacy-fallback reason.
+ */
+export function buildClaimStatusDetail(raw: unknown): ClaimStatusDetail | undefined {
+  const record = asRecord(raw);
+  if (!record) return undefined;
+  const summary = buildClaimSummary(record);
+  if (!summary) return undefined;
+  return {
+    ...summary,
+    currentWalletCanClaim:
+      typeof record.currentWalletCanClaim === "boolean"
+        ? record.currentWalletCanClaim
+        : null,
+    ...(text(record.claimedBy) ? { claimedBy: text(record.claimedBy) } : {}),
+    ...(text(record.claimedAt) ? { claimedAt: text(record.claimedAt) } : {}),
+    ...(text(record.claimExpiresAt)
+      ? { claimExpiresAt: text(record.claimExpiresAt) }
+      : {}),
+    ...(typeof record.claimNumber === "number"
+      ? { claimNumber: nonNegInt(record.claimNumber) }
+      : {}),
+    ...(text(record.sessionId) ? { sessionId: text(record.sessionId) } : {}),
+    ...(text(record.expiredAt) ? { expiredAt: text(record.expiredAt) } : {}),
+  };
+}
+
+/**
+ * Pull the claim block off a `/jobs/definition?jobId=...` payload —
+ * which wraps the block under `claimStatus`. Falls back to the bare
+ * top-level fields if the payload is the compact-row shape.
+ */
+export function extractClaimStatus(payload: unknown): ClaimStatusDetail | undefined {
+  const record = asRecord(payload);
+  if (!record) return undefined;
+  if (record.claimStatus && typeof record.claimStatus === "object") {
+    return buildClaimStatusDetail(record.claimStatus);
+  }
+  return buildClaimStatusDetail(record);
+}
+
+/** Pretty label for the row pill / badge. */
+export const CLAIM_STATE_LABEL: Record<ClaimEffectiveState, string> = {
+  claimable: "Claimable",
+  claimed: "Claimed",
+  expired: "Expired",
+  submitted: "Submitted",
+  exhausted: "Exhausted",
+};
+
+/** Tone the existing palette already covers. */
+export const CLAIM_STATE_TONE: Record<
+  ClaimEffectiveState,
+  "ok" | "neutral" | "warn" | "muted" | "bad"
+> = {
+  claimable: "ok",
+  claimed: "neutral",
+  submitted: "warn",
+  expired: "warn",
+  exhausted: "muted",
+};
+
+const REASON_LABEL: Record<string, string> = {
+  claimable: "Ready to claim",
+  claimed_by_other_wallet: "Claimed by another wallet",
+  already_claimed_by_current_wallet: "Already claimed by this wallet",
+  retry_limit_exhausted: "Retry limit exhausted",
+  claim_ttl_expired_reopen_available: "Expired claim can be reopened",
+  paused: "Paused — not claimable",
+  archived: "Archived — not claimable",
+  stale: "Stale — not claimable",
+  submitted: "Submitted — awaiting verification",
+};
+
+/**
+ * Render a backend reason code as operator-readable copy. Unknown codes
+ * fall back to the raw string with underscores replaced by spaces so we
+ * never silently swallow a new reason kind the backend starts emitting.
+ */
+export function formatClaimReason(reason: ClaimReason): string {
+  if (REASON_LABEL[reason]) return REASON_LABEL[reason];
+  return reason.replace(/_/g, " ");
+}
+
+function parseEffectiveState(value: unknown): ClaimEffectiveState | null {
+  if (typeof value !== "string") return null;
+  return ALLOWED_EFFECTIVE.includes(value as ClaimEffectiveState)
+    ? (value as ClaimEffectiveState)
+    : null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function nonNegInt(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  return Math.floor(parsed);
+}
+
+function text(value: unknown): string {
+  return typeof value === "string" && value.trim() ? value.trim() : "";
+}

--- a/app/lib/api/run-adapters.ts
+++ b/app/lib/api/run-adapters.ts
@@ -10,6 +10,7 @@ import type {
   WikipediaJobContext,
 } from "@/components/runs/types";
 import { buildJobLifecycle } from "@/lib/api/job-lifecycle";
+import { buildClaimSummary } from "@/lib/api/claim-status";
 
 type RawRecord = Record<string, unknown>;
 
@@ -567,6 +568,11 @@ export function buildRunRows(payload: unknown): RunRow[] {
                       .join(" · ")
                   : `${id} · ${category} · ${tier}`;
     const lifecycle = buildJobLifecycle(job.lifecycle);
+    // Compact claim block read straight off the row. The backend
+    // documents `claimabilitySource: "claimStatus"` — claimable rows
+    // and pills must derive from this, never from `lifecycle.status`
+    // alone (a row can be lifecycle.open + claim.exhausted).
+    const claim = buildClaimSummary(job);
     return {
       id,
       sessionId: text(job.sessionId),
@@ -574,6 +580,7 @@ export function buildRunRows(payload: unknown): RunRow[] {
       jobMeta,
       ...(source ? { source } : {}),
       ...(lifecycle ? { lifecycle } : {}),
+      ...(claim ? { claim } : {}),
       worker: {
         variant: worker ? "a" : "unclaimed",
         initials: worker ? "AG" : "-",
@@ -746,6 +753,11 @@ export function buildRecommendationCards(
       ],
       fit,
       hot: index === 0,
+      // Pass the live claim contract through so the JobCard's Claim
+      // button gates correctly on the rail. Recommendation rows are
+      // joined to the job feed by id above (`lookupJob`), so the
+      // contract is already present when the backend emits it.
+      ...(buildClaimSummary(job) ? { claim: buildClaimSummary(job)! } : {}),
     };
   });
 }


### PR DESCRIPTION
Implements the design brief: backend now emits a separate claim contract (\`effectiveState\`, \`claimable\`, \`reason\`, \`retryLimit\`, \`claimAttemptCount\`, \`remainingClaimAttempts\` on compact rows; \`claimStatus\` block on \`/jobs/definition\`). UI must derive claimability from this, not from \`lifecycle.status\`.

**Live verification**: the two prod Wikipedia rows currently come back \`{ state: \"exhausted\", claimable: false, reason: \"retry_limit_exhausted\" }\` — they should render as Exhausted, not Open / Ready.

## What changes
- **\`app/lib/api/claim-status.ts\`** — single source for parsing the claim block. \`buildClaimSummary\` reads the compact shape off \`/jobs[]\`; \`extractClaimStatus\` reads the full block off \`/jobs/definition\`. \`formatClaimReason\` covers all documented reason codes and falls back to the raw code on unknowns.
- **\`RunRow.claim\`** — new optional block. Plumbed through \`buildRunRows\` and \`buildRecommendationCards\`.
- **\`EffectiveStatePill\`** — new pill component on queue rows. Five tones (claimable=green, claimed=blue-tint, submitted/expired=amber, exhausted=muted). Replaces the legacy state pill when the row carries the new contract; older fixtures unaffected.
- **JobCard Claim button** — \`disabled\` unless \`claim.claimable === true\`, with \`title=\` reason for hover. New copy line under the meta grid surfaces state + reason + remaining attempts.
- **RunSemanticBlock** — leads with claim-state / claimable / reason / attempts before the legacy state/lifecycle line, so the plain-HTML detail summary for browser agents (from #77) shows the operational answer first.

## Acceptance criteria from brief
- [x] No job appears claimable just because \`lifecycle.status\` is \`open\`
- [x] Exhausted jobs render as Exhausted (not Open)
- [x] Expired retryable jobs render via \`effectiveState\` (covered by reason \`claim_ttl_expired_reopen_available\`)
- [x] Claim button respects \`claimable\`
- [x] \`claimabilitySource: claimStatus\` rule is obvious through behaviour — the pill, the disabled state, and the reason copy all read from the same block

## Test plan
- [x] \`npm run typecheck:app\`
- [x] \`npm run build:frontend\`
- [ ] After deploy: load \`/runs\`, the two Wikipedia rows show Exhausted (muted), the Claim button on those rail cards is disabled with \"Retry limit exhausted\" tooltip; the open-data rows show Claimable (green) and the button is active.