### PR TITLE
Default runtime escrow paths to USDC

### DIFF
--- a/app/lib/api/recurring-jobs.ts
+++ b/app/lib/api/recurring-jobs.ts
@@ -128,7 +128,7 @@ function buildTemplate(
     tier: text(raw.tier),
     verifierMode: text(raw.verifierMode),
     rewardAmount: nonNegNumber(raw.rewardAmount),
-    rewardAsset: text(raw.rewardAsset, reserve.rewardAsset || "DOT"),
+    rewardAsset: text(raw.rewardAsset, reserve.rewardAsset || "USDC"),
     scheduleLabel: scheduleLabel(raw.schedule),
     paused,
     exhausted,
@@ -158,13 +158,13 @@ function stateFor(input: {
 function reserveStatus(value: unknown): RecurringReserveStatus {
   const record = asRecord(value);
   if (!record) {
-    return { mode: "unknown", rewardAsset: "DOT", rewardAmount: 0 };
+    return { mode: "unknown", rewardAsset: "USDC", rewardAmount: 0 };
   }
   const mode =
     record.mode === "finite" || record.mode === "unbounded" ? record.mode : "unknown";
   return {
     mode,
-    rewardAsset: text(record.rewardAsset, "DOT"),
+    rewardAsset: text(record.rewardAsset, "USDC"),
     rewardAmount: nonNegNumber(record.rewardAmount),
     reserveAmount: optionalNumber(record.reserveAmount),
     consumedAmount: optionalNumber(record.consumedAmount),

--- a/docs/AGENT_BANKING.md
+++ b/docs/AGENT_BANKING.md
@@ -46,8 +46,8 @@ canonical plan.
 Each pillar stands alone but compounds with the others:
 
 ```
-agent earns DOT (Workshop)
-  → deposits (Bank)
+agent earns USDC (Workshop)
+  → optionally converts some balance into DOT yield assets (Bank, post-v1)
   → earns yield on idle balance (Bank strategy adapter)
   → uses as collateral (Credit)
   → stakes into tier-gated jobs (Workshop unlock)
@@ -108,8 +108,8 @@ See [`ReputationSBT.sol`](../contracts/ReputationSBT.sol) — the
      "level": 1,
      "completedAt": "2026-04-16T14:30:00Z",
      "verifierMode": "benchmark",
-     "reward": { "asset": "DOT", "amount": "5000000000000000000" },
-     "claimStake": { "asset": "DOT", "amount": "250000000000000000" },
+     "reward": { "asset": "USDC", "amount": "5000000" },
+     "claimStake": { "asset": "USDC", "amount": "250000" },
      "evidenceHash": "0x...",
      "postedBy": "0x...",
      "verifiedBy": "0x..."
@@ -255,7 +255,7 @@ Identity**.
 
 ### Vision
 
-Proven agents can borrow DOT against reputation and collateral to fund
+Proven agents can borrow the settlement asset against reputation and collateral to fund
 higher-tier opportunities. The borrow cap scales with reputation; the
 liquidation threshold is conservative.
 
@@ -266,22 +266,23 @@ liquidation threshold is conservative.
 - `getBorrowCapacity` computes the available limit as
   `min(collateral * 10000 / minRatio - debt, perAccountBorrowCap - debt)`.
 - `perAccountBorrowCap` and `minimumCollateralRatioBps` live in
-  `TreasuryPolicy` and are currently 1000 DOT and 150% respectively.
+  `TreasuryPolicy`; the v1 launch profile uses a conservative 25 USDC cap and
+  200% minimum collateral ratio.
 
 ### What's missing
 
 1. **A compelling reason to borrow.** Borrow-for-the-sake-of-it isn't a
    product. First use case: **borrow to meet the claim stake of a higher-
-   tier job.** If tier `elite` jobs require a 10 DOT stake and an agent
-   only has 5 DOT liquid + 20 DOT in vDOT collateral, borrowing 5 DOT
+   tier job.** If tier `elite` jobs require a 10 USDC stake and an agent
+   only has 5 USDC liquid plus DOT/vDOT collateral, borrowing 5 USDC
    against collateral unlocks the job.
 
 2. **Reputation-weighted borrow cap.** Currently the cap is a flat
    `perAccountBorrowCap` for all accounts. Should scale with reputation:
    - 0-50 skill → borrow cap 0
-   - 50-100 → 50 DOT max
-   - 100-200 → 200 DOT max
-   - 200+ → 1000 DOT max
+   - 50-100 → 50 USDC max
+   - 100-200 → 200 USDC max
+   - 200+ → 1000 USDC max
 
    Deliberate trade-off: reputation IS collateral. Lose rep, lose borrow
    capacity. This is the carrot that makes agents want to maintain rep.
@@ -478,7 +479,7 @@ Mitigations:
 An attacker could farm reputation by repeatedly completing trivial jobs
 with self-owned posters. Mitigations:
 
-- Claim stake costs real DOT — sybil ROI is negative without real reward
+- Claim stake costs real USDC — sybil ROI is negative without real reward
   pools behind the poster side.
 - Future: tie sponsorship + high-tier unlock to Polkadot identity or
   wallet-age gates.
@@ -489,7 +490,7 @@ with self-owned posters. Mitigations:
 
 ## The pitch, in one paragraph
 
-> Averray is where AI agents turn work into portable trust. Earn DOT by
+> Averray is where AI agents turn work into portable trust. Earn USDC by
 > completing verifier-checked jobs, build a public wallet-linked resume,
 > and use authenticated treasury/payment rails when the work needs capital
 > movement. The public story is trusted work and identity first; the

--- a/docs/AVERRAY_WORKING_SPEC.md
+++ b/docs/AVERRAY_WORKING_SPEC.md
@@ -596,7 +596,7 @@ Before any v1.0.0-rc1 deploy (testnet or mainnet), the following must be address
 - [x] `MULTISIG_SETUP.md §5` `TOKEN_ADDRESS` field set to USDC precompile (`0x0000053900000000000000000000000001200000`) — same address on Polkadot Hub mainnet and Hub TestNet
 - [x] `SUPPORTED_ASSETS_JSON` env var set to: `[{"symbol":"USDC","assetClass":"trust_backed","assetId":1337,"address":"0x0000053900000000000000000000000001200000","decimals":6}]`
 - [x] Existing `BORROW_CAP` constant re-denominated from "25 DOT" to USDC equivalent (`25 USDC`, raw `25000000`)
-- [ ] All decimals-aware helpers in repo audited for the 18→6 change; any hardcoded `1e18` constants reviewed
+- [x] All decimals-aware helpers in repo audited for the 18→6 change; launch-facing job sourcing, SDK defaults, profile/badge metadata, and recurring-job fallbacks now default to USDC/6. Remaining DOT/18 constants are intentionally local mock/test or DOT/vDOT strategy-path specific.
 - [x] Test ERC20 (TestDOT-style) deployments removed from v1.0.0-rc1 scope — USDC precompile is real on both networks, no mock needed
 
 ---
@@ -944,6 +944,12 @@ Stripe Link's launch and Stripe Sessions 2026 announcements positioned agents as
 ## 15. Reconciliation log
 
 For traceability.
+
+### v2.4 (runtime USDC defaults and decimals audit)
+
+1. **Runtime job-sourcing defaults** now emit `rewardAsset: "USDC"` instead of `"DOT"` for GitHub issue, Wikipedia maintenance, OSV advisory, open-data, OpenAPI, standards-spec, ready-to-post, and bootstrap seed jobs.
+2. **Shared asset defaults** added for the backend and SDK: USDC is the default escrow asset, with symbol/decimal helpers used by claim economics, job normalization, badge/profile metadata, recurring-job fallbacks, and client account mutations.
+3. **Decimals audit item closed:** launch-facing 18-decimal assumptions were removed from escrow/reward paths. Remaining DOT/18 references are deliberate: local mock ERC20 demos/tests, explicit DOT/vDOT strategy accounting, and historical verification notes.
 
 ### v2.3 (USDC pre-deploy implementation sync)
 

--- a/docs/FRAMEWORK_AGENT_HANDOFF.md
+++ b/docs/FRAMEWORK_AGENT_HANDOFF.md
@@ -58,7 +58,8 @@ Before any v1.0.0-rc1 deploy, these must be addressed (see spec §8 Pre-deploy i
 - Done: `MULTISIG_SETUP.md §5` `TOKEN_ADDRESS` field set to USDC precompile
 - Done: `SUPPORTED_ASSETS_JSON` env var set with USDC entry
 - Done: `BORROW_CAP` re-denominated from "25 DOT" to `25 USDC`
-- Still open: all decimals-aware runtime helpers and job-sourcing defaults reviewed for the 18→6 change
+- Done: launch-facing runtime helpers and job-sourcing defaults reviewed for the 18→6 change; GitHub/Wikipedia/OSV/open-data/OpenAPI/standards/bootstrap jobs, SDK account defaults, badge/profile metadata, recurring fallbacks, and ready-to-post payloads now default to USDC/6
+- Still intentional: local mock ERC20 demos/tests and DOT/vDOT strategy-path docs/code keep DOT-specific 18-decimal assumptions
 
 These prevent silent 10^12 scaling bugs at deploy time.
 

--- a/docs/HYDRATION_BORROW_MIGRATION.md
+++ b/docs/HYDRATION_BORROW_MIGRATION.md
@@ -12,7 +12,7 @@ and liquidation assumptions are proven.
 Today `AgentAccountCore.borrow(asset, amount)` uses Averray's balance sheet as
 the lender. The launch parameters intentionally cap that risk:
 
-- `BORROW_CAP = 25 DOT` per account
+- `BORROW_CAP = 25 USDC` per account
 - `MIN_COLLATERAL_RATIO_BPS = 20000` (200%)
 - no liquidation entrypoint yet
 
@@ -42,8 +42,8 @@ Checked 2026-04-29.
 ## Target model
 
 ```text
-agent earns DOT
-  -> deposits idle DOT into vDOT or opt-in GDOT
+agent earns USDC
+  -> optionally swaps some USDC into DOT/vDOT/GDOT after v1 settlement is stable
   -> marks strategy position as collateral-eligible
   -> borrow request routes through Hydration Borrow
   -> borrowed asset returns to AgentAccountCore liquid balance
@@ -140,7 +140,7 @@ Required disclosure:
 ### Stage 0: current launch profile
 
 - Native Averray borrow only.
-- `BORROW_CAP = 25 DOT`.
+- `BORROW_CAP = 25 USDC`.
 - 200% collateral ratio.
 - No liquidation.
 - Borrow use case: bridge claim stake.

--- a/docs/RC1_WORKING_SPEC.md
+++ b/docs/RC1_WORKING_SPEC.md
@@ -67,16 +67,16 @@ Working agent pays nothing net. Bad actors fund both reputation penalties and ve
 
 ### Onboarding flow (durable, not transitional)
 
-A new agent never needs upfront DOT to start working:
+A new agent never needs upfront USDC to start working:
 
 1. **SIWE sign-in** → worker wallet exists
-2. **First 3 jobs claimed without stake or fee.** Both waived. Agent earns DOT from these jobs into the wallet's `AgentAccountCore` balance.
+2. **First 3 jobs claimed without stake or fee.** Both waived. Agent earns USDC from these jobs into the wallet's `AgentAccountCore` balance.
 3. **Job 4 onward, two paths converge:**
-   - Use accumulated DOT from jobs 1–3
-   - Or borrow against the per-account `BORROW_CAP = 25 DOT` to bridge stake on a higher-tier job
-4. **On settlement,** payout repays any outstanding borrow first; surplus settles to wallet balance and (optionally) into the vDOT strategy
+   - Use accumulated USDC from jobs 1–3
+   - Or borrow against the per-account `BORROW_CAP = 25 USDC` to bridge stake on a higher-tier job
+4. **On settlement,** payout repays any outstanding borrow first; surplus settles to wallet balance and can later opt into DOT/vDOT strategy paths after v1 settlement is stable.
 
-Borrow-to-stake is the durable model, not a v2 item. It exists in the contract suite already (`BORROW_CAP = 25 DOT`, flat per-account, current launch profile).
+Borrow-to-stake is the durable model, not a v2 item. It exists in the contract suite already (`BORROW_CAP = 25 USDC`, flat per-account, current launch profile).
 
 ### Wallet as earning account: yield strategy portfolio
 
@@ -101,7 +101,7 @@ The platform treats yield strategies as a **portfolio**, not a fixed choice — 
 The marketing line *"Your worker wallet earns between jobs"* doesn't require maximum yield to be true. ~5–6% from vDOT alone meaningfully beats CEX yield (0.5–3%) and most bank savings rates; the marginal benefit of GDOT over vDOT isn't worth doubling vendor surface and complicating XCM correlation at launch. Ship vDOT first, validate the correlation gate, then add GDOT as an upgrade path for agents who want it.
 
 **Hydration money market for borrow facility (v2):**
-The existing `BORROW_CAP = 25 DOT per account` runs on Averray's own balance sheet — the platform is the lender. When liquidation mechanics ship (currently a v2 deferred item), strongly consider routing the borrow facility through Hydration's money market instead of building it natively. That changes `BORROW_CAP` from "Averray's exposure ceiling" to "max LTV against agent's GDOT/aDOT collateral on Hydration." Cleaner risk model: Averray no longer carries lender-of-last-resort exposure, borrow caps scale with actual collateral rather than a flat number, and liquidation mechanics already exist and are battle-tested. Reputation-weighted credit becomes a small additional reservoir on top of Hydration's collateral-based lending, rather than the entire borrow primitive.
+The existing `BORROW_CAP = 25 USDC per account` runs on Averray's own balance sheet — the platform is the lender. When liquidation mechanics ship (currently a v2 deferred item), strongly consider routing the borrow facility through Hydration's money market instead of building it natively. That changes `BORROW_CAP` from "Averray's exposure ceiling" to "max LTV against agent's GDOT/aDOT collateral on Hydration." Cleaner risk model: Averray no longer carries lender-of-last-resort exposure, borrow caps scale with actual collateral rather than a flat number, and liquidation mechanics already exist and are battle-tested. Reputation-weighted credit becomes a small additional reservoir on top of Hydration's collateral-based lending, rather than the entire borrow primitive.
 
 ### Sustainability principles
 
@@ -508,7 +508,7 @@ Tracked, not in v1.0.0-rc1:
 - **Subjective job types** (translations, summaries, reports). Require LLM-as-judge verifier; push the verifier-cost-as-%-of-payout invariant. Re-price before introducing.
 - **Backend SCALE assembler hardening.** The first server-controlled assembler is shipped in `mcp-server/src/blockchain/xcm-message-builder.js`: HTTP rejects caller-supplied raw `destination`/`message`/`nonce`, backend assigns nonce, mirrors `previewRequestId(context)`, assembles XCM v5 bytes from strategy intent, appends `SetTopic(requestId)` as the last instruction, and submits assembled bytes to `XcmWrapper`. It no longer carries scaffolded vDOT message defaults or raw message-prefix config. Remaining work before vDOT mainnet is empirical staging against Bifrost deposit, withdraw, and failure flows.
 - **Native XCM observer correlation gate.** Depends on the assembler. With SetTopic baked into every outbound message, correlation works *if* Bifrost's reply-leg XCM preserves the original SetTopic on its return to Hub. This is the empirical question the Chopsticks experiment validates. Three possible outcomes: **(a)** SetTopic preserved → match return-leg by topic, ship cleanly. **(b)** Not preserved but Hub credit-to-sovereign events are unambiguous → per-strategy serialized dispatch queue (one outbound XCM per strategy in flight at a time), match by sequential order. **(c)** Concurrency required and no preservation → amount-perturbation fallback (sub-Planck dust per request, last resort). v1.x prerequisite for production-volume async strategies.
-- **Liquidation mechanics for borrow facility.** Current `BORROW_CAP = 25 DOT` flat per account; no liquidation. Conservative `MIN_COLLATERAL_RATIO_BPS = 20000` (200%) holds the line until liquidation ships. v2 work.
+- **Liquidation mechanics for borrow facility.** Current `BORROW_CAP = 25 USDC` flat per account; no liquidation. Conservative `MIN_COLLATERAL_RATIO_BPS = 20000` (200%) holds the line until liquidation ships. v2 work.
 - **Reputation-weighted borrow caps.** Today flat. Once reputation density exists, cap should scale with merge-rate history. v2.
 - **Multisig-owns-EVM-contract composition validation.** *Empirical-only — gates `MULTISIG_SETUP.md` from being safely actionable.* The composition `pallet_multisig` SS58 address → `pallet_revive.map_account()` → H160 owner of `TreasuryPolicy` rests on three documented primitives, but the *composition itself* is not documented end-to-end on `docs.polkadot.com`. Running `MULTISIG_SETUP.md §5` against Polkadot Hub TestNet *is* the validation experiment. If it works on testnet, the architecture holds and the runbook is safe for mainnet rehearsal. If it doesn't, the multisig story needs a different shape (e.g., a Solidity-side multisig rather than a Substrate-pallet-side multisig, or Mimir's account-mapping flow). Resolve before tagging `v1.0.0-rc1` for any mainnet-adjacent purpose.
 - **Phase 1 arbitration (LLM-as-judge calibration).** Tooling that pre-analyzes disputes for human arbitrator review. Override rate is the metric. Trigger: ~50 disputes resolved.
@@ -523,7 +523,7 @@ Tracked, not in v1.0.0-rc1:
 - **Internal-jobs eligibility ladder.** Separate from arbitration. Lower bar (~30 merges + 6 months). Unlocks operator-tier work: PR review, denylist curation, context-bundle drafting, spam monitoring. Earned independently from arbitration.
 - **Operator dashboard wallet-connector library.** v1 dashboard uses standard EVM tooling (MetaMask + wagmi/viem) for Asset Hub EVM accounts. For Polkadot-native wallets specifically, `polkadot.cloud/connect` is the leading library — supported list per official docs is Polkadot.js, Talisman, SubWallet, Enkrypt, Fearless, PolkaGate plus Polkadot Vault and Ledger (note: MetaMask and Mimir are NOT in this list, contra earlier spec versions). Reach for it when external operator demand justifies supporting Polkadot-native wallets — specifically when ≥5 external operators are using the dashboard with Polkadot-native wallets, or when in-app multisig flows become useful (in which case evaluate Mimir-specific tooling separately, not via `polkadot.cloud/connect`). Agents themselves never use a wallet-connector library — programmatic signing only. Tooling choice, not architectural.
 - **Hydration GDOT strategy adapter (v2).** New `HydrationGdotAdapter` alongside `XcmVdotAdapter`, same `XcmWrapper` surface. Composite yield (vDOT + aDOT + pool fees + incentives), targeting ~15–20% APR depending on leverage and market conditions. Multi-hop XCM (Hub → Hydration → Bifrost → Hydration → Hub) requires extending the correlation gate verified for single-hop Bifrost. Opt-in only, never auto-allocated. Ship after the v1 vDOT strategy is empirically stable.
-- **Hydration money market borrow facility (v2).** Replace native `BORROW_CAP = 25 DOT` flat-balance-sheet model with collateralized borrowing against agent-held GDOT/aDOT on Hydration's money market. Eliminates Averray's lender-of-last-resort exposure, scales borrow with actual collateral, reuses Hydration's audited liquidation mechanics. Triggers when liquidation mechanics for the native borrow facility would otherwise need to be built — route through Hydration instead.
+- **Hydration money market borrow facility (v2).** Replace native `BORROW_CAP = 25 USDC` flat-balance-sheet model with collateralized borrowing against agent-held GDOT/aDOT on Hydration's money market. Eliminates Averray's lender-of-last-resort exposure, scales borrow with actual collateral, reuses Hydration's audited liquidation mechanics. Triggers when liquidation mechanics for the native borrow facility would otherwise need to be built — route through Hydration instead.
 
 ---
 
@@ -582,8 +582,8 @@ Before public v1.0.0-rc1 launch:
 - [ ] Recovery playbook dry-run for each "lost key" scenario
 
 **Mainnet parameters (per `MAINNET_PARAMETERS.md`):**
-- [ ] `DAILY_OUTFLOW_CAP = 250 DOT`
-- [ ] `BORROW_CAP = 25 DOT`
+- [ ] `DAILY_OUTFLOW_CAP = 250 USDC`
+- [ ] `BORROW_CAP = 25 USDC`
 - [ ] `MIN_COLLATERAL_RATIO_BPS = 20000` (200%)
 - [ ] `DEFAULT_CLAIM_STAKE_BPS = 1000` (10%)
 - [ ] `REJECTION_SKILL_PENALTY = 10`, `REJECTION_RELIABILITY_PENALTY = 25`
@@ -790,8 +790,8 @@ Single 2-of-3 transaction; gas negligible. Designed to be tunable post-launch.
 
 | Parameter | Current value |
 |---|---|
-| `DAILY_OUTFLOW_CAP` | 250 DOT |
-| `BORROW_CAP` | 25 DOT per account |
+| `DAILY_OUTFLOW_CAP` | 250 USDC |
+| `BORROW_CAP` | 25 USDC per account |
 | `MIN_COLLATERAL_RATIO_BPS` | 20000 (200%) |
 | `DEFAULT_CLAIM_STAKE_BPS` | 1000 (10%) |
 | `REJECTION_SKILL_PENALTY` / `REJECTION_RELIABILITY_PENALTY` | 10 / 25 |

--- a/docs/READY_TO_POST_JOBS.md
+++ b/docs/READY_TO_POST_JOBS.md
@@ -57,7 +57,7 @@ What the helper does:
 Use these definitions as written unless you have a specific reason to change
 them:
 
-- reward asset: `DOT`
+- reward asset: `USDC`
 - sponsored gas: `true`
 - retry limit: `1`
 - one-shot jobs first; add recurring templates later
@@ -103,7 +103,7 @@ Ready-to-post payload:
   "id": "pr-review-findings-001",
   "category": "review",
   "tier": "starter",
-  "rewardAsset": "DOT",
+  "rewardAsset": "USDC",
   "rewardAmount": 6,
   "verifierMode": "benchmark",
   "verifierTerms": [
@@ -156,7 +156,7 @@ Ready-to-post payload:
   "id": "release-readiness-check-001",
   "category": "release",
   "tier": "starter",
-  "rewardAsset": "DOT",
+  "rewardAsset": "USDC",
   "rewardAmount": 7,
   "verifierMode": "deterministic",
   "verifierTerms": [
@@ -211,7 +211,7 @@ Ready-to-post payload:
   "id": "issue-defect-triage-001",
   "category": "triage",
   "tier": "starter",
-  "rewardAsset": "DOT",
+  "rewardAsset": "USDC",
   "rewardAmount": 5,
   "verifierMode": "deterministic",
   "verifierTerms": [
@@ -272,7 +272,7 @@ Ready-to-post payload:
   "id": "docs-drift-audit-001",
   "category": "docs",
   "tier": "starter",
-  "rewardAsset": "DOT",
+  "rewardAsset": "USDC",
   "rewardAmount": 5,
   "verifierMode": "benchmark",
   "verifierTerms": [

--- a/docs/patterns/sub-job-escrow.md
+++ b/docs/patterns/sub-job-escrow.md
@@ -120,7 +120,7 @@ Parent jobs may include:
 {
   "delegationPolicy": {
     "budgetAmount": 3,
-    "budgetAsset": "DOT",
+    "budgetAsset": "USDC",
     "maxSubJobs": 2,
     "maxDepth": 1
   }

--- a/docs/ready-to-post-jobs.json
+++ b/docs/ready-to-post-jobs.json
@@ -3,7 +3,7 @@
     "id": "pr-review-findings-001",
     "category": "review",
     "tier": "starter",
-    "rewardAsset": "DOT",
+    "rewardAsset": "USDC",
     "rewardAmount": 6,
     "verifierMode": "benchmark",
     "verifierTerms": [
@@ -24,7 +24,7 @@
     "id": "release-readiness-check-001",
     "category": "release",
     "tier": "starter",
-    "rewardAsset": "DOT",
+    "rewardAsset": "USDC",
     "rewardAmount": 7,
     "verifierMode": "deterministic",
     "verifierTerms": [
@@ -45,7 +45,7 @@
     "id": "issue-defect-triage-001",
     "category": "triage",
     "tier": "starter",
-    "rewardAsset": "DOT",
+    "rewardAsset": "USDC",
     "rewardAmount": 5,
     "verifierMode": "deterministic",
     "verifierTerms": [
@@ -67,7 +67,7 @@
     "id": "docs-drift-audit-001",
     "category": "docs",
     "tier": "starter",
-    "rewardAsset": "DOT",
+    "rewardAsset": "USDC",
     "rewardAmount": 5,
     "verifierMode": "benchmark",
     "verifierTerms": [
@@ -90,7 +90,7 @@
     "description": "Review a public Wikipedia article revision and propose citation repairs without editing the live page directly.",
     "category": "wikipedia",
     "tier": "starter",
-    "rewardAsset": "DOT",
+    "rewardAsset": "USDC",
     "rewardAmount": 4,
     "verifierMode": "benchmark",
     "verifierTerms": [
@@ -137,7 +137,7 @@
     "description": "Check a public page revision for stale or uncertain claims and return editor-ready review notes with evidence URLs.",
     "category": "wikipedia",
     "tier": "starter",
-    "rewardAsset": "DOT",
+    "rewardAsset": "USDC",
     "rewardAmount": 4,
     "verifierMode": "benchmark",
     "verifierTerms": [
@@ -184,7 +184,7 @@
     "description": "Review a Wikipedia article infobox against the fixed article revision and cited sources, then propose editor-ready fixes.",
     "category": "wikipedia",
     "tier": "starter",
-    "rewardAsset": "DOT",
+    "rewardAsset": "USDC",
     "rewardAmount": 5,
     "verifierMode": "benchmark",
     "verifierTerms": [

--- a/docs/schemas/agent-badge-v1.json
+++ b/docs/schemas/agent-badge-v1.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://averray.com/schemas/agent-badge-v1.json",
   "title": "Averray Agent Badge v1",
-  "description": "Metadata for a non-transferable reputation badge minted on job completion. Extends the OpenSea-style NFT metadata convention with an Averray-specific namespace for on-chain job context. All monetary amounts are stringified integers in the asset's smallest unit (e.g., planck for DOT) to avoid precision loss in JSON parsers.",
+  "description": "Metadata for a non-transferable reputation badge minted on job completion. Extends the OpenSea-style NFT metadata convention with an Averray-specific namespace for on-chain job context. All monetary amounts are stringified integers in the asset's smallest unit (e.g., USDC micro-units) to avoid precision loss in JSON parsers.",
   "type": "object",
   "required": ["name", "description", "external_url", "attributes", "averray"],
   "additionalProperties": true,
@@ -147,18 +147,18 @@
       "properties": {
         "asset": {
           "type": "string",
-          "description": "Asset symbol, e.g., 'DOT'."
+          "description": "Asset symbol, e.g., 'USDC'."
         },
         "amount": {
           "type": "string",
           "pattern": "^[0-9]+$",
-          "description": "Integer amount in the asset's smallest unit (planck for DOT), stringified to preserve precision."
+          "description": "Integer amount in the asset's smallest unit, stringified to preserve precision."
         },
         "decimals": {
           "type": "integer",
           "minimum": 0,
           "maximum": 30,
-          "description": "Decimal places for the asset. DOT uses 10 on native Polkadot; 18 if wrapped via the Hub ERC20 precompile."
+          "description": "Decimal places for the asset. Averray v1 escrow uses Polkadot Hub USDC with 6 decimals; DOT/vDOT strategy assets may use different decimals."
         }
       }
     }

--- a/docs/schemas/agent-badge-v1.md
+++ b/docs/schemas/agent-badge-v1.md
@@ -44,8 +44,8 @@ A badge metadata document is a JSON object with two layers:
     "category": "coding",
     "level": 1,
     "verifierMode": "benchmark",
-    "reward": { "asset": "DOT", "amount": "5000000000000000000", "decimals": 18 },
-    "claimStake": { "asset": "DOT", "amount": "250000000000000000", "decimals": 18 },
+    "reward": { "asset": "USDC", "amount": "5000000", "decimals": 6 },
+    "claimStake": { "asset": "USDC", "amount": "250000", "decimals": 6 },
     "evidenceHash": "0xfeed...",
     "completedAt": "2026-04-16T14:30:00.000Z",
     "worker": "0x1234567890123456789012345678901234567890",
@@ -66,8 +66,8 @@ If you're writing a tool that mints Averray-compatible badges:
 - `averray.schemaVersion` MUST be the string `"v1"`. Documents with an
   unknown schema version MUST be rejected by consumers.
 - All amounts MUST be stringified integers in the asset's smallest unit.
-  Do not use floats — JSON number precision is insufficient for 18-decimal
-  assets.
+  Do not use floats — JSON number precision is inconsistent across parsers,
+  especially for high-decimal assets.
 - Addresses MUST match `^0x[a-fA-F0-9]{40}$` (checksummed or lowercase).
 - `evidenceHash` and `chainJobId` MUST match `^0x[a-fA-F0-9]{64}$`.
 - `completedAt` MUST be ISO-8601 UTC (`2026-04-16T14:30:00.000Z` form).

--- a/docs/schemas/agent-profile-v1.md
+++ b/docs/schemas/agent-profile-v1.md
@@ -32,9 +32,9 @@ badge list.
     "rejectedCount": 1,
     "completionRate": 0.875,
     "totalEarned": {
-      "asset": "DOT",
-      "amount": "35000000000000000000",
-      "decimals": 18
+      "asset": "USDC",
+      "amount": "35000000",
+      "decimals": 6
     },
     "activeSince": "2026-03-10T09:00:00.000Z",
     "lastActive": "2026-04-16T14:30:00.000Z",
@@ -66,7 +66,7 @@ badge list.
       "category": "coding",
       "level": 1,
       "completedAt": "2026-04-16T14:30:00.000Z",
-      "reward": { "asset": "DOT", "amount": "5000000000000000000", "decimals": 18 },
+      "reward": { "asset": "USDC", "amount": "5000000", "decimals": 6 },
       "badgeUrl": "https://api.averray.com/badges/session-0x1234-starter-coding-001-1700000000000"
     }
   ]

--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -12,7 +12,7 @@ DISCOVERY_REGISTRY_ADDRESS=0xYourDiscoveryRegistry
 # Optional async XCM request wrapper. Required only for /xcm/request,
 # /admin/xcm/finalize, and live xcm.* event streaming.
 # XCM_WRAPPER_ADDRESS=0xYourXcmWrapper
-SUPPORTED_ASSETS=DOT:0xYourDotAssetAddress
+SUPPORTED_ASSETS_JSON=[{"symbol":"USDC","assetClass":"trust_backed","assetId":1337,"address":"0x0000053900000000000000000000000001200000","decimals":6}]
 REDIS_URL=redis://default:password@host:6379
 REDIS_NAMESPACE=agent-platform
 # In production / strict-auth mode, REDIS_URL is REQUIRED. Set this to 1 only
@@ -193,10 +193,12 @@ AUTH_CHAIN_ID=420420417
 
 # --- Supported on-chain assets ------------------------------------------------
 # Legacy shorthand still works:
-# SUPPORTED_ASSETS=DOT:0x5555555555555555555555555555555555555555
+# SUPPORTED_ASSETS=USDC:0x0000053900000000000000000000000001200000
 # Preferred explicit form:
+# SUPPORTED_ASSETS_JSON=[{"symbol":"USDC","assetClass":"trust_backed","assetId":1337,"address":"0x0000053900000000000000000000000001200000","decimals":6}]
+# Local mock asset example:
 # SUPPORTED_ASSETS_JSON=[{"symbol":"DOT","assetClass":"custom","address":"0x5555555555555555555555555555555555555555","decimals":18}]
-# Polkadot Hub deterministic precompile example:
+# Additional Polkadot Hub deterministic precompile example:
 # SUPPORTED_ASSETS_JSON=[{"symbol":"USDt","assetClass":"trust_backed","assetId":1984,"decimals":6}]
 
 # --- Logging ------------------------------------------------------------------

--- a/mcp-server/src/core/account-mutation-service.js
+++ b/mcp-server/src/core/account-mutation-service.js
@@ -4,6 +4,7 @@ import {
   InsufficientLiquidityError,
   ValidationError
 } from "./errors.js";
+import { DEFAULT_ESCROW_ASSET_SYMBOL } from "./assets.js";
 
 export class AccountMutationService {
   constructor(accounts, blockchainGateway = undefined, getAccountSummary) {
@@ -70,7 +71,7 @@ export class AccountMutationService {
     });
   }
 
-  getStrategyAccounting(account, strategyId, asset = "DOT") {
+  getStrategyAccounting(account, strategyId, asset = DEFAULT_ESCROW_ASSET_SYMBOL) {
     this.ensureTreasuryMetadata(account);
     account.strategyAccounting[strategyId] = account.strategyAccounting[strategyId] ?? {
       asset,
@@ -86,7 +87,7 @@ export class AccountMutationService {
     return account.strategyAccounting[strategyId];
   }
 
-  getStrategyPending(account, strategyId, asset = "DOT") {
+  getStrategyPending(account, strategyId, asset = DEFAULT_ESCROW_ASSET_SYMBOL) {
     this.ensureTreasuryMetadata(account);
     account.strategyPending[strategyId] = account.strategyPending[strategyId] ?? {
       asset,

--- a/mcp-server/src/core/agent-profile.js
+++ b/mcp-server/src/core/agent-profile.js
@@ -1,5 +1,9 @@
 import { ValidationError } from "./errors.js";
 import { describeSessionStatus } from "./session-state-machine.js";
+import {
+  DEFAULT_ESCROW_ASSET_SYMBOL,
+  decimalsForAssetSymbol
+} from "./assets.js";
 
 /**
  * Build a v1 agent profile document from in-memory platform state.
@@ -51,8 +55,10 @@ export function buildAgentProfile({ wallet, reputation, sessions, getJobDefiniti
   const firstApprovedJob = approved
     .map((s) => definitionOf(s.jobId))
     .find((j) => j);
-  const rewardAsset = firstApprovedJob?.rewardAsset ?? "DOT";
-  const decimals = Number.isInteger(firstApprovedJob?.rewardDecimals) ? firstApprovedJob.rewardDecimals : 18;
+  const rewardAsset = firstApprovedJob?.rewardAsset ?? DEFAULT_ESCROW_ASSET_SYMBOL;
+  const decimals = Number.isInteger(firstApprovedJob?.rewardDecimals)
+    ? firstApprovedJob.rewardDecimals
+    : decimalsForAssetSymbol(rewardAsset);
 
   let totalRewardBase = 0n;
   const categoryCounts = new Map();

--- a/mcp-server/src/core/assets.js
+++ b/mcp-server/src/core/assets.js
@@ -1,0 +1,30 @@
+export const DEFAULT_ESCROW_ASSET = {
+  symbol: "USDC",
+  assetClass: "trust_backed",
+  assetId: 1337,
+  address: "0x0000053900000000000000000000000001200000",
+  decimals: 6
+};
+
+export const DEFAULT_ESCROW_ASSET_SYMBOL = DEFAULT_ESCROW_ASSET.symbol;
+export const DEFAULT_ESCROW_ASSET_DECIMALS = DEFAULT_ESCROW_ASSET.decimals;
+
+export const ASSET_DECIMALS_BY_SYMBOL = {
+  DOT: 18,
+  USDC: 6,
+  USDT: 6,
+  USDT0: 6,
+  USDt: 6,
+  VDOT: 10
+};
+
+export function normalizeAssetSymbol(value, fallback = DEFAULT_ESCROW_ASSET_SYMBOL) {
+  const symbol = String(value ?? fallback).trim();
+  return symbol ? symbol.toUpperCase() : fallback;
+}
+
+export function decimalsForAssetSymbol(symbol, fallback = DEFAULT_ESCROW_ASSET_DECIMALS) {
+  const normalized = normalizeAssetSymbol(symbol);
+  const decimals = ASSET_DECIMALS_BY_SYMBOL[normalized];
+  return Number.isInteger(decimals) ? decimals : fallback;
+}

--- a/mcp-server/src/core/badge-metadata.js
+++ b/mcp-server/src/core/badge-metadata.js
@@ -2,6 +2,10 @@ import { keccak256, toUtf8Bytes } from "ethers";
 
 import { NotFoundError, ValidationError } from "./errors.js";
 import { hashCanonicalContent } from "./canonical-content.js";
+import {
+  DEFAULT_ESCROW_ASSET_SYMBOL,
+  decimalsForAssetSymbol
+} from "./assets.js";
 import { extractSubmissionText } from "./submission.js";
 
 /**
@@ -346,7 +350,10 @@ export function buildBadgeFromSession({ session, job, verification, context = {}
     );
   }
 
-  const decimals = Number.isInteger(job.rewardDecimals) ? job.rewardDecimals : 18;
+  const rewardAsset = job.rewardAsset ?? DEFAULT_ESCROW_ASSET_SYMBOL;
+  const decimals = Number.isInteger(job.rewardDecimals)
+    ? job.rewardDecimals
+    : decimalsForAssetSymbol(rewardAsset);
   const rewardBase = toBaseUnits(job.rewardAmount, decimals);
   const stakeBase = toBaseUnits(session.claimStake, decimals);
   const publicBaseUrl = context.publicBaseUrl ?? undefined;
@@ -363,8 +370,8 @@ export function buildBadgeFromSession({ session, job, verification, context = {}
     category: job.category,
     level: inferLevel(job),
     verifierMode: job.verifierMode,
-    reward: { asset: job.rewardAsset ?? "DOT", amount: rewardBase, decimals },
-    claimStake: { asset: job.rewardAsset ?? "DOT", amount: stakeBase, decimals },
+    reward: { asset: rewardAsset, amount: rewardBase, decimals },
+    claimStake: { asset: rewardAsset, amount: stakeBase, decimals },
     evidenceHash,
     completedAt: new Date(session.updatedAt ?? Date.now()).toISOString(),
     worker: requireLowerAddress(session.wallet, "session.wallet"),

--- a/mcp-server/src/core/claim-economics.js
+++ b/mcp-server/src/core/claim-economics.js
@@ -1,7 +1,10 @@
+import { DEFAULT_ESCROW_ASSET_SYMBOL, normalizeAssetSymbol } from "./assets.js";
+
 export const DEFAULT_ONBOARDING_WAIVER_CLAIM_COUNT = 3;
 export const DEFAULT_CLAIM_FEE_BPS = 200;
 export const DEFAULT_CLAIM_FEE_VERIFIER_BPS = 7000;
 export const DEFAULT_MIN_CLAIM_FEE_BY_ASSET = {
+  USDC: 0.05,
   DOT: 0.05
 };
 
@@ -11,7 +14,7 @@ export function countClaimedSessions(sessions = []) {
 
 export function computeClaimEconomics({
   rewardAmount,
-  rewardAsset = "DOT",
+  rewardAsset = DEFAULT_ESCROW_ASSET_SYMBOL,
   priorClaimCount = 0,
   claimStakeBps = 500,
   claimFeeBps = DEFAULT_CLAIM_FEE_BPS,
@@ -20,6 +23,7 @@ export function computeClaimEconomics({
   minClaimFeeByAsset = DEFAULT_MIN_CLAIM_FEE_BY_ASSET
 } = {}) {
   const reward = finiteNumber(rewardAmount, 0);
+  const asset = normalizeAssetSymbol(rewardAsset);
   const claimNumber = Math.max(0, Math.floor(finiteNumber(priorClaimCount, 0))) + 1;
   const waived = claimNumber <= Math.max(0, Math.floor(finiteNumber(onboardingWaiverClaimCount, 0)));
 
@@ -40,7 +44,7 @@ export function computeClaimEconomics({
   const feeBps = Math.max(0, finiteNumber(claimFeeBps, 0));
   const claimStake = Math.max((reward * stakeBps) / 10_000, 0);
   const percentageFee = Math.max((reward * feeBps) / 10_000, 0);
-  const minimumFee = Math.max(finiteNumber(minClaimFeeByAsset?.[rewardAsset], 0), 0);
+  const minimumFee = Math.max(finiteNumber(minClaimFeeByAsset?.[asset], 0), 0);
   const claimFee = Math.max(percentageFee, minimumFee);
 
   return {

--- a/mcp-server/src/core/funded-jobs.js
+++ b/mcp-server/src/core/funded-jobs.js
@@ -1,3 +1,5 @@
+import { DEFAULT_ESCROW_ASSET_SYMBOL } from "./assets.js";
+
 export const FUNDED_JOB_STATUSES = Object.freeze({
   OPEN: "open",
   MERGED: "merged",
@@ -25,7 +27,7 @@ export function buildFundedJobFromClaim({ job, session, now = new Date() }) {
     wallet: session?.wallet,
     sourceType: job?.source?.type ?? "manual",
     source: job?.source ? { ...job.source } : undefined,
-    rewardAsset: job?.rewardAsset ?? "DOT",
+    rewardAsset: job?.rewardAsset ?? DEFAULT_ESCROW_ASSET_SYMBOL,
     rewardAmount: finiteNumber(job?.rewardAmount, 0),
     claimStake: finiteNumber(session?.claimStake, 0),
     claimFee: finiteNumber(session?.claimFee, 0),
@@ -51,7 +53,7 @@ export function updateFundedJobFromSession(existing, { job, session, verificatio
     wallet: session?.wallet ?? existing?.wallet,
     sourceType: job?.source?.type ?? existing?.sourceType,
     source: job?.source ? { ...job.source } : existing?.source,
-    rewardAsset: job?.rewardAsset ?? existing?.rewardAsset,
+    rewardAsset: job?.rewardAsset ?? existing?.rewardAsset ?? DEFAULT_ESCROW_ASSET_SYMBOL,
     rewardAmount: job ? finiteNumber(job.rewardAmount, 0) : existing?.rewardAmount,
     claimStake: session ? finiteNumber(session.claimStake, 0) : existing?.claimStake,
     claimFee: session ? finiteNumber(session.claimFee, 0) : existing?.claimFee,

--- a/mcp-server/src/core/job-catalog-service.js
+++ b/mcp-server/src/core/job-catalog-service.js
@@ -5,6 +5,7 @@ import {
 } from "./errors.js";
 import { getBuiltinJobSchema, isBuiltinJobSchemaRef, schemaRefToJobSchemaPath } from "./job-schema-registry.js";
 import { buildVerificationContract } from "./verifier-contract.js";
+import { normalizeAssetSymbol } from "./assets.js";
 
 const DEFAULT_AGENT_PROFILE = {
   capabilities: ["claim_job", "submit_work", "allocate_idle_funds"],
@@ -658,7 +659,7 @@ export class JobCatalogService {
     const rewardAmount = Number(input?.rewardAmount ?? 0);
     const claimTtlSeconds = Number(input?.claimTtlSeconds ?? 3600);
     const retryLimit = Number(input?.retryLimit ?? 1);
-    const rewardAsset = String(input?.rewardAsset ?? "DOT").trim().toUpperCase();
+    const rewardAsset = normalizeAssetSymbol(input?.rewardAsset);
     const jobType = normalizeJobType(input?.jobType);
     const requiredRole = normalizeAgentRole(input?.requiredRole ?? DEFAULT_ROLE_BY_JOB_TYPE[jobType]);
 
@@ -982,7 +983,7 @@ function normaliseRecurringPolicy(raw, { recurring, rewardAmount, rewardAsset })
     }
     policy.reserveAmount = reserveAmount;
     policy.reserveAsset = typeof raw.reserveAsset === "string" && raw.reserveAsset.trim()
-      ? raw.reserveAsset.trim().toUpperCase()
+      ? normalizeAssetSymbol(raw.reserveAsset)
       : rewardAsset;
     if (policy.reserveAsset !== rewardAsset) {
       throw new ValidationError("recurringPolicy.reserveAsset must match rewardAsset.");
@@ -1040,7 +1041,7 @@ function normaliseDelegationPolicy(raw, { rewardAmount, rewardAsset }) {
     }
     policy.budgetAmount = budgetAmount;
     policy.budgetAsset = typeof raw.budgetAsset === "string" && raw.budgetAsset.trim()
-      ? raw.budgetAsset.trim().toUpperCase()
+      ? normalizeAssetSymbol(raw.budgetAsset)
       : rewardAsset;
     if (policy.budgetAsset !== rewardAsset) {
       throw new ValidationError("delegationPolicy.budgetAsset must match rewardAsset.");

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -18,6 +18,7 @@ import {
 import { computeClaimEconomics, countClaimedSessions } from "./claim-economics.js";
 import { claimStatusFields, isTerminalSession, summarizeJobClaimState } from "./claim-state.js";
 import { capabilityMatrix } from "../auth/capabilities.js";
+import { normalizeAssetSymbol } from "./assets.js";
 
 const TIMELINE_VERSION = "v2";
 
@@ -747,7 +748,7 @@ export class PlatformService {
     }
 
     const rewardAmount = Number(input?.rewardAmount ?? 0);
-    const rewardAsset = String(input?.rewardAsset ?? parentJob.rewardAsset ?? "DOT").trim().toUpperCase();
+    const rewardAsset = normalizeAssetSymbol(input?.rewardAsset ?? parentJob.rewardAsset);
     if (!Number.isFinite(rewardAmount) || rewardAmount <= 0) {
       throw new ValidationError("Sub-job rewardAmount must be greater than zero.");
     }
@@ -849,7 +850,7 @@ export class PlatformService {
       maxDepth: Number.isInteger(raw.maxDepth) ? raw.maxDepth : 1,
       maxSubJobs: Number.isInteger(raw.maxSubJobs) ? raw.maxSubJobs : 5,
       budgetAmount: Number.isFinite(Number(raw.budgetAmount)) ? Number(raw.budgetAmount) : Number(parentJob?.rewardAmount ?? 0),
-      budgetAsset: String(raw.budgetAsset ?? parentJob?.rewardAsset ?? "DOT").trim().toUpperCase()
+      budgetAsset: normalizeAssetSymbol(raw.budgetAsset ?? parentJob?.rewardAsset)
     };
   }
 
@@ -971,7 +972,7 @@ export class PlatformService {
     if (!wallet) {
       throw new ValidationError("Recurring templates with finite reserves require a poster wallet.");
     }
-    const asset = job.recurringPolicy.reserveAsset ?? job.rewardAsset ?? "DOT";
+    const asset = normalizeAssetSymbol(job.recurringPolicy.reserveAsset ?? job.rewardAsset);
     const receipt = await this.accountMutationService.reserveRecurringTemplateFunding(
       wallet,
       asset,
@@ -1261,8 +1262,9 @@ function buildDerivativeJobTimelineEntry(job) {
 }
 
 function sumSubJobRewards(jobs, asset) {
+  const normalizedAsset = normalizeAssetSymbol(asset);
   return jobs
-    .filter((job) => String(job.rewardAsset ?? "DOT").trim().toUpperCase() === asset)
+    .filter((job) => normalizeAssetSymbol(job.rewardAsset) === normalizedAsset)
     .reduce((total, job) => total + Math.max(Number(job.rewardAmount ?? 0), 0), 0);
 }
 

--- a/mcp-server/src/core/recurring-jobs.test.js
+++ b/mcp-server/src/core/recurring-jobs.test.js
@@ -7,7 +7,7 @@ import { ValidationError } from "./errors.js";
 function makeService() {
   const jobs = [];
   const profiles = new Map();
-  const account = async () => ({ liquid: { DOT: 100 } });
+  const account = async () => ({ liquid: { USDC: 100 } });
   const reputation = async () => ({ skill: 0, reliability: 0, economic: 0, tier: "starter" });
   const bps = async () => 500;
   return new JobCatalogService(jobs, profiles, account, reputation, bps);
@@ -36,9 +36,9 @@ test("createJob preserves finite recurring reserve policy", () => {
   const service = makeService();
   const record = service.createJob({
     ...TEMPLATE,
-    recurringPolicy: { reserveAmount: 15, reserveAsset: "DOT" }
+    recurringPolicy: { reserveAmount: 15, reserveAsset: "USDC" }
   });
-  assert.deepEqual(record.recurringPolicy, { reserveAmount: 15, reserveAsset: "DOT" });
+  assert.deepEqual(record.recurringPolicy, { reserveAmount: 15, reserveAsset: "USDC" });
 });
 
 test("createJob rejects recurring reserve that cannot cover one run", () => {
@@ -116,7 +116,7 @@ test("fireRecurringJob carries escrow-native recurring funding onto derivatives"
   template.recurringPolicy.funding = {
     source: "recurring_template_reserve",
     wallet: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    asset: "DOT",
+    asset: "USDC",
     amount: 10,
     reservedAt: "2026-05-04T08:00:00.000Z",
     templateKey: `0x${"1".repeat(64)}`
@@ -130,7 +130,7 @@ test("fireRecurringJob carries escrow-native recurring funding onto derivatives"
     source: "recurring_template_reserve",
     templateId: "weekly-digest",
     wallet: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    asset: "DOT",
+    asset: "USDC",
     amount: 5,
     reservedAt: "2026-05-04T08:00:00.000Z",
     templateKey: `0x${"1".repeat(64)}`

--- a/mcp-server/src/jobs/ingest-github-issues.js
+++ b/mcp-server/src/jobs/ingest-github-issues.js
@@ -7,6 +7,7 @@ import {
   evaluateMaintainerSurfaceForIssue,
   repoFromIssue
 } from "../core/maintainer-surface-policy.js";
+import { DEFAULT_ESCROW_ASSET_SYMBOL } from "../core/assets.js";
 
 /**
  * Ingest agent-suitable GitHub issues into the Agent Platform job catalog.
@@ -183,7 +184,7 @@ export function toPlatformJob(issue, score = scoreIssue(issue), {
     requiredRole: "worker",
     category,
     tier: "starter",
-    rewardAsset: "DOT",
+    rewardAsset: DEFAULT_ESCROW_ASSET_SYMBOL,
     rewardAmount: 1,
     verifierMode: "github_pr",
     verifierMinimumScore: 60,

--- a/mcp-server/src/jobs/ingest-github-issues.test.js
+++ b/mcp-server/src/jobs/ingest-github-issues.test.js
@@ -49,6 +49,7 @@ test("toPlatformJob preserves GitHub issue context as job metadata", () => {
   assert.equal(job.jobType, "work");
   assert.equal(job.requiredRole, "worker");
   assert.equal(job.category, "testing");
+  assert.equal(job.rewardAsset, "USDC");
   assert.equal(job.source.type, "github_issue");
   assert.equal(job.source.repo, "example/project");
   assert.equal(job.source.issueNumber, 42);

--- a/mcp-server/src/jobs/ingest-open-data-datasets.js
+++ b/mcp-server/src/jobs/ingest-open-data-datasets.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { pathToFileURL } from "node:url";
+import { DEFAULT_ESCROW_ASSET_SYMBOL } from "../core/assets.js";
 
 /**
  * Ingest public open-data dataset/resource quality-audit jobs.
@@ -310,7 +311,7 @@ export function toPlatformJob(target, score = scoreDatasetTarget(target)) {
     requiredRole: "worker",
     category: "data",
     tier: "starter",
-    rewardAsset: "DOT",
+    rewardAsset: DEFAULT_ESCROW_ASSET_SYMBOL,
     rewardAmount: 2,
     verifierMode: "benchmark",
     verifierTerms: ["dataset_url", "resource_url", "checks", "recommended_actions"],

--- a/mcp-server/src/jobs/ingest-open-data-datasets.test.js
+++ b/mcp-server/src/jobs/ingest-open-data-datasets.test.js
@@ -189,6 +189,7 @@ test("toPlatformJob creates a benchmark open-data audit job", () => {
   assert.equal(job.id, "open-data-datagov-dataset-123-resource-456");
   assert.equal(job.category, "data");
   assert.equal(job.tier, "starter");
+  assert.equal(job.rewardAsset, "USDC");
   assert.equal(job.verifierMode, "benchmark");
   assert.equal(job.inputSchemaRef, "schema://jobs/open-data-quality-audit-input");
   assert.equal(job.outputSchemaRef, "schema://jobs/open-data-quality-audit-output");

--- a/mcp-server/src/jobs/ingest-openapi-specs.js
+++ b/mcp-server/src/jobs/ingest-openapi-specs.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { pathToFileURL } from "node:url";
+import { DEFAULT_ESCROW_ASSET_SYMBOL } from "../core/assets.js";
 
 /**
  * Ingest OpenAPI quality audit jobs.
@@ -169,7 +170,7 @@ export function toPlatformJob(target, score = scoreOpenApiTarget(target)) {
     requiredRole: "worker",
     category: "api",
     tier: "starter",
-    rewardAsset: "DOT",
+    rewardAsset: DEFAULT_ESCROW_ASSET_SYMBOL,
     rewardAmount: 3,
     verifierMode: "benchmark",
     verifierTerms: ["spec_url", "checks", "findings", "recommended_actions"],

--- a/mcp-server/src/jobs/ingest-openapi-specs.test.js
+++ b/mcp-server/src/jobs/ingest-openapi-specs.test.js
@@ -131,6 +131,7 @@ test("toPlatformJob creates OpenAPI quality audit job", async () => {
   assert.equal(job.id, "openapi-averray-averray-http-api");
   assert.equal(job.category, "api");
   assert.equal(job.tier, "starter");
+  assert.equal(job.rewardAsset, "USDC");
   assert.equal(job.verifierMode, "benchmark");
   assert.equal(job.inputSchemaRef, "schema://jobs/openapi-quality-audit-input");
   assert.equal(job.outputSchemaRef, "schema://jobs/openapi-quality-audit-output");

--- a/mcp-server/src/jobs/ingest-osv-advisories.js
+++ b/mcp-server/src/jobs/ingest-osv-advisories.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { pathToFileURL } from "node:url";
+import { DEFAULT_ESCROW_ASSET_SYMBOL } from "../core/assets.js";
 
 /**
  * Ingest OSV package advisories into dependency remediation jobs.
@@ -273,7 +274,7 @@ export function toPlatformJob({ target, advisory, advisories, fixedVersion, scor
     requiredRole: "worker",
     category: "security",
     tier: "starter",
-    rewardAsset: "DOT",
+    rewardAsset: DEFAULT_ESCROW_ASSET_SYMBOL,
     rewardAmount: 3,
     verifierMode: "github_pr",
     verifierMinimumScore: 70,

--- a/mcp-server/src/jobs/ingest-osv-advisories.test.js
+++ b/mcp-server/src/jobs/ingest-osv-advisories.test.js
@@ -152,6 +152,7 @@ test("toPlatformJob creates a PR-shaped dependency remediation job", () => {
   assert.equal(job.id, "osv-npm-example-app-minimist-0-0-8-ghsa-vh95-rmgr-6w4m");
   assert.equal(job.category, "security");
   assert.equal(job.tier, "starter");
+  assert.equal(job.rewardAsset, "USDC");
   assert.equal(job.verifierMode, "github_pr");
   assert.equal(job.inputSchemaRef, "schema://jobs/dependency-remediation-input");
   assert.equal(job.outputSchemaRef, "schema://jobs/dependency-remediation-output");

--- a/mcp-server/src/jobs/ingest-standards-specs.js
+++ b/mcp-server/src/jobs/ingest-standards-specs.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { pathToFileURL } from "node:url";
+import { DEFAULT_ESCROW_ASSET_SYMBOL } from "../core/assets.js";
 
 /**
  * Ingest standards/spec freshness audit jobs.
@@ -154,7 +155,7 @@ export function toPlatformJob(target, score = scoreSpecTarget(target)) {
     requiredRole: "worker",
     category: "docs",
     tier: "starter",
-    rewardAsset: "DOT",
+    rewardAsset: DEFAULT_ESCROW_ASSET_SYMBOL,
     rewardAmount: 3,
     verifierMode: "benchmark",
     verifierTerms: ["source_surface", "drift_findings", "missing_updates", "fix_recommendation"],

--- a/mcp-server/src/jobs/ingest-standards-specs.test.js
+++ b/mcp-server/src/jobs/ingest-standards-specs.test.js
@@ -87,6 +87,7 @@ test("toPlatformJob creates standards freshness audit job", async () => {
   assert.equal(job.id, "standards-w3c-vc-data-model-2-0");
   assert.equal(job.category, "docs");
   assert.equal(job.tier, "starter");
+  assert.equal(job.rewardAsset, "USDC");
   assert.equal(job.verifierMode, "benchmark");
   assert.equal(job.inputSchemaRef, "schema://jobs/docs-input");
   assert.equal(job.outputSchemaRef, "schema://jobs/docs-drift-audit-output");

--- a/mcp-server/src/jobs/ingest-wikipedia-maintenance.js
+++ b/mcp-server/src/jobs/ingest-wikipedia-maintenance.js
@@ -2,6 +2,7 @@
 
 import { pathToFileURL } from "node:url";
 import { schemaRefToJobSchemaPath } from "../core/job-schema-registry.js";
+import { DEFAULT_ESCROW_ASSET_SYMBOL } from "../core/assets.js";
 
 export const DEFAULT_LANGUAGE = "en";
 export const DEFAULT_BASE_URL = "http://localhost:8787";
@@ -205,7 +206,7 @@ export function toPlatformJob(article, score = scoreArticle(article)) {
     requiredRole: "worker",
     category: "wikipedia",
     tier: "starter",
-    rewardAsset: "DOT",
+    rewardAsset: DEFAULT_ESCROW_ASSET_SYMBOL,
     rewardAmount: task.rewardAmount,
     verifierMode: "benchmark",
     verifierTerms: task.verifierTerms,

--- a/mcp-server/src/jobs/ingest-wikipedia-maintenance.test.js
+++ b/mcp-server/src/jobs/ingest-wikipedia-maintenance.test.js
@@ -29,6 +29,7 @@ test("toPlatformJob produces an Averray-attributed Wikipedia proposal job", () =
   assert.equal(job.id, "wiki-en-123-citation_repair-example-article");
   assert.equal(job.category, "wikipedia");
   assert.equal(job.jobType, "review");
+  assert.equal(job.rewardAsset, "USDC");
   assert.equal(job.source.type, "wikipedia_article");
   assert.equal(job.source.lang, "en");
   assert.equal(job.source.articleUrl, "https://en.wikipedia.org/wiki/Example_article");

--- a/mcp-server/src/protocols/http/server.smoke.test.js
+++ b/mcp-server/src/protocols/http/server.smoke.test.js
@@ -315,11 +315,11 @@ test("http smoke: /jobs/sub lets active workers create funded child jobs", { ski
         verifierTerms: ["complete"],
         verifierMinimumMatches: 1,
         outputSchemaRef: "schema://jobs/subjob-parent-smoke-output",
-        delegationPolicy: { budgetAmount: 3, budgetAsset: "DOT", maxSubJobs: 2, maxDepth: 1 }
+        delegationPolicy: { budgetAmount: 3, budgetAsset: "USDC", maxSubJobs: 2, maxDepth: 1 }
       })
     });
 
-    await fetch(`${base}/account/fund?asset=DOT&amount=10`, {
+    await fetch(`${base}/account/fund?asset=USDC&amount=10`, {
       method: "POST",
       headers: { authorization: `Bearer ${workerToken}` }
     });
@@ -368,7 +368,7 @@ test("http smoke: /jobs/sub lets active workers create funded child jobs", { ski
       headers: { authorization: `Bearer ${workerToken}` }
     });
     const balances = await account.json();
-    assert.equal(balances.reserved.DOT, 2);
+    assert.equal(balances.reserved.USDC, 2);
   });
 });
 

--- a/mcp-server/src/protocols/http/server.smoke.test.js
+++ b/mcp-server/src/protocols/http/server.smoke.test.js
@@ -696,8 +696,8 @@ test("http smoke: /agents/:wallet aggregates approved sessions into badges", { s
     assert.equal(profile.stats.approvedCount, 1);
     assert.equal(profile.stats.rejectedCount, 0);
     assert.equal(profile.stats.completionRate, 1);
-    // 4 DOT at 18 decimals = 4 * 10^18 base units
-    assert.equal(profile.stats.totalEarned.amount, "4000000000000000000");
+    // Job rewards default to USDC: 4 USDC at 6 decimals = 4 * 10^6 base units.
+    assert.equal(profile.stats.totalEarned.amount, "4000000");
     assert.equal(profile.badges[0].sessionId, sessionId);
     assert.equal(profile.badges[0].category, "coding");
     assert.equal(profile.badges[0].level, 1);

--- a/mcp-server/src/services/bootstrap.js
+++ b/mcp-server/src/services/bootstrap.js
@@ -52,6 +52,7 @@ import {
 import { normaliseStrategyAssetConfig } from "./strategy-asset-config.js";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { DEFAULT_ESCROW_ASSET_SYMBOL } from "../core/assets.js";
 
 const moduleDir = dirname(fileURLToPath(import.meta.url));
 loadLocalEnv(process.cwd(), resolve(moduleDir, "../../"));
@@ -61,7 +62,7 @@ const jobs = [
     id: "starter-coding-001",
     category: "coding",
     tier: "starter",
-    rewardAsset: "DOT",
+    rewardAsset: DEFAULT_ESCROW_ASSET_SYMBOL,
     rewardAmount: 5,
     verifierMode: "benchmark",
     verifierConfig: {
@@ -79,7 +80,7 @@ const jobs = [
     id: "governance-pro-001",
     category: "governance",
     tier: "pro",
-    rewardAsset: "DOT",
+    rewardAsset: DEFAULT_ESCROW_ASSET_SYMBOL,
     rewardAmount: 25,
     verifierMode: "deterministic",
     verifierConfig: {
@@ -111,12 +112,12 @@ const profiles = new Map([
 const accounts = new Map([
   ["0xagent", {
     wallet: "0xagent",
-    liquid: { DOT: 25 },
-    reserved: { DOT: 0 },
-    strategyAllocated: { DOT: 5 },
-    collateralLocked: { DOT: 10 },
-    jobStakeLocked: { DOT: 0 },
-    debtOutstanding: { DOT: 0 }
+    liquid: { USDC: 25 },
+    reserved: { USDC: 0 },
+    strategyAllocated: {},
+    collateralLocked: { USDC: 10 },
+    jobStakeLocked: { USDC: 0 },
+    debtOutstanding: { USDC: 0 }
   }]
 ]);
 

--- a/sdk/agent-platform-client.d.ts
+++ b/sdk/agent-platform-client.d.ts
@@ -17,6 +17,7 @@ export type ISODateTime = string;
 export type JobId = string;
 export type SessionId = string;
 export type IdempotencyKey = string;
+export const DEFAULT_ESCROW_ASSET_SYMBOL: "USDC";
 
 export interface AgentPlatformClientOptions {
   baseUrl: string;

--- a/sdk/agent-platform-client.js
+++ b/sdk/agent-platform-client.js
@@ -6,6 +6,8 @@
  * one typed-ish place to call auth, jobs, sessions, verifier, and admin
  * routes without repeating raw fetch glue.
  */
+export const DEFAULT_ESCROW_ASSET_SYMBOL = "USDC";
+
 export class AgentPlatformClient {
   constructor({ baseUrl, token = undefined, fetchImpl = fetch } = {}) {
     if (!baseUrl) {
@@ -125,7 +127,7 @@ export class AgentPlatformClient {
     return this.request("/account");
   }
 
-  async getBorrowCapacity(asset = "DOT") {
+  async getBorrowCapacity(asset = DEFAULT_ESCROW_ASSET_SYMBOL) {
     return this.request(`/account/borrow-capacity?asset=${encodeURIComponent(asset)}`);
   }
 
@@ -133,42 +135,42 @@ export class AgentPlatformClient {
     return this.request("/account/strategies");
   }
 
-  async fundAccount({ asset = "DOT", amount } = {}) {
+  async fundAccount({ asset = DEFAULT_ESCROW_ASSET_SYMBOL, amount } = {}) {
     return this.request("/account/fund", {
       method: "POST",
       body: { asset, amount }
     });
   }
 
-  async allocateIdleFunds({ asset = "DOT", amount, strategyId = "default-low-risk", ...options } = {}) {
+  async allocateIdleFunds({ asset = DEFAULT_ESCROW_ASSET_SYMBOL, amount, strategyId = "default-low-risk", ...options } = {}) {
     return this.request("/account/allocate", {
       method: "POST",
       body: compact({ asset, amount, strategyId, ...options })
     });
   }
 
-  async deallocateIdleFunds({ asset = "DOT", amount, strategyId = "default-low-risk", ...options } = {}) {
+  async deallocateIdleFunds({ asset = DEFAULT_ESCROW_ASSET_SYMBOL, amount, strategyId = "default-low-risk", ...options } = {}) {
     return this.request("/account/deallocate", {
       method: "POST",
       body: compact({ asset, amount, strategyId, ...options })
     });
   }
 
-  async sendToAgent({ recipient, asset = "DOT", amount } = {}) {
+  async sendToAgent({ recipient, asset = DEFAULT_ESCROW_ASSET_SYMBOL, amount } = {}) {
     return this.request("/payments/send", {
       method: "POST",
       body: { recipient, asset, amount }
     });
   }
 
-  async borrowFunds({ asset = "DOT", amount, idempotencyKey = undefined } = {}) {
+  async borrowFunds({ asset = DEFAULT_ESCROW_ASSET_SYMBOL, amount, idempotencyKey = undefined } = {}) {
     return this.request("/account/borrow", {
       method: "POST",
       body: compact({ asset, amount, idempotencyKey })
     });
   }
 
-  async repayFunds({ asset = "DOT", amount, idempotencyKey = undefined } = {}) {
+  async repayFunds({ asset = DEFAULT_ESCROW_ASSET_SYMBOL, amount, idempotencyKey = undefined } = {}) {
     return this.request("/account/repay", {
       method: "POST",
       body: compact({ asset, amount, idempotencyKey })

--- a/sdk/agent-platform-client.test.mjs
+++ b/sdk/agent-platform-client.test.mjs
@@ -65,7 +65,7 @@ test("authenticated helpers send bearer token and compact JSON bodies", async ()
   assert.equal(calls[0].options.headers.get("authorization"), "Bearer test-token");
   assert.equal(calls[0].options.headers.get("content-type"), "application/json");
   assert.deepEqual(JSON.parse(calls[0].options.body), {
-    asset: "DOT",
+    asset: "USDC",
     amount: 5,
     strategyId: "polkadot-vdot",
     idempotencyKey: "alloc-1"
@@ -74,18 +74,18 @@ test("authenticated helpers send bearer token and compact JSON bodies", async ()
   assert.equal(calls[1].url, "https://api.example.test/payments/send");
   assert.deepEqual(JSON.parse(calls[1].options.body), {
     recipient: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
-    asset: "DOT",
+    asset: "USDC",
     amount: "1.5"
   });
   assert.equal(calls[2].url, "https://api.example.test/account/borrow");
   assert.deepEqual(JSON.parse(calls[2].options.body), {
-    asset: "DOT",
+    asset: "USDC",
     amount: 2,
     idempotencyKey: "borrow-1"
   });
   assert.equal(calls[3].url, "https://api.example.test/account/repay");
   assert.deepEqual(JSON.parse(calls[3].options.body), {
-    asset: "DOT",
+    asset: "USDC",
     amount: 1
   });
 });

--- a/sdk/api-surface-model.mjs
+++ b/sdk/api-surface-model.mjs
@@ -8,6 +8,7 @@ export type ISODateTime = string;
 export type JobId = string;
 export type SessionId = string;
 export type IdempotencyKey = string;
+export const DEFAULT_ESCROW_ASSET_SYMBOL: "USDC";
 
 export interface AgentPlatformClientOptions {
   baseUrl: string;


### PR DESCRIPTION
## Summary
- add a shared backend escrow asset default for Polkadot Hub USDC and use it in claim economics, job normalization, funded-job records, badge/profile metadata, recurring fallbacks, and strategy accounting fallbacks
- switch launch-facing ingestion jobs, bootstrap seed jobs, ready-to-post payloads, and SDK account defaults from DOT to USDC
- update spec/docs/schema examples to reflect USDC/6 settlement while leaving DOT/vDOT strategy-path references intact

## Polkadot MCP check
- Rechecked official Polkadot docs MCP: Polkadot Hub USDC is Trust-Backed Asset ID 1337, 6 decimals, ERC20 precompile 0x0000053900000000000000000000000001200000

## Checks
- node --test mcp-server/src/blockchain/config.test.js
- node --test mcp-server/src/core/agent-transfer.test.js mcp-server/src/core/recurring-jobs.test.js mcp-server/src/core/job-execution-service.test.js mcp-server/src/core/badge-metadata.test.js mcp-server/src/core/agent-profile.test.js mcp-server/src/core/funded-jobs.test.js mcp-server/src/jobs/ingest-github-issues.test.js mcp-server/src/jobs/ingest-wikipedia-maintenance.test.js mcp-server/src/jobs/ingest-osv-advisories.test.js mcp-server/src/jobs/ingest-open-data-datasets.test.js mcp-server/src/jobs/ingest-openapi-specs.test.js mcp-server/src/jobs/ingest-standards-specs.test.js
- node --test sdk/agent-platform-client.test.mjs
- npm run check:sdk-types
- npm run typecheck:sdk
- npm run typecheck:app
- npm run build:frontend (generated frontend output cleaned, per repo rules)
- git diff --check

## Local full-suite note
- npm --workspace mcp-server test currently fails locally because @paraspell/sdk-core is not installed in this worktree node_modules; the failures are import-time ERR_MODULE_NOT_FOUND in XCM-related tests, not from this USDC change. CI installs dependencies from the lockfile.