### PR TITLE
Standardize job timeline observability

### DIFF
--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -267,14 +267,30 @@ The platform needs to answer operator questions like:
 - did stake move?
 - did a recurring template fire?
 
-Today, some of this exists in logs, some in sessions, some in verification
-results, and some only in the operator app.
+Some of this exists in logs, some in sessions, some in verification results,
+and some only in the operator app. The backend now exposes the shared
+job/session timeline spine, but the remaining work is to make every producer
+emit into it with the same topic taxonomy.
 
-### Gaps today
+### Current implementation
 
-- no unified job/session timeline view in the backend model
-- recurring and sub-job lineage are visible only indirectly
-- verification and funding state are not yet merged into one operational trace
+- `/session/timeline` exposes v2 session lifecycle, verification, child-job,
+  and child-session events
+- `/admin/jobs/timeline` exposes v2 job state, sessions, verification,
+  child/derivative lineage, and replayed event-bus entries
+- timeline entries use one canonical envelope with `id`, `type`, `at`,
+  `timestamp`, `correlationId`, `phase`, `source`, `topic`, `severity`,
+  direct `jobId` / `sessionId` / `wallet` fields, and compact `data`
+- recurring template fire history is reconstructed through derivative jobs,
+  and sub-job lineage is reconstructed through `parentSessionId`
+
+### Remaining gaps
+
+- not every producer emits a canonical topic and payload shape yet
+- event-bus replay is still in-memory, so long-term history is reconstructed
+  mostly from state snapshots
+- funding and settlement state are not fully folded into the same timeline
+- operator UI still needs richer timeline filtering and source labels
 
 ### Improve to
 
@@ -285,10 +301,11 @@ results, and some only in the operator app.
 
 ### Concrete next changes
 
-- standardize platform event topics and payload shapes
-- store or reconstruct timelines from events plus state snapshots
-- add admin/session endpoints for timeline inspection
-- include recurring template fire history and parent/child links in those views
+- standardize the remaining platform event topics and payload shapes
+- persist the event log or extend state snapshots where replay windows are too
+  short for audits
+- merge funding, settlement, and dispute state into the same job/session trace
+- expose UI/SDK filters for source, topic, wallet, and correlation id
 
 ### What this unlocks
 

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -18,6 +18,8 @@ import {
 import { computeClaimEconomics, countClaimedSessions } from "./claim-economics.js";
 import { claimStatusFields, isTerminalSession, summarizeJobClaimState } from "./claim-state.js";
 
+const TIMELINE_VERSION = "v2";
+
 const STARTER_REPUTATION = {
   skill: 0,
   reliability: 0,
@@ -109,7 +111,7 @@ export class PlatformService {
 
   getSessionStateMachine() {
     return {
-      timelineVersion: "v2",
+      timelineVersion: TIMELINE_VERSION,
       statuses: getSessionStateMachineDefinition()
     };
   }
@@ -562,63 +564,19 @@ export class PlatformService {
     );
     const lifecycle = buildSessionLifecycle(session, verification);
 
-    const transitions = (session.statusHistory ?? []).map((entry, index) => ({
-      id: `${sessionId}:transition:${index}`,
-      type: "session_transition",
-      at: entry.at,
-      correlationId: sessionId,
-      phase: describeSessionStatus(entry.to).phase,
-      data: entry
-    }));
-    const verificationEvents = verification
-      ? [{
-          id: `${sessionId}:verification`,
-          type: "verification",
-          at: verification.session?.updatedAt ?? verification.session?.resolvedAt ?? new Date().toISOString(),
-          correlationId: sessionId,
-          phase: "verification",
-          data: {
-            outcome: verification.outcome,
-            reasonCode: verification.reasonCode,
-            handler: verification.handler,
-            handlerVersion: verification.handlerVersion,
-            verifierConfigVersion: verification.verifierConfigVersion
-          }
-        }]
-      : [];
+    const transitions = buildSessionTimelineEntries(session, { correlationId: sessionId });
+    const verificationEvents = [buildVerificationTimelineEntry(session, verification, { correlationId: sessionId })]
+      .filter(Boolean);
     const childEvents = childRuns.flatMap(({ job, sessions }) => ([
-      {
-        id: `${job.id}:child-job`,
-        type: "child_job",
-        at: job.firedAt ?? sessions[0]?.updatedAt ?? session.updatedAt,
-        correlationId: sessionId,
-        phase: "child_job",
-        data: {
-          jobId: job.id,
-          templateId: job.templateId,
-          parentSessionId: job.parentSessionId
-        }
-      },
-      ...sessions.map((childSession) => ({
-        id: `${childSession.sessionId}:child-session`,
-        type: "child_session",
-        at: childSession.updatedAt,
-        correlationId: sessionId,
-        phase: describeSessionStatus(childSession.status).phase,
-        data: {
-          sessionId: childSession.sessionId,
-          jobId: childSession.jobId,
-          wallet: childSession.wallet,
-          status: childSession.status
-        }
-      }))
+      buildChildJobTimelineEntry(job, { correlationId: sessionId }),
+      ...sessions.map((childSession) => buildChildSessionTimelineEntry(childSession, { correlationId: sessionId }))
     ]));
 
     const timeline = [...transitions, ...verificationEvents, ...childEvents]
-      .sort((left, right) => String(left.at ?? "").localeCompare(String(right.at ?? "")));
+      .sort(compareTimelineEntries);
 
     return {
-      timelineVersion: "v2",
+      timelineVersion: TIMELINE_VERSION,
       session,
       lifecycle,
       verification,
@@ -688,7 +646,7 @@ export class PlatformService {
       .sort(compareTimelineEntries);
 
     return {
-      timelineVersion: "v2",
+      timelineVersion: TIMELINE_VERSION,
       job,
       lineage: {
         templateId: job.templateId ?? null,
@@ -951,14 +909,18 @@ export class PlatformService {
 }
 
 function buildJobStateTimelineEntry(job, sessions) {
-  return {
+  return buildTimelineEntry({
     id: `${job.id}:job-state`,
     type: "job_state",
     at: firstDefined(job.lifecycle?.updatedAt, job.createdAt, job.firedAt, sessions[0]?.updatedAt),
     correlationId: job.id,
     phase: "job",
+    source: "state",
+    topic: "job.state",
+    jobId: job.id,
+    sessionId: job.sessionId,
+    wallet: job.claimedBy,
     data: compactTimelineData({
-      jobId: job.id,
       category: job.category,
       tier: job.tier,
       verifierMode: job.verifierMode,
@@ -971,47 +933,54 @@ function buildJobStateTimelineEntry(job, sessions) {
       claimedBy: job.claimedBy,
       claimExpiresAt: job.claimExpiresAt
     })
-  };
+  });
 }
 
-function buildSessionTimelineEntries(session) {
+function buildSessionTimelineEntries(session, options = {}) {
+  const correlationId = options.correlationId ?? session.sessionId;
   const history = Array.isArray(session.statusHistory) ? session.statusHistory : [];
   if (!history.length) {
-    return [{
+    return [buildTimelineEntry({
       id: `${session.sessionId}:session-snapshot`,
       type: "session_snapshot",
       at: firstDefined(session.updatedAt, session.claimedAt),
-      correlationId: session.sessionId,
+      correlationId,
       phase: describeSessionStatus(session.status).phase,
+      source: "state",
+      topic: "session.snapshot",
+      severity: timelineSeverityForSessionStatus(session.status),
+      jobId: session.jobId,
+      sessionId: session.sessionId,
+      wallet: session.wallet,
       data: compactTimelineData({
-        sessionId: session.sessionId,
-        jobId: session.jobId,
-        wallet: session.wallet,
         status: session.status
       })
-    }];
+    })];
   }
-  return history.map((entry, index) => ({
+  return history.map((entry, index) => buildTimelineEntry({
     id: `${session.sessionId}:transition:${index}`,
     type: "session_transition",
     at: entry.at,
-    correlationId: session.sessionId,
+    correlationId,
     phase: describeSessionStatus(entry.to).phase,
+    source: "state",
+    topic: "session.transition",
+    severity: timelineSeverityForSessionStatus(entry.to),
+    jobId: session.jobId,
+    sessionId: session.sessionId,
+    wallet: session.wallet,
     data: {
-      sessionId: session.sessionId,
-      jobId: session.jobId,
-      wallet: session.wallet,
       ...entry
     }
   }));
 }
 
-function buildVerificationTimelineEntry(session) {
-  const verification = session.verification ?? session.verificationSummary;
+function buildVerificationTimelineEntry(session, verificationOverride = undefined, options = {}) {
+  const verification = verificationOverride ?? session.verification ?? session.verificationSummary;
   if (!verification) {
     return undefined;
   }
-  return {
+  return buildTimelineEntry({
     id: `${session.sessionId}:verification`,
     type: "verification",
     at: firstDefined(
@@ -1020,89 +989,150 @@ function buildVerificationTimelineEntry(session) {
       session.resolvedAt,
       session.updatedAt
     ),
-    correlationId: session.sessionId,
+    correlationId: options.correlationId ?? session.sessionId,
     phase: "verification",
+    source: "verification",
+    topic: "session.verification",
+    severity: verification.outcome === "rejected" ? "error" : "info",
+    jobId: session.jobId,
+    sessionId: session.sessionId,
+    wallet: session.wallet,
     data: compactTimelineData({
-      sessionId: session.sessionId,
-      jobId: session.jobId,
       outcome: verification.outcome,
       reasonCode: verification.reasonCode,
       handler: verification.handler,
       handlerVersion: verification.handlerVersion,
       verifierConfigVersion: verification.verifierConfigVersion
     })
-  };
+  });
 }
 
-function buildChildJobTimelineEntry(job) {
-  return {
+function buildChildJobTimelineEntry(job, options = {}) {
+  return buildTimelineEntry({
     id: `${job.id}:child-job`,
     type: "child_job",
     at: firstDefined(job.createdAt, job.firedAt, job.lifecycle?.updatedAt),
-    correlationId: job.parentSessionId ?? job.id,
+    correlationId: options.correlationId ?? job.parentSessionId ?? job.id,
     phase: "child_job",
+    source: "lineage",
+    topic: "job.child_created",
+    jobId: job.id,
+    sessionId: job.parentSessionId,
     data: compactTimelineData({
-      jobId: job.id,
       parentSessionId: job.parentSessionId,
       category: job.category,
       tier: job.tier,
       verifierMode: job.verifierMode,
       lifecycle: job.lifecycle
     })
-  };
+  });
 }
 
-function buildChildSessionTimelineEntry(session) {
-  return {
+function buildChildSessionTimelineEntry(session, options = {}) {
+  return buildTimelineEntry({
     id: `${session.sessionId}:child-session`,
     type: "child_session",
     at: firstDefined(session.updatedAt, session.claimedAt),
-    correlationId: session.sessionId,
+    correlationId: options.correlationId ?? session.sessionId,
     phase: describeSessionStatus(session.status).phase,
+    source: "lineage",
+    topic: "session.child_snapshot",
+    severity: timelineSeverityForSessionStatus(session.status),
+    jobId: session.jobId,
+    sessionId: session.sessionId,
+    wallet: session.wallet,
     data: compactTimelineData({
-      sessionId: session.sessionId,
-      jobId: session.jobId,
-      wallet: session.wallet,
       status: session.status
     })
-  };
+  });
 }
 
 function buildDerivativeJobTimelineEntry(job) {
-  return {
+  return buildTimelineEntry({
     id: `${job.id}:derivative-job`,
     type: "derivative_job",
     at: firstDefined(job.firedAt, job.createdAt, job.lifecycle?.updatedAt),
     correlationId: job.templateId ?? job.id,
     phase: "recurring",
+    source: "lineage",
+    topic: "job.recurring_fired",
+    jobId: job.id,
     data: compactTimelineData({
-      jobId: job.id,
       templateId: job.templateId,
       firedAt: job.firedAt,
       category: job.category,
       tier: job.tier,
       lifecycle: job.lifecycle
     })
-  };
+  });
 }
 
 function buildEventBusTimelineEntry(event, index) {
-  return {
+  return buildTimelineEntry({
     id: event.id ?? `event-bus:${index}`,
     type: "event_bus",
     at: event.timestamp,
     correlationId: event.sessionId ?? event.jobId,
     phase: event.topic,
+    source: "event_bus",
+    topic: event.topic,
+    jobId: event.jobId,
+    sessionId: event.sessionId,
+    wallet: event.wallet,
     data: compactTimelineData({
-      topic: event.topic,
-      jobId: event.jobId,
-      sessionId: event.sessionId,
-      wallet: event.wallet,
       blockNumber: event.blockNumber,
       txHash: event.txHash,
       ...event.data
     })
+  });
+}
+
+function buildTimelineEntry({
+  id,
+  type,
+  at,
+  correlationId,
+  phase,
+  source = "state",
+  topic,
+  severity = "info",
+  jobId,
+  sessionId,
+  wallet,
+  data = {}
+}) {
+  const timestamp = firstDefined(at);
+  return {
+    id,
+    type,
+    at: timestamp,
+    timestamp,
+    correlationId,
+    phase,
+    source,
+    topic,
+    severity,
+    jobId,
+    sessionId,
+    wallet,
+    data: compactTimelineData({
+      topic,
+      jobId,
+      sessionId,
+      wallet,
+      ...data
+    })
   };
+}
+
+function timelineSeverityForSessionStatus(status) {
+  if (["failed", "rejected", "slashed"].includes(status)) {
+    return "error";
+  }
+  if (status === "disputed") {
+    return "warn";
+  }
+  return "info";
 }
 
 function compareTimelineEntries(left, right) {

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -232,6 +232,19 @@ test("getSessionTimeline includes transitions and verification state", async () 
   assert.ok(timeline.timeline.some((entry) => entry.type === "session_transition"));
   assert.ok(timeline.timeline.some((entry) => entry.type === "verification"));
   assert.ok(timeline.timeline.every((entry) => entry.correlationId === submitted.sessionId));
+  assert.ok(timeline.timeline.every((entry) => entry.timestamp === entry.at));
+  assert.ok(timeline.timeline.every((entry) => entry.source && entry.topic && entry.severity));
+  assert.ok(timeline.timeline.every((entry) => entry.sessionId === submitted.sessionId || entry.type === "child_job"));
+  const submittedTransition = timeline.timeline.find((entry) => entry.type === "session_transition" && entry.data.to === "submitted");
+  assert.equal(submittedTransition.topic, "session.transition");
+  assert.equal(submittedTransition.source, "state");
+  assert.equal(submittedTransition.jobId, submitted.jobId);
+  assert.equal(submittedTransition.sessionId, submitted.sessionId);
+  const verificationEvent = timeline.timeline.find((entry) => entry.type === "verification");
+  assert.equal(verificationEvent.topic, "session.verification");
+  assert.equal(verificationEvent.source, "verification");
+  assert.equal(verificationEvent.data.handlerVersion, 1);
+  assert.equal(verificationEvent.data.verifierConfigVersion, 1);
 });
 
 test("getJobTimeline stitches sessions, verification, events, and child lineage", async () => {
@@ -278,6 +291,20 @@ test("getJobTimeline stitches sessions, verification, events, and child lineage"
   assert.ok(timeline.timeline.some((entry) => entry.type === "verification"));
   assert.ok(timeline.timeline.some((entry) => entry.type === "child_job"));
   assert.ok(timeline.timeline.some((entry) => entry.type === "event_bus" && entry.data.topic === "session.claimed"));
+  assert.ok(timeline.timeline.every((entry) => entry.timestamp === entry.at));
+  assert.ok(timeline.timeline.every((entry) => entry.source && entry.topic && entry.severity));
+  const jobState = timeline.timeline.find((entry) => entry.type === "job_state");
+  assert.equal(jobState.topic, "job.state");
+  assert.equal(jobState.source, "state");
+  assert.equal(jobState.jobId, "parent-job-001");
+  const childJob = timeline.timeline.find((entry) => entry.type === "child_job");
+  assert.equal(childJob.topic, "job.child_created");
+  assert.equal(childJob.source, "lineage");
+  assert.equal(childJob.jobId, subJob.id);
+  const claimedEvent = timeline.timeline.find((entry) => entry.type === "event_bus" && entry.topic === "session.claimed");
+  assert.equal(claimedEvent.source, "event_bus");
+  assert.equal(claimedEvent.jobId, "parent-job-001");
+  assert.equal(claimedEvent.sessionId, submitted.sessionId);
 });
 
 test("getAdminStatus surfaces recurring scheduler anomalies", async () => {


### PR DESCRIPTION
## What changed
- Added a canonical v2 timeline entry envelope for session/job timelines while preserving existing fields.
- Tagged timeline entries with source, topic, severity, direct job/session/wallet ids, and timestamp.
- Updated roadmap Spec 5 with current implementation and remaining gaps.

## Checks run
- node --test mcp-server/src/core/platform-service.test.js
- node --test mcp-server/src/core/event-bus.test.js
- npm --workspace mcp-server test
- git diff --check

## Impact
- Backend: yes
- Frontend: no generated/frontend changes
- Indexer/Caddy/contracts/public site: no
- Env/VPS secrets: none