### PR TITLE
Fix Wikipedia inventory reissue collisions

### DIFF
--- a/mcp-server/src/services/inventory-replenishment.js
+++ b/mcp-server/src/services/inventory-replenishment.js
@@ -10,7 +10,18 @@ export async function buildInventorySnapshot(platformService, {
   const jobs = typeof platformService.listJobsWithSessions === "function"
     ? await platformService.listJobsWithSessions({ now })
     : platformService.listJobs();
+  const allJobs = typeof platformService.listJobs === "function"
+    ? platformService.listJobs({
+      includeArchived: true,
+      includePaused: true,
+      includeStale: true,
+      now
+    })
+    : jobs;
   const sourceJobs = jobs
+    .filter((job) => job?.source?.type === sourceType)
+    .filter((job) => !job.recurring);
+  const allSourceJobs = allJobs
     .filter((job) => job?.source?.type === sourceType)
     .filter((job) => !job.recurring);
   const scopedJobs = sourceJobs
@@ -23,8 +34,10 @@ export async function buildInventorySnapshot(platformService, {
       .map(sourceKeyForJob)
       .filter(Boolean)
   );
-  const allSourceKeys = new Set(sourceJobs.map(sourceKeyForJob).filter(Boolean));
-  const allJobIds = new Set(jobs.map((job) => job?.id).filter(Boolean));
+  const allSourceKeys = new Set(allSourceJobs.map(sourceKeyForJob).filter(Boolean));
+  const allJobIds = new Set(
+    allJobs.flatMap((job) => normalizedJobIdEntries(job?.id)).filter(Boolean)
+  );
 
   return {
     jobs,
@@ -56,10 +69,13 @@ export function withReissueJobId(job, existingJobIds, {
   now = new Date(),
   reason = "inventory_replenishment"
 } = {}) {
-  if (!existingJobIds.has(job.id)) {
-    return job;
+  const normalizedId = normalizeJobId(job.id);
+  const normalizedJob = normalizedId === job.id ? job : { ...job, id: normalizedId };
+  if (!existingJobIds.has(normalizedId)) {
+    existingJobIds.add(normalizedId);
+    return normalizedJob;
   }
-  const base = truncateJobId(job.id, 108);
+  const base = truncateJobId(normalizedId, 108);
   let index = 2;
   let id = `${base}-r${index}`;
   while (existingJobIds.has(id)) {
@@ -68,11 +84,11 @@ export function withReissueJobId(job, existingJobIds, {
   }
   existingJobIds.add(id);
   return {
-    ...job,
+    ...normalizedJob,
     id,
     source: {
       ...job.source,
-      reissueOf: job.id,
+      reissueOf: normalizedId,
       reissueReason: reason,
       reissuedAt: now.toISOString(),
       reissueNumber: index
@@ -115,4 +131,18 @@ function isActiveSourceJob(job) {
 
 function truncateJobId(jobId, maxLength) {
   return String(jobId ?? "").slice(0, maxLength).replace(/-+$/u, "");
+}
+
+function normalizedJobIdEntries(jobId) {
+  const raw = String(jobId ?? "").trim();
+  const normalized = normalizeJobId(raw);
+  return raw && raw !== normalized ? [raw, normalized] : [normalized];
+}
+
+function normalizeJobId(value) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 }

--- a/mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.test.js
+++ b/mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.test.js
@@ -5,8 +5,10 @@ import {
   WikipediaMaintenanceIngestionScheduler,
   loadWikipediaMaintenanceIngestionConfig
 } from "./wikipedia-maintenance-ingestion-scheduler.js";
+import { JobCatalogService } from "../core/job-catalog-service.js";
 
 const GENERATED_WIKI_JOB_ID = "wiki-en-123-citation_repair-example-article";
+const CANONICAL_WIKI_JOB_ID = "wiki-en-123-citation-repair-example-article";
 const SILENT_LOGGER = {
   info() {},
   warn() {}
@@ -169,10 +171,63 @@ test("WikipediaMaintenanceIngestionScheduler reissues exhausted source jobs with
 
   assert.equal(summary.createdCount, 1);
   assert.equal(jobs.length, 2);
-  assert.equal(jobs[0].id, `${GENERATED_WIKI_JOB_ID}-r2`);
-  assert.equal(jobs[0].source.reissueOf, GENERATED_WIKI_JOB_ID);
+  assert.equal(jobs[0].id, `${CANONICAL_WIKI_JOB_ID}-r2`);
+  assert.equal(jobs[0].source.reissueOf, CANONICAL_WIKI_JOB_ID);
   assert.equal(jobs[0].source.reissueReason, "inventory_replenishment");
   assert.equal(jobs[1].effectiveState, "exhausted");
+});
+
+test("WikipediaMaintenanceIngestionScheduler avoids hidden stale job id collisions", async () => {
+  const catalog = new JobCatalogService(
+    [{
+      id: GENERATED_WIKI_JOB_ID,
+      category: "wikipedia",
+      tier: "starter",
+      lifecycle: {
+        status: "open",
+        createdAt: "2026-04-01T00:00:00.000Z",
+        updatedAt: "2026-04-01T00:00:00.000Z",
+        staleAt: "2026-04-15T00:00:00.000Z"
+      },
+      source: {
+        type: "wikipedia_article",
+        language: "en",
+        pageId: 123,
+        revisionId: "987654321",
+        taskType: "citation_repair"
+      }
+    }],
+    [],
+    () => ({}),
+    () => ({}),
+    () => 0
+  );
+  const platform = {
+    listJobs(options = {}) {
+      return catalog.listJobs(options);
+    },
+    createJob(job) {
+      return catalog.createJob(job);
+    }
+  };
+  const scheduler = new WikipediaMaintenanceIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    minClaimableJobs: 1,
+    categories: [{ title: "Category:All articles with dead external links", taskType: "citation_repair" }],
+    minScore: 55,
+    fetchImpl: makeFetch(),
+    logger: SILENT_LOGGER
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-25T10:00:00.000Z"));
+  const jobs = catalog.listJobs({ includeStale: true });
+
+  assert.equal(summary.createdCount, 1);
+  assert.deepEqual(summary.errors, []);
+  assert.equal(jobs.length, 2);
+  assert.equal(jobs[0].id, `${CANONICAL_WIKI_JOB_ID}-r2`);
+  assert.equal(jobs[0].source.reissueOf, CANONICAL_WIKI_JOB_ID);
 });
 
 test("loadWikipediaMaintenanceIngestionConfig parses env knobs safely", () => {


### PR DESCRIPTION
## What changed
- Build replenishment snapshots from the visible/session-joined job list for claimability, but collect all catalog IDs from paused/archived/stale jobs so reissues cannot collide with hidden historical jobs.
- Canonicalize generated job IDs the same way the catalog does before checking for collisions, covering raw Wikipedia task IDs like citation_repair -> citation-repair.
- Added a regression test using the real JobCatalogService path for hidden stale job collisions.

## Checks
- node --test mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.test.js
- npm --workspace mcp-server test
- git diff --check

## Impact
- Backend only: Wikipedia provider inventory replenishment.
- No frontend, indexer, Caddy, contracts, or public site changes.
- No environment or VPS secret changes.

## Notes
- Public production status showed Wikipedia replenishment unhealthy with candidates found but zero created. Local reproduction confirmed a JobCatalogService ID collision when stale historical jobs were hidden from the snapshot and generated IDs were not canonicalized before create.