### PR TITLE
Audit log: distinguish signed-out empty state from genuinely-quiet

### DIFF
--- a/app/app/(authed)/audit-log/page.tsx
+++ b/app/app/(authed)/audit-log/page.tsx
@@ -10,6 +10,7 @@ import {
 import { AuditTimeline } from "@/components/audit/AuditTimeline";
 import type { AuditActor, AuditCategory, AuditEvent, AuditSource } from "@/components/audit/types";
 import { useAudit } from "@/lib/api/hooks";
+import { ApiError } from "@/lib/api/client";
 import { freshnessFromRequests } from "@/components/shell/DataFreshnessPill";
 
 const DAY_BUCKETS: Record<AuditFilter["day"], (d: string, now?: Date) => boolean> = {
@@ -56,6 +57,18 @@ export default function AuditLogPage() {
   }, [events, filter]);
 
   const freshness = freshnessFromRequests(auditRequest);
+  // The /audit endpoint requires SIWE auth. When the viewer is signed
+  // out the request 401s and we render zero events — but the generic
+  // "no events match" copy reads as if the platform itself is quiet.
+  // Distinguish the two so the empty state can prompt sign-in.
+  const unauthenticated =
+    auditRequest.error instanceof ApiError &&
+    (auditRequest.error.status === 401 || auditRequest.error.status === 403);
+  const filtersApplied =
+    filter.source !== "all" ||
+    filter.category !== "all" ||
+    filter.day !== "all" ||
+    filter.q.trim().length > 0;
 
   return (
     <div className="flex w-full max-w-[1100px] flex-col gap-5">
@@ -80,7 +93,11 @@ export default function AuditLogPage() {
 
       <AuditAggregateStrip events={events} />
       <AuditFilterRail filter={filter} onChange={setFilter} />
-      <AuditTimeline events={filtered} />
+      <AuditTimeline
+        events={filtered}
+        unauthenticated={unauthenticated}
+        filtersApplied={filtersApplied}
+      />
 
       <p
         className="font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]"

--- a/app/components/audit/AuditTimeline.tsx
+++ b/app/components/audit/AuditTimeline.tsx
@@ -18,7 +18,20 @@ const DAY_LABEL: Record<string, string> = {
  * Entries are link-through only — clicking an event opens the relevant
  * surface (receipts, runs, policies, disputes) in the same tab.
  */
-export function AuditTimeline({ events }: { events: AuditEvent[] }) {
+export function AuditTimeline({
+  events,
+  unauthenticated,
+  filtersApplied,
+}: {
+  events: AuditEvent[];
+  /** True when the data fetch failed with 401/403 — the page renders
+   *  a sign-in hint instead of the generic "no events match" copy. */
+  unauthenticated?: boolean;
+  /** True when at least one filter (source/category/day/q) is set
+   *  beyond defaults. Distinguishes "your filters didn't match
+   *  anything" from "the log itself is quiet for everyone". */
+  filtersApplied?: boolean;
+}) {
   if (events.length === 0) {
     return (
       <div className="rounded-[10px] border border-dashed border-[var(--avy-line)] bg-[rgba(255,253,247,0.5)] p-8 text-center">
@@ -26,8 +39,11 @@ export function AuditTimeline({ events }: { events: AuditEvent[] }) {
           className="m-0 font-[family-name:var(--font-mono)] text-[13px] text-[var(--avy-muted)]"
           style={{ letterSpacing: 0 }}
         >
-          No events match these filters. The log is append-only, so a quiet
-          window means the platform is quiet — not stalled.
+          {unauthenticated
+            ? "Sign in with your operator wallet to load the audit log. Every claim, submission, and verification on this platform shows up here once you're authenticated."
+            : filtersApplied
+              ? "No events match these filters. Clear them to see the full log."
+              : "No events recorded yet. The log is append-only, so a quiet window means the platform is quiet — not stalled."}
         </p>
       </div>
     );


### PR DESCRIPTION
Quick polish you'll see immediately on \`/audit-log\` while signed-out.

## Why
The \`/audit\` endpoint requires SIWE auth and 401s anonymous viewers. The page rendered an empty list with the generic \"No events match these filters. The log is append-only, so a quiet window means the platform is quiet — not stalled.\" That reads as if the platform has no activity — but the user's own agent has been claiming, submitting, and verifying sessions all along. They just need to sign in to see them. (The backend already synthesizes audit events from \`listRecentSessions\` — every claim becomes a \`session.claimed\` row, every submit a \`session.submitted\`, etc.)

## What
Splits the empty state into three branches:
- **Unauthenticated** (401/403): \"Sign in with your operator wallet to load the audit log. Every claim, submission, and verification on this platform shows up here once you're authenticated.\"
- **Filters applied but no match**: \"No events match these filters. Clear them to see the full log.\"
- **Authenticated, no filters, no events**: existing \"quiet window\" copy.

Auth detection reuses \`ApiError.status\` like the freshness pill does (PR #69). The page passes two small booleans (\`unauthenticated\`, \`filtersApplied\`) into the timeline, which stays pure.

## Test plan
- [x] \`npm run typecheck:app\`
- [x] \`npm run build:frontend\`
- [ ] After deploy, signed-out: empty state should prompt sign-in instead of saying \"the platform is quiet\".
- [ ] Signed in with no events: existing quiet-window copy.
- [ ] Apply a filter that excludes all events: \"Clear them to see the full log\".