### PR TITLE
Drive runs lifecycle rail + submit gate from live claim state

### DIFF
--- a/app/app/(authed)/runs/page.tsx
+++ b/app/app/(authed)/runs/page.tsx
@@ -20,13 +20,14 @@ import { LoadedRunView } from "@/components/runs/LoadedRunView";
 import { LifecycleRail } from "@/components/runs/LifecycleRail";
 import {
   FIXTURE_FILTERS,
-  FIXTURE_LIFECYCLE,
-  FIXTURE_LIFECYCLE_OPEN_DATA,
-  FIXTURE_LIFECYCLE_OSV,
-  FIXTURE_LIFECYCLE_WIKIPEDIA,
   FIXTURE_RECOMMENDATIONS,
   FIXTURE_RUN_ROWS,
 } from "@/components/runs/fixtures";
+import {
+  buildLifecycleStages,
+  describeClaimer,
+  formatDeadline,
+} from "@/components/runs/buildLifecycleStages";
 import { useAdminJobs, useJobs, useRecommendations } from "@/lib/api/hooks";
 import { freshnessFromRequests } from "@/components/shell/DataFreshnessPill";
 import {
@@ -192,52 +193,43 @@ function RunsPageInner() {
   // right per-source field set inside each branch — no per-source
   // intermediate variables needed.
   const selectedSource = selectedRow?.source;
-  const lifecycleContextNote =
-    selectedSource?.type === "wikipedia_article" ? (
-      <>
-        Window closes in{" "}
-        <b className="font-semibold text-[var(--avy-ink)]">21m 46s</b>
-        {" · "}verification{" "}
-        <b className="font-semibold text-[var(--avy-ink)]">
-          wikipedia_proposal_review
-        </b>
-        {" · "}proposal{" "}
-        <b className="font-semibold text-[var(--avy-ink)]">submitted</b> ·
-        pending Averray review
-      </>
-    ) : selectedSource?.type === "osv_advisory" ? (
-      <>
-        Window closes in{" "}
-        <b className="font-semibold text-[var(--avy-ink)]">21m 46s</b>
-        {" · "}verification{" "}
-        <b className="font-semibold text-[var(--avy-ink)]">osv_dependency_pr</b>
-        {" · "}advisory{" "}
-        <b className="font-semibold text-[var(--avy-ink)]">
-          {selectedSource.advisoryId}
-        </b>{" "}
-        · PR pending merge
-      </>
-    ) : selectedSource?.type === "open_data_dataset" ? (
-      <>
-        Window closes in{" "}
-        <b className="font-semibold text-[var(--avy-ink)]">21m 46s</b>
-        {" · "}verification{" "}
-        <b className="font-semibold text-[var(--avy-ink)]">
-          open_data_quality_audit
-        </b>
-        {" · "}audit{" "}
-        <b className="font-semibold text-[var(--avy-ink)]">submitted</b>
-      </>
-    ) : (
-      <>
-        Window closes in{" "}
-        <b className="font-semibold text-[var(--avy-ink)]">21m 46s</b>
-        {" · "}verification{" "}
-        <b className="font-semibold text-[var(--avy-ink)]">github_pr</b>
-        {" · "}PR{" "}
-        <b className="font-semibold text-[var(--avy-ink)]">#4931</b> opened
-      </>
-    );
+  const verificationLabel =
+    selectedSource?.type === "wikipedia_article"
+      ? "wikipedia_proposal_review"
+      : selectedSource?.type === "osv_advisory"
+        ? "osv_dependency_pr"
+        : selectedSource?.type === "open_data_dataset"
+          ? "open_data_quality_audit"
+          : "github_pr";
+  const claim = selectedRow?.claim;
+  const deadlineLabel = claim?.claimExpiresAt
+    ? formatDeadline(claim.claimExpiresAt)
+    : "";
+  const stateLabel = claim
+    ? claim.state === "claimed"
+      ? `claimed${claim.claimedBy ? ` ${describeClaimer(claim.claimedBy, undefined)}` : ""}`
+      : claim.state === "submitted"
+        ? "submitted, awaiting verifier"
+        : claim.state === "expired"
+          ? "claim expired — reopenable"
+          : claim.state === "exhausted"
+            ? "no retries left"
+            : "ready to claim"
+    : "no claim state";
+  const lifecycleContextNote = (
+    <>
+      {deadlineLabel ? (
+        <>
+          Window <b className="font-semibold text-[var(--avy-ink)]">{deadlineLabel}</b>
+          {" · "}
+        </>
+      ) : null}
+      verification{" "}
+      <b className="font-semibold text-[var(--avy-ink)]">{verificationLabel}</b>
+      {" · "}
+      <b className="font-semibold text-[var(--avy-ink)]">{stateLabel}</b>
+    </>
+  );
   const lifecycleNext =
     selectedSource?.type === "wikipedia_article"
       ? {
@@ -335,15 +327,10 @@ function RunsPageInner() {
       <LifecycleRail
         runId={selectedId}
         contextNote={lifecycleContextNote}
-        stages={
-          selectedSource?.type === "wikipedia_article"
-            ? FIXTURE_LIFECYCLE_WIKIPEDIA
-            : selectedSource?.type === "osv_advisory"
-              ? FIXTURE_LIFECYCLE_OSV
-              : selectedSource?.type === "open_data_dataset"
-                ? FIXTURE_LIFECYCLE_OPEN_DATA
-                : FIXTURE_LIFECYCLE
-        }
+        stages={buildLifecycleStages({
+          claim: selectedRow?.claim,
+          source: selectedSource,
+        })}
         next={lifecycleNext}
       />
 

--- a/app/components/runs/LoadedRunPanel.tsx
+++ b/app/components/runs/LoadedRunPanel.tsx
@@ -103,6 +103,13 @@ export interface LoadedRunPanelProps {
     onSubmit?: (evidence: string) => void | Promise<void>;
     submitting?: boolean;
     error?: string | null;
+    /**
+     * When set, the submit button is rendered disabled and the string
+     * is shown instead of the submit-error line. Gates the button on
+     * claimable / wallet ownership / canSubmit so a signed-out viewer
+     * doesn't fire a useless 401.
+     */
+    disabledReason?: string;
   };
   verifier: {
     runner: string;
@@ -380,12 +387,15 @@ export function LoadedRunPanel(props: LoadedRunPanelProps) {
             </p>
             <button
               type="button"
-              disabled={props.submission.submitting}
+              disabled={
+                props.submission.submitting || Boolean(props.submission.disabledReason)
+              }
               onClick={() => {
                 props.submission.onSubmit?.(evidenceValue);
               }}
-              className="inline-flex h-9 shrink-0 items-center gap-2 whitespace-nowrap rounded-[8px] bg-[var(--avy-accent)] px-3.5 font-[family-name:var(--font-display)] text-[11.5px] font-bold uppercase text-[var(--fg-invert)] transition-transform hover:-translate-y-px hover:bg-[var(--avy-accent-2)]"
+              className="inline-flex h-9 shrink-0 items-center gap-2 whitespace-nowrap rounded-[8px] bg-[var(--avy-accent)] px-3.5 font-[family-name:var(--font-display)] text-[11.5px] font-bold uppercase text-[var(--fg-invert)] transition-transform hover:-translate-y-px hover:bg-[var(--avy-accent-2)] disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:translate-y-0 disabled:hover:bg-[var(--avy-accent)]"
               style={{ letterSpacing: "0.04em" }}
+              title={props.submission.disabledReason}
             >
               {props.submission.submitting ? "Submitting..." : props.submission.cta}
               <span
@@ -395,7 +405,14 @@ export function LoadedRunPanel(props: LoadedRunPanelProps) {
                 ⏎
               </span>
             </button>
-            {props.submission.error ? (
+            {props.submission.disabledReason ? (
+              <span
+                className="font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
+                style={{ letterSpacing: 0 }}
+              >
+                {props.submission.disabledReason}
+              </span>
+            ) : props.submission.error ? (
               <span
                 className="font-[family-name:var(--font-mono)] text-[11px] text-[#8c2a17]"
                 style={{ letterSpacing: 0 }}

--- a/app/components/runs/LoadedRunView.tsx
+++ b/app/components/runs/LoadedRunView.tsx
@@ -12,12 +12,13 @@ import {
 } from "./ReceiptPreviewDrawer";
 import {
   FIXTURE_JOB_DEFINITIONS,
-  FIXTURE_LIFECYCLE,
-  FIXTURE_LIFECYCLE_OPEN_DATA,
-  FIXTURE_LIFECYCLE_OSV,
-  FIXTURE_LIFECYCLE_WIKIPEDIA,
   FIXTURE_RUN_ROWS,
 } from "./fixtures";
+import {
+  buildLifecycleStages,
+  describeClaimer,
+  formatDeadline,
+} from "./buildLifecycleStages";
 import type { RunRow } from "./RunQueueTable";
 import { ApiError, swrFetcher } from "@/lib/api/client";
 import { useAdminJobs, useJobDefinition, useJobs } from "@/lib/api/hooks";
@@ -262,6 +263,24 @@ export function LoadedRunView({
           onSubmit: handleSubmit,
           submitting,
           error: submitError,
+          // Gate the button on the live claim state. A row that's not
+          // in `claimed` can't be submitted — either there's no claim
+          // (claimable / expired / exhausted) or someone already
+          // submitted (state: submitted). The string surfaces in the
+          // disabled-button title and replaces the error line, so a
+          // signed-out viewer sees "claim this run first" instead of
+          // a useless 401 after clicking.
+          disabledReason: !loadedRow.claim
+            ? undefined
+            : loadedRow.claim.state === "claimed"
+              ? undefined
+              : loadedRow.claim.state === "submitted"
+                ? "Already submitted — awaiting verifier"
+                : loadedRow.claim.state === "expired"
+                  ? "Claim expired — reopen before submitting"
+                  : loadedRow.claim.state === "exhausted"
+                    ? "No retries left on this row"
+                    : "Claim this run before submitting evidence",
         }}
         verifier={
           loadedOpenData
@@ -610,64 +629,47 @@ export function LoadedRunView({
       {showLifecycle ? (
         <LifecycleRail
           runId={loadedRow.id}
-          contextNote={
-            loadedWikipedia ? (
+          contextNote={(() => {
+            const verificationLabel =
+              loadedWikipedia?.verification.method ??
+              loadedOsv?.verification.method ??
+              loadedOpenData?.verification.method ??
+              "github_pr";
+            const claim = loadedRow.claim;
+            const deadlineLabel = claim?.claimExpiresAt
+              ? formatDeadline(claim.claimExpiresAt)
+              : "";
+            const stateLabel = claim
+              ? claim.state === "claimed"
+                ? `claimed${claim.claimedBy ? ` ${describeClaimer(claim.claimedBy, undefined)}` : ""}`
+                : claim.state === "submitted"
+                  ? "submitted, awaiting verifier"
+                  : claim.state === "expired"
+                    ? "claim expired — reopenable"
+                    : claim.state === "exhausted"
+                      ? "no retries left"
+                      : "ready to claim"
+              : "no claim state";
+            return (
               <>
-                Window closes in{" "}
-                <b className="font-semibold text-[var(--avy-ink)]">21m 46s</b>
-                {" · "}verification{" "}
-                <b className="font-semibold text-[var(--avy-ink)]">
-                  {loadedWikipedia.verification.method}
-                </b>
-                {" · "}proposal{" "}
-                <b className="font-semibold text-[var(--avy-ink)]">submitted</b>{" "}
-                · pending Averray review
+                {deadlineLabel ? (
+                  <>
+                    Window{" "}
+                    <b className="font-semibold text-[var(--avy-ink)]">{deadlineLabel}</b>
+                    {" · "}
+                  </>
+                ) : null}
+                verification{" "}
+                <b className="font-semibold text-[var(--avy-ink)]">{verificationLabel}</b>
+                {" · "}
+                <b className="font-semibold text-[var(--avy-ink)]">{stateLabel}</b>
               </>
-            ) : loadedOsv ? (
-              <>
-                Window closes in{" "}
-                <b className="font-semibold text-[var(--avy-ink)]">21m 46s</b>
-                {" · "}verification{" "}
-                <b className="font-semibold text-[var(--avy-ink)]">
-                  {loadedOsv.verification.method}
-                </b>
-                {" · "}advisory{" "}
-                <b className="font-semibold text-[var(--avy-ink)]">
-                  {loadedOsv.advisoryId}
-                </b>{" "}
-                · PR pending merge
-              </>
-            ) : loadedOpenData ? (
-              <>
-                Window closes in{" "}
-                <b className="font-semibold text-[var(--avy-ink)]">21m 46s</b>
-                {" · "}verification{" "}
-                <b className="font-semibold text-[var(--avy-ink)]">
-                  {loadedOpenData.verification.method}
-                </b>
-                {" · "}audit{" "}
-                <b className="font-semibold text-[var(--avy-ink)]">submitted</b>
-              </>
-            ) : (
-              <>
-                Window closes in{" "}
-                <b className="font-semibold text-[var(--avy-ink)]">21m 46s</b>
-                {" · "}verification{" "}
-                <b className="font-semibold text-[var(--avy-ink)]">github_pr</b>
-                {" · "}PR{" "}
-                <b className="font-semibold text-[var(--avy-ink)]">#4931</b> opened
-              </>
-            )
-          }
-          stages={
-            loadedWikipedia
-              ? FIXTURE_LIFECYCLE_WIKIPEDIA
-              : loadedOsv
-                ? FIXTURE_LIFECYCLE_OSV
-                : loadedOpenData
-                  ? FIXTURE_LIFECYCLE_OPEN_DATA
-                  : FIXTURE_LIFECYCLE
-          }
+            );
+          })()}
+          stages={buildLifecycleStages({
+            claim: loadedRow.claim,
+            source: loadedRow.source,
+          })}
           next={{
             label: "Next",
             value: loadedWikipedia

--- a/app/components/runs/buildLifecycleStages.ts
+++ b/app/components/runs/buildLifecycleStages.ts
@@ -1,0 +1,186 @@
+/**
+ * Live session-lifecycle stages for the runs panel.
+ *
+ * Replaces the four FIXTURE_LIFECYCLE_* arrays at the page level. A row
+ * loaded from `/jobs[]` or `/admin/jobs[]` carries `claim.state`,
+ * `claim.claimedAt`, and `claim.claimExpiresAt` once the run has a
+ * session in flight; this builder turns those into the 5-stage rail
+ * the LifecycleRail component already knows how to render.
+ *
+ * Source-aware on the third stage label (PR submitted / Proposal
+ * submitted / Audit submitted) so the copy matches the loaded row's
+ * provenance — same split as the FIXTURE_LIFECYCLE_* variants.
+ */
+
+import type { LifecycleStage } from "./LifecycleRail";
+import type { JobSource } from "./types";
+import type { ClaimEffectiveState, ClaimSummary } from "@/lib/api/claim-status";
+
+interface BuildArgs {
+  /** Live claim state from the loaded row. Optional so we can still
+   *  render a sensible 5-stage skeleton when the row is fixture-only. */
+  claim?: ClaimSummary;
+  source?: JobSource;
+  /** Falls back to `Date.now()` so SSR + first paint produce a stable
+   *  rail; callers in client components can pass a memoised "now" when
+   *  they want to drive the deadline countdown. */
+  now?: Date;
+}
+
+const SUBMITTED_LABEL: Record<string, string> = {
+  github_issue: "PR submitted",
+  wikipedia_article: "Proposal submitted",
+  osv_advisory: "PR submitted",
+  open_data_dataset: "Audit submitted",
+  openapi_spec: "Audit submitted",
+  standards_spec: "Audit submitted",
+  native: "Submitted",
+};
+
+export function buildLifecycleStages({
+  claim,
+  source,
+  now = new Date(),
+}: BuildArgs): LifecycleStage[] {
+  const submittedLabel = SUBMITTED_LABEL[source?.type ?? "native"] ?? "Submitted";
+  const state: ClaimEffectiveState = claim?.state ?? "claimable";
+
+  // The first stage is always "Ready" (the catalog row exists). We
+  // only mark the rest based on what the live state tells us.
+  const stages: Array<Omit<LifecycleStage, "index">> = [
+    {
+      label: "Ready",
+      meta: "—",
+      state: "done",
+    },
+    {
+      label: "Claimed",
+      meta: claim?.claimedAt
+        ? `${formatTime(claim.claimedAt)}${
+            claim.claimedBy ? ` · by ${shortWallet(claim.claimedBy)}` : ""
+          }`
+        : "—",
+      state: stageStateFor(state, "claimed"),
+    },
+    {
+      label: submittedLabel,
+      meta: state === "submitted" || isPostSubmission(state)
+        ? "evidence sent"
+        : claim?.claimExpiresAt && state === "claimed"
+          ? deadlineCountdown(claim.claimExpiresAt, now)
+          : "—",
+      state: stageStateFor(state, "submitted"),
+    },
+    {
+      label: "Verified",
+      meta: state === "submitted" ? "awaiting verifier" : "—",
+      state: stageStateFor(state, "verified"),
+    },
+    {
+      label: "Paid",
+      meta: "—",
+      state: stageStateFor(state, "paid"),
+    },
+  ];
+  return stages.map((stage, idx) => ({ ...stage, index: idx + 1 }));
+}
+
+/**
+ * For each rail stage, derive its visual state (done / current /
+ * pending) from the live claim `effectiveState`.
+ *
+ * The mapping has to be lossy — there's no first-class "verified" or
+ * "paid" claim state today (verification + settlement are downstream
+ * of `submitted`). We treat `submitted` as "Submitted is done, Verified
+ * is current"; once a verified/settled state surfaces we can extend
+ * this without churning callers.
+ */
+function stageStateFor(
+  state: ClaimEffectiveState,
+  stage: "claimed" | "submitted" | "verified" | "paid"
+): LifecycleStage["state"] {
+  if (state === "exhausted" || state === "expired") {
+    // The row is out of attempts; nothing past Ready is current. Mark
+    // everything else as pending so the rail doesn't pretend a future
+    // claim is in progress.
+    return "pending";
+  }
+  if (state === "claimable") {
+    return "pending";
+  }
+  if (state === "claimed") {
+    if (stage === "claimed") return "current";
+    return "pending";
+  }
+  if (state === "submitted") {
+    if (stage === "claimed") return "done";
+    if (stage === "submitted") return "done";
+    if (stage === "verified") return "current";
+    return "pending";
+  }
+  return "pending";
+}
+
+function isPostSubmission(state: ClaimEffectiveState): boolean {
+  return state === "submitted";
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  // HH:MM:SS UTC — matches the visual rhythm the fixture rail used.
+  const hh = String(d.getUTCHours()).padStart(2, "0");
+  const mm = String(d.getUTCMinutes()).padStart(2, "0");
+  const ss = String(d.getUTCSeconds()).padStart(2, "0");
+  return `${hh}:${mm}:${ss}`;
+}
+
+function shortWallet(wallet: string): string {
+  const trimmed = wallet.trim();
+  if (trimmed.length <= 10) return trimmed;
+  return `${trimmed.slice(0, 6)}…${trimmed.slice(-4)}`;
+}
+
+function deadlineCountdown(iso: string, now: Date): string {
+  const deadline = Date.parse(iso);
+  if (!Number.isFinite(deadline)) return "—";
+  const diff = deadline - now.getTime();
+  if (diff <= 0) return "deadline passed";
+  const minutes = Math.floor(diff / 60_000);
+  const seconds = Math.floor((diff % 60_000) / 1000);
+  if (minutes >= 60) {
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    return `closes in ${hours}h ${mins}m`;
+  }
+  return `closes in ${minutes}m ${String(seconds).padStart(2, "0")}s`;
+}
+
+/**
+ * Same idea as `deadlineCountdown` but exposed for the page-level
+ * "Window closes in 21m 46s" header. Returns the raw ISO when no
+ * deadline is known so callers can drop the line entirely.
+ */
+export function formatDeadline(iso: string | undefined, now: Date = new Date()): string {
+  if (!iso) return "";
+  return deadlineCountdown(iso, now);
+}
+
+/**
+ * Friendly "by 0x30bc…ee05" / "by you" label for the CLAIMED stage.
+ * Pass the connected wallet (lowercase) when known so we render
+ * "(you)" instead of the bare address.
+ */
+export function describeClaimer(
+  claimedBy: string | undefined,
+  connectedWallet: string | undefined
+): string {
+  if (!claimedBy) return "";
+  if (
+    connectedWallet &&
+    claimedBy.toLowerCase() === connectedWallet.toLowerCase()
+  ) {
+    return "by you";
+  }
+  return `by ${shortWallet(claimedBy)}`;
+}

--- a/app/lib/api/claim-status.ts
+++ b/app/lib/api/claim-status.ts
@@ -56,6 +56,16 @@ export interface ClaimSummary {
   claimAttemptCount: number;
   /** What's left in the retry budget. 0 means exhausted. */
   remainingClaimAttempts: number;
+  /**
+   * Wallet that currently holds the claim, when one is active. Used by
+   * the loaded-run panel + lifecycle rail to render the real claimer
+   * (instead of the legacy "by you" fixture string).
+   */
+  claimedBy?: string;
+  /** ISO timestamp of when the active claim opened. */
+  claimedAt?: string;
+  /** ISO timestamp of when the active claim's TTL expires. */
+  claimExpiresAt?: string;
 }
 
 export interface ClaimStatusDetail extends ClaimSummary {
@@ -107,6 +117,11 @@ export function buildClaimSummary(raw: unknown): ClaimSummary | undefined {
     retryLimit: nonNegInt(record.retryLimit),
     claimAttemptCount: nonNegInt(record.claimAttemptCount),
     remainingClaimAttempts: nonNegInt(record.remainingClaimAttempts),
+    ...(text(record.claimedBy) ? { claimedBy: text(record.claimedBy) } : {}),
+    ...(text(record.claimedAt) ? { claimedAt: text(record.claimedAt) } : {}),
+    ...(text(record.claimExpiresAt)
+      ? { claimExpiresAt: text(record.claimExpiresAt) }
+      : {}),
   };
 }
 


### PR DESCRIPTION
## Why
You showed me the agent's claim ON `/runs` rendering correctly in the queue (CLAIMED pill + worker chip `0x30bc…ee05`) but the **session lifecycle rail at the bottom was lying** — it showed PROPOSAL SUBMITTED ✓ done, CLAIMED \"by you\", a hardcoded 21m 46s countdown, and a fake \"PR #4931 opened\" line, all from FIXTURE_LIFECYCLE_*. The submit button was also always enabled, including for signed-out viewers.

## What changes
- **\`ClaimSummary\`** now carries optional \`claimedBy\` / \`claimedAt\` / \`claimExpiresAt\`. The compact-row parser reads them when present.
- **New \`buildLifecycleStages\` helper** maps live \`row.claim\` → 5-stage rail. Source-aware on the third stage label (PR submitted / Proposal submitted / Audit submitted).
- **\`/runs\` page + \`LoadedRunView\`** swap the four \`FIXTURE_LIFECYCLE_*\` expressions for \`buildLifecycleStages(...)\`. Context-note header uses new \`formatDeadline\` + \`describeClaimer\` helpers — real countdown, real claimer wallet (with \"by you\" only when the connected wallet matches).
- **\`LoadedRunPanel\` submit prop** gains \`disabledReason\`. \`LoadedRunView\` fills it from claim state: \`submitted\` → \"Already submitted — awaiting verifier\"; \`expired\` → \"Claim expired — reopen before submitting\"; \`exhausted\` → \"No retries left on this row\"; no active claim → \"Claim this run before submitting evidence\".

## Verified against live data
Wallet \`0x30BC…eE05\` currently holds \`wiki-en-58158792-citation-repair-r2\`. Live row carries \`state: \"claimed\"\`, \`claimedAt: 2026-05-02T09:28:22Z\`, \`claimExpiresAt: 2026-05-02T10:28:22Z\`. After this PR the rail renders \`CLAIMED · 09:28:22 · by 0x30bc…ee05\` as current, the third stage stays pending until a real submission lands, and the deadline countdown reads off \`claimExpiresAt\`.

## Defer
Fully wallet-aware submit gate (compare \`claim.claimedBy\` to the connected viewer wallet so a foreign wallet sees a stronger \"not your claim\" hint). Today the gate fires on \`claim.state\`, which already covers the worst offenders.

## Test plan
- [x] \`npm run typecheck:app\`
- [x] \`npm run build:frontend\`
- [ ] After deploy: load \`/runs?source=wikipedia&state=claimed\`, click into the live claimed row, confirm rail shows CLAIMED current (not PROPOSAL SUBMITTED done) and the deadline counts down toward 10:28 UTC
- [ ] Click into any non-claimed row: submit button is disabled with a hint, no useless 401