### PR TITLE
Make recurring jobs reserve-aware

### DIFF
--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -377,28 +377,32 @@ product, but today they are still a pattern plus manual fire endpoint.
 
 ### Gaps today
 
-- no built-in scheduler worker
-- no durable `lastFiredAt` / `nextFireAt` runtime record
-- no failure policy beyond external retries
-- no reserve-aware fire control
+- on-chain poster reserve funding is still represented as backend policy
+  metadata rather than an escrow-native subscription pool
+- missed-fire behavior is conservative and does not backfill every skipped
+  interval
+- operator UI still needs richer controls for reserve exhaustion and next
+  firing
 
 ### Improve to
 
-- a proper scheduler runtime
-- status visibility for templates
+- scheduler runtime as a product primitive
+- status visibility for templates and reserve exhaustion
 - pause/resume controls
 - conservative missed-fire behavior
 
 ### Concrete next changes
 
-- add a scheduler worker that scans recurring templates on boot
-- persist template runtime metadata:
+- [x] add a scheduler worker that scans recurring templates on boot
+- [x] persist template runtime metadata:
   - `lastFiredAt`
   - `nextFireAt`
   - `lastResult`
   - `paused`
-- gate firing on available reserve and policy checks
-- expose status in admin endpoints and operator UI
+- [x] gate firing on finite template reserve policy
+- [x] expose status in admin endpoints
+- [ ] wire operator UI controls for reserve exhaustion and next firing
+- [ ] back recurring reserve with escrow-native/on-chain poster funding
 
 ### What this unlocks
 

--- a/docs/patterns/recurring-jobs.md
+++ b/docs/patterns/recurring-jobs.md
@@ -26,6 +26,11 @@ Shipped today:
 - **Scheduler runtime** scans templates, computes `nextFireAt`, fires due
   templates, persists `lastFiredAt` / `nextFireAt` / `lastResult`, and
   exposes status through `/admin/status`.
+- **Reserve-aware fire control**: templates may include
+  `recurringPolicy.reserveAmount` or `recurringPolicy.maxRuns`. The runtime
+  consumes one reward-sized slot per derivative and stops firing with
+  `lastResult.status = "reserve_exhausted"` once the reserve can no longer
+  cover the next run.
 - **Pause/resume controls**: `POST /admin/jobs/pause` and
   `POST /admin/jobs/resume` update recurring runtime state. Both accept
   optional `idempotencyKey`; replay returns the stored admin-status
@@ -67,6 +72,11 @@ Content-Type: application/json
     "timezone": "Europe/Zurich",
     "startAt": "2026-04-20T00:00:00Z",
     "endAt": "2026-10-31T23:59:59Z"
+  },
+  "recurringPolicy": {
+    "reserveAmount": 20,
+    "reserveAsset": "DOT",
+    "maxRuns": 4
   }
 }
 ```
@@ -101,6 +111,13 @@ Returns the derivative job as the response body. The derivative:
   templates.
 - Inherits every other field (category, tier, reward, verifier rules)
   from the template.
+- Does not inherit `recurringPolicy`; the reserve belongs to the template,
+  not to individual one-shot derivatives.
+
+If the template has a finite reserve and the remaining reserve is less than
+one derivative reward, firing fails with `recurring_reserve_exhausted`.
+The scheduler records this as `lastResult.status = "reserve_exhausted"` and
+does not compute another `nextFireAt`.
 
 Any agent can now claim the derivative via `/jobs/claim?jobId=weekly-digest-run-…`.
 
@@ -194,7 +211,9 @@ Absolute numbers to watch (via `/metrics`):
 - **Subscription billing semantics.** The platform doesn't bill the
   poster periodically — the poster funds the template's reserve pool,
   each derivative consumes from that pool. Out of reserve = derivatives
-  stop minting (future scheduler will check this).
+  stop minting. v1 tracks this as finite `recurringPolicy` metadata; a
+  later on-chain funding flow can make the same policy authoritative on
+  escrow balances.
 - **Agent-initiated subscriptions.** Only the poster decides cadence
   today. Giving workers an "always claim this" switch is a v3+
   feature.

--- a/mcp-server/src/core/job-catalog-service.js
+++ b/mcp-server/src/core/job-catalog-service.js
@@ -249,8 +249,11 @@ export class JobCatalogService {
           rewardAsset: template.rewardAsset,
           verifierMode: template.verifierMode,
           schedule: template.schedule,
+          recurringPolicy: template.recurringPolicy,
+          reserve: this.buildRecurringReserveStatus(template, derivatives),
           derivativeCount: derivatives.length,
           paused: Boolean(template.runtime?.paused),
+          exhausted: Boolean(template.runtime?.exhausted),
           lastFiredAt: template.runtime?.lastFiredAt ?? latest?.firedAt,
           nextFireAt: template.runtime?.nextFireAt,
           lastResult: template.runtime?.lastResult,
@@ -287,6 +290,36 @@ export class JobCatalogService {
     }
     template.runtime = nextRuntime;
     return { ...template.runtime };
+  }
+
+  buildRecurringReserveStatus(template, derivatives = undefined) {
+    const reserveAmount = Number(template?.recurringPolicy?.reserveAmount);
+    if (!Number.isFinite(reserveAmount)) {
+      return {
+        mode: "unbounded",
+        rewardAsset: template.rewardAsset,
+        rewardAmount: template.rewardAmount
+      };
+    }
+
+    const runCount = Array.isArray(derivatives)
+      ? derivatives.length
+      : this.jobs.filter((job) => job.templateId === template.id).length;
+    const rewardAmount = Math.max(Number(template.rewardAmount ?? 0), 0);
+    const consumedAmount = Math.max(runCount * rewardAmount, 0);
+    const remainingAmount = Math.max(reserveAmount - consumedAmount, 0);
+    const remainingRuns = rewardAmount > 0 ? Math.floor(remainingAmount / rewardAmount) : 0;
+
+    return {
+      mode: "finite",
+      rewardAsset: template.rewardAsset,
+      rewardAmount,
+      reserveAmount,
+      consumedAmount,
+      remainingAmount,
+      remainingRuns,
+      exhausted: remainingAmount < rewardAmount
+    };
   }
 
   pauseRecurringTemplate(templateId, pausedAt = new Date()) {
@@ -656,6 +689,11 @@ export class JobCatalogService {
     const source = normalisePlainObject(input?.source, "source");
     const verification = normalisePlainObject(input?.verification, "verification");
     const lifecycle = normaliseLifecycle(input?.lifecycle, { disableStale: recurring });
+    const recurringPolicy = normaliseRecurringPolicy(input?.recurringPolicy, {
+      recurring,
+      rewardAmount,
+      rewardAsset
+    });
 
     return {
       id,
@@ -682,7 +720,8 @@ export class JobCatalogService {
       ...(verification ? { verification } : {}),
       ...(parentSessionId ? { parentSessionId } : {}),
       ...(recurring ? { recurring: true } : {}),
-      ...(schedule ? { schedule } : {})
+      ...(schedule ? { schedule } : {}),
+      ...(recurringPolicy ? { recurringPolicy } : {})
     };
   }
 
@@ -697,6 +736,24 @@ export class JobCatalogService {
    */
   fireRecurringJob(templateId, { firedAt = new Date() } = {}) {
     const template = this.getRecurringTemplate(templateId);
+    const reserve = this.buildRecurringReserveStatus(template);
+    if (reserve.exhausted) {
+      this.updateRecurringTemplateRuntime(templateId, {
+        exhausted: true,
+        nextFireAt: undefined,
+        lastResult: {
+          status: "reserve_exhausted",
+          at: firedAt.toISOString(),
+          message: `Recurring reserve exhausted for ${templateId}`,
+          reserve
+        }
+      });
+      throw new ConflictError(
+        `Recurring reserve exhausted for ${templateId}`,
+        "recurring_reserve_exhausted",
+        { templateId, reserve }
+      );
+    }
     const stamp = firedAt.toISOString().replace(/[:.]/g, "-").replace("Z", "").slice(0, 19);
     const derivativeId = this.normalizeId(`${templateId}-run-${stamp}`);
     if (this.jobs.some((candidate) => candidate.id === derivativeId)) {
@@ -717,13 +774,19 @@ export class JobCatalogService {
       })
     };
     delete derivative.schedule;
+    delete derivative.recurringPolicy;
     this.jobs.unshift(derivative);
+    const nextReserve = this.buildRecurringReserveStatus(template);
     this.updateRecurringTemplateRuntime(templateId, {
       lastFiredAt: firedAt.toISOString(),
+      nextFireAt: nextReserve.exhausted ? undefined : template.runtime?.nextFireAt,
+      reserve: nextReserve,
+      exhausted: Boolean(nextReserve.exhausted),
       lastResult: {
         status: "fired",
         at: firedAt.toISOString(),
-        derivativeId
+        derivativeId,
+        reserve: nextReserve
       }
     });
     return derivative;
@@ -848,6 +911,53 @@ function normaliseSchedule(raw, recurring) {
     }
   }
   return normalised;
+}
+
+function normaliseRecurringPolicy(raw, { recurring, rewardAmount, rewardAsset }) {
+  if (!raw) {
+    return undefined;
+  }
+  if (!recurring) {
+    throw new ValidationError("recurringPolicy is only valid for recurring jobs");
+  }
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw new ValidationError("recurringPolicy must be an object if provided.");
+  }
+
+  const policy = {};
+  if (raw.reserveAmount !== undefined && raw.reserveAmount !== null && raw.reserveAmount !== "") {
+    const reserveAmount = Number(raw.reserveAmount);
+    if (!Number.isFinite(reserveAmount) || reserveAmount <= 0) {
+      throw new ValidationError("recurringPolicy.reserveAmount must be greater than zero.");
+    }
+    if (reserveAmount < rewardAmount) {
+      throw new ValidationError("recurringPolicy.reserveAmount must cover at least one run.");
+    }
+    policy.reserveAmount = reserveAmount;
+    policy.reserveAsset = typeof raw.reserveAsset === "string" && raw.reserveAsset.trim()
+      ? raw.reserveAsset.trim().toUpperCase()
+      : rewardAsset;
+    if (policy.reserveAsset !== rewardAsset) {
+      throw new ValidationError("recurringPolicy.reserveAsset must match rewardAsset.");
+    }
+  }
+
+  if (raw.maxRuns !== undefined && raw.maxRuns !== null && raw.maxRuns !== "") {
+    const maxRuns = Number(raw.maxRuns);
+    if (!Number.isInteger(maxRuns) || maxRuns < 1) {
+      throw new ValidationError("recurringPolicy.maxRuns must be a positive integer.");
+    }
+    policy.maxRuns = maxRuns;
+    const impliedReserve = maxRuns * rewardAmount;
+    if (policy.reserveAmount === undefined) {
+      policy.reserveAmount = impliedReserve;
+      policy.reserveAsset = rewardAsset;
+    } else if (policy.reserveAmount < impliedReserve) {
+      throw new ValidationError("recurringPolicy.reserveAmount must cover maxRuns * rewardAmount.");
+    }
+  }
+
+  return Object.keys(policy).length ? policy : undefined;
 }
 
 /**

--- a/mcp-server/src/core/recurring-jobs.test.js
+++ b/mcp-server/src/core/recurring-jobs.test.js
@@ -32,6 +32,26 @@ test("createJob preserves recurring + schedule fields", () => {
   assert.deepEqual(record.schedule, { cron: "0 9 * * 1", timezone: "Europe/Zurich" });
 });
 
+test("createJob preserves finite recurring reserve policy", () => {
+  const service = makeService();
+  const record = service.createJob({
+    ...TEMPLATE,
+    recurringPolicy: { reserveAmount: 15, reserveAsset: "DOT" }
+  });
+  assert.deepEqual(record.recurringPolicy, { reserveAmount: 15, reserveAsset: "DOT" });
+});
+
+test("createJob rejects recurring reserve that cannot cover one run", () => {
+  const service = makeService();
+  assert.throws(
+    () => service.createJob({
+      ...TEMPLATE,
+      recurringPolicy: { reserveAmount: 4 }
+    }),
+    (err) => err instanceof ValidationError && /cover at least one run/.test(err.message)
+  );
+});
+
 test("createJob rejects recurring: true without a schedule", () => {
   const service = makeService();
   assert.throws(
@@ -69,7 +89,7 @@ test("non-recurring jobs work without a schedule", () => {
 
 test("fireRecurringJob produces a derivative with deterministic id", () => {
   const service = makeService();
-  service.createJob(TEMPLATE);
+  service.createJob({ ...TEMPLATE, recurringPolicy: { reserveAmount: 10 } });
   const derivative = service.fireRecurringJob("weekly-digest", {
     firedAt: new Date("2026-04-20T09:00:00.000Z")
   });
@@ -83,6 +103,11 @@ test("fireRecurringJob produces a derivative with deterministic id", () => {
   assert.equal(derivative.rewardAmount, 5);
   // Schedule is stripped from the derivative (it's a one-shot run)
   assert.equal(derivative.schedule, undefined);
+  assert.equal(derivative.recurringPolicy, undefined);
+
+  const status = service.getRecurringTemplateStatus();
+  assert.equal(status.templates[0].reserve.remainingAmount, 5);
+  assert.equal(status.templates[0].reserve.remainingRuns, 1);
 });
 
 test("fireRecurringJob rejects non-recurring templates", () => {
@@ -103,6 +128,30 @@ test("fireRecurringJob rejects collisions (same template + same second)", () => 
     () => service.fireRecurringJob("weekly-digest", { firedAt: when }),
     (err) => err.code === "recurring_job_collision"
   );
+});
+
+test("fireRecurringJob stops when a finite recurring reserve is exhausted", () => {
+  const service = makeService();
+  service.createJob({ ...TEMPLATE, recurringPolicy: { reserveAmount: 10 } });
+  service.fireRecurringJob("weekly-digest", { firedAt: new Date("2026-04-20T09:00:00.000Z") });
+  service.updateRecurringTemplateRuntime("weekly-digest", { nextFireAt: "2026-04-27T09:00:00.000Z" });
+  service.fireRecurringJob("weekly-digest", { firedAt: new Date("2026-04-27T09:00:00.000Z") });
+
+  const depleted = service.getRecurringTemplateStatus();
+  assert.equal(depleted.templates[0].exhausted, true);
+  assert.equal(depleted.templates[0].nextFireAt, undefined);
+  assert.equal(depleted.templates[0].lastResult.status, "fired");
+
+  assert.throws(
+    () => service.fireRecurringJob("weekly-digest", { firedAt: new Date("2026-05-04T09:00:00.000Z") }),
+    (err) => err.code === "recurring_reserve_exhausted"
+      && err.details.reserve.remainingAmount === 0
+  );
+
+  const status = service.getRecurringTemplateStatus();
+  assert.equal(status.templates[0].exhausted, true);
+  assert.equal(status.templates[0].reserve.exhausted, true);
+  assert.equal(status.templates[0].lastResult.status, "reserve_exhausted");
 });
 
 test("getRecurringTemplateStatus summarizes templates and latest derivatives", () => {

--- a/mcp-server/src/services/recurring-scheduler.js
+++ b/mcp-server/src/services/recurring-scheduler.js
@@ -40,10 +40,15 @@ export class RecurringSchedulerService {
           lastResult: template.lastResult,
           ...(this.runtime.get(template.templateId) ?? {})
         };
-        const nextFireAt = runtime.nextFireAt ?? computeNextFireAt(template.schedule, now)?.toISOString();
+        const exhausted = Boolean(runtime.exhausted ?? template.exhausted ?? template.reserve?.exhausted);
+        const nextFireAt = exhausted
+          ? undefined
+          : (runtime.nextFireAt ?? computeNextFireAt(template.schedule, now)?.toISOString());
         return {
           templateId: template.templateId,
           paused: Boolean(runtime.paused),
+          exhausted,
+          reserve: runtime.reserve ?? template.reserve,
           lastFiredAt: runtime.lastFiredAt ?? template.lastFiredAt,
           nextFireAt,
           lastResult: runtime.lastResult
@@ -75,6 +80,19 @@ export class RecurringSchedulerService {
       if (runtime.paused) {
         continue;
       }
+      if (runtime.exhausted || template.exhausted || template.reserve?.exhausted) {
+        this.runtime.set(template.templateId, {
+          ...runtime,
+          exhausted: true,
+          nextFireAt: undefined,
+          reserve: runtime.reserve ?? template.reserve,
+          lastResult: runtime.lastResult ?? template.lastResult ?? {
+            status: "reserve_exhausted",
+            at: now.toISOString()
+          }
+        });
+        continue;
+      }
       const nextFireAt = runtime.nextFireAt
         ? new Date(runtime.nextFireAt)
         : computeNextFireAt(template.schedule, now, runtime.lastFiredAt);
@@ -95,24 +113,38 @@ export class RecurringSchedulerService {
 
       try {
         const derivative = this.platformService.fireRecurringJob(template.templateId, { firedAt: now });
-        const upcoming = computeNextFireAt(template.schedule, new Date(now.getTime() + 60_000), now.toISOString());
+        const updatedTemplate = this.platformService
+          .getRecurringTemplateStatus()
+          .templates
+          .find((candidate) => candidate.templateId === template.templateId);
+        const reserve = updatedTemplate?.reserve;
+        const exhausted = Boolean(updatedTemplate?.exhausted ?? reserve?.exhausted);
+        const upcoming = exhausted
+          ? undefined
+          : computeNextFireAt(template.schedule, new Date(now.getTime() + 60_000), now.toISOString());
         this.runtime.set(template.templateId, {
           ...runtime,
+          exhausted,
+          reserve,
           lastFiredAt: now.toISOString(),
           nextFireAt: upcoming?.toISOString(),
           lastResult: {
             status: "fired",
             at: now.toISOString(),
-            derivativeId: derivative.id
+            derivativeId: derivative.id,
+            ...(reserve ? { reserve } : {})
           }
         });
         this.platformService.jobCatalogService?.updateRecurringTemplateRuntime?.(template.templateId, {
+          exhausted,
+          reserve,
           lastFiredAt: now.toISOString(),
           nextFireAt: upcoming?.toISOString(),
           lastResult: {
             status: "fired",
             at: now.toISOString(),
-            derivativeId: derivative.id
+            derivativeId: derivative.id,
+            ...(reserve ? { reserve } : {})
           }
         });
         this.eventBus?.publish({
@@ -129,22 +161,36 @@ export class RecurringSchedulerService {
         fired.push(derivative);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        const status = error instanceof ConflictError ? "conflict" : "failed";
+        const status = error?.code === "recurring_reserve_exhausted"
+          ? "reserve_exhausted"
+          : (error instanceof ConflictError ? "conflict" : "failed");
+        const reserve = error?.details?.reserve;
+        const exhausted = status === "reserve_exhausted";
         this.runtime.set(template.templateId, {
           ...runtime,
-          nextFireAt: computeNextFireAt(template.schedule, new Date(now.getTime() + 60_000), runtime.lastFiredAt)?.toISOString(),
+          exhausted,
+          reserve: reserve ?? runtime.reserve,
+          nextFireAt: exhausted
+            ? undefined
+            : computeNextFireAt(template.schedule, new Date(now.getTime() + 60_000), runtime.lastFiredAt)?.toISOString(),
           lastResult: {
             status,
             at: now.toISOString(),
-            message
+            message,
+            ...(reserve ? { reserve } : {})
           }
         });
         this.platformService.jobCatalogService?.updateRecurringTemplateRuntime?.(template.templateId, {
-          nextFireAt: computeNextFireAt(template.schedule, new Date(now.getTime() + 60_000), runtime.lastFiredAt)?.toISOString(),
+          exhausted,
+          reserve,
+          nextFireAt: exhausted
+            ? undefined
+            : computeNextFireAt(template.schedule, new Date(now.getTime() + 60_000), runtime.lastFiredAt)?.toISOString(),
           lastResult: {
             status,
             at: now.toISOString(),
-            message
+            message,
+            ...(reserve ? { reserve } : {})
           }
         });
         this.logger.warn?.({ templateId: template.templateId, err: error }, "recurring_scheduler.fire_failed");

--- a/mcp-server/src/services/recurring-scheduler.test.js
+++ b/mcp-server/src/services/recurring-scheduler.test.js
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
+import { ConflictError } from "../core/errors.js";
 import { computeNextFireAt, RecurringSchedulerService } from "./recurring-scheduler.js";
 
 test("computeNextFireAt resolves the next matching minute", () => {
@@ -53,7 +54,10 @@ test("RecurringSchedulerService fires due templates and records runtime status",
     }
   };
 
-  const scheduler = new RecurringSchedulerService(platformService, undefined, { enabled: true });
+  const scheduler = new RecurringSchedulerService(platformService, undefined, {
+    enabled: true,
+    logger: { warn() {} }
+  });
   await scheduler.runDueTemplates(new Date("2026-04-20T09:00:00.000Z"));
   assert.equal(fired.length, 1);
 
@@ -81,7 +85,10 @@ test("RecurringSchedulerService pause/resume updates template runtime", async ()
       assert.equal(templateId, "weekly-digest");
     }
   };
-  const scheduler = new RecurringSchedulerService(platformService, undefined, { enabled: true });
+  const scheduler = new RecurringSchedulerService(platformService, undefined, {
+    enabled: true,
+    logger: { warn() {} }
+  });
   await scheduler.pauseTemplate("weekly-digest");
   let status = await scheduler.getStatus(new Date("2026-04-20T09:01:00.000Z"));
   assert.equal(status.templates[0].paused, true);
@@ -89,4 +96,63 @@ test("RecurringSchedulerService pause/resume updates template runtime", async ()
   await scheduler.resumeTemplate("weekly-digest");
   status = await scheduler.getStatus(new Date("2026-04-20T09:01:00.000Z"));
   assert.equal(status.templates[0].paused, false);
+});
+
+test("RecurringSchedulerService records reserve exhaustion and stops rescheduling", async () => {
+  const initialReserve = {
+    mode: "finite",
+    rewardAsset: "DOT",
+    rewardAmount: 5,
+    reserveAmount: 5,
+    consumedAmount: 0,
+    remainingAmount: 5,
+    remainingRuns: 1,
+    exhausted: false
+  };
+  const exhaustedReserve = {
+    ...initialReserve,
+    consumedAmount: 5,
+    remainingAmount: 0,
+    remainingRuns: 0,
+    exhausted: true
+  };
+  const templateRuntime = {};
+  const platformService = {
+    getRecurringTemplateStatus() {
+      return {
+        templates: [
+          {
+            templateId: "weekly-digest",
+            schedule: { cron: "0 9 * * 1" },
+            reserve: initialReserve,
+            ...templateRuntime
+          }
+        ]
+      };
+    },
+    fireRecurringJob() {
+      throw new ConflictError("Recurring reserve exhausted for weekly-digest", "recurring_reserve_exhausted", {
+        templateId: "weekly-digest",
+        reserve: exhaustedReserve
+      });
+    },
+    jobCatalogService: {
+      updateRecurringTemplateRuntime(templateId, patch) {
+        assert.equal(templateId, "weekly-digest");
+        Object.assign(templateRuntime, patch);
+      }
+    }
+  };
+
+  const scheduler = new RecurringSchedulerService(platformService, undefined, {
+    enabled: true,
+    logger: { warn() {} }
+  });
+  await scheduler.runDueTemplates(new Date("2026-04-20T09:00:00.000Z"));
+
+  const status = await scheduler.getStatus(new Date("2026-04-20T09:01:00.000Z"));
+  assert.equal(status.templates[0].exhausted, true);
+  assert.equal(status.templates[0].nextFireAt, undefined);
+  assert.equal(status.templates[0].lastResult.status, "reserve_exhausted");
+  assert.equal(status.templates[0].reserve.remainingRuns, 0);
 });


### PR DESCRIPTION
## Summary
- add finite recurringPolicy reserve/maxRuns normalization for recurring templates
- stop manual and scheduler fires with recurring_reserve_exhausted once reserve cannot cover another derivative
- surface reserve/exhausted runtime status and document the first-class recurring runtime shape

## Checks
- node --test mcp-server/src/core/recurring-jobs.test.js mcp-server/src/services/recurring-scheduler.test.js
- npm --workspace mcp-server test
- git diff --check

## Impact
- Backend: recurring job catalog + scheduler runtime
- Docs: recurring jobs pattern + framework roadmap
- Frontend/indexer/contracts/public site: no direct changes

## Notes
- No env or VPS secret changes required.
- Fresh worktree needed npm install before the full backend suite because @paraspell/sdk-core was not present in node_modules.