### PR TITLE
Add submission contract validation UI

### DIFF
--- a/app/components/runs/LoadedRunPanel.tsx
+++ b/app/components/runs/LoadedRunPanel.tsx
@@ -81,6 +81,29 @@ export interface VerifierVerdict {
   scoreLabel: string;
 }
 
+export interface SubmissionValidationState {
+  status: "not_checked" | "valid" | "invalid";
+  message?: string;
+  path?: string;
+  details?: unknown;
+}
+
+export interface SubmissionContractView {
+  endpoint?: string;
+  validationEndpoint?: string;
+  structuredSubmissionRequired?: boolean;
+  schemaValidates?: string;
+  doNotWrapInOutput?: boolean;
+  outputSchemaRef?: string;
+  outputSchemaUrl?: string;
+  submitPayloadExample?: unknown;
+  invalidWrappedOutputHint?: string;
+  schemaContract?: unknown;
+  validation: SubmissionValidationState;
+  validating?: boolean;
+  onValidate?: (draft: string) => void | Promise<void>;
+}
+
 export interface LoadedRunPanelProps {
   kicker: string;
   title: string;
@@ -97,6 +120,7 @@ export interface LoadedRunPanelProps {
     metaRight: string;
     metaFoot: string;
   };
+  submissionContract?: SubmissionContractView;
   submission: {
     note: React.ReactNode;
     cta: string;
@@ -376,6 +400,14 @@ export function LoadedRunPanel(props: LoadedRunPanelProps) {
               </div>
             </div>
           )}
+
+          {props.submissionContract ? (
+            <SubmissionContractPanel
+              contract={props.submissionContract}
+              draft={evidenceValue}
+              onDraftChange={setEvidenceValue}
+            />
+          ) : null}
 
           {/* Submit
               ─────────────────────────────────────────────────
@@ -1899,6 +1931,232 @@ function InstructionsTab({ ctx }: { ctx: GitHubJobContext }) {
       {ctx.agentInstructions}
     </p>
   );
+}
+
+function SubmissionContractPanel({
+  contract,
+  draft,
+  onDraftChange,
+}: {
+  contract: SubmissionContractView;
+  draft: string;
+  onDraftChange: (value: string) => void;
+}) {
+  const output = schemaOutput(contract.schemaContract);
+  const input = schemaInput(contract.schemaContract);
+  const validation = contract.validation;
+  const validationTone =
+    validation.status === "valid"
+      ? "text-[var(--avy-accent)]"
+      : validation.status === "invalid"
+        ? "text-[#8c2a17]"
+        : "text-[var(--avy-muted)]";
+
+  return (
+    <div>
+      <BlockLabel
+        right={
+          <span className="font-[family-name:var(--font-mono)] text-[var(--avy-muted)]">
+            {contract.validationEndpoint ?? "POST /jobs/validate-submission"}
+          </span>
+        }
+      >
+        Submission contract
+      </BlockLabel>
+      <div className="flex flex-col gap-3 rounded-[8px] border border-[var(--avy-line)] bg-white p-3">
+        <div className="grid grid-cols-1 gap-2 font-[family-name:var(--font-mono)] text-[11px] sm:grid-cols-2">
+          <ContractFact
+            label="Submit endpoint"
+            value={contract.endpoint ?? "POST /jobs/submit"}
+          />
+          <ContractFact
+            label="Validates"
+            value={contract.schemaValidates ?? output.validates ?? "payload.submission"}
+          />
+          <ContractFact
+            label="Structured required"
+            value={contract.structuredSubmissionRequired ? "true" : "false"}
+          />
+          <ContractFact
+            label="Do not wrap"
+            value={contract.doNotWrapInOutput ? "submission.output" : "not specified"}
+          />
+          <ContractFact
+            label="Input schema"
+            value={input.schemaRef ?? "not emitted"}
+            href={input.schemaUrl}
+          />
+          <ContractFact
+            label="Output schema"
+            value={contract.outputSchemaRef ?? output.schemaRef ?? "not emitted"}
+            href={contract.outputSchemaUrl ?? output.schemaUrl}
+          />
+        </div>
+
+        <div className="rounded-[7px] border border-[color:rgba(140,42,23,0.22)] bg-[color:rgba(140,42,23,0.045)] px-3 py-2 font-[family-name:var(--font-mono)] text-[11px] leading-[1.5] text-[#8c2a17]">
+          {contract.invalidWrappedOutputHint ??
+            "Do not wrap under submission.output. Send the schema object directly as payload.submission."}
+        </div>
+
+        <div>
+          <SubLabel>Exact JSON submit example</SubLabel>
+          <pre
+            className="max-h-[220px] overflow-auto rounded-[7px] border border-[var(--avy-line)] bg-[#131715] px-3 py-2.5 font-[family-name:var(--font-mono)] text-[11px] leading-[1.55] text-[#f5f3ee]"
+            style={{ letterSpacing: 0 }}
+          >
+            {formatJson(contract.submitPayloadExample)}
+          </pre>
+        </div>
+
+        <div>
+          <div className="mb-1 flex items-center justify-between gap-2">
+            <SubLabel>Draft payload.submission</SubLabel>
+            <span
+              className={`font-[family-name:var(--font-mono)] text-[10.5px] ${validationTone}`}
+              style={{ letterSpacing: 0 }}
+            >
+              {validationLabel(validation)}
+            </span>
+          </div>
+          <textarea
+            spellCheck={false}
+            value={draft}
+            onChange={(event) => onDraftChange(event.target.value)}
+            className="min-h-[190px] w-full resize-y rounded-[7px] border border-[var(--avy-line)] bg-[#fffdf7] px-3 py-2.5 font-[family-name:var(--font-mono)] text-[11.5px] leading-[1.55] text-[var(--avy-ink)] outline-none focus:border-[var(--avy-accent)] focus:ring-2 focus:ring-[color:rgba(30,102,66,0.15)]"
+            style={{ letterSpacing: 0 }}
+          />
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-2 border-t border-[var(--avy-line-soft)] pt-2">
+          <p
+            className="m-0 min-w-0 flex-1 font-[family-name:var(--font-mono)] text-[10.5px] leading-[1.45] text-[var(--avy-muted)]"
+            style={{ letterSpacing: 0 }}
+          >
+            Read-only check. Sends{" "}
+            <b className="font-semibold text-[var(--avy-ink)]">
+              {"{ jobId, submission }"}
+            </b>{" "}
+            to the validation endpoint; it does not claim or submit the job.
+          </p>
+          <button
+            type="button"
+            onClick={() => contract.onValidate?.(draft)}
+            disabled={contract.validating || !contract.onValidate}
+            className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-[8px] border border-[color:rgba(30,102,66,0.26)] bg-[var(--avy-paper-solid)] px-3 font-[family-name:var(--font-display)] text-[11px] font-bold uppercase text-[var(--avy-accent)] transition-transform hover:-translate-y-px disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:translate-y-0"
+            style={{ letterSpacing: "0.06em" }}
+          >
+            {contract.validating ? "Checking..." : "Validate draft"}
+          </button>
+        </div>
+
+        {validation.status === "invalid" ? (
+          <div
+            className="rounded-[7px] border border-[color:rgba(140,42,23,0.18)] bg-[color:rgba(140,42,23,0.035)] px-3 py-2 font-[family-name:var(--font-mono)] text-[11px] leading-[1.5] text-[#8c2a17]"
+            style={{ letterSpacing: 0 }}
+          >
+            <b className="font-semibold">Invalid</b>
+            {validation.message ? <> · {validation.message}</> : null}
+            {validation.path ? <> · path {validation.path}</> : null}
+            {validation.details ? (
+              <pre className="mt-1 max-h-[140px] overflow-auto whitespace-pre-wrap">
+                {formatJson(validation.details)}
+              </pre>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function ContractFact({
+  label,
+  value,
+  href,
+}: {
+  label: string;
+  value: string;
+  href?: string;
+}) {
+  return (
+    <div className="min-w-0 rounded-[6px] border border-[var(--avy-line-soft)] bg-[#faf8f1] px-2.5 py-2">
+      <dt
+        className="font-[family-name:var(--font-display)] text-[9.5px] font-extrabold uppercase text-[var(--avy-muted)]"
+        style={{ letterSpacing: "0.12em" }}
+      >
+        {label}
+      </dt>
+      <dd
+        className="m-0 mt-0.5 min-w-0 break-words text-[var(--avy-ink)]"
+        style={{ letterSpacing: 0 }}
+      >
+        {href ? (
+          <a
+            href={href}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="text-[var(--avy-accent)] hover:underline"
+          >
+            {value}
+          </a>
+        ) : (
+          value
+        )}
+      </dd>
+    </div>
+  );
+}
+
+function validationLabel(validation: SubmissionValidationState): string {
+  if (validation.status === "valid") return "Valid";
+  if (validation.status === "invalid") {
+    return validation.path ? `Invalid · ${validation.path}` : "Invalid";
+  }
+  return "Not checked";
+}
+
+function formatJson(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value ?? null, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function schemaInput(value: unknown): { schemaRef?: string; schemaUrl?: string } {
+  const record = asRecordLocal(value);
+  return schemaRecord(record?.input);
+}
+
+function schemaOutput(
+  value: unknown
+): { schemaRef?: string; schemaUrl?: string; validates?: string } {
+  const record = asRecordLocal(value);
+  return schemaRecord(record?.output);
+}
+
+function schemaRecord(value: unknown): {
+  schemaRef?: string;
+  schemaUrl?: string;
+  validates?: string;
+} {
+  const record = asRecordLocal(value);
+  return {
+    schemaRef: textLocal(record?.schemaRef),
+    schemaUrl: textLocal(record?.schemaUrl),
+    validates: textLocal(record?.validates),
+  };
+}
+
+function asRecordLocal(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function textLocal(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 function SubmissionTab({ ctx }: { ctx: GitHubJobContext }) {

--- a/app/components/runs/LoadedRunView.tsx
+++ b/app/components/runs/LoadedRunView.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { mutate } from "swr";
-import { LoadedRunPanel } from "./LoadedRunPanel";
+import {
+  LoadedRunPanel,
+  type SubmissionValidationState,
+} from "./LoadedRunPanel";
 import { LifecycleRail } from "./LifecycleRail";
 import { LifecycleActionBar } from "./LifecycleActionBar";
 import { RunSemanticBlock } from "./RunSemanticBlock";
@@ -17,7 +20,12 @@ import {
 } from "./buildLifecycleStages";
 import type { RunRow } from "./RunQueueTable";
 import { ApiError, swrFetcher } from "@/lib/api/client";
-import { useAdminJobs, useJobDefinition, useJobs } from "@/lib/api/hooks";
+import {
+  useAdminJobs,
+  useJobDefinition,
+  useJobPreflight,
+  useJobs,
+} from "@/lib/api/hooks";
 import {
   buildGitHubContext,
   buildOpenDataContext,
@@ -74,6 +82,7 @@ export function LoadedRunView({
   const loadedRow = rows.find((row) => row.id === runId) ?? rows[0];
 
   const jobDefinition = useJobDefinition(loadedRow?.id ?? null);
+  const jobPreflight = useJobPreflight(loadedRow?.id ?? null);
   const selectedJob = loadedRow
     ? asRecord(jobDefinition.data) ?? rawJobs.find((job) => job.id === loadedRow.id)
     : undefined;
@@ -84,7 +93,16 @@ export function LoadedRunView({
 
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [validatingDraft, setValidatingDraft] = useState(false);
+  const [validationState, setValidationState] = useState<SubmissionValidationState>({
+    status: "not_checked",
+  });
   const [receiptOpen, setReceiptOpen] = useState(false);
+
+  useEffect(() => {
+    setValidationState({ status: "not_checked" });
+    setSubmitError(null);
+  }, [loadedRow?.id]);
 
   if (!loadedRow) {
     return (
@@ -101,7 +119,12 @@ export function LoadedRunView({
   // textarea into a useful template editor: the operator sees the
   // schema-shaped example pre-filled, edits the placeholder values,
   // and submits something the verifier can actually validate.
-  const submissionContract = asRecord(selectedJob?.submissionContract);
+  const preflightRecord = asRecord(jobPreflight.data);
+  const submissionContract =
+    asRecord(selectedJob?.submissionContract) ??
+    asRecord(preflightRecord?.submissionContract);
+  const schemaContract =
+    asRecord(selectedJob?.schemaContract) ?? asRecord(preflightRecord?.schemaContract);
   const submissionExample = asRecord(
     asRecord(submissionContract?.submitPayloadExample)?.submission
   );
@@ -112,6 +135,32 @@ export function LoadedRunView({
     typeof submissionContract?.outputSchemaUrl === "string"
       ? submissionContract.outputSchemaUrl
       : undefined;
+  const structuredSubmissionRequired =
+    submissionContract?.structuredSubmissionRequired === true;
+
+  const handleValidateDraft = async (draft: string) => {
+    setValidatingDraft(true);
+    setSubmitError(null);
+    try {
+      const submission = parseDirectSubmissionDraft(draft);
+      const result = await swrFetcher([
+        "/jobs/validate-submission",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jobId: loadedRow.id,
+            submission,
+          }),
+        },
+      ]);
+      setValidationState(validationStateFromResponse(result));
+    } catch (err) {
+      setValidationState(validationStateFromError(err));
+    } finally {
+      setValidatingDraft(false);
+    }
+  };
 
   const handleSubmit = async (evidence: string) => {
     setSubmitError(null);
@@ -121,13 +170,9 @@ export function LoadedRunView({
     }
     setSubmitting(true);
     try {
-      // The backend validates `payload.submission` directly against the
-      // job's output schema (PR #123). If the operator typed a JSON
-      // object that matches the schema, send it as-is. Otherwise fall
-      // back to the legacy text-evidence wrapping so older fixtures
-      // and free-text smoke tests still get a 4xx that says what's
-      // wrong instead of failing silently here.
-      const submission = parseSubmissionInput(evidence, loadedRow.id);
+      const submission = structuredSubmissionRequired
+        ? parseDirectSubmissionDraft(evidence)
+        : parseSubmissionInput(evidence, loadedRow.id);
       await swrFetcher([
         "/jobs/submit",
         {
@@ -149,6 +194,7 @@ export function LoadedRunView({
       const apiMessage = extractApiErrorMessage(err);
       setSubmitError(
         apiMessage ??
+          (err instanceof Error ? err.message : undefined) ??
           "Could not submit this run. Check session ownership and the submission shape."
       );
     } finally {
@@ -188,6 +234,13 @@ export function LoadedRunView({
         jobId={loadedRow.id}
         lifecycle={loadedRow.lifecycle}
       />
+      {submissionContract ? (
+        <SubmissionReadinessStrip
+          contract={submissionContract}
+          schemaContract={schemaContract}
+          preflight={preflightRecord}
+        />
+      ) : null}
       <LoadedRunPanel
         kicker={kicker}
         title={loadedRow.title}
@@ -225,6 +278,28 @@ export function LoadedRunView({
           metaFoot: outputSchemaUrl ? `output schema · ${outputSchemaUrl}` : "",
           sample: submissionSample,
         }}
+        submissionContract={
+          submissionContract
+            ? {
+                endpoint: text(submissionContract.endpoint),
+                validationEndpoint: text(submissionContract.validationEndpoint),
+                structuredSubmissionRequired:
+                  submissionContract.structuredSubmissionRequired === true,
+                schemaValidates: text(submissionContract.schemaValidates),
+                doNotWrapInOutput: submissionContract.doNotWrapInOutput === true,
+                outputSchemaRef: text(submissionContract.outputSchemaRef),
+                outputSchemaUrl: text(submissionContract.outputSchemaUrl),
+                submitPayloadExample: submissionContract.submitPayloadExample,
+                invalidWrappedOutputHint: text(
+                  submissionContract.invalidWrappedOutputHint
+                ),
+                schemaContract,
+                validation: validationState,
+                validating: validatingDraft,
+                onValidate: handleValidateDraft,
+              }
+            : undefined
+        }
         submission={{
           note: loadedWikipedia ? (
             <>
@@ -707,6 +782,89 @@ export function LoadedRunView({
   );
 }
 
+function SubmissionReadinessStrip({
+  contract,
+  schemaContract,
+  preflight,
+}: {
+  contract: Record<string, unknown>;
+  schemaContract: Record<string, unknown> | null;
+  preflight: Record<string, unknown> | null;
+}) {
+  const output = asRecord(schemaContract?.output);
+  const endpoint = text(
+    contract.validationEndpoint,
+    text(output?.validationEndpoint, "POST /jobs/validate-submission")
+  );
+  const schemaRef = text(
+    contract.outputSchemaRef,
+    text(output?.schemaRef, text(preflight?.requiredOutputSchema, "not emitted"))
+  );
+  const schemaUrl = text(contract.outputSchemaUrl, text(output?.schemaUrl, ""));
+  const validates = text(
+    contract.schemaValidates,
+    text(output?.validates, "payload.submission")
+  );
+  const structured = contract.structuredSubmissionRequired === true;
+
+  return (
+    <section className="rounded-[10px] border border-[var(--avy-line)] bg-[var(--avy-paper)] p-[0.75rem_0.95rem] shadow-[var(--shadow-card)]">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]">
+        <span
+          className="font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase text-[var(--avy-muted)]"
+          style={{ letterSpacing: "0.14em" }}
+        >
+          Preflight submission readiness
+        </span>
+        <ReadinessFact
+          label="structuredSubmissionRequired"
+          value={structured ? "true" : "false"}
+          accent={structured}
+        />
+        <ReadinessFact label="outputSchemaRef" value={schemaRef} href={schemaUrl} />
+        <ReadinessFact label="validationEndpoint" value={endpoint} />
+        <ReadinessFact label="validates" value={validates} />
+      </div>
+    </section>
+  );
+}
+
+function ReadinessFact({
+  label,
+  value,
+  href,
+  accent = false,
+}: {
+  label: string;
+  value: string;
+  href?: string;
+  accent?: boolean;
+}) {
+  return (
+    <span className="inline-flex min-w-0 items-center gap-1">
+      <span className="text-[var(--avy-muted)]">{label}</span>
+      <b
+        className={`min-w-0 break-words font-semibold ${
+          accent ? "text-[var(--avy-accent)]" : "text-[var(--avy-ink)]"
+        }`}
+      >
+        {href ? (
+          <a
+            href={href}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="text-[var(--avy-accent)] hover:underline"
+          >
+            {value}
+          </a>
+        ) : (
+          value
+        )}
+      </b>
+    </span>
+  );
+}
+
 /**
  * Read an operator's textarea content as a submission body. Two paths:
  *   - JSON-object input → forward verbatim as `payload.submission`. This
@@ -734,6 +892,75 @@ function parseSubmissionInput(evidence: string, jobId: string): unknown {
     jobId,
     submittedAt: new Date().toISOString(),
   };
+}
+
+function parseDirectSubmissionDraft(draft: string): unknown {
+  const trimmed = draft.trim();
+  if (!trimmed) {
+    throw new Error("Draft is empty. Paste the schema object for payload.submission.");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (error) {
+    throw new Error(
+      error instanceof Error
+        ? `Invalid JSON draft: ${error.message}`
+        : "Invalid JSON draft."
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("payload.submission must be a JSON object.");
+  }
+  return parsed;
+}
+
+function validationStateFromResponse(payload: unknown): SubmissionValidationState {
+  const record = asRecord(payload);
+  if (!record) {
+    return {
+      status: "invalid",
+      message: "Validation endpoint returned an unexpected response.",
+      details: payload,
+    };
+  }
+  if (record.valid === true) return { status: "valid" };
+  return {
+    status: "invalid",
+    message: text(record.message, "Draft does not match the output schema."),
+    path: validationPath(record),
+    details: record.details ?? record,
+  };
+}
+
+function validationStateFromError(err: unknown): SubmissionValidationState {
+  if (err instanceof ApiError) {
+    const record = asRecord(err.body);
+    return {
+      status: "invalid",
+      message: record ? text(record.message, err.message) : err.message,
+      path: record ? validationPath(record) : undefined,
+      details: record?.details ?? err.body,
+    };
+  }
+  return {
+    status: "invalid",
+    message: err instanceof Error ? err.message : "Could not validate draft.",
+  };
+}
+
+function validationPath(record: Record<string, unknown>): string | undefined {
+  const details = asRecord(record.details);
+  return (
+    text(record.path) ||
+    text(record.expectedPath) ||
+    text(record.expected) ||
+    text(details?.path) ||
+    text(details?.expectedPath) ||
+    text(details?.expected) ||
+    text(details?.received) ||
+    undefined
+  );
 }
 
 /**
@@ -772,6 +999,10 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : null;
+}
+
+function text(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
 }
 
 /**

--- a/app/lib/api/hooks.ts
+++ b/app/lib/api/hooks.ts
@@ -31,6 +31,8 @@ export const useJobs = () => useApi("/jobs");
 export const useRecommendations = () => useApi("/jobs/recommendations");
 export const useJobDefinition = (id: string | null) =>
   useApi(id ? `/jobs/definition?jobId=${encodeURIComponent(id)}` : null);
+export const useJobPreflight = (id: string | null) =>
+  useApi(id ? `/jobs/preflight?jobId=${encodeURIComponent(id)}` : null);
 export const useSessions = () => useApi("/sessions");
 export const useAdminSessions = () =>
   useApi("/admin/sessions?limit=100", { refreshInterval: 15_000 });


### PR DESCRIPTION
## What changed
- Adds a schema-native Submission contract panel on the run detail surface.
- Shows the submit endpoint, validation endpoint, validates path, input/output schema refs and links, exact JSON submit example, and the explicit no submission.output wrapping warning.
- Adds an editable payload.submission draft editor and a read-only Validate draft action that posts { jobId, submission } to /jobs/validate-submission.
- Shows Not checked / Valid / Invalid states, including backend message, details, and path hints when present.
- Surfaces structuredSubmissionRequired, outputSchemaRef, validationEndpoint, and validates in the preflight/readiness strip.
- Structured jobs now submit only the direct schema object; the legacy text wrapper remains only for non-schema jobs.

## Checks run
- npm run typecheck:app
- npm run build:frontend
- git diff --check
- Local dev route smoke: /runs and /runs/detail returned 200

## Impact
- Frontend/operator app only.
- No backend, indexer, contracts, Caddy, public site, or environment changes.
- Generated frontend export output was not committed.
- Hosted/company-server UI validation was not performed from this environment.