### PR TITLE
Enforce sub-job orchestration lineage

### DIFF
--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -421,10 +421,9 @@ delegation feel like a framework feature instead of just a metadata convention.
 
 ### Gaps today
 
-- `parentSessionId` is preserved but not strongly orchestrated
-- no parent budget policy or depth policy
-- no parent-centric child session view in the backend model
-- no narrower route for authenticated worker-created sub-jobs
+- profile and dashboard surfaces still need richer sub-contracting views
+- no on-chain parent/child linkage
+- no automatic parent-to-child payout streaming
 
 ### Improve to
 
@@ -434,11 +433,13 @@ delegation feel like a framework feature instead of just a metadata convention.
 
 ### Concrete next changes
 
-- add a dedicated sub-job creation route that only works for the active worker
+- [x] add a dedicated sub-job creation route that only works for the active worker
   on an in-flight parent session
-- persist parent/child indexes for fast lookup
-- expose child runs on session detail endpoints
-- optionally add delegation budget fields later
+- [x] persist parent/child indexes for fast lookup
+- [x] expose child runs on session detail endpoints
+- [x] add delegation budget and depth policy fields
+- [x] reserve the child reward from the parent wallet at sub-job creation
+- [ ] extend profile and operator UI surfaces around sub-contracting history
 
 ### What this unlocks
 

--- a/docs/patterns/sub-job-escrow.md
+++ b/docs/patterns/sub-job-escrow.md
@@ -20,8 +20,8 @@ agent than for you. You can:
 
 1. Stay inside the parent claim and do it all yourself.
 2. Post a sub-job for the piece you'd rather delegate, let another
-   agent complete it, pay them out of your reward, and use their
-   output to finish the parent job.
+   agent complete it, reserve their reward from your wallet, and use
+   their output to finish the parent job.
 
 Option 2 is what this pattern describes. The same escrow semantics —
 stake, verify, pay, slash — protect the parent agent from a bad
@@ -36,9 +36,10 @@ posterA ── fund Y DOT ──▶ EscrowCore ── claim ──▶ workerB (t
                                                      │
                                                      │  while working:
                                                      ▼
-                                            post sub-job via /admin/jobs
+                                            post sub-job via /jobs/sub
                                             (parentSessionId = workerB's
-                                             active session)
+                                             active session, funded from
+                                             workerB's wallet)
                                                      │
                                                      ▼
                                            ◀── claim ── workerC
@@ -46,39 +47,32 @@ posterA ── fund Y DOT ──▶ EscrowCore ── claim ──▶ workerB (t
                                                      │
                                            workerC's stake released,
                                            workerC paid from workerB's
-                                           reserved funding pool
+                                           reserved sub-job funding
                                                      │
                                                      ▼
                                             workerB combines workerC's
                                             output with its own work,
                                             submits parent evidence,
                                             verifier OKs parent,
-                                            workerB paid the remainder
+                                            workerB keeps parent reward
+                                            minus its delegated cost
 ```
 
 ---
 
 ## Mechanical steps
 
-### Prereq: parent agent has an admin role
+### Prereq: parent agent owns an active parent session
 
-Sub-job creation calls `POST /admin/jobs`, which requires the `admin`
-role (see [README.md](../../README.md) auth section). That means the
-wallet posting the sub-job must be in `AUTH_ADMIN_WALLETS` on the
-backend.
+Sub-job creation uses the dedicated `POST /jobs/sub` route. It is
+available to ordinary authenticated workers, not only admins, but it is
+narrowly scoped:
 
-Two sensible configurations:
-
-- **Permissionless sub-jobs**: add every wallet that might act as a
-  parent to `AUTH_ADMIN_WALLETS`. Simple, noisy.
-- **Platform-brokered sub-jobs**: expose a dedicated `/jobs/sub` route
-  (not yet implemented — future work) that lets any authenticated
-  wallet post a sub-job *only* if it currently holds an active session
-  they're the worker on. This removes the admin-role requirement for
-  the narrow "agent sub-contracts its own work" case.
-
-For v1, use the permissioned-admin approach. The second one is an item
-for the sequencing table after Pillar 3 is closed end-to-end.
+- `parentSessionId` must belong to the signed-in wallet.
+- The parent session must still be active (`claimed` or `submitted`).
+- The child reward must fit the parent job's `delegationPolicy`.
+- The child reward is reserved from the parent wallet when the sub-job is
+  created.
 
 ### 1. Parent claims a top-level job
 
@@ -88,27 +82,54 @@ Standard flow via `/jobs/claim`. Records `parentSession.sessionId`,
 ### 2. Parent posts a sub-job
 
 ```bash
-./scripts/post_sub_job.sh \
-  --parent-session "$parentSession_sessionId" \
-  --label summarise-inputs \
-  --category coding \
-  --reward 2 \
-  --api https://api.averray.com \
-  --token "$PARENT_ADMIN_JWT"
+curl -fsS https://api.averray.com/jobs/sub \
+  -H "authorization: Bearer $PARENT_WORKER_JWT" \
+  -H "content-type: application/json" \
+  -d '{
+    "parentSessionId": "'"$parentSession_sessionId"'",
+    "id": "sub-'"${parentSession_sessionId:0:8}"'-summarise-inputs",
+    "category": "coding",
+    "tier": "starter",
+    "rewardAmount": 2,
+    "verifierMode": "benchmark",
+    "verifierTerms": ["summary"],
+    "verifierMinimumMatches": 1,
+    "claimTtlSeconds": 1800
+  }'
 ```
 
-The script:
+The route:
 
-- Mints a deterministic sub-job id (`sub-<first-8-of-parent>-<label>`)
-  so dashboards can group sub-jobs under their parent.
-- Forwards `parentSessionId` as a field on the job record. The
+- Requires the caller to supply a normal job id. A stable convention such
+  as `sub-<first-8-of-parent>-<label>` keeps dashboards easy to scan.
+- Preserves `parentSessionId` as a field on the job record. The
   normalizer in [job-catalog-service.js](../../mcp-server/src/core/job-catalog-service.js)
   preserves it; indexers and frontend panels can read it to reconstruct
   the lineage.
+- Adds top-level `lineage.kind = "sub_job"` metadata with the parent job,
+  parent wallet, depth, budget consumption, and funding reservation.
 
-The backend call lands on `POST /admin/jobs`. Claim stake + verifier
-rules behave identically to a normal job — the only thing that makes
-this a "sub-job" is the `parentSessionId` link.
+Claim stake + verifier rules behave identically to a normal job. The
+sub-job-specific constraints are all on creation.
+
+### Delegation policy
+
+Parent jobs may include:
+
+```json
+{
+  "delegationPolicy": {
+    "budgetAmount": 3,
+    "budgetAsset": "DOT",
+    "maxSubJobs": 2,
+    "maxDepth": 1
+  }
+}
+```
+
+Defaults are conservative: budget equals the parent reward, `maxSubJobs`
+is `5`, and `maxDepth` is `1` (children are allowed, grandchildren are
+blocked unless the relevant parent job explicitly opts in).
 
 ### 3. Sub-worker claims + completes
 
@@ -124,8 +145,10 @@ it into its own output, and submits the parent's evidence via
 
 ### 5. Parent verifier resolves
 
-Standard resolution. Parent gets paid the remainder (parent reward
-minus what was paid to sub-workers).
+Standard resolution. Parent gets paid the parent reward through the
+normal parent session. The sub-worker payout was already reserved from
+the parent wallet when the child job was created, so the parent should
+price sub-jobs as part of its own margin.
 
 ---
 
@@ -151,10 +174,10 @@ Reasons:
 ## Safety
 
 Nothing about sub-jobs bypasses the parent agent's own liquidity gate.
-The parent must post its sub-job from its own wallet's liquid balance,
-which means it can't delegate more reward than it can actually cover.
-`reserveForJob` locks the sub-reward immediately on sub-job creation,
-identical to a top-level funding.
+The parent posts its sub-job from its own wallet's liquid balance, which
+means it can't delegate more reward than it can actually cover.
+`reserveForJob` locks the sub-reward immediately on `POST /jobs/sub`,
+identical to top-level funding.
 
 Likewise, a dishonest sub-worker is slashable under the existing
 dispute flow. If the sub-worker's evidence is rejected, the parent
@@ -167,28 +190,25 @@ opens a dispute on the sub-job — no new machinery needed.
 Once at least one sub-job exists in the wild, the frontend session-
 detail and agent-profile panels can surface:
 
-- "Child runs" list on the parent session: fetch sessions whose job's
-  `parentSessionId` matches the currently-rendered session id.
+- "Child runs" list on the parent session: `GET /session/timeline`
+  includes child job ids, child session ids, sub-job budget, and the
+  policy that governed creation.
 - "Parent run" breadcrumb on a sub-session: single lookup + link back.
 - "Recent sub-contracting activity" on the agent profile: count the
   sessions the agent has completed that carry a `parentSessionId`.
-
-None of these require new backend endpoints — they all compose over
-the existing `/sessions` and `/jobs/definition` surfaces.
 
 ---
 
 ## Non-goals for v1
 
-- **No automatic parent-to-child payout streaming.** The parent pays
-  sub-workers when it settles its own job via the existing escrow —
-  there's no atomic "split my reward now" path. The
+- **No automatic parent-to-child payout streaming.** The child reward is
+  reserved from the parent wallet when the sub-job is created; it is not
+  atomically split out of the parent session reward. The
   [sendToAgent primitive](../payments/send-to-agent.md) can be used for
   ad-hoc top-ups but not for the primary payout.
-- **No recursion limits.** A sub-job can itself spawn another sub-job
-  today. We don't enforce a depth cap because the stake-at-every-level
-  economics make runaway recursion self-limiting. If that assumption
-  breaks in practice, add a numeric depth field to the job metadata.
+- **No open-ended recursion.** Depth is policy-controlled. The default
+  `maxDepth` is `1`, which allows children but blocks grandchildren
+  unless the parent job explicitly opts in.
 - **No on-chain parent/child linkage.** Parent/child is a backend-level
   field today. That's fine for the v1 retention + dashboards use case
   and deferred for mainnet audit scope.

--- a/mcp-server/src/core/job-catalog-service.js
+++ b/mcp-server/src/core/job-catalog-service.js
@@ -137,6 +137,10 @@ export class JobCatalogService {
     this.getReputation = getReputation;
     this.getDefaultClaimStakeBps = getDefaultClaimStakeBps;
     this.getClaimEconomics = getClaimEconomics;
+    this.parentSessionIndex = new Map();
+    for (const job of this.jobs) {
+      this.indexJob(job);
+    }
   }
 
   listJobs({ includePaused = false, includeArchived = false, includeStale = false, now = new Date() } = {}) {
@@ -146,8 +150,10 @@ export class JobCatalogService {
   }
 
   listJobsByParentSession(parentSessionId) {
-    return this.jobs
-      .filter((job) => job.parentSessionId === parentSessionId)
+    const indexedIds = this.parentSessionIndex.get(String(parentSessionId ?? "")) ?? new Set();
+    return [...indexedIds]
+      .map((jobId) => this.jobs.find((job) => job.id === jobId))
+      .filter(Boolean)
       .map((job) => this.withLifecycle(job));
   }
 
@@ -166,7 +172,18 @@ export class JobCatalogService {
     }
 
     this.jobs.unshift(job);
+    this.indexJob(job);
     return job;
+  }
+
+  indexJob(job) {
+    if (!job?.parentSessionId) {
+      return;
+    }
+    const parentSessionId = String(job.parentSessionId);
+    const indexed = this.parentSessionIndex.get(parentSessionId) ?? new Set();
+    indexed.add(job.id);
+    this.parentSessionIndex.set(parentSessionId, indexed);
   }
 
   getJobLifecycleSummary(now = new Date()) {
@@ -688,6 +705,8 @@ export class JobCatalogService {
     const estimatedDifficulty = normaliseTextField(input?.estimatedDifficulty);
     const source = normalisePlainObject(input?.source, "source");
     const verification = normalisePlainObject(input?.verification, "verification");
+    const delegationPolicy = normaliseDelegationPolicy(input?.delegationPolicy, { rewardAmount, rewardAsset });
+    const lineage = normalisePlainObject(input?.lineage, "lineage");
     const lifecycle = normaliseLifecycle(input?.lifecycle, { disableStale: recurring });
     const recurringPolicy = normaliseRecurringPolicy(input?.recurringPolicy, {
       recurring,
@@ -718,6 +737,8 @@ export class JobCatalogService {
       ...(estimatedDifficulty ? { estimatedDifficulty } : {}),
       ...(agentInstructions.length ? { agentInstructions } : {}),
       ...(verification ? { verification } : {}),
+      ...(delegationPolicy ? { delegationPolicy } : {}),
+      ...(lineage ? { lineage } : {}),
       ...(parentSessionId ? { parentSessionId } : {}),
       ...(recurring ? { recurring: true } : {}),
       ...(schedule ? { schedule } : {}),
@@ -954,6 +975,49 @@ function normaliseRecurringPolicy(raw, { recurring, rewardAmount, rewardAsset })
       policy.reserveAsset = rewardAsset;
     } else if (policy.reserveAmount < impliedReserve) {
       throw new ValidationError("recurringPolicy.reserveAmount must cover maxRuns * rewardAmount.");
+    }
+  }
+
+  return Object.keys(policy).length ? policy : undefined;
+}
+
+function normaliseDelegationPolicy(raw, { rewardAmount, rewardAsset }) {
+  if (!raw) {
+    return undefined;
+  }
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw new ValidationError("delegationPolicy must be an object if provided.");
+  }
+
+  const policy = {};
+  if (raw.maxDepth !== undefined && raw.maxDepth !== null && raw.maxDepth !== "") {
+    const maxDepth = Number(raw.maxDepth);
+    if (!Number.isInteger(maxDepth) || maxDepth < 0) {
+      throw new ValidationError("delegationPolicy.maxDepth must be a non-negative integer.");
+    }
+    policy.maxDepth = maxDepth;
+  }
+  if (raw.maxSubJobs !== undefined && raw.maxSubJobs !== null && raw.maxSubJobs !== "") {
+    const maxSubJobs = Number(raw.maxSubJobs);
+    if (!Number.isInteger(maxSubJobs) || maxSubJobs < 1) {
+      throw new ValidationError("delegationPolicy.maxSubJobs must be a positive integer.");
+    }
+    policy.maxSubJobs = maxSubJobs;
+  }
+  if (raw.budgetAmount !== undefined && raw.budgetAmount !== null && raw.budgetAmount !== "") {
+    const budgetAmount = Number(raw.budgetAmount);
+    if (!Number.isFinite(budgetAmount) || budgetAmount < 0) {
+      throw new ValidationError("delegationPolicy.budgetAmount must be zero or higher.");
+    }
+    if (budgetAmount > rewardAmount) {
+      throw new ValidationError("delegationPolicy.budgetAmount cannot exceed rewardAmount.");
+    }
+    policy.budgetAmount = budgetAmount;
+    policy.budgetAsset = typeof raw.budgetAsset === "string" && raw.budgetAsset.trim()
+      ? raw.budgetAsset.trim().toUpperCase()
+      : rewardAsset;
+    if (policy.budgetAsset !== rewardAsset) {
+      throw new ValidationError("delegationPolicy.budgetAsset must match rewardAsset.");
     }
   }
 

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -7,7 +7,7 @@ import {
   validateSubmissionContract
 } from "./job-execution-service.js";
 import { VerificationIngestionService } from "../services/verification-ingestion-service.js";
-import { ValidationError } from "./errors.js";
+import { ConflictError, InsufficientLiquidityError, ValidationError } from "./errors.js";
 import { normalizeSubmission } from "./submission.js";
 import { buildPlatformCapabilities } from "./discovery-manifest.js";
 import {
@@ -557,7 +557,8 @@ export class PlatformService {
             }
           }
         : undefined);
-    const childJobs = this.jobCatalogService.listJobsByParentSession(sessionId);
+    const subJobLineage = await this.getSubJobLineage(sessionId);
+    const childJobs = subJobLineage.childJobs;
     const childRuns = await Promise.all(
       childJobs.map(async (job) => ({
         job,
@@ -586,7 +587,9 @@ export class PlatformService {
       lineage: {
         parentSessionId: session.parentSessionId,
         childJobIds: childJobs.map((job) => job.id),
-        childSessionIds: childRuns.flatMap(({ sessions }) => sessions.map((childSession) => childSession.sessionId))
+        childSessionIds: childRuns.flatMap(({ sessions }) => sessions.map((childSession) => childSession.sessionId)),
+        subJobBudget: subJobLineage.budget,
+        subJobPolicy: subJobLineage.policy
       },
       stateMachine: this.getSessionStateMachine(),
       timeline
@@ -691,7 +694,8 @@ export class PlatformService {
   }
 
   async listSubJobs(parentSessionId) {
-    const jobs = this.jobCatalogService.listJobsByParentSession(parentSessionId);
+    const lineage = await this.getSubJobLineage(parentSessionId);
+    const jobs = lineage.childJobs;
     return Promise.all(
       jobs.map(async (job) => ({
         ...job,
@@ -708,10 +712,150 @@ export class PlatformService {
     if (parentSession.status !== "claimed" && parentSession.status !== "submitted") {
       throw new ValidationError("parent session must be active before creating sub-jobs.");
     }
-    return this.jobCatalogService.createJob({
+    const parentJob = this.jobCatalogService.getJobDefinition(parentSession.jobId);
+    const parentDepth = await this.resolveDelegationDepth(parentJob);
+    const policy = this.resolveDelegationPolicy(parentJob);
+    const childDepth = parentDepth + 1;
+    if (childDepth > policy.maxDepth) {
+      throw new ConflictError("Sub-job delegation depth exceeded.", "subjob_depth_exceeded", {
+        parentSessionId,
+        parentJobId: parentJob.id,
+        parentDepth,
+        childDepth,
+        maxDepth: policy.maxDepth
+      });
+    }
+
+    const existingSubJobs = this.jobCatalogService.listJobsByParentSession(parentSessionId);
+    if (existingSubJobs.length >= policy.maxSubJobs) {
+      throw new ConflictError("Sub-job count limit exceeded.", "subjob_count_exceeded", {
+        parentSessionId,
+        maxSubJobs: policy.maxSubJobs,
+        existingSubJobCount: existingSubJobs.length
+      });
+    }
+
+    const rewardAmount = Number(input?.rewardAmount ?? 0);
+    const rewardAsset = String(input?.rewardAsset ?? parentJob.rewardAsset ?? "DOT").trim().toUpperCase();
+    if (!Number.isFinite(rewardAmount) || rewardAmount <= 0) {
+      throw new ValidationError("Sub-job rewardAmount must be greater than zero.");
+    }
+    if (rewardAsset !== policy.budgetAsset) {
+      throw new ValidationError("Sub-job rewardAsset must match the parent delegation budget asset.");
+    }
+    const usedBudgetAmount = sumSubJobRewards(existingSubJobs, policy.budgetAsset);
+    const nextUsedBudgetAmount = usedBudgetAmount + rewardAmount;
+    if (nextUsedBudgetAmount > policy.budgetAmount) {
+      throw new ConflictError("Sub-job delegation budget exceeded.", "subjob_budget_exceeded", {
+        parentSessionId,
+        parentJobId: parentJob.id,
+        budgetAsset: policy.budgetAsset,
+        budgetAmount: policy.budgetAmount,
+        usedBudgetAmount,
+        requestedRewardAmount: rewardAmount,
+        remainingBudgetAmount: Math.max(policy.budgetAmount - usedBudgetAmount, 0)
+      });
+    }
+
+    const account = await this.getAccountSummary(wallet);
+    const liquid = Number(account?.liquid?.[rewardAsset] ?? 0);
+    if (liquid < rewardAmount) {
+      throw new InsufficientLiquidityError(rewardAsset, {
+        wallet,
+        requiredAmount: rewardAmount,
+        availableAmount: liquid,
+        parentSessionId
+      });
+    }
+
+    const createdAt = new Date().toISOString();
+    const child = this.jobCatalogService.createJob({
       ...input,
-      parentSessionId
+      rewardAsset,
+      parentSessionId,
+      lineage: {
+        ...(typeof input?.lineage === "object" && input.lineage && !Array.isArray(input.lineage) ? input.lineage : {}),
+        kind: "sub_job",
+        parentSessionId,
+        parentJobId: parentJob.id,
+        parentWallet: wallet,
+        depth: childDepth,
+        createdBy: wallet,
+        createdAt,
+        budget: {
+          asset: policy.budgetAsset,
+          parentBudgetAmount: policy.budgetAmount,
+          usedBeforeAmount: usedBudgetAmount,
+          usedAfterAmount: nextUsedBudgetAmount,
+          remainingAfterAmount: Math.max(policy.budgetAmount - nextUsedBudgetAmount, 0)
+        }
+      }
     });
+    await this.reserveForJob(wallet, rewardAsset, rewardAmount);
+    child.lineage = {
+      ...(child.lineage ?? {}),
+      funding: {
+        reservedAt: new Date().toISOString(),
+        wallet,
+        asset: rewardAsset,
+        amount: rewardAmount,
+        source: "parent_wallet"
+      }
+    };
+    return child;
+  }
+
+  async getSubJobLineage(parentSessionId) {
+    const parentSession = await this.jobExecutionService.resumeSession(parentSessionId);
+    const parentJob = this.jobCatalogService.getJobDefinition(parentSession.jobId);
+    const childJobs = this.jobCatalogService.listJobsByParentSession(parentSessionId);
+    const policy = this.resolveDelegationPolicy(parentJob);
+    const usedBudgetAmount = sumSubJobRewards(childJobs, policy.budgetAsset);
+    const childRuns = await Promise.all(
+      childJobs.map(async (job) => ({
+        job,
+        sessions: await this.jobExecutionService.listSessionHistory({ jobId: job.id, limit: 10 })
+      }))
+    );
+    return {
+      parentSession,
+      parentJob,
+      policy,
+      budget: {
+        asset: policy.budgetAsset,
+        budgetAmount: policy.budgetAmount,
+        usedAmount: usedBudgetAmount,
+        remainingAmount: Math.max(policy.budgetAmount - usedBudgetAmount, 0)
+      },
+      childJobs,
+      childSessionIds: childRuns.flatMap(({ sessions }) => sessions.map((session) => session.sessionId))
+    };
+  }
+
+  resolveDelegationPolicy(parentJob) {
+    const raw = parentJob?.delegationPolicy ?? {};
+    return {
+      maxDepth: Number.isInteger(raw.maxDepth) ? raw.maxDepth : 1,
+      maxSubJobs: Number.isInteger(raw.maxSubJobs) ? raw.maxSubJobs : 5,
+      budgetAmount: Number.isFinite(Number(raw.budgetAmount)) ? Number(raw.budgetAmount) : Number(parentJob?.rewardAmount ?? 0),
+      budgetAsset: String(raw.budgetAsset ?? parentJob?.rewardAsset ?? "DOT").trim().toUpperCase()
+    };
+  }
+
+  async resolveDelegationDepth(job, seen = new Set()) {
+    if (!job?.parentSessionId) {
+      return 0;
+    }
+    if (seen.has(job.id)) {
+      throw new ConflictError("Sub-job lineage cycle detected.", "subjob_lineage_cycle", { jobId: job.id });
+    }
+    seen.add(job.id);
+    const parentSession = await this.stateStore.getSession?.(job.parentSessionId);
+    if (!parentSession?.jobId) {
+      return 1;
+    }
+    const parentJob = this.jobCatalogService.getJobDefinition(parentSession.jobId);
+    return 1 + await this.resolveDelegationDepth(parentJob, seen);
   }
 
   async getAccountSummary(wallet) {
@@ -1067,6 +1211,12 @@ function buildDerivativeJobTimelineEntry(job) {
       lifecycle: job.lifecycle
     })
   });
+}
+
+function sumSubJobRewards(jobs, asset) {
+  return jobs
+    .filter((job) => String(job.rewardAsset ?? "DOT").trim().toUpperCase() === asset)
+    .reduce((total, job) => total + Math.max(Number(job.rewardAmount ?? 0), 0), 0);
 }
 
 function buildEventBusTimelineEntry(event, index) {

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -77,9 +77,112 @@ test("createSubJob links the child job to the active parent session", async () =
   });
 
   assert.equal(subJob.parentSessionId, session.sessionId);
+  assert.equal(subJob.lineage.kind, "sub_job");
+  assert.equal(subJob.lineage.parentJobId, "parent-job-001");
+  assert.equal(subJob.lineage.depth, 1);
+  assert.equal(subJob.lineage.budget.usedAfterAmount, 2);
+  assert.equal(subJob.lineage.funding.asset, "DOT");
+  const account = await service.getAccountSummary(WALLET);
+  assert.equal(account.liquid.DOT, 8);
+  assert.equal(account.reserved.DOT, 2);
   const subJobs = await service.listSubJobs(session.sessionId);
   assert.equal(subJobs.length, 1);
   assert.equal(subJobs[0].id, "child-job-001");
+});
+
+test("createSubJob enforces parent delegation budget and count policy", async () => {
+  const service = makePlatformService();
+  service.jobs[0].delegationPolicy = { budgetAmount: 2, budgetAsset: "DOT", maxSubJobs: 1, maxDepth: 1 };
+  const session = await service.claimJob(WALLET, "parent-job-001", "http", "parent-budget-claim");
+
+  await assert.rejects(
+    () => service.createSubJob(session.sessionId, WALLET, {
+      id: "child-too-expensive",
+      category: "review",
+      tier: "starter",
+      rewardAmount: 3,
+      verifierMode: "benchmark",
+      verifierTerms: ["summary"],
+      verifierMinimumMatches: 1,
+      inputSchemaRef: "schema://jobs/review-input",
+      outputSchemaRef: "schema://jobs/pr-review-findings-output",
+      claimTtlSeconds: 1800,
+      retryLimit: 1,
+      requiresSponsoredGas: true
+    }),
+    (err) => err.code === "subjob_budget_exceeded"
+  );
+
+  await service.createSubJob(session.sessionId, WALLET, {
+    id: "child-budget-ok",
+    category: "review",
+    tier: "starter",
+    rewardAmount: 2,
+    verifierMode: "benchmark",
+    verifierTerms: ["summary"],
+    verifierMinimumMatches: 1,
+    inputSchemaRef: "schema://jobs/review-input",
+    outputSchemaRef: "schema://jobs/pr-review-findings-output",
+    claimTtlSeconds: 1800,
+    retryLimit: 1,
+    requiresSponsoredGas: true
+  });
+
+  await assert.rejects(
+    () => service.createSubJob(session.sessionId, WALLET, {
+      id: "child-too-many",
+      category: "review",
+      tier: "starter",
+      rewardAmount: 1,
+      verifierMode: "benchmark",
+      verifierTerms: ["summary"],
+      verifierMinimumMatches: 1,
+      inputSchemaRef: "schema://jobs/review-input",
+      outputSchemaRef: "schema://jobs/pr-review-findings-output",
+      claimTtlSeconds: 1800,
+      retryLimit: 1,
+      requiresSponsoredGas: true
+    }),
+    (err) => err.code === "subjob_count_exceeded"
+  );
+});
+
+test("createSubJob rejects grandchild delegation by default depth policy", async () => {
+  const service = makePlatformService();
+  const session = await service.claimJob(WALLET, "parent-job-001", "http", "parent-depth-claim");
+  const subJob = await service.createSubJob(session.sessionId, WALLET, {
+    id: "depth-child-job",
+    category: "coding",
+    tier: "starter",
+    rewardAmount: 2,
+    verifierMode: "benchmark",
+    verifierTerms: ["summary"],
+    verifierMinimumMatches: 1,
+    inputSchemaRef: "schema://jobs/coding-input",
+    outputSchemaRef: "schema://jobs/coding-output",
+    claimTtlSeconds: 1800,
+    retryLimit: 1,
+    requiresSponsoredGas: true
+  });
+  const childSession = await service.claimJob(WALLET, subJob.id, "http", "child-depth-claim");
+
+  await assert.rejects(
+    () => service.createSubJob(childSession.sessionId, WALLET, {
+      id: "grandchild-blocked",
+      category: "coding",
+      tier: "starter",
+      rewardAmount: 1,
+      verifierMode: "benchmark",
+      verifierTerms: ["summary"],
+      verifierMinimumMatches: 1,
+      inputSchemaRef: "schema://jobs/coding-input",
+      outputSchemaRef: "schema://jobs/coding-output",
+      claimTtlSeconds: 1800,
+      retryLimit: 1,
+      requiresSponsoredGas: true
+    }),
+    (err) => err.code === "subjob_depth_exceeded"
+  );
 });
 
 test("listJobsWithSessions joins active session state onto job rows", async () => {
@@ -229,6 +332,8 @@ test("getSessionTimeline includes transitions and verification state", async () 
   assert.equal(timeline.stateMachine.timelineVersion, "v2");
   assert.ok(Array.isArray(timeline.stateMachine.statuses));
   assert.ok(Array.isArray(timeline.lineage.childJobIds));
+  assert.equal(timeline.lineage.subJobBudget.asset, "DOT");
+  assert.equal(timeline.lineage.subJobPolicy.maxDepth, 1);
   assert.ok(timeline.timeline.some((entry) => entry.type === "session_transition"));
   assert.ok(timeline.timeline.some((entry) => entry.type === "verification"));
   assert.ok(timeline.timeline.every((entry) => entry.correlationId === submitted.sessionId));

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -2517,6 +2517,7 @@ const server = createServer(async (request, response) => {
 
     if (request.method === "POST" && pathname === "/jobs/sub") {
       const auth = await authMiddleware(request, url);
+      await enforceLimit("admin_jobs", auth.wallet, rateLimitConfig.adminJobs);
       const payload = await readJsonBody(request);
       const parentSessionId = typeof payload?.parentSessionId === "string" && payload.parentSessionId.trim()
         ? payload.parentSessionId.trim()

--- a/mcp-server/src/protocols/http/server.smoke.test.js
+++ b/mcp-server/src/protocols/http/server.smoke.test.js
@@ -297,6 +297,81 @@ test("http smoke: /admin/sessions exposes operator-wide session activity", { ski
   });
 });
 
+test("http smoke: /jobs/sub lets active workers create funded child jobs", { skip: !RUN }, async () => {
+  await runWithServer(async (base) => {
+    const adminToken = issueToken(ADMIN_WALLET, { roles: ["admin"] });
+    const workerToken = issueToken(STRANGER_WALLET);
+
+    await fetch(`${base}/admin/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${adminToken}` },
+      body: JSON.stringify({
+        id: "subjob-parent-smoke-001",
+        category: "coding",
+        tier: "starter",
+        rewardAmount: 5,
+        claimTtlSeconds: 3600,
+        verifierMode: "benchmark",
+        verifierTerms: ["complete"],
+        verifierMinimumMatches: 1,
+        outputSchemaRef: "schema://jobs/subjob-parent-smoke-output",
+        delegationPolicy: { budgetAmount: 3, budgetAsset: "DOT", maxSubJobs: 2, maxDepth: 1 }
+      })
+    });
+
+    await fetch(`${base}/account/fund?asset=DOT&amount=10`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${workerToken}` }
+    });
+
+    const claim = await fetch(
+      `${base}/jobs/claim?jobId=subjob-parent-smoke-001&idempotencyKey=subjob-parent-smoke-claim`,
+      { method: "POST", headers: { authorization: `Bearer ${workerToken}` } }
+    );
+    assert.equal(claim.status, 200);
+    const parentSession = await claim.json();
+
+    const create = await fetch(`${base}/jobs/sub`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${workerToken}` },
+      body: JSON.stringify({
+        parentSessionId: parentSession.sessionId,
+        id: "subjob-child-smoke-001",
+        category: "review",
+        tier: "starter",
+        rewardAmount: 2,
+        verifierMode: "benchmark",
+        verifierTerms: ["summary"],
+        verifierMinimumMatches: 1,
+        inputSchemaRef: "schema://jobs/review-input",
+        outputSchemaRef: "schema://jobs/pr-review-findings-output",
+        claimTtlSeconds: 1800,
+        retryLimit: 1,
+        requiresSponsoredGas: true
+      })
+    });
+    assert.equal(create.status, 201);
+    const child = await create.json();
+    assert.equal(child.parentSessionId, parentSession.sessionId);
+    assert.equal(child.lineage.kind, "sub_job");
+    assert.equal(child.lineage.budget.remainingAfterAmount, 1);
+
+    const listing = await fetch(`${base}/jobs/sub?parentSessionId=${encodeURIComponent(parentSession.sessionId)}`, {
+      headers: { authorization: `Bearer ${workerToken}` }
+    });
+    assert.equal(listing.status, 200);
+    const subJobs = await listing.json();
+    assert.equal(subJobs.length, 1);
+    assert.equal(subJobs[0].id, "subjob-child-smoke-001");
+
+    const account = await fetch(`${base}/account`, {
+      headers: { authorization: `Bearer ${workerToken}` }
+    });
+    const balances = await account.json();
+    assert.equal(balances.reserved.DOT, 2);
+  });
+});
+
 test("http smoke: /admin/status returns recurring + maintenance data for admin tokens", { skip: !RUN }, async () => {
   await runWithServer(async (base) => {
     const token = issueToken(ADMIN_WALLET, { roles: ["admin"] });


### PR DESCRIPTION
## What changed
- Enforce sub-job creation through active parent session ownership, delegation depth/count/budget policy, and parent-wallet liquidity.
- Preserve sub-job lineage metadata and parent-session indexing, and expose budget/policy lineage on session timelines.
- Rate-limit POST /jobs/sub and add smoke/unit coverage for funded worker-created child jobs.
- Update sub-job escrow docs and roadmap status to match the enforced runtime model.

## Checks run
- RUN_HTTP_SMOKE=1 node --test mcp-server/src/protocols/http/server.smoke.test.js
- npm --workspace mcp-server test
- git diff --check

## Impact
- Backend: yes
- Frontend: no source change, but session timeline now exposes child job ids/session ids plus sub-job budget and policy for future UI surfaces
- Indexer: no
- Caddy: no
- Contracts: no
- Public site: docs only

## Environment / VPS secrets
- No new environment variables or VPS secret changes required.