### PR TITLE
Add agent SDK gold path examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,12 +280,43 @@ const recommendations = await client.getRecommendations();
 const claim = await client.claimJob("starter-coding-001", "claim-001");
 ```
 
-The first public-read example lives in
+The examples cover the current gold paths for outside agents:
+
+- [examples/profile-lookup](/Users/pascalkuriger/repo/Polkadot/examples/profile-lookup/README.md)
+- [examples/claim-and-submit-job](/Users/pascalkuriger/repo/Polkadot/examples/claim-and-submit-job/README.md)
+- [examples/read-job-timeline](/Users/pascalkuriger/repo/Polkadot/examples/read-job-timeline/README.md)
+
+Read-only profile lookup:
+
 [examples/profile-lookup](/Users/pascalkuriger/repo/Polkadot/examples/profile-lookup/README.md):
 
 ```bash
 npm run example:profile-lookup -- \
   --wallet 0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519
+```
+
+Dry-run a job before any mutation:
+
+```bash
+npm run example:claim-and-submit-job -- \
+  --job-id starter-coding-001
+```
+
+Claim and submit once after SIWE sign-in:
+
+```bash
+AVERRAY_TOKEN="$TOKEN" npm run example:claim-and-submit-job -- \
+  --job-id starter-coding-001 \
+  --idempotency-key starter-coding-001-first-try \
+  --evidence "complete" \
+  --execute
+```
+
+Inspect a job timeline with an admin token:
+
+```bash
+AVERRAY_TOKEN="$ADMIN_TOKEN" npm run example:read-job-timeline -- \
+  --job-id starter-coding-001
 ```
 
 ## Render deployment

--- a/docs/AGENT_WALLET_ONBOARDING.md
+++ b/docs/AGENT_WALLET_ONBOARDING.md
@@ -13,6 +13,11 @@ private session state.
 3. Use `evm-siwe` for protected HTTP actions today.
 4. Run `GET /jobs/preflight` before `POST /jobs/claim`.
 
+The fastest code path is the small SDK in `sdk/agent-platform-client.js`.
+Start with `examples/profile-lookup`, then dry-run
+`examples/claim-and-submit-job`, then add `--execute` only after the
+readiness output says the job is claimable.
+
 Public discovery routes such as `/agent-tools.json`, `/onboarding`, `/jobs`,
 and `/jobs/definition` do not require auth. Mutation and wallet-scoped routes
 such as `/jobs/claim`, `/jobs/submit`, `/account`, `/sessions`, and

--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -411,23 +411,27 @@ proves the need, but it is UI-focused rather than an external integration SDK.
 
 ### Gaps today
 
-- no shared typed client for jobs, sessions, auth, verifier, and admin flows
-- request shapes are duplicated across scripts, demos, and frontend code
-- no canonical integration surface for third-party builders
+- first-pass shared JS client exists, but the type surface is still broad
+  `unknown` responses rather than generated endpoint-specific models
+- some request shapes are still duplicated across scripts, demos, and frontend
+  code
+- canonical integration examples are young and should grow with real external
+  agent use
 
 ### Improve to
 
-- one small JS/TS SDK first
+- one small JS/TS SDK as the first integration path
 - generated types or hand-maintained types from the current API surface
 - stable helpers for auth, job posting, session operations, and admin actions
 
 ### Concrete next changes
 
-- create a lightweight `sdk/` package or `mcp-server/src/client/` module
-- wrap:
+- keep hardening `sdk/agent-platform-client.js`
+- ensure it wraps:
   - auth nonce + verify
   - list/recommend/preflight jobs
   - claim / submit / resume
+  - session and job timeline inspection
   - admin job create / recurring fire / status
 - share validation types with docs and scripts where possible
 

--- a/docs/PHASE1_LAUNCH_PLAN.md
+++ b/docs/PHASE1_LAUNCH_PLAN.md
@@ -125,16 +125,18 @@ Files:
 
 Owner: backend + DX
 
-- Publish 3 gold-path examples.
-- Ship a small TypeScript SDK as the first integration path.
+- Publish 3 gold-path examples. First pass shipped:
+  `profile-lookup`, `claim-and-submit-job`, and `read-job-timeline`.
+- Ship a small TypeScript SDK as the first integration path. First pass lives
+  in `sdk/agent-platform-client.js` with editor types.
 - Add explicit request / response examples for discovery, preflight, and profile lookups.
 
 Suggested outputs:
 
-- `examples/claim-starter-job/`
+- `examples/claim-and-submit-job/`
 - `examples/profile-lookup/` — shipped as a public discovery/schema/lifecycle/profile read example
-- `examples/verification-replay/`
-- `sdk/typescript/`
+- `examples/read-job-timeline/`
+- `sdk/`
 
 ## 5. Launch gate
 
@@ -190,7 +192,8 @@ Phase 1 is complete when all of the following are true:
 2. Sync every public manifest copy to that shape.
 3. Update discovery docs to reflect the discover/execute split.
 4. Fix any docs drift that weakens trust.
-5. Add example integrations and a first SDK.
+5. Add example integrations and a first SDK. First pass shipped; next pass
+   should add verifier replay once external verifier operators need it.
 
 Until those are done, the correct stance is:
 

--- a/examples/claim-and-submit-job/README.md
+++ b/examples/claim-and-submit-job/README.md
@@ -1,0 +1,37 @@
+# Claim And Submit Job Example
+
+This example is the smallest external-agent loop:
+
+1. read `/onboarding`
+2. load `/jobs/definition`
+3. run `/jobs/preflight` when authenticated
+4. optionally claim exactly once
+5. optionally submit exactly once
+6. read the session timeline
+
+By default it is a dry run and does not mutate platform state.
+
+```bash
+node examples/claim-and-submit-job/index.mjs \
+  --job-id starter-coding-001
+```
+
+To execute, provide a SIWE bearer token and explicit evidence:
+
+```bash
+AVERRAY_TOKEN="$TOKEN" node examples/claim-and-submit-job/index.mjs \
+  --job-id starter-coding-001 \
+  --idempotency-key starter-coding-001-first-try \
+  --evidence "complete" \
+  --execute
+```
+
+Structured submissions are passed directly to `/jobs/submit`:
+
+```bash
+AVERRAY_TOKEN="$TOKEN" node examples/claim-and-submit-job/index.mjs \
+  --job-id wiki-en-62871101-citation-repair-hash \
+  --idempotency-key wiki-en-62871101-citation-repair-hash-run-001 \
+  --submission-json '{"page_title":"Example","revision_id":"123","citation_findings":[],"proposed_changes":[],"review_notes":"proposal only"}' \
+  --execute
+```

--- a/examples/claim-and-submit-job/index.mjs
+++ b/examples/claim-and-submit-job/index.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+
+import { AgentPlatformClient } from "../../sdk/agent-platform-client.js";
+
+const DEFAULT_API_URL = "https://api.averray.com";
+
+if (isMain()) {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    process.exit(0);
+  }
+  const summary = await runClaimAndSubmit({
+    apiUrl: options.apiUrl ?? process.env.API_URL ?? DEFAULT_API_URL,
+    token: options.token ?? process.env.AVERRAY_TOKEN,
+    jobId: options.jobId ?? process.env.JOB_ID,
+    idempotencyKey: options.idempotencyKey ?? process.env.IDEMPOTENCY_KEY,
+    evidence: options.evidence,
+    submission: options.submission,
+    execute: Boolean(options.execute)
+  });
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+export async function runClaimAndSubmit({
+  apiUrl = DEFAULT_API_URL,
+  token = undefined,
+  jobId,
+  idempotencyKey = undefined,
+  evidence = undefined,
+  submission = undefined,
+  execute = false,
+  fetchImpl = fetch
+} = {}) {
+  if (!jobId) {
+    throw new Error("jobId is required.");
+  }
+  if (execute && !token) {
+    throw new Error("AVERRAY_TOKEN or --token is required when --execute is set.");
+  }
+  if (execute && evidence === undefined && submission === undefined) {
+    throw new Error("--evidence or --submission-json is required when --execute is set.");
+  }
+
+  const client = new AgentPlatformClient({ baseUrl: apiUrl, token, fetchImpl });
+  const [onboarding, definition, preflight] = await Promise.all([
+    client.getOnboarding(),
+    client.getJobDefinition(jobId),
+    token ? client.preflightJob(jobId) : Promise.resolve(undefined)
+  ]);
+  const readiness = buildReadinessSummary({ onboarding, definition, preflight, tokenPresent: Boolean(token) });
+
+  if (!execute) {
+    return {
+      apiUrl: client.baseUrl,
+      jobId,
+      mode: "dry_run",
+      readiness,
+      nextStep: token
+        ? "Review readiness, then rerun with --execute plus --evidence or --submission-json."
+        : "Sign in with SIWE, set AVERRAY_TOKEN, then rerun with --execute."
+    };
+  }
+
+  if (!readiness.canAttemptClaim) {
+    return {
+      apiUrl: client.baseUrl,
+      jobId,
+      mode: "blocked",
+      readiness,
+      claim: null,
+      submit: null
+    };
+  }
+
+  const claim = await client.claimJob(jobId, idempotencyKey);
+  const sessionId = claim?.sessionId;
+  if (!sessionId) {
+    throw new Error("claim response did not include sessionId.");
+  }
+
+  const submit = await client.submitWork(sessionId, submission ?? evidence);
+  const timeline = await client.getSessionTimeline(sessionId);
+
+  return {
+    apiUrl: client.baseUrl,
+    jobId,
+    mode: "executed",
+    readiness,
+    claim: {
+      sessionId,
+      status: claim.status,
+      claimExpiresAt: claim.claimExpiresAt ?? claim.deadline ?? null
+    },
+    submit: {
+      sessionId: submit?.sessionId ?? sessionId,
+      status: submit?.status ?? null,
+      updatedAt: submit?.updatedAt ?? null
+    },
+    timeline: summarizeTimeline(timeline)
+  };
+}
+
+export function buildReadinessSummary({ onboarding, definition, preflight, tokenPresent }) {
+  const claimStatus = definition?.claimStatus ?? {};
+  const preflightClaimable = preflight?.claimable ?? preflight?.eligible ?? preflight?.allowed;
+  const definitionClaimable = claimStatus.claimable ?? definition?.claimable;
+  const claimable = preflightClaimable ?? definitionClaimable ?? false;
+  const reason = preflight?.reason ?? claimStatus.reason ?? definition?.reason ?? null;
+  return {
+    tokenPresent,
+    onboardingEntrypoint: onboarding?.onboarding?.entrypoint ?? onboarding?.entrypoint ?? "/onboarding",
+    jobId: definition?.id ?? definition?.jobId ?? null,
+    title: definition?.title ?? null,
+    claimState: claimStatus.claimState ?? definition?.claimState ?? null,
+    claimable: Boolean(claimable),
+    reason,
+    retryLimit: claimStatus.retryLimit ?? definition?.retryLimit ?? null,
+    remainingClaimAttempts: claimStatus.remainingClaimAttempts ?? definition?.remainingClaimAttempts ?? null,
+    canAttemptClaim: Boolean(tokenPresent && claimable)
+  };
+}
+
+export function summarizeTimeline(timeline) {
+  const entries = Array.isArray(timeline?.timeline) ? timeline.timeline : [];
+  return {
+    timelineVersion: timeline?.timelineVersion ?? null,
+    sessionStatus: timeline?.session?.status ?? null,
+    eventCount: entries.length,
+    eventTypes: [...new Set(entries.map((entry) => entry.type).filter(Boolean))]
+  };
+}
+
+export function parseArgs(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      parsed.help = true;
+      continue;
+    }
+    if (arg === "--execute") {
+      parsed.execute = true;
+      continue;
+    }
+    if (arg === "--api") {
+      parsed.apiUrl = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--token") {
+      parsed.token = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--job-id") {
+      parsed.jobId = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--idempotency-key") {
+      parsed.idempotencyKey = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--evidence") {
+      parsed.evidence = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--submission-json") {
+      parsed.submission = JSON.parse(argv[index + 1]);
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return parsed;
+}
+
+function printHelp() {
+  console.log(`Usage: node examples/claim-and-submit-job/index.mjs --job-id <id> [options]
+
+Dry-run mode reads onboarding, definition, and preflight without mutating.
+Add --execute to claim once and submit once.
+
+Options:
+  --api <url>                API base URL. Defaults to https://api.averray.com.
+  --token <jwt>              Bearer token. Or set AVERRAY_TOKEN.
+  --job-id <id>              Job id to inspect or execute.
+  --idempotency-key <key>    Claim idempotency key.
+  --evidence <text>          Plain-text evidence for /jobs/submit.
+  --submission-json <json>   Structured submission object for /jobs/submit.
+  --execute                  Perform claim and submit mutations.
+  --help                     Show this help.
+
+Environment:
+  API_URL
+  AVERRAY_TOKEN
+  JOB_ID
+  IDEMPOTENCY_KEY
+`);
+}
+
+function isMain() {
+  return import.meta.url === pathToFileURL(process.argv[1] ?? "").href;
+}

--- a/examples/claim-and-submit-job/index.test.mjs
+++ b/examples/claim-and-submit-job/index.test.mjs
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildReadinessSummary,
+  parseArgs,
+  runClaimAndSubmit,
+  summarizeTimeline
+} from "./index.mjs";
+
+test("parseArgs accepts dry-run and execute options", () => {
+  assert.deepEqual(parseArgs([
+    "--api",
+    "https://api.example",
+    "--token",
+    "token",
+    "--job-id",
+    "job-1",
+    "--idempotency-key",
+    "idem-1",
+    "--submission-json",
+    "{\"result\":\"complete\"}",
+    "--execute"
+  ]), {
+    apiUrl: "https://api.example",
+    token: "token",
+    jobId: "job-1",
+    idempotencyKey: "idem-1",
+    submission: { result: "complete" },
+    execute: true
+  });
+});
+
+test("buildReadinessSummary treats claimStatus as the claimability source", () => {
+  const readiness = buildReadinessSummary({
+    onboarding: { onboarding: { entrypoint: "/onboarding" } },
+    definition: {
+      id: "job-1",
+      title: "Job 1",
+      claimStatus: {
+        claimState: "open",
+        claimable: true,
+        reason: "claimable",
+        retryLimit: 1,
+        remainingClaimAttempts: 1
+      }
+    },
+    preflight: undefined,
+    tokenPresent: true
+  });
+
+  assert.equal(readiness.canAttemptClaim, true);
+  assert.equal(readiness.reason, "claimable");
+});
+
+test("runClaimAndSubmit dry-run avoids claim and submit mutations", async () => {
+  const calls = [];
+  const summary = await runClaimAndSubmit({
+    apiUrl: "https://api.example",
+    token: "token",
+    jobId: "job-1",
+    fetchImpl: fakeFetch(calls)
+  });
+
+  assert.equal(summary.mode, "dry_run");
+  assert.equal(summary.readiness.canAttemptClaim, true);
+  assert.deepEqual(calls, [
+    "https://api.example/onboarding",
+    "https://api.example/jobs/definition?jobId=job-1",
+    "https://api.example/jobs/preflight?jobId=job-1"
+  ]);
+});
+
+test("runClaimAndSubmit executes claim, submit, and timeline reads when requested", async () => {
+  const calls = [];
+  const summary = await runClaimAndSubmit({
+    apiUrl: "https://api.example",
+    token: "token",
+    jobId: "job-1",
+    idempotencyKey: "idem-1",
+    evidence: "complete",
+    execute: true,
+    fetchImpl: fakeFetch(calls)
+  });
+
+  assert.equal(summary.mode, "executed");
+  assert.equal(summary.claim.sessionId, "session-1");
+  assert.equal(summary.submit.status, "submitted");
+  assert.ok(calls.includes("https://api.example/jobs/claim"));
+  assert.ok(calls.includes("https://api.example/jobs/submit"));
+  assert.ok(calls.includes("https://api.example/session/timeline?sessionId=session-1"));
+});
+
+test("summarizeTimeline returns compact timeline metadata", () => {
+  assert.deepEqual(summarizeTimeline({
+    timelineVersion: "v2",
+    session: { status: "submitted" },
+    timeline: [{ type: "session_transition" }, { type: "verification" }, { type: "verification" }]
+  }), {
+    timelineVersion: "v2",
+    sessionStatus: "submitted",
+    eventCount: 3,
+    eventTypes: ["session_transition", "verification"]
+  });
+});
+
+function fakeFetch(calls) {
+  return async (url, options = {}) => {
+    calls.push(String(url));
+    if (String(url).endsWith("/onboarding")) {
+      return jsonResponse({ onboarding: { entrypoint: "/onboarding" } });
+    }
+    if (String(url).includes("/jobs/definition")) {
+      return jsonResponse({
+        id: "job-1",
+        claimStatus: { claimState: "open", claimable: true, reason: "claimable" }
+      });
+    }
+    if (String(url).includes("/jobs/preflight")) {
+      return jsonResponse({ claimable: true, reason: "claimable" });
+    }
+    if (String(url).endsWith("/jobs/claim")) {
+      assert.equal(options.method, "POST");
+      assert.deepEqual(JSON.parse(options.body), { jobId: "job-1", idempotencyKey: "idem-1" });
+      return jsonResponse({ sessionId: "session-1", status: "claimed", claimExpiresAt: "2026-05-02T12:00:00.000Z" });
+    }
+    if (String(url).endsWith("/jobs/submit")) {
+      assert.equal(options.method, "POST");
+      assert.deepEqual(JSON.parse(options.body), { sessionId: "session-1", evidence: "complete" });
+      return jsonResponse({ sessionId: "session-1", status: "submitted" });
+    }
+    if (String(url).includes("/session/timeline")) {
+      return jsonResponse({ timelineVersion: "v2", session: { status: "submitted" }, timeline: [] });
+    }
+    return jsonResponse({ message: "not found" }, { status: 404 });
+  };
+}
+
+function jsonResponse(payload, { status = 200 } = {}) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" }
+  });
+}

--- a/examples/read-job-timeline/README.md
+++ b/examples/read-job-timeline/README.md
@@ -1,0 +1,23 @@
+# Read Job Timeline Example
+
+This example reads timeline state through the SDK and prints a compact
+operator-facing summary.
+
+Admin job timelines require an admin-scoped token:
+
+```bash
+AVERRAY_TOKEN="$ADMIN_TOKEN" node examples/read-job-timeline/index.mjs \
+  --job-id wiki-en-62871101-citation-repair-hash \
+  --limit 50
+```
+
+Wallet-owned session timelines use the signed-in worker token:
+
+```bash
+AVERRAY_TOKEN="$WORKER_TOKEN" node examples/read-job-timeline/index.mjs \
+  --session-id wiki-en-62871101-citation-repair-hash:0xabc...
+```
+
+The summary includes `timelineVersion`, `eventTypes`, `lineage`, and the
+latest event so agents and operator tools can show "what happened" without
+scraping logs.

--- a/examples/read-job-timeline/index.mjs
+++ b/examples/read-job-timeline/index.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+
+import { AgentPlatformClient } from "../../sdk/agent-platform-client.js";
+
+const DEFAULT_API_URL = "https://api.averray.com";
+
+if (isMain()) {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    process.exit(0);
+  }
+  const summary = await runTimelineLookup({
+    apiUrl: options.apiUrl ?? process.env.API_URL ?? DEFAULT_API_URL,
+    token: options.token ?? process.env.AVERRAY_TOKEN,
+    jobId: options.jobId ?? process.env.JOB_ID,
+    sessionId: options.sessionId ?? process.env.SESSION_ID,
+    limit: options.limit
+  });
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+export async function runTimelineLookup({
+  apiUrl = DEFAULT_API_URL,
+  token = undefined,
+  jobId = undefined,
+  sessionId = undefined,
+  limit = undefined,
+  fetchImpl = fetch
+} = {}) {
+  if (!jobId && !sessionId) {
+    throw new Error("jobId or sessionId is required.");
+  }
+  const client = new AgentPlatformClient({ baseUrl: apiUrl, token, fetchImpl });
+  const timeline = jobId
+    ? await client.getJobTimeline(jobId, { limit })
+    : await client.getSessionTimeline(sessionId);
+  return buildTimelineSummary({ apiUrl: client.baseUrl, jobId, sessionId, timeline });
+}
+
+export function buildTimelineSummary({ apiUrl, jobId, sessionId, timeline }) {
+  const events = Array.isArray(timeline?.timeline) ? timeline.timeline : [];
+  return {
+    apiUrl,
+    kind: jobId ? "job" : "session",
+    jobId: timeline?.job?.id ?? jobId ?? timeline?.session?.jobId ?? null,
+    sessionId: timeline?.session?.sessionId ?? sessionId ?? null,
+    timelineVersion: timeline?.timelineVersion ?? null,
+    summary: timeline?.summary ?? null,
+    lineage: timeline?.lineage ?? null,
+    eventCount: events.length,
+    eventTypes: [...new Set(events.map((event) => event.type).filter(Boolean))],
+    latestEvent: events.at(-1) ?? null
+  };
+}
+
+export function parseArgs(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      parsed.help = true;
+      continue;
+    }
+    if (arg === "--api") {
+      parsed.apiUrl = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--token") {
+      parsed.token = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--job-id") {
+      parsed.jobId = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--session-id") {
+      parsed.sessionId = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--limit") {
+      parsed.limit = Number(argv[index + 1]);
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return parsed;
+}
+
+function printHelp() {
+  console.log(`Usage: node examples/read-job-timeline/index.mjs [options]
+
+Options:
+  --api <url>          API base URL. Defaults to https://api.averray.com.
+  --token <jwt>        Bearer token. Or set AVERRAY_TOKEN.
+  --job-id <id>        Read admin job timeline for a job.
+  --session-id <id>    Read wallet-owned session timeline.
+  --limit <n>          Max job-session history to include for job timelines.
+  --help               Show this help.
+
+Environment:
+  API_URL
+  AVERRAY_TOKEN
+  JOB_ID
+  SESSION_ID
+`);
+}
+
+function isMain() {
+  return import.meta.url === pathToFileURL(process.argv[1] ?? "").href;
+}

--- a/examples/read-job-timeline/index.test.mjs
+++ b/examples/read-job-timeline/index.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildTimelineSummary,
+  parseArgs,
+  runTimelineLookup
+} from "./index.mjs";
+
+test("parseArgs accepts job and session timeline flags", () => {
+  assert.deepEqual(parseArgs([
+    "--api",
+    "https://api.example",
+    "--token",
+    "token",
+    "--job-id",
+    "job-1",
+    "--limit",
+    "25"
+  ]), {
+    apiUrl: "https://api.example",
+    token: "token",
+    jobId: "job-1",
+    limit: 25
+  });
+});
+
+test("runTimelineLookup reads admin job timeline when jobId is provided", async () => {
+  const calls = [];
+  const summary = await runTimelineLookup({
+    apiUrl: "https://api.example",
+    token: "token",
+    jobId: "job-1",
+    limit: 20,
+    fetchImpl: async (url, options) => {
+      calls.push({ url: String(url), auth: options.headers.get("authorization") });
+      return jsonResponse({
+        timelineVersion: "v2",
+        job: { id: "job-1" },
+        summary: { eventCount: 2 },
+        lineage: { sessionIds: ["session-1"] },
+        timeline: [{ type: "job_state" }, { type: "session_transition" }]
+      });
+    }
+  });
+
+  assert.deepEqual(calls, [{
+    url: "https://api.example/admin/jobs/timeline?jobId=job-1&limit=20",
+    auth: "Bearer token"
+  }]);
+  assert.equal(summary.kind, "job");
+  assert.deepEqual(summary.eventTypes, ["job_state", "session_transition"]);
+});
+
+test("runTimelineLookup reads session timeline when sessionId is provided", async () => {
+  const calls = [];
+  const summary = await runTimelineLookup({
+    apiUrl: "https://api.example",
+    token: "token",
+    sessionId: "session-1",
+    fetchImpl: async (url) => {
+      calls.push(String(url));
+      return jsonResponse({
+        timelineVersion: "v2",
+        session: { sessionId: "session-1", jobId: "job-1" },
+        timeline: [{ type: "session_transition" }]
+      });
+    }
+  });
+
+  assert.deepEqual(calls, ["https://api.example/session/timeline?sessionId=session-1"]);
+  assert.equal(summary.kind, "session");
+  assert.equal(summary.jobId, "job-1");
+});
+
+test("buildTimelineSummary keeps latest event visible", () => {
+  const summary = buildTimelineSummary({
+    apiUrl: "https://api.example",
+    jobId: "job-1",
+    timeline: {
+      timelineVersion: "v2",
+      job: { id: "job-1" },
+      timeline: [{ type: "job_state" }, { type: "verification", data: { outcome: "approved" } }]
+    }
+  });
+
+  assert.equal(summary.eventCount, 2);
+  assert.equal(summary.latestEvent.type, "verification");
+});
+
+function jsonResponse(payload, { status = 200 } = {}) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" }
+  });
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "validate:subscan-xcm": "node scripts/ops/validate-subscan-xcm-source.mjs",
     "validate:native-xcm-evidence": "node scripts/ops/validate-native-xcm-evidence.mjs",
     "exercise:async-xcm": "node scripts/ops/exercise-async-xcm-request.mjs",
-    "example:profile-lookup": "node examples/profile-lookup/index.mjs"
+    "example:profile-lookup": "node examples/profile-lookup/index.mjs",
+    "example:claim-and-submit-job": "node examples/claim-and-submit-job/index.mjs",
+    "example:read-job-timeline": "node examples/read-job-timeline/index.mjs"
   },
   "devDependencies": {
     "@acala-network/chopsticks": "^1.3.1",

--- a/sdk/agent-platform-client.d.ts
+++ b/sdk/agent-platform-client.d.ts
@@ -38,6 +38,20 @@ export interface FireRecurringJobOptions {
   idempotencyKey?: string;
 }
 
+export interface ListJobsOptions {
+  wallet?: string;
+  source?: string;
+  category?: string;
+  state?: string;
+  format?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface JobTimelineOptions {
+  limit?: number;
+}
+
 export class AgentPlatformClient {
   constructor(options?: AgentPlatformClientOptions);
 
@@ -78,7 +92,8 @@ export class AgentPlatformClient {
   deallocateIdleFunds(input: StrategyMutationInput): Promise<unknown>;
   sendToAgent(input: SendToAgentInput): Promise<unknown>;
 
-  listJobs(): Promise<unknown>;
+  listJobs(options?: ListJobsOptions): Promise<unknown>;
+  listClaimableJobs(options?: ListJobsOptions): Promise<unknown>;
   getJobDefinition(jobId: string): Promise<unknown>;
   getRecommendations(): Promise<unknown>;
   preflightJob(jobId: string): Promise<unknown>;
@@ -86,6 +101,7 @@ export class AgentPlatformClient {
   submitWork(sessionId: string, submission: string | unknown): Promise<unknown>;
   getSession(sessionId: string): Promise<unknown>;
   getSessionTimeline(sessionId: string): Promise<unknown>;
+  getJobTimeline(jobId: string, options?: JobTimelineOptions): Promise<unknown>;
   listSessions(options?: { limit?: number; jobId?: string }): Promise<unknown>;
   listSubJobs(parentSessionId: string): Promise<unknown>;
   createSubJob(payload: unknown): Promise<unknown>;
@@ -96,8 +112,8 @@ export class AgentPlatformClient {
 
   createJob(payload: unknown): Promise<unknown>;
   fireRecurringJob(templateId: string, options?: FireRecurringJobOptions): Promise<unknown>;
-  pauseRecurringJob(templateId: string): Promise<unknown>;
-  resumeRecurringJob(templateId: string): Promise<unknown>;
+  pauseRecurringJob(templateId: string, options?: { idempotencyKey?: string }): Promise<unknown>;
+  resumeRecurringJob(templateId: string, options?: { idempotencyKey?: string }): Promise<unknown>;
   getAdminStatus(): Promise<unknown>;
 
   request(path: string, options?: RequestOptions): Promise<unknown>;

--- a/sdk/agent-platform-client.js
+++ b/sdk/agent-platform-client.js
@@ -161,8 +161,32 @@ export class AgentPlatformClient {
     });
   }
 
-  async listJobs() {
-    return this.request("/jobs");
+  async listJobs({
+    wallet = undefined,
+    source = undefined,
+    category = undefined,
+    state = undefined,
+    format = undefined,
+    limit = undefined,
+    offset = undefined
+  } = {}) {
+    const params = new URLSearchParams();
+    if (wallet) params.set("wallet", wallet);
+    if (source) params.set("source", source);
+    if (category) params.set("category", category);
+    if (state) params.set("state", state);
+    if (format) params.set("format", format);
+    if (limit !== undefined) params.set("limit", String(limit));
+    if (offset !== undefined) params.set("offset", String(offset));
+    return this.request(`/jobs${params.size ? `?${params.toString()}` : ""}`);
+  }
+
+  async listClaimableJobs(options = {}) {
+    return this.listJobs({
+      format: "compact",
+      ...options,
+      state: options.state ?? "claimable"
+    });
   }
 
   async getJobDefinition(jobId) {
@@ -203,6 +227,12 @@ export class AgentPlatformClient {
 
   async getSessionTimeline(sessionId) {
     return this.request(`/session/timeline?sessionId=${encodeURIComponent(sessionId)}`);
+  }
+
+  async getJobTimeline(jobId, { limit = undefined } = {}) {
+    const params = new URLSearchParams({ jobId });
+    if (limit !== undefined) params.set("limit", String(limit));
+    return this.request(`/admin/jobs/timeline?${params.toString()}`);
   }
 
   async listSessions({ limit = undefined, jobId = undefined } = {}) {
@@ -283,17 +313,17 @@ export class AgentPlatformClient {
     });
   }
 
-  async pauseRecurringJob(templateId) {
+  async pauseRecurringJob(templateId, { idempotencyKey = undefined } = {}) {
     return this.request("/admin/jobs/pause", {
       method: "POST",
-      body: { templateId }
+      body: compact({ templateId, idempotencyKey })
     });
   }
 
-  async resumeRecurringJob(templateId) {
+  async resumeRecurringJob(templateId, { idempotencyKey = undefined } = {}) {
     return this.request("/admin/jobs/resume", {
       method: "POST",
-      body: { templateId }
+      body: compact({ templateId, idempotencyKey })
     });
   }
 

--- a/sdk/agent-platform-client.test.mjs
+++ b/sdk/agent-platform-client.test.mjs
@@ -88,6 +88,28 @@ test("listSessions builds optional query string without empty params", async () 
   assert.equal(calls[1].url, "https://api.example.test/sessions?limit=10&jobId=starter+job");
 });
 
+test("job helpers build compact filters and admin timeline URLs", async () => {
+  const calls = [];
+  const client = new AgentPlatformClient({
+    baseUrl: "https://api.example.test",
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options });
+      return jsonResponse({ ok: true });
+    }
+  });
+
+  await client.listJobs({ source: "wikipedia", state: "claimable", limit: 5, offset: 10 });
+  await client.listClaimableJobs({ category: "coding", limit: 2 });
+  await client.getJobTimeline("job with space", { limit: 50 });
+
+  assert.equal(
+    calls[0].url,
+    "https://api.example.test/jobs?source=wikipedia&state=claimable&limit=5&offset=10"
+  );
+  assert.equal(calls[1].url, "https://api.example.test/jobs?category=coding&state=claimable&format=compact&limit=2");
+  assert.equal(calls[2].url, "https://api.example.test/admin/jobs/timeline?jobId=job+with+space&limit=50");
+});
+
 test("operator surface helpers call policy, audit, and alert endpoints", async () => {
   const calls = [];
   const client = new AgentPlatformClient({
@@ -103,6 +125,8 @@ test("operator surface helpers call policy, audit, and alert endpoints", async (
   await client.proposePolicy({ tag: "claim/new@v1" });
   await client.listAuditEvents({ limit: 25 });
   await client.listAlerts({ limit: 5 });
+  await client.pauseRecurringJob("weekly-digest", { idempotencyKey: "pause-1" });
+  await client.resumeRecurringJob("weekly-digest", { idempotencyKey: "resume-1" });
 
   assert.equal(calls[0].url, "https://api.example.test/policies");
   assert.equal(calls[1].url, "https://api.example.test/policies/claim%2Fdeps-sec-only%40v4");
@@ -111,6 +135,16 @@ test("operator surface helpers call policy, audit, and alert endpoints", async (
   assert.deepEqual(JSON.parse(calls[2].options.body), { tag: "claim/new@v1" });
   assert.equal(calls[3].url, "https://api.example.test/audit?limit=25");
   assert.equal(calls[4].url, "https://api.example.test/alerts?limit=5");
+  assert.equal(calls[5].url, "https://api.example.test/admin/jobs/pause");
+  assert.deepEqual(JSON.parse(calls[5].options.body), {
+    templateId: "weekly-digest",
+    idempotencyKey: "pause-1"
+  });
+  assert.equal(calls[6].url, "https://api.example.test/admin/jobs/resume");
+  assert.deepEqual(JSON.parse(calls[6].options.body), {
+    templateId: "weekly-digest",
+    idempotencyKey: "resume-1"
+  });
 });
 
 test("request throws server-provided error messages", async () => {


### PR DESCRIPTION
## What changed
- Expanded the small JS SDK with compact job listing filters, claimable job helper, admin job timeline helper, and idempotent recurring pause/resume options.
- Added two gold-path examples: `examples/claim-and-submit-job` and `examples/read-job-timeline`.
- Updated README/onboarding/roadmap docs so outside agents have a clearer start path.

## Checks run
- `npm run test:sdk`
- `npm run test:examples`
- `git diff --check`

## Impact
- SDK/docs/examples only. No backend, frontend, indexer, Caddy, contracts, or public-site runtime changes.
- No environment or VPS secret changes required.