### PR TITLE
Version verifier audit contracts

### DIFF
--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -77,30 +77,33 @@ and works for v1, but the contract between:
 
 is still too loose for high-trust operation.
 
-### Gaps today
+### Current implementation
 
-- `benchmark` and `deterministic` handlers operate on plain text evidence
-- there is no versioned verifier config envelope
-- verification results are stored, but the framework does not treat them as
-  a replayable artifact with a clear input snapshot
-- there is no notion of verifier policy version or handler version in the
-  stored result
+- job definitions and preflight responses expose a `verificationContract`
+  envelope with handler, verifier config version, config hash, and replay/result
+  endpoints
+- verification results persist `verificationInput`,
+  `verificationInputHash`, `verifierConfigSnapshot`, `verifierConfigHash`,
+  `verifierConfigVersion`, and `handlerVersion`
+- direct verification ingestion and `/verifier/run` both enrich stored verdicts
+  with the same audit fields
+- `/verifier/replay` evaluates against the stored verifier config snapshot when
+  one exists, so audits are not silently affected by later config edits
 
-### Improve to
+### Remaining gaps
 
-- versioned verifier configs
-- explicit evidence shape per verifier mode
-- persisted verification input snapshot
-- persisted handler version and policy version
-- deterministic replay command for disputes and audits
+- `benchmark` and `deterministic` handlers can still operate on plain text
+  evidence for legacy jobs
+- verifier policy version is not yet separate from verifier config version
+- replay still uses the current handler implementation; `handlerVersion`
+  records the version that ran, but the code itself is not version-pinned
 
 ### Concrete next changes
 
-- add `verifierConfig.version`
 - add `evidenceSchemaRef` or `submissionSchemaRef` to jobs
-- persist `verificationInput`, `verifierConfigVersion`, and `handlerVersion`
-  alongside the verdict
-- add a `replayVerification(sessionId)` internal path for audit and dispute use
+- split `policyVersion` from `verifierConfig.version` when verifier rules move
+  beyond simple config data
+- add handler-versioned replay fixtures before introducing v2 verifier handlers
 
 ### What this unlocks
 

--- a/mcp-server/src/core/job-catalog-metadata.test.js
+++ b/mcp-server/src/core/job-catalog-metadata.test.js
@@ -223,6 +223,12 @@ test("public Wikipedia definitions include direct agent affordances", () => {
   assert.equal(job.submissionContract.submitPayloadExample.submission.page_title, "Example article");
   assert.equal(job.schemaContract.output.validationEndpoint, "POST /jobs/validate-submission");
   assert.equal(job.schemaContract.output.validates, "payload.submission");
+  assert.equal(job.verificationContract.version, "verification-contract-v1");
+  assert.equal(job.verificationContract.verifierMode, "benchmark");
+  assert.equal(job.verificationContract.handler, "benchmark");
+  assert.equal(job.verificationContract.verifierConfigVersion, 1);
+  assert.equal(job.verificationContract.replayEndpoint, "POST /verifier/replay");
+  assert.equal(typeof job.verificationContract.verifierConfigHash, "string");
 });
 
 test("reviewer role gate blocks low-score agents", async () => {

--- a/mcp-server/src/core/job-catalog-service.js
+++ b/mcp-server/src/core/job-catalog-service.js
@@ -4,6 +4,7 @@ import {
   ValidationError
 } from "./errors.js";
 import { getBuiltinJobSchema, isBuiltinJobSchemaRef, schemaRefToJobSchemaPath } from "./job-schema-registry.js";
+import { buildVerificationContract } from "./verifier-contract.js";
 
 const DEFAULT_AGENT_PROFILE = {
   capabilities: ["claim_job", "submit_work", "allocate_idle_funds"],
@@ -391,6 +392,7 @@ export class JobCatalogService {
       strategyUnwindNeeded: liquid < claimEconomics.totalClaimLock,
       requiredOutputSchema: job.outputSchemaRef,
       submissionContract: buildSubmissionContract(job),
+      verificationContract: buildVerificationContract(job),
       verifierMode: job.verifierMode,
       verifierConfig: job.verifierConfig,
       tier: job.tier,
@@ -494,11 +496,13 @@ export class JobCatalogService {
     const publicDetails = buildPublicJobDetails(job);
     const submissionContract = buildSubmissionContract(job);
     const schemaContract = buildSchemaContract(job);
+    const verificationContract = buildVerificationContract(job);
     return {
       ...job,
       ...(publicDetails ? { publicDetails } : {}),
       ...(submissionContract ? { submissionContract } : {}),
       ...(schemaContract ? { schemaContract } : {}),
+      verificationContract,
       lifecycle: this.buildLifecycle(job, now)
     };
   }

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -96,7 +96,11 @@ export class PlatformService {
       this.getClaimableJobDefinition.bind(this),
       this.getClaimEconomicsConfig.bind(this)
     );
-    this.verificationIngestionService = new VerificationIngestionService(this.stateStore, this.eventBus);
+    this.verificationIngestionService = new VerificationIngestionService(
+      this.stateStore,
+      this.eventBus,
+      this.getJobDefinition.bind(this)
+    );
   }
 
   getPlatformCapabilities() {

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -197,10 +197,17 @@ test("getSessionTimeline includes transitions and verification state", async () 
     outcome: "approved",
     reasonCode: "BENCHMARK_THRESHOLD_MET"
   });
+  const result = await service.stateStore.getVerificationResult(submitted.sessionId);
 
   const timeline = await service.getSessionTimeline(submitted.sessionId);
   assert.equal(timeline.timelineVersion, "v2");
   assert.equal(timeline.session.status, "resolved");
+  assert.equal(result.verifierConfigVersion, 1);
+  assert.equal(result.verificationContract.version, "verification-contract-v1");
+  assert.equal(result.verificationContract.handler, "benchmark");
+  assert.equal(result.verificationInput.kind, "structured");
+  assert.equal(typeof result.verifierConfigHash, "string");
+  assert.equal(typeof result.verificationInputHash, "string");
   assert.equal(timeline.lifecycle.currentPhase, "terminal");
   assert.equal(timeline.stateMachine.timelineVersion, "v2");
   assert.ok(Array.isArray(timeline.stateMachine.statuses));

--- a/mcp-server/src/core/verifier-contract.js
+++ b/mcp-server/src/core/verifier-contract.js
@@ -1,0 +1,83 @@
+import { hashCanonicalContent } from "./canonical-content.js";
+
+export const VERIFICATION_CONTRACT_VERSION = "verification-contract-v1";
+
+export function buildVerificationContract(job, { verdict = undefined, verificationInput = undefined } = {}) {
+  const verifierConfig = cloneJson(job?.verifierConfig);
+  const verifierConfigVersion = normalizeVersion(verifierConfig?.version);
+  const handler = firstString(verdict?.handler, verifierConfig?.handler, job?.verifierMode, "unknown");
+  const handlerVersion = normalizeOptionalVersion(verdict?.handlerVersion);
+  const hasInput = verificationInput !== undefined;
+
+  return compact({
+    version: VERIFICATION_CONTRACT_VERSION,
+    verifierMode: firstString(job?.verifierMode, undefined),
+    handler,
+    handlerVersion,
+    verifierConfigVersion,
+    verifierConfigHash: hashCanonicalContent(verifierConfig ?? null),
+    verificationInputHash: hasInput ? hashCanonicalContent(verificationInput ?? null) : undefined,
+    replayEndpoint: "POST /verifier/replay",
+    resultEndpoint: "GET /verifier/result",
+    snapshotFields: [
+      "verificationInput",
+      "verificationInputHash",
+      "verifierConfigSnapshot",
+      "verifierConfigHash",
+      "verifierConfigVersion",
+      "handlerVersion"
+    ]
+  });
+}
+
+export function buildVerificationAuditFields(job, { verdict = {}, verificationInput = undefined } = {}) {
+  const verifierConfigSnapshot = cloneJson(job?.verifierConfig);
+  const contract = buildVerificationContract(job, { verdict, verificationInput });
+  const fields = {
+    verifierConfigVersion: contract.verifierConfigVersion,
+    verifierConfigHash: contract.verifierConfigHash,
+    verifierConfigSnapshot,
+    verificationContract: contract
+  };
+
+  if (contract.handlerVersion !== undefined) {
+    fields.handlerVersion = contract.handlerVersion;
+  }
+  if (verificationInput !== undefined) {
+    fields.verificationInput = verificationInput;
+    fields.verificationInputHash = contract.verificationInputHash;
+  }
+
+  return compact(fields);
+}
+
+export function jobWithVerifierConfigSnapshot(job, verifierConfigSnapshot) {
+  return {
+    ...job,
+    verifierConfig: cloneJson(verifierConfigSnapshot ?? job?.verifierConfig)
+  };
+}
+
+function normalizeVersion(value) {
+  const number = Number(value ?? 1);
+  return Number.isInteger(number) && number > 0 ? number : 1;
+}
+
+function normalizeOptionalVersion(value) {
+  if (value === undefined || value === null) return undefined;
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : undefined;
+}
+
+function firstString(...values) {
+  return values.find((value) => typeof value === "string" && value.trim())?.trim();
+}
+
+function cloneJson(value) {
+  if (value === undefined) return undefined;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function compact(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}

--- a/mcp-server/src/services/verification-ingestion-service.js
+++ b/mcp-server/src/services/verification-ingestion-service.js
@@ -1,10 +1,12 @@
 import { transitionSession } from "../core/session-state-machine.js";
 import { updateFundedJobFromSession } from "../core/funded-jobs.js";
+import { buildVerificationAuditFields } from "../core/verifier-contract.js";
 
 export class VerificationIngestionService {
-  constructor(stateStore, eventBus = undefined) {
+  constructor(stateStore, eventBus = undefined, getJobDefinition = undefined) {
     this.stateStore = stateStore;
     this.eventBus = eventBus;
+    this.getJobDefinition = getJobDefinition;
   }
 
   async ingest(sessionId, verdict) {
@@ -14,6 +16,11 @@ export class VerificationIngestionService {
     if (!session) {
       return undefined;
     }
+    const job = this.resolveJob(session, verdict);
+    const verificationInput = verdict.verificationInput ?? session.submission ?? "";
+    const auditFields = job
+      ? buildVerificationAuditFields(job, { verdict, verificationInput })
+      : {};
 
     const status = verdict.outcome === "approved"
       ? "resolved"
@@ -27,14 +34,17 @@ export class VerificationIngestionService {
         outcome: verdict.outcome,
         reasonCode: verdict.reasonCode,
         handler: verdict.handler,
-        handlerVersion: verdict.handlerVersion
+        handlerVersion: auditFields.handlerVersion ?? verdict.handlerVersion,
+        verifierConfigVersion: auditFields.verifierConfigVersion
       }
     }, status, {
       reason: "verification_resolved",
       metadata: {
         outcome: verdict.outcome,
         reasonCode: verdict.reasonCode,
-        handler: verdict.handler
+        handler: verdict.handler,
+        handlerVersion: auditFields.handlerVersion ?? verdict.handlerVersion,
+        verifierConfigVersion: auditFields.verifierConfigVersion
       }
     });
     const updatedSession = await this.stateStore.upsertSession(transitioned);
@@ -45,6 +55,7 @@ export class VerificationIngestionService {
     }));
     await this.stateStore.upsertVerificationResult(updatedSession.sessionId, {
       ...verdict,
+      ...auditFields,
       session: {
         sessionId: updatedSession.sessionId,
         jobId: updatedSession.jobId,
@@ -65,9 +76,24 @@ export class VerificationIngestionService {
       data: {
         outcome: verdict.outcome,
         reasonCode: verdict.reasonCode,
-        status
+        status,
+        handler: verdict.handler,
+        handlerVersion: auditFields.handlerVersion ?? verdict.handlerVersion,
+        verifierConfigVersion: auditFields.verifierConfigVersion
       }
     });
     return updatedSession;
+  }
+
+  resolveJob(session, verdict) {
+    const jobId = session?.jobId ?? verdict?.jobId;
+    if (!jobId || typeof this.getJobDefinition !== "function") {
+      return undefined;
+    }
+    try {
+      return this.getJobDefinition(jobId);
+    } catch {
+      return undefined;
+    }
   }
 }

--- a/mcp-server/src/services/verifier-service.js
+++ b/mcp-server/src/services/verifier-service.js
@@ -1,5 +1,9 @@
 import { VerifierRegistry } from "./verifier-handlers.js";
 import { hashCanonicalContent } from "../core/canonical-content.js";
+import {
+  buildVerificationAuditFields,
+  jobWithVerifierConfigSnapshot
+} from "../core/verifier-contract.js";
 
 export class VerifierService {
   constructor(platformService, stateStore, blockchainGateway = undefined, registry = new VerifierRegistry()) {
@@ -38,8 +42,7 @@ export class VerifierService {
       ...verdict,
       sessionId,
       metadataURI,
-      verifierConfigVersion: job.verifierConfig?.version ?? 1,
-      verificationInput,
+      ...buildVerificationAuditFields(job, { verdict, verificationInput }),
       session: updatedSession ?? session
     };
 
@@ -51,14 +54,14 @@ export class VerifierService {
     const job = this.platformService.getJobDefinition(session.jobId);
     const existing = await this.stateStore.getVerificationResult(sessionId);
     const verificationInput = existing?.verificationInput ?? this.resolveVerificationInput(session);
-    const verdict = await this.registry.evaluate(job, verificationInput);
+    const replayJob = jobWithVerifierConfigSnapshot(job, existing?.verifierConfigSnapshot);
+    const verdict = await this.registry.evaluate(replayJob, verificationInput);
     return {
       ...verdict,
       sessionId,
       replay: true,
       originalOutcome: existing?.outcome,
-      verifierConfigVersion: job.verifierConfig?.version ?? 1,
-      verificationInput
+      ...buildVerificationAuditFields(replayJob, { verdict, verificationInput })
     };
   }
 

--- a/mcp-server/src/services/verifier-service.test.js
+++ b/mcp-server/src/services/verifier-service.test.js
@@ -58,12 +58,25 @@ test("verifySubmission persists verification input and supports replay", async (
   assert.equal(result.outcome, "approved");
   assert.equal(result.handlerVersion, 1);
   assert.equal(result.verifierConfigVersion, 1);
+  assert.deepEqual(result.verifierConfigSnapshot, job.verifierConfig);
+  assert.equal(result.verificationContract.version, "verification-contract-v1");
+  assert.equal(result.verificationContract.handler, "deterministic");
+  assert.equal(result.verificationContract.handlerVersion, 1);
+  assert.equal(typeof result.verifierConfigHash, "string");
+  assert.equal(typeof result.verificationInputHash, "string");
   assert.equal(result.verificationInput.kind, "structured");
+
+  job.verifierConfig = {
+    ...job.verifierConfig,
+    expectedOutputs: ["this live config would fail the original submission"]
+  };
 
   const replay = await service.replayVerification(SESSION_ID);
   assert.equal(replay.replay, true);
   assert.equal(replay.outcome, "approved");
   assert.equal(replay.originalOutcome, "approved");
+  assert.equal(replay.verifierConfigHash, result.verifierConfigHash);
+  assert.deepEqual(replay.verifierConfigSnapshot.expectedOutputs, ["release_id", "checks_passed", "go_no_go"]);
 });
 
 test("github_pr verifier scores structured PR evidence and exposes reputation signals", async () => {


### PR DESCRIPTION
## Summary
- add a reusable verifier contract/audit snapshot with config/input hashes
- persist verifier config snapshots, input snapshots, handler versions, and contract metadata across verifier run and ingestion paths
- replay verification against the stored config snapshot when available, and expose verificationContract on job definitions/preflight
- update the framework roadmap to mark this slice and remaining verifier-versioning gaps

## Checks
- node --test mcp-server/src/services/verifier-service.test.js mcp-server/src/core/platform-service.test.js mcp-server/src/core/job-catalog-metadata.test.js
- npm --workspace mcp-server test
- git diff --check

## Impact
- Backend/API: yes
- Frontend: no direct UI changes required, but job definitions now expose verificationContract for future audit panels
- Indexer/contracts/public site/Caddy: no
- Env/VPS secrets: none