### PR TITLE
Real median settle time on the Sessions strip

### DIFF
--- a/app/components/sessions/SessionsAggregateStrip.tsx
+++ b/app/components/sessions/SessionsAggregateStrip.tsx
@@ -56,16 +56,7 @@ export function SessionsAggregateStrip({ sessions }: { sessions: SessionDetail[]
         }
         tone={settled.length > 0 ? "ok" : "muted"}
       />
-      <Card
-        label="Avg settle time"
-        // Median/avg requires raw claimedAt → settledAt timestamps,
-        // which the SessionRow adapter doesn't surface yet. Show an
-        // honest placeholder rather than the previous fixture
-        // "3m 12s · p50 2m40s · p95 8m02s".
-        value="—"
-        meta="raw timestamps not exposed yet"
-        tone="muted"
-      />
+      <SettleTimeCard sessions={settled} />
       <Card
         label="Open anomalies"
         value={`${anomalies.length}`}
@@ -117,6 +108,153 @@ function Card({ label, value, unit, meta, tone = "muted" }: CardProps) {
       </span>
     </article>
   );
+}
+
+/**
+ * "Avg settle time" card — derived from real claimedAt → settledAt
+ * deltas across the settled rows in scope. Falls back to an honest
+ * `—` when:
+ *   - no rows are in the `settled` state, or
+ *   - settled rows exist but the row adapter didn't surface the raw
+ *     claimedAt / settledAt pair (older sessions before the
+ *     timestamps field was plumbed; renders as "n timestamp(s) missing"
+ *     so the gap is visible to the operator).
+ *
+ * Median is the headline value (resilient to one outlier dominating
+ * the average). p50 / p95 are also surfaced when ≥ 2 / ≥ 5 settled
+ * rows are available, so an auditor can see tail latency at a glance.
+ */
+function SettleTimeCard({ sessions }: { sessions: SessionDetail[] }) {
+  if (sessions.length === 0) {
+    return (
+      <Card
+        label="Median settle time"
+        value="—"
+        meta="no settlements in scope"
+        tone="muted"
+      />
+    );
+  }
+
+  const durations: number[] = [];
+  let missing = 0;
+  for (const session of sessions) {
+    const claimed = session.timestamps?.claimedAt;
+    const settled = session.timestamps?.settledAt;
+    if (!claimed || !settled) {
+      missing += 1;
+      continue;
+    }
+    const claimedTs = Date.parse(claimed);
+    const settledTs = Date.parse(settled);
+    if (!Number.isFinite(claimedTs) || !Number.isFinite(settledTs) || settledTs < claimedTs) {
+      missing += 1;
+      continue;
+    }
+    durations.push(settledTs - claimedTs);
+  }
+
+  if (durations.length === 0) {
+    return (
+      <Card
+        label="Median settle time"
+        value="—"
+        meta={
+          missing > 0
+            ? `${missing} timestamp${missing === 1 ? "" : "s"} missing`
+            : "no settlements in scope"
+        }
+        tone="muted"
+      />
+    );
+  }
+
+  const sorted = [...durations].sort((a, b) => a - b);
+  const median = percentile(sorted, 0.5);
+  const p95 = sorted.length >= 5 ? percentile(sorted, 0.95) : undefined;
+  const headline = formatDurationCompact(median);
+  // Compose meta: "p50 14m · p95 18m" when we have enough rows,
+  // "n=1" when there's only one, plus a "k missing timestamps" tail
+  // when the adapter dropped some rows.
+  const metaParts: string[] = [];
+  if (sorted.length >= 2) metaParts.push(`p50 ${formatDurationLong(median)}`);
+  else metaParts.push(`n=${sorted.length}`);
+  if (p95 !== undefined) metaParts.push(`p95 ${formatDurationLong(p95)}`);
+  if (missing > 0) {
+    metaParts.push(
+      `${missing} missing timestamp${missing === 1 ? "" : "s"}`
+    );
+  }
+  return (
+    <Card
+      label="Median settle time"
+      value={headline.value}
+      unit={headline.unit}
+      meta={metaParts.join(" · ")}
+      tone="muted"
+    />
+  );
+}
+
+/**
+ * Linear-interpolated percentile over a sorted ascending array of
+ * durations (ms). Stable for small samples — a typical operator view
+ * has fewer than a dozen settled rows visible.
+ */
+function percentile(sortedAsc: number[], p: number): number {
+  if (sortedAsc.length === 0) return 0;
+  if (sortedAsc.length === 1) return sortedAsc[0];
+  const rank = (sortedAsc.length - 1) * p;
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  if (lo === hi) return sortedAsc[lo];
+  return sortedAsc[lo] + (sortedAsc[hi] - sortedAsc[lo]) * (rank - lo);
+}
+
+interface FormattedDuration {
+  value: string;
+  unit: string;
+}
+
+/**
+ * Compact display ("3m 12s", "14m", "2h 4m"). Drops the smaller unit
+ * once the duration crosses an hour so the headline number stays
+ * readable at the card's 2rem display weight.
+ */
+function formatDurationCompact(ms: number): FormattedDuration {
+  if (!Number.isFinite(ms) || ms < 0) return { value: "—", unit: "" };
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) {
+    return { value: `${totalSeconds}`, unit: "s" };
+  }
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes < 60) {
+    return seconds === 0
+      ? { value: `${minutes}`, unit: "m" }
+      : { value: `${minutes}m`, unit: `${seconds}s` };
+  }
+  const hours = Math.floor(minutes / 60);
+  const remMinutes = minutes % 60;
+  return remMinutes === 0
+    ? { value: `${hours}`, unit: "h" }
+    : { value: `${hours}h`, unit: `${remMinutes}m` };
+}
+
+/** Single-string variant for meta text — same buckets as the
+ *  compact formatter but as one string ("3m 12s", "14m", "2h 4m"). */
+function formatDurationLong(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "—";
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes < 60) {
+    return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const remMinutes = minutes % 60;
+  return remMinutes === 0 ? `${hours}h` : `${hours}h ${remMinutes}m`;
 }
 
 interface EscrowTotal {

--- a/app/components/sessions/types.ts
+++ b/app/components/sessions/types.ts
@@ -76,6 +76,23 @@ export interface SessionRow {
   ageStale?: boolean;
   lastEvent: { text: string; meta: string; tone?: "neutral" | "accent" | "warn" | "bad" };
   openedAt: string;
+  /**
+   * Raw ISO timestamps from the backend session record. The `openedAt`
+   * field above is a display string (e.g. "14:48 UTC"); these are the
+   * unformatted source-of-truth values aggregate views need to compute
+   * real durations like avg / p50 / p95 settle time.
+   * Optional because older sessions may not have all four fields.
+   */
+  timestamps?: {
+    claimedAt?: string;
+    submittedAt?: string;
+    /** When the session reached its terminal state (verified, settled,
+     *  rejected, slashed). Maps to `resolvedAt` on the backend, falling
+     *  back to `closedAt`. */
+    settledAt?: string;
+    /** Most-recent backend mutation; useful for "age" recomputation. */
+    updatedAt?: string;
+  };
 }
 
 export interface SessionDetail extends SessionRow {

--- a/app/lib/api/session-adapters.ts
+++ b/app/lib/api/session-adapters.ts
@@ -125,6 +125,24 @@ function timeLabel(value: unknown): string {
   }).format(parsed);
 }
 
+/**
+ * Validate that a value is a parseable ISO-8601 string and return it
+ * verbatim. Returns undefined for missing / non-string / unparseable
+ * inputs so the caller can decide whether to drop the field entirely.
+ *
+ * Aggregate views (e.g. SessionsAggregateStrip's avg settle time)
+ * read the raw ISO so they can compute durations; without this the
+ * adapter would only ship pre-formatted display strings like
+ * "May 2, 14:48".
+ */
+function stringIso(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  if (!Number.isFinite(Date.parse(trimmed))) return undefined;
+  return trimmed;
+}
+
 function ageLabel(value: unknown): string {
   const raw = text(value);
   const parsed = Date.parse(raw);
@@ -237,6 +255,23 @@ export function buildSessionDetails(sessionPayload: unknown, jobsPayload: unknow
     const currentState = state(session.status);
     const updatedAt = session.updatedAt ?? session.resolvedAt ?? session.submittedAt ?? session.claimedAt;
     const verification = asRecord(session.verification);
+    // Settled timestamp = resolvedAt (verifier produced a final
+    // outcome) and falls back to closedAt for sessions whose terminal
+    // state predates the resolvedAt rollout. Both are ISO strings on
+    // the backend payload.
+    const rawClaimedAt = stringIso(session.claimedAt);
+    const rawSubmittedAt = stringIso(session.submittedAt);
+    const rawSettledAt = stringIso(session.resolvedAt) ?? stringIso(session.closedAt);
+    const rawUpdatedAt = stringIso(session.updatedAt) ?? stringIso(updatedAt);
+    const timestamps =
+      rawClaimedAt || rawSubmittedAt || rawSettledAt || rawUpdatedAt
+        ? {
+            ...(rawClaimedAt ? { claimedAt: rawClaimedAt } : {}),
+            ...(rawSubmittedAt ? { submittedAt: rawSubmittedAt } : {}),
+            ...(rawSettledAt ? { settledAt: rawSettledAt } : {}),
+            ...(rawUpdatedAt ? { updatedAt: rawUpdatedAt } : {}),
+          }
+        : undefined;
 
     const sourceKind = sourceKindFromJob(job);
 
@@ -266,6 +301,7 @@ export function buildSessionDetails(sessionPayload: unknown, jobsPayload: unknow
         tone: currentState === "approved" || currentState === "settled" ? "accent" : currentState === "disputed" ? "warn" : "neutral",
       },
       openedAt: timeLabel(session.claimedAt),
+      ...(timestamps ? { timestamps } : {}),
       policy: text(job.outputSchemaRef, "schema pending"),
       receipt: currentState === "approved" || currentState === "settled" ? text(session.sessionId) : undefined,
       lifecycle: lifecycle(session),


### PR DESCRIPTION
Closes the \`—\` placeholder I left on the \"Avg settle time\" card in the previous strip-honesty PR.

## What changes
- **\`SessionRow\` gains an optional \`timestamps\` block**: \`claimedAt\`, \`submittedAt\`, \`settledAt\` (\`resolvedAt\` with \`closedAt\` fallback), \`updatedAt\` — raw ISO strings. The existing display fields (\`openedAt\`, \`age\`, \`lastEvent.meta\`) are unchanged; \`timestamps\` is the unformatted source-of-truth aggregate views need.
- **\`session-adapters.ts\`** reads each timestamp via a new \`stringIso\` validator (Date.parse must succeed) and only attaches the block when ≥1 field is present.
- **\`SessionsAggregateStrip\`** third card becomes \`SettleTimeCard\`:
  - headline = **median** \`claimedAt → settledAt\` duration over settled rows in scope, formatted compactly (\`3m 12s\`, \`14m\`, \`2h 4m\`)
  - meta line:
    - \`p50 X · p95 Y\` when ≥5 settled rows
    - \`p50 X\` when ≥2 settled rows
    - \`n=1\` for a single sample
    - appends \`k missing timestamp(s)\` whenever some settled rows lacked a claim/settle pair so the gap is visible
  - falls back to \`—\` / \"no settlements in scope\" or \"k timestamp(s) missing\" when nothing is computable
- Card label changes from \"Avg settle time\" to \"Median settle time\" to match the headline.
- Median is the headline (resilient to a single outlier in small samples). p95 surfaces at ≥5 rows where the tail estimate is meaningful.

## Test plan
- [x] \`npm run typecheck:app\`
- [x] \`npm run build:frontend\`
- [ ] After deploy: with the current single active session, card reads \`Median settle time / — / no settlements in scope\`. Once a settlement lands, headline switches to the real duration.