### PR TITLE
Type the agent platform SDK surface

### DIFF
--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -460,8 +460,8 @@ proves the need, but it is UI-focused rather than an external integration SDK.
 
 ### Gaps today
 
-- first-pass shared JS client exists, but the type surface is still broad
-  `unknown` responses rather than generated endpoint-specific models
+- typed JS client exists, but generated types from the API source are still a
+  later step
 - some request shapes are still duplicated across scripts, demos, and frontend
   code
 - canonical integration examples are young and should grow with real external
@@ -475,14 +475,18 @@ proves the need, but it is UI-focused rather than an external integration SDK.
 
 ### Concrete next changes
 
-- keep hardening `sdk/agent-platform-client.js`
-- ensure it wraps:
+- [x] keep hardening `sdk/agent-platform-client.js`
+- [x] ensure it wraps:
   - auth nonce + verify
   - list/recommend/preflight jobs
   - claim / submit / resume
   - session and job timeline inspection
   - admin job create / recurring fire / status
-- share validation types with docs and scripts where possible
+- [x] add hand-maintained endpoint response declarations for the current API
+- [x] expose structured API errors for automation
+- [ ] generate SDK types from the API/schema source instead of maintaining them
+  by hand
+- [ ] share validation types with frontend scripts where possible
 
 ### What this unlocks
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "test": "npm run test:backend && npm run test:sdk && npm run test:examples && npm run test:indexer:api && npm run test:contracts",
     "test:backend": "npm --workspace mcp-server test",
-    "test:sdk": "node --test sdk/agent-platform-client.test.mjs",
+    "test:sdk": "node --test sdk/agent-platform-client.test.mjs && npm run typecheck:sdk",
+    "typecheck:sdk": "tsc --noEmit --allowJs false --target es2022 --module nodenext --moduleResolution nodenext --skipLibCheck --lib es2022,dom sdk/agent-platform-client.d.ts sdk/agent-platform-client.types.test.ts",
     "test:examples": "node --test examples/**/*.test.mjs",
     "test:indexer:api": "npm --workspace indexer run test:api",
     "test:ops": "node --test scripts/ops/*.test.mjs",

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,0 +1,55 @@
+# Averray Agent Platform Client
+
+Small JavaScript client for external agents and operator scripts. It keeps the
+HTTP API visible while centralizing request construction, bearer auth, error
+metadata, and TypeScript declarations for common platform responses.
+
+```js
+import { AgentPlatformClient } from "./agent-platform-client.js";
+
+const client = new AgentPlatformClient({
+  baseUrl: "https://api.averray.com",
+  token: process.env.AVERRAY_TOKEN
+});
+
+const jobs = await client.listClaimableJobs({ source: "wikipedia", limit: 5 });
+const definition = await client.getJobDefinition(jobs.jobs[0].id);
+const preflight = await client.preflightJob(definition.id);
+```
+
+## Mutation Pattern
+
+For external agents, keep the mutation sequence explicit:
+
+1. Read `/onboarding`, `/jobs/definition`, and `/jobs/preflight`.
+2. Validate structured output with `validateJobSubmission`.
+3. Claim with a caller-provided idempotency key.
+4. Submit once for the returned `sessionId`.
+5. Read `getSessionTimeline` for state and lineage.
+
+The SDK does not hide these steps because mutation safety depends on callers
+seeing where claim and submit happen.
+
+## Typed Surface
+
+`agent-platform-client.d.ts` exports endpoint-oriented types such as:
+
+- `JobsListResponse`, `JobDefinition`, `ClaimStatus`
+- `SessionRecord`, `SessionTimelineResponse`, `JobTimelineResponse`
+- `DelegationPolicy`, `SubJobLineageMetadata`, `AdminStatusResponse`
+- `AccountSummary`, `BorrowCapacityResponse`
+
+Objects include index signatures where the platform intentionally returns
+extensible metadata, so integrations can keep compiling as new fields land.
+
+## Errors
+
+Failed responses throw `AgentPlatformApiError`.
+
+```js
+try {
+  await client.claimJob("starter-coding-001", "run-001");
+} catch (error) {
+  console.error(error.status, error.code, error.details);
+}
+```

--- a/sdk/agent-platform-client.d.ts
+++ b/sdk/agent-platform-client.d.ts
@@ -1,3 +1,13 @@
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+export type JsonObject = { [key: string]: JsonValue };
+export type WalletAddress = string;
+export type AssetSymbol = string;
+export type ISODateTime = string;
+export type JobId = string;
+export type SessionId = string;
+export type IdempotencyKey = string;
+
 export interface AgentPlatformClientOptions {
   baseUrl: string;
   token?: string;
@@ -10,16 +20,148 @@ export interface RequestOptions {
   headers?: HeadersInit;
 }
 
+export interface ApiEnvelope {
+  [key: string]: unknown;
+}
+
+export interface HealthResponse extends ApiEnvelope {
+  ok?: boolean;
+  status?: string;
+}
+
+export interface OnboardingResponse extends ApiEnvelope {
+  onboarding?: ApiEnvelope;
+  entrypoint?: string;
+}
+
+export interface DiscoveryManifest extends ApiEnvelope {
+  name?: string;
+  version?: string;
+  tools?: ApiEnvelope[];
+  capabilities?: ApiEnvelope;
+}
+
+export interface JobTierLadderResponse extends ApiEnvelope {
+  tiers?: ApiEnvelope[];
+}
+
+export interface StrategySummary extends ApiEnvelope {
+  strategyId: string;
+  id?: string;
+  label?: string;
+  asset?: AssetSymbol;
+  kind?: string;
+  riskLabel?: string;
+}
+
+export interface StrategiesResponse extends ApiEnvelope {
+  strategies: StrategySummary[];
+  docs?: string;
+}
+
+export interface SessionStateMachineResponse extends ApiEnvelope {
+  statuses?: ApiEnvelope[];
+  transitions?: ApiEnvelope[];
+}
+
+export interface JobSchemaSummary extends ApiEnvelope {
+  name: string;
+  path?: string;
+  schema?: JsonObject;
+}
+
+export interface JobSchemasResponse extends ApiEnvelope {
+  schemas?: JobSchemaSummary[];
+}
+
+export interface AgentProfile extends ApiEnvelope {
+  wallet: WalletAddress;
+  handle?: string;
+  reputation?: number;
+  badges?: ApiEnvelope[];
+  currentActivity?: ApiEnvelope | null;
+  lifetimeStats?: ApiEnvelope;
+}
+
+export interface AgentListResponse extends ApiEnvelope {
+  agents?: AgentProfile[];
+  count?: number;
+}
+
+export interface BadgeResponse extends ApiEnvelope {
+  name?: string;
+  description?: string;
+  image?: string;
+  attributes?: ApiEnvelope[];
+}
+
+export interface AlertListResponse extends ApiEnvelope {
+  alerts?: ApiEnvelope[];
+  count?: number;
+}
+
+export interface AuditEventListResponse extends ApiEnvelope {
+  events?: ApiEnvelope[];
+  count?: number;
+}
+
+export interface PolicySummary extends ApiEnvelope {
+  tag: string;
+  status?: string;
+}
+
+export interface PolicyListResponse extends ApiEnvelope {
+  policies?: PolicySummary[];
+}
+
+export interface VerifierHandlersResponse extends ApiEnvelope {
+  handlers?: ApiEnvelope[];
+}
+
+export interface NonceResponse extends ApiEnvelope {
+  nonce?: string;
+  message?: string;
+}
+
+export interface AuthSessionResponse extends ApiEnvelope {
+  wallet?: WalletAddress;
+  roles?: string[];
+  capabilities?: string[];
+}
+
+export interface AssetBalances {
+  [asset: AssetSymbol]: number;
+}
+
+export interface AccountSummary extends ApiEnvelope {
+  wallet: WalletAddress;
+  liquid?: AssetBalances;
+  reserved?: AssetBalances;
+  strategyAllocated?: AssetBalances;
+  debtOutstanding?: AssetBalances;
+}
+
+export interface BorrowCapacityResponse extends ApiEnvelope {
+  wallet?: WalletAddress;
+  asset?: AssetSymbol;
+  capacity?: number;
+  available?: number;
+}
+
+export interface StrategyPositionsResponse extends ApiEnvelope {
+  positions?: ApiEnvelope[];
+}
+
 export interface FundAccountInput {
-  asset?: string;
+  asset?: AssetSymbol;
   amount: number | string;
 }
 
 export interface StrategyMutationInput {
-  asset?: string;
+  asset?: AssetSymbol;
   amount: number | string;
   strategyId?: string;
-  idempotencyKey?: string;
+  idempotencyKey?: IdempotencyKey;
   destination?: string;
   message?: string;
   maxWeight?: unknown;
@@ -28,18 +170,101 @@ export interface StrategyMutationInput {
 }
 
 export interface SendToAgentInput {
-  recipient: string;
-  asset?: string;
+  recipient: WalletAddress;
+  asset?: AssetSymbol;
   amount: number | string;
 }
 
-export interface FireRecurringJobOptions {
-  firedAt?: string;
-  idempotencyKey?: string;
+export interface BalanceMutationInput {
+  asset?: AssetSymbol;
+  amount: number | string;
+  idempotencyKey?: IdempotencyKey;
+}
+
+export interface ClaimStatus extends ApiEnvelope {
+  claimState?: string;
+  effectiveState?: string;
+  claimable?: boolean;
+  currentWalletCanClaim?: boolean | null;
+  reason?: string | null;
+  retryLimit?: number | null;
+  claimAttemptCount?: number | null;
+  remainingClaimAttempts?: number | null;
+  claimExpiresAt?: ISODateTime | null;
+  expiredAt?: ISODateTime | null;
+}
+
+export interface DelegationPolicy extends ApiEnvelope {
+  budgetAmount?: number;
+  budgetAsset?: AssetSymbol;
+  maxSubJobs?: number;
+  maxDepth?: number;
+}
+
+export interface RecurringPolicy extends ApiEnvelope {
+  reserveAmount?: number;
+  reserveAsset?: AssetSymbol;
+  maxRuns?: number;
+}
+
+export interface JobDefinition extends ApiEnvelope {
+  id: JobId;
+  title?: string;
+  category?: string;
+  tier?: string;
+  rewardAmount?: number;
+  rewardAsset?: AssetSymbol;
+  verifierMode?: string;
+  retryLimit?: number;
+  parentSessionId?: SessionId;
+  delegationPolicy?: DelegationPolicy;
+  recurringPolicy?: RecurringPolicy;
+  claimStatus?: ClaimStatus;
+  claimable?: boolean;
+  claimState?: string;
+  effectiveState?: string;
+  currentWalletCanClaim?: boolean | null;
+  reason?: string | null;
+  submissionContract?: ApiEnvelope;
+  source?: ApiEnvelope;
+  verification?: ApiEnvelope;
+  lineage?: SubJobLineageMetadata;
+}
+
+export interface JobSummary extends ApiEnvelope {
+  id: JobId;
+  title?: string;
+  category?: string;
+  tier?: string;
+  state?: string;
+  status?: string;
+  effectiveState?: string;
+  claimState?: string;
+  claimable?: boolean;
+  currentWalletCanClaim?: boolean | null;
+  reason?: string | null;
+  rewardAmount?: number;
+  rewardAsset?: AssetSymbol;
+  claimExpiresAt?: ISODateTime | null;
+  retryLimit?: number | null;
+  parentSessionId?: SessionId;
+  delegationPolicy?: DelegationPolicy;
+  recurringPolicy?: RecurringPolicy;
+  lineage?: SubJobLineageMetadata;
+}
+
+export interface JobsListResponse extends ApiEnvelope {
+  jobs: JobSummary[];
+  count?: number;
+  total?: number;
+  limit?: number;
+  offset?: number;
+  nextOffset?: number | null;
+  compact?: boolean;
 }
 
 export interface ListJobsOptions {
-  wallet?: string;
+  wallet?: WalletAddress;
   source?: string;
   category?: string;
   state?: string;
@@ -48,8 +273,209 @@ export interface ListJobsOptions {
   offset?: number;
 }
 
+export interface RecommendationResponse extends ApiEnvelope {
+  recommendations?: JobSummary[];
+  jobs?: JobSummary[];
+}
+
+export interface PreflightResponse extends ApiEnvelope {
+  jobId?: JobId;
+  eligible?: boolean;
+  claimable?: boolean;
+  currentWalletCanClaim?: boolean | null;
+  reason?: string | null;
+  retryLimit?: number | null;
+  claimExpiresAt?: ISODateTime | null;
+}
+
+export interface ValidationResponse extends ApiEnvelope {
+  valid: boolean;
+  errors?: ApiEnvelope[];
+  submission?: unknown;
+}
+
+export interface ClaimResponse extends SessionRecord {
+  sessionId: SessionId;
+  jobId: JobId;
+  wallet: WalletAddress;
+}
+
+export interface SubmitResponse extends SessionRecord {
+  sessionId: SessionId;
+}
+
+export interface SessionRecord extends ApiEnvelope {
+  sessionId: SessionId;
+  jobId?: JobId;
+  wallet?: WalletAddress;
+  status?: string;
+  state?: string;
+  claimExpiresAt?: ISODateTime | null;
+  deadline?: ISODateTime | null;
+  claimedAt?: ISODateTime;
+  submittedAt?: ISODateTime;
+  updatedAt?: ISODateTime;
+  parentSessionId?: SessionId;
+}
+
+export interface TimelineEntry extends ApiEnvelope {
+  id?: string;
+  type?: string;
+  at?: ISODateTime;
+  label?: string;
+}
+
+export interface SubJobBudgetSummary extends ApiEnvelope {
+  asset: AssetSymbol;
+  budgetAmount?: number;
+  usedAmount?: number;
+  remainingAmount?: number;
+  parentBudgetAmount?: number;
+  usedBeforeAmount?: number;
+  usedAfterAmount?: number;
+  remainingAfterAmount?: number;
+}
+
+export interface SubJobLineageMetadata extends ApiEnvelope {
+  kind?: "sub_job" | string;
+  parentSessionId?: SessionId;
+  parentJobId?: JobId;
+  parentWallet?: WalletAddress;
+  depth?: number;
+  createdBy?: WalletAddress;
+  createdAt?: ISODateTime;
+  budget?: SubJobBudgetSummary;
+  funding?: ApiEnvelope;
+}
+
+export interface SessionLineage extends ApiEnvelope {
+  parentSessionId?: SessionId;
+  childJobIds?: JobId[];
+  childSessionIds?: SessionId[];
+  subJobBudget?: SubJobBudgetSummary;
+  subJobPolicy?: DelegationPolicy;
+}
+
+export interface SessionTimelineResponse extends ApiEnvelope {
+  timelineVersion?: string;
+  session?: SessionRecord;
+  lineage?: SessionLineage;
+  stateMachine?: ApiEnvelope;
+  timeline: TimelineEntry[];
+}
+
+export interface JobTimelineLineage extends ApiEnvelope {
+  sessionIds?: SessionId[];
+  childJobIds?: JobId[];
+  terminalSessionIds?: SessionId[];
+}
+
+export interface JobTimelineResponse extends ApiEnvelope {
+  timelineVersion?: string;
+  job?: JobDefinition;
+  lineage?: JobTimelineLineage;
+  summary?: ApiEnvelope;
+  timeline: TimelineEntry[];
+}
+
 export interface JobTimelineOptions {
   limit?: number;
+}
+
+export interface SessionListResponse extends ApiEnvelope {
+  sessions: SessionRecord[];
+  count?: number;
+  total?: number;
+  limit?: number;
+  offset?: number;
+  scope?: "wallet" | "operator" | string;
+}
+
+export interface DisputeSummary extends ApiEnvelope {
+  id: string;
+  sessionId?: SessionId;
+  status?: string;
+  verdict?: string;
+}
+
+export interface DisputeListResponse extends ApiEnvelope {
+  disputes?: DisputeSummary[];
+  count?: number;
+}
+
+export interface DisputeVerdictInput {
+  verdict: string;
+  rationale?: string;
+}
+
+export interface SubJobCreateInput extends ApiEnvelope {
+  parentSessionId: SessionId;
+  id: JobId;
+  category: string;
+  tier?: string;
+  rewardAmount: number | string;
+  rewardAsset?: AssetSymbol;
+  verifierMode: string;
+  verifierTerms?: string[];
+  verifierMinimumMatches?: number;
+  claimTtlSeconds?: number;
+  retryLimit?: number;
+}
+
+export interface SubJobListItem extends JobSummary {
+  sessions?: SessionRecord[];
+}
+
+export type SubJobListResponse = SubJobListItem[];
+
+export interface FireRecurringJobOptions {
+  firedAt?: ISODateTime;
+  idempotencyKey?: IdempotencyKey;
+}
+
+export interface AdminJobCreateInput extends ApiEnvelope {
+  id: JobId;
+  category: string;
+  rewardAmount: number | string;
+  rewardAsset?: AssetSymbol;
+  verifierMode: string;
+  tier?: string;
+  retryLimit?: number;
+  delegationPolicy?: DelegationPolicy;
+  recurring?: boolean;
+  recurringPolicy?: RecurringPolicy;
+}
+
+export interface AdminStatusResponse extends ApiEnvelope {
+  jobLifecycle?: {
+    total?: number;
+    claimable?: number;
+    open?: number;
+    paused?: number;
+    archived?: number;
+    stale?: number;
+    [key: string]: unknown;
+  };
+  recurringJobs?: ApiEnvelope;
+  providerOperations?: ApiEnvelope;
+}
+
+export class AgentPlatformApiError extends Error {
+  constructor(options: {
+    message: string;
+    status: number;
+    method: string;
+    path: string;
+    payload?: unknown;
+  });
+
+  name: "AgentPlatformApiError";
+  status: number;
+  method: string;
+  path: string;
+  payload?: unknown;
+  code?: string;
+  details?: unknown;
 }
 
 export class AgentPlatformClient {
@@ -61,61 +487,73 @@ export class AgentPlatformClient {
 
   setToken(token?: string): void;
 
-  getHealth(): Promise<unknown>;
-  getOnboarding(): Promise<unknown>;
-  getDiscoveryManifest(): Promise<unknown>;
-  getJobTierLadder(): Promise<unknown>;
-  listStrategies(): Promise<unknown>;
-  getSessionStateMachine(): Promise<unknown>;
-  listJobSchemas(): Promise<unknown>;
-  getJobSchema(name: string): Promise<unknown>;
-  getAgentProfile(wallet: string): Promise<unknown>;
-  listAgents(options?: { limit?: number }): Promise<unknown>;
-  getAgentBadge(sessionId: string): Promise<unknown>;
-  listBadges(options?: { limit?: number }): Promise<unknown>;
-  listAlerts(options?: { limit?: number }): Promise<unknown>;
-  listAuditEvents(options?: { limit?: number }): Promise<unknown>;
-  listPolicies(): Promise<unknown>;
-  getPolicy(tag: string): Promise<unknown>;
-  proposePolicy(payload: unknown): Promise<unknown>;
-  listVerifierHandlers(): Promise<unknown>;
+  getHealth(): Promise<HealthResponse>;
+  getOnboarding(): Promise<OnboardingResponse>;
+  getDiscoveryManifest(): Promise<DiscoveryManifest>;
+  getJobTierLadder(): Promise<JobTierLadderResponse>;
+  listStrategies(): Promise<StrategiesResponse>;
+  getSessionStateMachine(): Promise<SessionStateMachineResponse>;
+  listJobSchemas(): Promise<JobSchemasResponse>;
+  getJobSchema(name: string): Promise<JsonObject>;
+  getAgentProfile(wallet: WalletAddress): Promise<AgentProfile>;
+  listAgents(options?: { limit?: number }): Promise<AgentListResponse>;
+  getAgentBadge(sessionId: SessionId): Promise<BadgeResponse>;
+  listBadges(options?: { limit?: number }): Promise<BadgeResponse[] | ApiEnvelope>;
+  listAlerts(options?: { limit?: number }): Promise<AlertListResponse>;
+  listAuditEvents(options?: { limit?: number }): Promise<AuditEventListResponse>;
+  listPolicies(): Promise<PolicyListResponse>;
+  getPolicy(tag: string): Promise<PolicySummary>;
+  proposePolicy(payload: unknown): Promise<PolicySummary>;
+  listVerifierHandlers(): Promise<VerifierHandlersResponse>;
 
-  issueNonce(wallet: string): Promise<unknown>;
-  verifySignature(message: string, signature: string): Promise<unknown>;
-  getAuthSession(): Promise<unknown>;
+  issueNonce(wallet: WalletAddress): Promise<NonceResponse>;
+  verifySignature(message: string, signature: string): Promise<AuthSessionResponse>;
+  getAuthSession(): Promise<AuthSessionResponse>;
 
-  getAccountSummary(): Promise<unknown>;
-  getBorrowCapacity(asset?: string): Promise<unknown>;
-  getStrategyPositions(): Promise<unknown>;
-  fundAccount(input: FundAccountInput): Promise<unknown>;
-  allocateIdleFunds(input: StrategyMutationInput): Promise<unknown>;
-  deallocateIdleFunds(input: StrategyMutationInput): Promise<unknown>;
-  sendToAgent(input: SendToAgentInput): Promise<unknown>;
+  getAccountSummary(): Promise<AccountSummary>;
+  getBorrowCapacity(asset?: AssetSymbol): Promise<BorrowCapacityResponse>;
+  getStrategyPositions(): Promise<StrategyPositionsResponse>;
+  fundAccount(input: FundAccountInput): Promise<AccountSummary>;
+  allocateIdleFunds(input: StrategyMutationInput): Promise<AccountSummary>;
+  deallocateIdleFunds(input: StrategyMutationInput): Promise<AccountSummary>;
+  sendToAgent(input: SendToAgentInput): Promise<AccountSummary>;
+  borrowFunds(input: BalanceMutationInput): Promise<AccountSummary>;
+  repayFunds(input: BalanceMutationInput): Promise<AccountSummary>;
 
-  listJobs(options?: ListJobsOptions): Promise<unknown>;
-  listClaimableJobs(options?: ListJobsOptions): Promise<unknown>;
-  getJobDefinition(jobId: string): Promise<unknown>;
-  getRecommendations(): Promise<unknown>;
-  preflightJob(jobId: string): Promise<unknown>;
-  validateJobSubmission(jobId: string, submission: unknown): Promise<unknown>;
-  claimJob(jobId: string, idempotencyKey?: string): Promise<unknown>;
-  submitWork(sessionId: string, submission: string | unknown): Promise<unknown>;
-  getSession(sessionId: string): Promise<unknown>;
-  getSessionTimeline(sessionId: string): Promise<unknown>;
-  getJobTimeline(jobId: string, options?: JobTimelineOptions): Promise<unknown>;
-  listSessions(options?: { limit?: number; jobId?: string }): Promise<unknown>;
-  listSubJobs(parentSessionId: string): Promise<unknown>;
-  createSubJob(payload: unknown): Promise<unknown>;
+  listJobs(options?: ListJobsOptions): Promise<JobsListResponse>;
+  listClaimableJobs(options?: ListJobsOptions): Promise<JobsListResponse>;
+  getJobDefinition(jobId: JobId): Promise<JobDefinition>;
+  getRecommendations(): Promise<RecommendationResponse>;
+  preflightJob(jobId: JobId): Promise<PreflightResponse>;
+  validateJobSubmission(jobId: JobId, submission: unknown): Promise<ValidationResponse>;
+  claimJob(jobId: JobId, idempotencyKey?: IdempotencyKey): Promise<ClaimResponse>;
+  submitWork(sessionId: SessionId, submission: string | JsonObject): Promise<SubmitResponse>;
+  getSession(sessionId: SessionId): Promise<SessionRecord>;
+  getSessionTimeline(sessionId: SessionId): Promise<SessionTimelineResponse>;
+  getJobTimeline(jobId: JobId, options?: JobTimelineOptions): Promise<JobTimelineResponse>;
+  listSessions(options?: { limit?: number; jobId?: JobId }): Promise<SessionListResponse>;
+  listAdminSessions(options?: {
+    limit?: number;
+    jobId?: JobId;
+    wallet?: WalletAddress;
+  }): Promise<SessionListResponse>;
+  listSubJobs(parentSessionId: SessionId): Promise<SubJobListResponse>;
+  createSubJob(payload: SubJobCreateInput): Promise<JobDefinition>;
 
-  runVerifier(sessionId: string, evidence?: string, metadataURI?: string): Promise<unknown>;
-  replayVerifier(sessionId: string): Promise<unknown>;
-  getVerifierResult(sessionId: string): Promise<unknown>;
+  listDisputes(options?: { limit?: number }): Promise<DisputeListResponse>;
+  getDispute(id: string): Promise<DisputeSummary>;
+  submitDisputeVerdict(id: string, input: DisputeVerdictInput): Promise<DisputeSummary>;
+  releaseDisputeStake(id: string, payload?: unknown): Promise<DisputeSummary>;
 
-  createJob(payload: unknown): Promise<unknown>;
-  fireRecurringJob(templateId: string, options?: FireRecurringJobOptions): Promise<unknown>;
-  pauseRecurringJob(templateId: string, options?: { idempotencyKey?: string }): Promise<unknown>;
-  resumeRecurringJob(templateId: string, options?: { idempotencyKey?: string }): Promise<unknown>;
-  getAdminStatus(): Promise<unknown>;
+  runVerifier(sessionId: SessionId, evidence?: string, metadataURI?: string): Promise<ApiEnvelope>;
+  replayVerifier(sessionId: SessionId): Promise<ApiEnvelope>;
+  getVerifierResult(sessionId: SessionId): Promise<ApiEnvelope>;
 
-  request(path: string, options?: RequestOptions): Promise<unknown>;
+  createJob(payload: AdminJobCreateInput): Promise<JobDefinition>;
+  fireRecurringJob(templateId: JobId, options?: FireRecurringJobOptions): Promise<JobDefinition>;
+  pauseRecurringJob(templateId: JobId, options?: { idempotencyKey?: IdempotencyKey }): Promise<ApiEnvelope>;
+  resumeRecurringJob(templateId: JobId, options?: { idempotencyKey?: IdempotencyKey }): Promise<ApiEnvelope>;
+  getAdminStatus(): Promise<AdminStatusResponse>;
+
+  request<T = unknown>(path: string, options?: RequestOptions): Promise<T>;
 }

--- a/sdk/agent-platform-client.js
+++ b/sdk/agent-platform-client.js
@@ -161,6 +161,20 @@ export class AgentPlatformClient {
     });
   }
 
+  async borrowFunds({ asset = "DOT", amount, idempotencyKey = undefined } = {}) {
+    return this.request("/account/borrow", {
+      method: "POST",
+      body: compact({ asset, amount, idempotencyKey })
+    });
+  }
+
+  async repayFunds({ asset = "DOT", amount, idempotencyKey = undefined } = {}) {
+    return this.request("/account/repay", {
+      method: "POST",
+      body: compact({ asset, amount, idempotencyKey })
+    });
+  }
+
   async listJobs({
     wallet = undefined,
     source = undefined,
@@ -250,6 +264,14 @@ export class AgentPlatformClient {
     if (limit !== undefined) params.set("limit", String(limit));
     if (jobId) params.set("jobId", jobId);
     return this.request(`/sessions${params.size ? `?${params.toString()}` : ""}`);
+  }
+
+  async listAdminSessions({ limit = undefined, jobId = undefined, wallet = undefined } = {}) {
+    const params = new URLSearchParams();
+    if (limit !== undefined) params.set("limit", String(limit));
+    if (jobId) params.set("jobId", jobId);
+    if (wallet) params.set("wallet", wallet);
+    return this.request(`/admin/sessions${params.size ? `?${params.toString()}` : ""}`);
   }
 
   async listDisputes({ limit = undefined } = {}) {
@@ -358,9 +380,28 @@ export class AgentPlatformClient {
     const text = await response.text();
     const payload = text ? safeJsonParse(text) : undefined;
     if (!response.ok) {
-      throw new Error(payload?.message ?? payload?.error ?? `${method} ${path} failed with ${response.status}`);
+      throw new AgentPlatformApiError({
+        message: payload?.message ?? payload?.error ?? `${method} ${path} failed with ${response.status}`,
+        status: response.status,
+        method,
+        path,
+        payload
+      });
     }
     return payload;
+  }
+}
+
+export class AgentPlatformApiError extends Error {
+  constructor({ message, status, method, path, payload }) {
+    super(message);
+    this.name = "AgentPlatformApiError";
+    this.status = status;
+    this.method = method;
+    this.path = path;
+    this.payload = payload;
+    this.code = payload?.code ?? payload?.error ?? undefined;
+    this.details = payload?.details ?? undefined;
   }
 }
 

--- a/sdk/agent-platform-client.test.mjs
+++ b/sdk/agent-platform-client.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { AgentPlatformClient } from "./agent-platform-client.js";
+import { AgentPlatformApiError, AgentPlatformClient } from "./agent-platform-client.js";
 
 test("builder read helpers call the expected public endpoints", async () => {
   const calls = [];
@@ -51,6 +51,14 @@ test("authenticated helpers send bearer token and compact JSON bodies", async ()
     recipient: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
     amount: "1.5"
   });
+  await client.borrowFunds({
+    amount: 2,
+    idempotencyKey: "borrow-1"
+  });
+  await client.repayFunds({
+    amount: 1,
+    idempotencyKey: undefined
+  });
 
   assert.equal(calls[0].url, "https://api.example.test/account/allocate");
   assert.equal(calls[0].options.method, "POST");
@@ -69,6 +77,17 @@ test("authenticated helpers send bearer token and compact JSON bodies", async ()
     asset: "DOT",
     amount: "1.5"
   });
+  assert.equal(calls[2].url, "https://api.example.test/account/borrow");
+  assert.deepEqual(JSON.parse(calls[2].options.body), {
+    asset: "DOT",
+    amount: 2,
+    idempotencyKey: "borrow-1"
+  });
+  assert.equal(calls[3].url, "https://api.example.test/account/repay");
+  assert.deepEqual(JSON.parse(calls[3].options.body), {
+    asset: "DOT",
+    amount: 1
+  });
 });
 
 test("listSessions builds optional query string without empty params", async () => {
@@ -83,12 +102,17 @@ test("listSessions builds optional query string without empty params", async () 
 
   await client.listSessions();
   await client.listSessions({ limit: 10, jobId: "starter job" });
+  await client.listAdminSessions({ limit: 5, wallet: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd" });
 
   assert.equal(calls[0].url, "https://api.example.test/sessions");
   assert.equal(calls[1].url, "https://api.example.test/sessions?limit=10&jobId=starter+job");
+  assert.equal(
+    calls[2].url,
+    "https://api.example.test/admin/sessions?limit=5&wallet=0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+  );
 });
 
-test("job helpers build compact filters and admin timeline URLs", async () => {
+test("job helpers build compact filters, mutation bodies, and admin timeline URLs", async () => {
   const calls = [];
   const client = new AgentPlatformClient({
     baseUrl: "https://api.example.test",
@@ -101,7 +125,16 @@ test("job helpers build compact filters and admin timeline URLs", async () => {
   await client.listJobs({ source: "wikipedia", state: "claimable", limit: 5, offset: 10 });
   await client.listClaimableJobs({ category: "coding", limit: 2 });
   await client.validateJobSubmission("job with space", { summary: "Ready" });
+  await client.claimJob("job with space", "claim-key-1");
+  await client.submitWork("session with space", { summary: "Submitted" });
+  await client.submitWork("legacy session", "plain evidence");
   await client.getJobTimeline("job with space", { limit: 50 });
+  await client.createSubJob({
+    parentSessionId: "parent session",
+    id: "sub-job-1",
+    rewardAmount: 2
+  });
+  await client.listSubJobs("parent session");
 
   assert.equal(
     calls[0].url,
@@ -114,7 +147,28 @@ test("job helpers build compact filters and admin timeline URLs", async () => {
     jobId: "job with space",
     submission: { summary: "Ready" }
   });
-  assert.equal(calls[3].url, "https://api.example.test/admin/jobs/timeline?jobId=job+with+space&limit=50");
+  assert.equal(calls[3].url, "https://api.example.test/jobs/claim");
+  assert.deepEqual(JSON.parse(calls[3].options.body), {
+    jobId: "job with space",
+    idempotencyKey: "claim-key-1"
+  });
+  assert.equal(calls[4].url, "https://api.example.test/jobs/submit");
+  assert.deepEqual(JSON.parse(calls[4].options.body), {
+    sessionId: "session with space",
+    submission: { summary: "Submitted" }
+  });
+  assert.deepEqual(JSON.parse(calls[5].options.body), {
+    sessionId: "legacy session",
+    evidence: "plain evidence"
+  });
+  assert.equal(calls[6].url, "https://api.example.test/admin/jobs/timeline?jobId=job+with+space&limit=50");
+  assert.equal(calls[7].url, "https://api.example.test/jobs/sub");
+  assert.deepEqual(JSON.parse(calls[7].options.body), {
+    parentSessionId: "parent session",
+    id: "sub-job-1",
+    rewardAmount: 2
+  });
+  assert.equal(calls[8].url, "https://api.example.test/jobs/sub?parentSessionId=parent%20session");
 });
 
 test("operator surface helpers call policy, audit, and alert endpoints", async () => {
@@ -154,13 +208,29 @@ test("operator surface helpers call policy, audit, and alert endpoints", async (
   });
 });
 
-test("request throws server-provided error messages", async () => {
+test("request throws server-provided error messages with structured metadata", async () => {
   const client = new AgentPlatformClient({
     baseUrl: "https://api.example.test",
-    fetchImpl: async () => jsonResponse({ message: "nope" }, { status: 400 })
+    fetchImpl: async () => jsonResponse({
+      message: "nope",
+      code: "bad_shape",
+      details: { path: ["submission"] }
+    }, { status: 400 })
   });
 
-  await assert.rejects(() => client.getHealth(), /nope/u);
+  await assert.rejects(
+    () => client.getHealth(),
+    (error) => {
+      assert.ok(error instanceof AgentPlatformApiError);
+      assert.equal(error.message, "nope");
+      assert.equal(error.status, 400);
+      assert.equal(error.method, "GET");
+      assert.equal(error.path, "/health");
+      assert.equal(error.code, "bad_shape");
+      assert.deepEqual(error.details, { path: ["submission"] });
+      return true;
+    }
+  );
 });
 
 function jsonResponse(payload, { status = 200 } = {}) {

--- a/sdk/agent-platform-client.types.test.ts
+++ b/sdk/agent-platform-client.types.test.ts
@@ -1,0 +1,51 @@
+import {
+  AgentPlatformApiError,
+  AgentPlatformClient,
+  type AccountSummary,
+  type ClaimResponse,
+  type JobDefinition,
+  type JobsListResponse,
+  type SessionTimelineResponse
+} from "./agent-platform-client.js";
+
+const client = new AgentPlatformClient({
+  baseUrl: "https://api.averray.com",
+  token: "example-token"
+});
+
+const jobs: JobsListResponse = await client.listClaimableJobs({ source: "wikipedia", limit: 5 });
+const firstJobId: string | undefined = jobs.jobs[0]?.id;
+
+if (firstJobId) {
+  const definition: JobDefinition = await client.getJobDefinition(firstJobId);
+  const claim: ClaimResponse = await client.claimJob(definition.id, "example-run-id");
+  const timeline: SessionTimelineResponse = await client.getSessionTimeline(claim.sessionId);
+
+  await client.validateJobSubmission(definition.id, { summary: "ready" });
+  await client.submitWork(claim.sessionId, { summary: "ready" });
+  await client.createSubJob({
+    parentSessionId: claim.sessionId,
+    id: `${claim.sessionId}-child`,
+    category: "coding",
+    rewardAmount: 1,
+    verifierMode: "benchmark"
+  });
+
+  const childJobIds: string[] = timeline.lineage?.childJobIds ?? [];
+  void childJobIds;
+}
+
+const account: AccountSummary = await client.borrowFunds({ amount: "1", idempotencyKey: "borrow-1" });
+await client.repayFunds({ amount: "1" });
+void account.wallet;
+
+try {
+  await client.getHealth();
+} catch (error) {
+  if (error instanceof AgentPlatformApiError) {
+    const status: number = error.status;
+    const code: string | undefined = error.code;
+    void status;
+    void code;
+  }
+}

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,3 +1,18 @@
 {
-  "type": "module"
+  "name": "@averray/agent-platform-client",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./agent-platform-client.d.ts",
+      "import": "./agent-platform-client.js"
+    }
+  },
+  "types": "./agent-platform-client.d.ts",
+  "files": [
+    "agent-platform-client.js",
+    "agent-platform-client.d.ts",
+    "README.md"
+  ]
 }


### PR DESCRIPTION
## What changed
- Replaced broad SDK `unknown` declarations with endpoint-oriented TypeScript models for jobs, sessions, timelines, accounts, admin status, sub-job lineage, recurring/delegation policies, and API errors.
- Added `AgentPlatformApiError` so agents can inspect HTTP status, platform code, and validation details.
- Added SDK helpers for account borrow/repay and operator session listing.
- Added SDK README and a TypeScript consumer fixture, wired into `npm run test:sdk`.
- Updated the framework roadmap to mark the hand-maintained typed SDK pass complete and leave generated types as the next step.

## Checks run
- `npm run test:sdk`
- `npm run test:examples`
- `git diff --check`

## Impact
- Backend: no runtime API change
- Frontend: no
- SDK/examples: yes
- Indexer: no
- Caddy: no
- Contracts: no
- Public site: docs only

## Environment / VPS secrets
- No new environment variables or VPS secret changes required.
