### PR TITLE
Share submission validation types with app

### DIFF
--- a/app/components/runs/LoadedRunPanel.tsx
+++ b/app/components/runs/LoadedRunPanel.tsx
@@ -2,6 +2,11 @@
 
 import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils/cn";
+import type {
+  JobSchemaContract,
+  SubmissionContract,
+  SubmissionValidationState,
+} from "@/lib/api/submission-contract";
 import { SourceBadge, type RunState } from "./StatePill";
 import { IssueMarkdown } from "./IssueMarkdown";
 import type {
@@ -81,24 +86,8 @@ export interface VerifierVerdict {
   scoreLabel: string;
 }
 
-export interface SubmissionValidationState {
-  status: "not_checked" | "valid" | "invalid";
-  message?: string;
-  path?: string;
-  details?: unknown;
-}
-
-export interface SubmissionContractView {
-  endpoint?: string;
-  validationEndpoint?: string;
-  structuredSubmissionRequired?: boolean;
-  schemaValidates?: string;
-  doNotWrapInOutput?: boolean;
-  outputSchemaRef?: string;
-  outputSchemaUrl?: string;
-  submitPayloadExample?: unknown;
-  invalidWrappedOutputHint?: string;
-  schemaContract?: unknown;
+export interface SubmissionContractView extends SubmissionContract {
+  schemaContract?: JobSchemaContract | null;
   validation: SubmissionValidationState;
   validating?: boolean;
   onValidate?: (draft: string) => void | Promise<void>;

--- a/app/components/runs/LoadedRunView.tsx
+++ b/app/components/runs/LoadedRunView.tsx
@@ -2,10 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { mutate } from "swr";
-import {
-  LoadedRunPanel,
-  type SubmissionValidationState,
-} from "./LoadedRunPanel";
+import { LoadedRunPanel } from "./LoadedRunPanel";
 import { LifecycleRail } from "./LifecycleRail";
 import { LifecycleActionBar } from "./LifecycleActionBar";
 import { RunSemanticBlock } from "./RunSemanticBlock";
@@ -35,6 +32,16 @@ import {
   extractRunJobs,
 } from "@/lib/api/run-adapters";
 import { extractAdminJobs } from "@/lib/api/job-lifecycle";
+import {
+  extractJobSchemaContract,
+  extractSubmissionContract,
+  extractSubmissionExample,
+  validationPath,
+  validationStateFromPayload,
+  type JobSchemaContract,
+  type SubmissionContract,
+  type SubmissionValidationState,
+} from "@/lib/api/submission-contract";
 
 /**
  * Self-contained detail view for a single run.
@@ -120,14 +127,9 @@ export function LoadedRunView({
   // schema-shaped example pre-filled, edits the placeholder values,
   // and submits something the verifier can actually validate.
   const preflightRecord = asRecord(jobPreflight.data);
-  const submissionContract =
-    asRecord(selectedJob?.submissionContract) ??
-    asRecord(preflightRecord?.submissionContract);
-  const schemaContract =
-    asRecord(selectedJob?.schemaContract) ?? asRecord(preflightRecord?.schemaContract);
-  const submissionExample = asRecord(
-    asRecord(submissionContract?.submitPayloadExample)?.submission
-  );
+  const submissionContract = extractSubmissionContract(selectedJob, preflightRecord);
+  const schemaContract = extractJobSchemaContract(selectedJob, preflightRecord);
+  const submissionExample = extractSubmissionExample(submissionContract);
   const submissionSample = submissionExample
     ? JSON.stringify(submissionExample, null, 2)
     : "";
@@ -154,7 +156,7 @@ export function LoadedRunView({
           }),
         },
       ]);
-      setValidationState(validationStateFromResponse(result));
+      setValidationState(validationStateFromPayload(result));
     } catch (err) {
       setValidationState(validationStateFromError(err));
     } finally {
@@ -787,8 +789,8 @@ function SubmissionReadinessStrip({
   schemaContract,
   preflight,
 }: {
-  contract: Record<string, unknown>;
-  schemaContract: Record<string, unknown> | null;
+  contract: SubmissionContract;
+  schemaContract: JobSchemaContract | null;
   preflight: Record<string, unknown> | null;
 }) {
   const output = asRecord(schemaContract?.output);
@@ -915,24 +917,6 @@ function parseDirectSubmissionDraft(draft: string): unknown {
   return parsed;
 }
 
-function validationStateFromResponse(payload: unknown): SubmissionValidationState {
-  const record = asRecord(payload);
-  if (!record) {
-    return {
-      status: "invalid",
-      message: "Validation endpoint returned an unexpected response.",
-      details: payload,
-    };
-  }
-  if (record.valid === true) return { status: "valid" };
-  return {
-    status: "invalid",
-    message: text(record.message, "Draft does not match the output schema."),
-    path: validationPath(record),
-    details: record.details ?? record,
-  };
-}
-
 function validationStateFromError(err: unknown): SubmissionValidationState {
   if (err instanceof ApiError) {
     const record = asRecord(err.body);
@@ -947,20 +931,6 @@ function validationStateFromError(err: unknown): SubmissionValidationState {
     status: "invalid",
     message: err instanceof Error ? err.message : "Could not validate draft.",
   };
-}
-
-function validationPath(record: Record<string, unknown>): string | undefined {
-  const details = asRecord(record.details);
-  return (
-    text(record.path) ||
-    text(record.expectedPath) ||
-    text(record.expected) ||
-    text(details?.path) ||
-    text(details?.expectedPath) ||
-    text(details?.expected) ||
-    text(details?.received) ||
-    undefined
-  );
 }
 
 /**

--- a/app/lib/api/submission-contract.ts
+++ b/app/lib/api/submission-contract.ts
@@ -1,0 +1,103 @@
+import type {
+  JobDefinition,
+  JobSchemaContract,
+  PreflightResponse,
+  SubmissionContract,
+  ValidationResponse,
+} from "../../../sdk/agent-platform-client.js";
+
+export type {
+  JobSchemaContract,
+  SubmissionContract,
+  ValidationResponse,
+};
+
+export interface SubmissionValidationState {
+  status: "not_checked" | "valid" | "invalid";
+  message?: string;
+  path?: string;
+  details?: unknown;
+}
+
+export function extractSubmissionContract(
+  ...payloads: unknown[]
+): SubmissionContract | undefined {
+  for (const payload of payloads) {
+    const record = asRecord(payload) as
+      | Partial<JobDefinition>
+      | Partial<PreflightResponse>
+      | null;
+    const contract = asRecord(record?.submissionContract);
+    if (contract) {
+      return contract as SubmissionContract;
+    }
+  }
+  return undefined;
+}
+
+export function extractJobSchemaContract(
+  ...payloads: unknown[]
+): JobSchemaContract | null {
+  for (const payload of payloads) {
+    const record = asRecord(payload) as
+      | Partial<JobDefinition>
+      | Partial<PreflightResponse>
+      | null;
+    const contract = asRecord(record?.schemaContract);
+    if (contract) {
+      return contract as JobSchemaContract;
+    }
+  }
+  return null;
+}
+
+export function extractSubmissionExample(
+  contract: SubmissionContract | undefined
+): Record<string, unknown> | null {
+  return asRecord(contract?.submitPayloadExample?.submission);
+}
+
+export function validationStateFromPayload(
+  payload: unknown
+): SubmissionValidationState {
+  const record = asRecord(payload) as ValidationResponse | null;
+  if (!record) {
+    return {
+      status: "invalid",
+      message: "Validation endpoint returned an unexpected response.",
+      details: payload,
+    };
+  }
+  if (record.valid === true) return { status: "valid" };
+  return {
+    status: "invalid",
+    message:
+      text(record.message) || "Draft does not match the output schema.",
+    path: validationPath(record),
+    details: record.details ?? record,
+  };
+}
+
+export function validationPath(record: Record<string, unknown>): string | undefined {
+  const details = asRecord(record.details);
+  return (
+    text(record.path) ||
+    text(record.expectedPath) ||
+    text(record.expected) ||
+    text(details?.path) ||
+    text(details?.expectedPath) ||
+    text(details?.expected) ||
+    text(details?.received) ||
+    undefined
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function text(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}

--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -486,7 +486,7 @@ proves the need, but it is UI-focused rather than an external integration SDK.
 - [x] expose structured API errors for automation
 - [x] generate SDK types from the API/schema source instead of maintaining them
   by hand
-- [ ] share validation types with frontend scripts where possible
+- [x] share validation types with frontend scripts where possible
 
 ### What this unlocks
 

--- a/sdk/agent-platform-client.d.ts
+++ b/sdk/agent-platform-client.d.ts
@@ -549,6 +549,38 @@ export type BuiltinJobSchemaRef = keyof BuiltinJobSchemaMap;
 export type BuiltinJobSchemaValue<T extends BuiltinJobSchemaRef> = BuiltinJobSchemaMap[T];
 export type StructuredSubmission = BuiltinJobSchemaMap[BuiltinJobSchemaRef] | JsonObject;
 
+export interface SubmissionPayloadExample<TSubmission = StructuredSubmission> extends ApiEnvelope {
+  sessionId?: SessionId | "<session-id>";
+  submission: TSubmission;
+}
+
+export interface SubmissionContract<TSubmission = StructuredSubmission> extends ApiEnvelope {
+  endpoint?: "POST /jobs/submit" | string;
+  validationEndpoint?: "POST /jobs/validate-submission" | string;
+  submissionShape?: "direct_schema_object" | string;
+  structuredSubmissionRequired?: boolean;
+  schemaValidates?: "payload.submission" | string;
+  doNotWrapInOutput?: boolean;
+  compatibilityAliases?: string[];
+  outputSchemaRef?: BuiltinJobSchemaRef | string;
+  outputSchemaUrl?: string;
+  submitPayloadExample?: SubmissionPayloadExample<TSubmission>;
+  invalidWrappedOutputHint?: string;
+}
+
+export interface SchemaContractSide extends ApiEnvelope {
+  schemaRef?: BuiltinJobSchemaRef | string;
+  schemaUrl?: string;
+  knownBuiltin?: boolean;
+  validates?: "payload.submission" | string;
+  validationEndpoint?: "POST /jobs/validate-submission" | string;
+}
+
+export interface JobSchemaContract extends ApiEnvelope {
+  input?: SchemaContractSide;
+  output?: SchemaContractSide;
+}
+
 export interface JobDefinition extends ApiEnvelope {
   id: JobId;
   title?: string;
@@ -567,7 +599,8 @@ export interface JobDefinition extends ApiEnvelope {
   effectiveState?: string;
   currentWalletCanClaim?: boolean | null;
   reason?: string | null;
-  submissionContract?: ApiEnvelope;
+  submissionContract?: SubmissionContract;
+  schemaContract?: JobSchemaContract;
   source?: ApiEnvelope;
   verification?: ApiEnvelope;
   lineage?: SubJobLineageMetadata;
@@ -593,6 +626,8 @@ export interface JobSummary extends ApiEnvelope {
   delegationPolicy?: DelegationPolicy;
   recurringPolicy?: RecurringPolicy;
   lineage?: SubJobLineageMetadata;
+  submissionContract?: SubmissionContract;
+  schemaContract?: JobSchemaContract;
 }
 
 export interface JobsListResponse extends ApiEnvelope {
@@ -628,12 +663,22 @@ export interface PreflightResponse extends ApiEnvelope {
   reason?: string | null;
   retryLimit?: number | null;
   claimExpiresAt?: ISODateTime | null;
+  submissionContract?: SubmissionContract;
+  schemaContract?: JobSchemaContract;
 }
 
 export interface ValidationResponse<TSubmission = unknown> extends ApiEnvelope {
   valid: boolean;
   errors?: ApiEnvelope[];
   submission?: TSubmission;
+  schemaRef?: BuiltinJobSchemaRef | string;
+  schemaValidates?: "payload.submission" | string;
+  submissionKind?: "structured" | string;
+  message?: string;
+  details?: ApiEnvelope;
+  path?: string;
+  expected?: string;
+  expectedPath?: string;
 }
 
 export interface ClaimResponse extends SessionRecord {

--- a/sdk/api-surface-model.mjs
+++ b/sdk/api-surface-model.mjs
@@ -210,6 +210,38 @@ export interface RecurringPolicy extends ApiEnvelope {
 
 {{BUILTIN_JOB_SCHEMA_TYPES}}
 
+export interface SubmissionPayloadExample<TSubmission = StructuredSubmission> extends ApiEnvelope {
+  sessionId?: SessionId | "<session-id>";
+  submission: TSubmission;
+}
+
+export interface SubmissionContract<TSubmission = StructuredSubmission> extends ApiEnvelope {
+  endpoint?: "POST /jobs/submit" | string;
+  validationEndpoint?: "POST /jobs/validate-submission" | string;
+  submissionShape?: "direct_schema_object" | string;
+  structuredSubmissionRequired?: boolean;
+  schemaValidates?: "payload.submission" | string;
+  doNotWrapInOutput?: boolean;
+  compatibilityAliases?: string[];
+  outputSchemaRef?: BuiltinJobSchemaRef | string;
+  outputSchemaUrl?: string;
+  submitPayloadExample?: SubmissionPayloadExample<TSubmission>;
+  invalidWrappedOutputHint?: string;
+}
+
+export interface SchemaContractSide extends ApiEnvelope {
+  schemaRef?: BuiltinJobSchemaRef | string;
+  schemaUrl?: string;
+  knownBuiltin?: boolean;
+  validates?: "payload.submission" | string;
+  validationEndpoint?: "POST /jobs/validate-submission" | string;
+}
+
+export interface JobSchemaContract extends ApiEnvelope {
+  input?: SchemaContractSide;
+  output?: SchemaContractSide;
+}
+
 export interface JobDefinition extends ApiEnvelope {
   id: JobId;
   title?: string;
@@ -228,7 +260,8 @@ export interface JobDefinition extends ApiEnvelope {
   effectiveState?: string;
   currentWalletCanClaim?: boolean | null;
   reason?: string | null;
-  submissionContract?: ApiEnvelope;
+  submissionContract?: SubmissionContract;
+  schemaContract?: JobSchemaContract;
   source?: ApiEnvelope;
   verification?: ApiEnvelope;
   lineage?: SubJobLineageMetadata;
@@ -254,6 +287,8 @@ export interface JobSummary extends ApiEnvelope {
   delegationPolicy?: DelegationPolicy;
   recurringPolicy?: RecurringPolicy;
   lineage?: SubJobLineageMetadata;
+  submissionContract?: SubmissionContract;
+  schemaContract?: JobSchemaContract;
 }
 
 export interface JobsListResponse extends ApiEnvelope {
@@ -289,12 +324,22 @@ export interface PreflightResponse extends ApiEnvelope {
   reason?: string | null;
   retryLimit?: number | null;
   claimExpiresAt?: ISODateTime | null;
+  submissionContract?: SubmissionContract;
+  schemaContract?: JobSchemaContract;
 }
 
 export interface ValidationResponse<TSubmission = unknown> extends ApiEnvelope {
   valid: boolean;
   errors?: ApiEnvelope[];
   submission?: TSubmission;
+  schemaRef?: BuiltinJobSchemaRef | string;
+  schemaValidates?: "payload.submission" | string;
+  submissionKind?: "structured" | string;
+  message?: string;
+  details?: ApiEnvelope;
+  path?: string;
+  expected?: string;
+  expectedPath?: string;
 }
 
 export interface ClaimResponse extends SessionRecord {


### PR DESCRIPTION
## Summary
- add SDK declaration types for submissionContract, schemaContract, and validation responses
- add an app-side submission-contract adapter that reuses those SDK types for run-detail validation UI
- remove duplicated validation state/response parsing from LoadedRunView and mark the roadmap item complete

## Checks
- npm run test:sdk
- npm run typecheck:app
- npm run build:frontend
- git diff --check

## Impact
- frontend app + SDK declaration surface + docs
- no backend runtime API change
- no indexer, Caddy, contracts, or public-site impact
- no required environment or VPS secret changes