### PR TITLE
Capability-aware operator buttons (auth-policy-v1)

### DIFF
--- a/app/components/overview/RecurringRuntimeCard.tsx
+++ b/app/components/overview/RecurringRuntimeCard.tsx
@@ -1,11 +1,17 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import { Flame, Pause, Play, RotateCw } from "lucide-react";
 import { mutate } from "swr";
 import { SectionHead } from "./SectionHead";
 import { swrFetcher } from "@/lib/api/client";
+import { useAuthSession } from "@/lib/api/hooks";
+import {
+  buildAuthSession,
+  canUseControl,
+  type ControlGate,
+} from "@/lib/auth/capabilities";
 import {
   postRecurringTemplateAction,
   refreshRecurringTemplateSurfaces,
@@ -15,6 +21,17 @@ import {
   type RecurringTemplateStatus,
 } from "@/lib/api/recurring-jobs";
 import { cn } from "@/lib/utils/cn";
+
+/**
+ * Per-action capability mapping. Matches the keys the backend
+ * declares in `capabilityMatrix.uiControls` so each button gates on
+ * exactly the capability the matching admin endpoint requires.
+ */
+const ACTION_CONTROL: Record<RecurringTemplateAction, string> = {
+  pause: "admin.jobs.pauseRecurring",
+  resume: "admin.jobs.resumeRecurring",
+  fire: "admin.jobs.fireRecurring",
+};
 
 export interface RecurringRuntimeCardProps {
   runtime: RecurringRuntimeSummary;
@@ -51,6 +68,16 @@ export function RecurringRuntimeCard({ runtime }: RecurringRuntimeCardProps) {
 function RecurringTemplateRow({ template }: { template: RecurringTemplateStatus }) {
   const [pending, setPending] = useState<RecurringTemplateAction | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const sessionRequest = useAuthSession();
+  const session = useMemo(
+    () => buildAuthSession(sessionRequest.data),
+    [sessionRequest.data]
+  );
+  const gates: Record<RecurringTemplateAction, ControlGate> = {
+    pause: canUseControl(session, ACTION_CONTROL.pause),
+    resume: canUseControl(session, ACTION_CONTROL.resume),
+    fire: canUseControl(session, ACTION_CONTROL.fire),
+  };
   const reserve = template.reserve;
   const finiteReserve = reserve.mode === "finite" && reserve.reserveAmount !== undefined;
   const fillPct =
@@ -144,6 +171,8 @@ function RecurringTemplateRow({ template }: { template: RecurringTemplateStatus 
             action="resume"
             label="Resume"
             pending={pending}
+            disabled={!gates.resume.allowed}
+            disabledReason={gates.resume.reason}
             icon={<Play size={13} />}
             onClick={() => onAction("resume")}
           />
@@ -152,6 +181,8 @@ function RecurringTemplateRow({ template }: { template: RecurringTemplateStatus 
             action="pause"
             label="Pause"
             pending={pending}
+            disabled={!gates.pause.allowed}
+            disabledReason={gates.pause.reason}
             icon={<Pause size={13} />}
             onClick={() => onAction("pause")}
           />
@@ -160,7 +191,14 @@ function RecurringTemplateRow({ template }: { template: RecurringTemplateStatus 
           action="fire"
           label="Fire"
           pending={pending}
-          disabled={template.paused || template.exhausted}
+          disabled={template.paused || template.exhausted || !gates.fire.allowed}
+          disabledReason={
+            template.paused
+              ? "Resume the template first"
+              : template.exhausted
+                ? "Reserve exhausted"
+                : gates.fire.reason
+          }
           icon={<Flame size={13} />}
           onClick={() => onAction("fire")}
         />
@@ -212,6 +250,7 @@ function ActionButton({
   label,
   pending,
   disabled = false,
+  disabledReason,
   icon,
   onClick,
 }: {
@@ -219,6 +258,10 @@ function ActionButton({
   label: string;
   pending: RecurringTemplateAction | null;
   disabled?: boolean;
+  /** Human-readable hint shown on hover when the button is disabled.
+   *  Capability-gate reasons surface here so the operator knows why
+   *  the action isn't available. */
+  disabledReason?: string;
   icon: ReactNode;
   onClick: () => void;
 }) {
@@ -228,10 +271,11 @@ function ActionButton({
       type="button"
       onClick={onClick}
       disabled={pending !== null || disabled}
+      title={disabled ? disabledReason : undefined}
       className={cn(
         "inline-flex h-8 items-center gap-1.5 rounded-full border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-2.5 font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase text-[var(--avy-ink)] transition-colors",
         "hover:border-[color:rgba(30,102,66,0.35)] hover:text-[var(--avy-accent)]",
-        "disabled:cursor-not-allowed disabled:opacity-50",
+        "disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-[var(--avy-line)] disabled:hover:text-[var(--avy-ink)]",
         active && "text-[var(--avy-accent)]"
       )}
       style={{ letterSpacing: "0.08em" }}

--- a/app/components/runs/LifecycleActionBar.tsx
+++ b/app/components/runs/LifecycleActionBar.tsx
@@ -1,8 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { mutate } from "swr";
 import { swrFetcher } from "@/lib/api/client";
+import { useAuthSession } from "@/lib/api/hooks";
+import {
+  buildAuthSession,
+  canUseControl,
+} from "@/lib/auth/capabilities";
 import {
   availableActions,
   formatLifecycleLabel,
@@ -30,6 +35,15 @@ export interface LifecycleActionBarProps {
 export function LifecycleActionBar({ jobId, lifecycle }: LifecycleActionBarProps) {
   const [pending, setPending] = useState<JobLifecycleAction | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const sessionRequest = useAuthSession();
+  const session = useMemo(
+    () => buildAuthSession(sessionRequest.data),
+    [sessionRequest.data]
+  );
+  // All four lifecycle actions go through the same `admin.jobs.lifecycle`
+  // UI control on the backend's capability matrix — one gate covers
+  // Pause / Archive / Reopen / Mark stale.
+  const gate = canUseControl(session, "admin.jobs.lifecycle");
 
   if (!lifecycle) return null;
 
@@ -79,11 +93,12 @@ export function LifecycleActionBar({ jobId, lifecycle }: LifecycleActionBarProps
             key={action}
             type="button"
             onClick={() => onClick(action)}
-            disabled={pending !== null}
+            disabled={pending !== null || !gate.allowed}
+            title={gate.reason}
             className={cn(
               "rounded-full border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-2.5 py-1 font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase transition-colors",
               "hover:border-[color:rgba(30,102,66,0.35)] hover:text-[var(--avy-accent)]",
-              "disabled:opacity-50 disabled:cursor-not-allowed",
+              "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:border-[var(--avy-line)] disabled:hover:text-current",
               pending === action && "text-[var(--avy-accent)]"
             )}
             style={{ letterSpacing: "0.08em" }}
@@ -93,6 +108,14 @@ export function LifecycleActionBar({ jobId, lifecycle }: LifecycleActionBarProps
         ))}
       </div>
 
+      {!gate.allowed && gate.reason ? (
+        <span
+          className="basis-full font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
+          style={{ letterSpacing: 0 }}
+        >
+          {gate.reason}
+        </span>
+      ) : null}
       {error ? (
         <span className="basis-full font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-warn)]">
           {error}

--- a/app/lib/api/hooks.ts
+++ b/app/lib/api/hooks.ts
@@ -24,6 +24,19 @@ export function useApi<T = unknown>(
 // backend doesn't yet emit full schemas. Claude Design's handoff and later
 // passes can narrow these as the UI settles.
 export const useAccount = () => useApi("/account");
+
+/**
+ * Resolved auth session — the signed-in wallet's effective roles +
+ * capabilities + the platform's capability matrix from PR #159. Used
+ * by the operator app to gate buttons before the user clicks (so a
+ * viewer without `jobs:lifecycle` sees disabled Pause/Archive/Reopen
+ * with a hint instead of clicking and getting a 403).
+ *
+ * 401s don't auto-retry (the `useApi` guard already handles that);
+ * consumers treat undefined data as "unauthenticated" and render
+ * gates as disabled.
+ */
+export const useAuthSession = () => useApi("/auth/session");
 export const useBorrowCapacity = (asset?: string) =>
   useApi(asset ? `/account/borrow-capacity?asset=${encodeURIComponent(asset)}` : "/account/borrow-capacity");
 export const useStrategyPositions = () => useApi("/account/strategies");

--- a/app/lib/auth/capabilities.ts
+++ b/app/lib/auth/capabilities.ts
@@ -1,0 +1,158 @@
+/**
+ * Auth-policy v1 (PR #159) adapter for the operator app.
+ *
+ * The backend exposes the platform's full capability matrix via
+ * `GET /auth/session`:
+ *
+ *   {
+ *     wallet, roles, capabilities,
+ *     capabilityMatrix: {
+ *       version, base, roles, routes, routeRules,
+ *       uiControls: { "<control-name>": ["<required-cap>", ...] },
+ *       automationActions: { ... }
+ *     }
+ *   }
+ *
+ * The operator app uses this to disable buttons whose required
+ * capabilities the signed-in viewer doesn't hold — so a viewer
+ * without `jobs:lifecycle` sees Pause/Archive/Reopen rendered
+ * disabled with a "you don't have this capability" hint, instead
+ * of clicking and getting a 403 from the backend.
+ */
+
+export interface CapabilityMatrix {
+  version: string;
+  base: string[];
+  roles: Record<string, string[]>;
+  uiControls: Record<string, string[]>;
+  automationActions: Record<string, string[]>;
+}
+
+export interface AuthSession {
+  wallet: string;
+  roles: string[];
+  capabilities: string[];
+  capabilityMatrix: CapabilityMatrix;
+}
+
+/** Parse the `/auth/session` payload. Returns `undefined` for missing
+ *  / malformed responses so callers can treat "unauthenticated" and
+ *  "not loaded yet" the same way. */
+export function buildAuthSession(payload: unknown): AuthSession | undefined {
+  const root = asRecord(payload);
+  if (!root) return undefined;
+  const wallet = text(root.wallet);
+  if (!wallet) return undefined;
+  const matrix = buildCapabilityMatrix(root.capabilityMatrix);
+  return {
+    wallet,
+    roles: stringArray(root.roles),
+    capabilities: stringArray(root.capabilities),
+    capabilityMatrix: matrix,
+  };
+}
+
+function buildCapabilityMatrix(raw: unknown): CapabilityMatrix {
+  const record = asRecord(raw);
+  if (!record) {
+    return {
+      version: "0",
+      base: [],
+      roles: {},
+      uiControls: {},
+      automationActions: {},
+    };
+  }
+  return {
+    version: text(record.version, "0"),
+    base: stringArray(record.base),
+    roles: stringMap(record.roles),
+    uiControls: stringMap(record.uiControls),
+    automationActions: stringMap(record.automationActions),
+  };
+}
+
+export interface ControlGate {
+  /** True when the viewer can fire this control. False when missing
+   *  capabilities (or when the session itself isn't loaded yet). */
+  allowed: boolean;
+  /** Capabilities the control needs (from the matrix). Empty array
+   *  for unknown controls — those are treated as allowed by default
+   *  so a new control name doesn't silently break. */
+  required: string[];
+  /** Capabilities the viewer is missing relative to `required`. */
+  missing: string[];
+  /** Human-readable hint suitable for a button's `title` attribute. */
+  reason?: string;
+}
+
+/**
+ * Decide whether the current viewer can use a control.
+ *
+ * `controlName` matches a key in `capabilityMatrix.uiControls`
+ * (e.g. `admin.jobs.lifecycle`, `admin.jobs.fireRecurring`). Unknown
+ * control names default to allowed — the matrix is the source of
+ * truth and an unmapped control means there's no gate to enforce.
+ */
+export function canUseControl(
+  session: AuthSession | undefined,
+  controlName: string
+): ControlGate {
+  if (!session) {
+    return {
+      allowed: false,
+      required: [],
+      missing: [],
+      reason: "Sign in to enable operator actions",
+    };
+  }
+  const required = session.capabilityMatrix.uiControls[controlName] ?? [];
+  if (required.length === 0) {
+    // No mapping → no gate. Lets new controls land additively.
+    return { allowed: true, required: [], missing: [] };
+  }
+  const have = new Set(session.capabilities);
+  const missing = required.filter((cap) => !have.has(cap));
+  if (missing.length === 0) {
+    return { allowed: true, required, missing: [] };
+  }
+  return {
+    allowed: false,
+    required,
+    missing,
+    reason: `Missing capability: ${missing.join(", ")}`,
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function text(value: unknown, fallback = ""): string {
+  if (typeof value !== "string") return fallback;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : fallback;
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const out: string[] = [];
+  for (const entry of value) {
+    if (typeof entry === "string" && entry.trim().length > 0) {
+      out.push(entry.trim());
+    }
+  }
+  return out;
+}
+
+function stringMap(value: unknown): Record<string, string[]> {
+  const record = asRecord(value);
+  if (!record) return {};
+  const out: Record<string, string[]> = {};
+  for (const [key, raw] of Object.entries(record)) {
+    out[key] = stringArray(raw);
+  }
+  return out;
+}


### PR DESCRIPTION
Second of three follow-ups against backend work that landed without UI wiring. (#1 was PR #167's job timeline panel.)

## Why
PR #159 added a versioned auth-policy-v1 capability matrix and exposed it on \`GET /auth/session\` along with the signed-in viewer's effective capabilities. The operator app wasn't reading it — Pause / Archive / Mark stale / Reopen buttons on \`/runs/detail\` and Resume / Pause / Fire buttons on the recurring-runtime panel always rendered enabled. A viewer without the right capability clicked, the backend 403'd, and the UI surfaced a generic \"Could not …\" message.

## What
- **\`app/lib/auth/capabilities.ts\`** — types + \`buildAuthSession\` parser for the \`/auth/session\` payload + \`canUseControl(session, controlName)\` helper that returns \`{ allowed, required, missing, reason }\`. Unknown control names default to allowed so new UI controls can land additively.
- **\`useAuthSession()\`** hook hits \`/auth/session\` (admin endpoint). 401s don't auto-retry; consumers treat undefined data as unauthenticated and render gates disabled.
- **\`LifecycleActionBar\`** — all four lifecycle actions go through \`admin.jobs.lifecycle\` on the matrix. One gate drives both the disabled flag and the per-button title; an inline hint line under the bar surfaces the reason without hovering.
- **\`RecurringRuntimeCard\`** — Pause / Resume / Fire each gate on their own UI control (\`admin.jobs.pauseRecurring\`, \`...resumeRecurring\`, \`...fireRecurring\`). Existing template-state guards (paused, exhausted) compose with capability gates — template-state messages win when both apply since they're more actionable.

## Defer
- Capability-aware Submit button on \`/runs/detail\` (already has richer disabledReason from claim state per PR #145; folding capability gating into that branch wants a separate small PR to make sure the overlap reads right).
- Visible role badge on the operator topbar. Matrix is now threaded — we can surface a \"operator · admin\" pill in a follow-up if the team wants it.

## Test plan
- [x] \`npm run typecheck:app\`
- [x] \`npm run build:frontend\`
- [ ] Signed-out: lifecycle bar + recurring buttons render disabled with \"Sign in to enable operator actions\".
- [ ] Signed-in non-admin: buttons render disabled with \"Missing capability: jobs:lifecycle\" (or matching).
- [ ] Signed-in admin: buttons enabled, fire actions as before.