### PR TITLE
Centralize auth capability policy

### DIFF
--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -323,12 +323,24 @@ emit into it with the same topic taxonomy.
 Auth is currently solid enough for launch, but capabilities are still spread
 across environment config, JWT roles, and route-level decisions.
 
-### Gaps today
+### Current implementation
 
-- roles are only `admin` and `verifier`
-- route protection is clear, but capability composition is still coarse
-- environment policy and runtime capability policy are not expressed in one
-  source of truth
+- `auth-policy-v1` defines the shared base capability set, role expansions,
+  method-aware route requirements, UI-control requirements, and automation
+  action requirements
+- auth middleware resolves capabilities from roles plus optional signed scopes,
+  and rejects route access when the required capabilities are missing
+- `/auth/session` and `/admin/status` expose the active capability matrix so
+  the operator app and automation clients can render controls from backend
+  policy instead of duplicating route rules
+
+### Remaining gaps
+
+- signed tokens are still issued from coarse environment role lists
+- future fine-grained delegated scopes are supported by the resolver, but do
+  not yet have an operator grant/revoke workflow
+- some public discovery docs still describe auth action requirements separately
+  from the runtime capability matrix
 
 ### Improve to
 
@@ -341,14 +353,12 @@ across environment config, JWT roles, and route-level decisions.
 
 ### Concrete next changes
 
-- document and codify route-to-capability mapping
-- add a capability resolver layer on top of roles
-- let admin status expose the active capability model to the operator app
-- prepare for future scopes such as:
-  - `jobs:create`
-  - `jobs:fire-recurring`
-  - `verifier:run`
-  - `ops:view`
+- add an operator-facing grant/revoke flow for scoped service tokens or
+  delegated wallets
+- align public onboarding action requirements with the versioned auth policy
+  payload
+- extend frontend controls to hide/disable actions from `authPolicy.uiControls`
+- add audit events when capability grants change
 
 ### What this unlocks
 

--- a/mcp-server/src/auth/auth.test.js
+++ b/mcp-server/src/auth/auth.test.js
@@ -362,6 +362,59 @@ test("requireAuth rejects token missing required role", async () => {
   );
 });
 
+test("requireAuth rejects token missing route capability", async () => {
+  const authConfig = {
+    secrets: [LONG_SECRET],
+    signingSecret: LONG_SECRET,
+    permissive: false,
+    strict: true,
+    adminWallets: new Set(),
+    verifierWallets: new Set()
+  };
+  const middleware = createAuthMiddleware({ authConfig, logger: silentLogger() });
+  const { token } = signToken(
+    { sub: "0xcccccccccccccccccccccccccccccccccccccccc", roles: [] },
+    { secret: LONG_SECRET, expiresInSeconds: 60 }
+  );
+  const request = { method: "GET", headers: { authorization: `Bearer ${token}` } };
+  const url = new URL("http://localhost/admin/status");
+  await assert.rejects(
+    () => middleware(request, url),
+    (error) => {
+      assert.ok(error instanceof AuthorizationError);
+      assert.equal(error.code, "missing_capability");
+      assert.deepEqual(error.details.requiredCapabilities, ["admin:status", "ops:view"]);
+      assert.deepEqual(error.details.missingCapabilities, ["admin:status", "ops:view"]);
+      return true;
+    }
+  );
+});
+
+test("requireAuth accepts explicit capability scopes without a role", async () => {
+  const authConfig = {
+    secrets: [LONG_SECRET],
+    signingSecret: LONG_SECRET,
+    permissive: false,
+    strict: true,
+    adminWallets: new Set(),
+    verifierWallets: new Set()
+  };
+  const middleware = createAuthMiddleware({ authConfig, logger: silentLogger() });
+  const { token } = signToken(
+    {
+      sub: "0xcccccccccccccccccccccccccccccccccccccccc",
+      roles: [],
+      capabilities: ["ops:view"]
+    },
+    { secret: LONG_SECRET, expiresInSeconds: 60 }
+  );
+  const request = { method: "GET", headers: { authorization: `Bearer ${token}` } };
+  const url = new URL("http://localhost/admin/jobs");
+  const result = await middleware(request, url);
+  assert.deepEqual(result.capabilityRequirements, ["ops:view"]);
+  assert.ok(result.capabilities.includes("ops:view"));
+});
+
 test("requireAuth in permissive mode resolves roles from env wallet lists", async () => {
   const adminWallet = "0xdddddddddddddddddddddddddddddddddddddddd";
   const authConfig = {

--- a/mcp-server/src/auth/capabilities.js
+++ b/mcp-server/src/auth/capabilities.js
@@ -1,3 +1,5 @@
+export const AUTH_POLICY_VERSION = "auth-policy-v1";
+
 const BASE_CAPABILITIES = [
   "account:read",
   "account:fund",
@@ -23,6 +25,7 @@ const BASE_CAPABILITIES = [
   "session:timeline",
   "strategies:list",
   "subjobs:read",
+  "subjobs:create",
   "xcm:read"
 ];
 
@@ -30,12 +33,15 @@ const ROLE_CAPABILITIES = {
   admin: [
     "admin:status",
     "disputes:release",
+    "jobs:ingest",
     "jobs:create",
     "jobs:fire-recurring",
+    "jobs:lifecycle",
     "jobs:pause-recurring",
     "jobs:resume-recurring",
     "jobs:timeline",
-    "subjobs:create",
+    "ops:view",
+    "policies:propose",
     "xcm:observe",
     "xcm:finalize"
   ],
@@ -48,6 +54,82 @@ const ROLE_CAPABILITIES = {
   ]
 };
 
+const ROUTE_CAPABILITY_RULES = [
+  { method: "GET", path: "/account", capabilities: ["account:read"] },
+  { method: "GET", path: "/account/strategies", capabilities: ["account:read", "strategies:list"] },
+  { method: "GET", path: "/account/borrow-capacity", capabilities: ["account:read"] },
+  { method: "POST", path: "/account/fund", capabilities: ["account:fund"] },
+  { method: "POST", path: "/account/allocate", capabilities: ["account:allocate"] },
+  { method: "POST", path: "/account/deallocate", capabilities: ["account:deallocate"] },
+  { method: "POST", path: "/account/borrow", capabilities: ["account:borrow"] },
+  { method: "POST", path: "/account/repay", capabilities: ["account:repay"] },
+  { method: "GET", path: "/alerts", capabilities: ["ops:view"] },
+  { method: "GET", path: "/audit", capabilities: ["ops:view"] },
+  { method: "GET", path: "/policies", capabilities: ["ops:view"] },
+  { method: "POST", path: "/policies", capabilities: ["policies:propose"] },
+  { method: "GET", path: "/disputes", capabilities: ["disputes:list"] },
+  { method: "GET", path: "/disputes/:id", capabilities: ["disputes:read"] },
+  { method: "POST", path: "/disputes/:id/verdict", capabilities: ["disputes:verdict"] },
+  { method: "POST", path: "/disputes/:id/release", capabilities: ["disputes:release"] },
+  { method: "GET", path: "/jobs/recommendations", capabilities: ["jobs:recommend"] },
+  { method: "GET", path: "/jobs/preflight", capabilities: ["jobs:preflight"] },
+  { method: "POST", path: "/jobs/claim", capabilities: ["jobs:claim"] },
+  { method: "POST", path: "/jobs/submit", capabilities: ["jobs:submit"] },
+  { method: "GET", path: "/jobs/sub", capabilities: ["subjobs:read"] },
+  { method: "POST", path: "/jobs/sub", capabilities: ["subjobs:create"] },
+  { method: "GET", path: "/session", capabilities: ["session:read"] },
+  { method: "GET", path: "/session/timeline", capabilities: ["session:timeline"] },
+  { method: "GET", path: "/sessions", capabilities: ["session:read"] },
+  { method: "GET", path: "/events", capabilities: ["events:read"] },
+  { method: "GET", path: "/xcm/request", capabilities: ["xcm:read"] },
+  { method: "POST", path: "/payments/send", capabilities: ["payments:send"] },
+  { method: "GET", path: "/reputation", capabilities: ["reputation:read"] },
+  { method: "GET", path: "/admin/jobs", capabilities: ["ops:view"] },
+  { method: "POST", path: "/admin/jobs", capabilities: ["jobs:create"] },
+  { method: "POST", path: "/admin/jobs/ingest/:provider", capabilities: ["jobs:ingest"] },
+  { method: "POST", path: "/admin/jobs/fire", capabilities: ["jobs:fire-recurring"] },
+  { method: "POST", path: "/admin/jobs/lifecycle", capabilities: ["jobs:lifecycle"] },
+  { method: "POST", path: "/admin/jobs/pause", capabilities: ["jobs:pause-recurring"] },
+  { method: "POST", path: "/admin/jobs/resume", capabilities: ["jobs:resume-recurring"] },
+  { method: "GET", path: "/admin/jobs/timeline", capabilities: ["jobs:timeline"] },
+  { method: "GET", path: "/admin/sessions", capabilities: ["ops:view"] },
+  { method: "GET", path: "/admin/status", capabilities: ["admin:status", "ops:view"] },
+  { method: "POST", path: "/admin/xcm/observe", capabilities: ["xcm:observe"] },
+  { method: "POST", path: "/admin/xcm/finalize", capabilities: ["xcm:finalize"] },
+  { method: "POST", path: "/verifier/replay", capabilities: ["verifier:replay"] },
+  { method: "POST", path: "/verifier/run", capabilities: ["verifier:run"] }
+];
+
+const UI_CONTROLS = {
+  "admin.jobs.create": ["jobs:create"],
+  "admin.jobs.ingest": ["jobs:ingest"],
+  "admin.jobs.fireRecurring": ["jobs:fire-recurring"],
+  "admin.jobs.lifecycle": ["jobs:lifecycle"],
+  "admin.jobs.pauseRecurring": ["jobs:pause-recurring"],
+  "admin.jobs.resumeRecurring": ["jobs:resume-recurring"],
+  "admin.jobs.timeline": ["jobs:timeline"],
+  "admin.sessions.view": ["ops:view"],
+  "admin.status.view": ["admin:status", "ops:view"],
+  "policies.propose": ["policies:propose"],
+  "verifier.run": ["verifier:run"],
+  "xcm.observe": ["xcm:observe"],
+  "xcm.finalize": ["xcm:finalize"]
+};
+
+const AUTOMATION_ACTIONS = {
+  "job.create": ["jobs:create"],
+  "job.ingest": ["jobs:ingest"],
+  "job.fireRecurring": ["jobs:fire-recurring"],
+  "job.lifecycle": ["jobs:lifecycle"],
+  "job.pauseRecurring": ["jobs:pause-recurring"],
+  "job.resumeRecurring": ["jobs:resume-recurring"],
+  "job.timeline": ["jobs:timeline"],
+  "policy.propose": ["policies:propose"],
+  "verifier.run": ["verifier:run"],
+  "xcm.observe": ["xcm:observe"],
+  "xcm.finalize": ["xcm:finalize"]
+};
+
 export function resolveCapabilities(claims = {}) {
   const capabilities = new Set(BASE_CAPABILITIES);
   const roles = Array.isArray(claims.roles) ? claims.roles : [];
@@ -56,57 +138,98 @@ export function resolveCapabilities(claims = {}) {
       capabilities.add(capability);
     }
   }
+  const explicitCapabilities = [
+    ...(Array.isArray(claims.capabilities) ? claims.capabilities : []),
+    ...(Array.isArray(claims.scopes) ? claims.scopes : [])
+  ];
+  for (const capability of explicitCapabilities) {
+    if (typeof capability === "string" && capability.trim()) {
+      capabilities.add(capability.trim());
+    }
+  }
   return [...capabilities].sort();
 }
 
 export function capabilityMatrix() {
+  const routes = {};
+  for (const rule of ROUTE_CAPABILITY_RULES) {
+    routes[rule.path] = [...new Set([...(routes[rule.path] ?? []), ...rule.capabilities])].sort();
+  }
   return {
+    version: AUTH_POLICY_VERSION,
     base: [...BASE_CAPABILITIES],
     roles: Object.fromEntries(
       Object.entries(ROLE_CAPABILITIES).map(([role, capabilities]) => [role, [...capabilities]])
     ),
-    routes: {
-      "/account": ["account:read"],
-      "/account/strategies": ["account:read", "strategies:list"],
-      "/account/fund": ["account:fund"],
-      "/account/allocate": ["account:allocate"],
-      "/account/deallocate": ["account:deallocate"],
-      "/account/borrow": ["account:borrow"],
-      "/account/repay": ["account:repay"],
-      "/agents": ["agents:list"],
-      "/badges": ["badges:list"],
-      "/content": ["content:write"],
-      "/content/:hash": ["content:read"],
-      "/content/:hash/publish": ["content:write"],
-      "/disputes": ["disputes:list"],
-      "/disputes/:id": ["disputes:read"],
-      "/disputes/:id/verdict": ["disputes:verdict"],
-      "/disputes/:id/release": ["disputes:release"],
-      "/jobs": ["jobs:list"],
-      "/jobs/recommendations": ["jobs:recommend"],
-      "/jobs/preflight": ["jobs:preflight"],
-      "/jobs/claim": ["jobs:claim"],
-      "/jobs/submit": ["jobs:submit"],
-      "/jobs/sub": ["subjobs:read", "subjobs:create"],
-      "/session": ["session:read"],
-      "/session/timeline": ["session:timeline"],
-      "/events": ["events:read"],
-      "/xcm/request": ["xcm:read"],
-      "/payments/send": ["payments:send"],
-      "/reputation": ["reputation:read"],
-      "/strategies": ["strategies:list"],
-      "/admin/status": ["admin:status"],
-      "/admin/jobs": ["jobs:create"],
-      "/admin/jobs/fire": ["jobs:fire-recurring"],
-      "/admin/jobs/pause": ["jobs:pause-recurring"],
-      "/admin/jobs/resume": ["jobs:resume-recurring"],
-      "/admin/jobs/timeline": ["jobs:timeline"],
-      "/admin/xcm/observe": ["xcm:observe"],
-      "/admin/xcm/finalize": ["xcm:finalize"],
-      "/verifier/handlers": ["verifier:handlers:read"],
-      "/verifier/result": ["verifier:result:read"],
-      "/verifier/replay": ["verifier:replay"],
-      "/verifier/run": ["verifier:run"]
-    }
+    routes,
+    routeRules: ROUTE_CAPABILITY_RULES.map((rule) => ({ ...rule, capabilities: [...rule.capabilities] })),
+    uiControls: cloneCapabilityRecord(UI_CONTROLS),
+    automationActions: cloneCapabilityRecord(AUTOMATION_ACTIONS)
   };
+}
+
+export function getRouteCapabilityRequirements(method = "*", pathname = "") {
+  const normalizedMethod = String(method || "*").toUpperCase();
+  const normalizedPath = normalizePath(pathname);
+  const rule = ROUTE_CAPABILITY_RULES.find((entry) => {
+    const methodMatches = entry.method === "*" || entry.method === normalizedMethod;
+    return methodMatches && pathMatches(entry.path, normalizedPath);
+  });
+  return rule ? [...rule.capabilities] : [];
+}
+
+export function hasCapability(claimsOrCapabilities = {}, capability) {
+  const capabilities = Array.isArray(claimsOrCapabilities)
+    ? claimsOrCapabilities
+    : resolveCapabilities(claimsOrCapabilities);
+  return capabilities.includes(capability);
+}
+
+export function missingCapabilities(claimsOrCapabilities = {}, requiredCapabilities = []) {
+  const capabilities = Array.isArray(claimsOrCapabilities)
+    ? claimsOrCapabilities
+    : resolveCapabilities(claimsOrCapabilities);
+  const capabilitySet = new Set(capabilities);
+  return normalizeCapabilityList(requiredCapabilities).filter((capability) => !capabilitySet.has(capability));
+}
+
+function normalizeCapabilityList(values = []) {
+  const raw = Array.isArray(values) ? values : [values];
+  return [...new Set(raw.map((value) => String(value ?? "").trim()).filter(Boolean))].sort();
+}
+
+function cloneCapabilityRecord(record) {
+  return Object.fromEntries(
+    Object.entries(record).map(([key, value]) => [key, [...value]])
+  );
+}
+
+function normalizePath(pathname) {
+  const value = String(pathname || "/").trim() || "/";
+  return value.endsWith("/") && value.length > 1 ? value.slice(0, -1) : value;
+}
+
+function pathMatches(template, pathname) {
+  const normalizedTemplate = normalizePath(template);
+  if (normalizedTemplate === pathname) {
+    return true;
+  }
+  const templateParts = normalizedTemplate.split("/").filter(Boolean);
+  const pathParts = pathname.split("/").filter(Boolean);
+  for (let index = 0; index < templateParts.length; index += 1) {
+    const templatePart = templateParts[index];
+    if (templatePart === ":path") {
+      return pathParts.length >= index;
+    }
+    if (pathParts[index] === undefined) {
+      return false;
+    }
+    if (templatePart.startsWith(":")) {
+      continue;
+    }
+    if (templatePart !== pathParts[index]) {
+      return false;
+    }
+  }
+  return templateParts.length === pathParts.length;
 }

--- a/mcp-server/src/auth/capabilities.test.js
+++ b/mcp-server/src/auth/capabilities.test.js
@@ -1,7 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { capabilityMatrix, resolveCapabilities } from "./capabilities.js";
+import {
+  AUTH_POLICY_VERSION,
+  capabilityMatrix,
+  getRouteCapabilityRequirements,
+  missingCapabilities,
+  resolveCapabilities
+} from "./capabilities.js";
 
 test("resolveCapabilities returns base capabilities for signed-in wallets", () => {
   const capabilities = resolveCapabilities({ roles: [] });
@@ -13,19 +19,34 @@ test("resolveCapabilities returns base capabilities for signed-in wallets", () =
 test("resolveCapabilities expands admin and verifier capabilities", () => {
   const capabilities = resolveCapabilities({ roles: ["admin", "verifier"] });
   assert.ok(capabilities.includes("jobs:create"));
+  assert.ok(capabilities.includes("jobs:ingest"));
+  assert.ok(capabilities.includes("jobs:lifecycle"));
   assert.ok(capabilities.includes("jobs:pause-recurring"));
   assert.ok(capabilities.includes("jobs:timeline"));
+  assert.ok(capabilities.includes("ops:view"));
   assert.ok(capabilities.includes("verifier:run"));
   assert.ok(capabilities.includes("subjobs:create"));
   assert.ok(capabilities.includes("xcm:observe"));
   assert.ok(capabilities.includes("xcm:finalize"));
 });
 
+test("resolveCapabilities includes explicit future scopes from signed claims", () => {
+  const capabilities = resolveCapabilities({
+    roles: [],
+    capabilities: ["jobs:create"],
+    scopes: ["ops:view", "jobs:create"]
+  });
+  assert.ok(capabilities.includes("jobs:create"));
+  assert.ok(capabilities.includes("ops:view"));
+});
+
 test("capabilityMatrix exposes base and role capability groups", () => {
   const matrix = capabilityMatrix();
+  assert.equal(matrix.version, AUTH_POLICY_VERSION);
   assert.ok(matrix.base.includes("jobs:list"));
   assert.ok(matrix.base.includes("jobs:submit"));
   assert.ok(matrix.roles.admin.includes("jobs:fire-recurring"));
+  assert.ok(matrix.roles.admin.includes("jobs:ingest"));
   assert.ok(matrix.roles.admin.includes("xcm:observe"));
   assert.ok(matrix.roles.admin.includes("xcm:finalize"));
   assert.ok(matrix.roles.verifier.includes("verifier:replay"));
@@ -33,4 +54,21 @@ test("capabilityMatrix exposes base and role capability groups", () => {
   assert.deepEqual(matrix.routes["/admin/jobs/timeline"], ["jobs:timeline"]);
   assert.deepEqual(matrix.routes["/admin/xcm/observe"], ["xcm:observe"]);
   assert.deepEqual(matrix.routes["/admin/xcm/finalize"], ["xcm:finalize"]);
+  assert.deepEqual(matrix.uiControls["admin.status.view"], ["admin:status", "ops:view"]);
+  assert.deepEqual(matrix.automationActions["job.fireRecurring"], ["jobs:fire-recurring"]);
+});
+
+test("getRouteCapabilityRequirements resolves method-specific route policies", () => {
+  assert.deepEqual(getRouteCapabilityRequirements("GET", "/admin/jobs"), ["ops:view"]);
+  assert.deepEqual(getRouteCapabilityRequirements("POST", "/admin/jobs"), ["jobs:create"]);
+  assert.deepEqual(getRouteCapabilityRequirements("POST", "/admin/jobs/ingest/wikipedia"), ["jobs:ingest"]);
+  assert.deepEqual(getRouteCapabilityRequirements("POST", "/disputes/dispute-123/verdict"), ["disputes:verdict"]);
+  assert.deepEqual(getRouteCapabilityRequirements("GET", "/unknown"), []);
+});
+
+test("missingCapabilities reports the exact capability gap", () => {
+  assert.deepEqual(
+    missingCapabilities(["jobs:create"], ["jobs:create", "ops:view"]),
+    ["ops:view"]
+  );
 });

--- a/mcp-server/src/auth/middleware.js
+++ b/mcp-server/src/auth/middleware.js
@@ -2,7 +2,11 @@ import { getAddress } from "ethers";
 import { AuthenticationError, AuthorizationError } from "../core/errors.js";
 import { verifyToken } from "./jwt.js";
 import { hasRole, resolveRoles } from "./config.js";
-import { resolveCapabilities } from "./capabilities.js";
+import {
+  getRouteCapabilityRequirements,
+  missingCapabilities,
+  resolveCapabilities
+} from "./capabilities.js";
 import { buildAuthRequirementDetails } from "../core/discovery-manifest.js";
 
 /**
@@ -14,6 +18,7 @@ import { buildAuthRequirementDetails } from "../core/discovery-manifest.js";
  * Options:
  *   - allowQueryToken: accept ?token= in the URL (used for SSE where headers are unavailable).
  *   - requireRole: throw AuthorizationError unless the verified claims include this role.
+ *   - requireCapability / requireCapabilities: require one or more resolved capabilities.
  *
  * In permissive mode, if no token is supplied, the middleware falls back to the
  * `wallet` query parameter with a warning. In strict mode, missing or invalid
@@ -26,8 +31,29 @@ import { buildAuthRequirementDetails } from "../core/discovery-manifest.js";
  * middleware rejects tokens whose `jti` is in the revocation list.
  */
 export function createAuthMiddleware({ authConfig, stateStore, logger = console }) {
-  return async function requireAuth(request, url, { allowQueryToken = false, requireRole = undefined } = {}) {
-    const authDetails = buildAuthRequirementDetails(request.method, url.pathname, { requireRole });
+  return async function requireAuth(
+    request,
+    url,
+    {
+      allowQueryToken = false,
+      requireRole = undefined,
+      requireCapability = undefined,
+      requireCapabilities = undefined,
+      enforceRouteCapabilities = true
+    } = {}
+  ) {
+    const routeCapabilities = enforceRouteCapabilities
+      ? getRouteCapabilityRequirements(request.method, url.pathname)
+      : [];
+    const requiredCapabilities = normalizeRequiredCapabilities([
+      ...routeCapabilities,
+      requireCapability,
+      ...(Array.isArray(requireCapabilities) ? requireCapabilities : [requireCapabilities])
+    ]);
+    const authDetails = buildAuthRequirementDetails(request.method, url.pathname, {
+      requireRole,
+      requiredCapabilities
+    });
     const headerToken = extractBearer(request);
     const queryToken = allowQueryToken ? (url.searchParams.get("token") ?? "").trim() || undefined : undefined;
     const token = headerToken ?? queryToken;
@@ -47,11 +73,14 @@ export function createAuthMiddleware({ authConfig, stateStore, logger = console 
               verifierWallets: authConfig.verifierWallets ?? new Set()
             })
           };
+          const capabilities = resolveCapabilities(permissiveClaims);
           enforceRole(permissiveClaims, requireRole, authDetails);
+          enforceCapabilities(capabilities, requiredCapabilities, authDetails);
           return {
             wallet: normalizeWallet(fallbackWallet),
             claims: permissiveClaims,
-            capabilities: resolveCapabilities(permissiveClaims),
+            capabilities,
+            capabilityRequirements: requiredCapabilities,
             via: "permissive_query"
           };
         }
@@ -78,12 +107,15 @@ export function createAuthMiddleware({ authConfig, stateStore, logger = console 
       }
     }
 
+    const capabilities = resolveCapabilities(claims);
     enforceRole(claims, requireRole, authDetails);
+    enforceCapabilities(capabilities, requiredCapabilities, authDetails);
 
     return {
       wallet: normalizeWallet(claims.sub),
       claims,
-      capabilities: resolveCapabilities(claims),
+      capabilities,
+      capabilityRequirements: requiredCapabilities,
       via: headerToken ? "header" : "query_token"
     };
   };
@@ -100,6 +132,30 @@ function enforceRole(claims, requireRole, authDetails = undefined) {
       requiredRole: requireRole
     });
   }
+}
+
+function enforceCapabilities(capabilities, requiredCapabilities, authDetails = undefined) {
+  if (!requiredCapabilities.length) {
+    return;
+  }
+  const missing = missingCapabilities(capabilities, requiredCapabilities);
+  if (missing.length) {
+    throw new AuthorizationError("Missing required capability.", "missing_capability", {
+      ...(authDetails ?? {}),
+      requiresAuth: true,
+      requiredCapabilities,
+      missingCapabilities: missing
+    });
+  }
+}
+
+function normalizeRequiredCapabilities(values = []) {
+  return [...new Set(
+    values
+      .flat()
+      .map((value) => String(value ?? "").trim())
+      .filter(Boolean)
+  )].sort();
 }
 
 function extractBearer(request) {

--- a/mcp-server/src/core/discovery-manifest.js
+++ b/mcp-server/src/core/discovery-manifest.js
@@ -1,3 +1,5 @@
+import { getRouteCapabilityRequirements } from "../auth/capabilities.js";
+
 const DEFAULT_BASE_URL = "https://api.averray.com";
 const DEFAULT_DISCOVERY_URL = "https://averray.com/.well-known/agent-tools.json";
 const DEFAULT_PROFILE_URL = "https://app.averray.com/agents/<wallet>";
@@ -257,7 +259,7 @@ const HTTP_ACTION_REQUIREMENTS = [
     walletModes: ["evm-siwe"]
   },
   {
-    method: "*",
+    method: "POST",
     path: "/verifier/:path",
     requiresAuth: true,
     requiredRole: "verifier",
@@ -431,15 +433,23 @@ export function getHttpActionRequirement(method = "*", pathname = "") {
   });
 }
 
-export function buildAuthRequirementDetails(method = "*", pathname = "", { requireRole = undefined } = {}) {
+export function buildAuthRequirementDetails(
+  method = "*",
+  pathname = "",
+  { requireRole = undefined, requiredCapabilities = undefined } = {}
+) {
   const requirement = getHttpActionRequirement(method, pathname) ?? {};
   const requiredRole = requireRole ?? requirement.requiredRole;
+  const capabilities = Array.isArray(requiredCapabilities)
+    ? requiredCapabilities
+    : getRouteCapabilityRequirements(method, pathname);
   return {
     requiresAuth: true,
     requiredAction:
       requirement.requiredAction
       ?? (requiredRole ? `${requiredRole}_wallet_sign_in` : "wallet_sign_in"),
     requiredRole,
+    requiredCapabilities: capabilities,
     authScheme: requirement.authScheme ?? "SIWE_JWT",
     walletModes: requirement.walletModes ?? ["evm-siwe"],
     authEntrypoints: AUTH_ENTRYPOINTS,

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -17,6 +17,7 @@ import {
 } from "./session-state-machine.js";
 import { computeClaimEconomics, countClaimedSessions } from "./claim-economics.js";
 import { claimStatusFields, isTerminalSession, summarizeJobClaimState } from "./claim-state.js";
+import { capabilityMatrix } from "../auth/capabilities.js";
 
 const TIMELINE_VERSION = "v2";
 
@@ -353,6 +354,7 @@ export class PlatformService {
             capabilities: auth.capabilities ?? []
           }
         : undefined,
+      authPolicy: capabilityMatrix(),
       anomalies,
       ops: {
         recentSessions: recentSessions.map((session) => ({

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -339,6 +339,10 @@ test("getAdminStatus surfaces recurring scheduler anomalies", async () => {
   });
 
   assert.equal(status.auth.wallet, WALLET);
+  assert.equal(status.authPolicy.version, "auth-policy-v1");
+  assert.ok(status.authPolicy.roles.admin.includes("admin:status"));
+  assert.deepEqual(status.authPolicy.routes["/admin/status"], ["admin:status", "ops:view"]);
+  assert.deepEqual(status.authPolicy.uiControls["admin.status.view"], ["admin:status", "ops:view"]);
   assert.ok(status.anomalies.some((entry) => entry.code === "recurring_attention"));
   assert.equal(status.jobLifecycle.total, 1);
   assert.equal(status.jobLifecycle.paused, 1);


### PR DESCRIPTION
## What changed
- Added versioned auth-policy-v1 with base capabilities, role expansions, method-aware route rules, UI controls, and automation action requirements.
- Auth middleware now resolves capabilities from roles plus optional signed scopes and enforces route/explicit capability requirements.
- Admin status now exposes the active auth policy matrix for the operator app.
- Updated the roadmap status for Spec 6.

## Checks run
- node --test mcp-server/src/auth/capabilities.test.js mcp-server/src/auth/auth.test.js mcp-server/src/core/discovery-manifest.test.js mcp-server/src/core/platform-service.test.js
- npm --workspace mcp-server test
- git diff --check

## Impact
- Backend: yes
- Frontend: no generated/frontend changes
- Indexer/Caddy/contracts/public site: no
- Env/VPS secrets: none