### PR TITLE
Add job session timeline endpoint

### DIFF
--- a/mcp-server/src/auth/capabilities.js
+++ b/mcp-server/src/auth/capabilities.js
@@ -34,6 +34,7 @@ const ROLE_CAPABILITIES = {
     "jobs:fire-recurring",
     "jobs:pause-recurring",
     "jobs:resume-recurring",
+    "jobs:timeline",
     "subjobs:create",
     "xcm:observe",
     "xcm:finalize"
@@ -99,6 +100,7 @@ export function capabilityMatrix() {
       "/admin/jobs/fire": ["jobs:fire-recurring"],
       "/admin/jobs/pause": ["jobs:pause-recurring"],
       "/admin/jobs/resume": ["jobs:resume-recurring"],
+      "/admin/jobs/timeline": ["jobs:timeline"],
       "/admin/xcm/observe": ["xcm:observe"],
       "/admin/xcm/finalize": ["xcm:finalize"],
       "/verifier/handlers": ["verifier:handlers:read"],

--- a/mcp-server/src/auth/capabilities.test.js
+++ b/mcp-server/src/auth/capabilities.test.js
@@ -14,6 +14,7 @@ test("resolveCapabilities expands admin and verifier capabilities", () => {
   const capabilities = resolveCapabilities({ roles: ["admin", "verifier"] });
   assert.ok(capabilities.includes("jobs:create"));
   assert.ok(capabilities.includes("jobs:pause-recurring"));
+  assert.ok(capabilities.includes("jobs:timeline"));
   assert.ok(capabilities.includes("verifier:run"));
   assert.ok(capabilities.includes("subjobs:create"));
   assert.ok(capabilities.includes("xcm:observe"));
@@ -29,6 +30,7 @@ test("capabilityMatrix exposes base and role capability groups", () => {
   assert.ok(matrix.roles.admin.includes("xcm:finalize"));
   assert.ok(matrix.roles.verifier.includes("verifier:replay"));
   assert.deepEqual(matrix.routes["/admin/jobs/pause"], ["jobs:pause-recurring"]);
+  assert.deepEqual(matrix.routes["/admin/jobs/timeline"], ["jobs:timeline"]);
   assert.deepEqual(matrix.routes["/admin/xcm/observe"], ["xcm:observe"]);
   assert.deepEqual(matrix.routes["/admin/xcm/finalize"], ["xcm:finalize"]);
 });

--- a/mcp-server/src/core/discovery-manifest.js
+++ b/mcp-server/src/core/discovery-manifest.js
@@ -40,6 +40,7 @@ const DISCOVERY_AUTHENTICATED_ENDPOINTS = [
   { path: "/reputation", description: "Current reputation scores + tier." },
   { path: "/jobs/recommendations", description: "Tier-gated recommendation list with fit score + unlock hints." },
   { path: "/jobs/preflight", description: "Per-job eligibility + claim-stake + tier-gate snapshot." },
+  { path: "/admin/jobs/timeline", description: "Admin-gated job/session timeline and lineage endpoint." },
   { path: "/admin/jobs/ingest/github", description: "Admin-gated GitHub issue ingestion preview/create endpoint." },
   { path: "/admin/jobs/ingest/open-data", description: "Admin-gated Data.gov open-data quality audit ingestion preview/create endpoint." },
   { path: "/admin/jobs/ingest/osv", description: "Admin-gated OSV npm advisory ingestion preview/create endpoint." },

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -11,7 +11,7 @@ import {
   getSessionStateMachineDefinition
 } from "./session-state-machine.js";
 import { computeClaimEconomics, countClaimedSessions } from "./claim-economics.js";
-import { claimStatusFields, summarizeJobClaimState } from "./claim-state.js";
+import { claimStatusFields, isTerminalSession, summarizeJobClaimState } from "./claim-state.js";
 
 const STARTER_REPUTATION = {
   skill: 0,
@@ -598,6 +598,99 @@ export class PlatformService {
     };
   }
 
+  async getJobTimeline(jobId, { wallet = undefined, now = new Date(), limit = 100 } = {}) {
+    const baseJob = this.jobCatalogService.getJobDefinition(jobId);
+    const [job, sessions] = await Promise.all([
+      this.attachClaimState(baseJob, { wallet, now }),
+      this.jobExecutionService.listSessionHistory({ jobId, limit })
+    ]);
+
+    const childRunsBySession = await Promise.all(
+      sessions.map(async (session) => {
+        const childJobs = this.jobCatalogService.listJobsByParentSession(session.sessionId);
+        const childRuns = await Promise.all(
+          childJobs.map(async (childJob) => ({
+            job: childJob,
+            sessions: await this.jobExecutionService.listSessionHistory({ jobId: childJob.id, limit: 10 })
+          }))
+        );
+        return { session, childRuns };
+      })
+    );
+    const childRuns = childRunsBySession.flatMap(({ childRuns: runs }) => runs);
+    const childJobs = childRuns.map(({ job }) => job);
+    const childSessions = childRuns.flatMap(({ sessions: childSessionRows }) => childSessionRows);
+    const derivativeJobs = job.recurring
+      ? this.jobCatalogService
+          .listJobs({ includePaused: true, includeArchived: true, includeStale: true, now })
+          .filter((candidate) => candidate.templateId === job.id)
+      : [];
+    const parentSession = job.parentSessionId
+      ? await this.stateStore.getSession?.(job.parentSessionId)
+      : undefined;
+    const eventBusReplay = this.eventBus?.replay?.({ jobId }, undefined) ?? { events: [], gap: false };
+
+    const sessionEvents = sessions.flatMap((session) => buildSessionTimelineEntries(session));
+    const verificationEvents = sessions
+      .map((session) => buildVerificationTimelineEntry(session))
+      .filter(Boolean);
+    const childEvents = childRuns.flatMap(({ job: childJob, sessions: childSessionRows }) => ([
+      buildChildJobTimelineEntry(childJob),
+      ...childSessionRows.map((childSession) => buildChildSessionTimelineEntry(childSession))
+    ]));
+    const derivativeEvents = derivativeJobs.map((derivative) => buildDerivativeJobTimelineEntry(derivative));
+    const eventBusEvents = eventBusReplay.events.map((event, index) => buildEventBusTimelineEntry(event, index));
+
+    const timeline = [
+      buildJobStateTimelineEntry(job, sessions),
+      ...sessionEvents,
+      ...verificationEvents,
+      ...childEvents,
+      ...derivativeEvents,
+      ...eventBusEvents
+    ]
+      .filter(Boolean)
+      .sort(compareTimelineEntries);
+
+    return {
+      timelineVersion: "v2",
+      job,
+      lineage: {
+        templateId: job.templateId ?? null,
+        recurringTemplate: Boolean(job.recurring),
+        derivativeJobIds: derivativeJobs.map((derivative) => derivative.id),
+        parentSessionId: job.parentSessionId ?? null,
+        parentSession: parentSession
+          ? {
+              sessionId: parentSession.sessionId,
+              jobId: parentSession.jobId,
+              wallet: parentSession.wallet,
+              status: parentSession.status,
+              updatedAt: parentSession.updatedAt
+            }
+          : null,
+        sessionIds: sessions.map((session) => session.sessionId),
+        childJobIds: childJobs.map((childJob) => childJob.id),
+        childSessionIds: childSessions.map((childSession) => childSession.sessionId)
+      },
+      summary: {
+        sessionCount: sessions.length,
+        activeSessionIds: sessions
+          .filter((session) => !isTerminalSession(session))
+          .map((session) => session.sessionId),
+        terminalSessionIds: sessions
+          .filter((session) => isTerminalSession(session))
+          .map((session) => session.sessionId),
+        childJobCount: childJobs.length,
+        derivativeJobCount: derivativeJobs.length,
+        eventCount: timeline.length,
+        eventBusGap: Boolean(eventBusReplay.gap),
+        latestSessionStatus: sessions[0]?.status ?? null
+      },
+      timeline
+    };
+  }
+
   async collectSessionHistory(wallet, options = {}) {
     return this.jobExecutionService.collectSessionHistory(wallet, options);
   }
@@ -820,6 +913,188 @@ export class PlatformService {
       providerOperations: sanitizeProviderOperations(providerOperations)
     };
   }
+}
+
+function buildJobStateTimelineEntry(job, sessions) {
+  return {
+    id: `${job.id}:job-state`,
+    type: "job_state",
+    at: firstDefined(job.lifecycle?.updatedAt, job.createdAt, job.firedAt, sessions[0]?.updatedAt),
+    correlationId: job.id,
+    phase: "job",
+    data: compactTimelineData({
+      jobId: job.id,
+      category: job.category,
+      tier: job.tier,
+      verifierMode: job.verifierMode,
+      lifecycle: job.lifecycle,
+      claimState: job.claimState,
+      effectiveState: job.effectiveState,
+      claimable: job.claimable,
+      reason: job.reason,
+      sessionId: job.sessionId,
+      claimedBy: job.claimedBy,
+      claimExpiresAt: job.claimExpiresAt
+    })
+  };
+}
+
+function buildSessionTimelineEntries(session) {
+  const history = Array.isArray(session.statusHistory) ? session.statusHistory : [];
+  if (!history.length) {
+    return [{
+      id: `${session.sessionId}:session-snapshot`,
+      type: "session_snapshot",
+      at: firstDefined(session.updatedAt, session.claimedAt),
+      correlationId: session.sessionId,
+      phase: describeSessionStatus(session.status).phase,
+      data: compactTimelineData({
+        sessionId: session.sessionId,
+        jobId: session.jobId,
+        wallet: session.wallet,
+        status: session.status
+      })
+    }];
+  }
+  return history.map((entry, index) => ({
+    id: `${session.sessionId}:transition:${index}`,
+    type: "session_transition",
+    at: entry.at,
+    correlationId: session.sessionId,
+    phase: describeSessionStatus(entry.to).phase,
+    data: {
+      sessionId: session.sessionId,
+      jobId: session.jobId,
+      wallet: session.wallet,
+      ...entry
+    }
+  }));
+}
+
+function buildVerificationTimelineEntry(session) {
+  const verification = session.verification ?? session.verificationSummary;
+  if (!verification) {
+    return undefined;
+  }
+  return {
+    id: `${session.sessionId}:verification`,
+    type: "verification",
+    at: firstDefined(
+      verification.session?.updatedAt,
+      verification.session?.resolvedAt,
+      session.resolvedAt,
+      session.updatedAt
+    ),
+    correlationId: session.sessionId,
+    phase: "verification",
+    data: compactTimelineData({
+      sessionId: session.sessionId,
+      jobId: session.jobId,
+      outcome: verification.outcome,
+      reasonCode: verification.reasonCode,
+      handler: verification.handler,
+      handlerVersion: verification.handlerVersion,
+      verifierConfigVersion: verification.verifierConfigVersion
+    })
+  };
+}
+
+function buildChildJobTimelineEntry(job) {
+  return {
+    id: `${job.id}:child-job`,
+    type: "child_job",
+    at: firstDefined(job.createdAt, job.firedAt, job.lifecycle?.updatedAt),
+    correlationId: job.parentSessionId ?? job.id,
+    phase: "child_job",
+    data: compactTimelineData({
+      jobId: job.id,
+      parentSessionId: job.parentSessionId,
+      category: job.category,
+      tier: job.tier,
+      verifierMode: job.verifierMode,
+      lifecycle: job.lifecycle
+    })
+  };
+}
+
+function buildChildSessionTimelineEntry(session) {
+  return {
+    id: `${session.sessionId}:child-session`,
+    type: "child_session",
+    at: firstDefined(session.updatedAt, session.claimedAt),
+    correlationId: session.sessionId,
+    phase: describeSessionStatus(session.status).phase,
+    data: compactTimelineData({
+      sessionId: session.sessionId,
+      jobId: session.jobId,
+      wallet: session.wallet,
+      status: session.status
+    })
+  };
+}
+
+function buildDerivativeJobTimelineEntry(job) {
+  return {
+    id: `${job.id}:derivative-job`,
+    type: "derivative_job",
+    at: firstDefined(job.firedAt, job.createdAt, job.lifecycle?.updatedAt),
+    correlationId: job.templateId ?? job.id,
+    phase: "recurring",
+    data: compactTimelineData({
+      jobId: job.id,
+      templateId: job.templateId,
+      firedAt: job.firedAt,
+      category: job.category,
+      tier: job.tier,
+      lifecycle: job.lifecycle
+    })
+  };
+}
+
+function buildEventBusTimelineEntry(event, index) {
+  return {
+    id: event.id ?? `event-bus:${index}`,
+    type: "event_bus",
+    at: event.timestamp,
+    correlationId: event.sessionId ?? event.jobId,
+    phase: event.topic,
+    data: compactTimelineData({
+      topic: event.topic,
+      jobId: event.jobId,
+      sessionId: event.sessionId,
+      wallet: event.wallet,
+      blockNumber: event.blockNumber,
+      txHash: event.txHash,
+      ...event.data
+    })
+  };
+}
+
+function compareTimelineEntries(left, right) {
+  const leftTime = timelineTime(left.at);
+  const rightTime = timelineTime(right.at);
+  if (leftTime !== rightTime) {
+    return leftTime - rightTime;
+  }
+  return String(left.id ?? "").localeCompare(String(right.id ?? ""));
+}
+
+function timelineTime(value) {
+  if (!value) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : Number.MAX_SAFE_INTEGER;
+}
+
+function firstDefined(...values) {
+  return values.find((value) => value !== undefined && value !== null) ?? null;
+}
+
+function compactTimelineData(value) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined)
+  );
 }
 
 /**

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -2,10 +2,11 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { PlatformService } from "./platform-service.js";
+import { EventBus } from "./event-bus.js";
 
 const WALLET = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
-function makePlatformService(blockchainGateway = undefined) {
+function makePlatformService(blockchainGateway = undefined, eventBus = undefined) {
   const jobs = [
     {
       id: "parent-job-001",
@@ -53,7 +54,7 @@ function makePlatformService(blockchainGateway = undefined) {
   const reputations = new Map([
     [WALLET, { skill: 50, reliability: 50, economic: 50, tier: "starter" }]
   ]);
-  return new PlatformService(jobs, profiles, accounts, reputations, blockchainGateway);
+  return new PlatformService(jobs, profiles, accounts, reputations, blockchainGateway, undefined, eventBus);
 }
 
 test("createSubJob links the child job to the active parent session", async () => {
@@ -183,6 +184,48 @@ test("getSessionTimeline includes transitions and verification state", async () 
   assert.ok(timeline.timeline.some((entry) => entry.type === "session_transition"));
   assert.ok(timeline.timeline.some((entry) => entry.type === "verification"));
   assert.ok(timeline.timeline.every((entry) => entry.correlationId === submitted.sessionId));
+});
+
+test("getJobTimeline stitches sessions, verification, events, and child lineage", async () => {
+  const eventBus = new EventBus();
+  const service = makePlatformService(undefined, eventBus);
+  const session = await service.claimJob(WALLET, "parent-job-001", "http", "job-timeline-claim");
+  const subJob = await service.createSubJob(session.sessionId, WALLET, {
+    id: "timeline-child-job-001",
+    category: "review",
+    tier: "starter",
+    rewardAmount: 2,
+    verifierMode: "benchmark",
+    verifierTerms: ["summary"],
+    verifierMinimumMatches: 1,
+    inputSchemaRef: "schema://jobs/review-input",
+    outputSchemaRef: "schema://jobs/pr-review-findings-output",
+    claimTtlSeconds: 1800,
+    retryLimit: 1,
+    requiresSponsoredGas: true
+  });
+  const submitted = await service.submitWork(session.sessionId, "http", "complete");
+  await service.ingestVerification(submitted.sessionId, {
+    jobId: submitted.jobId,
+    handler: "benchmark",
+    handlerVersion: 1,
+    outcome: "approved",
+    reasonCode: "BENCHMARK_THRESHOLD_MET"
+  });
+
+  const timeline = await service.getJobTimeline("parent-job-001", { wallet: WALLET });
+  assert.equal(timeline.timelineVersion, "v2");
+  assert.equal(timeline.job.id, "parent-job-001");
+  assert.equal(timeline.job.claimState, "exhausted");
+  assert.equal(timeline.summary.sessionCount, 1);
+  assert.equal(timeline.summary.childJobCount, 1);
+  assert.deepEqual(timeline.lineage.sessionIds, [submitted.sessionId]);
+  assert.deepEqual(timeline.lineage.childJobIds, [subJob.id]);
+  assert.ok(timeline.timeline.some((entry) => entry.type === "job_state"));
+  assert.ok(timeline.timeline.some((entry) => entry.type === "session_transition" && entry.data.to === "submitted"));
+  assert.ok(timeline.timeline.some((entry) => entry.type === "verification"));
+  assert.ok(timeline.timeline.some((entry) => entry.type === "child_job"));
+  assert.ok(timeline.timeline.some((entry) => entry.type === "event_bus" && entry.data.topic === "session.claimed"));
 });
 
 test("getAdminStatus surfaces recurring scheduler anomalies", async () => {

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -980,6 +980,7 @@ function metricPathLabel(pathname) {
     "/session/state-machine",
     "/strategies",
     "/admin/jobs",
+    "/admin/jobs/timeline",
     "/admin/sessions",
     "/admin/jobs/ingest/github",
     "/admin/jobs/ingest/openapi",
@@ -1273,6 +1274,7 @@ const server = createServer(async (request, response) => {
           "/verifier/handlers",
           "/verifier/replay",
           "/admin/jobs",
+          "/admin/jobs/timeline",
           "/admin/sessions",
           "/admin/jobs/ingest/github",
           "/admin/jobs/ingest/openapi",
@@ -1384,6 +1386,23 @@ const server = createServer(async (request, response) => {
         }),
         jobLifecycle: service.getJobLifecycleSummary()
       });
+    }
+
+    if (request.method === "GET" && pathname === "/admin/jobs/timeline") {
+      const auth = await authMiddleware(request, url, { requireRole: "admin" });
+      await enforceLimit("admin_jobs", auth.wallet, rateLimitConfig.adminJobs);
+      const jobId = url.searchParams.get("jobId") ?? "";
+      if (!jobId.trim()) {
+        throw new ValidationError("jobId is required.");
+      }
+      return respond(
+        response,
+        200,
+        await service.getJobTimeline(jobId.trim(), {
+          wallet: auth.wallet,
+          limit: parseLimit(url, 100, 250)
+        })
+      );
     }
 
     if (request.method === "GET" && pathname === "/admin/sessions") {

--- a/mcp-server/src/protocols/http/server.smoke.test.js
+++ b/mcp-server/src/protocols/http/server.smoke.test.js
@@ -161,6 +161,38 @@ test("http smoke: /admin/jobs accepts admin-scoped token", { skip: !RUN }, async
   });
 });
 
+test("http smoke: /admin/jobs/timeline exposes job lineage", { skip: !RUN }, async () => {
+  await runWithServer(async (base) => {
+    const token = issueToken(ADMIN_WALLET, { roles: ["admin"] });
+    const jobId = "smoke-job-timeline-001";
+    const create = await fetch(`${base}/admin/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        id: jobId,
+        category: "coding",
+        tier: "starter",
+        rewardAmount: 1,
+        verifierMode: "benchmark",
+        verifierTerms: ["complete"],
+        verifierMinimumMatches: 1,
+        outputSchemaRef: "schema://jobs/smoke-output"
+      })
+    });
+    assert.equal(create.status, 201);
+
+    const response = await fetch(`${base}/admin/jobs/timeline?jobId=${jobId}`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.timelineVersion, "v2");
+    assert.equal(payload.job.id, jobId);
+    assert.deepEqual(payload.lineage.sessionIds, []);
+    assert.ok(payload.timeline.some((entry) => entry.type === "job_state"));
+  });
+});
+
 test("http smoke: /admin/sessions exposes operator-wide session activity", { skip: !RUN }, async () => {
   await runWithServer(async (base) => {
     const adminToken = issueToken(ADMIN_WALLET, { roles: ["admin"] });


### PR DESCRIPTION
## What changed
- Added `PlatformService.getJobTimeline()` to stitch job claim state, sessions, verification, child-job lineage, recurring derivatives, and event-bus events into one operator-facing timeline.
- Exposed `GET /admin/jobs/timeline?jobId=...` behind the admin role and added it to capability/discovery surfaces.
- Covered the service and HTTP route with unit/smoke tests.

## Checks run
- `npm --workspace mcp-server test`
- `RUN_HTTP_SMOKE=1 node --test mcp-server/src/protocols/http/server.smoke.test.js`
- `git diff --check`

## Impact
- Backend/API only. No frontend, indexer, contracts, Caddy, or public-site changes.
- No environment or VPS secret changes required.