### PR TITLE
Fix overview live summary counts

### DIFF
--- a/app/app/(authed)/overview/page.tsx
+++ b/app/app/(authed)/overview/page.tsx
@@ -20,6 +20,7 @@ import {
   useAlerts,
   useHealth,
   useJobs,
+  usePolicies,
   useProviderOperations,
   usePublicProviderOperations,
   useStrategyPositions,
@@ -29,6 +30,7 @@ import { extractRunJobs } from "@/lib/api/run-adapters";
 import { buildProviderOperations } from "@/lib/api/provider-operations";
 import {
   buildJobLifecycleSummary,
+  buildPublicJobLifecycleSummary,
   EMPTY_JOB_LIFECYCLE_SUMMARY,
 } from "@/lib/api/job-lifecycle";
 import {
@@ -44,6 +46,7 @@ export default function OverviewPage() {
   const strategyPositions = useStrategyPositions();
   const health = useHealth();
   const apiAlerts = useAlerts();
+  const policies = usePolicies();
   const providerOps = useProviderOperations();
   const publicProviderOps = usePublicProviderOperations();
 
@@ -75,12 +78,34 @@ export default function OverviewPage() {
     () => buildLaneCards(jobs.data, sessions.data, strategyPositions.data),
     [jobs.data, sessions.data, strategyPositions.data]
   );
+  const policiesAppliedToday = useMemo(
+    () => countPoliciesAppliedToday(policies.data),
+    [policies.data]
+  );
   const liveJobs = extractRunJobs(jobs.data);
-  const lifecycleSummary = useMemo(
+  const adminLifecycleSummary = useMemo(
     () => buildJobLifecycleSummary(providerOps.data),
     [providerOps.data]
   );
+  const publicLifecycleSummary = useMemo(
+    () => buildPublicJobLifecycleSummary(jobs.data),
+    [jobs.data]
+  );
+  const hasAdminLifecycleData = adminLifecycleSummary.total > 0;
+  const hasPublicLifecycleData = publicLifecycleSummary.total > 0;
+  const lifecycleSummary = hasAdminLifecycleData
+    ? adminLifecycleSummary
+    : hasPublicLifecycleData
+      ? publicLifecycleSummary
+      : EMPTY_JOB_LIFECYCLE_SUMMARY;
   const hasLifecycleData = lifecycleSummary.total > 0;
+  const lifecycleMeta = hasAdminLifecycleData
+    ? "live API · /admin/status"
+    : hasPublicLifecycleData
+      ? "live API · /jobs"
+      : jobs.isLoading
+        ? "waiting for live API"
+        : "no jobs yet";
   const liveProviderOps = useMemo(
     () => buildProviderOperations(providerOps.data ?? publicProviderOps.data),
     [providerOps.data, publicProviderOps.data]
@@ -101,6 +126,7 @@ export default function OverviewPage() {
     strategyPositions,
     health,
     apiAlerts,
+    policies,
     providerOps,
     publicProviderOps
   );
@@ -117,12 +143,12 @@ export default function OverviewPage() {
         awaitingSignature={hasLiveOverview ? disputedSessions : 0}
         lastReceiptTime={health.data ? "live" : "unavailable"}
         treasuryPosture={liveVitals[3]?.value === "Amber" ? "Amber" : "Green"}
-        policiesAppliedToday={hasLiveOverview ? liveLanes.length : 0}
+        policiesAppliedToday={policiesAppliedToday}
       />
       <RoomVitals vitals={vitals} comparedTo={hasLiveOverview ? "live API" : "waiting for live API"} />
       <JobLifecycleStrip
         summary={hasLifecycleData ? lifecycleSummary : EMPTY_JOB_LIFECYCLE_SUMMARY}
-        meta={hasLifecycleData ? "live API · /admin/status" : "no jobs yet"}
+        meta={lifecycleMeta}
       />
       <NeedsActionList alerts={alerts} meta={`${alerts.length} open`} />
       <LaneStatusGrid lanes={lanes} meta={hasLiveOverview ? "live API snapshot" : undefined} />
@@ -162,6 +188,31 @@ function extractAlerts(data: unknown): AlertItem[] {
       alerts.push(alert);
       return alerts;
     }, []);
+}
+
+function countPoliciesAppliedToday(data: unknown): number {
+  if (!Array.isArray(data)) return 0;
+  const today = new Date().toISOString().slice(0, 10);
+  return data.reduce((count, item) => {
+    if (!item || typeof item !== "object") return count;
+    const record = item as Record<string, unknown>;
+    if (text(record.state, "").toLowerCase() !== "active") return count;
+    const lastChange = record.lastChange;
+    const lastChangeRecord =
+      lastChange && typeof lastChange === "object"
+        ? (lastChange as Record<string, unknown>)
+        : undefined;
+    const dates = [record.activeSince, lastChangeRecord?.at];
+    return dates.some((date) => isSameUtcDate(date, today)) ? count + 1 : count;
+  }, 0);
+}
+
+function isSameUtcDate(value: unknown, today: string): boolean {
+  if (typeof value !== "string" || !value.trim()) return false;
+  const match = value.match(/\d{4}-\d{2}-\d{2}/);
+  if (match) return match[0] === today;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) && new Date(parsed).toISOString().slice(0, 10) === today;
 }
 
 function text(value: unknown, fallback: string): string {

--- a/app/lib/api/job-lifecycle.ts
+++ b/app/lib/api/job-lifecycle.ts
@@ -74,6 +74,52 @@ export function buildJobLifecycleSummary(payload: unknown): JobLifecycleSummary 
   };
 }
 
+/**
+ * Derive a public lifecycle summary from `/jobs` rows. This is intentionally
+ * a fallback for signed-out overview pages: `/admin/status` remains the richer
+ * operator source, but public jobs are enough to avoid showing an all-zero
+ * lifecycle strip while the queue visibly contains open work.
+ */
+export function buildPublicJobLifecycleSummary(payload: unknown): JobLifecycleSummary {
+  const jobs = extractJobRows(payload);
+  if (!jobs.length) return EMPTY_JOB_LIFECYCLE_SUMMARY;
+
+  return jobs.reduce<JobLifecycleSummary>((summary, job) => {
+    const lifecycle = asRecord(job.lifecycle);
+    const status = text(lifecycle?.status) || text(job.status);
+    const state = text(lifecycle?.state) || text(job.state) || status || "open";
+    const effectiveState = text(job.effectiveState);
+    const claimable =
+      job.claimable === true ||
+      effectiveState === "claimable" ||
+      (!effectiveState && state === "open");
+
+    summary.total += 1;
+    if (
+      status === "open" ||
+      state === "open" ||
+      state === "ready" ||
+      state === "claimable" ||
+      effectiveState === "claimable"
+    ) {
+      summary.open += 1;
+    }
+    if (claimable) {
+      summary.claimable += 1;
+    }
+    if (state === "stale") {
+      summary.stale += 1;
+    }
+    if (status === "paused" || state === "paused") {
+      summary.paused += 1;
+    }
+    if (status === "archived" || state === "archived") {
+      summary.archived += 1;
+    }
+    return summary;
+  }, { ...EMPTY_JOB_LIFECYCLE_SUMMARY });
+}
+
 /** Pull a single job's lifecycle block off a raw job object. */
 export function buildJobLifecycle(raw: unknown): JobLifecycle | undefined {
   const record = asRecord(raw);
@@ -169,6 +215,15 @@ export function extractAdminJobs(payload: unknown): unknown[] {
   if (!root) return [];
   if (Array.isArray(root.jobs)) return root.jobs;
   return [];
+}
+
+function extractJobRows(payload: unknown): Record<string, unknown>[] {
+  if (Array.isArray(payload)) {
+    return payload.map(asRecord).filter(Boolean) as Record<string, unknown>[];
+  }
+  const root = asRecord(payload);
+  if (!root || !Array.isArray(root.jobs)) return [];
+  return root.jobs.map(asRecord).filter(Boolean) as Record<string, unknown>[];
 }
 
 /**


### PR DESCRIPTION
## What changed
- Use the public /jobs feed as the signed-out fallback for the Overview job lifecycle strip instead of showing all-zero lifecycle counts when /admin/status is unavailable.
- Replace the Overview hero's placeholder policies-applied-today count with a real /policies-derived UTC-day count.
- Keep the lifecycle metadata honest by labeling whether counts came from /admin/status, /jobs, or are still loading.

## Checks run
- npm run typecheck:app
- npm run build:frontend
- git diff --check

## Impact
- Frontend/operator app only.
- No backend, indexer, Caddy, contracts, public site, or environment changes.