### PR TITLE
Harden admin mutation idempotency

### DIFF
--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -219,27 +219,32 @@ The claim path already has a good start with idempotency keys and claim locks.
 Admin mutations and some operator flows should reach the same standard before
 load and automation grow.
 
-### Gaps today
+### Current implementation
 
-- claim idempotency is stronger than job creation idempotency
-- posting bundles, recurring fires, and future schedulers need duplicate-safe
-  semantics
-- some mutation routes still depend on callers simply not repeating requests
+- claim idempotency is enforced through session lookup and claim locks
+- `POST /admin/jobs`, `POST /admin/jobs/fire`, recurring pause/resume, and
+  async XCM admin actions can persist mutation receipts in the state store
+- admin job creation, manual recurring fires, and recurring pause/resume store
+  canonical request hashes with their idempotency receipts, so same-key replays
+  return the original result while same-key payload drift fails with a clear
+  conflict
 
-### Improve to
+### Remaining gaps
 
-- idempotency support across all meaningful write routes
-- duplicate-safe admin posting
-- clearer conflict codes for retries and replays
+- provider ingestion endpoints still rely mostly on deterministic job ids and
+  duplicate-skip behavior rather than explicit idempotency receipts
+- async XCM actions replay receipts but still need the same canonical
+  payload-drift guard as create/fire/pause/resume
+- future dispute and settlement routes should adopt the same receipt wrapper
 
 ### Concrete next changes
 
-- add optional idempotency keys to:
-  - `POST /admin/jobs`
-  - `POST /admin/jobs/fire`
-  - future dispute and settlement routes
-- persist mutation receipts in the state store
-- expose conflict reasons cleanly for operators and scripts
+- extend canonical request-hash receipts to async XCM admin routes
+- add optional idempotency keys to provider ingestion routes where callers need
+  whole-run replay semantics
+- reuse the same receipt wrapper for future dispute and settlement routes
+- expose idempotency replay/conflict metadata in operator-facing docs and SDK
+  helpers
 
 ### What this unlocks
 

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -4,9 +4,11 @@ import { createPlatformRuntime } from "../../services/bootstrap.js";
 import {
   AuthenticationError,
   AuthorizationError,
+  ConflictError,
   normalizeError,
   ValidationError
 } from "../../core/errors.js";
+import { hashCanonicalContent } from "../../core/canonical-content.js";
 import { buildSiweMessage, verifySiweMessage } from "../../auth/siwe.js";
 import { signToken } from "../../auth/jwt.js";
 import { extractClientKey } from "../../auth/rate-limit.js";
@@ -1117,6 +1119,75 @@ function parseAsyncTreasuryOptions(payload = {}, url, { defaultRecipient = undef
     recipient,
     requestedShares
   };
+}
+
+function parseIdempotencyKey(payload = {}) {
+  return typeof payload?.idempotencyKey === "string" && payload.idempotencyKey.trim()
+    ? payload.idempotencyKey.trim()
+    : undefined;
+}
+
+function stripIdempotencyKey(payload = {}) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return payload;
+  }
+  const { idempotencyKey, ...rest } = payload;
+  return rest;
+}
+
+function buildMutationRequestHash({ route, wallet, payload }) {
+  return hashCanonicalContent({
+    route,
+    wallet,
+    payload: stripIdempotencyKey(payload)
+  });
+}
+
+function isMutationReceiptEnvelope(receipt) {
+  return Boolean(
+    receipt
+    && typeof receipt === "object"
+    && typeof receipt.requestHash === "string"
+    && Object.prototype.hasOwnProperty.call(receipt, "response")
+  );
+}
+
+async function getIdempotentMutationReplay({ bucket, key, requestHash }) {
+  if (!key) {
+    return undefined;
+  }
+  const existing = await stateStore.getMutationReceipt?.(bucket, key);
+  if (!existing) {
+    return undefined;
+  }
+  if (!isMutationReceiptEnvelope(existing)) {
+    return { statusCode: 200, body: existing };
+  }
+  if (existing.requestHash !== requestHash) {
+    throw new ConflictError(
+      "Idempotency key was already used with a different request payload.",
+      "idempotency_key_payload_mismatch",
+      {
+        bucket,
+        originalRequestHash: existing.requestHash,
+        requestHash
+      }
+    );
+  }
+  return { statusCode: 200, body: existing.response };
+}
+
+async function storeIdempotentMutationReceipt({ bucket, key, requestHash, response, statusCode }) {
+  if (!key) {
+    return response;
+  }
+  await stateStore.upsertMutationReceipt?.(bucket, key, {
+    requestHash,
+    statusCode,
+    response,
+    createdAt: new Date().toISOString()
+  });
+  return response;
 }
 
 function buildLaneAttention({ shares, isMock, debtTotal, borrowCapacity, deploymentShareBps }) {
@@ -2461,18 +2532,25 @@ const server = createServer(async (request, response) => {
       const auth = await authMiddleware(request, url, { requireRole: "admin" });
       await enforceLimit("admin_jobs", auth.wallet, rateLimitConfig.adminJobs);
       const payload = await readJsonBody(request);
-      const idempotencyKey = typeof payload?.idempotencyKey === "string" && payload.idempotencyKey.trim()
-        ? payload.idempotencyKey.trim()
-        : undefined;
+      const idempotencyKey = parseIdempotencyKey(payload);
       const mutationKey = idempotencyKey ? `${auth.wallet}:${idempotencyKey}` : undefined;
-      const existing = mutationKey ? await stateStore.getMutationReceipt?.("admin_jobs", mutationKey) : undefined;
-      if (existing) {
-        return respond(response, 200, existing);
+      const requestHash = buildMutationRequestHash({ route: "/admin/jobs", wallet: auth.wallet, payload });
+      const replay = await getIdempotentMutationReplay({
+        bucket: "admin_jobs",
+        key: mutationKey,
+        requestHash
+      });
+      if (replay) {
+        return respond(response, replay.statusCode, replay.body);
       }
       const created = service.createJob(payload);
-      if (mutationKey) {
-        await stateStore.upsertMutationReceipt?.("admin_jobs", mutationKey, created);
-      }
+      await storeIdempotentMutationReceipt({
+        bucket: "admin_jobs",
+        key: mutationKey,
+        requestHash,
+        response: created,
+        statusCode: 201
+      });
       return respond(response, 201, created);
     }
 
@@ -2836,22 +2914,34 @@ const server = createServer(async (request, response) => {
       if (!templateId) {
         throw new ValidationError("templateId is required.");
       }
-      const idempotencyKey = typeof payload?.idempotencyKey === "string" && payload.idempotencyKey.trim()
-        ? payload.idempotencyKey.trim()
-        : undefined;
+      const idempotencyKey = parseIdempotencyKey(payload);
       const mutationKey = idempotencyKey ? `${auth.wallet}:${idempotencyKey}` : undefined;
-      const existing = mutationKey ? await stateStore.getMutationReceipt?.("admin_jobs_fire", mutationKey) : undefined;
-      if (existing) {
-        return respond(response, 200, existing);
-      }
       const firedAt = payload?.firedAt ? new Date(payload.firedAt) : new Date();
       if (Number.isNaN(firedAt.getTime())) {
         throw new ValidationError("firedAt must be ISO-8601 if provided.");
       }
-      const derivative = service.fireRecurringJob(templateId, { firedAt });
-      if (mutationKey) {
-        await stateStore.upsertMutationReceipt?.("admin_jobs_fire", mutationKey, derivative);
+      const normalizedPayload = {
+        ...payload,
+        templateId,
+        firedAt: payload?.firedAt ? firedAt.toISOString() : "__server_now__"
+      };
+      const requestHash = buildMutationRequestHash({ route: "/admin/jobs/fire", wallet: auth.wallet, payload: normalizedPayload });
+      const replay = await getIdempotentMutationReplay({
+        bucket: "admin_jobs_fire",
+        key: mutationKey,
+        requestHash
+      });
+      if (replay) {
+        return respond(response, replay.statusCode, replay.body);
       }
+      const derivative = service.fireRecurringJob(templateId, { firedAt });
+      await storeIdempotentMutationReceipt({
+        bucket: "admin_jobs_fire",
+        key: mutationKey,
+        requestHash,
+        response: derivative,
+        statusCode: 201
+      });
       return respond(response, 201, derivative);
     }
 
@@ -2883,19 +2973,30 @@ const server = createServer(async (request, response) => {
       if (!templateId) {
         throw new ValidationError("templateId is required.");
       }
-      const idempotencyKey = typeof payload?.idempotencyKey === "string" && payload.idempotencyKey.trim()
-        ? payload.idempotencyKey.trim()
-        : undefined;
+      const idempotencyKey = parseIdempotencyKey(payload);
       const mutationKey = idempotencyKey ? `${auth.wallet}:${templateId}:${idempotencyKey}` : undefined;
-      const existing = mutationKey ? await stateStore.getMutationReceipt?.("admin_jobs_pause", mutationKey) : undefined;
-      if (existing) {
-        return respond(response, 200, existing);
+      const requestHash = buildMutationRequestHash({
+        route: "/admin/jobs/pause",
+        wallet: auth.wallet,
+        payload: { ...payload, templateId }
+      });
+      const replay = await getIdempotentMutationReplay({
+        bucket: "admin_jobs_pause",
+        key: mutationKey,
+        requestHash
+      });
+      if (replay) {
+        return respond(response, replay.statusCode, replay.body);
       }
       await service.pauseRecurringTemplate(templateId);
       const status = await service.getAdminStatus({ auth });
-      if (mutationKey) {
-        await stateStore.upsertMutationReceipt?.("admin_jobs_pause", mutationKey, status);
-      }
+      await storeIdempotentMutationReceipt({
+        bucket: "admin_jobs_pause",
+        key: mutationKey,
+        requestHash,
+        response: status,
+        statusCode: 200
+      });
       return respond(response, 200, status);
     }
 
@@ -2907,19 +3008,30 @@ const server = createServer(async (request, response) => {
       if (!templateId) {
         throw new ValidationError("templateId is required.");
       }
-      const idempotencyKey = typeof payload?.idempotencyKey === "string" && payload.idempotencyKey.trim()
-        ? payload.idempotencyKey.trim()
-        : undefined;
+      const idempotencyKey = parseIdempotencyKey(payload);
       const mutationKey = idempotencyKey ? `${auth.wallet}:${templateId}:${idempotencyKey}` : undefined;
-      const existing = mutationKey ? await stateStore.getMutationReceipt?.("admin_jobs_resume", mutationKey) : undefined;
-      if (existing) {
-        return respond(response, 200, existing);
+      const requestHash = buildMutationRequestHash({
+        route: "/admin/jobs/resume",
+        wallet: auth.wallet,
+        payload: { ...payload, templateId }
+      });
+      const replay = await getIdempotentMutationReplay({
+        bucket: "admin_jobs_resume",
+        key: mutationKey,
+        requestHash
+      });
+      if (replay) {
+        return respond(response, replay.statusCode, replay.body);
       }
       await service.resumeRecurringTemplate(templateId);
       const status = await service.getAdminStatus({ auth });
-      if (mutationKey) {
-        await stateStore.upsertMutationReceipt?.("admin_jobs_resume", mutationKey, status);
-      }
+      await storeIdempotentMutationReceipt({
+        bucket: "admin_jobs_resume",
+        key: mutationKey,
+        requestHash,
+        response: status,
+        statusCode: 200
+      });
       return respond(response, 200, status);
     }
 

--- a/mcp-server/src/protocols/http/server.smoke.test.js
+++ b/mcp-server/src/protocols/http/server.smoke.test.js
@@ -1013,6 +1013,112 @@ test("http smoke: /admin/jobs/fire produces a derivative from a recurring templa
   });
 });
 
+test("http smoke: admin job creation idempotency replays and rejects payload drift", { skip: !RUN }, async () => {
+  await runWithServer(async (base) => {
+    const adminToken = issueToken(ADMIN_WALLET, { roles: ["admin"] });
+    const headers = { "content-type": "application/json", authorization: `Bearer ${adminToken}` };
+    const payload = {
+      id: "admin-idempotency-create-smoke",
+      category: "coding",
+      tier: "starter",
+      rewardAmount: 2,
+      verifierMode: "benchmark",
+      verifierTerms: ["complete"],
+      verifierMinimumMatches: 1,
+      idempotencyKey: "admin-create-same-key"
+    };
+
+    const create = await fetch(`${base}/admin/jobs`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload)
+    });
+    assert.equal(create.status, 201);
+    const created = await create.json();
+
+    const replay = await fetch(`${base}/admin/jobs`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ verifierTerms: ["complete"], ...payload })
+    });
+    assert.equal(replay.status, 200);
+    assert.deepEqual(await replay.json(), created);
+
+    const drift = await fetch(`${base}/admin/jobs`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        ...payload,
+        id: "admin-idempotency-create-smoke-other"
+      })
+    });
+    assert.equal(drift.status, 409);
+    const body = await drift.json();
+    assert.equal(body.error, "idempotency_key_payload_mismatch");
+    assert.equal(body.details.bucket, "admin_jobs");
+    assert.ok(body.details.originalRequestHash);
+    assert.ok(body.details.requestHash);
+  });
+});
+
+test("http smoke: admin recurring fire idempotency replays and rejects firedAt drift", { skip: !RUN }, async () => {
+  await runWithServer(async (base) => {
+    const adminToken = issueToken(ADMIN_WALLET, { roles: ["admin"] });
+    const headers = { "content-type": "application/json", authorization: `Bearer ${adminToken}` };
+
+    const template = await fetch(`${base}/admin/jobs`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        id: "recurring-fire-idempotency-smoke",
+        category: "coding",
+        tier: "starter",
+        rewardAmount: 2,
+        verifierMode: "benchmark",
+        verifierTerms: ["complete"],
+        verifierMinimumMatches: 1,
+        recurring: true,
+        schedule: { cron: "0 9 * * 1", timezone: "Europe/Zurich" }
+      })
+    });
+    assert.equal(template.status, 201);
+
+    const firePayload = {
+      templateId: "recurring-fire-idempotency-smoke",
+      firedAt: "2026-04-20T09:00:00.000Z",
+      idempotencyKey: "fire-same-key"
+    };
+    const fire = await fetch(`${base}/admin/jobs/fire`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(firePayload)
+    });
+    assert.equal(fire.status, 201);
+    const derivative = await fire.json();
+
+    const replay = await fetch(`${base}/admin/jobs/fire`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(firePayload)
+    });
+    assert.equal(replay.status, 200);
+    assert.deepEqual(await replay.json(), derivative);
+
+    const drift = await fetch(`${base}/admin/jobs/fire`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        ...firePayload,
+        firedAt: "2026-04-27T09:00:00.000Z"
+      })
+    });
+    assert.equal(drift.status, 409);
+    const body = await drift.json();
+    assert.equal(body.error, "idempotency_key_payload_mismatch");
+    assert.equal(body.details.bucket, "admin_jobs_fire");
+  });
+});
+
 test("http smoke: recurring pause/resume accept idempotency keys", { skip: !RUN }, async () => {
   await runWithServer(async (base) => {
     const adminToken = issueToken(ADMIN_WALLET, { roles: ["admin"] });
@@ -1057,6 +1163,20 @@ test("http smoke: recurring pause/resume accept idempotency keys", { skip: !RUN 
     });
     assert.equal(pauseReplay.status, 200);
     assert.deepEqual(await pauseReplay.json(), paused);
+
+    const pauseDrift = await fetch(`${base}/admin/jobs/pause`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        templateId: "recurring-idempotency-smoke",
+        idempotencyKey: "same-client-key",
+        reason: "different operator annotation"
+      })
+    });
+    assert.equal(pauseDrift.status, 409);
+    const pauseDriftBody = await pauseDrift.json();
+    assert.equal(pauseDriftBody.error, "idempotency_key_payload_mismatch");
+    assert.equal(pauseDriftBody.details.bucket, "admin_jobs_pause");
 
     const resume = await fetch(`${base}/admin/jobs/resume`, {
       method: "POST",


### PR DESCRIPTION
## What changed
- Store canonical request hashes alongside admin mutation receipts.
- Replay same-key/same-payload admin job creation, recurring fire, pause, and resume without changing response bodies.
- Reject same-key/different-payload replays with `409 idempotency_key_payload_mismatch`.
- Update the core framework roadmap for the idempotent admin mutation spec slice.

## Checks
- RUN_HTTP_SMOKE=1 node --test mcp-server/src/protocols/http/server.smoke.test.js
- npm --workspace mcp-server test
- git diff --check

## Impact
- Backend: yes
- Frontend: no
- Indexer: no
- Caddy: no
- Contracts: no
- Public site: no

## Environment / VPS secrets
- None