### PR TITLE
Schedule bootstrap self-report emails

### DIFF
--- a/docs/AVERRAY_WORKING_SPEC.md
+++ b/docs/AVERRAY_WORKING_SPEC.md
@@ -945,6 +945,12 @@ Stripe Link's launch and Stripe Sessions 2026 announcements positioned agents as
 
 For traceability.
 
+### v2.5 (bootstrap self-report scheduler)
+
+1. **Weekly bootstrap self-report email path added:** backend now has a disabled-by-default scheduler that generates the existing funded-jobs weekly report and sends it through a Resend-compatible HTTP email provider.
+2. **Operational status exposed:** `/admin/status` includes `bootstrapSelfReport` with enabled/running/provider/recipient/last-run state so the operator can verify whether the weekly report is actually armed.
+3. **Launch checklist remains live-gated:** the code path exists, but the pre-launch checkbox should only be marked complete after production env sets recipients/API key and the first scheduled report is delivered.
+
 ### v2.4 (runtime USDC defaults and decimals audit)
 
 1. **Runtime job-sourcing defaults** now emit `rewardAsset: "USDC"` instead of `"DOT"` for GitHub issue, Wikipedia maintenance, OSV advisory, open-data, OpenAPI, standards-spec, ready-to-post, and bootstrap seed jobs.

--- a/docs/FRAMEWORK_AGENT_HANDOFF.md
+++ b/docs/FRAMEWORK_AGENT_HANDOFF.md
@@ -81,7 +81,7 @@ The following can proceed in parallel (gated only by item B above for anything m
 **Backend:**
 - SCALE assembler (`mcp-server/src/blockchain/xcm-message-builder/`) — *only needed for v1.x yield strategy, not v1.0.0-rc1 launch*
 - Dispute-flow wiring — `POST /disputes/:id/verdict` and `/release` to actually call `EscrowCore.resolveDispute`
-- Pre-launch instrumentation — `funded_jobs` table, daily upstream-status poller, weekly self-report
+- Pre-launch instrumentation — `funded_jobs` table, daily upstream-status poller, weekly self-report scheduler code exists; production still needs email recipients/provider secrets and first-delivery verification before the launch checklist item is closed.
 
 **v1.x reputation deepening (don't gate v1.0.0-rc1 contract deploy but ship before public launch):**
 - Public agent profile page at `averray.com/agent/<wallet>` (~2 weeks frontend; reads from indexer)

--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -130,6 +130,16 @@ AUTH_CHAIN_ID=420420417
 # UPSTREAM_STATUS_POLLER_ENABLED=false
 # UPSTREAM_STATUS_POLLER_INTERVAL_MS=86400000
 # UPSTREAM_STATUS_POLLER_BATCH_SIZE=50
+# Weekly email self-report for the bootstrap gate. Disabled until an email
+# provider and recipient list are explicitly configured.
+# BOOTSTRAP_SELF_REPORT_ENABLED=false
+# BOOTSTRAP_SELF_REPORT_INTERVAL_MS=604800000
+# BOOTSTRAP_SELF_REPORT_SEND_ON_START=false
+# BOOTSTRAP_SELF_REPORT_FROM="Averray <ops@averray.com>"
+# BOOTSTRAP_SELF_REPORT_TO="pascal@example.com"
+# BOOTSTRAP_SELF_REPORT_SUBJECT_PREFIX="Averray bootstrap self-report"
+# RESEND_API_KEY=
+# RESEND_API_BASE_URL=https://api.resend.com
 
 # --- Wikipedia maintenance job ingestion -------------------------------------
 # Production defaults to enabled with dry-run disabled, capped at two jobs per

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -76,6 +76,7 @@ export class PlatformService {
     this.xcmSettlementWatcher = undefined;
     this.xcmObservationRelay = undefined;
     this.upstreamStatusPoller = undefined;
+    this.bootstrapSelfReportScheduler = undefined;
 
     this.accountMutationService = new AccountMutationService(
       this.accounts,
@@ -195,6 +196,7 @@ export class PlatformService {
       standardsIngestion,
       openApiIngestion,
       upstreamStatus,
+      bootstrapSelfReport,
       jobStaleSweeper,
       recentSessions
     ] = await Promise.all([
@@ -280,6 +282,16 @@ export class PlatformService {
         running: false,
         intervalMs: 0,
         batchSize: 0,
+        lastRun: undefined
+      },
+      this.bootstrapSelfReportScheduler?.getStatus?.() ?? {
+        enabled: false,
+        running: false,
+        intervalMs: 0,
+        sendOnStart: false,
+        recipientCount: 0,
+        providerConfigured: false,
+        nextRunAt: undefined,
         lastRun: undefined
       },
       this.jobStaleSweeper?.getStatus?.() ?? {
@@ -410,6 +422,7 @@ export class PlatformService {
       standardsIngestion: standardsIngestion,
       openApiIngestion: openApiIngestion,
       upstreamStatus,
+      bootstrapSelfReport,
       xcmSettlementWatcher: await this.xcmSettlementWatcher?.getStatus?.() ?? {
         enabled: false,
         running: false,

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -656,6 +656,19 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
       };
     }
   };
+  service.bootstrapSelfReportScheduler = {
+    getStatus() {
+      return {
+        enabled: true,
+        running: true,
+        intervalMs: 604800000,
+        recipientCount: 1,
+        providerConfigured: true,
+        nextRunAt: "2026-05-08T00:00:00.000Z",
+        lastRun: { status: "sent", email: { providerId: "email_123" } }
+      };
+    }
+  };
 
   const status = await service.getAdminStatus();
   assert.equal(status.osvIngestion.packageCount, 0);
@@ -692,6 +705,8 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
   assert.equal(status.providerOperations.openApi.lastRun.errorCount, 1);
   assert.equal(status.jobStaleSweeper.mode, "live");
   assert.equal(status.jobStaleSweeper.lastRun.updatedCount, 2);
+  assert.equal(status.bootstrapSelfReport.providerConfigured, true);
+  assert.equal(status.bootstrapSelfReport.lastRun.email.providerId, "email_123");
 
   // Public sanitized counterpart preserves health / mode / counts but
   // strips lastRun.skipped[] and lastRun.errors[] (which can carry

--- a/mcp-server/src/services/bootstrap-self-report-scheduler.js
+++ b/mcp-server/src/services/bootstrap-self-report-scheduler.js
@@ -1,0 +1,341 @@
+const DEFAULT_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
+const DEFAULT_RESEND_API_BASE_URL = "https://api.resend.com";
+
+export class BootstrapSelfReportSchedulerService {
+  constructor(upstreamStatusPoller, eventBus = undefined, {
+    enabled = false,
+    intervalMs = DEFAULT_INTERVAL_MS,
+    sendOnStart = false,
+    from = undefined,
+    to = [],
+    subjectPrefix = "Averray bootstrap self-report",
+    resendApiKey = undefined,
+    resendApiBaseUrl = DEFAULT_RESEND_API_BASE_URL,
+    fetchImpl = fetch,
+    emailSender = undefined,
+    logger = console
+  } = {}) {
+    this.upstreamStatusPoller = upstreamStatusPoller;
+    this.eventBus = eventBus;
+    this.enabled = enabled;
+    this.intervalMs = intervalMs;
+    this.sendOnStart = sendOnStart;
+    this.from = normalizeText(from);
+    this.to = normalizeRecipients(to);
+    this.subjectPrefix = normalizeText(subjectPrefix) || "Averray bootstrap self-report";
+    this.resendApiKey = normalizeText(resendApiKey);
+    this.resendApiBaseUrl = normalizeText(resendApiBaseUrl) || DEFAULT_RESEND_API_BASE_URL;
+    this.fetchImpl = fetchImpl;
+    this.emailSender = emailSender;
+    this.logger = logger;
+    this.running = false;
+    this.timer = undefined;
+    this.nextRunAt = undefined;
+    this.lastRun = undefined;
+  }
+
+  start() {
+    if (!this.enabled || this.running) return;
+    this.running = true;
+    this.scheduleNext(this.sendOnStart ? 0 : this.intervalMs);
+  }
+
+  stop() {
+    this.running = false;
+    this.nextRunAt = undefined;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  async getStatus() {
+    return {
+      enabled: this.enabled,
+      running: this.running,
+      intervalMs: this.intervalMs,
+      sendOnStart: this.sendOnStart,
+      recipientCount: this.to.length,
+      providerConfigured: Boolean(this.emailSender || (this.resendApiKey && this.from && this.to.length)),
+      nextRunAt: this.nextRunAt,
+      lastRun: this.lastRun
+    };
+  }
+
+  async runOnce(now = new Date()) {
+    const summary = {
+      startedAt: now.toISOString(),
+      finishedAt: undefined,
+      status: "pending",
+      skipped: [],
+      errors: [],
+      report: undefined,
+      email: undefined
+    };
+
+    if (!this.enabled) {
+      summary.status = "skipped";
+      summary.skipped.push({ reason: "disabled" });
+      return this.finishRun(summary);
+    }
+    if (!this.upstreamStatusPoller?.generateWeeklyReport) {
+      summary.status = "skipped";
+      summary.skipped.push({ reason: "missing_report_generator" });
+      return this.finishRun(summary);
+    }
+    if (!this.hasEmailConfig()) {
+      summary.status = "skipped";
+      summary.skipped.push({ reason: "missing_email_config" });
+      return this.finishRun(summary);
+    }
+
+    try {
+      const report = await this.upstreamStatusPoller.generateWeeklyReport({ now });
+      const email = buildBootstrapSelfReportEmail(report, {
+        now,
+        from: this.from,
+        to: this.to,
+        subjectPrefix: this.subjectPrefix
+      });
+      const sendResult = await this.sendEmail(email, {
+        idempotencyKey: `bootstrap-self-report-${isoDate(now)}`
+      });
+      summary.status = "sent";
+      summary.report = compactReport(report);
+      summary.email = {
+        to: this.to,
+        subject: email.subject,
+        providerId: sendResult?.id ?? sendResult?.data?.id
+      };
+      this.eventBus?.publish?.({
+        id: `bootstrap-self-report-${Date.now()}`,
+        topic: "bootstrap.self_report.sent",
+        timestamp: now.toISOString(),
+        data: {
+          status: summary.status,
+          report: summary.report,
+          email: summary.email
+        }
+      });
+    } catch (error) {
+      summary.status = "failed";
+      summary.errors.push({ message: error?.message ?? String(error) });
+      this.logger.warn?.({ err: error }, "bootstrap_self_report.send_failed");
+    }
+
+    return this.finishRun(summary);
+  }
+
+  async runOnceAndSchedule() {
+    await this.runOnce(new Date());
+    if (!this.running) return;
+    this.scheduleNext(this.intervalMs);
+  }
+
+  hasEmailConfig() {
+    return Boolean(this.emailSender || (this.resendApiKey && this.from && this.to.length));
+  }
+
+  async sendEmail(email, { idempotencyKey } = {}) {
+    if (this.emailSender) {
+      return this.emailSender(email, { idempotencyKey });
+    }
+    return sendResendEmail(email, {
+      apiKey: this.resendApiKey,
+      apiBaseUrl: this.resendApiBaseUrl,
+      fetchImpl: this.fetchImpl,
+      idempotencyKey
+    });
+  }
+
+  scheduleNext(delayMs) {
+    if (!this.running) return;
+    if (this.timer) clearTimeout(this.timer);
+    const delay = Math.max(0, Number(delayMs) || 0);
+    this.nextRunAt = new Date(Date.now() + delay).toISOString();
+    this.timer = setTimeout(() => {
+      void this.runOnceAndSchedule();
+    }, delay);
+    this.timer.unref?.();
+  }
+
+  finishRun(summary) {
+    summary.finishedAt = new Date().toISOString();
+    this.lastRun = summary;
+    return summary;
+  }
+}
+
+export function buildBootstrapSelfReportEmail(report, {
+  now = new Date(),
+  from = undefined,
+  to = [],
+  subjectPrefix = "Averray bootstrap self-report"
+} = {}) {
+  const subject = `${subjectPrefix} - ${isoDate(now)}`;
+  const mergeRate = report.mergeRate === null || report.mergeRate === undefined
+    ? "n/a"
+    : formatPercent(report.mergeRate);
+  const topReasons = report.topCloseReasons?.length
+    ? report.topCloseReasons.map((entry) => `- ${entry.reason}: ${entry.count}`).join("\n")
+    : "- none";
+  const text = [
+    "Averray weekly bootstrap self-report",
+    "",
+    `Window: ${report.window?.from ?? "n/a"} to ${report.window?.to ?? "n/a"}`,
+    `Total funded jobs: ${report.totalFundedJobs}`,
+    `Final jobs: ${report.finalJobs}`,
+    `Successful jobs: ${report.successfulJobs}`,
+    `Merge rate: ${mergeRate}`,
+    `Total reserved: ${report.totalReserved}`,
+    `Confirmed payout: ${report.confirmedPayout}`,
+    `Total receipts: ${report.totalReceipts}`,
+    "",
+    "Statuses:",
+    JSON.stringify(report.statuses ?? {}, null, 2),
+    "",
+    "Source types:",
+    JSON.stringify(report.sourceTypes ?? {}, null, 2),
+    "",
+    "Top close reasons:",
+    topReasons,
+    "",
+    "Raw report:",
+    JSON.stringify(report, null, 2)
+  ].join("\n");
+  const html = [
+    "<h1>Averray weekly bootstrap self-report</h1>",
+    "<dl>",
+    `<dt>Window</dt><dd>${escapeHtml(report.window?.from ?? "n/a")} to ${escapeHtml(report.window?.to ?? "n/a")}</dd>`,
+    `<dt>Total funded jobs</dt><dd>${escapeHtml(report.totalFundedJobs)}</dd>`,
+    `<dt>Final jobs</dt><dd>${escapeHtml(report.finalJobs)}</dd>`,
+    `<dt>Successful jobs</dt><dd>${escapeHtml(report.successfulJobs)}</dd>`,
+    `<dt>Merge rate</dt><dd>${escapeHtml(mergeRate)}</dd>`,
+    `<dt>Total reserved</dt><dd>${escapeHtml(report.totalReserved)}</dd>`,
+    `<dt>Confirmed payout</dt><dd>${escapeHtml(report.confirmedPayout)}</dd>`,
+    `<dt>Total receipts</dt><dd>${escapeHtml(report.totalReceipts)}</dd>`,
+    "</dl>",
+    "<h2>Top close reasons</h2>",
+    `<pre>${escapeHtml(topReasons)}</pre>`,
+    "<h2>Raw report</h2>",
+    `<pre>${escapeHtml(JSON.stringify(report, null, 2))}</pre>`
+  ].join("\n");
+  return {
+    from,
+    to,
+    subject,
+    text,
+    html
+  };
+}
+
+export async function sendResendEmail(email, {
+  apiKey,
+  apiBaseUrl = DEFAULT_RESEND_API_BASE_URL,
+  fetchImpl = fetch,
+  idempotencyKey = undefined
+} = {}) {
+  const baseUrl = String(apiBaseUrl || DEFAULT_RESEND_API_BASE_URL).replace(/\/+$/u, "");
+  const response = await fetchImpl(`${baseUrl}/emails`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      "content-type": "application/json",
+      ...(idempotencyKey ? { "Idempotency-Key": idempotencyKey } : {})
+    },
+    body: JSON.stringify({
+      from: email.from,
+      to: email.to,
+      subject: email.subject,
+      text: email.text,
+      html: email.html
+    })
+  });
+  const bodyText = await response.text();
+  let body;
+  try {
+    body = bodyText ? JSON.parse(bodyText) : {};
+  } catch {
+    body = { raw: bodyText };
+  }
+  if (!response.ok) {
+    throw new Error(`Resend email send failed (${response.status}): ${bodyText}`);
+  }
+  return body;
+}
+
+export function loadBootstrapSelfReportSchedulerConfig(env = process.env) {
+  return {
+    enabled: parseBooleanEnv(env.BOOTSTRAP_SELF_REPORT_ENABLED),
+    intervalMs: parsePositiveInt(env.BOOTSTRAP_SELF_REPORT_INTERVAL_MS, DEFAULT_INTERVAL_MS),
+    sendOnStart: parseBooleanEnv(env.BOOTSTRAP_SELF_REPORT_SEND_ON_START),
+    from: env.BOOTSTRAP_SELF_REPORT_FROM?.trim(),
+    to: parseRecipients(env.BOOTSTRAP_SELF_REPORT_TO),
+    subjectPrefix: env.BOOTSTRAP_SELF_REPORT_SUBJECT_PREFIX?.trim() || "Averray bootstrap self-report",
+    resendApiKey: env.RESEND_API_KEY?.trim() || env.BOOTSTRAP_SELF_REPORT_RESEND_API_KEY?.trim(),
+    resendApiBaseUrl: env.RESEND_API_BASE_URL?.trim() || DEFAULT_RESEND_API_BASE_URL
+  };
+}
+
+function compactReport(report) {
+  return {
+    generatedAt: report.generatedAt,
+    window: report.window,
+    totalFundedJobs: report.totalFundedJobs,
+    finalJobs: report.finalJobs,
+    successfulJobs: report.successfulJobs,
+    mergeRate: report.mergeRate,
+    totalReserved: report.totalReserved,
+    confirmedPayout: report.confirmedPayout,
+    totalReceipts: report.totalReceipts,
+    topCloseReasons: report.topCloseReasons
+  };
+}
+
+function parseRecipients(raw) {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return normalizeRecipients(parsed);
+  } catch {
+    // Fall through to comma-separated parsing.
+  }
+  return normalizeRecipients(String(raw).split(","));
+}
+
+function normalizeRecipients(value) {
+  return (Array.isArray(value) ? value : [value])
+    .map((entry) => normalizeText(entry))
+    .filter(Boolean);
+}
+
+function normalizeText(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function formatPercent(value) {
+  return `${(Number(value) * 100).toFixed(1)}%`;
+}
+
+function isoDate(value) {
+  return new Date(value).toISOString().slice(0, 10);
+}
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function parseBooleanEnv(raw) {
+  if (raw === undefined || raw === null || raw === "") return false;
+  return ["1", "true", "yes", "on"].includes(String(raw).trim().toLowerCase());
+}
+
+function parsePositiveInt(raw, fallback) {
+  const value = Number(raw);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}

--- a/mcp-server/src/services/bootstrap-self-report-scheduler.test.js
+++ b/mcp-server/src/services/bootstrap-self-report-scheduler.test.js
@@ -1,0 +1,133 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  BootstrapSelfReportSchedulerService,
+  buildBootstrapSelfReportEmail,
+  loadBootstrapSelfReportSchedulerConfig,
+  sendResendEmail
+} from "./bootstrap-self-report-scheduler.js";
+
+const report = {
+  generatedAt: "2026-05-08T00:00:00.000Z",
+  window: {
+    from: "2026-05-01T00:00:00.000Z",
+    to: "2026-05-08T00:00:00.000Z"
+  },
+  totalFundedJobs: 4,
+  finalJobs: 2,
+  successfulJobs: 1,
+  mergeRate: 0.5,
+  totalReserved: 7,
+  confirmedPayout: 2,
+  totalReceipts: 3,
+  statuses: { merged: 1, closed_unmerged: 1, open: 2 },
+  sourceTypes: { github_issue: 3, wikipedia_article: 1 },
+  topCloseReasons: [{ reason: "closed_unmerged", count: 1 }]
+};
+
+test("buildBootstrapSelfReportEmail renders operator-ready text and HTML", () => {
+  const email = buildBootstrapSelfReportEmail(report, {
+    now: new Date("2026-05-08T12:00:00.000Z"),
+    from: "Averray <ops@example.com>",
+    to: ["pascal@example.com"]
+  });
+
+  assert.equal(email.subject, "Averray bootstrap self-report - 2026-05-08");
+  assert.match(email.text, /Merge rate: 50\.0%/u);
+  assert.match(email.html, /closed_unmerged/u);
+});
+
+test("BootstrapSelfReportSchedulerService sends the generated report", async () => {
+  const events = [];
+  const poller = {
+    async generateWeeklyReport() {
+      return report;
+    }
+  };
+  const scheduler = new BootstrapSelfReportSchedulerService(poller, {
+    publish(event) {
+      events.push(event);
+    }
+  }, {
+    enabled: true,
+    from: "Averray <ops@example.com>",
+    to: ["pascal@example.com"],
+    emailSender: async (email, options) => {
+      assert.equal(email.to[0], "pascal@example.com");
+      assert.equal(options.idempotencyKey, "bootstrap-self-report-2026-05-08");
+      return { id: "email_123" };
+    }
+  });
+
+  const result = await scheduler.runOnce(new Date("2026-05-08T12:00:00.000Z"));
+
+  assert.equal(result.status, "sent");
+  assert.equal(result.report.mergeRate, 0.5);
+  assert.equal(result.email.providerId, "email_123");
+  assert.equal(events[0].topic, "bootstrap.self_report.sent");
+});
+
+test("BootstrapSelfReportSchedulerService skips when email config is missing", async () => {
+  const scheduler = new BootstrapSelfReportSchedulerService({
+    async generateWeeklyReport() {
+      return report;
+    }
+  }, undefined, {
+    enabled: true
+  });
+
+  const result = await scheduler.runOnce(new Date("2026-05-08T12:00:00.000Z"));
+
+  assert.equal(result.status, "skipped");
+  assert.deepEqual(result.skipped, [{ reason: "missing_email_config" }]);
+});
+
+test("sendResendEmail posts to the Resend emails endpoint", async () => {
+  const calls = [];
+  const result = await sendResendEmail({
+    from: "Averray <ops@example.com>",
+    to: ["pascal@example.com"],
+    subject: "Report",
+    text: "hello",
+    html: "<p>hello</p>"
+  }, {
+    apiKey: "secret",
+    idempotencyKey: "report-2026-05-08",
+    fetchImpl: async (url, options) => {
+      calls.push({ url: String(url), options });
+      return {
+        ok: true,
+        status: 200,
+        async text() {
+          return JSON.stringify({ id: "email_456" });
+        }
+      };
+    }
+  });
+
+  assert.equal(result.id, "email_456");
+  assert.equal(calls[0].url, "https://api.resend.com/emails");
+  assert.equal(calls[0].options.headers.authorization, "Bearer secret");
+  assert.equal(calls[0].options.headers["Idempotency-Key"], "report-2026-05-08");
+  assert.deepEqual(JSON.parse(calls[0].options.body).to, ["pascal@example.com"]);
+});
+
+test("loadBootstrapSelfReportSchedulerConfig parses env", () => {
+  const config = loadBootstrapSelfReportSchedulerConfig({
+    BOOTSTRAP_SELF_REPORT_ENABLED: "true",
+    BOOTSTRAP_SELF_REPORT_INTERVAL_MS: "1234",
+    BOOTSTRAP_SELF_REPORT_SEND_ON_START: "yes",
+    BOOTSTRAP_SELF_REPORT_FROM: "Averray <ops@example.com>",
+    BOOTSTRAP_SELF_REPORT_TO: "pascal@example.com,ops@example.com",
+    BOOTSTRAP_SELF_REPORT_SUBJECT_PREFIX: "Weekly Averray report",
+    RESEND_API_KEY: "secret"
+  });
+
+  assert.equal(config.enabled, true);
+  assert.equal(config.intervalMs, 1234);
+  assert.equal(config.sendOnStart, true);
+  assert.deepEqual(config.to, ["pascal@example.com", "ops@example.com"]);
+  assert.equal(config.subjectPrefix, "Weekly Averray report");
+  assert.equal(config.resendApiKey, "secret");
+});

--- a/mcp-server/src/services/bootstrap.js
+++ b/mcp-server/src/services/bootstrap.js
@@ -46,6 +46,10 @@ import {
   loadUpstreamStatusPollerConfig
 } from "./upstream-status-poller.js";
 import {
+  BootstrapSelfReportSchedulerService,
+  loadBootstrapSelfReportSchedulerConfig
+} from "./bootstrap-self-report-scheduler.js";
+import {
   JobStaleSweeperService,
   loadJobStaleSweeperConfig
 } from "./job-stale-sweeper.js";
@@ -239,6 +243,12 @@ export async function createPlatformRuntime() {
       logger
     })
   );
+  const bootstrapSelfReportScheduler = initStep("init-bootstrap-self-report-scheduler", logger, () =>
+    new BootstrapSelfReportSchedulerService(upstreamStatusPoller, eventBus, {
+      ...loadBootstrapSelfReportSchedulerConfig(process.env),
+      logger
+    })
+  );
   const jobStaleSweeper = initStep("init-job-stale-sweeper", logger, () =>
     new JobStaleSweeperService(platformService, stateStore, eventBus, {
       ...loadJobStaleSweeperConfig(process.env),
@@ -255,6 +265,7 @@ export async function createPlatformRuntime() {
   platformService.xcmSettlementWatcher = xcmSettlementWatcher;
   platformService.xcmObservationRelay = xcmObservationRelay;
   platformService.upstreamStatusPoller = upstreamStatusPoller;
+  platformService.bootstrapSelfReportScheduler = bootstrapSelfReportScheduler;
   platformService.jobStaleSweeper = jobStaleSweeper;
   recurringScheduler.start();
   githubIssueIngestionScheduler.start();
@@ -266,6 +277,7 @@ export async function createPlatformRuntime() {
   xcmSettlementWatcher.start();
   xcmObservationRelay.start();
   upstreamStatusPoller.start();
+  bootstrapSelfReportScheduler.start();
   jobStaleSweeper.start();
 
   const authMiddleware = createAuthMiddleware({ authConfig, stateStore, logger });


### PR DESCRIPTION
## What changed
- Added a disabled-by-default bootstrap self-report scheduler that generates the existing funded-jobs weekly report and sends it through a Resend-compatible HTTP email path.
- Wired scheduler status into admin status as `bootstrapSelfReport`.
- Documented the env knobs and noted that the launch checklist remains live-gated until production recipients/API key are set and the first report is delivered.

## Checks run
- `node --test mcp-server/src/services/bootstrap-self-report-scheduler.test.js mcp-server/src/services/upstream-status-poller.test.js mcp-server/src/core/platform-service.test.js`
- `node --test mcp-server/src/protocols/http/server.smoke.test.js` (smoke cases skipped by default)
- `git diff --check`
- `npm --workspace mcp-server test` attempted; local run is blocked by missing `@paraspell/sdk-core` in this worktree, same local dependency gap seen earlier. CI performs a clean install and is the full-suite gate.

## Impact
- Backend: yes
- Frontend: no
- Indexer: no
- Contracts: no
- Public site: no
- Env/secrets: optional before enabling: `BOOTSTRAP_SELF_REPORT_ENABLED=true`, `BOOTSTRAP_SELF_REPORT_FROM`, `BOOTSTRAP_SELF_REPORT_TO`, and `RESEND_API_KEY`.