### PR TITLE
Operator-wide session UI polish (PR #142 follow-up)

### DIFF
--- a/app/app/(authed)/overview/page.tsx
+++ b/app/app/(authed)/overview/page.tsx
@@ -51,6 +51,21 @@ export default function OverviewPage() {
     () => buildRoomVitals(jobs.data, sessions.data, account.data, strategyPositions.data),
     [account.data, jobs.data, sessions.data, strategyPositions.data]
   );
+  // The Runs-in-motion + Agents-active cards both pull from
+  // /admin/sessions. While that request is still in flight on first
+  // paint, we don't want the cards to claim "0" or "no claims
+  // observed yet" — we just don't know yet. Replace the deltas with
+  // a loading hint until the request resolves; once it's resolved
+  // (data or error), buildRoomVitals' real copy takes over.
+  const sessionsLoading = sessions.isLoading && !sessions.data && !sessions.error;
+  const vitalsWithLoadingHints = useMemo(() => {
+    if (!sessionsLoading) return liveVitals;
+    return liveVitals.map((v) =>
+      v.label === "Runs in motion" || v.label === "Agents active"
+        ? { ...v, delta: "waiting for /admin/sessions…" }
+        : v
+    );
+  }, [liveVitals, sessionsLoading]);
   const liveAlerts = useMemo(
     () => buildOverviewAlerts(sessions.data, account.data),
     [account.data, sessions.data]
@@ -72,7 +87,7 @@ export default function OverviewPage() {
   );
   const providerRows = liveProviderOps;
   const hasLiveOverview = Boolean(jobs.data || sessions.data || account.data || strategyPositions.data);
-  const vitals = liveVitals;
+  const vitals = vitalsWithLoadingHints;
   const alerts = endpointAlerts.length ? endpointAlerts : liveAlerts;
   const lanes = liveLanes;
   const disputedSessions = Array.isArray(sessions.data)

--- a/app/app/(authed)/sessions/page.tsx
+++ b/app/app/(authed)/sessions/page.tsx
@@ -102,10 +102,26 @@ export default function SessionsPage() {
           Sessions
         </h1>
         <p className="m-0 mt-0.5 max-w-[62ch] font-[family-name:var(--font-body)] text-[16px] leading-[1.55] text-[var(--avy-muted)]">
-          Every capital-movement lifecycle keyed to a run. Funded, claimed, submitted,
-          verified, settled — or disputed and slashed. Auditors read this page; nobody
-          edits it.
+          Every capital-movement lifecycle keyed to a run — across every worker
+          wallet, not just yours. Funded, claimed, submitted, verified, settled —
+          or disputed and slashed. Auditors read this page; nobody edits it.
         </p>
+        {/*
+         * Scope hint — the page reads /admin/sessions (operator-wide),
+         * not /sessions (your wallet only). Surface that explicitly so
+         * the operator doesn't mistake an external-agent claim for
+         * activity from their own signed-in wallet.
+         */}
+        <span
+          className="mt-1 inline-flex w-fit items-center gap-1.5 rounded-full border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-2.5 py-1 font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
+          style={{ letterSpacing: 0 }}
+          title="Operator-wide session activity sourced from /admin/sessions (every worker wallet, capped at the most recent 100). The wallet-scoped /sessions endpoint is reserved for 'my history' views."
+        >
+          <span className="h-1.5 w-1.5 rounded-full bg-[var(--avy-accent)]" />
+          operator-wide
+          <span className="opacity-40">·</span>
+          <code className="text-[var(--avy-ink)]">/admin/sessions</code>
+        </span>
       </header>
 
       <SessionsAggregateStrip sessions={sessions} />

--- a/app/components/agents/AgentDirectoryTable.tsx
+++ b/app/components/agents/AgentDirectoryTable.tsx
@@ -2,9 +2,10 @@
 
 import { cn } from "@/lib/utils/cn";
 import { Sparkline } from "@/components/overview/Sparkline";
+import { formatDeadline } from "@/components/runs/buildLifecycleStages";
 import { BadgeStrip } from "./BadgeStrip";
 import { TierChip } from "./TierChip";
-import type { AgentRecord } from "./types";
+import type { AgentRecord, AgentActiveSession } from "./types";
 
 export interface AgentDirectoryTableProps {
   rows: AgentRecord[];
@@ -179,6 +180,9 @@ export function AgentDirectoryTable({
                       >
                         {a.activity.when}
                       </div>
+                      {a.activeSession ? (
+                        <ActiveSessionLine session={a.activeSession} />
+                      ) : null}
                     </Td>
                     <Td>
                       <span
@@ -215,6 +219,43 @@ export function AgentDirectoryTable({
           ＋ Invite new agent
         </button>
       </footer>
+    </div>
+  );
+}
+
+/**
+ * Compact one-liner that surfaces the agent's currently-claimed run on
+ * the row itself. Previously this lived only in the drawer body, so an
+ * operator scanning the directory couldn't tell which agents had a
+ * job in flight without clicking into each row. Reads jobId + the live
+ * deadline countdown from the agent's `currentActivity` block (mapped
+ * onto AgentActiveSession by the adapter).
+ */
+function ActiveSessionLine({ session }: { session: AgentActiveSession }) {
+  const deadlineLabel = session.deadlineAt ? formatDeadline(session.deadlineAt) : "";
+  const verb =
+    session.status === "submitted"
+      ? "Submitted"
+      : session.status === "disputed"
+        ? "Disputed"
+        : "On";
+  return (
+    <div
+      className="mt-1 inline-flex flex-wrap items-center gap-1 rounded-[6px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-1.5 py-0.5 font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]"
+      style={{ letterSpacing: 0 }}
+      title={`Active session ${session.sessionId}`}
+    >
+      <span className="h-1.5 w-1.5 rounded-full bg-[var(--avy-accent)]" />
+      <span>
+        {verb}{" "}
+        <span className="text-[var(--avy-accent)]">{session.jobId}</span>
+      </span>
+      {deadlineLabel ? (
+        <>
+          <span className="opacity-40">·</span>
+          <span>{deadlineLabel}</span>
+        </>
+      ) : null}
     </div>
   );
 }

--- a/app/components/sessions/SessionsTable.tsx
+++ b/app/components/sessions/SessionsTable.tsx
@@ -55,7 +55,9 @@ export function SessionsTable({
                   className="p-8 text-center font-[family-name:var(--font-mono)] text-[13px] text-[var(--avy-muted)]"
                   style={{ letterSpacing: 0 }}
                 >
-                  No sessions match these filters.
+                  {totalCount === 0
+                    ? "No worker sessions have been observed yet."
+                    : "No sessions match these filters."}
                 </td>
               </tr>
             ) : (

--- a/app/components/shell/OperatorRail.tsx
+++ b/app/components/shell/OperatorRail.tsx
@@ -20,12 +20,12 @@ import { signOut } from "@/lib/auth/siwe";
 import { shortAddress } from "@/lib/format";
 import { Button } from "@/components/ui/button";
 import {
+  useAdminSessions,
   useAgents,
   useBadges,
   useDisputes,
   useJobs,
   usePolicies,
-  useSessions,
 } from "@/lib/api/hooks";
 
 interface NavItem {
@@ -73,7 +73,10 @@ export function OperatorRail() {
   const jobs = useJobs();
   const badges = useBadges();
   const agents = useAgents();
-  const sessions = useSessions();
+  // Operator-wide count for the left-rail "Sessions" badge — should
+  // include external-agent activity, not just the signed-in wallet's
+  // own sessions. Matches what the /sessions page itself reads.
+  const sessions = useAdminSessions();
   const policies = usePolicies();
   const disputes = useDisputes();
   const counts: Record<string, number | string | undefined> = {

--- a/app/lib/api/treasury-adapters.ts
+++ b/app/lib/api/treasury-adapters.ts
@@ -208,8 +208,28 @@ export function buildRoomVitals(jobsPayload: unknown, sessionsPayload: unknown, 
   const activeAgents = new Set(sessions.map((s) => text(s.wallet)).filter(Boolean)).size;
 
   return [
-    { label: "Runs in motion", value: jobs.length || sessions.length, spark: spark(12), delta: "live jobs + sessions", deltaTone: "good" },
-    { label: "Agents active", value: activeAgents || "-", spark: spark(8), sparkColor: "#8a8f88", delta: activeAgents ? "from active claims" : "from session history", deltaTone: "neutral" },
+    {
+      label: "Runs in motion",
+      value: jobs.length || sessions.length,
+      spark: spark(12),
+      // Both surfaces feed this card: every open job in the catalog
+      // plus every active session pulled from /admin/sessions
+      // (operator-wide, includes external-agent claims). The hint
+      // makes that obvious so a reader doesn't think the number is
+      // wallet-scoped.
+      delta: "open jobs + operator-wide sessions",
+      deltaTone: "good",
+    },
+    {
+      label: "Agents active",
+      value: activeAgents || "-",
+      spark: spark(8),
+      sparkColor: "#8a8f88",
+      delta: activeAgents
+        ? "distinct wallets · operator-wide"
+        : "no claims observed yet · operator-wide",
+      deltaTone: "neutral",
+    },
     { label: "Capital at work", value: fmt(capital), unit: "DOT", spark: spark(20), delta: "strategy + stake", deltaTone: "good" },
     { label: "Treasury posture", value: attentionCount ? "Amber" : "Green", valueAccent: !attentionCount, spark: spark(1), delta: attentionCount ? `${attentionCount} lane attention` : "No lane attention", deltaTone: attentionCount ? "warn" : "good" },
   ];


### PR DESCRIPTION
Frontend follow-up to PR #142 — surfaces \`/admin/sessions\` on the operator dashboards and sharpens the copy so external-agent claims read correctly.

## What changes

### \`/sessions\`
- Header description now says \"across every worker wallet, not just yours\" + a small operator-wide pill pointing at \`/admin/sessions\` makes the source explicit.
- \`SessionsTable\` empty state splits the two cases: \`totalCount === 0\` → \"No worker sessions have been observed yet.\"; \`totalCount > 0\` → \"No sessions match these filters.\"

### \`/overview\`
- Room-vitals deltas spell out the source: \"open jobs + operator-wide sessions\" on Runs in motion, \"distinct wallets · operator-wide\" / \"no claims observed yet · operator-wide\" on Agents active.
- While \`/admin/sessions\` is still in flight on first paint, both deltas swap to \"waiting for /admin/sessions…\" so the UI doesn't falsely claim \"0\" or \"no claims yet\". Once resolved (data or error) the real copy takes over.

### \`OperatorRail\` (left chrome)
- \"Sessions\" badge count switches from \`useSessions\` to \`useAdminSessions\` so the rail and the \`/sessions\` page agree.

### \`/agents\`
- Directory rows render a compact Active session pill under Recent activity when \`currentActivity\` is populated: \`● On <jobId> · closes in 21m\`. Reads the live deadline straight from the existing \`AgentActiveSession\` mapping. Operator no longer needs to open the drawer to see which agents have something in flight.

## Brief constraints respected
- Per the brief: no fallback fixture counts. Zero stays zero everywhere this PR touches.

## Test plan
- [x] \`npm run typecheck:app\`
- [x] \`npm run build:frontend\`
- [ ] After deploy: load \`/agents\` signed-in. The 30BC wallet's row should show the Active session pill (jobId + countdown). Load \`/overview\` and confirm the Runs in motion / Agents active deltas read \"operator-wide\" instead of being silent about scope.