### PR TITLE
Harden session state transitions

### DIFF
--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -174,29 +174,33 @@ and
 That works, but it still behaves more like a set of updates than a strict state
 machine.
 
-### Gaps today
+### Current implementation
 
-- legal transitions are implicit
-- `claimed`, `submitted`, `resolved`, `rejected`, `closed`, `expired`,
-  `timed_out` exist, but transition rules are not centralized
-- evidence submission, verification, settlement, and dispute posture are not
-  modeled as first-class states
-- retries and re-open semantics are thin
+- `session-state-machine.js` defines the canonical transition table and public
+  status metadata
+- claim, submit, verification ingestion, expiry, and dispute resolution now
+  route through shared transition guards
+- duplicate submit attempts and verifier callbacks on non-verifiable sessions
+  fail closed before submission replacement, handler execution, chain
+  settlement, or verification result ingestion
+- sessions persist compact `statusHistory` entries with reason, timestamp, and
+  metadata
 
-### Improve to
+### Remaining gaps
 
-- one explicit session transition table
-- precondition checks per transition
-- consistent event emission per transition
-- terminal-state semantics enforced in one place
+- settlement and dispute posture are still mostly transition outcomes and
+  metadata, not separately typed workflow phases
+- retries and re-open semantics still live primarily in claim handling
+- transition coverage is focused on high-risk guards rather than full property
+  coverage across every legal and illegal edge
 
 ### Concrete next changes
 
-- create a `session-state-machine.js` module
-- define allowed transitions and side effects
-- route `claimJob`, `submitWork`, verification ingestion, timeout handling,
-  and future dispute actions through it
-- persist a compact state transition history for each session
+- route future settlement, timeout, and dispute actions through dedicated
+  state-machine helpers
+- add fixture or property tests for every legal and illegal transition
+- expose richer transition reason taxonomy for operator UI timelines and agent
+  diagnostics
 
 ### What this unlocks
 

--- a/mcp-server/src/core/job-execution-service.js
+++ b/mcp-server/src/core/job-execution-service.js
@@ -5,7 +5,12 @@ import {
   NotFoundError,
   ValidationError
 } from "./errors.js";
-import { buildSessionLifecycle, describeSessionStatus, transitionSession } from "./session-state-machine.js";
+import {
+  assertSessionCanTransition,
+  buildSessionLifecycle,
+  describeSessionStatus,
+  transitionSession
+} from "./session-state-machine.js";
 import { hashSubmission, isStructuredSubmission, normalizeSubmission } from "./submission.js";
 import { getBuiltinJobSchema, validateAgainstSchema, validateStructuredSubmission } from "./job-schema-registry.js";
 import {
@@ -226,6 +231,7 @@ export class JobExecutionService {
         this.buildClaimExpiryDetails(refreshed, job)
       );
     }
+    assertSessionCanTransition(refreshed, "submitted", { reason: "work_submitted" });
     const submission = normalizeSubmission(normalizeSubmitPayloadShape(job.outputSchemaRef, submissionInput));
     validateSubmissionContract(job.outputSchemaRef, submission);
     await this.enforceMaintainerOpenPrCap(job, submission);

--- a/mcp-server/src/core/job-execution-service.test.js
+++ b/mcp-server/src/core/job-execution-service.test.js
@@ -161,6 +161,38 @@ test("submitWork rejects structured output when the schema ref is unknown", asyn
   );
 });
 
+test("submitWork rejects duplicate submissions before replacing stored output", async () => {
+  const stateStore = new MemoryStateStore();
+  const job = makeJob({ outputSchemaRef: "schema://jobs/coding-output" });
+  const service = new JobExecutionService(stateStore, undefined, () => job);
+
+  const claimed = await service.claimJob(WALLET, job.id, "http", "idemp-duplicate-submit");
+  const original = {
+    summary: "Parser fixed.",
+    output: "Added regression coverage.",
+    status: "complete"
+  };
+  await service.submitWork(claimed.sessionId, "http", original);
+
+  await assert.rejects(
+    () => service.submitWork(claimed.sessionId, "http", {
+      summary: "Overwrite attempt.",
+      output: "This should never replace the stored submission.",
+      status: "complete"
+    }),
+    (error) => {
+      assert.equal(error.code, "invalid_session_transition");
+      assert.equal(error.details.currentStatus, "submitted");
+      assert.equal(error.details.nextStatus, "submitted");
+      return true;
+    }
+  );
+
+  const stored = await stateStore.getSession(claimed.sessionId);
+  assert.deepEqual(stored.submission.structured, original);
+  assert.equal(stored.statusHistory.length, 2);
+});
+
 test("submitWork rejects and materializes expired claims before mutation", async () => {
   const stateStore = new MemoryStateStore();
   const job = makeJob({

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -198,6 +198,23 @@ test("getSessionTimeline includes transitions and verification state", async () 
     reasonCode: "BENCHMARK_THRESHOLD_MET"
   });
   const result = await service.stateStore.getVerificationResult(submitted.sessionId);
+  await assert.rejects(
+    () => service.ingestVerification(submitted.sessionId, {
+      jobId: submitted.jobId,
+      handler: "benchmark",
+      handlerVersion: 1,
+      outcome: "rejected",
+      reasonCode: "LATE_REJECT"
+    }),
+    (error) => {
+      assert.equal(error.code, "invalid_session_transition");
+      assert.equal(error.details.currentStatus, "resolved");
+      assert.equal(error.details.terminal, true);
+      return true;
+    }
+  );
+  const stillResolved = await service.stateStore.getSession(submitted.sessionId);
+  assert.equal(stillResolved.verificationSummary.reasonCode, "BENCHMARK_THRESHOLD_MET");
 
   const timeline = await service.getSessionTimeline(submitted.sessionId);
   assert.equal(timeline.timelineVersion, "v2");

--- a/mcp-server/src/core/session-state-machine.js
+++ b/mcp-server/src/core/session-state-machine.js
@@ -71,18 +71,7 @@ const STATUS_METADATA = {
 
 export function transitionSession(session, nextStatus, { reason, timestamp = new Date().toISOString(), metadata = undefined } = {}) {
   const currentStatus = session?.status ?? "__new__";
-  if (currentStatus === nextStatus) {
-    return session;
-  }
-
-  const allowed = ALLOWED_TRANSITIONS.get(currentStatus) ?? new Set();
-  if (!allowed.has(nextStatus)) {
-    throw new ConflictError(
-      `Invalid session transition: ${currentStatus} -> ${nextStatus}`,
-      "invalid_session_transition",
-      { currentStatus, nextStatus, reason }
-    );
-  }
+  assertSessionCanTransition(session, nextStatus, { reason });
 
   const history = [...(session?.statusHistory ?? []), compact({
     from: currentStatus === "__new__" ? null : currentStatus,
@@ -105,6 +94,50 @@ export function transitionSession(session, nextStatus, { reason, timestamp = new
     expiredAt: nextStatus === "expired" ? timestamp : session?.expiredAt,
     timedOutAt: nextStatus === "timed_out" ? timestamp : session?.timedOutAt
   });
+}
+
+export function canTransitionSession(session, nextStatus) {
+  const currentStatus = session?.status ?? "__new__";
+  return (ALLOWED_TRANSITIONS.get(currentStatus) ?? new Set()).has(nextStatus);
+}
+
+export function assertSessionCanTransition(session, nextStatus, { reason = undefined } = {}) {
+  const currentStatus = session?.status ?? "__new__";
+  const allowedTransitions = getAllowedSessionTransitions(currentStatus);
+  if (allowedTransitions.includes(nextStatus)) {
+    return true;
+  }
+  throw new ConflictError(
+    `Invalid session transition: ${currentStatus} -> ${nextStatus}`,
+    "invalid_session_transition",
+    {
+      currentStatus,
+      nextStatus,
+      reason,
+      allowedTransitions,
+      currentPhase: describeSessionStatus(currentStatus).phase,
+      terminal: describeSessionStatus(currentStatus).terminal
+    }
+  );
+}
+
+export function assertSessionCanReceiveVerification(session, { reason = "verification_resolved" } = {}) {
+  const currentStatus = session?.status ?? "__new__";
+  if (currentStatus === "submitted" || currentStatus === "disputed") {
+    return true;
+  }
+  throw new ConflictError(
+    `Session ${session?.sessionId ?? "<unknown>"} cannot receive verification while ${currentStatus}.`,
+    "invalid_session_transition",
+    {
+      currentStatus,
+      nextStatus: "resolved|rejected|disputed",
+      reason,
+      allowedTransitions: getAllowedSessionTransitions(currentStatus),
+      currentPhase: describeSessionStatus(currentStatus).phase,
+      terminal: describeSessionStatus(currentStatus).terminal
+    }
+  );
 }
 
 export function getAllowedSessionTransitions(status = "__new__") {

--- a/mcp-server/src/core/session-state-machine.test.js
+++ b/mcp-server/src/core/session-state-machine.test.js
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  assertSessionCanTransition,
   buildSessionLifecycle,
   describeSessionStatus,
   getSessionStateMachineDefinition,
@@ -37,4 +38,32 @@ test("getSessionStateMachineDefinition returns stable public statuses", () => {
   assert.ok(statuses.some((entry) => entry.status === "claimed"));
   assert.ok(statuses.some((entry) => entry.status === "resolved" && entry.terminal === true));
   assert.ok(!statuses.some((entry) => entry.status === "__new__"));
+});
+
+test("transitionSession rejects duplicate and illegal transitions with operator context", () => {
+  const claimed = transitionSession({ sessionId: "s1" }, "claimed", {
+    reason: "job_claimed",
+    timestamp: "2026-04-23T10:00:00.000Z"
+  });
+
+  assert.throws(
+    () => transitionSession(claimed, "claimed", { reason: "duplicate_claim" }),
+    (error) => {
+      assert.equal(error.code, "invalid_session_transition");
+      assert.equal(error.details.currentStatus, "claimed");
+      assert.equal(error.details.nextStatus, "claimed");
+      assert.deepEqual(error.details.allowedTransitions.sort(), ["closed", "expired", "submitted", "timed_out"]);
+      return true;
+    }
+  );
+
+  assert.throws(
+    () => assertSessionCanTransition(claimed, "resolved", { reason: "skip_submit" }),
+    (error) => {
+      assert.equal(error.code, "invalid_session_transition");
+      assert.equal(error.details.currentPhase, "work");
+      assert.equal(error.details.terminal, false);
+      return true;
+    }
+  );
 });

--- a/mcp-server/src/services/verification-ingestion-service.js
+++ b/mcp-server/src/services/verification-ingestion-service.js
@@ -1,4 +1,7 @@
-import { transitionSession } from "../core/session-state-machine.js";
+import {
+  assertSessionCanReceiveVerification,
+  transitionSession
+} from "../core/session-state-machine.js";
 import { updateFundedJobFromSession } from "../core/funded-jobs.js";
 import { buildVerificationAuditFields } from "../core/verifier-contract.js";
 
@@ -16,6 +19,7 @@ export class VerificationIngestionService {
     if (!session) {
       return undefined;
     }
+    assertSessionCanReceiveVerification(session);
     const job = this.resolveJob(session, verdict);
     const verificationInput = verdict.verificationInput ?? session.submission ?? "";
     const auditFields = job

--- a/mcp-server/src/services/verifier-service.js
+++ b/mcp-server/src/services/verifier-service.js
@@ -4,6 +4,7 @@ import {
   buildVerificationAuditFields,
   jobWithVerifierConfigSnapshot
 } from "../core/verifier-contract.js";
+import { assertSessionCanReceiveVerification } from "../core/session-state-machine.js";
 
 export class VerifierService {
   constructor(platformService, stateStore, blockchainGateway = undefined, registry = new VerifierRegistry()) {
@@ -15,6 +16,7 @@ export class VerifierService {
 
   async verifySubmission({ sessionId, evidence = undefined, metadataURI = "ipfs://pending-badge" }) {
     const session = await this.platformService.resumeSession(sessionId);
+    assertSessionCanReceiveVerification(session);
     const job = this.platformService.getJobDefinition(session.jobId);
     const chainJobId = session.chainJobId ?? session.jobId;
     const verificationInput = this.resolveVerificationInput(session, evidence);

--- a/mcp-server/src/services/verifier-service.test.js
+++ b/mcp-server/src/services/verifier-service.test.js
@@ -79,6 +79,56 @@ test("verifySubmission persists verification input and supports replay", async (
   assert.deepEqual(replay.verifierConfigSnapshot.expectedOutputs, ["release_id", "checks_passed", "go_no_go"]);
 });
 
+test("verifySubmission rejects non-verifiable sessions before handler or chain side effects", async () => {
+  const stateStore = new MemoryStateStore();
+  const claimed = transitionSession({
+    sessionId: SESSION_ID,
+    wallet: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    jobId: "release-readiness-check-001"
+  }, "claimed", { reason: "job_claimed" });
+  await stateStore.upsertSession(claimed);
+
+  let evaluated = false;
+  let resolvedOnChain = false;
+  const service = new VerifierService(
+    {
+      resumeSession: (sessionId) => stateStore.getSession(sessionId),
+      getJobDefinition: () => {
+        throw new Error("job definition should not be needed before transition guard");
+      },
+      ingestVerification: () => {
+        throw new Error("verification should not ingest before transition guard");
+      }
+    },
+    stateStore,
+    {
+      isEnabled: () => true,
+      resolveSinglePayout: async () => {
+        resolvedOnChain = true;
+      }
+    },
+    {
+      evaluate: async () => {
+        evaluated = true;
+        return { outcome: "approved" };
+      },
+      listHandlers: () => []
+    }
+  );
+
+  await assert.rejects(
+    () => service.verifySubmission({ sessionId: SESSION_ID }),
+    (error) => {
+      assert.equal(error.code, "invalid_session_transition");
+      assert.equal(error.details.currentStatus, "claimed");
+      assert.equal(error.details.nextStatus, "resolved|rejected|disputed");
+      return true;
+    }
+  );
+  assert.equal(evaluated, false);
+  assert.equal(resolvedOnChain, false);
+});
+
 test("github_pr verifier scores structured PR evidence and exposes reputation signals", async () => {
   const registry = new VerifierRegistry();
   const job = {


### PR DESCRIPTION
## What changed
- Centralize session transition preflight helpers in the state machine.
- Reject duplicate/illegal submit transitions before submission replacement or schema side effects.
- Reject verifier and verification-ingestion work on non-verifiable or terminal sessions before handler, chain, or result side effects.
- Update the core framework roadmap with the current state-machine implementation and remaining gaps.

## Checks
- node --test mcp-server/src/core/session-state-machine.test.js mcp-server/src/core/job-execution-service.test.js mcp-server/src/services/verifier-service.test.js mcp-server/src/core/platform-service.test.js
- npm --workspace mcp-server test
- git diff --check

## Impact
- Backend: yes
- Frontend: no
- Indexer: no
- Caddy: no
- Contracts: no
- Public site: no

## Environment / VPS secrets
- None