### PR TITLE
Replenish claimable Wikipedia job inventory

### DIFF
--- a/docs/PUBLIC_JOB_SOURCES.md
+++ b/docs/PUBLIC_JOB_SOURCES.md
@@ -61,9 +61,15 @@ claiming: `jobId`, `source: "wikipedia"`, `taskType`, `pageTitle`, `lang`,
 
 In production, this crawler is enabled by default and creates jobs
 autonomously with conservative caps: two jobs per run, twenty open Wikipedia
-jobs maximum, and a thirty-minute interval. Set
+jobs maximum, a minimum of two claimable Wikipedia jobs, and a thirty-minute
+interval. The scheduler counts effective claimability from `claimStatus`, so
+exhausted jobs stay auditable without blocking fresh inventory. Replenished
+jobs receive distinct reissue ids when they come from a source item whose
+previous job is exhausted. Set
 `WIKIPEDIA_INGEST_ENABLED=false` to disable it, or
 `WIKIPEDIA_INGEST_DRY_RUN=true` to observe candidates without creating jobs.
+Use `WIKIPEDIA_INGEST_MIN_CLAIMABLE_JOBS` to tune the minimum claimable
+Wikipedia inventory.
 
 ### Initial job types
 
@@ -188,8 +194,9 @@ operator dashboard. It is keyed by source:
 
 Each provider entry reports `label`, `enabled`, `running`, `dryRun`, `mode`,
 `health`, `intervalMs`, `maxJobsPerRun`, optional provider-specific caps such as
-`maxJobsPerQuery`, `maxOpenJobs`, `currentOpenJobs`, `targetCount`, `lastRunAt`,
-and a compact `lastRun` summary. The older provider-specific fields such as
+`maxJobsPerQuery`, `maxOpenJobs`, `currentOpenJobs`, optional
+`minClaimableJobs` / `currentClaimableJobs`, `targetCount`, `lastRunAt`, and a
+compact `lastRun` summary. The older provider-specific fields such as
 `osvIngestion` and `openDataIngestion` remain available for compatibility, but
 new admin UI should render from `providerOperations`.
 

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -923,6 +923,10 @@ function buildProviderOperationStatus({ label, status, targetCountField }) {
     ...(status.maxJobsPerQuery !== undefined ? { maxJobsPerQuery: toNonNegativeInteger(status.maxJobsPerQuery) } : {}),
     maxOpenJobs: toNonNegativeInteger(status.maxOpenJobs),
     currentOpenJobs,
+    ...(status.minClaimableJobs !== undefined ? { minClaimableJobs: toNonNegativeInteger(status.minClaimableJobs) } : {}),
+    ...(status.currentClaimableJobs !== undefined
+      ? { currentClaimableJobs: toNonNegativeInteger(status.currentClaimableJobs) }
+      : {}),
     targetCount: toNonNegativeInteger(status[targetCountField]),
     ...(queryCount !== undefined ? { queryCount } : {}),
     ...(nextQuery ? { nextQuery } : {}),

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -296,6 +296,8 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
         maxJobsPerRun: 2,
         maxOpenJobs: 10,
         currentOpenJobs: 0,
+        minClaimableJobs: 2,
+        currentClaimableJobs: 0,
         lastRun: { candidateCount: 0, createdCount: 0, skipped: [{ reason: "no_candidates" }], errors: [] }
       };
     }
@@ -408,6 +410,8 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
   assert.equal(status.providerOperations.github.lastRun.createdCount, 1);
   assert.equal(status.providerOperations.github.lastRun.skippedCount, 1);
   assert.equal(status.providerOperations.github.lastRun.skipped[0].reason, "source_already_ingested");
+  assert.equal(status.providerOperations.wikipedia.minClaimableJobs, 2);
+  assert.equal(status.providerOperations.wikipedia.currentClaimableJobs, 0);
   assert.equal(status.providerOperations.osv.targetCount, 1);
   assert.equal(status.providerOperations.openData.mode, "live");
   assert.equal(status.providerOperations.openData.health, "healthy");
@@ -440,6 +444,8 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
   // Health, mode, counts, and human-readable summary survive…
   assert.equal(publicStatus.providerOperations.github.mode, "dry_run");
   assert.equal(publicStatus.providerOperations.github.currentOpenJobs, 3);
+  assert.equal(publicStatus.providerOperations.wikipedia.minClaimableJobs, 2);
+  assert.equal(publicStatus.providerOperations.wikipedia.currentClaimableJobs, 0);
   assert.equal(publicStatus.providerOperations.github.lastRun.skippedCount, 1);
   assert.equal(publicStatus.providerOperations.openApi.health, "error");
   assert.equal(publicStatus.providerOperations.openApi.lastRun.errorCount, 1);

--- a/mcp-server/src/services/inventory-replenishment.js
+++ b/mcp-server/src/services/inventory-replenishment.js
@@ -1,0 +1,118 @@
+const ACTIVE_SOURCE_STATES = new Set(["claimable", "claimed", "expired"]);
+
+export async function buildInventorySnapshot(platformService, {
+  sourceType,
+  category = undefined,
+  tier = undefined,
+  sourceKeyForJob,
+  now = new Date()
+} = {}) {
+  const jobs = typeof platformService.listJobsWithSessions === "function"
+    ? await platformService.listJobsWithSessions({ now })
+    : platformService.listJobs();
+  const sourceJobs = jobs
+    .filter((job) => job?.source?.type === sourceType)
+    .filter((job) => !job.recurring);
+  const scopedJobs = sourceJobs
+    .filter((job) => category ? job.category === category : true)
+    .filter((job) => tier ? job.tier === tier : true);
+  const claimableJobs = scopedJobs.filter(isClaimableJob);
+  const activeSourceKeys = new Set(
+    sourceJobs
+      .filter(isActiveSourceJob)
+      .map(sourceKeyForJob)
+      .filter(Boolean)
+  );
+  const allSourceKeys = new Set(sourceJobs.map(sourceKeyForJob).filter(Boolean));
+  const allJobIds = new Set(jobs.map((job) => job?.id).filter(Boolean));
+
+  return {
+    jobs,
+    scopedJobs,
+    claimableJobs,
+    activeSourceKeys,
+    allSourceKeys,
+    allJobIds,
+    claimableCount: claimableJobs.length,
+    totalCount: scopedJobs.length
+  };
+}
+
+export function desiredInventoryCreates({
+  claimableCount,
+  minClaimableJobs = 0,
+  maxJobsPerRun = 0,
+  maxOpenJobs = Number.POSITIVE_INFINITY,
+  activeCount = claimableCount
+} = {}) {
+  const needed = minClaimableJobs > 0
+    ? Math.max(0, minClaimableJobs - claimableCount)
+    : maxJobsPerRun;
+  const openCapacity = Math.max(0, maxOpenJobs - activeCount);
+  return Math.max(0, Math.min(maxJobsPerRun, needed, openCapacity));
+}
+
+export function withReissueJobId(job, existingJobIds, {
+  now = new Date(),
+  reason = "inventory_replenishment"
+} = {}) {
+  if (!existingJobIds.has(job.id)) {
+    return job;
+  }
+  const base = truncateJobId(job.id, 108);
+  let index = 2;
+  let id = `${base}-r${index}`;
+  while (existingJobIds.has(id)) {
+    index += 1;
+    id = `${base}-r${index}`;
+  }
+  existingJobIds.add(id);
+  return {
+    ...job,
+    id,
+    source: {
+      ...job.source,
+      reissueOf: job.id,
+      reissueReason: reason,
+      reissuedAt: now.toISOString(),
+      reissueNumber: index
+    }
+  };
+}
+
+export function parseNonNegativeInt(raw, fallback) {
+  if (raw === undefined || raw === null || raw === "") {
+    return fallback;
+  }
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 0) {
+    return fallback;
+  }
+  return value;
+}
+
+function isClaimableJob(job) {
+  if (job?.claimable === true || job?.effectiveState === "claimable") {
+    return true;
+  }
+  if (job?.claimable === false || job?.effectiveState) {
+    return false;
+  }
+  const lifecycleState = job?.lifecycle?.state ?? job?.lifecycle?.status ?? job?.state ?? "open";
+  return lifecycleState === "open";
+}
+
+function isActiveSourceJob(job) {
+  if (ACTIVE_SOURCE_STATES.has(job?.effectiveState) || job?.claimable === true) {
+    return true;
+  }
+  if (job?.effectiveState || job?.claimable === false) {
+    return false;
+  }
+  const lifecycleState = job?.lifecycle?.state ?? job?.lifecycle?.status ?? job?.state ?? "open";
+  return lifecycleState === "open";
+}
+
+function truncateJobId(jobId, maxLength) {
+  return String(jobId ?? "").slice(0, maxLength).replace(/-+$/u, "");
+}

--- a/mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.js
+++ b/mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.js
@@ -1,4 +1,10 @@
 import { ingestWikipediaMaintenance, parseCategories, wikipediaArticleKey } from "../jobs/ingest-wikipedia-maintenance.js";
+import {
+  buildInventorySnapshot,
+  desiredInventoryCreates,
+  parseNonNegativeInt,
+  withReissueJobId
+} from "./inventory-replenishment.js";
 
 export class WikipediaMaintenanceIngestionScheduler {
   constructor(platformService, eventBus = undefined, {
@@ -10,6 +16,7 @@ export class WikipediaMaintenanceIngestionScheduler {
     minScore = 75,
     maxJobsPerRun = 2,
     maxOpenJobs = 20,
+    minClaimableJobs = 0,
     fetchImpl = fetch,
     logger = console
   } = {}) {
@@ -23,6 +30,7 @@ export class WikipediaMaintenanceIngestionScheduler {
     this.minScore = minScore;
     this.maxJobsPerRun = maxJobsPerRun;
     this.maxOpenJobs = maxOpenJobs;
+    this.minClaimableJobs = minClaimableJobs;
     this.fetchImpl = fetchImpl;
     this.logger = logger;
     this.timer = undefined;
@@ -47,6 +55,7 @@ export class WikipediaMaintenanceIngestionScheduler {
   }
 
   async getStatus() {
+    const inventory = await this.inventorySnapshot();
     return {
       enabled: this.enabled,
       running: this.running,
@@ -57,19 +66,24 @@ export class WikipediaMaintenanceIngestionScheduler {
       minScore: this.minScore,
       maxJobsPerRun: this.maxJobsPerRun,
       maxOpenJobs: this.maxOpenJobs,
-      currentOpenJobs: this.countOpenWikipediaJobs(),
+      minClaimableJobs: this.minClaimableJobs,
+      currentOpenJobs: inventory.claimableCount,
+      currentClaimableJobs: inventory.claimableCount,
       lastRun: this.lastRun
     };
   }
 
   async runOnce(now = new Date()) {
     const startedAt = now.toISOString();
-    const openWikipediaJobs = this.countOpenWikipediaJobs();
+    const inventory = await this.inventorySnapshot(now);
+    const claimableWikipediaJobs = inventory.claimableCount;
     const summary = {
       startedAt,
       finishedAt: undefined,
       dryRun: this.dryRun,
-      openWikipediaJobs,
+      claimableWikipediaJobs,
+      minClaimableJobs: this.minClaimableJobs,
+      activeSourceCount: inventory.activeSourceKeys.size,
       candidateCount: 0,
       createdCount: 0,
       skipped: [],
@@ -80,51 +94,69 @@ export class WikipediaMaintenanceIngestionScheduler {
       summary.skipped.push({ reason: "disabled" });
       return this.finishRun(summary);
     }
-    if (openWikipediaJobs >= this.maxOpenJobs) {
-      summary.skipped.push({ reason: "max_open_jobs_reached", openWikipediaJobs, maxOpenJobs: this.maxOpenJobs });
+    const remaining = desiredInventoryCreates({
+      claimableCount: claimableWikipediaJobs,
+      minClaimableJobs: this.minClaimableJobs,
+      maxJobsPerRun: this.maxJobsPerRun,
+      maxOpenJobs: this.maxOpenJobs,
+      activeCount: inventory.activeSourceKeys.size
+    });
+    if (remaining <= 0) {
+      summary.skipped.push({
+        reason: inventory.activeSourceKeys.size >= this.maxOpenJobs
+          ? "max_open_jobs_reached"
+          : "minimum_claimable_satisfied",
+        claimableWikipediaJobs,
+        minClaimableJobs: this.minClaimableJobs,
+        maxOpenJobs: this.maxOpenJobs
+      });
       return this.finishRun(summary);
     }
 
-    const remaining = Math.max(0, Math.min(this.maxJobsPerRun, this.maxOpenJobs - openWikipediaJobs));
-    const seenSources = this.existingWikipediaArticleKeys();
+    this.logger.info?.({
+      source: "wikipedia",
+      category: "wikipedia",
+      tier: "starter",
+      claimableWikipediaJobs,
+      minClaimableJobs: this.minClaimableJobs,
+      desiredCreateCount: remaining
+    }, "inventory.replenish.wikipedia");
+    const seenSources = new Set(inventory.activeSourceKeys);
+    const candidateLimit = Math.max(remaining * 3, remaining + seenSources.size);
     try {
       const result = await ingestWikipediaMaintenance({
         language: this.language,
         categories: this.categories,
-        limit: remaining,
+        limit: candidateLimit,
         minScore: this.minScore,
         fetchImpl: this.fetchImpl
       });
       summary.candidateCount = result.count;
       for (const job of result.jobs) {
+        if (summary.createdCount >= remaining) break;
         const sourceKey = wikipediaJobKey(job);
         if (sourceKey && seenSources.has(sourceKey)) {
           summary.skipped.push({ id: job.id, reason: "source_already_ingested" });
           continue;
         }
-        if (this.platformService.getJobDefinition) {
-          try {
-            this.platformService.getJobDefinition(job.id);
-            summary.skipped.push({ id: job.id, reason: "job_already_exists" });
-            continue;
-          } catch {
-            // Missing jobs are expected and created below.
-          }
-        }
+        const replenishedJob = withReissueJobId(job, inventory.allJobIds, { now });
         if (!this.dryRun) {
-          this.platformService.createJob(job);
+          this.platformService.createJob(replenishedJob);
         }
         seenSources.add(sourceKey);
         summary.createdCount += 1;
         this.eventBus?.publish?.({
-          id: `platform-wikipedia-ingest-${job.id}-${Date.now()}`,
+          id: `platform-wikipedia-ingest-${replenishedJob.id}-${Date.now()}`,
           topic: "jobs.ingest.wikipedia",
-          jobId: job.id,
+          jobId: replenishedJob.id,
           timestamp: new Date().toISOString(),
           data: {
             dryRun: this.dryRun,
-            jobId: job.id,
-            source: job.source
+            jobId: replenishedJob.id,
+            source: replenishedJob.source,
+            reason: "inventory_replenishment",
+            claimableBefore: claimableWikipediaJobs,
+            minClaimableJobs: this.minClaimableJobs
           }
         });
       }
@@ -156,11 +188,14 @@ export class WikipediaMaintenanceIngestionScheduler {
     return summary;
   }
 
-  countOpenWikipediaJobs() {
-    return this.platformService.listJobs()
-      .filter((job) => job.source?.type === "wikipedia_article")
-      .filter((job) => !job.recurring)
-      .length;
+  async inventorySnapshot(now = new Date()) {
+    return buildInventorySnapshot(this.platformService, {
+      sourceType: "wikipedia_article",
+      category: "wikipedia",
+      tier: "starter",
+      sourceKeyForJob: wikipediaJobKey,
+      now
+    });
   }
 
   existingWikipediaArticleKeys() {
@@ -186,7 +221,11 @@ export function loadWikipediaMaintenanceIngestionConfig(env = process.env) {
     categories: parseCategories(env.WIKIPEDIA_INGEST_CATEGORIES_JSON ?? env.WIKIPEDIA_INGEST_CATEGORIES),
     minScore: parsePositiveInt(env.WIKIPEDIA_INGEST_MIN_SCORE, 75),
     maxJobsPerRun: parsePositiveInt(env.WIKIPEDIA_INGEST_MAX_JOBS_PER_RUN, 2),
-    maxOpenJobs: parsePositiveInt(env.WIKIPEDIA_INGEST_MAX_OPEN_JOBS, 20)
+    maxOpenJobs: parsePositiveInt(env.WIKIPEDIA_INGEST_MAX_OPEN_JOBS, 20),
+    minClaimableJobs: parseNonNegativeInt(
+      env.WIKIPEDIA_INGEST_MIN_CLAIMABLE_JOBS,
+      productionDefault ? 2 : 0
+    )
   };
 }
 

--- a/mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.test.js
+++ b/mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.test.js
@@ -6,6 +6,12 @@ import {
   loadWikipediaMaintenanceIngestionConfig
 } from "./wikipedia-maintenance-ingestion-scheduler.js";
 
+const GENERATED_WIKI_JOB_ID = "wiki-en-123-citation_repair-example-article";
+const SILENT_LOGGER = {
+  info() {},
+  warn() {}
+};
+
 function makeFetch() {
   return async (url) => {
     if (String(url).includes("list=categorymembers")) {
@@ -47,6 +53,9 @@ function makePlatformService(initialJobs = []) {
         throw new Error("not found");
       }
       return job;
+    },
+    async listJobsWithSessions() {
+      return [...jobs];
     }
   };
 }
@@ -58,7 +67,8 @@ test("WikipediaMaintenanceIngestionScheduler dry-run does not create jobs", asyn
     dryRun: true,
     categories: [{ title: "Category:All articles with dead external links", taskType: "citation_repair" }],
     minScore: 55,
-    fetchImpl: makeFetch()
+    fetchImpl: makeFetch(),
+    logger: SILENT_LOGGER
   });
 
   const summary = await scheduler.runOnce(new Date("2026-04-25T10:00:00.000Z"));
@@ -74,7 +84,8 @@ test("WikipediaMaintenanceIngestionScheduler creates jobs when dryRun is false",
     dryRun: false,
     categories: [{ title: "Category:All articles with dead external links", taskType: "citation_repair" }],
     minScore: 55,
-    fetchImpl: makeFetch()
+    fetchImpl: makeFetch(),
+    logger: SILENT_LOGGER
   });
 
   const summary = await scheduler.runOnce(new Date("2026-04-25T10:00:00.000Z"));
@@ -101,13 +112,67 @@ test("WikipediaMaintenanceIngestionScheduler dedupes by article revision", async
     dryRun: false,
     categories: [{ title: "Category:All articles with dead external links", taskType: "citation_repair" }],
     minScore: 55,
-    fetchImpl: makeFetch()
+    fetchImpl: makeFetch(),
+    logger: SILENT_LOGGER
   });
 
   const summary = await scheduler.runOnce(new Date("2026-04-25T10:00:00.000Z"));
   assert.equal(summary.createdCount, 0);
   assert.equal(platform.listJobs().length, 1);
   assert.equal(summary.skipped[0].reason, "source_already_ingested");
+});
+
+test("WikipediaMaintenanceIngestionScheduler skips replenishment when minimum claimable inventory is satisfied", async () => {
+  const platform = makePlatformService([
+    claimableWikipediaJob("wiki-1", 1),
+    claimableWikipediaJob("wiki-2", 2)
+  ]);
+  const scheduler = new WikipediaMaintenanceIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    minClaimableJobs: 2,
+    fetchImpl: async () => {
+      throw new Error("fetch should not run");
+    },
+    logger: SILENT_LOGGER
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-25T10:00:00.000Z"));
+
+  assert.equal(summary.createdCount, 0);
+  assert.equal(summary.claimableWikipediaJobs, 2);
+  assert.equal(summary.skipped[0].reason, "minimum_claimable_satisfied");
+});
+
+test("WikipediaMaintenanceIngestionScheduler reissues exhausted source jobs with a fresh id", async () => {
+  const platform = makePlatformService([
+    {
+      ...claimableWikipediaJob(GENERATED_WIKI_JOB_ID, 123),
+      claimable: false,
+      effectiveState: "exhausted",
+      claimState: "exhausted",
+      reason: "retry_limit_exhausted"
+    }
+  ]);
+  const scheduler = new WikipediaMaintenanceIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    minClaimableJobs: 1,
+    categories: [{ title: "Category:All articles with dead external links", taskType: "citation_repair" }],
+    minScore: 55,
+    fetchImpl: makeFetch(),
+    logger: SILENT_LOGGER
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-25T10:00:00.000Z"));
+  const jobs = platform.listJobs();
+
+  assert.equal(summary.createdCount, 1);
+  assert.equal(jobs.length, 2);
+  assert.equal(jobs[0].id, `${GENERATED_WIKI_JOB_ID}-r2`);
+  assert.equal(jobs[0].source.reissueOf, GENERATED_WIKI_JOB_ID);
+  assert.equal(jobs[0].source.reissueReason, "inventory_replenishment");
+  assert.equal(jobs[1].effectiveState, "exhausted");
 });
 
 test("loadWikipediaMaintenanceIngestionConfig parses env knobs safely", () => {
@@ -119,6 +184,7 @@ test("loadWikipediaMaintenanceIngestionConfig parses env knobs safely", () => {
     WIKIPEDIA_INGEST_MIN_SCORE: "80",
     WIKIPEDIA_INGEST_MAX_JOBS_PER_RUN: "3",
     WIKIPEDIA_INGEST_MAX_OPEN_JOBS: "12",
+    WIKIPEDIA_INGEST_MIN_CLAIMABLE_JOBS: "4",
     WIKIPEDIA_INGEST_CATEGORIES_JSON: '[{"title":"Category:Wikipedia articles in need of updating","taskType":"freshness_check"}]'
   });
 
@@ -129,6 +195,7 @@ test("loadWikipediaMaintenanceIngestionConfig parses env knobs safely", () => {
   assert.equal(config.minScore, 80);
   assert.equal(config.maxJobsPerRun, 3);
   assert.equal(config.maxOpenJobs, 12);
+  assert.equal(config.minClaimableJobs, 4);
   assert.deepEqual(config.categories, [
     { title: "Category:Wikipedia articles in need of updating", taskType: "freshness_check" }
   ]);
@@ -145,6 +212,7 @@ test("loadWikipediaMaintenanceIngestionConfig enables production ingestion by de
   assert.equal(config.language, "en");
   assert.equal(config.maxJobsPerRun, 2);
   assert.equal(config.maxOpenJobs, 20);
+  assert.equal(config.minClaimableJobs, 2);
 });
 
 test("loadWikipediaMaintenanceIngestionConfig stays opt-in outside production", () => {
@@ -154,6 +222,7 @@ test("loadWikipediaMaintenanceIngestionConfig stays opt-in outside production", 
 
   assert.equal(config.enabled, false);
   assert.equal(config.dryRun, true);
+  assert.equal(config.minClaimableJobs, 0);
 });
 
 function jsonResponse(payload) {
@@ -161,6 +230,23 @@ function jsonResponse(payload) {
     ok: true,
     async json() {
       return payload;
+    }
+  };
+}
+
+function claimableWikipediaJob(id, pageId) {
+  return {
+    id,
+    category: "wikipedia",
+    tier: "starter",
+    claimable: true,
+    effectiveState: "claimable",
+    source: {
+      type: "wikipedia_article",
+      language: "en",
+      pageId,
+      revisionId: "987654321",
+      taskType: "citation_repair"
     }
   };
 }


### PR DESCRIPTION
## Summary
- count Wikipedia inventory by effective claimability instead of raw catalog rows
- keep exhausted Wikipedia jobs auditable while allowing fresh claimable reissue rows with distinct ids
- add configurable WIKIPEDIA_INGEST_MIN_CLAIMABLE_JOBS, defaulting to 2 in production
- expose min/current claimable inventory in providerOperations and document the scheduler behavior

## Checks
- npm --workspace mcp-server test
- node --test mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.test.js mcp-server/src/core/platform-service.test.js
- git diff --check
- Polkadot MCP docs cross-check: smart-contract JSON-RPC surface unchanged; no chain/RPC behavior added by this scheduler patch

## Impact
- Backend scheduler + docs only
- No frontend, indexer, Caddy, contracts, or public site source changes
- No required environment changes; optional WIKIPEDIA_INGEST_MIN_CLAIMABLE_JOBS tunes the claimable inventory floor

Closes #134