### PR TITLE
Job timeline panel on /runs/detail (consumes PR #149 + #158)

### DIFF
--- a/app/components/runs/JobTimelinePanel.tsx
+++ b/app/components/runs/JobTimelinePanel.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useMemo } from "react";
+import { cn } from "@/lib/utils/cn";
+import {
+  buildJobTimeline,
+  describeTimelineDetail,
+  describeTimelineEntry,
+  EMPTY_JOB_TIMELINE,
+  type TimelineEntry,
+  type TimelineSeverity,
+  type TimelineSource,
+} from "@/lib/api/job-timeline";
+import { useJobTimeline } from "@/lib/api/hooks";
+import { ApiError } from "@/lib/api/client";
+
+/**
+ * "Everything that happened to this job" panel for /runs/detail.
+ *
+ * The 5-stage `LifecycleRail` above this panel gives the at-a-glance
+ * answer (Ready → Claimed → Submitted → Verified → Paid). This panel
+ * is the full chronological log driven by `GET /admin/jobs/timeline`
+ * (PR #149) so an auditor can see child runs, recurring derivatives,
+ * verifier reason codes, raw event-bus rows, and severity-tagged
+ * transitions in one read.
+ */
+export function JobTimelinePanel({ jobId }: { jobId: string }) {
+  const request = useJobTimeline(jobId);
+  const data = useMemo(() => buildJobTimeline(request.data), [request.data]);
+  const unauthenticated =
+    request.error instanceof ApiError &&
+    (request.error.status === 401 || request.error.status === 403);
+
+  return (
+    <section
+      aria-labelledby="job-timeline-heading"
+      className="flex flex-col gap-3 rounded-[10px] border border-[var(--avy-line)] bg-[var(--avy-paper)] p-4 shadow-[var(--shadow-card)]"
+    >
+      <header className="flex flex-wrap items-baseline justify-between gap-2">
+        <div className="flex flex-col gap-0.5">
+          <span
+            className="font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase text-[var(--avy-accent)]"
+            style={{ letterSpacing: "0.12em" }}
+          >
+            Job timeline
+          </span>
+          <h2
+            id="job-timeline-heading"
+            className="m-0 font-[family-name:var(--font-display)] text-[16px] font-bold text-[var(--avy-ink)]"
+          >
+            Every event recorded for this job
+          </h2>
+        </div>
+        <TimelineSummary
+          data={data}
+          loading={Boolean(request.isLoading)}
+          unauthenticated={unauthenticated}
+        />
+      </header>
+
+      <ul className="flex flex-col">
+        {data.timeline.length === 0 ? (
+          <EmptyRow
+            unauthenticated={unauthenticated}
+            loading={Boolean(request.isLoading)}
+          />
+        ) : (
+          data.timeline.map((entry, idx) => (
+            <TimelineRow
+              key={entry.id}
+              entry={entry}
+              isLast={idx === data.timeline.length - 1}
+            />
+          ))
+        )}
+      </ul>
+
+      {data.summary.eventBusGap ? (
+        <p
+          className="m-0 font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-warn)]"
+          style={{ letterSpacing: 0 }}
+        >
+          ⚠ event-bus replay reported a gap — older events may be missing.
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+function TimelineSummary({
+  data,
+  loading,
+  unauthenticated,
+}: {
+  data: ReturnType<typeof buildJobTimeline>;
+  loading: boolean;
+  unauthenticated: boolean;
+}) {
+  if (unauthenticated) {
+    return (
+      <span
+        className="font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
+        style={{ letterSpacing: 0 }}
+      >
+        sign in to load
+      </span>
+    );
+  }
+  if (loading && data.summary.eventCount === 0) {
+    return (
+      <span
+        className="font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
+        style={{ letterSpacing: 0 }}
+      >
+        loading…
+      </span>
+    );
+  }
+  const { summary, lineage } = data;
+  const segments: string[] = [];
+  if (summary.sessionCount > 0) {
+    segments.push(
+      `${summary.sessionCount} session${summary.sessionCount === 1 ? "" : "s"}`
+    );
+  }
+  if (summary.childJobCount > 0) {
+    segments.push(`${summary.childJobCount} child`);
+  }
+  if (lineage.recurringTemplate) {
+    segments.push(
+      `${summary.derivativeJobCount} derivative${summary.derivativeJobCount === 1 ? "" : "s"}`
+    );
+  }
+  if (segments.length === 0 && summary.eventCount > 0) {
+    segments.push(`${summary.eventCount} event${summary.eventCount === 1 ? "" : "s"}`);
+  }
+  return (
+    <span
+      className="font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
+      style={{ letterSpacing: 0 }}
+    >
+      {segments.length > 0 ? segments.join(" · ") : "/admin/jobs/timeline"}
+    </span>
+  );
+}
+
+function EmptyRow({
+  unauthenticated,
+  loading,
+}: {
+  unauthenticated: boolean;
+  loading: boolean;
+}) {
+  return (
+    <li className="rounded-[8px] border border-dashed border-[var(--avy-line)] bg-[rgba(255,253,247,0.5)] p-4 text-center">
+      <p
+        className="m-0 font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-muted)]"
+        style={{ letterSpacing: 0 }}
+      >
+        {unauthenticated
+          ? "Sign in with your operator wallet to load the timeline. /admin/jobs/timeline is admin-gated."
+          : loading
+            ? "Loading timeline…"
+            : "No events recorded for this job yet."}
+      </p>
+    </li>
+  );
+}
+
+function TimelineRow({
+  entry,
+  isLast,
+}: {
+  entry: TimelineEntry;
+  isLast: boolean;
+}) {
+  return (
+    <li className="relative flex gap-3 pb-3">
+      {/* Vertical gutter line tying entries together. */}
+      {!isLast ? (
+        <span
+          aria-hidden="true"
+          className="absolute left-[6.5px] top-3 bottom-0 w-px bg-[var(--avy-line)]"
+        />
+      ) : null}
+      <SeverityDot severity={entry.severity} />
+      <div className="min-w-0 flex-1 -mt-0.5 flex flex-col gap-0.5">
+        <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-0.5">
+          <span className="font-[family-name:var(--font-body)] text-[13px] font-semibold text-[var(--avy-ink)]">
+            {describeTimelineEntry(entry)}
+          </span>
+          <span
+            className="font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)] whitespace-nowrap"
+            style={{ letterSpacing: 0 }}
+            title={entry.at}
+          >
+            {formatTimestamp(entry.at)}
+          </span>
+        </div>
+        <div
+          className="flex flex-wrap items-center gap-1.5 font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
+          style={{ letterSpacing: 0 }}
+        >
+          <SourceChip source={entry.source} />
+          {entry.topic ? <span>{entry.topic}</span> : null}
+          {describeTimelineDetail(entry) ? (
+            <>
+              <span className="opacity-40">·</span>
+              <span className="text-[var(--avy-ink)]/80">
+                {describeTimelineDetail(entry)}
+              </span>
+            </>
+          ) : null}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function SeverityDot({ severity }: { severity: TimelineSeverity }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "mt-1 h-3 w-3 shrink-0 rounded-full ring-2",
+        severity === "error" &&
+          "bg-[var(--avy-warn)] ring-[var(--avy-warn-soft,rgba(167,97,34,0.18))]",
+        severity === "warn" &&
+          "bg-[var(--avy-warn)] ring-[var(--avy-warn-soft,rgba(167,97,34,0.18))] opacity-75",
+        severity === "info" &&
+          "bg-[var(--avy-accent)] ring-[color:rgba(30,102,66,0.18)]"
+      )}
+    />
+  );
+}
+
+function SourceChip({ source }: { source: TimelineSource }) {
+  // Source chip carries the entry's origin (state machine, verifier,
+  // event bus, …). Keeps the row scannable without re-printing the
+  // full topic string.
+  return (
+    <span
+      className={cn(
+        "rounded-[4px] px-1.5 py-px font-[family-name:var(--font-display)] text-[9.5px] font-extrabold uppercase",
+        source === "event_bus" && "bg-[#1f2a3a] text-white",
+        source === "verification" && "bg-[var(--avy-accent-wash)] text-[var(--avy-accent)]",
+        source === "state" && "bg-[color:rgba(17,19,21,0.06)] text-[var(--avy-ink)]",
+        source === "lineage" && "bg-[#2a1f3a] text-white",
+        source === "schedule" && "bg-[#3a2a1f] text-white",
+        // Unknown source kinds — neutral fill so the row still
+        // renders and the operator can read the topic.
+        ![
+          "event_bus",
+          "verification",
+          "state",
+          "lineage",
+          "schedule",
+        ].includes(source as string) && "bg-[color:rgba(17,19,21,0.06)] text-[var(--avy-ink)]"
+      )}
+      style={{ letterSpacing: "0.08em" }}
+    >
+      {String(source).replace(/_/g, " ")}
+    </span>
+  );
+}
+
+function formatTimestamp(iso: string | undefined): string {
+  if (!iso) return "—";
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return iso;
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).format(t);
+}
+
+// Re-export the empty constant for callers that want to render a
+// stable shape during SSR / first paint.
+export { EMPTY_JOB_TIMELINE };

--- a/app/components/runs/LoadedRunView.tsx
+++ b/app/components/runs/LoadedRunView.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { mutate } from "swr";
 import { LoadedRunPanel } from "./LoadedRunPanel";
 import { LifecycleRail } from "./LifecycleRail";
+import { JobTimelinePanel } from "./JobTimelinePanel";
 import { LifecycleActionBar } from "./LifecycleActionBar";
 import { RunSemanticBlock } from "./RunSemanticBlock";
 import {
@@ -768,6 +769,14 @@ export function LoadedRunView({
           }}
         />
       ) : null}
+
+      {/* Job timeline (PR #149) — full chronological log of every
+       *  event the backend has stitched for this job: state
+       *  transitions, verifier outcomes, child-run lineage, recurring
+       *  derivatives, raw event-bus rows. Only on the standalone
+       *  detail page (showLifecycle === true); the queue page already
+       *  has the rail above the sticky pane. */}
+      {showLifecycle ? <JobTimelinePanel jobId={loadedRow.id} /> : null}
 
       <ReceiptPreviewDrawer
         open={receiptOpen}

--- a/app/lib/api/hooks.ts
+++ b/app/lib/api/hooks.ts
@@ -77,6 +77,21 @@ export const usePublicProviderOperations = () =>
  */
 export const useAdminJobs = () =>
   useApi("/admin/jobs", { refreshInterval: 15_000 });
+
+/**
+ * Stitched job timeline (PR #149) — claim state + sessions +
+ * verification + child-run lineage + recurring derivatives +
+ * event-bus events for one job. Powers the JobTimelinePanel under
+ * /runs/detail. Skips the fetch when no jobId is selected so the
+ * panel doesn't 400 on first paint.
+ */
+export const useJobTimeline = (jobId: string | null) =>
+  useApi(
+    jobId
+      ? `/admin/jobs/timeline?jobId=${encodeURIComponent(jobId)}&limit=100`
+      : null,
+    { refreshInterval: 15_000 }
+  );
 export const useOnboarding = () => useApi("/onboarding");
 export const useVerifierHandlers = () => useApi("/verifier/handlers");
 export const useSessionStateMachine = () => useApi("/session/state-machine");

--- a/app/lib/api/job-timeline.ts
+++ b/app/lib/api/job-timeline.ts
@@ -1,0 +1,312 @@
+/**
+ * Adapter for `GET /admin/jobs/timeline?jobId=...` (PR #149).
+ *
+ * The endpoint stitches claim state + sessions + verification +
+ * child-job lineage + recurring derivatives + event-bus events into a
+ * single chronologically-sorted entry list. Each entry follows the v2
+ * envelope from PR #158:
+ *
+ *   { id, type, at, correlationId, phase, source, topic, severity,
+ *     jobId, sessionId, wallet, data }
+ *
+ * The catalog `LifecycleRail` already shows the 5-stage at-a-glance
+ * (Ready → Claimed → Submitted → Verified → Paid). The frontend hook
+ * for this endpoint is the source for a richer "everything that
+ * happened to this job" panel that surfaces the rail's missing
+ * detail: child runs, recurring derivatives, raw event-bus events,
+ * verifier reason codes.
+ */
+
+export type TimelineSeverity = "info" | "warn" | "error";
+
+export type TimelineSource =
+  | "state"
+  | "verification"
+  | "event_bus"
+  | "lineage"
+  | "schedule"
+  // Anything else the backend adds later — we still render the row
+  // with a generic chip rather than dropping the entry.
+  | (string & {});
+
+export interface TimelineEntry {
+  id: string;
+  /** Coarse classifier — `job_state`, `session_transition`, `verification`,
+   *  `child_job`, `derivative_job`, `event_bus`, `session_snapshot`. */
+  type: string;
+  /** ISO timestamp; may be undefined for entries the backend can't
+   *  date-stamp yet. Renders as "—" in that case. */
+  at?: string;
+  correlationId?: string;
+  phase?: string;
+  source: TimelineSource;
+  topic?: string;
+  severity: TimelineSeverity;
+  jobId?: string;
+  sessionId?: string;
+  wallet?: string;
+  /** Free-form structured data shaped by the entry type. The panel
+   *  surfaces the most useful keys per entry kind without locking the
+   *  shape down — new fields land additively. */
+  data: Record<string, unknown>;
+}
+
+export interface TimelineLineage {
+  templateId: string | null;
+  recurringTemplate: boolean;
+  derivativeJobIds: string[];
+  parentSessionId: string | null;
+  parentSession: {
+    sessionId: string;
+    jobId: string;
+    wallet: string;
+    status: string;
+    updatedAt?: string;
+  } | null;
+  sessionIds: string[];
+  childJobIds: string[];
+  childSessionIds: string[];
+}
+
+export interface TimelineSummary {
+  sessionCount: number;
+  activeSessionIds: string[];
+  terminalSessionIds: string[];
+  childJobCount: number;
+  derivativeJobCount: number;
+  eventCount: number;
+  eventBusGap: boolean;
+  latestSessionStatus: string | null;
+}
+
+export interface JobTimeline {
+  timelineVersion: string;
+  /** Snapshot of the job document at fetch time (publicDetails,
+   *  lifecycle, claim state). Useful for context the panel may show
+   *  alongside the entry list. */
+  job: Record<string, unknown> | null;
+  lineage: TimelineLineage;
+  summary: TimelineSummary;
+  timeline: TimelineEntry[];
+}
+
+export const EMPTY_JOB_TIMELINE: JobTimeline = {
+  timelineVersion: "0",
+  job: null,
+  lineage: {
+    templateId: null,
+    recurringTemplate: false,
+    derivativeJobIds: [],
+    parentSessionId: null,
+    parentSession: null,
+    sessionIds: [],
+    childJobIds: [],
+    childSessionIds: [],
+  },
+  summary: {
+    sessionCount: 0,
+    activeSessionIds: [],
+    terminalSessionIds: [],
+    childJobCount: 0,
+    derivativeJobCount: 0,
+    eventCount: 0,
+    eventBusGap: false,
+    latestSessionStatus: null,
+  },
+  timeline: [],
+};
+
+export function buildJobTimeline(payload: unknown): JobTimeline {
+  const root = asRecord(payload);
+  if (!root) return EMPTY_JOB_TIMELINE;
+
+  const lineage = asRecord(root.lineage) ?? {};
+  const summary = asRecord(root.summary) ?? {};
+  const timelineRaw = Array.isArray(root.timeline) ? root.timeline : [];
+
+  return {
+    timelineVersion: text(root.timelineVersion, "0"),
+    job: asRecord(root.job),
+    lineage: {
+      templateId: text(lineage.templateId) || null,
+      recurringTemplate: Boolean(lineage.recurringTemplate),
+      derivativeJobIds: stringArray(lineage.derivativeJobIds),
+      parentSessionId: text(lineage.parentSessionId) || null,
+      parentSession: parentSessionFor(lineage.parentSession),
+      sessionIds: stringArray(lineage.sessionIds),
+      childJobIds: stringArray(lineage.childJobIds),
+      childSessionIds: stringArray(lineage.childSessionIds),
+    },
+    summary: {
+      sessionCount: nonNegInt(summary.sessionCount),
+      activeSessionIds: stringArray(summary.activeSessionIds),
+      terminalSessionIds: stringArray(summary.terminalSessionIds),
+      childJobCount: nonNegInt(summary.childJobCount),
+      derivativeJobCount: nonNegInt(summary.derivativeJobCount),
+      eventCount: nonNegInt(summary.eventCount),
+      eventBusGap: Boolean(summary.eventBusGap),
+      latestSessionStatus: text(summary.latestSessionStatus) || null,
+    },
+    timeline: timelineRaw
+      .map(buildTimelineEntry)
+      .filter((entry): entry is TimelineEntry => entry !== null),
+  };
+}
+
+function buildTimelineEntry(raw: unknown): TimelineEntry | null {
+  const record = asRecord(raw);
+  if (!record) return null;
+  const id = text(record.id);
+  if (!id) return null;
+  return {
+    id,
+    type: text(record.type, "event"),
+    ...(text(record.at) ? { at: text(record.at) } : {}),
+    ...(text(record.correlationId)
+      ? { correlationId: text(record.correlationId) }
+      : {}),
+    ...(text(record.phase) ? { phase: text(record.phase) } : {}),
+    source: parseSource(record.source),
+    ...(text(record.topic) ? { topic: text(record.topic) } : {}),
+    severity: parseSeverity(record.severity),
+    ...(text(record.jobId) ? { jobId: text(record.jobId) } : {}),
+    ...(text(record.sessionId) ? { sessionId: text(record.sessionId) } : {}),
+    ...(text(record.wallet) ? { wallet: text(record.wallet) } : {}),
+    data: asRecord(record.data) ?? {},
+  };
+}
+
+function parseSeverity(value: unknown): TimelineSeverity {
+  if (value === "warn" || value === "error") return value;
+  return "info";
+}
+
+function parseSource(value: unknown): TimelineSource {
+  if (typeof value !== "string" || !value.trim()) return "state";
+  return value.trim();
+}
+
+function parentSessionFor(value: unknown): TimelineLineage["parentSession"] {
+  const record = asRecord(value);
+  if (!record) return null;
+  const sessionId = text(record.sessionId);
+  const jobId = text(record.jobId);
+  const wallet = text(record.wallet);
+  const status = text(record.status);
+  if (!sessionId || !jobId) return null;
+  return {
+    sessionId,
+    jobId,
+    wallet,
+    status,
+    ...(text(record.updatedAt) ? { updatedAt: text(record.updatedAt) } : {}),
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function text(value: unknown, fallback = ""): string {
+  if (typeof value !== "string") return fallback;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : fallback;
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter((entry): entry is string => entry.length > 0);
+}
+
+function nonNegInt(value: unknown): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.floor(n);
+}
+
+/**
+ * Human label for a timeline entry. The backend keeps `type` /
+ * `topic` in machine form; the panel renders this label as the row's
+ * primary text. Falls through to `type` when we don't recognise the
+ * combination so a new event type lands additively.
+ */
+export function describeTimelineEntry(entry: TimelineEntry): string {
+  switch (entry.type) {
+    case "job_state":
+      return "Job state";
+    case "session_snapshot":
+      return entry.data.status
+        ? `Session ${entry.data.status}`
+        : "Session snapshot";
+    case "session_transition":
+      return entry.data.to
+        ? `Session → ${entry.data.to}`
+        : entry.data.status
+          ? `Session ${entry.data.status}`
+          : "Session transition";
+    case "verification":
+      return entry.data.outcome
+        ? `Verifier ${entry.data.outcome}`
+        : "Verifier resolved";
+    case "child_job":
+      return "Child job created";
+    case "derivative_job":
+      return "Recurring derivative";
+    case "event_bus":
+      return entry.topic ?? "Event";
+    default:
+      return entry.topic ?? entry.type;
+  }
+}
+
+/**
+ * Compact "secondary" string for the row — typically the most useful
+ * detail beyond the headline label (e.g. handler version, reason
+ * code, child job id). Returns empty string when nothing to add.
+ */
+export function describeTimelineDetail(entry: TimelineEntry): string {
+  const parts: string[] = [];
+  const data = entry.data;
+  switch (entry.type) {
+    case "verification":
+      if (typeof data.handler === "string") parts.push(data.handler);
+      if (typeof data.reasonCode === "string") parts.push(data.reasonCode);
+      break;
+    case "session_transition":
+      if (typeof data.from === "string" && typeof data.to === "string") {
+        parts.push(`${data.from} → ${data.to}`);
+      }
+      break;
+    case "child_job":
+      if (typeof data.childJobId === "string") parts.push(data.childJobId);
+      break;
+    case "derivative_job":
+      if (typeof data.derivativeJobId === "string")
+        parts.push(data.derivativeJobId);
+      break;
+    case "event_bus":
+      if (typeof data.txHash === "string") parts.push(data.txHash);
+      else if (typeof data.blockNumber === "number")
+        parts.push(`block ${data.blockNumber}`);
+      break;
+    case "job_state":
+      if (typeof data.effectiveState === "string")
+        parts.push(`state: ${data.effectiveState}`);
+      else if (typeof data.claimState === "string")
+        parts.push(`state: ${data.claimState}`);
+      break;
+  }
+  if (entry.sessionId && entry.type !== "job_state") {
+    parts.push(shortId(entry.sessionId));
+  }
+  return parts.join(" · ");
+}
+
+function shortId(value: string): string {
+  if (value.length <= 12) return value;
+  return `${value.slice(0, 6)}…${value.slice(-4)}`;
+}


### PR DESCRIPTION
First of three follow-ups against backend work that landed but hadn't been wired into the operator app.

## What
Wires \`GET /admin/jobs/timeline?jobId=...\` (PR #149) into a new panel on \`/runs/detail\`. The endpoint stitches claim state, sessions, verification outcomes, child-run lineage, recurring derivatives, and event-bus events into one chronologically-sorted entry list. Today \`/runs/detail\` only showed the 5-stage \`LifecycleRail\` (Ready → Claimed → Submitted → Verified → Paid), which is a thin slice of the same idea.

- **\`app/lib/api/job-timeline.ts\`** — types + \`buildJobTimeline\` parser for the v2 envelope (PR #158: \`source\`, \`topic\`, \`severity\`, \`type\`, \`phase\`, \`correlationId\`, ids, \`data\`). Drops malformed rows defensively, permissive on unknown source/severity values.
- **\`describeTimelineEntry\` / \`describeTimelineDetail\`** — per-kind labels: verifier handler + reason code, from → to transitions, child/derivative ids, txHash / blockNumber for event-bus rows.
- **\`useJobTimeline(jobId)\`** — admin hook, 15s refresh, skips fetch when no jobId.
- **\`JobTimelinePanel\`** — vertical event log with severity dot, source chip (state / verification / event_bus / lineage / schedule), topic, per-kind detail. Compact summary header (\"3 sessions · 1 child\"). Empty state distinguishes signed-out / loading / quiet. Surfaces \`eventBusGap\` from the backend.
- **\`LoadedRunView\`** renders the panel below \`LifecycleRail\` on the standalone detail page only (\`showLifecycle === true\`); queue page keeps the at-a-glance rail.

## Test plan
- [x] \`npm run typecheck:app\`
- [x] \`npm run build:frontend\`
- [ ] After deploy, signed-in: load \`/runs/detail/?id=wiki-en-58158792-citation-repair-r5\` and expect to see claim/session events, verifier resolution, and any event-bus rows from the live job. Signed-out: empty-state row prompts sign-in.

## What's next
- Capability matrix (PR #159) → drive disabled hints on operator buttons
- Lifecycle rail severity coloring from v2 envelope (PR #158) — separate, smaller PR