### PR TITLE
Add recurring job operator controls

### DIFF
--- a/app/app/(authed)/overview/page.tsx
+++ b/app/app/(authed)/overview/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/overview/LaneStatusGrid";
 import { PlatformPulse } from "@/components/overview/PlatformPulse";
 import { ProviderOperationsCard } from "@/components/overview/ProviderOperationsCard";
+import { RecurringRuntimeCard } from "@/components/overview/RecurringRuntimeCard";
 import { JobLifecycleStrip } from "@/components/overview/JobLifecycleStrip";
 import {
   useAccount,
@@ -29,6 +30,7 @@ import {
 import { freshnessFromRequests } from "@/components/shell/DataFreshnessPill";
 import { extractRunJobs } from "@/lib/api/run-adapters";
 import { buildProviderOperations } from "@/lib/api/provider-operations";
+import { buildRecurringRuntimeSummary } from "@/lib/api/recurring-jobs";
 import {
   buildJobLifecycleSummary,
   buildPublicJobLifecycleSummary,
@@ -116,6 +118,10 @@ export default function OverviewPage() {
     () => buildProviderOperations(providerOps.data ?? publicProviderOps.data),
     [providerOps.data, publicProviderOps.data]
   );
+  const recurringRuntime = useMemo(
+    () => buildRecurringRuntimeSummary(providerOps.data),
+    [providerOps.data]
+  );
   const providerRows = liveProviderOps;
   const hasLiveOverview = Boolean(jobs.data || sessions.data || account.data || strategyPositions.data);
   const vitals = vitalsWithLoadingHints;
@@ -167,6 +173,7 @@ export default function OverviewPage() {
             : "no provider operations reported"
         }
       />
+      <RecurringRuntimeCard runtime={recurringRuntime} />
       <PlatformPulse
         events={[]}
         endpoint="/events"

--- a/app/components/overview/RecurringRuntimeCard.tsx
+++ b/app/components/overview/RecurringRuntimeCard.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import { useState } from "react";
+import type { ReactNode } from "react";
+import { Flame, Pause, Play, RotateCw } from "lucide-react";
+import { mutate } from "swr";
+import { SectionHead } from "./SectionHead";
+import { swrFetcher } from "@/lib/api/client";
+import {
+  postRecurringTemplateAction,
+  refreshRecurringTemplateSurfaces,
+  type RecurringRuntimeSummary,
+  type RecurringTemplateAction,
+  type RecurringTemplateState,
+  type RecurringTemplateStatus,
+} from "@/lib/api/recurring-jobs";
+import { cn } from "@/lib/utils/cn";
+
+export interface RecurringRuntimeCardProps {
+  runtime: RecurringRuntimeSummary;
+}
+
+const STATE_LABEL: Record<RecurringTemplateState, string> = {
+  scheduled: "Scheduled",
+  paused: "Paused",
+  exhausted: "Reserve exhausted",
+  attention: "Needs attention",
+};
+
+export function RecurringRuntimeCard({ runtime }: RecurringRuntimeCardProps) {
+  const meta = runtime.enabled
+    ? `${runtime.running ? "scheduler running" : "scheduler idle"} · ${runtime.count} templates`
+    : `${runtime.count} templates · scheduler disabled`;
+
+  return (
+    <section>
+      <SectionHead title="Recurring jobs" meta={meta} />
+      <div className="overflow-hidden rounded-[10px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] shadow-[var(--shadow-card)]">
+        {runtime.templates.length === 0 ? (
+          <EmptyRow enabled={runtime.enabled} />
+        ) : (
+          runtime.templates.map((template) => (
+            <RecurringTemplateRow key={template.templateId} template={template} />
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+function RecurringTemplateRow({ template }: { template: RecurringTemplateStatus }) {
+  const [pending, setPending] = useState<RecurringTemplateAction | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const reserve = template.reserve;
+  const finiteReserve = reserve.mode === "finite" && reserve.reserveAmount !== undefined;
+  const fillPct =
+    finiteReserve && reserve.reserveAmount && reserve.reserveAmount > 0
+      ? Math.min(100, Math.round(((reserve.consumedAmount ?? 0) / reserve.reserveAmount) * 100))
+      : 0;
+
+  const onAction = async (action: RecurringTemplateAction) => {
+    setError(null);
+    setPending(action);
+    try {
+      await postRecurringTemplateAction(swrFetcher, template.templateId, action);
+      await refreshRecurringTemplateSurfaces(mutate);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : `Could not ${action} template.`);
+    } finally {
+      setPending(null);
+    }
+  };
+
+  return (
+    <div className="grid grid-cols-1 gap-3 border-b border-[var(--avy-line-soft)] p-[0.95rem_1.15rem] last:border-b-0 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)_minmax(0,1fr)_auto]">
+      <div className="flex min-w-0 flex-col gap-1.5">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="min-w-0 truncate font-[family-name:var(--font-display)] text-[14px] font-bold text-[var(--avy-ink)]">
+            {template.templateId}
+          </span>
+          <StatePill state={template.state} />
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5 font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]">
+          <span>{template.scheduleLabel}</span>
+          <span>·</span>
+          <span>{template.category}</span>
+          {template.tier ? (
+            <>
+              <span>·</span>
+              <span>{template.tier}</span>
+            </>
+          ) : null}
+        </div>
+      </div>
+
+      <MetricStack
+        label="next fire"
+        value={
+          template.exhausted
+            ? "stopped"
+            : template.paused
+              ? "paused"
+              : formatDateTime(template.nextFireAt)
+        }
+        sub={
+          template.lastFiredAt
+            ? `last ${formatRelative(template.lastFiredAt)}`
+            : "no fires yet"
+        }
+      />
+
+      <div className="flex min-w-0 flex-col gap-1.5">
+        <div className="flex items-baseline justify-between gap-2 font-[family-name:var(--font-mono)] text-[12px]">
+          <span className="text-[var(--avy-muted)]">reserve</span>
+          <span className={template.exhausted ? "text-[var(--avy-warn)]" : "text-[var(--avy-ink)]"}>
+            {formatReserve(template)}
+          </span>
+        </div>
+        {finiteReserve ? (
+          <div className="h-1 overflow-hidden rounded-full bg-[color:rgba(17,19,21,0.06)]">
+            <div
+              className={cn(
+                "h-full rounded-full transition-[width]",
+                template.exhausted ? "bg-[var(--avy-warn)]" : "bg-[var(--avy-accent)]"
+              )}
+              style={{ width: `${fillPct}%` }}
+            />
+          </div>
+        ) : (
+          <span className="font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]">
+            unbounded metadata reserve
+          </span>
+        )}
+        <span className="font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]">
+          {template.lastResult
+            ? `last result ${template.lastResult.status}`
+            : `${template.derivativeCount} derivative${template.derivativeCount === 1 ? "" : "s"}`}
+        </span>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-start gap-1.5 lg:justify-end">
+        {template.paused ? (
+          <ActionButton
+            action="resume"
+            label="Resume"
+            pending={pending}
+            icon={<Play size={13} />}
+            onClick={() => onAction("resume")}
+          />
+        ) : (
+          <ActionButton
+            action="pause"
+            label="Pause"
+            pending={pending}
+            icon={<Pause size={13} />}
+            onClick={() => onAction("pause")}
+          />
+        )}
+        <ActionButton
+          action="fire"
+          label="Fire"
+          pending={pending}
+          disabled={template.paused || template.exhausted}
+          icon={<Flame size={13} />}
+          onClick={() => onAction("fire")}
+        />
+        {template.latestRunId ? (
+          <a
+            href={`/runs?run=${encodeURIComponent(template.latestRunId)}`}
+            className="inline-flex h-8 items-center rounded-full border border-[var(--avy-line)] bg-[var(--avy-paper)] px-2.5 font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase text-[var(--avy-ink)] transition-colors hover:border-[color:rgba(30,102,66,0.35)] hover:text-[var(--avy-accent)]"
+            style={{ letterSpacing: "0.08em" }}
+          >
+            Latest
+          </a>
+        ) : null}
+        {error ? (
+          <span className="basis-full text-right font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-warn)]">
+            {error}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function MetricStack({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub: string;
+}) {
+  return (
+    <div className="flex min-w-0 flex-col gap-1">
+      <span className="font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-muted)]" style={{ letterSpacing: "0.12em" }}>
+        {label}
+      </span>
+      <span className="min-w-0 break-words font-[family-name:var(--font-mono)] text-[12px] font-semibold text-[var(--avy-ink)]">
+        {value}
+      </span>
+      <span className="font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]">
+        {sub}
+      </span>
+    </div>
+  );
+}
+
+function ActionButton({
+  action,
+  label,
+  pending,
+  disabled = false,
+  icon,
+  onClick,
+}: {
+  action: RecurringTemplateAction;
+  label: string;
+  pending: RecurringTemplateAction | null;
+  disabled?: boolean;
+  icon: ReactNode;
+  onClick: () => void;
+}) {
+  const active = pending === action;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={pending !== null || disabled}
+      className={cn(
+        "inline-flex h-8 items-center gap-1.5 rounded-full border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-2.5 font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase text-[var(--avy-ink)] transition-colors",
+        "hover:border-[color:rgba(30,102,66,0.35)] hover:text-[var(--avy-accent)]",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        active && "text-[var(--avy-accent)]"
+      )}
+      style={{ letterSpacing: "0.08em" }}
+    >
+      {active ? <RotateCw size={13} className="animate-spin" /> : icon}
+      {active ? "Working" : label}
+    </button>
+  );
+}
+
+function StatePill({ state }: { state: RecurringTemplateState }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase",
+        state === "scheduled" && "bg-[var(--avy-accent-soft)] text-[var(--avy-accent)]",
+        state === "paused" && "bg-[color:rgba(17,19,21,0.06)] text-[var(--avy-muted)]",
+        state === "attention" && "bg-[var(--avy-warn-soft)] text-[var(--avy-warn)]",
+        state === "exhausted" && "bg-[#f3d7d4] text-[#a0322a]"
+      )}
+      style={{ letterSpacing: "0.1em" }}
+    >
+      <span className="h-[5px] w-[5px] rounded-full bg-current" />
+      {STATE_LABEL[state]}
+    </span>
+  );
+}
+
+function EmptyRow({ enabled }: { enabled: boolean }) {
+  return (
+    <div className="p-[1.05rem_1.15rem] font-[family-name:var(--font-body)] text-[13px] text-[var(--avy-muted)]">
+      {enabled
+        ? "No recurring templates are configured yet."
+        : "Recurring scheduler status is unavailable right now."}
+    </div>
+  );
+}
+
+function formatReserve(template: RecurringTemplateStatus): string {
+  const reserve = template.reserve;
+  if (reserve.mode !== "finite") return reserve.mode;
+  const remaining = formatAmount(reserve.remainingAmount ?? 0, reserve.rewardAsset);
+  const total = formatAmount(reserve.reserveAmount ?? 0, reserve.rewardAsset);
+  const runs = reserve.remainingRuns ?? 0;
+  return `${remaining} / ${total} · ${runs} run${runs === 1 ? "" : "s"}`;
+}
+
+function formatAmount(value: number, asset: string): string {
+  return `${trimNumber(value)} ${asset}`;
+}
+
+function trimNumber(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(3).replace(/0+$/u, "").replace(/\.$/u, "");
+}
+
+function formatDateTime(iso: string | undefined): string {
+  if (!iso) return "not scheduled";
+  const parsed = Date.parse(iso);
+  if (!Number.isFinite(parsed)) return iso;
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZoneName: "short",
+  }).format(new Date(parsed));
+}
+
+function formatRelative(iso: string): string {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return iso;
+  const deltaSec = Math.max(0, Math.round((Date.now() - t) / 1000));
+  if (deltaSec < 60) return `${deltaSec}s ago`;
+  const deltaMin = Math.round(deltaSec / 60);
+  if (deltaMin < 60) return `${deltaMin}m ago`;
+  const deltaHr = Math.round(deltaMin / 60);
+  if (deltaHr < 24) return `${deltaHr}h ago`;
+  const deltaDay = Math.round(deltaHr / 24);
+  return `${deltaDay}d ago`;
+}

--- a/app/lib/api/recurring-jobs.ts
+++ b/app/lib/api/recurring-jobs.ts
@@ -1,0 +1,249 @@
+export type RecurringTemplateState = "scheduled" | "paused" | "exhausted" | "attention";
+
+export interface RecurringReserveStatus {
+  mode: "finite" | "unbounded" | "unknown";
+  rewardAsset: string;
+  rewardAmount: number;
+  reserveAmount?: number;
+  consumedAmount?: number;
+  remainingAmount?: number;
+  remainingRuns?: number;
+  exhausted?: boolean;
+}
+
+export interface RecurringLastResult {
+  status: string;
+  at?: string;
+  derivativeId?: string;
+  message?: string;
+}
+
+export interface RecurringTemplateStatus {
+  templateId: string;
+  category: string;
+  tier?: string;
+  verifierMode?: string;
+  rewardAmount: number;
+  rewardAsset: string;
+  scheduleLabel: string;
+  paused: boolean;
+  exhausted: boolean;
+  state: RecurringTemplateState;
+  nextFireAt?: string;
+  lastFiredAt?: string;
+  lastResult?: RecurringLastResult;
+  derivativeCount: number;
+  latestRunId?: string;
+  reserve: RecurringReserveStatus;
+}
+
+export interface RecurringRuntimeSummary {
+  count: number;
+  enabled: boolean;
+  running: boolean;
+  templates: RecurringTemplateStatus[];
+}
+
+export type RecurringTemplateAction = "fire" | "pause" | "resume";
+
+export type JsonFetcher = <T = unknown>(
+  key: string | [string, RequestInit?]
+) => Promise<T>;
+
+export function buildRecurringRuntimeSummary(payload: unknown): RecurringRuntimeSummary {
+  const root = asRecord(payload);
+  const recurring = asRecord(root?.recurring);
+  const scheduler = asRecord(root?.scheduler);
+  const schedulerTemplates = new Map<string, Record<string, unknown>>();
+  for (const entry of arrayOfRecords(scheduler?.templates)) {
+    const id = text(entry.templateId);
+    if (id) schedulerTemplates.set(id, entry);
+  }
+
+  const templates = arrayOfRecords(recurring?.templates)
+    .map((template) => buildTemplate(template, schedulerTemplates.get(text(template.templateId))))
+    .filter((template): template is RecurringTemplateStatus => Boolean(template))
+    .sort(byOperatorPriority);
+
+  return {
+    count: nonNegInt(recurring?.count ?? templates.length),
+    enabled: scheduler?.enabled === true,
+    running: scheduler?.running === true,
+    templates,
+  };
+}
+
+export async function postRecurringTemplateAction(
+  fetcher: JsonFetcher,
+  templateId: string,
+  action: RecurringTemplateAction
+): Promise<unknown> {
+  const path =
+    action === "fire"
+      ? "/admin/jobs/fire"
+      : action === "pause"
+        ? "/admin/jobs/pause"
+        : "/admin/jobs/resume";
+  return fetcher([
+    path,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        templateId,
+        idempotencyKey: `${action}-${templateId}-${new Date().toISOString()}`,
+      }),
+    },
+  ]);
+}
+
+export async function refreshRecurringTemplateSurfaces(
+  mutate: (key: string) => Promise<unknown>
+): Promise<void> {
+  await Promise.all([
+    mutate("/admin/status"),
+    mutate("/admin/jobs"),
+    mutate("/jobs"),
+  ]);
+}
+
+function buildTemplate(
+  raw: Record<string, unknown>,
+  runtime: Record<string, unknown> | undefined
+): RecurringTemplateStatus | null {
+  const templateId = text(raw.templateId);
+  if (!templateId) return null;
+  const reserve = reserveStatus(raw.reserve ?? runtime?.reserve);
+  const lastResult = lastResultStatus(runtime?.lastResult ?? raw.lastResult);
+  const paused = runtime?.paused === true || raw.paused === true;
+  const exhausted =
+    runtime?.exhausted === true ||
+    raw.exhausted === true ||
+    reserve.exhausted === true ||
+    lastResult?.status === "reserve_exhausted";
+  const state = stateFor({ paused, exhausted, lastResult });
+  return {
+    templateId,
+    category: text(raw.category, "job"),
+    tier: text(raw.tier),
+    verifierMode: text(raw.verifierMode),
+    rewardAmount: nonNegNumber(raw.rewardAmount),
+    rewardAsset: text(raw.rewardAsset, reserve.rewardAsset || "DOT"),
+    scheduleLabel: scheduleLabel(raw.schedule),
+    paused,
+    exhausted,
+    state,
+    nextFireAt: text(runtime?.nextFireAt ?? raw.nextFireAt),
+    lastFiredAt: text(runtime?.lastFiredAt ?? raw.lastFiredAt),
+    lastResult,
+    derivativeCount: nonNegInt(raw.derivativeCount),
+    latestRunId: text(asRecord(raw.latestRun)?.id ?? raw.lastDerivativeId),
+    reserve,
+  };
+}
+
+function stateFor(input: {
+  paused: boolean;
+  exhausted: boolean;
+  lastResult?: RecurringLastResult;
+}): RecurringTemplateState {
+  if (input.exhausted) return "exhausted";
+  if (input.paused) return "paused";
+  if (input.lastResult?.status === "failed" || input.lastResult?.status === "invalid_schedule") {
+    return "attention";
+  }
+  return "scheduled";
+}
+
+function reserveStatus(value: unknown): RecurringReserveStatus {
+  const record = asRecord(value);
+  if (!record) {
+    return { mode: "unknown", rewardAsset: "DOT", rewardAmount: 0 };
+  }
+  const mode =
+    record.mode === "finite" || record.mode === "unbounded" ? record.mode : "unknown";
+  return {
+    mode,
+    rewardAsset: text(record.rewardAsset, "DOT"),
+    rewardAmount: nonNegNumber(record.rewardAmount),
+    reserveAmount: optionalNumber(record.reserveAmount),
+    consumedAmount: optionalNumber(record.consumedAmount),
+    remainingAmount: optionalNumber(record.remainingAmount),
+    remainingRuns: optionalInt(record.remainingRuns),
+    exhausted: record.exhausted === true,
+  };
+}
+
+function lastResultStatus(value: unknown): RecurringLastResult | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+  const status = text(record.status);
+  if (!status) return undefined;
+  return {
+    status,
+    at: text(record.at),
+    derivativeId: text(record.derivativeId),
+    message: text(record.message),
+  };
+}
+
+function scheduleLabel(value: unknown): string {
+  const schedule = asRecord(value);
+  const cron = text(schedule?.cron);
+  const timezone = text(schedule?.timezone);
+  if (cron && timezone) return `${cron} · ${timezone}`;
+  return cron || timezone || "schedule missing";
+}
+
+function byOperatorPriority(
+  left: RecurringTemplateStatus,
+  right: RecurringTemplateStatus
+): number {
+  const priority: Record<RecurringTemplateState, number> = {
+    exhausted: 0,
+    attention: 1,
+    paused: 2,
+    scheduled: 3,
+  };
+  const stateDelta = priority[left.state] - priority[right.state];
+  if (stateDelta !== 0) return stateDelta;
+  return left.templateId.localeCompare(right.templateId);
+}
+
+function arrayOfRecords(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is Record<string, unknown> => Boolean(asRecord(entry)))
+    : [];
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function text(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function nonNegInt(value: unknown): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  return Math.floor(parsed);
+}
+
+function nonNegNumber(value: unknown): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  return parsed;
+}
+
+function optionalNumber(value: unknown): number | undefined {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function optionalInt(value: unknown): number | undefined {
+  const parsed = optionalNumber(value);
+  return parsed === undefined ? undefined : Math.floor(parsed);
+}

--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -401,7 +401,7 @@ product, but today they are still a pattern plus manual fire endpoint.
   - `paused`
 - [x] gate firing on finite template reserve policy
 - [x] expose status in admin endpoints
-- [ ] wire operator UI controls for reserve exhaustion and next firing
+- [x] wire operator UI controls for reserve exhaustion and next firing
 - [ ] back recurring reserve with escrow-native/on-chain poster funding
 
 ### What this unlocks


### PR DESCRIPTION
## Summary
- add a recurring runtime adapter for /admin/status recurring + scheduler state
- add an overview recurring jobs panel with next-fire, reserve exhaustion, last-result, and latest derivative visibility
- wire pause/resume/fire controls to idempotent admin endpoints and refresh admin job/status feeds
- mark the recurring UI controls roadmap item complete

## Checks
- npm run typecheck:app
- npm run build:frontend
- git diff --check

## Impact
- frontend app + docs only
- no backend runtime API change
- no indexer, Caddy, contracts, or public-site impact
- no required environment or VPS secret changes