### PR TITLE
Avoid Wikipedia replenishment session ID reuse

### DIFF
--- a/mcp-server/src/services/inventory-replenishment.js
+++ b/mcp-server/src/services/inventory-replenishment.js
@@ -18,6 +18,7 @@ export async function buildInventorySnapshot(platformService, {
       now
     })
     : jobs;
+  const historicalSessionJobIds = await listHistoricalSessionJobIds(platformService);
   const sourceJobs = jobs
     .filter((job) => job?.source?.type === sourceType)
     .filter((job) => !job.recurring);
@@ -36,7 +37,10 @@ export async function buildInventorySnapshot(platformService, {
   );
   const allSourceKeys = new Set(allSourceJobs.map(sourceKeyForJob).filter(Boolean));
   const allJobIds = new Set(
-    allJobs.flatMap((job) => normalizedJobIdEntries(job?.id)).filter(Boolean)
+    [
+      ...allJobs.map((job) => job?.id),
+      ...historicalSessionJobIds
+    ].flatMap(normalizedJobIdEntries).filter(Boolean)
   );
 
   return {
@@ -145,4 +149,14 @@ function normalizeJobId(value) {
     .toLowerCase()
     .replace(/[^a-z0-9-]+/g, "-")
     .replace(/^-+|-+$/g, "");
+}
+
+async function listHistoricalSessionJobIds(platformService) {
+  const stateStore = platformService?.stateStore;
+  const sessions = typeof stateStore?.listRecentSessions === "function"
+    ? await stateStore.listRecentSessions(10_000)
+    : typeof platformService?.listRecentSessions === "function"
+      ? await platformService.listRecentSessions(10_000)
+      : [];
+  return sessions.map((session) => session?.jobId).filter(Boolean);
 }

--- a/mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.test.js
+++ b/mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.test.js
@@ -230,6 +230,43 @@ test("WikipediaMaintenanceIngestionScheduler avoids hidden stale job id collisio
   assert.equal(jobs[0].source.reissueOf, CANONICAL_WIKI_JOB_ID);
 });
 
+test("WikipediaMaintenanceIngestionScheduler avoids historical session id collisions", async () => {
+  const platform = {
+    jobs: [],
+    listJobs() {
+      return [...this.jobs];
+    },
+    createJob(job) {
+      this.jobs.unshift(job);
+      return job;
+    },
+    async listRecentSessions() {
+      return [{
+        sessionId: `${CANONICAL_WIKI_JOB_ID}:0x30BC468dA4E95a8FA4b3f2043c86687a57CdeE05`,
+        jobId: CANONICAL_WIKI_JOB_ID,
+        wallet: "0x30BC468dA4E95a8FA4b3f2043c86687a57CdeE05",
+        status: "expired"
+      }];
+    }
+  };
+  const scheduler = new WikipediaMaintenanceIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    minClaimableJobs: 1,
+    categories: [{ title: "Category:All articles with dead external links", taskType: "citation_repair" }],
+    minScore: 55,
+    fetchImpl: makeFetch(),
+    logger: SILENT_LOGGER
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-25T10:00:00.000Z"));
+
+  assert.equal(summary.createdCount, 1);
+  assert.deepEqual(summary.errors, []);
+  assert.equal(platform.jobs[0].id, `${CANONICAL_WIKI_JOB_ID}-r2`);
+  assert.equal(platform.jobs[0].source.reissueOf, CANONICAL_WIKI_JOB_ID);
+});
+
 test("loadWikipediaMaintenanceIngestionConfig parses env knobs safely", () => {
   const config = loadWikipediaMaintenanceIngestionConfig({
     WIKIPEDIA_INGEST_ENABLED: "true",


### PR DESCRIPTION
## What changed
- Include historical session job IDs in the replenishment collision set, not just visible/catalog job IDs.
- This prevents newly replenished Wikipedia jobs from reusing IDs that already have expired/exhausted Redis session history.
- Added a regression test covering the production shape: catalog has no current job row, but recent session history still references the generated job ID.

## Checks
- node --test mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.test.js
- npm --workspace mcp-server test
- git diff --check

## Impact
- Backend only: provider inventory replenishment.
- No frontend, indexer, Caddy, contracts, or public site changes.
- No environment or VPS secret changes.

## Notes
- Follow-up to #137. The first hotfix made Wikipedia creation healthy, but live verification showed the created rows immediately inherited exhausted claim state from old sessions because the generated IDs matched historical Redis session job IDs.