### PR TITLE
Sessions strip: drop fixture metrics, tighten page header

### DIFF
--- a/app/app/(authed)/sessions/page.tsx
+++ b/app/app/(authed)/sessions/page.tsx
@@ -91,37 +91,40 @@ export default function SessionsPage() {
     <div className="flex w-full max-w-[1100px] flex-col gap-5">
       <SessionsTopbar freshness={freshness} />
 
-      <header className="flex flex-col gap-1.5">
+      {/*
+       * Tighter header layout — eyebrow above, h1 + scope pill on one
+       * row so the operator-wide hint reads as a label on the page
+       * title (not a dangling pill below the description). One-line
+       * description trades the long marketing-flavour copy for a
+       * single sentence the auditor can scan.
+       */}
+      <header className="flex flex-col gap-1">
         <span
           className="font-[family-name:var(--font-display)] text-[11.5px] font-extrabold uppercase text-[var(--avy-accent)]"
           style={{ letterSpacing: "0.12em" }}
         >
           Capital movement
         </span>
-        <h1 className="m-0 font-[family-name:var(--font-display)] text-[2.4rem] font-bold leading-none text-[var(--avy-ink)]">
-          Sessions
-        </h1>
-        <p className="m-0 mt-0.5 max-w-[62ch] font-[family-name:var(--font-body)] text-[16px] leading-[1.55] text-[var(--avy-muted)]">
-          Every capital-movement lifecycle keyed to a run — across every worker
-          wallet, not just yours. Funded, claimed, submitted, verified, settled —
-          or disputed and slashed. Auditors read this page; nobody edits it.
+        <div className="flex flex-wrap items-baseline gap-3">
+          <h1 className="m-0 font-[family-name:var(--font-display)] text-[2.4rem] font-bold leading-none text-[var(--avy-ink)]">
+            Sessions
+          </h1>
+          <span
+            className="inline-flex items-center gap-1.5 rounded-full border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-2.5 py-1 font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
+            style={{ letterSpacing: 0 }}
+            title="Operator-wide session activity sourced from /admin/sessions (every worker wallet, capped at the most recent 100). The wallet-scoped /sessions endpoint is reserved for 'my history' views."
+          >
+            <span className="h-1.5 w-1.5 rounded-full bg-[var(--avy-accent)]" />
+            operator-wide
+            <span className="opacity-40">·</span>
+            <code className="text-[var(--avy-ink)]">/admin/sessions</code>
+          </span>
+        </div>
+        <p className="m-0 mt-1 max-w-[64ch] font-[family-name:var(--font-body)] text-[14.5px] leading-[1.5] text-[var(--avy-muted)]">
+          Read-only ledger of every capital-movement lifecycle —
+          claimed, submitted, verified, settled, or disputed — across
+          every worker wallet. Auditors read this page; nobody edits it.
         </p>
-        {/*
-         * Scope hint — the page reads /admin/sessions (operator-wide),
-         * not /sessions (your wallet only). Surface that explicitly so
-         * the operator doesn't mistake an external-agent claim for
-         * activity from their own signed-in wallet.
-         */}
-        <span
-          className="mt-1 inline-flex w-fit items-center gap-1.5 rounded-full border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-2.5 py-1 font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
-          style={{ letterSpacing: 0 }}
-          title="Operator-wide session activity sourced from /admin/sessions (every worker wallet, capped at the most recent 100). The wallet-scoped /sessions endpoint is reserved for 'my history' views."
-        >
-          <span className="h-1.5 w-1.5 rounded-full bg-[var(--avy-accent)]" />
-          operator-wide
-          <span className="opacity-40">·</span>
-          <code className="text-[var(--avy-ink)]">/admin/sessions</code>
-        </span>
       </header>
 
       <SessionsAggregateStrip sessions={sessions} />

--- a/app/components/sessions/SessionsAggregateStrip.tsx
+++ b/app/components/sessions/SessionsAggregateStrip.tsx
@@ -1,44 +1,76 @@
 import { cn } from "@/lib/utils/cn";
-import { Sparkline } from "@/components/overview/Sparkline";
 import type { SessionDetail } from "./types";
 
+/**
+ * Top-of-page aggregate cards for the Sessions surface.
+ *
+ * Every value is derived from the live SessionDetail[]. When something
+ * isn't computable from what we have today (e.g. median settle time
+ * needs raw claim/settle timestamps that the row adapter doesn't carry
+ * yet), the card shows an honest `—` placeholder with a meta line
+ * that explains the gap, instead of the previous fixture string. Same
+ * principle as the rest of the operator dashboard: zero stays zero,
+ * unknown stays unknown.
+ */
 export function SessionsAggregateStrip({ sessions }: { sessions: SessionDetail[] }) {
-  const funded24h = sessions.length;
-  const settled24h = sessions.filter((s) => s.state === "settled").length;
+  // Sessions still in flight — claimed or submitted but not yet
+  // settled or anomalous. Aliased to "in flight" instead of the old
+  // "24h funded" framing, which implied a 24h window we never
+  // filtered to.
+  const inFlight = sessions.filter(
+    (s) => s.state === "active" || s.state === "submitted"
+  );
+  const settled = sessions.filter((s) => s.state === "settled");
   const anomalies = sessions.filter(
     (s) => s.state === "disputed" || s.state === "slashed" || s.state === "rejected"
-  ).length;
+  );
+
+  // Total escrow currently locked across in-flight rows, grouped by
+  // asset. Multi-asset stacks render as `4.00 DOT · 12.00 USDC`.
+  const inFlightEscrow = sumEscrowByAsset(inFlight);
+  const settledEscrow = sumEscrowByAsset(settled);
 
   return (
     <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
       <Card
-        label="24h funded"
-        value={`${funded24h}`}
-        unit="sessions"
-        meta="~ 166 DOT routed · +4 vs prior 24h"
-        tone="ok"
+        label="In flight"
+        value={`${inFlight.length}`}
+        unit={inFlight.length === 1 ? "session" : "sessions"}
+        meta={
+          inFlightEscrow.length
+            ? `${formatEscrowList(inFlightEscrow)} locked`
+            : sessions.length === 0
+              ? "no sessions observed yet"
+              : "no escrow currently locked"
+        }
+        tone={inFlight.length > 0 ? "ok" : "muted"}
       />
       <Card
-        label="24h settled"
-        value={`${settled24h}`}
-        unit="sessions"
-        meta="~ 18 DOT paid out · median 3m12s"
-        tone="ok"
-        right={<Sparkline points={[1, 2, 2, 3, 2, 4, 3, 5]} width={72} height={20} />}
+        label="Settled"
+        value={`${settled.length}`}
+        unit={settled.length === 1 ? "session" : "sessions"}
+        meta={
+          settledEscrow.length
+            ? `${formatEscrowList(settledEscrow)} paid out`
+            : "no settlements in scope"
+        }
+        tone={settled.length > 0 ? "ok" : "muted"}
       />
       <Card
         label="Avg settle time"
-        value="3m"
-        unit="12s"
-        meta="p50 2m40s · p95 8m02s"
+        // Median/avg requires raw claimedAt → settledAt timestamps,
+        // which the SessionRow adapter doesn't surface yet. Show an
+        // honest placeholder rather than the previous fixture
+        // "3m 12s · p50 2m40s · p95 8m02s".
+        value="—"
+        meta="raw timestamps not exposed yet"
         tone="muted"
-        right={<Sparkline points={[4, 5, 3, 4, 3, 3, 4, 3]} width={72} height={20} />}
       />
       <Card
         label="Open anomalies"
-        value={`${anomalies}`}
-        meta={anomalies > 0 ? "triage in /disputes" : "clean"}
-        tone={anomalies > 0 ? "warn" : "ok"}
+        value={`${anomalies.length}`}
+        meta={anomalies.length > 0 ? "triage in /disputes" : "clean"}
+        tone={anomalies.length > 0 ? "warn" : "ok"}
       />
     </div>
   );
@@ -50,23 +82,22 @@ interface CardProps {
   unit?: string;
   meta: string;
   tone?: "ok" | "warn" | "muted";
-  right?: React.ReactNode;
 }
 
-function Card({ label, value, unit, meta, tone = "muted", right }: CardProps) {
+function Card({ label, value, unit, meta, tone = "muted" }: CardProps) {
   return (
     <article className="flex min-h-[96px] flex-col gap-1.5 rounded-[10px] border border-[var(--avy-line)] bg-[var(--avy-paper)] p-4 shadow-[var(--shadow-card)] backdrop-blur-[8px]">
-      <div className="flex items-baseline justify-between">
-        <span
-          className="font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase text-[var(--avy-accent)]"
-          style={{ letterSpacing: "0.12em" }}
-        >
-          {label}
-        </span>
-        {right}
-      </div>
       <span
-        className="flex items-baseline gap-1.5 font-[family-name:var(--font-display)] text-[2rem] font-bold leading-none tabular-nums text-[var(--avy-ink)]"
+        className="font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase text-[var(--avy-accent)]"
+        style={{ letterSpacing: "0.12em" }}
+      >
+        {label}
+      </span>
+      <span
+        className={cn(
+          "flex items-baseline gap-1.5 font-[family-name:var(--font-display)] text-[2rem] font-bold leading-none tabular-nums",
+          value === "—" ? "text-[var(--avy-muted)]" : "text-[var(--avy-ink)]"
+        )}
         style={{ letterSpacing: "-0.01em" }}
       >
         {value}
@@ -79,10 +110,45 @@ function Card({ label, value, unit, meta, tone = "muted", right }: CardProps) {
           tone === "warn" && "text-[var(--avy-warn)]",
           tone === "muted" && "text-[var(--avy-muted)]"
         )}
+        style={{ letterSpacing: 0 }}
       >
         <span className="h-1.5 w-1.5 rounded-full bg-current opacity-70" />
         {meta}
       </span>
     </article>
   );
+}
+
+interface EscrowTotal {
+  asset: string;
+  amount: number;
+}
+
+/**
+ * Sum escrow amounts grouped by asset. Returns an array sorted by
+ * descending amount so the largest asset shows first when there are
+ * mixed-asset sessions.
+ */
+function sumEscrowByAsset(sessions: SessionDetail[]): EscrowTotal[] {
+  const totals = new Map<string, number>();
+  for (const session of sessions) {
+    const amount = Number(session.escrow.amount);
+    if (!Number.isFinite(amount) || amount <= 0) continue;
+    totals.set(session.escrow.asset, (totals.get(session.escrow.asset) ?? 0) + amount);
+  }
+  return Array.from(totals.entries())
+    .map(([asset, amount]) => ({ asset, amount }))
+    .sort((a, b) => b.amount - a.amount);
+}
+
+function formatEscrowList(totals: EscrowTotal[]): string {
+  return totals
+    .map((entry) => `${formatAmount(entry.amount)} ${entry.asset}`)
+    .join(" · ");
+}
+
+function formatAmount(value: number): string {
+  if (Number.isInteger(value)) return value.toString();
+  if (value < 1) return value.toFixed(2);
+  return value.toFixed(value < 100 ? 2 : 0);
 }


### PR DESCRIPTION
Polish from the live \`/sessions\` screenshot.

## Aggregate strip — drop the fixture decoration
Four cards were a mix of live + hardcoded values: anomaly count was real, everything else (\"+4 vs prior 24h\", \"~166 DOT routed\", \"~18 DOT paid out · median 3m12s\", \"Avg settle time 3m 12s · p50 2m40s · p95 8m02s\", and two decorative sparklines drawn from hardcoded arrays) was fixture. With one live session today those numbers read like marketing copy.

Every value now derives from \`SessionDetail[]\`:
- **In flight** — count of \`active\` + \`submitted\`; meta sums escrow currently locked grouped by asset (e.g. \`4.00 DOT locked\`). Empty states: \"no sessions observed yet\" / \"no escrow currently locked\".
- **Settled** — count + total paid-out escrow by asset; \"no settlements in scope\" when zero.
- **Avg settle time** — honest \`—\` with \"raw timestamps not exposed yet\". Computing a real median needs claimedAt → settledAt on the row adapter, which is a follow-up.
- **Open anomalies** — unchanged.

Sparklines removed from all four cards. No time-series exists yet; a flat live line beats a synthetic trending one.

## Header polish
Eyebrow → h1 → long description → scope pill was four stacked elements eating ~200px. Tightens to: eyebrow → h1 + scope pill inline → one-line description. Operator-wide hint now reads as a label on the title rather than a dangling chip.

## Test plan
- [x] \`npm run typecheck:app\`
- [x] \`npm run build:frontend\`
- [ ] After deploy: load \`/sessions\`. With one active session, In flight = 1, Settled = 0 with \"no settlements in scope\", Avg settle time = \`—\`, Open anomalies = 0.