### PR TITLE
Fix two layout bugs on /runs (submit button squash, queue meta overflow)

### DIFF
--- a/app/components/runs/LoadedRunPanel.tsx
+++ b/app/components/runs/LoadedRunPanel.tsx
@@ -377,48 +377,59 @@ export function LoadedRunPanel(props: LoadedRunPanelProps) {
             </div>
           )}
 
-          {/* Submit */}
-          <div className="flex items-center justify-between gap-3 rounded-[8px] border border-[var(--avy-line)] bg-[#fffdf7] px-3.5 py-3">
-            <p
-              className="m-0 flex-1 min-w-0 font-[family-name:var(--font-mono)] text-[11px] leading-[1.4] text-[var(--avy-muted)]"
-              style={{ letterSpacing: 0 }}
-            >
-              {props.submission.note}
-            </p>
-            <button
-              type="button"
-              disabled={
-                props.submission.submitting || Boolean(props.submission.disabledReason)
-              }
-              onClick={() => {
-                props.submission.onSubmit?.(evidenceValue);
-              }}
-              className="inline-flex h-9 shrink-0 items-center gap-2 whitespace-nowrap rounded-[8px] bg-[var(--avy-accent)] px-3.5 font-[family-name:var(--font-display)] text-[11.5px] font-bold uppercase text-[var(--fg-invert)] transition-transform hover:-translate-y-px hover:bg-[var(--avy-accent-2)] disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:translate-y-0 disabled:hover:bg-[var(--avy-accent)]"
-              style={{ letterSpacing: "0.04em" }}
-              title={props.submission.disabledReason}
-            >
-              {props.submission.submitting ? "Submitting..." : props.submission.cta}
-              <span
-                className="rounded-[3px] bg-black/20 px-1.5 py-px font-[family-name:var(--font-mono)] text-[10.5px] font-medium text-white/70"
+          {/* Submit
+              ─────────────────────────────────────────────────
+              The note and the button live on row 1; the disabled
+              hint / error line sits on row 2 below them. The previous
+              layout flattened all three into a single flex row with
+              `justify-between`, which squashed the button between the
+              note (flex-1) and the disabledReason text whenever the
+              disabledReason was set — visible on signed-out viewers
+              loading a claimable run. Stacking keeps the button at
+              its natural width regardless of whether a hint is shown. */}
+          <div className="rounded-[8px] border border-[var(--avy-line)] bg-[#fffdf7] px-3.5 py-3">
+            <div className="flex items-center justify-between gap-3">
+              <p
+                className="m-0 min-w-0 flex-1 font-[family-name:var(--font-mono)] text-[11px] leading-[1.4] text-[var(--avy-muted)]"
                 style={{ letterSpacing: 0 }}
               >
-                ⏎
-              </span>
-            </button>
+                {props.submission.note}
+              </p>
+              <button
+                type="button"
+                disabled={
+                  props.submission.submitting || Boolean(props.submission.disabledReason)
+                }
+                onClick={() => {
+                  props.submission.onSubmit?.(evidenceValue);
+                }}
+                className="inline-flex h-9 shrink-0 items-center gap-2 whitespace-nowrap rounded-[8px] bg-[var(--avy-accent)] px-3.5 font-[family-name:var(--font-display)] text-[11.5px] font-bold uppercase text-[var(--fg-invert)] transition-transform hover:-translate-y-px hover:bg-[var(--avy-accent-2)] disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:translate-y-0 disabled:hover:bg-[var(--avy-accent)]"
+                style={{ letterSpacing: "0.04em" }}
+                title={props.submission.disabledReason}
+              >
+                {props.submission.submitting ? "Submitting..." : props.submission.cta}
+                <span
+                  className="rounded-[3px] bg-black/20 px-1.5 py-px font-[family-name:var(--font-mono)] text-[10.5px] font-medium text-white/70"
+                  style={{ letterSpacing: 0 }}
+                >
+                  ⏎
+                </span>
+              </button>
+            </div>
             {props.submission.disabledReason ? (
-              <span
-                className="font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
+              <p
+                className="m-0 mt-2 font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
                 style={{ letterSpacing: 0 }}
               >
                 {props.submission.disabledReason}
-              </span>
+              </p>
             ) : props.submission.error ? (
-              <span
-                className="font-[family-name:var(--font-mono)] text-[11px] text-[#8c2a17]"
+              <p
+                className="m-0 mt-2 font-[family-name:var(--font-mono)] text-[11px] text-[#8c2a17]"
                 style={{ letterSpacing: 0 }}
               >
                 {props.submission.error}
-              </span>
+              </p>
             ) : null}
           </div>
         </div>

--- a/app/components/runs/RunQueueTable.tsx
+++ b/app/components/runs/RunQueueTable.tsx
@@ -193,7 +193,7 @@ function RunRowCard({
                     </span>
                   </span>
                   <span className="shrink-0 opacity-40">·</span>
-                  <span className="shrink-0 whitespace-nowrap">
+                  <span className="min-w-0 truncate whitespace-nowrap">
                     {row.jobMeta}
                   </span>
                 </>
@@ -207,7 +207,7 @@ function RunRowCard({
                     </span>
                   </span>
                   <span className="shrink-0 opacity-40">·</span>
-                  <span className="shrink-0 whitespace-nowrap">
+                  <span className="min-w-0 truncate whitespace-nowrap">
                     {row.jobMeta}
                   </span>
                 </>
@@ -227,7 +227,7 @@ function RunRowCard({
                     </span>
                   </span>
                   <span className="shrink-0 opacity-40">·</span>
-                  <span className="shrink-0 whitespace-nowrap">
+                  <span className="min-w-0 truncate whitespace-nowrap">
                     {row.jobMeta}
                   </span>
                 </>
@@ -238,7 +238,7 @@ function RunRowCard({
                     {row.source.datasetTitle}
                   </span>
                   <span className="shrink-0 opacity-40">·</span>
-                  <span className="shrink-0 truncate whitespace-nowrap">
+                  <span className="min-w-0 truncate whitespace-nowrap">
                     {row.jobMeta}
                   </span>
                 </>
@@ -252,7 +252,7 @@ function RunRowCard({
                     </span>
                   </span>
                   <span className="shrink-0 opacity-40">·</span>
-                  <span className="shrink-0 truncate whitespace-nowrap">
+                  <span className="min-w-0 truncate whitespace-nowrap">
                     {row.jobMeta}
                   </span>
                 </>
@@ -266,7 +266,7 @@ function RunRowCard({
                     </span>
                   </span>
                   <span className="shrink-0 opacity-40">·</span>
-                  <span className="shrink-0 truncate whitespace-nowrap">
+                  <span className="min-w-0 truncate whitespace-nowrap">
                     {row.jobMeta}
                   </span>
                 </>


### PR DESCRIPTION
Two layout bugs caught from a live \`/runs\` screenshot.

## 1. Submit panel — button squashed when disabledReason is set
The submit row was a flex container with three peer children: note (flex-1), button (shrink-0), and a third sibling for the disabledReason / error hint. With \`justify-between\`, the third child stole space from the button, leaving it half-overlaid by the wrapping note text. Visible whenever a signed-out viewer loaded a claimable run (the gate I added in the live-session-lifecycle PR).

**Fix**: row 1 holds note + button; row 2 (when present) holds the disabled hint or error message. Button keeps its natural width regardless of whether a hint is shown.

## 2. Queue rows — long source-line meta overlapped the stake/age column
Each source variant rendered the meta as \`<span className=\"shrink-0 whitespace-nowrap\">{row.jobMeta}</span>\`. \`shrink-0\` blocked truncation, so for OSV (\`npm / @hono/node-server · GHSA-92pp-h63x-v22m\`), DATA.GOV (\`Data.gov · <agency> · CSV · quality audit\`), OPENAPI (\`averray · OpenAPI 3.1.0 · 10 ops · quality audit\`), and STANDARDS rows the meta pushed past the title block and bled into the right-side stake column.

**Fix**: replace \`shrink-0\` with \`min-w-0 truncate\` on the meta span in all six source branches. Identity + meta now share the available width via flex shrink — when narrow, both clip with \`…\`. Identity stays readable because it sits first.

## Test plan
- [x] \`npm run typecheck:app\`
- [x] \`npm run build:frontend\`
- [ ] After deploy: load \`/runs\` signed-out. Submit button on the loaded panel should sit at its natural width with the \"Claim this run before submitting evidence\" hint underneath. OSV / DATA.GOV / OPENAPI / STANDARDS rows should clip their meta text with \`…\` instead of bleeding into the stake column.