### PR TITLE
Remove stale operator fixture fallbacks

### DIFF
--- a/app/app/(authed)/agents/page.tsx
+++ b/app/app/(authed)/agents/page.tsx
@@ -258,7 +258,7 @@ export default function AgentsPage() {
   const [openHandle, setOpenHandle] = useState<string | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const liveAgents = useMemo(() => extractAgents(agentsRequest.data), [agentsRequest.data]);
-  const agents = liveAgents.length ? liveAgents : AGENTS;
+  const agents = liveAgents;
   const openAgentFromList = openHandle
     ? agents.find((a) => a.handle === openHandle) ?? null
     : null;

--- a/app/app/(authed)/audit-log/page.tsx
+++ b/app/app/(authed)/audit-log/page.tsx
@@ -8,14 +8,9 @@ import {
   type AuditFilter,
 } from "@/components/audit/AuditFilterRail";
 import { AuditTimeline } from "@/components/audit/AuditTimeline";
-import { AUDIT_EVENTS } from "@/components/audit/data";
 import type { AuditActor, AuditCategory, AuditEvent, AuditSource } from "@/components/audit/types";
 import { useAudit } from "@/lib/api/hooks";
 import { freshnessFromRequests } from "@/components/shell/DataFreshnessPill";
-
-// TODO(data): wire to useApi("/audit") once backend emits an event
-// stream. The SSE channel in lib/events/stream.ts already carries most
-// of these topic names — the audit log is just the persisted version.
 
 const DAY_BUCKETS: Record<AuditFilter["day"], (d: string) => boolean> = {
   all: () => true,
@@ -33,7 +28,7 @@ export default function AuditLogPage() {
     q: "",
   });
   const liveEvents = useMemo(() => extractAuditEvents(auditRequest.data), [auditRequest.data]);
-  const events = liveEvents.length ? liveEvents : AUDIT_EVENTS;
+  const events = liveEvents;
 
   const filtered = useMemo(() => {
     const q = filter.q.trim().toLowerCase();

--- a/app/app/(authed)/disputes/page.tsx
+++ b/app/app/(authed)/disputes/page.tsx
@@ -12,15 +12,9 @@ import { DisputesTable } from "@/components/disputes/DisputesTable";
 import { DisputesLegend } from "@/components/disputes/DisputesLegend";
 import { DisputeDrawerBody } from "@/components/disputes/DisputeDrawerBody";
 import { DisputeStatePill, OriginPill } from "@/components/disputes/pills";
-import { DISPUTES } from "@/components/disputes/data";
 import { extractDispute, extractDisputeList } from "@/lib/api/dispute-adapters";
 import { useDispute, useDisputes } from "@/lib/api/hooks";
 import { freshnessFromRequests } from "@/components/shell/DataFreshnessPill";
-
-// TODO(data): wire to useApi("/disputes") once the backend emits the list.
-// Drill-in swaps to useApi(`/disputes/${id}`) for the drawer. Fixture for
-// now so the decision panel, evidence diff, and stake-hold radios can be
-// exercised against realistic shapes.
 
 export default function DisputesPage() {
   const disputesRequest = useDisputes();
@@ -36,7 +30,7 @@ export default function DisputesPage() {
     () => extractDisputeList(disputesRequest.data),
     [disputesRequest.data]
   );
-  const disputes = liveDisputes.length ? liveDisputes : DISPUTES;
+  const disputes = liveDisputes;
   const isLive = liveDisputes.length > 0;
   const pickedFromList = pickedId
     ? disputes.find((d) => d.id === pickedId) ?? null

--- a/app/app/(authed)/overview/page.tsx
+++ b/app/app/(authed)/overview/page.tsx
@@ -3,25 +3,18 @@
 import { useMemo } from "react";
 import { OverviewTopbar } from "@/components/overview/OverviewTopbar";
 import { MissionHero } from "@/components/overview/MissionHero";
-import { RoomVitals, type KpiData } from "@/components/overview/RoomVitals";
+import { RoomVitals } from "@/components/overview/RoomVitals";
 import {
   NeedsActionList,
   type AlertItem,
 } from "@/components/overview/NeedsActionList";
 import {
   LaneStatusGrid,
-  type LaneCardData,
 } from "@/components/overview/LaneStatusGrid";
-import {
-  PlatformPulse,
-  type PulseEvent,
-} from "@/components/overview/PlatformPulse";
-import {
-  ProviderOperationsCard,
-  PROVIDER_OPERATIONS_FIXTURE,
-} from "@/components/overview/ProviderOperationsCard";
+import { PlatformPulse } from "@/components/overview/PlatformPulse";
+import { ProviderOperationsCard } from "@/components/overview/ProviderOperationsCard";
 import { JobLifecycleStrip } from "@/components/overview/JobLifecycleStrip";
-import { useAccount, useAlerts, useHealth, useJobs, useProviderOperations, useSessions, useStrategyPositions } from "@/lib/api/hooks";
+import { useAccount, useAlerts, useHealth, useJobs, useProviderOperations, usePublicProviderOperations, useSessions, useStrategyPositions } from "@/lib/api/hooks";
 import { freshnessFromRequests } from "@/components/shell/DataFreshnessPill";
 import { extractRunJobs } from "@/lib/api/run-adapters";
 import { buildProviderOperations } from "@/lib/api/provider-operations";
@@ -35,324 +28,6 @@ import {
   buildRoomVitals,
 } from "@/lib/api/treasury-adapters";
 
-// TODO(data): replace each block's seed data with the matching SWR hook
-//   - Room vitals: useOnboarding() + useSessions() + useAccount()
-//   - Needs action now: useSessions().filter(needsAction)
-//   - Lanes: derived from useSessions() + useAccount() + usePolicies()
-//   - Platform pulse: startEventStream() from lib/events/stream.ts
-// Until those hook response shapes are stable, the page renders the same
-// fixture data Claude Design used so the layout reads correctly.
-
-const ROOM_VITALS: KpiData[] = [
-  {
-    label: "Runs in motion",
-    value: "14",
-    spark: [8, 9, 7, 10, 11, 9, 12, 11, 13, 12, 14],
-    delta: (
-      <>
-        <span className="font-[family-name:var(--font-display)] text-[11px] font-extrabold">
-          ↑
-        </span>
-        +3 since 09:00 · +21% vs yest.
-      </>
-    ),
-    deltaTone: "good",
-  },
-  {
-    label: "Agents active",
-    value: "8",
-    spark: [8, 8, 7, 8, 8, 9, 8, 7, 8, 8, 8],
-    sparkColor: "#8a8f88",
-    delta: <>→ flat vs. yesterday · 2 idle &gt;1h</>,
-    deltaTone: "neutral",
-  },
-  {
-    label: "Capital at work",
-    value: "214",
-    unit: "DOT",
-    spark: [182, 189, 195, 190, 198, 201, 196, 205, 207, 210, 214],
-    delta: (
-      <>
-        <span className="font-[family-name:var(--font-display)] text-[11px] font-extrabold">
-          ↑
-        </span>
-        +18 DOT locked · +9.2%
-      </>
-    ),
-    deltaTone: "good",
-  },
-  {
-    label: "Treasury posture",
-    value: "Green",
-    valueAccent: true,
-    spark: Array.from({ length: 11 }, (_, i) => 1 + Math.sin(i / 2) * 0.05),
-    delta: <>Stable 6d · coverage 3.2×</>,
-    deltaTone: "good",
-  },
-];
-
-const NEEDS_ACTION: AlertItem[] = [
-  {
-    id: "dispute-r_4e10c",
-    tone: "warn",
-    title: "Dispute on handoff signature",
-    ref: "run-2739 · r_4e10c",
-    body: (
-      <>
-        Co-signer{" "}
-        <code className="rounded-[6px] bg-[color:rgba(17,19,21,0.05)] px-1.5 py-px font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-ink)]">
-          0x9A13…0cb2
-        </code>{" "}
-        reports payload hash mismatch. Stake of <b>3 DOT</b> locked pending
-        verifier review.
-      </>
-    ),
-    ctaLabel: "Open in Runs →",
-    ctaHref: "/runs",
-  },
-  {
-    id: "schema-dual-sign",
-    tone: "warn",
-    title: "Schema migration awaiting second signer",
-    ref: "run-2736",
-    body: (
-      <>
-        Policy{" "}
-        <code className="rounded-[6px] bg-[color:rgba(17,19,21,0.05)] px-1.5 py-px font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-ink)]">
-          ops/schema-dual-sign
-        </code>{" "}
-        requires a second operator signature before settlement. Blocked 12 min.
-      </>
-    ),
-    ctaLabel: "Open in Policies →",
-    ctaHref: "/policies",
-  },
-  {
-    id: "topup-suggested",
-    tone: "accent",
-    title: "Top-up suggested on worker wallet",
-    ref: "0xFd2E…6519",
-    body: (
-      <>
-        In-app DOT balance at <b>18 DOT</b>. At current claim rate, runway is{" "}
-        <b>~4h</b>. Native gas unaffected.
-      </>
-    ),
-    ctaLabel: "Open in Treasury →",
-    ctaHref: "/treasury",
-  },
-];
-
-const LANES: LaneCardData[] = [
-  {
-    name: "Runs",
-    href: "/runs",
-    pillLabel: "Healthy",
-    pillTone: "ok",
-    metrics: [
-      { label: "queue", value: "14" },
-      { label: "verified 15m", value: "32" },
-      { label: "p50", value: "18s" },
-    ],
-    recentEvent: (
-      <>
-        <b className="font-semibold text-[var(--avy-ink)]">gov-review-2</b> signed
-        r_4e12a · 42s ago
-      </>
-    ),
-  },
-  {
-    name: "Treasury",
-    href: "/treasury",
-    pillLabel: "Stable",
-    pillTone: "ok",
-    metrics: [
-      { label: "locked", value: "214 DOT" },
-      { label: "coverage", value: "3.2×" },
-      { label: "settle p90", value: "6.1s" },
-    ],
-    recentEvent: (
-      <>
-        Stake locked on run-2739 ·{" "}
-        <b className="font-semibold text-[var(--avy-ink)]">3 DOT</b> · 1m ago
-      </>
-    ),
-  },
-  {
-    name: "Governance",
-    href: "/policies",
-    pillLabel: "Needs signer",
-    pillTone: "warn",
-    metrics: [
-      { label: "policies", value: "22 active" },
-      { label: "disputes", value: "2" },
-      { label: "backlog", value: "1" },
-    ],
-    recentEvent: (
-      <>
-        Policy{" "}
-        <b className="font-semibold text-[var(--avy-ink)]">
-          ops/schema-dual-sign
-        </b>{" "}
-        attached · 12m ago
-      </>
-    ),
-  },
-];
-
-const PULSE_EVENTS: PulseEvent[] = [
-  {
-    id: "evt-1",
-    kind: "runs",
-    tone: "accent",
-    topicNamespace: "runs",
-    topicAction: "verified",
-    address: "0xFd2E…6519",
-    message: (
-      <>
-        Receipt{" "}
-        <span className="font-[family-name:var(--font-mono)] text-xs text-[var(--avy-accent)]">
-          r_4e12a
-        </span>{" "}
-        signed by <b className="font-semibold">gov-review-2</b>, co-signed by{" "}
-        <b className="font-semibold">0x9A13…0cb2</b>.
-      </>
-    ),
-    time: "42s ago",
-  },
-  {
-    id: "evt-2",
-    kind: "stake",
-    tone: "accent",
-    topicNamespace: "stake",
-    topicAction: "locked",
-    address: "0x9A13…0cb2",
-    message: (
-      <>
-        <b className="font-semibold">3 DOT</b> claim stake locked on{" "}
-        <span className="font-[family-name:var(--font-mono)] text-xs text-[var(--avy-accent)]">
-          run-2739
-        </span>{" "}
-        pending verifier review.
-      </>
-    ),
-    time: "1m ago",
-  },
-  {
-    id: "evt-3",
-    kind: "runs",
-    tone: "warn",
-    topicNamespace: "runs",
-    topicAction: "disputed",
-    address: "0xA4E2…11ab",
-    message: (
-      <>
-        Dispute opened on{" "}
-        <span className="font-[family-name:var(--font-mono)] text-xs text-[var(--avy-accent)]">
-          r_4e10c
-        </span>{" "}
-        — signature on handoff payload did not verify.
-      </>
-    ),
-    time: "6m ago",
-  },
-  {
-    id: "evt-4",
-    kind: "runs",
-    tone: "accent",
-    topicNamespace: "runs",
-    topicAction: "submitted",
-    address: "0x7B01…ae22",
-    message: (
-      <>
-        <b className="font-semibold">writer-gov-1</b> submitted output for{" "}
-        <span className="font-[family-name:var(--font-mono)] text-xs text-[var(--avy-accent)]">
-          run-2738
-        </span>{" "}
-        · docs refresh v3.1.
-      </>
-    ),
-    time: "10m ago",
-  },
-  {
-    id: "evt-5",
-    kind: "identity",
-    tone: "blue",
-    topicNamespace: "identity",
-    topicAction: "badge_minted",
-    address: "0x2C77…4f90",
-    message: (
-      <>
-        <b className="font-semibold">coding-hand-1</b> minted{" "}
-        <span className="font-[family-name:var(--font-mono)] text-xs text-[var(--avy-accent)]">
-          starter-coding-001
-        </span>{" "}
-        badge · tier 1, evidence attached.
-      </>
-    ),
-    time: "14m ago",
-  },
-  {
-    id: "evt-6",
-    kind: "runs",
-    tone: "neutral",
-    topicNamespace: "runs",
-    topicAction: "claimed",
-    address: "0x5F30…cc18",
-    message: (
-      <>
-        <b className="font-semibold">ops-migrator-1</b> claimed{" "}
-        <span className="font-[family-name:var(--font-mono)] text-xs text-[var(--avy-accent)]">
-          run-2736
-        </span>{" "}
-        · schema migration · users table.
-      </>
-    ),
-    time: "19m ago",
-  },
-  {
-    id: "evt-7",
-    kind: "stake",
-    tone: "accent",
-    topicNamespace: "stake",
-    topicAction: "released",
-    address: "0xFd2E…6519",
-    message: (
-      <>
-        <b className="font-semibold">1.5 DOT</b> released to{" "}
-        <b className="font-semibold">coding-hand-1</b> after verify on{" "}
-        <span className="font-[family-name:var(--font-mono)] text-xs text-[var(--avy-accent)]">
-          run-2735
-        </span>
-        .
-      </>
-    ),
-    time: "23m ago",
-  },
-  {
-    id: "evt-8",
-    kind: "runs",
-    tone: "accent",
-    topicNamespace: "runs",
-    topicAction: "verified",
-    address: "0xE01A…7731",
-    message: (
-      <>
-        Receipt{" "}
-        <span className="font-[family-name:var(--font-mono)] text-xs text-[var(--avy-accent)]">
-          r_4e0f8
-        </span>{" "}
-        verified on{" "}
-        <span className="font-[family-name:var(--font-mono)] text-xs text-[var(--avy-accent)]">
-          run-2738
-        </span>{" "}
-        · writer/no-external-links pass.
-      </>
-    ),
-    time: "28m ago",
-  },
-];
-
 export default function OverviewPage() {
   const jobs = useJobs();
   const sessions = useSessions();
@@ -361,6 +36,7 @@ export default function OverviewPage() {
   const health = useHealth();
   const apiAlerts = useAlerts();
   const providerOps = useProviderOperations();
+  const publicProviderOps = usePublicProviderOperations();
 
   const liveVitals = useMemo(
     () => buildRoomVitals(jobs.data, sessions.data, account.data, strategyPositions.data),
@@ -382,16 +58,14 @@ export default function OverviewPage() {
   );
   const hasLifecycleData = lifecycleSummary.total > 0;
   const liveProviderOps = useMemo(
-    () => buildProviderOperations(providerOps.data),
-    [providerOps.data]
+    () => buildProviderOperations(providerOps.data ?? publicProviderOps.data),
+    [providerOps.data, publicProviderOps.data]
   );
-  const providerRows = liveProviderOps.length
-    ? liveProviderOps
-    : PROVIDER_OPERATIONS_FIXTURE;
+  const providerRows = liveProviderOps;
   const hasLiveOverview = Boolean(jobs.data || sessions.data || account.data || strategyPositions.data);
-  const vitals = hasLiveOverview ? liveVitals : ROOM_VITALS;
-  const alerts = endpointAlerts.length ? endpointAlerts : liveAlerts.length ? liveAlerts : NEEDS_ACTION;
-  const lanes = hasLiveOverview ? liveLanes : LANES;
+  const vitals = liveVitals;
+  const alerts = endpointAlerts.length ? endpointAlerts : liveAlerts;
+  const lanes = liveLanes;
   const disputedSessions = Array.isArray(sessions.data)
     ? sessions.data.filter((session) => session?.status === "disputed").length
     : 0;
@@ -403,7 +77,8 @@ export default function OverviewPage() {
     strategyPositions,
     health,
     apiAlerts,
-    providerOps
+    providerOps,
+    publicProviderOps
   );
 
   return (
@@ -414,13 +89,13 @@ export default function OverviewPage() {
         // fallbacks — the previous form (`liveJobs.length || 14`) silently
         // showed the fixture's `14` whenever live data legitimately
         // returned zero rows, masking real "queue is empty" signals.
-        openRuns={hasLiveOverview ? liveJobs.length : 14}
-        awaitingSignature={hasLiveOverview ? disputedSessions : 2}
-        lastReceiptTime={health.data ? "live" : "14:08 UTC"}
+        openRuns={hasLiveOverview ? liveJobs.length : 0}
+        awaitingSignature={hasLiveOverview ? disputedSessions : 0}
+        lastReceiptTime={health.data ? "live" : "unavailable"}
         treasuryPosture={liveVitals[3]?.value === "Amber" ? "Amber" : "Green"}
-        policiesAppliedToday={hasLiveOverview ? liveLanes.length : 22}
+        policiesAppliedToday={hasLiveOverview ? liveLanes.length : 0}
       />
-      <RoomVitals vitals={vitals} comparedTo={hasLiveOverview ? "live API" : "14:08 UTC yesterday"} />
+      <RoomVitals vitals={vitals} comparedTo={hasLiveOverview ? "live API" : "waiting for live API"} />
       <JobLifecycleStrip
         summary={hasLifecycleData ? lifecycleSummary : EMPTY_JOB_LIFECYCLE_SUMMARY}
         meta={hasLifecycleData ? "live API · /admin/status" : "no jobs yet"}
@@ -432,13 +107,13 @@ export default function OverviewPage() {
         meta={
           liveProviderOps.length
             ? `${liveProviderOps.length} sources · live API`
-            : `${PROVIDER_OPERATIONS_FIXTURE.length} sources`
+            : "no provider operations reported"
         }
       />
       <PlatformPulse
-        events={PULSE_EVENTS}
-        endpoint={health.data ? "/events" : "wss://events.averray.com/v1/pulse"}
-        meta="last 30 min · 48 events"
+        events={[]}
+        endpoint="/events"
+        meta="event stream requires wallet"
       />
     </div>
   );

--- a/app/app/(authed)/policies/page.tsx
+++ b/app/app/(authed)/policies/page.tsx
@@ -14,7 +14,6 @@ import {
   PolicyDrawerBody,
   PolicyDrawerHeader,
 } from "@/components/policies/PolicyDrawerBody";
-import { POLICIES } from "@/components/policies/policies-data";
 import { SIGNERS } from "@/components/policies/signers";
 import type { Policy, PolicyState } from "@/components/policies/types";
 import { usePolicies, usePolicy } from "@/lib/api/hooks";
@@ -27,10 +26,6 @@ const STATUS_TO_STATE: Record<Exclude<PoliciesFilter["status"], "all">, PolicySt
   retired: "Retired",
 };
 
-// TODO(data): replace the seed roster with useApi("/policies") once the
-// backend emits a list endpoint. Drill-in swaps to useApi(`/policies/${tag}`).
-// Propose-change form posts to POST /admin/policies and queues a proposal.
-
 export default function PoliciesPage() {
   const policiesRequest = usePolicies();
   const [filter, setFilter] = useState<PoliciesFilter>({
@@ -42,7 +37,7 @@ export default function PoliciesPage() {
   const [pickedId, setPickedId] = useState<string | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const livePolicies = useMemo(() => extractPolicies(policiesRequest.data), [policiesRequest.data]);
-  const policies = livePolicies.length ? livePolicies : POLICIES;
+  const policies = livePolicies;
   const pickedFromList = pickedId ? policies.find((p) => p.id === pickedId) ?? null : null;
   const detailRequest = usePolicy(drawerOpen && pickedFromList ? pickedFromList.tag : null);
   const pickedDetail = extractPolicy(detailRequest.data);

--- a/app/app/(authed)/receipts/page.tsx
+++ b/app/app/(authed)/receipts/page.tsx
@@ -12,7 +12,6 @@ import {
 } from "@/components/receipts/ReceiptsFilters";
 import {
   ReceiptsTable,
-  type ReceiptRow,
 } from "@/components/receipts/ReceiptsTable";
 import {
   ReceiptShapesLegend,
@@ -30,28 +29,21 @@ import {
 import { useBadge, useBadges } from "@/lib/api/hooks";
 import { freshnessFromRequests } from "@/components/shell/DataFreshnessPill";
 
-// TODO(data): wire to useApi("/badges") and useApi(`/badges/${sessionId}`).
-// Fixture matches the handoff exactly so the page reads correctly until
-// the backend emits a stable list endpoint for receipts.
-
 const KPIS: ReceiptsKpi[] = [
   {
     label: "Total receipts",
-    value: "2,134",
-    unit: "all-time",
-    meta: "since 2025-11-06 · base mainnet",
+    value: "0",
+    unit: "indexed",
+    meta: "from /badges",
   },
   {
     label: "Signed in 24h",
-    value: "127",
-    spark: [14, 12, 15, 10, 13, 8, 11, 7, 9, 5, 8, 4, 6, 3],
-    sparkPulse: true,
-    meta: "+11% vs 7d avg",
-    metaTone: "ok",
+    value: "0",
+    meta: "signed in the last 24h",
   },
   {
     label: "Co-signed",
-    value: "96.2",
+    value: "0.0",
     unit: "%",
     pillRight: (
       <span
@@ -61,15 +53,13 @@ const KPIS: ReceiptsKpi[] = [
         within target
       </span>
     ),
-    meta: "target ≥ 95% · last 30d",
-    metaTone: "ok",
+    meta: "0 of 0 receipts · signer chain present",
+    metaTone: "warn",
   },
   {
     label: "Avg time-to-sign",
-    value: "18.4",
-    unit: "s",
-    spark: [6, 8, 5, 9, 7, 11, 9, 13, 10, 14, 11, 15, 13, 16],
-    meta: "median 14.2s · p95 41s",
+    value: "—",
+    meta: "timing not emitted by /badges yet",
   },
 ];
 
@@ -111,169 +101,6 @@ const FILTERS: FilterGroup[] = [
   },
 ];
 
-const ROWS: ReceiptRow[] = [
-  {
-    id: "r_4e14c",
-    kind: "run",
-    subject: "run-2745",
-    subjectSub: "coding-hand-3",
-    source: "github",
-    signers: [
-      { initials: "P", tone: "sage", role: "operator", address: "0xFd2EAE…6519" },
-      { initials: "C", tone: "ink", role: "cosigner", address: "0x9A13BC…0cb2" },
-      { initials: "V", tone: "blue", role: "verifier", address: "0x4D1E…7EbC" },
-    ],
-    policy: "coding/lint-strict@v2",
-    size: "8.9 KB",
-    signedAt: "14:14:02 UTC",
-  },
-  {
-    id: "r_4e14b",
-    kind: "settle",
-    subject: "loan-0a14",
-    subjectSub: "stake movement",
-    signers: [
-      { initials: "P", tone: "sage", role: "operator", address: "0xFd2EAE…6519" },
-      { initials: "C", tone: "clay", role: "cosigner", address: "0xB712…9908" },
-    ],
-    policy: "treasury/unwind-safe@v1",
-    size: "4.1 KB",
-    signedAt: "14:12:51 UTC",
-  },
-  {
-    id: "r_4e14a",
-    kind: "run",
-    subject: "run-2744",
-    subjectSub: "writer-gov-1",
-    source: "wikipedia",
-    signers: [
-      { initials: "P", tone: "sage", role: "operator", address: "0xFd2EAE…6519" },
-      { initials: "C", tone: "ink", role: "cosigner", address: "0x9A13BC…0cb2" },
-    ],
-    policy: "writer-gov/cited@v3",
-    size: "14.2 KB",
-    signedAt: "14:11:18 UTC",
-  },
-  {
-    id: "r_4e145",
-    kind: "run",
-    subject: "run-2751",
-    subjectSub: "coding-hand-3",
-    source: "osv",
-    signers: [
-      { initials: "P", tone: "sage", role: "operator", address: "0xFd2EAE…6519" },
-      { initials: "C", tone: "ink", role: "cosigner", address: "0x9A13BC…0cb2" },
-      { initials: "V", tone: "blue", role: "verifier", address: "0x4D1E…7EbC" },
-    ],
-    policy: "security/osv-deps@v1",
-    size: "11.8 KB",
-    signedAt: "14:09:52 UTC",
-  },
-  {
-    id: "r_4e144",
-    kind: "run",
-    subject: "run-2752",
-    subjectSub: "writer-gov-1",
-    source: "data_gov",
-    signers: [
-      { initials: "P", tone: "sage", role: "operator", address: "0xFd2EAE…6519" },
-      { initials: "V", tone: "blue", role: "verifier", address: "0x4D1E…7EbC" },
-    ],
-    policy: "data/open-data-audit@v1",
-    size: "9.1 KB",
-    signedAt: "14:09:21 UTC",
-  },
-  {
-    id: "r_4e139",
-    kind: "badge",
-    subject: "coding-tier-2",
-    subjectSub: "agent award",
-    signers: [
-      { initials: "V", tone: "blue", role: "verifier", address: "0x4D1E…7EbC" },
-    ],
-    policy: "reputation/tier-up",
-    size: "2.7 KB",
-    signedAt: "14:10:40 UTC",
-  },
-  {
-    id: "r_4e138",
-    kind: "policy",
-    subject: "ops/schema-dual-sign",
-    subjectSub: "revision v4",
-    signers: [
-      { initials: "P", tone: "sage", role: "operator", address: "0xFd2EAE…6519" },
-    ],
-    policy: "ops/schema-dual-sign@v4",
-    size: "1.8 KB",
-    signedAt: "14:10:02 UTC",
-  },
-  {
-    id: "r_4e137",
-    kind: "run",
-    subject: "run-2743",
-    subjectSub: "gov-review-2",
-    signers: [
-      { initials: "P", tone: "sage", role: "operator", address: "0xFd2EAE…6519" },
-      { initials: "C", tone: "ink", role: "cosigner", address: "0x9A13BC…0cb2" },
-      { initials: "V", tone: "blue", role: "verifier", address: "0x4D1E…7EbC" },
-    ],
-    policy: "deps/sec-only@v2",
-    size: "6.3 KB",
-    signedAt: "14:09:47 UTC",
-  },
-  {
-    id: "r_4e12a",
-    kind: "run",
-    subject: "run-2742",
-    subjectSub: "writer-gov-1",
-    signers: [
-      { initials: "P", tone: "sage", role: "operator", address: "0xFd2EAE…6519" },
-      { initials: "C", tone: "ink", role: "cosigner", address: "0x9A13BC…0cb2" },
-      { initials: "V", tone: "blue", role: "verifier", address: "0x4D1E…7EbC" },
-    ],
-    policy: "writer-gov/cited@v3",
-    size: "12.4 KB",
-    signedAt: "14:08:42 UTC",
-  },
-  {
-    id: "r_4e119",
-    kind: "settle",
-    subject: "loan-0a13",
-    subjectSub: "stake movement",
-    signers: [
-      { initials: "P", tone: "sage", role: "operator", address: "0xFd2EAE…6519" },
-    ],
-    policy: "treasury/unwind-safe@v1",
-    size: "3.8 KB",
-    signedAt: "14:07:02 UTC",
-  },
-  {
-    id: "r_4e118",
-    kind: "run",
-    subject: "run-2741",
-    subjectSub: "gov-review-2",
-    signers: [
-      { initials: "P", tone: "sage", role: "operator", address: "0xFd2EAE…6519" },
-      { initials: "C", tone: "muted", role: "cosigner", address: "pending…" },
-    ],
-    policy: "deps/sec-only@v2",
-    size: "5.9 KB",
-    signedAt: "14:06:31 UTC",
-  },
-  {
-    id: "r_4e117",
-    kind: "badge",
-    subject: "governance-1",
-    subjectSub: "agent award",
-    signers: [
-      { initials: "V", tone: "blue", role: "verifier", address: "0x4D1E…7EbC" },
-    ],
-    policy: "reputation/tier-up",
-    size: "2.4 KB",
-    signedAt: "14:04:15 UTC",
-  },
-];
-
 const SHAPES: ShapeEntry[] = [
   {
     kind: "run",
@@ -311,14 +138,11 @@ const SHAPES: ShapeEntry[] = [
 
 export default function ReceiptsPage() {
   const badgesRequest = useBadges();
-  const [selectedId, setSelectedId] = useState<string | null>("r_4e12a");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const liveRows = useMemo(() => extractReceiptRows(badgesRequest.data), [badgesRequest.data]);
-  const rows = useMemo(
-    () => (liveRows.length ? liveRows : ROWS.map(fixtureReceiptRow)),
-    [liveRows]
-  );
-  const kpis = useMemo(() => receiptKpis(rows, liveRows.length > 0), [liveRows.length, rows]);
+  const rows = liveRows;
+  const kpis = useMemo(() => receiptKpis(rows), [rows]);
   const selected = selectedId ? rows.find((r) => r.id === selectedId) ?? null : null;
   const detailRequest = useBadge(drawerOpen && selected ? selected.sessionId : null);
   const drawerModel = selected ? buildReceiptDrawer(selected, detailRequest.data) : null;
@@ -355,7 +179,7 @@ export default function ReceiptsPage() {
           setDrawerOpen(true);
         }}
         shownCount={rows.length}
-        totalCount={liveRows.length ? rows.length : 2134}
+        totalCount={rows.length}
       />
       <ReceiptShapesLegend shapes={SHAPES} />
 
@@ -400,16 +224,7 @@ export default function ReceiptsPage() {
   );
 }
 
-function fixtureReceiptRow(row: ReceiptRow): ReceiptRowWithMeta {
-  return {
-    ...row,
-    sessionId: row.subject,
-    issuedAtIso: "",
-  };
-}
-
-function receiptKpis(rows: ReceiptRowWithMeta[], live: boolean): ReceiptsKpi[] {
-  if (!live) return KPIS;
+function receiptKpis(rows: ReceiptRowWithMeta[]): ReceiptsKpi[] {
   const now = Date.now();
   const signed24h = rows.filter((row) => {
     const parsed = Date.parse(row.issuedAtIso);
@@ -436,7 +251,12 @@ function receiptKpis(rows: ReceiptRowWithMeta[], live: boolean): ReceiptsKpi[] {
       meta: `${coSigned} of ${rows.length} receipts · signer chain present`,
       metaTone: coSignedPct >= 95 ? "ok" : "warn",
     },
-    KPIS[3],
+    {
+      ...KPIS[3],
+      value: "—",
+      unit: undefined,
+      meta: "timing not emitted by /badges yet",
+    },
   ];
 }
 

--- a/app/app/(authed)/runs/detail/page.tsx
+++ b/app/app/(authed)/runs/detail/page.tsx
@@ -30,7 +30,7 @@ export default function RunDetailPage() {
 
 function RunDetailInner() {
   const searchParams = useSearchParams();
-  const runId = searchParams?.get("id") ?? "run-2742";
+  const runId = searchParams?.get("id") ?? "";
 
   return (
     <div className="flex w-full max-w-[1100px] flex-col gap-4">
@@ -46,7 +46,7 @@ function RunDetailInner() {
           className="font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]"
           style={{ letterSpacing: 0 }}
         >
-          run <b className="text-[var(--avy-ink)]">{runId}</b> · fullscreen view
+          run <b className="text-[var(--avy-ink)]">{runId || "none selected"}</b> · fullscreen view
         </span>
       </div>
 

--- a/app/app/(authed)/runs/page.tsx
+++ b/app/app/(authed)/runs/page.tsx
@@ -19,9 +19,7 @@ import { RecommendationRail } from "@/components/runs/RecommendationRail";
 import { LoadedRunView } from "@/components/runs/LoadedRunView";
 import { LifecycleRail } from "@/components/runs/LifecycleRail";
 import {
-  FIXTURE_FILTERS,
   FIXTURE_RECOMMENDATIONS,
-  FIXTURE_RUN_ROWS,
 } from "@/components/runs/fixtures";
 import {
   buildLifecycleStages,
@@ -44,7 +42,7 @@ import { extractAdminJobs } from "@/lib/api/job-lifecycle";
  * Layout: email-client split pane. Queue on the left (card-row list of
  * all open runs), sticky detail pane on the right driven by LoadedRunView.
  * Clicking a queue row just updates `selectedId`; LoadedRunView owns all
- * the hooks, fixture fallback, and submit/drawer state for that run.
+ * the hooks plus submit/drawer state for that run.
  *
  * Lifecycle rail + recommendation rail sit below the split pane so they
  * don't steal horizontal room from the two primary panes.
@@ -86,7 +84,7 @@ function RunsPageInner() {
   const [activeFilter, setActiveFilter] = useState<QueueFilter>(initialState);
   const [activeSource, setActiveSource] = useState<SourceFilter>(initialSource);
   const [showClosed, setShowClosed] = useState(false);
-  const [selectedId, setSelectedId] = useState<string>(runParam ?? "run-2742");
+  const [selectedId, setSelectedId] = useState<string>(runParam ?? "");
 
   // Sync filter state into the URL query string so links are
   // shareable and a browser agent can deep-link to a narrowed
@@ -136,7 +134,7 @@ function RunsPageInner() {
   const adminPayload = adminJobs.data ? extractAdminJobs(adminJobs.data) : [];
   const sourceForRows = adminPayload.length ? adminPayload : jobs.data;
   const liveRows = useMemo(() => buildRunRows(sourceForRows), [sourceForRows]);
-  const rows = liveRows.length ? liveRows : FIXTURE_RUN_ROWS;
+  const rows = liveRows;
   const filters = useMemo(() => buildRunFilters(rows), [rows]);
   const sourceFilters = useMemo(() => buildSourceFilters(rows), [rows]);
   const recommendationCards = useMemo(() => {
@@ -153,7 +151,7 @@ function RunsPageInner() {
   // Keep selectedId valid when the rows list changes (e.g. live data
   // arrives and the previously-selected fixture id isn't in it).
   useEffect(() => {
-    if (rows.length && !rows.some((row) => row.id === selectedId)) {
+    if (rows.length && (!selectedId || !rows.some((row) => row.id === selectedId))) {
       setSelectedId(rows[0].id);
     }
   }, [rows, selectedId]);
@@ -257,7 +255,7 @@ function RunsPageInner() {
 
   const assignedToMe = rows.filter((row) => row.worker.isSelf).length;
   const liveStatus = jobs.error
-    ? "fixture fallback"
+    ? "live API unavailable"
     : jobs.isLoading
       ? "loading live jobs"
       : "live API";
@@ -267,7 +265,7 @@ function RunsPageInner() {
     <div className="flex w-full max-w-[1440px] flex-col gap-3.5">
       <RunsTopbar freshness={freshness} />
       <QueueBar
-        filters={filters.length ? filters : FIXTURE_FILTERS}
+        filters={filters}
         active={activeFilter}
         onChange={onStateChange}
       />
@@ -312,15 +310,21 @@ function RunsPageInner() {
           liveStatus={liveStatus}
         />
         <div className="xl:sticky xl:top-6 xl:max-h-[calc(100vh-3rem)] xl:overflow-y-auto">
-          <LoadedRunView
-            runId={selectedId}
-            standaloneUrl={`/runs/detail/?id=${encodeURIComponent(selectedId)}`}
-            // The queue page renders the lifecycle rail below the split
-            // pane (full width) so it doesn't steal vertical room from
-            // the sticky panel column. The standalone detail page will
-            // render it inline instead.
-            showLifecycle={false}
-          />
+          {selectedRow ? (
+            <LoadedRunView
+              runId={selectedId}
+              standaloneUrl={`/runs/detail/?id=${encodeURIComponent(selectedId)}`}
+              // The queue page renders the lifecycle rail below the split
+              // pane (full width) so it doesn't steal vertical room from
+              // the sticky panel column. The standalone detail page will
+              // render it inline instead.
+              showLifecycle={false}
+            />
+          ) : (
+            <div className="rounded-[10px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] p-5 font-[family-name:var(--font-body)] text-sm text-[var(--avy-muted)] shadow-[var(--shadow-card)]">
+              No live run selected.
+            </div>
+          )}
         </div>
       </div>
 

--- a/app/app/(authed)/sessions/page.tsx
+++ b/app/app/(authed)/sessions/page.tsx
@@ -11,14 +11,9 @@ import {
 import { SessionsTable } from "@/components/sessions/SessionsTable";
 import { SessionDrawerBody } from "@/components/sessions/SessionDrawerBody";
 import { SessionStatePill } from "@/components/sessions/pills";
-import { SESSIONS } from "@/components/sessions/data";
 import { useJobs, useSession, useSessions, useSessionTimeline } from "@/lib/api/hooks";
 import { freshnessFromRequests } from "@/components/shell/DataFreshnessPill";
 import { buildSessionDetails, mergeSessionTimeline } from "@/lib/api/session-adapters";
-
-// TODO(data): wire to useApi("/sessions") once the backend emits
-// the list shape. Drill-in swaps to useApi(`/sessions/${id}`) for
-// the drawer.
 
 function valueBucket(amountStr: string): SessionsFilter["value"] {
   const n = Number(amountStr);
@@ -45,7 +40,7 @@ export default function SessionsPage() {
     () => buildSessionDetails(sessionsQuery.data, jobsQuery.data),
     [jobsQuery.data, sessionsQuery.data]
   );
-  const sessions = liveSessions.length ? liveSessions : SESSIONS;
+  const sessions = liveSessions;
 
   const filtered = useMemo(() => {
     const q = filter.q.trim().toLowerCase();

--- a/app/app/(authed)/treasury/page.tsx
+++ b/app/app/(authed)/treasury/page.tsx
@@ -36,17 +36,6 @@ import {
   buildStrategyLanes,
 } from "@/lib/api/treasury-adapters";
 
-// TODO(data): wire each block to its hook in lib/api/hooks.ts
-//   - Balance sheet: useAccount() + useBorrowCapacity()
-//   - Strategy routing: useStrategyPositions() + useStrategies()
-//   - Credit line: useBorrowCapacity(asset)
-//   - XCM observer: dedicated hook (not in SDK yet — backend exposes
-//     staged /account/xcm/* endpoints once async observer lands)
-//   - Account positions: derived from useAccount()
-//   - Policy gate: useStrategies() + onboarding manifest
-// Until the hook response shapes are stable, the page renders the same
-// fixture data Claude Design used so the layout reads correctly.
-
 const BALANCE_CARDS: BalanceCard[] = [
   {
     label: "Spendable",
@@ -288,25 +277,10 @@ export default function TreasuryPage() {
     () => buildCreditLine(account.data, borrowCapacity.data),
     [account.data, borrowCapacity.data]
   );
-  const balanceCards = account.data || strategyPositions.data ? liveBalanceCards : BALANCE_CARDS;
-  const lanes = liveLanes.length ? liveLanes : LANES;
-  const positions = account.data || strategyPositions.data ? livePositions : POSITIONS;
-  const loans = liveCredit.loans.length ? liveCredit.loans : [
-    {
-      id: "loan-0a14",
-      name: "USDC · bridge float",
-      sub: "loan-0a14 · opened 2026-04-19 · maturity 2026-05-19",
-      amount: "312,000",
-      amountUnit: "DOT equiv.",
-    },
-    {
-      id: "loan-0a18",
-      name: "aUSD · working capital",
-      sub: "loan-0a18 · opened 2026-04-22 · maturity rolling",
-      amount: "190,220",
-      amountUnit: "DOT equiv.",
-    },
-  ];
+  const balanceCards = liveBalanceCards;
+  const lanes = liveLanes;
+  const positions = livePositions;
+  const loans = liveCredit.loans;
 
   const freshness = freshnessFromRequests(account, strategyPositions);
 
@@ -319,21 +293,21 @@ export default function TreasuryPage() {
       />
       <StrategyRoutingTable
         lanes={lanes}
-        sub={`${lanes.length} lanes · ${strategyPositions.error ? "fixture fallback" : "live API"} · policy gov/alloc-dual-sign`}
+        sub={`${lanes.length} lanes · ${strategyPositions.error ? "unavailable" : "live API"} · strategy positions`}
       />
 
       <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
         <CreditLinePanel
-          capacityUsed={borrowCapacity.data ? liveCredit.capacityUsed : "502,220"}
-          capacityTotal={borrowCapacity.data ? liveCredit.capacityTotal : "612,500 DOT"}
-          usedPct={borrowCapacity.data ? liveCredit.usedPct : 82}
-          headerPct={borrowCapacity.data ? liveCredit.headerPct : 3}
-          headroom={borrowCapacity.data ? liveCredit.headroom : "110,280 DOT"}
-          nextMark={borrowCapacity.data ? liveCredit.nextMark : "14:15 UTC"}
-          policyCap={borrowCapacity.data ? liveCredit.policyCap : "85%"}
+          capacityUsed={liveCredit.capacityUsed}
+          capacityTotal={liveCredit.capacityTotal}
+          usedPct={liveCredit.usedPct}
+          headerPct={liveCredit.headerPct}
+          headroom={liveCredit.headroom}
+          nextMark={liveCredit.nextMark}
+          policyCap={liveCredit.policyCap}
           loans={loans}
         />
-        <XcmObserverLane phases={XCM_PHASES} sub="lane xcm-v3 · 4 in flight" />
+        <XcmObserverLane phases={[]} sub="XCM observer not emitted by API yet" />
       </div>
 
       <AccountPositionsGrid
@@ -342,8 +316,8 @@ export default function TreasuryPage() {
       />
 
       <PolicyGateFooter
-        items={POLICIES}
-        sub="3 active · last change 2026-04-22 by 0x9A13…0cb2"
+        items={[]}
+        sub="policy gate feed not emitted by API yet"
       />
 
       <p className="flex flex-wrap gap-x-5 gap-y-1 font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]">

--- a/app/components/agents/AgentsTopbar.tsx
+++ b/app/components/agents/AgentsTopbar.tsx
@@ -7,17 +7,14 @@ import {
 } from "@/components/shell/DataFreshnessPill";
 
 const pad = (n: number) => String(n).padStart(2, "0");
-const SEED_BLOCK = 20_414_788;
 
 export function AgentsTopbar({ freshness }: { freshness?: FreshnessState }) {
   const [time, setTime] = useState("");
-  const [block, setBlock] = useState(SEED_BLOCK);
 
   useEffect(() => {
     const tick = () => {
       const d = new Date();
       setTime(`${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}`);
-      setBlock((b) => b + 1);
     };
     tick();
     const id = setInterval(tick, 1000);
@@ -38,12 +35,10 @@ export function AgentsTopbar({ freshness }: { freshness?: FreshnessState }) {
         <div
           className="inline-flex items-center gap-2 rounded-[8px] border border-[var(--avy-line)] bg-[var(--avy-paper)] px-2.5 py-1.5 font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-muted)]"
           suppressHydrationWarning
-          title="Live UTC clock + Polkadot block height"
+          title="Live UTC clock"
         >
           <span className="h-1.5 w-1.5 rounded-full bg-[var(--avy-accent)] [animation:pulse_1.6s_ease-in-out_infinite]" />
           <span>{time || "—"} UTC</span>
-          <span className="opacity-40">·</span>
-          <span className="text-[var(--avy-accent)]">#{block.toLocaleString()}</span>
         </div>
         {freshness ? <DataFreshnessPill state={freshness} /> : null}
         <button

--- a/app/components/audit/AuditTopbar.tsx
+++ b/app/components/audit/AuditTopbar.tsx
@@ -7,11 +7,9 @@ import {
 } from "@/components/shell/DataFreshnessPill";
 
 const pad = (n: number) => String(n).padStart(2, "0");
-const SEED_BLOCK = 28_419_712;
 
 export function AuditTopbar({ freshness }: { freshness?: FreshnessState }) {
   const [time, setTime] = useState("");
-  const [block, setBlock] = useState(SEED_BLOCK);
 
   useEffect(() => {
     const tick = () => {
@@ -20,10 +18,8 @@ export function AuditTopbar({ freshness }: { freshness?: FreshnessState }) {
     };
     tick();
     const tId = setInterval(tick, 1000);
-    const bId = setInterval(() => setBlock((b) => b + 1), 6000);
     return () => {
       clearInterval(tId);
-      clearInterval(bId);
     };
   }, []);
 
@@ -44,8 +40,6 @@ export function AuditTopbar({ freshness }: { freshness?: FreshnessState }) {
         >
           <span className="h-1.5 w-1.5 rounded-full bg-[var(--avy-accent)] [animation:pulse_2s_infinite]" />
           <span className="text-[var(--avy-ink)]">{time || "—"} UTC</span>
-          <span className="opacity-40">·</span>
-          <span className="text-[var(--avy-accent)]">#{block.toLocaleString()}</span>
         </span>
       </div>
       <div className="flex items-center gap-2">

--- a/app/components/disputes/DisputesTopbar.tsx
+++ b/app/components/disputes/DisputesTopbar.tsx
@@ -7,11 +7,9 @@ import {
 } from "@/components/shell/DataFreshnessPill";
 
 const pad = (n: number) => String(n).padStart(2, "0");
-const SEED_BLOCK = 28_419_517;
 
 export function DisputesTopbar({ freshness }: { freshness?: FreshnessState }) {
   const [time, setTime] = useState("");
-  const [block, setBlock] = useState(SEED_BLOCK);
 
   useEffect(() => {
     const tick = () => {
@@ -22,10 +20,8 @@ export function DisputesTopbar({ freshness }: { freshness?: FreshnessState }) {
     };
     tick();
     const tId = setInterval(tick, 1000);
-    const bId = setInterval(() => setBlock((b) => b + 1), 6000);
     return () => {
       clearInterval(tId);
-      clearInterval(bId);
     };
   }, []);
 
@@ -46,8 +42,6 @@ export function DisputesTopbar({ freshness }: { freshness?: FreshnessState }) {
         >
           <span className="h-1.5 w-1.5 rounded-full bg-[var(--avy-accent)] [animation:pulse_2s_infinite]" />
           <span className="text-[var(--avy-ink)]">{time || "—"} UTC</span>
-          <span className="opacity-40">·</span>
-          <span className="text-[var(--avy-accent)]">#{block.toLocaleString()}</span>
         </span>
       </div>
       <div className="flex items-center gap-2">

--- a/app/components/overview/OverviewTopbar.tsx
+++ b/app/components/overview/OverviewTopbar.tsx
@@ -8,11 +8,9 @@ import {
 } from "@/components/shell/DataFreshnessPill";
 
 const pad = (n: number) => String(n).padStart(2, "0");
-const SEED_BLOCK = 28_419_821;
 
 export function OverviewTopbar({ freshness }: { freshness?: FreshnessState }) {
   const [time, setTime] = useState("");
-  const [block, setBlock] = useState(SEED_BLOCK);
 
   useEffect(() => {
     const tick = () => {
@@ -21,10 +19,8 @@ export function OverviewTopbar({ freshness }: { freshness?: FreshnessState }) {
     };
     tick();
     const tId = setInterval(tick, 1000);
-    const bId = setInterval(() => setBlock((b) => b + 1), 6000);
     return () => {
       clearInterval(tId);
-      clearInterval(bId);
     };
   }, []);
 
@@ -45,8 +41,6 @@ export function OverviewTopbar({ freshness }: { freshness?: FreshnessState }) {
         >
           <span className="h-1.5 w-1.5 rounded-full bg-[var(--avy-accent)] [animation:pulse_2s_infinite]" />
           <span className="text-[var(--avy-ink)]">{time || "—"} UTC</span>
-          <span className="opacity-40">·</span>
-          <span className="text-[var(--avy-accent)]">#{block.toLocaleString()}</span>
         </span>
       </div>
       <div className="flex items-center gap-2">

--- a/app/components/overview/PlatformPulse.tsx
+++ b/app/components/overview/PlatformPulse.tsx
@@ -36,6 +36,7 @@ export function PlatformPulse({ events, endpoint, meta }: PlatformPulseProps) {
   const [active, setActive] = useState<EventKind>("all");
 
   const visible = active === "all" ? events : events.filter((e) => e.kind === active);
+  const hasEvents = events.length > 0;
 
   return (
     <section>
@@ -53,8 +54,13 @@ export function PlatformPulse({ events, endpoint, meta }: PlatformPulseProps) {
               className="inline-flex items-center gap-1.5 font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-accent)]"
               style={{ letterSpacing: "0.12em" }}
             >
-              <span className="h-1.5 w-1.5 rounded-full bg-[var(--avy-accent)] [animation:pulse_2.2s_ease-in-out_infinite]" />
-              Streaming
+              <span
+                className={cn(
+                  "h-1.5 w-1.5 rounded-full bg-[var(--avy-accent)]",
+                  hasEvents && "[animation:pulse_2.2s_ease-in-out_infinite]"
+                )}
+              />
+              {hasEvents ? "Streaming" : "No live events"}
             </span>
           </div>
           <div
@@ -80,9 +86,13 @@ export function PlatformPulse({ events, endpoint, meta }: PlatformPulseProps) {
         </div>
 
         <div>
-          {visible.map((event) => (
-            <EventRow key={event.id} event={event} />
-          ))}
+          {visible.length ? (
+            visible.map((event) => <EventRow key={event.id} event={event} />)
+          ) : (
+            <div className="p-[1rem_1.15rem] font-[family-name:var(--font-body)] text-[13.5px] leading-[1.45] text-[var(--avy-muted)]">
+              No live pulse events available for this view.
+            </div>
+          )}
         </div>
 
         <div className="flex items-center justify-between border-t border-[var(--avy-line-soft)] bg-[rgba(250,248,241,0.6)] p-[0.85rem_1.15rem] font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]">
@@ -90,12 +100,12 @@ export function PlatformPulse({ events, endpoint, meta }: PlatformPulseProps) {
             Stream endpoint ·{" "}
             <span className="text-[var(--avy-ink)]">{endpoint}</span>
           </span>
-          <a
-            className="cursor-pointer font-[family-name:var(--font-display)] text-[11px] font-extrabold uppercase text-[var(--avy-accent)]"
+          <span
+            className="font-[family-name:var(--font-display)] text-[11px] font-extrabold uppercase text-[var(--avy-muted)]"
             style={{ letterSpacing: "0.08em" }}
           >
-            Open full log →
-          </a>
+            Full log locked
+          </span>
         </div>
       </div>
     </section>

--- a/app/components/policies/PoliciesTopbar.tsx
+++ b/app/components/policies/PoliciesTopbar.tsx
@@ -7,11 +7,9 @@ import {
 } from "@/components/shell/DataFreshnessPill";
 
 const pad = (n: number) => String(n).padStart(2, "0");
-const SEED_BLOCK = 28_419_304;
 
 export function PoliciesTopbar({ freshness }: { freshness?: FreshnessState }) {
   const [time, setTime] = useState("");
-  const [block, setBlock] = useState(SEED_BLOCK);
 
   useEffect(() => {
     const tick = () => {
@@ -20,10 +18,8 @@ export function PoliciesTopbar({ freshness }: { freshness?: FreshnessState }) {
     };
     tick();
     const tId = setInterval(tick, 1000);
-    const bId = setInterval(() => setBlock((b) => b + 1), 6000);
     return () => {
       clearInterval(tId);
-      clearInterval(bId);
     };
   }, []);
 
@@ -44,8 +40,6 @@ export function PoliciesTopbar({ freshness }: { freshness?: FreshnessState }) {
         >
           <span className="h-1.5 w-1.5 rounded-full bg-[var(--avy-accent)] [animation:pulse_2s_infinite]" />
           <span className="text-[var(--avy-ink)]">{time || "—"} UTC</span>
-          <span className="opacity-40">·</span>
-          <span className="text-[var(--avy-accent)]">#{block.toLocaleString()}</span>
         </span>
       </div>
       <div className="flex items-center gap-2">

--- a/app/components/receipts/ReceiptsTopbar.tsx
+++ b/app/components/receipts/ReceiptsTopbar.tsx
@@ -7,7 +7,6 @@ import {
 } from "@/components/shell/DataFreshnessPill";
 
 const pad = (n: number) => String(n).padStart(2, "0");
-const SEED_BLOCK = 18_204_917;
 
 function formatClock(d: Date): string {
   return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())} · ${pad(
@@ -17,20 +16,11 @@ function formatClock(d: Date): string {
 
 export function ReceiptsTopbar({ freshness }: { freshness?: FreshnessState }) {
   const [clock, setClock] = useState("");
-  const [block, setBlock] = useState(SEED_BLOCK);
 
   useEffect(() => {
     const tick = () => setClock(formatClock(new Date()));
     tick();
     const id = setInterval(tick, 1000);
-    return () => clearInterval(id);
-  }, []);
-
-  useEffect(() => {
-    // Block counter ~6s base-mainnet cadence; jitter for liveness.
-    const id = setInterval(() => {
-      setBlock((b) => (Math.random() > 0.5 ? b + 1 : b));
-    }, 6000);
     return () => clearInterval(id);
   }, []);
 
@@ -52,10 +42,6 @@ export function ReceiptsTopbar({ freshness }: { freshness?: FreshnessState }) {
         <span className="inline-flex items-center gap-1.5 text-[var(--avy-ink)]">
           <span className="h-1.5 w-1.5 rounded-full bg-[var(--avy-accent)] [animation:pulse_2s_infinite]" />
           {clock || "—"}
-        </span>
-        <span className="h-3.5 w-px bg-[var(--avy-line)]" />
-        <span>
-          block <b className="font-semibold text-[var(--avy-ink)]">{block.toLocaleString()}</b>
         </span>
       </div>
 

--- a/app/components/runs/LoadedRunView.tsx
+++ b/app/components/runs/LoadedRunView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { mutate } from "swr";
 import { LoadedRunPanel } from "./LoadedRunPanel";
 import { LifecycleRail } from "./LifecycleRail";
@@ -10,10 +10,6 @@ import {
   ReceiptPreviewDrawer,
   type ReceiptPreviewDraft,
 } from "./ReceiptPreviewDrawer";
-import {
-  FIXTURE_JOB_DEFINITIONS,
-  FIXTURE_RUN_ROWS,
-} from "./fixtures";
 import {
   buildLifecycleStages,
   describeClaimer,
@@ -35,7 +31,7 @@ import { extractAdminJobs } from "@/lib/api/job-lifecycle";
 /**
  * Self-contained detail view for a single run.
  *
- * Looks up the row (live or fixture), resolves the job definition,
+ * Looks up the live row, resolves the job definition,
  * builds the GitHub job context, wires the submit handler, owns the
  * receipt-preview drawer state, and renders LoadedRunPanel + LifecycleRail.
  *
@@ -44,7 +40,7 @@ import { extractAdminJobs } from "@/lib/api/job-lifecycle";
  *     (selectedRunId tracks the clicked row)
  *   - `/runs/detail/?id=<id>` — the standalone fullscreen view
  *
- * Keeps the fixture-driven verifier / settlement / lifecycle copy inline
+ * Keeps the static verifier / settlement / lifecycle copy inline
  * because the backend doesn't yet stream real verifier output; swap
  * these for live data once those endpoints land.
  */
@@ -73,24 +69,30 @@ export function LoadedRunView({
   const adminPayload = adminJobs.data ? extractAdminJobs(adminJobs.data) : [];
   const sourceForRows = adminPayload.length ? adminPayload : jobs.data;
   const liveRows = useMemo(() => buildRunRows(sourceForRows), [sourceForRows]);
-  const rows = liveRows.length ? liveRows : FIXTURE_RUN_ROWS;
+  const rows = liveRows;
   const rawJobs = useMemo(() => extractRunJobs(sourceForRows), [sourceForRows]);
-  const loadedRow =
-    rows.find((row) => row.id === runId) ?? rows[0] ?? FIXTURE_RUN_ROWS[0];
+  const loadedRow = rows.find((row) => row.id === runId) ?? rows[0];
 
-  const jobDefinition = useJobDefinition(loadedRow.id);
-  const selectedJob =
-    asRecord(jobDefinition.data) ??
-    rawJobs.find((job) => job.id === loadedRow.id) ??
-    FIXTURE_JOB_DEFINITIONS.find((def) => def.id === loadedRow.id);
-  const loadedGitHub = buildGitHubContext(loadedRow, selectedJob);
-  const loadedWikipedia = buildWikipediaContext(loadedRow, selectedJob);
-  const loadedOsv = buildOsvContext(loadedRow, selectedJob);
-  const loadedOpenData = buildOpenDataContext(loadedRow, selectedJob);
+  const jobDefinition = useJobDefinition(loadedRow?.id ?? null);
+  const selectedJob = loadedRow
+    ? asRecord(jobDefinition.data) ?? rawJobs.find((job) => job.id === loadedRow.id)
+    : undefined;
+  const loadedGitHub = loadedRow ? buildGitHubContext(loadedRow, selectedJob) : undefined;
+  const loadedWikipedia = loadedRow ? buildWikipediaContext(loadedRow, selectedJob) : undefined;
+  const loadedOsv = loadedRow ? buildOsvContext(loadedRow, selectedJob) : undefined;
+  const loadedOpenData = loadedRow ? buildOpenDataContext(loadedRow, selectedJob) : undefined;
 
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [receiptOpen, setReceiptOpen] = useState(false);
+
+  if (!loadedRow) {
+    return (
+      <div className="rounded-[10px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] p-5 font-[family-name:var(--font-body)] text-sm text-[var(--avy-muted)] shadow-[var(--shadow-card)]">
+        No live run details available.
+      </div>
+    );
+  }
 
   // PR #123 added a per-job `submissionContract` block on /jobs that
   // tells callers exactly what shape `payload.submission` should take
@@ -201,7 +203,7 @@ export function LoadedRunView({
           amount: loadedRow.stake,
           aux: selectedJob
             ? `${selectedJob.rewardAsset ?? "DOT"} reward · verifier ${selectedJob.verifierMode ?? "unknown"}`
-            : "fixture data · waiting for live selection",
+            : "waiting for live job definition",
           breakdown: {
             worker: `${loadedRow.stake} DOT`,
             verifier: "0 DOT",

--- a/app/components/runs/RunsTopbar.tsx
+++ b/app/components/runs/RunsTopbar.tsx
@@ -13,18 +13,13 @@ function formatTime(d: Date): string {
   return `${hh}:${mm}:${ss}`;
 }
 
-const SEED_BLOCK = 24_118_402;
-
 export function RunsTopbar({ freshness }: { freshness?: FreshnessState }) {
   const [time, setTime] = useState("");
-  const [block, setBlock] = useState(SEED_BLOCK);
 
   useEffect(() => {
     const tick = () => {
       const d = new Date();
       setTime(formatTime(d));
-      // Polkadot block ~6s cadence — bump every 6s mod for the demo clock.
-      if (d.getUTCSeconds() % 6 === 0) setBlock((b) => b + 1);
     };
     tick();
     const id = setInterval(tick, 1000);
@@ -49,9 +44,6 @@ export function RunsTopbar({ freshness }: { freshness?: FreshnessState }) {
         <span className="inline-block h-1.5 w-1.5 rounded-full bg-[#2d8e5e] shadow-[0_0_0_3px_rgba(45,142,94,0.18)]" />
         <span className="text-[var(--avy-muted)]">UTC</span>
         <span>{time || "—"}</span>
-        <span className="text-[var(--avy-muted)]">·</span>
-        <span className="text-[var(--avy-muted)]">block</span>
-        <span>{block.toLocaleString()}</span>
       </div>
 
       <div className="flex items-center justify-self-end gap-2">

--- a/app/components/sessions/SessionsTable.tsx
+++ b/app/components/sessions/SessionsTable.tsx
@@ -169,11 +169,12 @@ export function SessionsTable({
       >
         <span>
           Showing <b className="font-semibold text-[var(--avy-ink)]">{rows.length}</b> of{" "}
-          <b className="font-semibold text-[var(--avy-ink)]">1,284</b>
+          <b className="font-semibold text-[var(--avy-ink)]">{totalCount.toLocaleString()}</b>
         </span>
         <button
           type="button"
-          className="cursor-pointer border-b border-dashed border-[color:rgba(30,102,66,0.4)] pb-px text-[var(--avy-accent)] hover:text-[var(--avy-accent-2)]"
+          disabled
+          className="cursor-not-allowed border-b border-dashed border-[color:rgba(30,102,66,0.25)] pb-px text-[var(--avy-muted)] opacity-70"
         >
           load more
         </button>

--- a/app/components/sessions/SessionsTopbar.tsx
+++ b/app/components/sessions/SessionsTopbar.tsx
@@ -7,11 +7,9 @@ import {
 } from "@/components/shell/DataFreshnessPill";
 
 const pad = (n: number) => String(n).padStart(2, "0");
-const SEED_BLOCK = 28_419_603;
 
 export function SessionsTopbar({ freshness }: { freshness?: FreshnessState }) {
   const [time, setTime] = useState("");
-  const [block, setBlock] = useState(SEED_BLOCK);
 
   useEffect(() => {
     const tick = () => {
@@ -20,10 +18,8 @@ export function SessionsTopbar({ freshness }: { freshness?: FreshnessState }) {
     };
     tick();
     const tId = setInterval(tick, 1000);
-    const bId = setInterval(() => setBlock((b) => b + 1), 6000);
     return () => {
       clearInterval(tId);
-      clearInterval(bId);
     };
   }, []);
 
@@ -44,8 +40,6 @@ export function SessionsTopbar({ freshness }: { freshness?: FreshnessState }) {
         >
           <span className="h-1.5 w-1.5 rounded-full bg-[var(--avy-accent)] [animation:pulse_2s_infinite]" />
           <span className="text-[var(--avy-ink)]">{time || "—"} UTC</span>
-          <span className="opacity-40">·</span>
-          <span className="text-[var(--avy-accent)]">#{block.toLocaleString()}</span>
         </span>
       </div>
       <div className="flex items-center gap-2">

--- a/app/components/shell/DataFreshnessPill.tsx
+++ b/app/components/shell/DataFreshnessPill.tsx
@@ -5,21 +5,19 @@ import { cn } from "@/lib/utils/cn";
 /**
  * "Where is this page reading from?" indicator.
  *
- * Every operator page mixes live SWR responses with fixture fallbacks,
- * which means a stale fixture can silently render after a backend
- * outage with no visual signal. This pill makes that distinction
- * explicit in the topbar, so an operator scanning the dashboard knows
- * whether to trust the numbers in front of them.
+ * Every operator page mixes several SWR responses, and some endpoints
+ * can be locked behind wallet auth or unavailable while the public
+ * surfaces still render. This pill makes that distinction explicit in
+ * the topbar, so an operator scanning the dashboard knows whether to
+ * trust the numbers in front of them.
  *
  * Three states only — keep it tight:
  *   - `live`     · everything resolved, no errors      → green
  *   - `loading`  · still waiting on the first response → blue, pulsing
  *   - `fallback` · request errored or returned nothing → amber
  *
- * "Error" is not a separate state because the UI behaviour is the
- * same in both cases (we render fixtures), and showing two different
- * pills for "the API is down" vs. "the API is intentionally not wired
- * yet" would just confuse operators who can't act on the difference.
+ * "Error" is not a separate state because operators mainly need to
+ * know that the current panel is not backed by a successful response.
  */
 export type FreshnessState = "live" | "loading" | "fallback";
 
@@ -47,14 +45,14 @@ const STATE_CLS: Record<
 const STATE_LABEL: Record<FreshnessState, string> = {
   live: "Live API",
   loading: "Loading",
-  fallback: "Fixture data",
+  fallback: "Unavailable",
 };
 
 const STATE_TITLE: Record<FreshnessState, string> = {
   live: "Live data from the operator API.",
   loading: "Still waiting on the first API response.",
   fallback:
-    "API errored or has not been wired yet — page is rendering fixture data.",
+    "API errored, is locked behind auth, or has not emitted this surface yet.",
 };
 
 export function DataFreshnessPill({

--- a/app/components/shell/OperatorRail.tsx
+++ b/app/components/shell/OperatorRail.tsx
@@ -40,18 +40,14 @@ interface NavGroup {
   items: NavItem[];
 }
 
-// Mirrors the IA from the Claude Design Overview: three groups, count chips.
-// Counts are seeded with the handoff fixture values so the rail reads
-// correctly out of the box; replace with live state when each surface
-// gets its data hook (e.g. counts.runs = useSessions().filter(s => s.open).length).
 const NAV_GROUPS: NavGroup[] = [
   {
     label: "Room",
     items: [
       { href: "/overview", label: "Overview", icon: LayoutDashboard },
-      { href: "/runs", label: "Runs", icon: Gauge, count: 14 },
-      { href: "/receipts", label: "Receipts", icon: ScrollText, count: "2,134" },
-      { href: "/agents", label: "Agents", icon: Users, count: 8 },
+      { href: "/runs", label: "Runs", icon: Gauge },
+      { href: "/receipts", label: "Receipts", icon: ScrollText },
+      { href: "/agents", label: "Agents", icon: Users },
     ],
   },
   {
@@ -64,8 +60,8 @@ const NAV_GROUPS: NavGroup[] = [
   {
     label: "Governance",
     items: [
-      { href: "/policies", label: "Policies", icon: ShieldCheck, count: 22 },
-      { href: "/disputes", label: "Disputes", icon: AlertTriangle, count: 2 },
+      { href: "/policies", label: "Policies", icon: ShieldCheck },
+      { href: "/disputes", label: "Disputes", icon: AlertTriangle },
       { href: "/audit-log", label: "Audit log", icon: FileCheck2 },
     ],
   },
@@ -84,7 +80,7 @@ export function OperatorRail() {
     "/runs": countOf(jobs.data),
     "/receipts": countOf(badges.data),
     "/agents": countOf(agents.data),
-    "/sessions": countOf(sessions.data),
+    "/sessions": countOf(sessions.data) ?? activeClaimCount(jobs.data),
     "/policies": countOf(policies.data),
     "/disputes": countOf(disputes.data),
   };
@@ -194,4 +190,44 @@ function countOf(value: unknown): number | undefined {
     if (Array.isArray(record[key])) return record[key].length;
   }
   return undefined;
+}
+
+function activeClaimCount(value: unknown): number | undefined {
+  const jobs = recordsFrom(value, ["jobs", "items", "data"]);
+  if (!jobs) return undefined;
+  const now = Date.now();
+  return jobs.filter((job) => {
+    const state = String(
+      job.effectiveState ?? job.claimState ?? job.state ?? job.lifecycle ?? ""
+    ).toLowerCase();
+    const claimedBy =
+      typeof job.claimedBy === "string" ||
+      typeof job.worker === "string" ||
+      typeof job.claimedByWallet === "string";
+    const expiresAt =
+      typeof job.claimExpiresAt === "string"
+        ? Date.parse(job.claimExpiresAt)
+        : undefined;
+    const unexpired = !expiresAt || Number.isNaN(expiresAt) || expiresAt > now;
+    return claimedBy && state.includes("claim") && unexpired;
+  }).length;
+}
+
+function recordsFrom(
+  value: unknown,
+  keys: string[]
+): Array<Record<string, unknown>> | undefined {
+  if (Array.isArray(value)) {
+    return value.filter(isRecord);
+  }
+  if (!isRecord(value)) return undefined;
+  for (const key of keys) {
+    const nested = value[key];
+    if (Array.isArray(nested)) return nested.filter(isRecord);
+  }
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object";
 }

--- a/app/components/treasury/PolicyGateFooter.tsx
+++ b/app/components/treasury/PolicyGateFooter.tsx
@@ -20,11 +20,17 @@ export function PolicyGateFooter({ items, sub }: PolicyGateFooterProps) {
       title="Policies currently governing this surface"
       sub={sub}
     >
-      <div className="grid grid-cols-1 gap-3 p-4 md:grid-cols-3">
-        {items.map((item) => (
-          <PolicyCard key={item.tag} item={item} />
-        ))}
-      </div>
+      {items.length ? (
+        <div className="grid grid-cols-1 gap-3 p-4 md:grid-cols-3">
+          {items.map((item) => (
+            <PolicyCard key={item.tag} item={item} />
+          ))}
+        </div>
+      ) : (
+        <div className="p-4 font-[family-name:var(--font-body)] text-[13px] text-[var(--avy-muted)]">
+          No live policy gate rows available.
+        </div>
+      )}
     </TreasuryPanel>
   );
 }

--- a/app/components/treasury/TreasuryTopbar.tsx
+++ b/app/components/treasury/TreasuryTopbar.tsx
@@ -7,7 +7,6 @@ import {
 } from "@/components/shell/DataFreshnessPill";
 
 const pad = (n: number) => String(n).padStart(2, "0");
-const SEED_BLOCK = 24_918_431;
 
 function formatTime(d: Date): string {
   return `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}`;
@@ -15,15 +14,11 @@ function formatTime(d: Date): string {
 
 export function TreasuryTopbar({ freshness }: { freshness?: FreshnessState }) {
   const [time, setTime] = useState("");
-  const [block, setBlock] = useState(SEED_BLOCK);
-  const finalized = block - 3;
 
   useEffect(() => {
     const tick = () => {
       const d = new Date();
       setTime(formatTime(d));
-      // ~6s Polkadot block cadence — advance on ~1/6 ticks.
-      if (Math.random() < 0.18) setBlock((b) => b + 1);
     };
     tick();
     const id = setInterval(tick, 1000);
@@ -48,15 +43,6 @@ export function TreasuryTopbar({ freshness }: { freshness?: FreshnessState }) {
         <span className="inline-flex items-center gap-1.5">
           <span className="h-1.5 w-1.5 rounded-full bg-[var(--avy-accent)] shadow-[0_0_0_3px_rgba(30,102,66,0.12)] [animation:pulse_2s_infinite]" />
           <span>{time || "—"} UTC</span>
-        </span>
-        <span className="opacity-40">·</span>
-        <span>
-          Block <span className="text-[var(--avy-ink)]">#{block.toLocaleString()}</span>
-        </span>
-        <span className="opacity-40">·</span>
-        <span>
-          Finalized{" "}
-          <span className="text-[var(--avy-ink)]">#{finalized.toLocaleString()}</span>
         </span>
       </div>
 

--- a/app/components/treasury/XcmObserverLane.tsx
+++ b/app/components/treasury/XcmObserverLane.tsx
@@ -18,15 +18,21 @@ export interface XcmObserverLaneProps {
 export function XcmObserverLane({ phases, sub }: XcmObserverLaneProps) {
   return (
     <TreasuryPanel eyebrow="XCM observer" title="Request → observe → settle" sub={sub}>
-      <div className="grid grid-cols-1 md:grid-cols-3">
-        {phases.map((phase, i) => (
-          <PhaseColumn
-            key={phase.step}
-            phase={phase}
-            isLast={i === phases.length - 1}
-          />
-        ))}
-      </div>
+      {phases.length ? (
+        <div className="grid grid-cols-1 md:grid-cols-3">
+          {phases.map((phase, i) => (
+            <PhaseColumn
+              key={phase.step}
+              phase={phase}
+              isLast={i === phases.length - 1}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="p-4 font-[family-name:var(--font-body)] text-[13px] text-[var(--avy-muted)]">
+          No live XCM observer events available.
+        </div>
+      )}
     </TreasuryPanel>
   );
 }

--- a/app/lib/api/hooks.ts
+++ b/app/lib/api/hooks.ts
@@ -64,6 +64,8 @@ export const useHealth = () => useApi("/health");
  */
 export const useProviderOperations = () =>
   useApi("/admin/status", { refreshInterval: 30_000 });
+export const usePublicProviderOperations = () =>
+  useApi("/status/providers", { refreshInterval: 30_000 });
 /**
  * Operator-side full job listing including paused, archived, and stale
  * rows so the operator app can show lifecycle controls. The public

--- a/app/lib/api/session-adapters.ts
+++ b/app/lib/api/session-adapters.ts
@@ -16,7 +16,7 @@ function asRecord(value: unknown): RawRecord {
 function asArray(value: unknown): RawRecord[] {
   if (Array.isArray(value)) return value.map(asRecord);
   const record = asRecord(value);
-  for (const key of ["items", "sessions", "history"]) {
+  for (const key of ["items", "sessions", "history", "jobs"]) {
     if (Array.isArray(record[key])) return record[key].map(asRecord);
   }
   return [];
@@ -139,6 +139,46 @@ function jobFor(jobs: RawRecord[], jobId: string): RawRecord {
   return jobs.find((job) => text(job.id) === jobId) ?? {};
 }
 
+function sessionKey(session: RawRecord): string {
+  return text(session.sessionId, text(session.id, `${text(session.jobId)}:${text(session.wallet)}`));
+}
+
+function isActiveClaim(job: RawRecord): boolean {
+  const effectiveState = text(job.effectiveState, text(job.claimState, text(job.state))).toLowerCase();
+  if (effectiveState !== "claimed") return false;
+  if (!text(job.claimedBy)) return false;
+  const expiresAt = text(job.claimExpiresAt);
+  return !expiresAt || Number.isNaN(Date.parse(expiresAt)) || Date.parse(expiresAt) > Date.now();
+}
+
+function claimedJobSession(job: RawRecord): RawRecord {
+  const wallet = text(job.claimedBy);
+  const jobId = text(job.id);
+  const reward = asRecord(job.reward);
+  return {
+    sessionId: text(job.sessionId, `${jobId}:${wallet}`),
+    jobId,
+    wallet,
+    status: "claimed",
+    claimedAt: text(job.claimedAt),
+    updatedAt: text(job.claimedAt),
+    claimStake: job.claimStake ?? reward.amount,
+    totalClaimLock: job.totalClaimLock ?? reward.amount,
+  };
+}
+
+function liveSessionRows(sessionPayload: unknown, jobs: RawRecord[]): RawRecord[] {
+  const sessions = asArray(sessionPayload);
+  const seen = new Set(sessions.map(sessionKey).filter(Boolean));
+  const claimed = jobs.filter(isActiveClaim).map(claimedJobSession).filter((session) => {
+    const key = sessionKey(session);
+    if (!key || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+  return [...sessions, ...claimed];
+}
+
 /**
  * Map a job's source.type onto the operator-app SourceKind enum so the
  * sessions table can render the same SourceBadge already shown on the
@@ -151,7 +191,7 @@ function jobFor(jobs: RawRecord[], jobId: string): RawRecord {
  * unknown source.type values fall through to undefined.
  */
 function sourceKindFromJob(job: RawRecord): SourceKind | undefined {
-  const sourceType = text(asRecord(job.source).type);
+  const sourceType = text(asRecord(job.source).type, text(job.sourceType));
   switch (sourceType) {
     case "github_issue":
       return "github";
@@ -187,12 +227,13 @@ function lifecycle(session: RawRecord) {
 
 export function buildSessionDetails(sessionPayload: unknown, jobsPayload: unknown): SessionDetail[] {
   const jobs = asArray(jobsPayload);
-  return asArray(sessionPayload).map((session) => {
+  return liveSessionRows(sessionPayload, jobs).map((session) => {
     const id = text(session.sessionId, text(session.id, "unknown-session"));
     const jobId = text(session.jobId, "unknown-job");
     const job = jobFor(jobs, jobId);
-    const rewardAsset = asset(job.rewardAsset);
-    const rewardAmount = amount(job.rewardAmount ?? session.claimStake);
+    const reward = asRecord(job.reward);
+    const rewardAsset = asset(job.rewardAsset ?? reward.asset);
+    const rewardAmount = amount(job.rewardAmount ?? reward.amount ?? session.claimStake);
     const currentState = state(session.status);
     const updatedAt = session.updatedAt ?? session.resolvedAt ?? session.submittedAt ?? session.claimedAt;
     const verification = asRecord(session.verification);


### PR DESCRIPTION
## What changed
- Stop operator pages from rendering stale demo rows when live API surfaces are empty, unauthorized, or unavailable.
- Derive Sessions and rail session counts from active claimed jobs so an external agent working now is reflected even when /sessions is private.
- Remove fake topbar block counters; keep only UTC time/data freshness because Polkadot Hub block state must come from real RPC such as eth_blockNumber, not local timers.
- Switch overview provider operations to the public /status/providers fallback when admin status is locked, and add honest empty states for pulse, XCM, and policy-gate surfaces.

## Checks run
- npm run typecheck:app
- npm run build:frontend
- Local browser smoke on /overview, /runs, /agents

## Affected surfaces
Frontend/operator app only. No backend, indexer, Caddy, contracts, public site, env, or VPS secret changes.