### PR TITLE
Expose operator-wide session activity

### DIFF
--- a/app/app/(authed)/overview/page.tsx
+++ b/app/app/(authed)/overview/page.tsx
@@ -14,7 +14,16 @@ import {
 import { PlatformPulse } from "@/components/overview/PlatformPulse";
 import { ProviderOperationsCard } from "@/components/overview/ProviderOperationsCard";
 import { JobLifecycleStrip } from "@/components/overview/JobLifecycleStrip";
-import { useAccount, useAlerts, useHealth, useJobs, useProviderOperations, usePublicProviderOperations, useSessions, useStrategyPositions } from "@/lib/api/hooks";
+import {
+  useAccount,
+  useAdminSessions,
+  useAlerts,
+  useHealth,
+  useJobs,
+  useProviderOperations,
+  usePublicProviderOperations,
+  useStrategyPositions,
+} from "@/lib/api/hooks";
 import { freshnessFromRequests } from "@/components/shell/DataFreshnessPill";
 import { extractRunJobs } from "@/lib/api/run-adapters";
 import { buildProviderOperations } from "@/lib/api/provider-operations";
@@ -30,7 +39,7 @@ import {
 
 export default function OverviewPage() {
   const jobs = useJobs();
-  const sessions = useSessions();
+  const sessions = useAdminSessions();
   const account = useAccount();
   const strategyPositions = useStrategyPositions();
   const health = useHealth();

--- a/app/app/(authed)/sessions/page.tsx
+++ b/app/app/(authed)/sessions/page.tsx
@@ -11,7 +11,12 @@ import {
 import { SessionsTable } from "@/components/sessions/SessionsTable";
 import { SessionDrawerBody } from "@/components/sessions/SessionDrawerBody";
 import { SessionStatePill } from "@/components/sessions/pills";
-import { useJobs, useSession, useSessions, useSessionTimeline } from "@/lib/api/hooks";
+import {
+  useAdminSessions,
+  useJobs,
+  useSession,
+  useSessionTimeline,
+} from "@/lib/api/hooks";
 import { freshnessFromRequests } from "@/components/shell/DataFreshnessPill";
 import { buildSessionDetails, mergeSessionTimeline } from "@/lib/api/session-adapters";
 
@@ -25,7 +30,7 @@ function valueBucket(amountStr: string): SessionsFilter["value"] {
 }
 
 export default function SessionsPage() {
-  const sessionsQuery = useSessions();
+  const sessionsQuery = useAdminSessions();
   const jobsQuery = useJobs();
   const [filter, setFilter] = useState<SessionsFilter>({
     state: "all",

--- a/app/lib/api/hooks.ts
+++ b/app/lib/api/hooks.ts
@@ -32,6 +32,8 @@ export const useRecommendations = () => useApi("/jobs/recommendations");
 export const useJobDefinition = (id: string | null) =>
   useApi(id ? `/jobs/definition?jobId=${encodeURIComponent(id)}` : null);
 export const useSessions = () => useApi("/sessions");
+export const useAdminSessions = () =>
+  useApi("/admin/sessions?limit=100", { refreshInterval: 15_000 });
 export const useAgents = () => useApi("/agents");
 export const useAgent = (wallet: string | null) =>
   useApi(wallet ? `/agents/${encodeURIComponent(wallet)}` : null);

--- a/mcp-server/src/core/discovery-manifest.js
+++ b/mcp-server/src/core/discovery-manifest.js
@@ -48,6 +48,7 @@ const DISCOVERY_AUTHENTICATED_ENDPOINTS = [
   { path: "/content/:hash/publish", description: "Owner/admin one-way early publish for private hash-addressed content." },
   { path: "/disputes", description: "Operator dispute queue derived from sessions requiring human review." },
   { path: "/disputes/:id", description: "Detailed dispute evidence, timeline, verdict, and stake release state." },
+  { path: "/admin/sessions", description: "Admin/operator-wide recent sessions across worker wallets." },
   { path: "/session", description: "Fetch a single session by id (owner-scoped)." },
   { path: "/sessions", description: "Historical sessions for the signed-in wallet." },
   { path: "/xcm/request?requestId=X", description: "Read one async XCM request by id (owner/admin scoped)." },

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -980,6 +980,7 @@ function metricPathLabel(pathname) {
     "/session/state-machine",
     "/strategies",
     "/admin/jobs",
+    "/admin/sessions",
     "/admin/jobs/ingest/github",
     "/admin/jobs/ingest/openapi",
     "/admin/jobs/ingest/open-data",
@@ -1272,6 +1273,7 @@ const server = createServer(async (request, response) => {
           "/verifier/handlers",
           "/verifier/replay",
           "/admin/jobs",
+          "/admin/sessions",
           "/admin/jobs/ingest/github",
           "/admin/jobs/ingest/openapi",
           "/admin/jobs/ingest/open-data",
@@ -1381,6 +1383,22 @@ const server = createServer(async (request, response) => {
           includeStale: true
         }),
         jobLifecycle: service.getJobLifecycleSummary()
+      });
+    }
+
+    if (request.method === "GET" && pathname === "/admin/sessions") {
+      await authMiddleware(request, url, { requireRole: "admin" });
+      const limit = parseLimit(url, 50, 250);
+      const jobId = url.searchParams.get("jobId") ?? undefined;
+      const sessions = jobId
+        ? await service.listSessionHistory({ jobId, limit })
+        : await service.listRecentSessions(limit);
+      return respond(response, 200, {
+        sessions,
+        count: sessions.length,
+        limit,
+        ...(jobId ? { jobId } : {}),
+        scope: "operator"
       });
     }
 

--- a/mcp-server/src/protocols/http/server.smoke.test.js
+++ b/mcp-server/src/protocols/http/server.smoke.test.js
@@ -161,6 +161,63 @@ test("http smoke: /admin/jobs accepts admin-scoped token", { skip: !RUN }, async
   });
 });
 
+test("http smoke: /admin/sessions exposes operator-wide session activity", { skip: !RUN }, async () => {
+  await runWithServer(async (base) => {
+    const adminToken = issueToken(ADMIN_WALLET, { roles: ["admin"] });
+    const workerToken = issueToken(STRANGER_WALLET);
+
+    await fetch(`${base}/admin/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${adminToken}` },
+      body: JSON.stringify({
+        id: "operator-session-smoke-001",
+        category: "coding",
+        tier: "starter",
+        rewardAmount: 1,
+        claimTtlSeconds: 3600,
+        verifierMode: "benchmark",
+        verifierTerms: ["complete"],
+        verifierMinimumMatches: 1,
+        outputSchemaRef: "schema://jobs/operator-session-smoke-output"
+      })
+    });
+
+    await fetch(`${base}/account/fund?asset=DOT&amount=10`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${workerToken}` }
+    });
+
+    const claim = await fetch(
+      `${base}/jobs/claim?jobId=operator-session-smoke-001&idempotencyKey=operator-session-smoke-claim`,
+      { method: "POST", headers: { authorization: `Bearer ${workerToken}` } }
+    );
+    assert.equal(claim.status, 200);
+    const claimed = await claim.json();
+
+    const walletScoped = await fetch(`${base}/sessions`, {
+      headers: { authorization: `Bearer ${adminToken}` }
+    });
+    assert.equal(walletScoped.status, 200);
+    assert.deepEqual(await walletScoped.json(), []);
+
+    const forbidden = await fetch(`${base}/admin/sessions`, {
+      headers: { authorization: `Bearer ${workerToken}` }
+    });
+    assert.equal(forbidden.status, 403);
+
+    const response = await fetch(`${base}/admin/sessions?limit=20`, {
+      headers: { authorization: `Bearer ${adminToken}` }
+    });
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.scope, "operator");
+    assert.equal(payload.count, 1);
+    assert.equal(payload.sessions[0].sessionId, claimed.sessionId);
+    assert.equal(payload.sessions[0].wallet, STRANGER_WALLET);
+    assert.equal(payload.sessions[0].jobId, "operator-session-smoke-001");
+  });
+});
+
 test("http smoke: /admin/status returns recurring + maintenance data for admin tokens", { skip: !RUN }, async () => {
   await runWithServer(async (base) => {
     const token = issueToken(ADMIN_WALLET, { roles: ["admin"] });


### PR DESCRIPTION
## What changed
- Adds GET /admin/sessions for admin/operator-wide recent session activity across worker wallets.
- Keeps /sessions wallet-scoped for agent-owned history.
- Points the operator Overview and Sessions pages at the admin session feed so external-agent claims/submissions show up live.
- Adds the route to discovery metadata and covers it in the HTTP smoke suite.

## Checks
- npm --workspace mcp-server test
- npm run typecheck:app
- npm run build:frontend
- RUN_HTTP_SMOKE=1 node --test mcp-server/src/protocols/http/server.smoke.test.js

## Impact
- Backend: new read-only admin route.
- Frontend: Overview and Sessions read operator-wide session activity.
- Contracts/indexer/Caddy/public site: no changes.
- Env/VPS secrets: no changes.