### PR TITLE
Lifecycle rail severity tint from v2 timeline envelope

### DIFF
--- a/app/app/(authed)/runs/page.tsx
+++ b/app/app/(authed)/runs/page.tsx
@@ -23,8 +23,9 @@ import {
   describeClaimer,
   formatDeadline,
 } from "@/components/runs/buildLifecycleStages";
-import { useAdminJobs, useJobs, useRecommendations } from "@/lib/api/hooks";
+import { useAdminJobs, useJobs, useJobTimeline, useRecommendations } from "@/lib/api/hooks";
 import { freshnessFromRequests } from "@/components/shell/DataFreshnessPill";
+import { buildJobTimeline } from "@/lib/api/job-timeline";
 import {
   buildRecommendationCards,
   buildRunFilters,
@@ -183,6 +184,14 @@ function RunsPageInner() {
   // verification path and implies a direct GitHub flow that doesn't
   // exist for that run.
   const selectedRow = rows.find((row) => row.id === selectedId) ?? rows[0];
+  // Pull the v2 timeline for the selected row so the rail below can
+  // tint stages with severity overlays. SWR shares the fetch with the
+  // sticky LoadedRunView pane (same key) so this is free.
+  const timelineRequest = useJobTimeline(selectedRow?.id ?? null);
+  const selectedTimeline = useMemo(
+    () => buildJobTimeline(timelineRequest.data),
+    [timelineRequest.data]
+  );
   // One source-of-truth narrow on `selectedRow.source`. The lifecycle
   // copy below switches on `selectedSource?.type` and TS narrows to the
   // right per-source field set inside each branch — no per-source
@@ -331,6 +340,7 @@ function RunsPageInner() {
         stages={buildLifecycleStages({
           claim: selectedRow?.claim,
           source: selectedSource,
+          timeline: selectedTimeline.timeline,
         })}
         next={lifecycleNext}
       />

--- a/app/components/runs/LifecycleRail.tsx
+++ b/app/components/runs/LifecycleRail.tsx
@@ -1,12 +1,23 @@
 import { cn } from "@/lib/utils/cn";
 
 export type StageState = "done" | "current" | "pending";
+/**
+ * Optional severity overlay derived from the v2 timeline envelope
+ * (PR #158). When the timeline carries a `warn`/`error` event tied
+ * to a stage (e.g. verification rejected, claim disputed), the
+ * builder sets `tone: "warn"` on that stage and the rail renders
+ * the dot/label in the warn palette without changing the stage's
+ * primary `state` (Submitted-but-warn still reads as Submitted-done,
+ * just colored to flag the issue).
+ */
+export type StageTone = "ok" | "warn" | "error";
 
 export interface LifecycleStage {
   index: number;
   label: string;
   meta: string;
   state: StageState;
+  tone?: StageTone;
 }
 
 export interface LifecycleRailProps {
@@ -76,18 +87,50 @@ function Stage({ stage }: { stage: LifecycleStage }) {
       <div
         className={cn(
           "grid h-7 w-7 place-items-center rounded-full border-2 bg-[var(--avy-paper-solid)] font-[family-name:var(--font-mono)] text-xs font-semibold transition-all",
-          stage.state === "pending" &&
-            "border-[color:rgba(17,19,21,0.18)] text-[var(--avy-muted)]",
-          stage.state === "done" &&
-            "border-[var(--avy-accent)] bg-[var(--avy-accent)] text-[#fffdf7]",
-          stage.state === "current" &&
-            "border-[var(--avy-accent)] text-[var(--avy-accent)] shadow-[0_0_0_5px_rgba(30,102,66,0.14)]"
+          // Default tone — keep the existing accent palette.
+          (!stage.tone || stage.tone === "ok") && [
+            stage.state === "pending" &&
+              "border-[color:rgba(17,19,21,0.18)] text-[var(--avy-muted)]",
+            stage.state === "done" &&
+              "border-[var(--avy-accent)] bg-[var(--avy-accent)] text-[#fffdf7]",
+            stage.state === "current" &&
+              "border-[var(--avy-accent)] text-[var(--avy-accent)] shadow-[0_0_0_5px_rgba(30,102,66,0.14)]",
+          ],
+          // Warn tone — amber dot regardless of state. Flags a
+          // soft-rejection / dispute / verifier-flag against this
+          // stage without changing whether the stage is "done".
+          stage.tone === "warn" && [
+            stage.state === "pending" &&
+              "border-[color:rgba(167,97,34,0.4)] text-[var(--avy-warn)]",
+            stage.state === "done" &&
+              "border-[var(--avy-warn)] bg-[var(--avy-warn)] text-[#fffdf7]",
+            stage.state === "current" &&
+              "border-[var(--avy-warn)] text-[var(--avy-warn)] shadow-[0_0_0_5px_rgba(167,97,34,0.18)]",
+          ],
+          // Error tone — same warn shape but with a deeper red ring
+          // when the backend marks a hard failure (verifier rejected,
+          // session slashed, etc.).
+          stage.tone === "error" && [
+            stage.state === "pending" &&
+              "border-[#a0322a]/60 text-[#a0322a]",
+            stage.state === "done" &&
+              "border-[#a0322a] bg-[#a0322a] text-[#fffdf7]",
+            stage.state === "current" &&
+              "border-[#a0322a] text-[#a0322a] shadow-[0_0_0_5px_rgba(160,50,42,0.18)]",
+          ]
         )}
         style={{ letterSpacing: 0 }}
+        title={
+          stage.tone === "warn"
+            ? "Warning recorded against this stage — see the timeline panel for the event"
+            : stage.tone === "error"
+              ? "Error recorded against this stage — see the timeline panel for the event"
+              : undefined
+        }
       >
         {stage.state === "done" ? (
           <span className="font-[family-name:var(--font-display)] text-sm font-extrabold">
-            ✓
+            {stage.tone === "warn" || stage.tone === "error" ? "!" : "✓"}
           </span>
         ) : (
           stage.index
@@ -96,11 +139,15 @@ function Stage({ stage }: { stage: LifecycleStage }) {
       <div
         className={cn(
           "text-center font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase",
-          stage.state === "current"
-            ? "text-[var(--avy-accent)]"
-            : stage.state === "done"
-              ? "text-[var(--avy-ink)]"
-              : "text-[var(--avy-muted)]"
+          stage.tone === "warn"
+            ? "text-[var(--avy-warn)]"
+            : stage.tone === "error"
+              ? "text-[#a0322a]"
+              : stage.state === "current"
+                ? "text-[var(--avy-accent)]"
+                : stage.state === "done"
+                  ? "text-[var(--avy-ink)]"
+                  : "text-[var(--avy-muted)]"
         )}
         style={{ letterSpacing: "0.1em" }}
       >
@@ -109,7 +156,13 @@ function Stage({ stage }: { stage: LifecycleStage }) {
       <div
         className={cn(
           "font-[family-name:var(--font-mono)] text-[10.5px]",
-          stage.state === "current" ? "text-[var(--avy-accent)]" : "text-[var(--avy-muted)]"
+          stage.tone === "warn"
+            ? "text-[var(--avy-warn)]"
+            : stage.tone === "error"
+              ? "text-[#a0322a]"
+              : stage.state === "current"
+                ? "text-[var(--avy-accent)]"
+                : "text-[var(--avy-muted)]"
         )}
         style={{ letterSpacing: 0 }}
       >

--- a/app/components/runs/LoadedRunView.tsx
+++ b/app/components/runs/LoadedRunView.tsx
@@ -23,7 +23,9 @@ import {
   useJobDefinition,
   useJobPreflight,
   useJobs,
+  useJobTimeline,
 } from "@/lib/api/hooks";
+import { buildJobTimeline } from "@/lib/api/job-timeline";
 import {
   buildGitHubContext,
   buildOpenDataContext,
@@ -79,6 +81,15 @@ export function LoadedRunView({
 }: LoadedRunViewProps) {
   const jobs = useJobs();
   const adminJobs = useAdminJobs();
+  // The timeline panel below the rail already fetches this; SWR
+  // dedupes by URL key so calling the hook here is free and lets
+  // the rail tint stages from the same v2-envelope severity events
+  // the panel renders.
+  const timelineRequest = useJobTimeline(runId);
+  const timelineData = useMemo(
+    () => buildJobTimeline(timelineRequest.data),
+    [timelineRequest.data]
+  );
   // Prefer the admin job feed (carries lifecycle metadata + paused/
   // archived/stale rows). Fall back to the public feed until the admin
   // payload arrives so we don't render an empty panel on first paint.
@@ -749,6 +760,7 @@ export function LoadedRunView({
           stages={buildLifecycleStages({
             claim: loadedRow.claim,
             source: loadedRow.source,
+            timeline: timelineData.timeline,
           })}
           next={{
             label: "Next",

--- a/app/components/runs/buildLifecycleStages.ts
+++ b/app/components/runs/buildLifecycleStages.ts
@@ -12,9 +12,10 @@
  * provenance — same split as the FIXTURE_LIFECYCLE_* variants.
  */
 
-import type { LifecycleStage } from "./LifecycleRail";
+import type { LifecycleStage, StageTone } from "./LifecycleRail";
 import type { JobSource } from "./types";
 import type { ClaimEffectiveState, ClaimSummary } from "@/lib/api/claim-status";
+import type { TimelineEntry } from "@/lib/api/job-timeline";
 
 interface BuildArgs {
   /** Live claim state from the loaded row. Optional so we can still
@@ -25,6 +26,11 @@ interface BuildArgs {
    *  rail; callers in client components can pass a memoised "now" when
    *  they want to drive the deadline countdown. */
   now?: Date;
+  /** Optional v2 timeline entries (PR #158). When supplied the
+   *  builder maps `severity: "warn" | "error"` events back to the
+   *  rail stage they reference and tints that stage to flag the
+   *  issue without changing whether it's "done". */
+  timeline?: TimelineEntry[];
 }
 
 const SUBMITTED_LABEL: Record<string, string> = {
@@ -41,9 +47,11 @@ export function buildLifecycleStages({
   claim,
   source,
   now = new Date(),
+  timeline,
 }: BuildArgs): LifecycleStage[] {
   const submittedLabel = SUBMITTED_LABEL[source?.type ?? "native"] ?? "Submitted";
   const state: ClaimEffectiveState = claim?.state ?? "claimable";
+  const tones = toneOverlayFromTimeline(timeline);
 
   // The first stage is always "Ready" (the catalog row exists). We
   // only mark the rest based on what the live state tells us.
@@ -52,6 +60,7 @@ export function buildLifecycleStages({
       label: "Ready",
       meta: "—",
       state: "done",
+      ...(tones.ready ? { tone: tones.ready } : {}),
     },
     {
       label: "Claimed",
@@ -61,6 +70,7 @@ export function buildLifecycleStages({
           }`
         : "—",
       state: stageStateFor(state, "claimed"),
+      ...(tones.claimed ? { tone: tones.claimed } : {}),
     },
     {
       label: submittedLabel,
@@ -70,19 +80,79 @@ export function buildLifecycleStages({
           ? deadlineCountdown(claim.claimExpiresAt, now)
           : "—",
       state: stageStateFor(state, "submitted"),
+      ...(tones.submitted ? { tone: tones.submitted } : {}),
     },
     {
       label: "Verified",
       meta: state === "submitted" ? "awaiting verifier" : "—",
       state: stageStateFor(state, "verified"),
+      ...(tones.verified ? { tone: tones.verified } : {}),
     },
     {
       label: "Paid",
       meta: "—",
       state: stageStateFor(state, "paid"),
+      ...(tones.paid ? { tone: tones.paid } : {}),
     },
   ];
   return stages.map((stage, idx) => ({ ...stage, index: idx + 1 }));
+}
+
+/**
+ * Map the v2 timeline entries to per-stage tone overlays. Returns the
+ * highest severity any event with a stage-relevant `phase` carries, so
+ * a single warn event tints the stage even when surrounded by info
+ * rows.
+ *
+ * The mapping is deliberately conservative — we only color a stage
+ * when the backend's `severity` field plus the entry `phase`/`type`
+ * pair clearly identifies which stage the issue belongs to. Anything
+ * else stays untinted.
+ */
+function toneOverlayFromTimeline(
+  timeline: TimelineEntry[] | undefined
+): Partial<Record<RailStage, StageTone>> {
+  if (!timeline || timeline.length === 0) return {};
+  const out: Partial<Record<RailStage, StageTone>> = {};
+  for (const entry of timeline) {
+    if (entry.severity !== "warn" && entry.severity !== "error") continue;
+    const stage = stageForEntry(entry);
+    if (!stage) continue;
+    out[stage] = mergeTone(out[stage], entry.severity);
+  }
+  return out;
+}
+
+type RailStage = "ready" | "claimed" | "submitted" | "verified" | "paid";
+
+function stageForEntry(entry: TimelineEntry): RailStage | undefined {
+  const phase = String(entry.phase ?? "").toLowerCase();
+  const type = String(entry.type ?? "").toLowerCase();
+  if (type === "verification" || phase === "verification") return "verified";
+  if (type === "session_transition" || type === "session_snapshot") {
+    // Map session phase to the rail stage. The backend phases are
+    // "claim", "work" (post-claim, pre-submit), "submit", "verify",
+    // "settle"; treat anything past submit as the verified stage.
+    if (phase === "settle") return "paid";
+    if (phase === "verify") return "verified";
+    if (phase === "submit") return "submitted";
+    if (phase === "work" || phase === "claim") return "claimed";
+  }
+  if (type === "child_job" || type === "derivative_job") {
+    // Lineage events live "after the claim" — surface as a flag on
+    // the Claimed stage rather than tinting the whole rail.
+    return "claimed";
+  }
+  return undefined;
+}
+
+function mergeTone(
+  current: StageTone | undefined,
+  incoming: "warn" | "error"
+): StageTone {
+  if (current === "error") return "error";
+  if (incoming === "error") return "error";
+  return "warn";
 }
 
 /**


### PR DESCRIPTION
Last of three follow-ups against backend work that landed without UI wiring (#167 was the timeline panel, #168 was capability gates).

## Why
PR #158 standardized timeline observability with a v2 envelope that tags every entry with \`source\`, \`topic\`, \`severity\`, and a machine-readable \`phase\`. The 5-stage \`LifecycleRail\` above the runs queue and on \`/runs/detail\` had no concept of severity — a verifier rejection or a session dispute drew the same green checkmark on the affected stage as a clean run. PR #167 added a panel below the rail that shows the timeline events, but the rail itself is the at-a-glance and was lying.

## What
- **\`LifecycleStage\`** gains an optional \`tone: \"ok\" | \"warn\" | \"error\"\`. Overlay only — \`state\` (done/current/pending) is unchanged so the rail's progression logic stays intact. Tinted stages swap dot/label colors and replace ✓ with \`!\`.
- **\`buildLifecycleStages\`** takes an optional \`timeline\` arg. Walks entries with \`severity ∈ {warn, error}\` and maps each to a rail stage by \`phase\` / \`type\`:
  - \`verification\` entries → Verified
  - \`phase: \"submit\"\` → Submitted
  - \`phase: \"verify\"\` → Verified
  - \`phase: \"settle\"\` → Paid
  - \`phase: \"work\" | \"claim\"\` → Claimed
  - \`child_job\` / \`derivative_job\` → Claimed
  Conservative on purpose; unknown entry kinds stay untinted so a new entry type can't paint the rail red by accident.
- **\`LoadedRunView\`** + **\`runs/page.tsx\`** both call \`useJobTimeline(jobId)\` alongside their existing hooks. SWR dedupes by URL key, so the rail and the timeline panel share one fetch.

## Defer
- Inline event list on the rail itself. \`JobTimelinePanel\` already serves that role; rail's job is the at-a-glance.
- Severity overlay on the rail's \`contextNote\` header — easier to design once we see the tint behavior against real warn/error events.

## Test plan
- [x] \`npm run typecheck:app\`
- [x] \`npm run build:frontend\`
- [ ] After deploy, signed-in: a job with a verifier-rejection entry should render the Verified stage in amber/red on both /runs (queue page) and /runs/detail. A clean job stays green throughout.