### PR TITLE
Back recurring reserves with escrow funding

### DIFF
--- a/contracts/AgentAccountCore.sol
+++ b/contracts/AgentAccountCore.sol
@@ -63,6 +63,7 @@ contract AgentAccountCore is ReentrancyGuard {
     mapping(bytes32 => StrategyRequest) public strategyRequests;
     mapping(address => mapping(address => uint256)) public pendingStrategyAssets;
     mapping(address => mapping(bytes32 => uint256)) public pendingStrategyWithdrawalShares;
+    mapping(address => mapping(address => mapping(bytes32 => uint256))) public recurringTemplateReserves;
 
     event Deposited(address indexed account, address indexed asset, uint256 amount);
     event Withdrawn(address indexed account, address indexed asset, uint256 amount);
@@ -70,7 +71,9 @@ contract AgentAccountCore is ReentrancyGuard {
     event ReservationReleased(address indexed account, address indexed asset, uint256 amount);
     event ReservationSettled(address indexed account, address indexed recipient, address indexed asset, uint256 amount);
     event StrategyAllocated(address indexed account, bytes32 indexed strategyId, address indexed asset, uint256 amount);
-    event StrategyDeallocated(address indexed account, bytes32 indexed strategyId, address indexed asset, uint256 amount);
+    event StrategyDeallocated(
+        address indexed account, bytes32 indexed strategyId, address indexed asset, uint256 amount
+    );
     event StrategyRequestQueued(
         address indexed account,
         bytes32 indexed strategyId,
@@ -94,11 +97,7 @@ contract AgentAccountCore is ReentrancyGuard {
     event JobStakeLocked(address indexed account, address indexed asset, uint256 amount);
     event JobStakeReleased(address indexed account, address indexed asset, uint256 amount);
     event JobStakeSlashed(
-        address indexed account,
-        address indexed asset,
-        uint256 amount,
-        uint256 posterAmount,
-        uint256 treasuryAmount
+        address indexed account, address indexed asset, uint256 amount, uint256 posterAmount, uint256 treasuryAmount
     );
     event ClaimFeeSlashed(
         address indexed account,
@@ -164,12 +163,44 @@ contract AgentAccountCore is ReentrancyGuard {
         emit Withdrawn(msg.sender, asset, amount);
     }
 
-    function reserveForJob(address account, address asset, uint256 amount) external whenNotPaused onlyOwnerOrOperator(account) onlySupportedAsset(asset) {
+    function reserveForJob(address account, address asset, uint256 amount)
+        external
+        whenNotPaused
+        onlyOwnerOrOperator(account)
+        onlySupportedAsset(asset)
+    {
         AssetPosition storage position = positions[account][asset];
         if (position.liquid < amount) revert InsufficientLiquidity();
         position.liquid -= amount;
         position.reserved += amount;
         emit Reserved(account, asset, amount);
+    }
+
+    function reserveForRecurringTemplate(address account, address asset, bytes32 templateId, uint256 amount)
+        external
+        whenNotPaused
+        onlyOwnerOrOperator(account)
+        onlySupportedAsset(asset)
+    {
+        if (templateId == bytes32(0)) revert ZeroAmount();
+        if (amount == 0) revert ZeroAmount();
+        AssetPosition storage position = positions[account][asset];
+        if (position.liquid < amount) revert InsufficientLiquidity();
+        position.liquid -= amount;
+        position.reserved += amount;
+        recurringTemplateReserves[account][asset][templateId] += amount;
+        emit Reserved(account, asset, amount);
+    }
+
+    function consumeRecurringTemplateReserve(
+        address account,
+        address asset,
+        bytes32 templateId,
+        uint256 amount
+    ) external whenNotPaused onlyOperator onlySupportedAsset(asset) {
+        uint256 templateReserve = recurringTemplateReserves[account][asset][templateId];
+        if (templateReserve < amount) revert InsufficientReserved();
+        recurringTemplateReserves[account][asset][templateId] = templateReserve - amount;
     }
 
     function refundReserved(address account, address asset, uint256 amount) external onlyOperator {
@@ -193,7 +224,11 @@ contract AgentAccountCore is ReentrancyGuard {
         emit ReservationSettled(account, recipient, asset, amount);
     }
 
-    function allocateIdleFunds(address account, bytes32 strategyId, uint256 amount) external whenNotPaused onlyOwnerOrOperator(account) {
+    function allocateIdleFunds(address account, bytes32 strategyId, uint256 amount)
+        external
+        whenNotPaused
+        onlyOwnerOrOperator(account)
+    {
         if (amount == 0) revert ZeroAmount();
         StrategyAdapterRegistry.StrategyMetadata memory strategy = registry.getStrategy(strategyId);
         if (strategy.adapter == address(0) || !strategy.active) revert InvalidStrategy();
@@ -211,7 +246,11 @@ contract AgentAccountCore is ReentrancyGuard {
         emit StrategyAllocated(account, strategyId, strategy.asset, amount);
     }
 
-    function deallocateIdleFunds(address account, bytes32 strategyId, uint256 amount) external whenNotPaused onlyOwnerOrOperator(account) {
+    function deallocateIdleFunds(address account, bytes32 strategyId, uint256 amount)
+        external
+        whenNotPaused
+        onlyOwnerOrOperator(account)
+    {
         if (amount == 0) revert ZeroAmount();
         StrategyAdapterRegistry.StrategyMetadata memory strategy = registry.getStrategy(strategyId);
         if (strategy.adapter == address(0) || !strategy.active) revert InvalidStrategy();
@@ -251,14 +290,10 @@ contract AgentAccountCore is ReentrancyGuard {
         }
 
         require(
-            _requireAsyncStrategyAdapter(adapterAddress).requestDeposit(
-                account,
-                params.amount,
-                params.destination,
-                params.message,
-                params.maxWeight,
-                params.nonce
-            ) == requestId,
+            _requireAsyncStrategyAdapter(adapterAddress)
+                .requestDeposit(
+                    account, params.amount, params.destination, params.message, params.maxWeight, params.nonce
+                ) == requestId,
             "REQUEST_ID_MISMATCH"
         );
     }
@@ -272,36 +307,35 @@ contract AgentAccountCore is ReentrancyGuard {
         if (params.shares == 0) revert ZeroAmount();
         if (params.recipient == address(0)) revert InvalidRecipient();
 
-        if (strategyShares[account][params.strategyId] < pendingStrategyWithdrawalShares[account][params.strategyId] + params.shares) {
+        if (
+            strategyShares[account][params.strategyId]
+                < pendingStrategyWithdrawalShares[account][params.strategyId] + params.shares
+        ) {
             revert InsufficientLiquidity();
         }
 
         (address adapterAddress, address asset) = _requireActiveStrategy(params.strategyId);
 
-        requestId = _previewWithdrawRequestId(params.strategyId, account, asset, params.recipient, params.shares, params.nonce);
+        requestId =
+            _previewWithdrawRequestId(params.strategyId, account, asset, params.recipient, params.shares, params.nonce);
 
         if (strategyRequests[requestId].account == address(0)) {
             _createPendingWithdrawRequest(
-                params.strategyId,
-                adapterAddress,
-                asset,
-                account,
-                requestId,
-                params.shares,
-                params.recipient
+                params.strategyId, adapterAddress, asset, account, requestId, params.shares, params.recipient
             );
         }
 
         require(
-            _requireAsyncStrategyAdapter(adapterAddress).requestWithdraw(
-                account,
-                params.shares,
-                params.recipient,
-                params.destination,
-                params.message,
-                params.maxWeight,
-                params.nonce
-            ) == requestId,
+            _requireAsyncStrategyAdapter(adapterAddress)
+                .requestWithdraw(
+                    account,
+                    params.shares,
+                    params.recipient,
+                    params.destination,
+                    params.message,
+                    params.maxWeight,
+                    params.nonce
+                ) == requestId,
             "REQUEST_ID_MISMATCH"
         );
     }
@@ -322,25 +356,17 @@ contract AgentAccountCore is ReentrancyGuard {
         if (request.account == address(0)) revert InvalidStrategyRequest();
         if (request.settled) {
             if (
-                request.status == status &&
-                request.settledAssets == settledAssets &&
-                request.settledShares == settledShares &&
-                request.remoteRef == remoteRef &&
-                request.failureCode == failureCode
+                request.status == status && request.settledAssets == settledAssets
+                    && request.settledShares == settledShares && request.remoteRef == remoteRef
+                    && request.failureCode == failureCode
             ) {
                 return;
             }
             revert InvalidStrategyRequest();
         }
 
-        IXcmStrategyAdapter(request.adapter).settleRequest(
-            requestId,
-            status,
-            settledAssets,
-            settledShares,
-            remoteRef,
-            failureCode
-        );
+        IXcmStrategyAdapter(request.adapter)
+            .settleRequest(requestId, status, settledAssets, settledShares, remoteRef, failureCode);
 
         if (request.kind == IXcmWrapper.RequestKind.Deposit) {
             pendingStrategyAssets[request.account][request.asset] -= request.requestedAssets;
@@ -372,13 +398,7 @@ contract AgentAccountCore is ReentrancyGuard {
 
         _refreshStrategyAllocated(request.account, request.asset);
         emit StrategyRequestSettled(
-            request.account,
-            request.strategyId,
-            requestId,
-            status,
-            settledAssets,
-            settledShares,
-            request.recipient
+            request.account, request.strategyId, requestId, status, settledAssets, settledShares, request.recipient
         );
     }
 
@@ -574,14 +594,22 @@ contract AgentAccountCore is ReentrancyGuard {
         return collateralLocked * 10_000 >= debtOutstanding * policy.minimumCollateralRatioBps();
     }
 
-    function _assetValueForShares(uint256 shares, uint256 totalAssets_, uint256 totalShares_) internal pure returns (uint256) {
+    function _assetValueForShares(uint256 shares, uint256 totalAssets_, uint256 totalShares_)
+        internal
+        pure
+        returns (uint256)
+    {
         if (shares == 0 || totalAssets_ == 0 || totalShares_ == 0) {
             return 0;
         }
         return (shares * totalAssets_) / totalShares_;
     }
 
-    function _sharesForAssetsRoundedUp(uint256 assets, uint256 totalAssets_, uint256 totalShares_) internal pure returns (uint256) {
+    function _sharesForAssetsRoundedUp(uint256 assets, uint256 totalAssets_, uint256 totalShares_)
+        internal
+        pure
+        returns (uint256)
+    {
         if (assets == 0 || totalAssets_ == 0 || totalShares_ == 0) {
             return 0;
         }
@@ -638,15 +666,7 @@ contract AgentAccountCore is ReentrancyGuard {
 
         SafeTransfer.safeApprove(asset, adapter, 0);
         SafeTransfer.safeApprove(asset, adapter, amount);
-        emit StrategyRequestQueued(
-            account,
-            strategyId,
-            requestId,
-            IXcmWrapper.RequestKind.Deposit,
-            amount,
-            0,
-            account
-        );
+        emit StrategyRequestQueued(account, strategyId, requestId, IXcmWrapper.RequestKind.Deposit, amount, 0, account);
     }
 
     function _createPendingWithdrawRequest(
@@ -677,13 +697,7 @@ contract AgentAccountCore is ReentrancyGuard {
         });
 
         emit StrategyRequestQueued(
-            account,
-            strategyId,
-            requestId,
-            IXcmWrapper.RequestKind.Withdraw,
-            0,
-            shares,
-            recipient
+            account, strategyId, requestId, IXcmWrapper.RequestKind.Withdraw, 0, shares, recipient
         );
     }
 
@@ -716,22 +730,13 @@ contract AgentAccountCore is ReentrancyGuard {
         return keccak256(abi.encode(strategyId, kind, account, asset, recipient, assets, shares, nonce));
     }
 
-    function _previewDepositRequestId(
-        bytes32 strategyId,
-        address account,
-        address asset,
-        uint256 amount,
-        uint64 nonce
-    ) internal pure returns (bytes32 requestId) {
+    function _previewDepositRequestId(bytes32 strategyId, address account, address asset, uint256 amount, uint64 nonce)
+        internal
+        pure
+        returns (bytes32 requestId)
+    {
         return _previewStrategyRequestId(
-            strategyId,
-            IXcmWrapper.RequestKind.Deposit,
-            account,
-            asset,
-            account,
-            amount,
-            0,
-            nonce
+            strategyId, IXcmWrapper.RequestKind.Deposit, account, asset, account, amount, 0, nonce
         );
     }
 
@@ -744,14 +749,7 @@ contract AgentAccountCore is ReentrancyGuard {
         uint64 nonce
     ) internal pure returns (bytes32 requestId) {
         return _previewStrategyRequestId(
-            strategyId,
-            IXcmWrapper.RequestKind.Withdraw,
-            account,
-            asset,
-            recipient,
-            0,
-            shares,
-            nonce
+            strategyId, IXcmWrapper.RequestKind.Withdraw, account, asset, recipient, 0, shares, nonce
         );
     }
 }

--- a/contracts/EscrowCore.sol
+++ b/contracts/EscrowCore.sol
@@ -61,6 +61,20 @@ contract EscrowCore is ReentrancyGuard {
         JobState state;
     }
 
+    struct RecurringSinglePayoutJob {
+        bytes32 jobId;
+        bytes32 templateId;
+        address poster;
+        address asset;
+        uint256 reward;
+        uint256 opsReserve;
+        uint256 contingencyReserve;
+        uint256 claimTtl;
+        bytes32 verifierMode;
+        bytes32 category;
+        bytes32 specHash;
+    }
+
     mapping(bytes32 => JobEscrow) internal _jobs;
     mapping(address => uint256) public workerClaimCount;
     mapping(bytes32 => uint256[]) public milestoneAmounts;
@@ -70,8 +84,24 @@ contract EscrowCore is ReentrancyGuard {
     mapping(bytes32 => uint256) public claimTtls;
     mapping(bytes32 => bool) public autoDisclosed;
 
-    event JobFunded(bytes32 indexed jobId, address indexed poster, address indexed asset, uint256 totalReserved, PayoutMode payoutMode);
-    event JobCreated(bytes32 indexed jobId, address indexed poster, bytes32 indexed specHash, address asset, uint256 totalReserved, PayoutMode payoutMode);
+    event JobFunded(
+        bytes32 indexed jobId,
+        address indexed poster,
+        address indexed asset,
+        uint256 totalReserved,
+        PayoutMode payoutMode
+    );
+    event JobCreated(
+        bytes32 indexed jobId,
+        address indexed poster,
+        bytes32 indexed specHash,
+        address asset,
+        uint256 totalReserved,
+        PayoutMode payoutMode
+    );
+    event RecurringJobFundedFromTemplate(
+        bytes32 indexed jobId, bytes32 indexed templateId, address indexed poster, address asset, uint256 totalReserved
+    );
     event JobClaimed(bytes32 indexed jobId, address indexed worker, uint256 claimExpiry, uint256 claimStake);
     event ClaimEconomicsLocked(
         bytes32 indexed jobId,
@@ -85,10 +115,16 @@ contract EscrowCore is ReentrancyGuard {
     event Submitted(bytes32 indexed jobId, address indexed worker, bytes32 indexed payloadHash);
     event JobReopened(bytes32 indexed jobId);
     event JobRejected(bytes32 indexed jobId, bytes32 reasonCode);
-    event Verified(bytes32 indexed jobId, address indexed verifier, bool approved, bytes32 reasonCode, bytes32 reasoningHash);
+    event Verified(
+        bytes32 indexed jobId, address indexed verifier, bool approved, bytes32 reasonCode, bytes32 reasoningHash
+    );
     event DisputeOpened(bytes32 indexed jobId, address indexed opener, uint256 disputedAt);
-    event DisputeResolved(bytes32 indexed jobId, address indexed arbitrator, uint256 workerPayout, bytes32 reasonCode, string metadataURI);
-    event AutoResolvedOnTimeout(bytes32 indexed jobId, address indexed caller, uint256 workerPayout, bytes32 reasonCode);
+    event DisputeResolved(
+        bytes32 indexed jobId, address indexed arbitrator, uint256 workerPayout, bytes32 reasonCode, string metadataURI
+    );
+    event AutoResolvedOnTimeout(
+        bytes32 indexed jobId, address indexed caller, uint256 workerPayout, bytes32 reasonCode
+    );
     event JobClosed(bytes32 indexed jobId, address indexed worker, uint256 releasedAmount);
     event Disclosed(bytes32 indexed hash, address indexed byWallet, uint64 timestamp);
     event AutoDisclosed(bytes32 indexed hash, uint64 timestamp);
@@ -120,6 +156,11 @@ contract EscrowCore is ReentrancyGuard {
 
     modifier onlyArbitrator() {
         if (!policy.arbitrators(msg.sender)) revert Unauthorized();
+        _;
+    }
+
+    modifier onlyOperator() {
+        if (!policy.serviceOperators(msg.sender)) revert Unauthorized();
         _;
     }
 
@@ -202,6 +243,35 @@ contract EscrowCore is ReentrancyGuard {
         accounts.reserveForJob(msg.sender, asset, total);
         emit JobFunded(jobId, msg.sender, asset, total, PayoutMode.Single);
         emit JobCreated(jobId, msg.sender, specHash, asset, total, PayoutMode.Single);
+    }
+
+    function createSinglePayoutJobFromRecurringReserve(RecurringSinglePayoutJob calldata params)
+        external
+        whenNotPaused
+        nonReentrant
+        onlyOperator
+    {
+        if (_jobs[params.jobId].state != JobState.None) revert InvalidState();
+        if (params.poster == address(0)) revert Unauthorized();
+        JobEscrow storage job = _jobs[params.jobId];
+        job.poster = params.poster;
+        job.worker = address(0);
+        job.asset = params.asset;
+        job.verifierMode = params.verifierMode;
+        job.category = params.category;
+        job.specHash = params.specHash;
+        job.reward = params.reward;
+        job.opsReserve = params.opsReserve;
+        job.contingencyReserve = params.contingencyReserve;
+        job.payoutMode = PayoutMode.Single;
+        job.state = JobState.Open;
+        claimTtls[params.jobId] = params.claimTtl;
+
+        uint256 total = params.reward + params.opsReserve + params.contingencyReserve;
+        accounts.consumeRecurringTemplateReserve(params.poster, params.asset, params.templateId, total);
+        emit RecurringJobFundedFromTemplate(params.jobId, params.templateId, params.poster, params.asset, total);
+        emit JobFunded(params.jobId, params.poster, params.asset, total, PayoutMode.Single);
+        emit JobCreated(params.jobId, params.poster, params.specHash, params.asset, total, PayoutMode.Single);
     }
 
     function createMilestoneJob(
@@ -334,12 +404,13 @@ contract EscrowCore is ReentrancyGuard {
         emit JobReopened(jobId);
     }
 
-    function resolveSinglePayout(bytes32 jobId, bool approved, bytes32 reasonCode, string calldata metadataURI, bytes32 reasoningHash)
-        external
-        whenNotPaused
-        nonReentrant
-        onlyVerifier
-    {
+    function resolveSinglePayout(
+        bytes32 jobId,
+        bool approved,
+        bytes32 reasonCode,
+        string calldata metadataURI,
+        bytes32 reasoningHash
+    ) external whenNotPaused nonReentrant onlyVerifier {
         JobEscrow storage job = _jobs[jobId];
         if (job.state != JobState.Submitted || job.payoutMode != PayoutMode.Single) revert InvalidState();
         emit Verified(jobId, msg.sender, approved, reasonCode, reasoningHash);
@@ -375,12 +446,14 @@ contract EscrowCore is ReentrancyGuard {
         emit JobClosed(jobId, job.worker, job.reward);
     }
 
-    function resolveMilestone(bytes32 jobId, uint256 milestoneIndex, bool approved, bytes32 reasonCode, string calldata metadataURI, bytes32 reasoningHash)
-        external
-        whenNotPaused
-        nonReentrant
-        onlyVerifier
-    {
+    function resolveMilestone(
+        bytes32 jobId,
+        uint256 milestoneIndex,
+        bool approved,
+        bytes32 reasonCode,
+        string calldata metadataURI,
+        bytes32 reasoningHash
+    ) external whenNotPaused nonReentrant onlyVerifier {
         JobEscrow storage job = _jobs[jobId];
         if (job.state != JobState.Submitted || job.payoutMode != PayoutMode.Milestone) revert InvalidState();
         if (milestoneReleased[jobId][milestoneIndex]) revert InvalidState();
@@ -486,9 +559,7 @@ contract EscrowCore is ReentrancyGuard {
         uint256 workerPayout,
         bytes32 reasonCode,
         string memory metadataURI
-    )
-        internal
-    {
+    ) internal {
         if (workerPayout > 0) {
             accounts.settleReservedTo(job.poster, job.asset, job.worker, workerPayout);
             job.released += workerPayout;
@@ -580,11 +651,7 @@ contract EscrowCore is ReentrancyGuard {
         job.claimEconomicsWaived = false;
         job.rejectingVerifier = address(0);
         reputation.slashReputation(
-            job.worker,
-            policy.rejectionSkillPenalty(),
-            policy.rejectionReliabilityPenalty(),
-            0,
-            REASON_REJECTED
+            job.worker, policy.rejectionSkillPenalty(), policy.rejectionReliabilityPenalty(), 0, REASON_REJECTED
         );
     }
 
@@ -606,11 +673,7 @@ contract EscrowCore is ReentrancyGuard {
         job.claimEconomicsWaived = false;
         job.rejectingVerifier = address(0);
         reputation.slashReputation(
-            job.worker,
-            policy.disputeLossSkillPenalty(),
-            policy.disputeLossReliabilityPenalty(),
-            0,
-            REASON_DISPUTE_LOST
+            job.worker, policy.disputeLossSkillPenalty(), policy.disputeLossReliabilityPenalty(), 0, REASON_DISPUTE_LOST
         );
     }
 }

--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -402,7 +402,7 @@ product, but today they are still a pattern plus manual fire endpoint.
 - [x] gate firing on finite template reserve policy
 - [x] expose status in admin endpoints
 - [x] wire operator UI controls for reserve exhaustion and next firing
-- [ ] back recurring reserve with escrow-native/on-chain poster funding
+- [x] back recurring reserve with escrow-native/on-chain poster funding
 
 ### What this unlocks
 

--- a/docs/patterns/recurring-jobs.md
+++ b/docs/patterns/recurring-jobs.md
@@ -31,6 +31,12 @@ Shipped today:
   consumes one reward-sized slot per derivative and stops firing with
   `lastResult.status = "reserve_exhausted"` once the reserve can no longer
   cover the next run.
+- **Escrow-native reserve funding**: admin-created recurring templates with a
+  finite reserve lock that reserve in `AgentAccountCore` under the poster
+  wallet. When a derivative is claimed on a chain-aware deployment,
+  `EscrowCore.createSinglePayoutJobFromRecurringReserve` consumes one
+  reward-sized slice of that template reserve instead of reserving fresh
+  poster liquid.
 - **Pause/resume controls**: `POST /admin/jobs/pause` and
   `POST /admin/jobs/resume` update recurring runtime state. Both accept
   optional `idempotencyKey`; replay returns the stored admin-status
@@ -118,6 +124,29 @@ If the template has a finite reserve and the remaining reserve is less than
 one derivative reward, firing fails with `recurring_reserve_exhausted`.
 The scheduler records this as `lastResult.status = "reserve_exhausted"` and
 does not compute another `nextFireAt`.
+
+On chain-enabled deployments, a derivative that came from a funded recurring
+template carries:
+
+```json
+{
+  "funding": {
+    "source": "recurring_template_reserve",
+    "templateId": "weekly-digest",
+    "wallet": "0x...",
+    "asset": "DOT",
+    "amount": 5
+  }
+}
+```
+
+That marker tells the backend to create the escrow job from the template
+reserve already held in `AgentAccountCore`. The worker still claims and
+submits the derivative through the ordinary `/jobs/claim` and `/jobs/submit`
+flow; settlement continues to use the normal poster reserved balance.
+The backend signer must be an approved `serviceOperator` for this path: it
+reserves the poster's template pool through `AgentAccountCore` and later
+creates the derivative through `EscrowCore`.
 
 Any agent can now claim the derivative via `/jobs/claim?jobId=weekly-digest-run-…`.
 
@@ -211,9 +240,9 @@ Absolute numbers to watch (via `/metrics`):
 - **Subscription billing semantics.** The platform doesn't bill the
   poster periodically — the poster funds the template's reserve pool,
   each derivative consumes from that pool. Out of reserve = derivatives
-  stop minting. v1 tracks this as finite `recurringPolicy` metadata; a
-  later on-chain funding flow can make the same policy authoritative on
-  escrow balances.
+  stop minting. The backend still projects the remaining reserve from
+  derivative count for UI/status purposes, and chain-enabled deployments
+  now make the finite pool authoritative in `AgentAccountCore`.
 - **Agent-initiated subscriptions.** Only the poster decides cadence
   today. Giving workers an "always claim this" switch is a v3+
   feature.

--- a/mcp-server/src/blockchain/abis.js
+++ b/mcp-server/src/blockchain/abis.js
@@ -5,6 +5,9 @@ export const AGENT_ACCOUNT_ABI = [
   "function getBorrowCapacity(address account, address asset) view returns (uint256)",
   "function deposit(address asset, uint256 amount)",
   "function reserveForJob(address account, address asset, uint256 amount)",
+  "function reserveForRecurringTemplate(address account, address asset, bytes32 templateId, uint256 amount)",
+  "function consumeRecurringTemplateReserve(address account, address asset, bytes32 templateId, uint256 amount)",
+  "function recurringTemplateReserves(address account, address asset, bytes32 templateId) view returns (uint256)",
   "function lockJobStake(address account, address asset, uint256 amount)",
   "function releaseJobStake(address account, address asset, uint256 amount)",
   "function slashJobStake(address account, address asset, uint256 amount, address posterRecipient)",
@@ -31,6 +34,7 @@ export const AGENT_ACCOUNT_ABI = [
 
 export const ESCROW_CORE_ABI = [
   "function createSinglePayoutJob(bytes32 jobId, address asset, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 claimTtl, bytes32 verifierMode, bytes32 category, bytes32 specHash)",
+  "function createSinglePayoutJobFromRecurringReserve((bytes32 jobId, bytes32 templateId, address poster, address asset, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 claimTtl, bytes32 verifierMode, bytes32 category, bytes32 specHash) params)",
   "function claimJob(bytes32 jobId)",
   "function handleClaimTimeout(bytes32 jobId)",
   "function submitWork(bytes32 jobId, bytes32 evidenceHash)",
@@ -47,6 +51,7 @@ export const ESCROW_CORE_ABI = [
   "function jobs(bytes32 jobId) view returns ((address poster, address worker, address asset, bytes32 verifierMode, bytes32 category, bytes32 specHash, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 released, uint256 claimExpiry, uint256 claimStake, uint16 claimStakeBps, uint256 claimFee, uint16 claimFeeBps, bool claimEconomicsWaived, address rejectingVerifier, uint256 rejectedAt, uint256 disputedAt, uint8 payoutMode, uint8 state))",
   "event JobFunded(bytes32 indexed jobId, address indexed poster, address indexed asset, uint256 totalReserved, uint8 payoutMode)",
   "event JobCreated(bytes32 indexed jobId, address indexed poster, bytes32 indexed specHash, address asset, uint256 totalReserved, uint8 payoutMode)",
+  "event RecurringJobFundedFromTemplate(bytes32 indexed jobId, bytes32 indexed templateId, address indexed poster, address asset, uint256 totalReserved)",
   "event JobClaimed(bytes32 indexed jobId, address indexed worker, uint256 claimExpiry, uint256 claimStake)",
   "event ClaimEconomicsLocked(bytes32 indexed jobId, address indexed worker, uint256 claimStake, uint256 claimFee, bool waived, uint256 claimNumber)",
   "event WorkSubmitted(bytes32 indexed jobId, address indexed worker, bytes32 evidenceHash)",

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -395,6 +395,26 @@ export class BlockchainGateway {
     });
   }
 
+  async reserveRecurringTemplateFunding(wallet, assetSymbol, amount, templateId) {
+    return this.withGatewayError("reserveRecurringTemplateFunding", async () => {
+      this.requireSigner("reserveRecurringTemplateFunding");
+      const asset = this.requireAsset(assetSymbol);
+      const templateKey = this.toJobId(templateId);
+      const baseAmount = this.toBaseUnits(amount, asset, "recurring reserve amount");
+      const tx = await this.accountContract.reserveForRecurringTemplate(wallet, asset.address, templateKey, baseAmount);
+      await tx.wait();
+      return {
+        wallet,
+        asset: asset.symbol,
+        amount: this.toDisplayUnits(baseAmount, asset),
+        amountRaw: baseAmount.toString(),
+        templateId,
+        templateKey,
+        source: "agent_account_recurring_template_reserve"
+      };
+    });
+  }
+
   async allocateIdleFunds(wallet, strategyId, amount) {
     return this.withGatewayError("allocateIdleFunds", async () => {
       this.requireSigner("allocateIdleFunds");
@@ -596,18 +616,21 @@ export class BlockchainGateway {
 
       const rewardAmount = this.toBaseUnits(job.rewardAmount ?? 0, asset, "job reward");
       const claimStake = this.toBaseUnits(claimStakeAmount ?? 0, asset, "claim lock amount");
-      const totalRequired = rewardAmount + claimStake;
+      const usesRecurringTemplateReserve = this.usesRecurringTemplateReserve(job);
+      const totalRequired = usesRecurringTemplateReserve ? rewardAmount : rewardAmount + claimStake;
       if (totalRequired <= 0n) {
         throw new ValidationError(`Job ${job.id} has no fundable reward`);
       }
 
       const token = new Contract(asset.address, ERC20_MOCK_ABI, this.signer);
       const signerAddress = await this.signer.getAddress();
-      const signerPosition = await this.accountContract.positions(signerAddress, asset.address);
+      const signerPosition = usesRecurringTemplateReserve
+        ? { liquid: 0n }
+        : await this.accountContract.positions(signerAddress, asset.address);
       const liquid = BigInt(signerPosition.liquid);
-      const shortfall = totalRequired > liquid ? totalRequired - liquid : 0n;
+      const shortfall = !usesRecurringTemplateReserve && totalRequired > liquid ? totalRequired - liquid : 0n;
 
-      if (shortfall > 0n) {
+      if (!usesRecurringTemplateReserve && shortfall > 0n) {
         const mintTx = await token.mint(signerAddress, shortfall);
         await mintTx.wait();
         const approveTx = await token.approve(this.config.agentAccountAddress, shortfall);
@@ -617,7 +640,8 @@ export class BlockchainGateway {
       }
 
       const specHash = hashCanonicalContent(job);
-      const createTx = await this.createSinglePayoutJobForLayout(
+      const createTx = await this.createSinglePayoutJobForJob(
+        job,
         live.contractLayout,
         this.toJobId(instanceJobId),
         asset.address,
@@ -632,6 +656,12 @@ export class BlockchainGateway {
       await createTx.wait();
       return this.getJob(instanceJobId);
     });
+  }
+
+  usesRecurringTemplateReserve(job) {
+    return job?.funding?.source === "recurring_template_reserve"
+      && Boolean(job?.funding?.wallet)
+      && Boolean(job?.funding?.templateId);
   }
 
   async submitWork(jobId, evidence) {
@@ -780,6 +810,54 @@ export class BlockchainGateway {
       );
     }
     return this.escrowContract.createSinglePayoutJob(
+      jobId,
+      assetAddress,
+      reward,
+      opsReserve,
+      contingencyReserve,
+      claimTtl,
+      verifierMode,
+      category,
+      specHash
+    );
+  }
+
+  async createSinglePayoutJobForJob(
+    job,
+    contractLayout,
+    jobId,
+    assetAddress,
+    reward,
+    opsReserve,
+    contingencyReserve,
+    claimTtl,
+    verifierMode,
+    category,
+    specHash
+  ) {
+    const funding = job?.funding;
+    if (
+      contractLayout !== "legacy"
+      && funding?.source === "recurring_template_reserve"
+      && funding?.wallet
+      && funding?.templateId
+    ) {
+      return this.escrowContract.createSinglePayoutJobFromRecurringReserve({
+        jobId,
+        templateId: this.toJobId(funding.templateId),
+        poster: funding.wallet,
+        asset: assetAddress,
+        reward,
+        opsReserve,
+        contingencyReserve,
+        claimTtl,
+        verifierMode,
+        category,
+        specHash
+      });
+    }
+    return this.createSinglePayoutJobForLayout(
+      contractLayout,
       jobId,
       assetAddress,
       reward,

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -252,6 +252,83 @@ test("ensureClaimStakeLiquidity checks fractional display locks against base-uni
   assert.equal(await gateway.ensureClaimStakeLiquidity("DOT", 0.48), true);
 });
 
+test("reserveRecurringTemplateFunding converts display amounts and records the template key", async () => {
+  const gateway = gatewayWithDot();
+  const calls = [];
+  gateway.signer = {};
+  gateway.accountContract = {
+    async reserveForRecurringTemplate(...args) {
+      calls.push(args);
+      return { async wait() {} };
+    }
+  };
+
+  const receipt = await gateway.reserveRecurringTemplateFunding(
+    "0x3333333333333333333333333333333333333333",
+    "DOT",
+    10,
+    "weekly-digest"
+  );
+
+  assert.deepEqual(calls, [[
+    "0x3333333333333333333333333333333333333333",
+    DOT_ASSET.address,
+    gateway.toJobId("weekly-digest"),
+    10_000_000_000_000_000_000n
+  ]]);
+  assert.equal(receipt.source, "agent_account_recurring_template_reserve");
+  assert.equal(receipt.amountRaw, "10000000000000000000");
+});
+
+test("createSinglePayoutJobForJob consumes recurring template reserve when funding metadata is present", async () => {
+  const gateway = gatewayWithDot();
+  const calls = [];
+  gateway.escrowContract = {
+    async createSinglePayoutJobFromRecurringReserve(...args) {
+      calls.push(args);
+      return { async wait() {} };
+    },
+    async createSinglePayoutJob() {
+      throw new Error("fresh reservation path should not be used");
+    }
+  };
+
+  await gateway.createSinglePayoutJobForJob(
+    {
+      funding: {
+        source: "recurring_template_reserve",
+        wallet: "0x3333333333333333333333333333333333333333",
+        templateId: "weekly-digest"
+      }
+    },
+    "rc1",
+    gateway.toJobId("weekly-digest-run-1"),
+    DOT_ASSET.address,
+    5_000_000_000_000_000_000n,
+    0,
+    0,
+    3600,
+    encodeBytes32String("BENCH"),
+    encodeBytes32String("WIKI"),
+    `0x${"1".repeat(64)}`
+  );
+
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0], [{
+    jobId: gateway.toJobId("weekly-digest-run-1"),
+    templateId: gateway.toJobId("weekly-digest"),
+    poster: "0x3333333333333333333333333333333333333333",
+    asset: DOT_ASSET.address,
+    reward: 5_000_000_000_000_000_000n,
+    opsReserve: 0,
+    contingencyReserve: 0,
+    claimTtl: 3600,
+    verifierMode: encodeBytes32String("BENCH"),
+    category: encodeBytes32String("WIKI"),
+    specHash: `0x${"1".repeat(64)}`
+  }]);
+});
+
 test("createSinglePayoutJobForLayout uses the legacy signature for legacy escrow deployments", async () => {
   const gateway = gatewayWithDot();
   const calls = [];

--- a/mcp-server/src/core/account-mutation-service.js
+++ b/mcp-server/src/core/account-mutation-service.js
@@ -220,6 +220,39 @@ export class AccountMutationService {
     return account;
   }
 
+  async reserveRecurringTemplateFunding(wallet, asset, amount, templateId) {
+    if (this.blockchainGateway?.isEnabled() && typeof this.blockchainGateway.reserveRecurringTemplateFunding === "function") {
+      return this.blockchainGateway.reserveRecurringTemplateFunding(wallet, asset, amount, templateId);
+    }
+
+    const account = await this.getAccountSummary(wallet);
+    const liquid = account.liquid[asset] ?? 0;
+    if (liquid < amount) {
+      throw new InsufficientLiquidityError(asset, {
+        wallet,
+        requiredAmount: amount,
+        availableAmount: liquid,
+        templateId
+      });
+    }
+
+    account.liquid[asset] = liquid - amount;
+    account.reserved[asset] = (account.reserved[asset] ?? 0) + amount;
+    account.recurringTemplateReserves = account.recurringTemplateReserves ?? {};
+    account.recurringTemplateReserves[templateId] = {
+      asset,
+      amount: (account.recurringTemplateReserves[templateId]?.amount ?? 0) + amount
+    };
+    this.accounts.set(wallet, account);
+    return {
+      wallet,
+      asset,
+      amount,
+      templateId,
+      source: "local_recurring_template_reserve"
+    };
+  }
+
   async lockJobStake(wallet, asset, amount, posterWallet = undefined) {
     if (this.blockchainGateway?.isEnabled()) {
       return this.getAccountSummary(wallet);

--- a/mcp-server/src/core/job-catalog-service.js
+++ b/mcp-server/src/core/job-catalog-service.js
@@ -176,6 +176,19 @@ export class JobCatalogService {
     return job;
   }
 
+  removeJob(jobId) {
+    const idx = this.jobs.findIndex((job) => job.id === jobId);
+    if (idx === -1) {
+      return false;
+    }
+    const [removed] = this.jobs.splice(idx, 1);
+    if (removed?.parentSessionId) {
+      const indexed = this.parentSessionIndex.get(String(removed.parentSessionId));
+      indexed?.delete(removed.id);
+    }
+    return true;
+  }
+
   indexJob(job) {
     if (!job?.parentSessionId) {
       return;
@@ -786,6 +799,19 @@ export class JobCatalogService {
       recurring: false,
       templateId,
       firedAt: firedAt.toISOString(),
+      ...(template.recurringPolicy?.funding
+        ? {
+            funding: {
+              source: "recurring_template_reserve",
+              templateId,
+              wallet: template.recurringPolicy.funding.wallet,
+              asset: template.recurringPolicy.funding.asset ?? template.rewardAsset,
+              amount: template.rewardAmount,
+              reservedAt: template.recurringPolicy.funding.reservedAt,
+              templateKey: template.recurringPolicy.funding.templateKey
+            }
+          }
+        : {}),
       lifecycle: normaliseLifecycle({
         ...(template.lifecycle ?? {}),
         status: "open",

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -147,6 +147,17 @@ export class PlatformService {
     return this.jobCatalogService.createJob(input);
   }
 
+  async createAdminJob(input, { posterWallet = undefined } = {}) {
+    const created = this.jobCatalogService.createJob(input);
+    try {
+      await this.reserveRecurringTemplateFunding(created, posterWallet);
+      return created;
+    } catch (error) {
+      this.jobCatalogService.removeJob(created.id);
+      throw error;
+    }
+  }
+
   updateJobLifecycle(jobId, patch = {}) {
     return this.jobCatalogService.updateJobLifecycle(jobId, patch);
   }
@@ -949,6 +960,42 @@ export class PlatformService {
 
   async reserveForJob(wallet, asset, amount) {
     return this.accountMutationService.reserveForJob(wallet, asset, amount);
+  }
+
+  async reserveRecurringTemplateFunding(job, posterWallet) {
+    const reserveAmount = Number(job?.recurringPolicy?.reserveAmount);
+    if (!job?.recurring || !Number.isFinite(reserveAmount) || reserveAmount <= 0) {
+      return undefined;
+    }
+    const wallet = String(posterWallet ?? "").trim();
+    if (!wallet) {
+      throw new ValidationError("Recurring templates with finite reserves require a poster wallet.");
+    }
+    const asset = job.recurringPolicy.reserveAsset ?? job.rewardAsset ?? "DOT";
+    const receipt = await this.accountMutationService.reserveRecurringTemplateFunding(
+      wallet,
+      asset,
+      reserveAmount,
+      job.id
+    );
+    const reservedAt = new Date().toISOString();
+    job.recurringPolicy = {
+      ...job.recurringPolicy,
+      funding: {
+        source: "recurring_template_reserve",
+        wallet,
+        asset,
+        amount: reserveAmount,
+        reservedAt,
+        ...(receipt?.amountRaw ? { amountRaw: receipt.amountRaw } : {}),
+        ...(receipt?.templateKey ? { templateKey: receipt.templateKey } : {})
+      }
+    };
+    this.jobCatalogService.updateRecurringTemplateRuntime(job.id, {
+      reserve: this.jobCatalogService.buildRecurringReserveStatus(job),
+      funding: job.recurringPolicy.funding
+    });
+    return receipt;
   }
 
   async sendToAgent(from, recipient, asset, amount) {

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -90,6 +90,37 @@ test("createSubJob links the child job to the active parent session", async () =
   assert.equal(subJobs[0].id, "child-job-001");
 });
 
+test("createAdminJob reserves finite recurring template funding from the poster wallet", async () => {
+  const service = makePlatformService();
+
+  const template = await service.createAdminJob({
+    id: "weekly-recurring-001",
+    category: "coding",
+    tier: "starter",
+    rewardAmount: 5,
+    rewardAsset: "DOT",
+    verifierMode: "benchmark",
+    verifierTerms: ["complete"],
+    verifierMinimumMatches: 1,
+    recurring: true,
+    schedule: { cron: "0 9 * * 1" },
+    recurringPolicy: { reserveAmount: 10, reserveAsset: "DOT" }
+  }, { posterWallet: WALLET });
+
+  assert.equal(template.recurringPolicy.funding.source, "recurring_template_reserve");
+  assert.equal(template.recurringPolicy.funding.wallet, WALLET);
+  const account = await service.getAccountSummary(WALLET);
+  assert.equal(account.liquid.DOT, 0);
+  assert.equal(account.reserved.DOT, 10);
+
+  const derivative = service.fireRecurringJob("weekly-recurring-001", {
+    firedAt: new Date("2026-05-04T09:00:00.000Z")
+  });
+  assert.equal(derivative.funding.source, "recurring_template_reserve");
+  assert.equal(derivative.funding.wallet, WALLET);
+  assert.equal(derivative.funding.amount, 5);
+});
+
 test("createSubJob enforces parent delegation budget and count policy", async () => {
   const service = makePlatformService();
   service.jobs[0].delegationPolicy = { budgetAmount: 2, budgetAsset: "DOT", maxSubJobs: 1, maxDepth: 1 };

--- a/mcp-server/src/core/recurring-jobs.test.js
+++ b/mcp-server/src/core/recurring-jobs.test.js
@@ -110,6 +110,33 @@ test("fireRecurringJob produces a derivative with deterministic id", () => {
   assert.equal(status.templates[0].reserve.remainingRuns, 1);
 });
 
+test("fireRecurringJob carries escrow-native recurring funding onto derivatives", () => {
+  const service = makeService();
+  const template = service.createJob({ ...TEMPLATE, recurringPolicy: { reserveAmount: 10 } });
+  template.recurringPolicy.funding = {
+    source: "recurring_template_reserve",
+    wallet: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    asset: "DOT",
+    amount: 10,
+    reservedAt: "2026-05-04T08:00:00.000Z",
+    templateKey: `0x${"1".repeat(64)}`
+  };
+
+  const derivative = service.fireRecurringJob("weekly-digest", {
+    firedAt: new Date("2026-05-04T09:00:00.000Z")
+  });
+
+  assert.deepEqual(derivative.funding, {
+    source: "recurring_template_reserve",
+    templateId: "weekly-digest",
+    wallet: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    asset: "DOT",
+    amount: 5,
+    reservedAt: "2026-05-04T08:00:00.000Z",
+    templateKey: `0x${"1".repeat(64)}`
+  });
+});
+
 test("fireRecurringJob rejects non-recurring templates", () => {
   const service = makeService();
   service.createJob({ ...TEMPLATE, recurring: false, schedule: undefined });

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -2544,7 +2544,7 @@ const server = createServer(async (request, response) => {
       if (replay) {
         return respond(response, replay.statusCode, replay.body);
       }
-      const created = service.createJob(payload);
+      const created = await service.createAdminJob(payload, { posterWallet: auth.wallet });
       await storeIdempotentMutationReceipt({
         bucket: "admin_jobs",
         key: mutationKey,

--- a/sdk/agent-platform-client.d.ts
+++ b/sdk/agent-platform-client.d.ts
@@ -147,6 +147,7 @@ export interface AccountSummary extends ApiEnvelope {
   wallet: WalletAddress;
   liquid?: AssetBalances;
   reserved?: AssetBalances;
+  recurringTemplateReserves?: Record<JobId, { asset?: AssetSymbol; amount?: number }>;
   strategyAllocated?: AssetBalances;
   debtOutstanding?: AssetBalances;
 }
@@ -215,6 +216,27 @@ export interface RecurringPolicy extends ApiEnvelope {
   reserveAmount?: number;
   reserveAsset?: AssetSymbol;
   maxRuns?: number;
+  funding?: RecurringTemplateFunding;
+}
+
+export interface RecurringTemplateFunding extends ApiEnvelope {
+  source?: "recurring_template_reserve" | string;
+  wallet?: WalletAddress;
+  asset?: AssetSymbol;
+  amount?: number;
+  amountRaw?: string;
+  reservedAt?: ISODateTime;
+  templateKey?: string;
+}
+
+export interface JobFunding extends ApiEnvelope {
+  source?: "recurring_template_reserve" | string;
+  templateId?: JobId;
+  wallet?: WalletAddress;
+  asset?: AssetSymbol;
+  amount?: number;
+  reservedAt?: ISODateTime;
+  templateKey?: string;
 }
 
 /** Generic coding job input. */
@@ -604,6 +626,7 @@ export interface JobDefinition extends ApiEnvelope {
   source?: ApiEnvelope;
   verification?: ApiEnvelope;
   lineage?: SubJobLineageMetadata;
+  funding?: JobFunding;
 }
 
 export interface JobSummary extends ApiEnvelope {
@@ -626,6 +649,7 @@ export interface JobSummary extends ApiEnvelope {
   delegationPolicy?: DelegationPolicy;
   recurringPolicy?: RecurringPolicy;
   lineage?: SubJobLineageMetadata;
+  funding?: JobFunding;
   submissionContract?: SubmissionContract;
   schemaContract?: JobSchemaContract;
 }

--- a/sdk/api-surface-model.mjs
+++ b/sdk/api-surface-model.mjs
@@ -138,6 +138,7 @@ export interface AccountSummary extends ApiEnvelope {
   wallet: WalletAddress;
   liquid?: AssetBalances;
   reserved?: AssetBalances;
+  recurringTemplateReserves?: Record<JobId, { asset?: AssetSymbol; amount?: number }>;
   strategyAllocated?: AssetBalances;
   debtOutstanding?: AssetBalances;
 }
@@ -206,6 +207,27 @@ export interface RecurringPolicy extends ApiEnvelope {
   reserveAmount?: number;
   reserveAsset?: AssetSymbol;
   maxRuns?: number;
+  funding?: RecurringTemplateFunding;
+}
+
+export interface RecurringTemplateFunding extends ApiEnvelope {
+  source?: "recurring_template_reserve" | string;
+  wallet?: WalletAddress;
+  asset?: AssetSymbol;
+  amount?: number;
+  amountRaw?: string;
+  reservedAt?: ISODateTime;
+  templateKey?: string;
+}
+
+export interface JobFunding extends ApiEnvelope {
+  source?: "recurring_template_reserve" | string;
+  templateId?: JobId;
+  wallet?: WalletAddress;
+  asset?: AssetSymbol;
+  amount?: number;
+  reservedAt?: ISODateTime;
+  templateKey?: string;
 }
 
 {{BUILTIN_JOB_SCHEMA_TYPES}}
@@ -265,6 +287,7 @@ export interface JobDefinition extends ApiEnvelope {
   source?: ApiEnvelope;
   verification?: ApiEnvelope;
   lineage?: SubJobLineageMetadata;
+  funding?: JobFunding;
 }
 
 export interface JobSummary extends ApiEnvelope {
@@ -287,6 +310,7 @@ export interface JobSummary extends ApiEnvelope {
   delegationPolicy?: DelegationPolicy;
   recurringPolicy?: RecurringPolicy;
   lineage?: SubJobLineageMetadata;
+  funding?: JobFunding;
   submissionContract?: SubmissionContract;
   schemaContract?: JobSchemaContract;
 }

--- a/test/AgentPlatform.t.sol
+++ b/test/AgentPlatform.t.sol
@@ -66,7 +66,9 @@ contract AgentPlatformTest is Test {
         bytes32 jobId = keccak256("job/single/1");
 
         vm.prank(poster);
-        escrow.createSinglePayoutJob(jobId, address(dot), 100 ether, 10 ether, 5 ether, 1 days, bytes32("AUTO"), bytes32("CODING"), SPEC_HASH);
+        escrow.createSinglePayoutJob(
+            jobId, address(dot), 100 ether, 10 ether, 5 ether, 1 days, bytes32("AUTO"), bytes32("CODING"), SPEC_HASH
+        );
 
         uint256 startingWorkerBalance = dot.balanceOf(worker);
 
@@ -94,6 +96,53 @@ contract AgentPlatformTest is Test {
         assertEq(reputation.balanceOf(worker), 1);
     }
 
+    function testRecurringTemplateReserveFundsDerivativeWithoutFreshPosterLiquid() public {
+        bytes32 templateId = keccak256("template/weekly/1");
+        bytes32 jobId = keccak256("template/weekly/1/run/1");
+
+        vm.prank(poster);
+        accounts.reserveForRecurringTemplate(poster, address(dot), templateId, 10 ether);
+
+        (uint256 liquidAfterTemplateReserve, uint256 reservedAfterTemplateReserve,,,,) =
+            accounts.positions(poster, address(dot));
+        assertEq(liquidAfterTemplateReserve, POSTER_DEPOSIT - 10 ether);
+        assertEq(reservedAfterTemplateReserve, 10 ether);
+        assertEq(accounts.recurringTemplateReserves(poster, address(dot), templateId), 10 ether);
+
+        escrow.createSinglePayoutJobFromRecurringReserve(
+            EscrowCore.RecurringSinglePayoutJob({
+                jobId: jobId,
+                templateId: templateId,
+                poster: poster,
+                asset: address(dot),
+                reward: 5 ether,
+                opsReserve: 0,
+                contingencyReserve: 0,
+                claimTtl: 1 days,
+                verifierMode: bytes32("AUTO"),
+                category: bytes32("CODING"),
+                specHash: SPEC_HASH
+            })
+        );
+
+        assertEq(accounts.recurringTemplateReserves(poster, address(dot), templateId), 5 ether);
+        (uint256 liquidAfterDerivative, uint256 reservedAfterDerivative,,,,) = accounts.positions(poster, address(dot));
+        assertEq(liquidAfterDerivative, POSTER_DEPOSIT - 10 ether);
+        assertEq(reservedAfterDerivative, 10 ether);
+
+        vm.prank(worker);
+        escrow.claimJob(jobId);
+        vm.prank(worker);
+        escrow.submitWork(jobId, keccak256("work"));
+        vm.prank(verifier);
+        escrow.resolveSinglePayout(jobId, true, bytes32("OK"), "ipfs://badge/recurring", REASONING_HASH);
+
+        (uint256 liquidAfterClose, uint256 reservedAfterClose,,,,) = accounts.positions(poster, address(dot));
+        assertEq(liquidAfterClose, POSTER_DEPOSIT - 10 ether);
+        assertEq(reservedAfterClose, 5 ether);
+        assertEq(dot.balanceOf(worker), 1_000 ether - WORKER_DEPOSIT + 5 ether);
+    }
+
     function testOnboardingWaivesFirstThreeClaimsThenLocksStakeAndFee() public {
         policy.setOnboardingWaiverClaimCount(3);
         policy.setClaimFeeBps(200);
@@ -102,7 +151,9 @@ contract AgentPlatformTest is Test {
         for (uint256 i = 0; i < 3; i++) {
             bytes32 jobId = keccak256(abi.encodePacked("job/onboarding/free", i));
             vm.prank(poster);
-            escrow.createSinglePayoutJob(jobId, address(dot), 50 ether, 0, 0, 1 days, bytes32("AUTO"), bytes32("DATA"), SPEC_HASH);
+            escrow.createSinglePayoutJob(
+                jobId, address(dot), 50 ether, 0, 0, 1 days, bytes32("AUTO"), bytes32("DATA"), SPEC_HASH
+            );
 
             vm.prank(worker);
             escrow.claimJob(jobId);
@@ -120,13 +171,15 @@ contract AgentPlatformTest is Test {
 
         bytes32 paidJobId = keccak256("job/onboarding/paid");
         vm.prank(poster);
-        escrow.createSinglePayoutJob(paidJobId, address(dot), 50 ether, 0, 0, 1 days, bytes32("AUTO"), bytes32("DATA"), SPEC_HASH);
+        escrow.createSinglePayoutJob(
+            paidJobId, address(dot), 50 ether, 0, 0, 1 days, bytes32("AUTO"), bytes32("DATA"), SPEC_HASH
+        );
 
         vm.prank(worker);
         escrow.claimJob(paidJobId);
 
         EscrowCore.JobEscrow memory paidJob = escrow.jobs(paidJobId);
-        (, , , , uint256 workerJobStake,) = accounts.positions(worker, address(dot));
+        (,,,, uint256 workerJobStake,) = accounts.positions(worker, address(dot));
 
         assertEq(escrow.workerClaimCount(worker), 4);
         assertEq(paidJob.claimStake, 2.5 ether);
@@ -141,12 +194,14 @@ contract AgentPlatformTest is Test {
 
         bytes32 jobId = keccak256("job/fee/success");
         vm.prank(poster);
-        escrow.createSinglePayoutJob(jobId, address(dot), 50 ether, 0, 0, 1 days, bytes32("AUTO"), bytes32("DATA"), SPEC_HASH);
+        escrow.createSinglePayoutJob(
+            jobId, address(dot), 50 ether, 0, 0, 1 days, bytes32("AUTO"), bytes32("DATA"), SPEC_HASH
+        );
 
         vm.prank(worker);
         escrow.claimJob(jobId);
 
-        (, , , , uint256 lockedAfterClaim,) = accounts.positions(worker, address(dot));
+        (,,,, uint256 lockedAfterClaim,) = accounts.positions(worker, address(dot));
         assertEq(lockedAfterClaim, 3.5 ether);
 
         vm.prank(worker);
@@ -169,7 +224,9 @@ contract AgentPlatformTest is Test {
 
         bytes32 jobId = keccak256("job/fee/rejected");
         vm.prank(poster);
-        escrow.createSinglePayoutJob(jobId, address(dot), 50 ether, 0, 0, 1 days, bytes32("AUTO"), bytes32("DATA"), SPEC_HASH);
+        escrow.createSinglePayoutJob(
+            jobId, address(dot), 50 ether, 0, 0, 1 days, bytes32("AUTO"), bytes32("DATA"), SPEC_HASH
+        );
 
         uint256 posterBalanceBefore = dot.balanceOf(poster);
         uint256 verifierBalanceBefore = dot.balanceOf(verifier);
@@ -187,7 +244,7 @@ contract AgentPlatformTest is Test {
         escrow.finalizeRejectedJob(jobId);
 
         EscrowCore.JobEscrow memory job = escrow.jobs(jobId);
-        (, , , , uint256 workerJobStake,) = accounts.positions(worker, address(dot));
+        (,,,, uint256 workerJobStake,) = accounts.positions(worker, address(dot));
 
         assertEq(job.claimStake, 0);
         assertEq(job.claimFee, 0);
@@ -204,14 +261,15 @@ contract AgentPlatformTest is Test {
         assertEq(capacity, 100 ether);
 
         accounts.borrow(address(dot), 100 ether);
-        (, , , uint256 collateralLocked, uint256 jobStakeLocked, uint256 debtOutstanding) = accounts.positions(worker, address(dot));
+        (,,, uint256 collateralLocked, uint256 jobStakeLocked, uint256 debtOutstanding) =
+            accounts.positions(worker, address(dot));
         assertEq(collateralLocked, 150 ether);
         assertEq(jobStakeLocked, 0);
         assertEq(debtOutstanding, 100 ether);
 
         dot.mint(worker, 100 ether);
         accounts.repay(address(dot), 100 ether);
-        (, , , , , debtOutstanding) = accounts.positions(worker, address(dot));
+        (,,,,, debtOutstanding) = accounts.positions(worker, address(dot));
         assertEq(debtOutstanding, 0);
         vm.stopPrank();
     }
@@ -250,7 +308,9 @@ contract AgentPlatformTest is Test {
         bytes32 jobId = keccak256("job/timeout/1");
 
         vm.prank(poster);
-        escrow.createSinglePayoutJob(jobId, address(dot), 50 ether, 5 ether, 5 ether, 1 days, bytes32("AUTO"), bytes32("DATA"), SPEC_HASH);
+        escrow.createSinglePayoutJob(
+            jobId, address(dot), 50 ether, 5 ether, 5 ether, 1 days, bytes32("AUTO"), bytes32("DATA"), SPEC_HASH
+        );
 
         uint256 posterBalanceBefore = dot.balanceOf(poster);
 
@@ -277,7 +337,9 @@ contract AgentPlatformTest is Test {
         bytes32 jobId = keccak256("job/timeout/2");
 
         vm.prank(poster);
-        escrow.createSinglePayoutJob(jobId, address(dot), 50 ether, 5 ether, 5 ether, 1 days, bytes32("AUTO"), bytes32("DATA"), SPEC_HASH);
+        escrow.createSinglePayoutJob(
+            jobId, address(dot), 50 ether, 5 ether, 5 ether, 1 days, bytes32("AUTO"), bytes32("DATA"), SPEC_HASH
+        );
 
         vm.prank(worker);
         escrow.claimJob(jobId);
@@ -309,7 +371,9 @@ contract AgentPlatformTest is Test {
         milestones[1] = 25 ether;
 
         vm.prank(poster);
-        escrow.createMilestoneJob(jobId, address(dot), milestones, 5 ether, 5 ether, 1 days, bytes32("AUTO"), bytes32("DATA"), SPEC_HASH);
+        escrow.createMilestoneJob(
+            jobId, address(dot), milestones, 5 ether, 5 ether, 1 days, bytes32("AUTO"), bytes32("DATA"), SPEC_HASH
+        );
 
         vm.prank(worker);
         escrow.claimJob(jobId);
@@ -324,7 +388,7 @@ contract AgentPlatformTest is Test {
 
         EscrowCore.JobEscrow memory job = escrow.jobs(jobId);
 
-        (, , , , uint256 workerJobStake,) = accounts.positions(worker, address(dot));
+        (,,,, uint256 workerJobStake,) = accounts.positions(worker, address(dot));
 
         assertEq(job.worker, worker);
         assertEq(job.claimExpiry, block.timestamp + 1 days);
@@ -339,7 +403,9 @@ contract AgentPlatformTest is Test {
         reputation.updateReputation(worker, 100, 100, 0);
 
         vm.prank(poster);
-        escrow.createSinglePayoutJob(jobId, address(dot), 50 ether, 5 ether, 5 ether, 1 days, bytes32("AUTO"), bytes32("DATA"), SPEC_HASH);
+        escrow.createSinglePayoutJob(
+            jobId, address(dot), 50 ether, 5 ether, 5 ether, 1 days, bytes32("AUTO"), bytes32("DATA"), SPEC_HASH
+        );
 
         uint256 posterBalanceBefore = dot.balanceOf(poster);
 
@@ -352,7 +418,7 @@ contract AgentPlatformTest is Test {
         vm.prank(verifier);
         escrow.resolveSinglePayout(jobId, false, bytes32("REJECTED"), "ipfs://badge/rejected", REASONING_HASH);
 
-        (, , , , uint256 workerJobStakeBeforeFinalize,) = accounts.positions(worker, address(dot));
+        (,,,, uint256 workerJobStakeBeforeFinalize,) = accounts.positions(worker, address(dot));
         (uint256 skillBefore, uint256 reliabilityBefore,) = reputation.reputations(worker);
         assertEq(workerJobStakeBeforeFinalize, 2.5 ether);
         assertEq(skillBefore, 100);
@@ -362,7 +428,7 @@ contract AgentPlatformTest is Test {
         escrow.finalizeRejectedJob(jobId);
 
         (uint256 liquidPoster, uint256 reservedPoster,,,,) = accounts.positions(poster, address(dot));
-        (, , , , uint256 workerJobStakeAfterFinalize,) = accounts.positions(worker, address(dot));
+        (,,,, uint256 workerJobStakeAfterFinalize,) = accounts.positions(worker, address(dot));
         (uint256 skillAfter, uint256 reliabilityAfter,) = reputation.reputations(worker);
 
         assertEq(liquidPoster, POSTER_DEPOSIT);
@@ -379,7 +445,9 @@ contract AgentPlatformTest is Test {
         reputation.updateReputation(worker, 100, 100, 0);
 
         vm.prank(poster);
-        escrow.createSinglePayoutJob(jobId, address(dot), 50 ether, 5 ether, 5 ether, 1 days, bytes32("AUTO"), bytes32("DATA"), SPEC_HASH);
+        escrow.createSinglePayoutJob(
+            jobId, address(dot), 50 ether, 5 ether, 5 ether, 1 days, bytes32("AUTO"), bytes32("DATA"), SPEC_HASH
+        );
 
         vm.prank(worker);
         escrow.claimJob(jobId);
@@ -399,7 +467,7 @@ contract AgentPlatformTest is Test {
         (bool finalizedDisputed,) = address(escrow).call(abi.encodeCall(escrow.finalizeRejectedJob, (jobId)));
         require(!finalizedDisputed, "EXPECTED_INVALID_STATE_REVERT");
 
-        (, , , , uint256 workerJobStake,) = accounts.positions(worker, address(dot));
+        (,,,, uint256 workerJobStake,) = accounts.positions(worker, address(dot));
         (uint256 skillAfter, uint256 reliabilityAfter,) = reputation.reputations(worker);
 
         assertEq(workerJobStake, 2.5 ether);
@@ -423,7 +491,9 @@ contract AgentPlatformTest is Test {
         reputation.updateReputation(worker, 100, 100, 0);
 
         vm.prank(poster);
-        escrow.createSinglePayoutJob(jobId, address(dot), 50 ether, 5 ether, 5 ether, 1 days, bytes32("AUTO"), bytes32("DATA"), SPEC_HASH);
+        escrow.createSinglePayoutJob(
+            jobId, address(dot), 50 ether, 5 ether, 5 ether, 1 days, bytes32("AUTO"), bytes32("DATA"), SPEC_HASH
+        );
 
         uint256 posterBalanceBefore = dot.balanceOf(poster);
 
@@ -442,7 +512,7 @@ contract AgentPlatformTest is Test {
         vm.prank(arbitrator);
         escrow.resolveDispute(jobId, 0, bytes32("DISPUTE_LOSS"), "ipfs://badge/dispute");
 
-        (, , , , uint256 workerJobStake,) = accounts.positions(worker, address(dot));
+        (,,,, uint256 workerJobStake,) = accounts.positions(worker, address(dot));
         (uint256 liquidPoster, uint256 reservedPoster,,,,) = accounts.positions(poster, address(dot));
         (uint256 skillAfter, uint256 reliabilityAfter,) = reputation.reputations(worker);
 
@@ -502,9 +572,8 @@ contract AgentPlatformTest is Test {
 
     function testSlashReputationRequiresOperator() public {
         vm.prank(worker);
-        (bool ok,) = address(reputation).call(
-            abi.encodeCall(reputation.slashReputation, (worker, 1, 1, 0, bytes32("NOPE")))
-        );
+        (bool ok,) =
+            address(reputation).call(abi.encodeCall(reputation.slashReputation, (worker, 1, 1, 0, bytes32("NOPE"))));
         require(!ok, "EXPECTED_UNAUTHORIZED_REVERT");
     }
 
@@ -513,15 +582,7 @@ contract AgentPlatformTest is Test {
 
         vm.prank(poster);
         escrow.createSinglePayoutJob(
-            jobId,
-            address(dot),
-            reward,
-            5 ether,
-            5 ether,
-            1 days,
-            bytes32("AUTO"),
-            bytes32("DATA"),
-            SPEC_HASH
+            jobId, address(dot), reward, 5 ether, 5 ether, 1 days, bytes32("AUTO"), bytes32("DATA"), SPEC_HASH
         );
 
         vm.prank(worker);


### PR DESCRIPTION
## What changed
- Added AgentAccountCore recurring template reserves and a consume path for derivative jobs.
- Added EscrowCore.createSinglePayoutJobFromRecurringReserve so recurring derivatives can be funded from a poster's pre-reserved template pool.
- Wired admin recurring template creation to reserve finite pools from the poster wallet, carry funding metadata onto derivatives, and use the reserved-pool contract path during chain job ensure.
- Updated recurring-job docs, SDK surface types, and the roadmap checkbox.

## Checks run
- npm --workspace mcp-server test
- forge test
- npm run generate:sdk-types
- node --test sdk/agent-platform-client.test.mjs
- npm run typecheck:app
- npm run build:app
- npm run build:frontend
- git diff --check

## Impact
- Backend: yes, admin recurring job creation and chain gateway funding path.
- Contracts: yes, AgentAccountCore and EscrowCore ABI/storage additions.
- Frontend: generated SDK types only; no operator UI source changes.
- Indexer/Caddy/public site: no.

## Deployment notes
- Requires a contract deployment/upgrade plan before live chain-enabled recurring templates use this path.
- The backend signer must be an approved serviceOperator so it can reserve the poster template pool and create derivatives from it.
- No new VPS secret is introduced by this PR.