### PR TITLE
Add read-only GitHub operator helper

### DIFF
--- a/docs/READY_TO_POST_JOBS.md
+++ b/docs/READY_TO_POST_JOBS.md
@@ -561,6 +561,27 @@ must not mutate the public API spec directly.
 
 ---
 
+## GitHub operator helper
+
+`GET /admin/github/status` gives operators and assistant surfaces a read-only
+GitHub digest across configured repositories. It reports open PRs, open issues,
+recent workflow failures, active workflow runs, and a short set of
+recommendations. It does not comment, merge, close, rerun workflows, or mutate
+GitHub state.
+
+Configure it with:
+
+```bash
+GITHUB_HELPER_REPOS=averray-agent/agent,depre-dev/averray-reference-agent
+GITHUB_HELPER_LIMIT=5
+```
+
+It reuses `GITHUB_TOKEN` when present for private repositories or higher rate
+limits. Keep this token read-only unless a separate write-capable workflow is
+explicitly introduced.
+
+---
+
 ## Before posting
 
 Quick operator checklist:

--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -121,6 +121,12 @@ AUTH_CHAIN_ID=420420417
 # GITHUB_INGEST_MAX_OPEN_JOBS=20
 # GITHUB_INGEST_QUERIES_JSON=["is:issue is:open label:\"good first issue\" language:TypeScript","is:issue is:open label:\"help wanted\" label:tests"]
 
+# --- GitHub operator helper ---------------------------------------------------
+# Read-only admin digest for PRs, issues, and recent workflow failures.
+# Uses GITHUB_TOKEN when present for private repos / higher rate limits.
+# GITHUB_HELPER_REPOS=averray-agent/agent,depre-dev/averray-reference-agent
+# GITHUB_HELPER_LIMIT=5
+
 # --- Bootstrap upstream status instrumentation -------------------------------
 # Disabled by default. When enabled, the server periodically refreshes
 # funded_jobs records from GitHub PR / MediaWiki evidence so the week-12 gate

--- a/mcp-server/src/core/github-operator-helper.js
+++ b/mcp-server/src/core/github-operator-helper.js
@@ -1,0 +1,332 @@
+const DEFAULT_GITHUB_API_BASE_URL = "https://api.github.com";
+const DEFAULT_LIMIT = 5;
+const MAX_LIMIT = 20;
+
+export function parseGithubHelperRepos(value = process.env.GITHUB_HELPER_REPOS ?? process.env.GITHUB_REPOSITORY ?? "") {
+  return String(value)
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => entry.replace(/^https:\/\/github\.com\//u, ""))
+    .map((entry) => entry.replace(/\.git$/u, ""))
+    .filter((entry) => /^[^/\s]+\/[^/\s]+$/u.test(entry))
+    .filter((entry, index, entries) => entries.indexOf(entry) === index);
+}
+
+export function normalizeGithubHelperLimit(value = process.env.GITHUB_HELPER_LIMIT ?? DEFAULT_LIMIT) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_LIMIT;
+  return Math.min(Math.trunc(parsed), MAX_LIMIT);
+}
+
+export async function collectGithubOperatorStatus({
+  repos = undefined,
+  githubToken = process.env.GITHUB_TOKEN,
+  apiBaseUrl = process.env.GITHUB_API_BASE_URL ?? DEFAULT_GITHUB_API_BASE_URL,
+  limit = undefined,
+  fetchImpl = fetch,
+  now = new Date()
+} = {}) {
+  const normalizedRepos = parseGithubHelperRepos(Array.isArray(repos) ? repos.join(",") : repos);
+  const normalizedLimit = normalizeGithubHelperLimit(limit);
+  const warnings = [];
+
+  if (normalizedRepos.length === 0) {
+    return {
+      schemaVersion: 1,
+      generatedAt: now.toISOString(),
+      mutates: false,
+      configured: false,
+      authConfigured: Boolean(githubToken),
+      health: "ok",
+      repoCount: 0,
+      totals: emptyTotals(),
+      repositories: [],
+      digest: {
+        summary: "GitHub helper is not configured. Set GITHUB_HELPER_REPOS to enable PR, issue, and CI digests.",
+        pullRequestsNeedingAttention: [],
+        issuesNeedingTriage: [],
+        ciFailures: []
+      },
+      warnings: [{
+        severity: "low",
+        code: "github_helper_not_configured",
+        message: "Set GITHUB_HELPER_REPOS=owner/repo[,owner/repo] to enable this read-only helper."
+      }],
+      recommendations: ["Set GITHUB_HELPER_REPOS and a read-only GITHUB_TOKEN for higher rate limits."]
+    };
+  }
+
+  const repositories = await Promise.all(normalizedRepos.map((repo) => collectRepoDigest({
+    repo,
+    githubToken,
+    apiBaseUrl,
+    limit: normalizedLimit,
+    fetchImpl,
+    warnings,
+    now
+  })));
+  const totals = repositories.reduce((accumulator, repo) => {
+    accumulator.openPullRequests += repo.openPullRequests.length;
+    accumulator.openIssues += repo.openIssues.length;
+    accumulator.failingWorkflowRuns += repo.workflowRuns.failed.length;
+    accumulator.activeWorkflowRuns += repo.workflowRuns.active.length;
+    return accumulator;
+  }, emptyTotals());
+  const pullRequestsNeedingAttention = repositories.flatMap((repo) =>
+    repo.openPullRequests
+      .filter((pr) => pr.isDraft || pr.reviewState === "needs_review" || pr.ageDays >= 7)
+      .map((pr) => ({
+        repo: repo.repo,
+        number: pr.number,
+        title: pr.title,
+        url: pr.url,
+        reason: pr.isDraft ? "draft" : (pr.ageDays >= 7 ? "stale" : "needs_review"),
+        updatedAt: pr.updatedAt
+      }))
+  ).slice(0, normalizedLimit);
+  const issuesNeedingTriage = repositories.flatMap((repo) =>
+    repo.openIssues
+      .filter((issue) => issue.commentCount === 0 || issue.ageDays >= 14)
+      .map((issue) => ({
+        repo: repo.repo,
+        number: issue.number,
+        title: issue.title,
+        url: issue.url,
+        reason: issue.commentCount === 0 ? "no_comments" : "stale",
+        updatedAt: issue.updatedAt
+      }))
+  ).slice(0, normalizedLimit);
+  const ciFailures = repositories.flatMap((repo) =>
+    repo.workflowRuns.failed.map((run) => ({
+      repo: repo.repo,
+      workflowName: run.workflowName,
+      runNumber: run.runNumber,
+      branch: run.branch,
+      conclusion: run.conclusion,
+      url: run.url,
+      explanation: run.explanation,
+      updatedAt: run.updatedAt
+    }))
+  ).slice(0, normalizedLimit);
+  const health = warnings.some((warning) => warning.severity === "high")
+    ? "degraded"
+    : (totals.failingWorkflowRuns > 0 || warnings.length > 0 ? "attention" : "ok");
+
+  return {
+    schemaVersion: 1,
+    generatedAt: now.toISOString(),
+    mutates: false,
+    configured: true,
+    authConfigured: Boolean(githubToken),
+    health,
+    repoCount: normalizedRepos.length,
+    totals,
+    repositories,
+    digest: {
+      summary: buildSummary({ totals, repoCount: normalizedRepos.length, health }),
+      pullRequestsNeedingAttention,
+      issuesNeedingTriage,
+      ciFailures
+    },
+    warnings,
+    recommendations: buildRecommendations({ totals, warnings, pullRequestsNeedingAttention, issuesNeedingTriage })
+  };
+}
+
+async function collectRepoDigest({ repo, githubToken, apiBaseUrl, limit, fetchImpl, warnings, now }) {
+  const [owner, name] = repo.split("/");
+  const headers = buildHeaders(githubToken);
+  const repoBase = `${apiBaseUrl.replace(/\/$/u, "")}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
+  const [repoInfo, pulls, issues, workflowRuns] = await Promise.all([
+    getJson(`${repoBase}`, { headers, fetchImpl, warnings, repo, label: "repo" }),
+    getJson(`${repoBase}/pulls?state=open&sort=updated&direction=desc&per_page=${limit}`, {
+      headers,
+      fetchImpl,
+      warnings,
+      repo,
+      label: "pulls",
+      fallback: []
+    }),
+    getJson(`${repoBase}/issues?state=open&sort=updated&direction=desc&per_page=${Math.min(limit * 2, 100)}`, {
+      headers,
+      fetchImpl,
+      warnings,
+      repo,
+      label: "issues",
+      fallback: []
+    }),
+    getJson(`${repoBase}/actions/runs?per_page=${limit}`, {
+      headers,
+      fetchImpl,
+      warnings,
+      repo,
+      label: "workflow_runs",
+      fallback: { workflow_runs: [] }
+    })
+  ]);
+  const openPullRequests = Array.isArray(pulls) ? pulls.map((pr) => summarizePullRequest(pr, now)) : [];
+  const openIssues = (Array.isArray(issues) ? issues : [])
+    .filter((issue) => !issue.pull_request)
+    .slice(0, limit)
+    .map((issue) => summarizeIssue(issue, now));
+  const workflowSummary = summarizeWorkflowRuns(workflowRuns?.workflow_runs ?? []);
+
+  return {
+    repo,
+    defaultBranch: repoInfo?.default_branch,
+    private: repoInfo?.private,
+    archived: repoInfo?.archived,
+    htmlUrl: repoInfo?.html_url ?? `https://github.com/${repo}`,
+    openPullRequests,
+    openIssues,
+    workflowRuns: workflowSummary,
+    needsAttention: openPullRequests.some((pr) => pr.isDraft || pr.ageDays >= 7)
+      || workflowSummary.failed.length > 0
+      || openIssues.some((issue) => issue.commentCount === 0 || issue.ageDays >= 14)
+  };
+}
+
+async function getJson(url, { headers, fetchImpl, warnings, repo, label, fallback = undefined }) {
+  try {
+    const response = await fetchImpl(url, { headers });
+    if (!response.ok) {
+      warnings.push({
+        severity: response.status >= 500 ? "high" : "medium",
+        code: "github_fetch_failed",
+        repo,
+        endpoint: label,
+        status: response.status,
+        message: `GitHub ${label} request failed with HTTP ${response.status}.`
+      });
+      return fallback;
+    }
+    return response.json();
+  } catch (error) {
+    warnings.push({
+      severity: "high",
+      code: "github_fetch_error",
+      repo,
+      endpoint: label,
+      message: error?.message ?? "GitHub request failed."
+    });
+    return fallback;
+  }
+}
+
+function buildHeaders(githubToken) {
+  return {
+    accept: "application/vnd.github+json",
+    "user-agent": "averray-github-operator-helper",
+    ...(githubToken ? { authorization: `Bearer ${githubToken}` } : {})
+  };
+}
+
+function summarizePullRequest(pr, now) {
+  return {
+    number: Number(pr.number),
+    title: String(pr.title ?? ""),
+    url: pr.html_url,
+    author: pr.user?.login,
+    branch: pr.head?.ref,
+    base: pr.base?.ref,
+    isDraft: Boolean(pr.draft),
+    reviewState: pr.draft ? "draft" : "needs_review",
+    ageDays: ageDays(pr.created_at, now),
+    createdAt: pr.created_at,
+    updatedAt: pr.updated_at
+  };
+}
+
+function summarizeIssue(issue, now) {
+  return {
+    number: Number(issue.number),
+    title: String(issue.title ?? ""),
+    url: issue.html_url,
+    author: issue.user?.login,
+    labels: (issue.labels ?? []).map((label) => typeof label === "string" ? label : label.name).filter(Boolean),
+    commentCount: Number(issue.comments ?? 0),
+    ageDays: ageDays(issue.created_at, now),
+    createdAt: issue.created_at,
+    updatedAt: issue.updated_at
+  };
+}
+
+function summarizeWorkflowRuns(runs) {
+  const summarized = runs.map((run) => ({
+    workflowName: run.name,
+    runNumber: Number(run.run_number),
+    branch: run.head_branch,
+    event: run.event,
+    status: run.status,
+    conclusion: run.conclusion,
+    url: run.html_url,
+    createdAt: run.created_at,
+    updatedAt: run.updated_at,
+    explanation: explainWorkflowRun(run)
+  }));
+  return {
+    recent: summarized,
+    failed: summarized.filter((run) => ["failure", "timed_out", "action_required"].includes(run.conclusion)),
+    active: summarized.filter((run) => run.status && run.status !== "completed")
+  };
+}
+
+function explainWorkflowRun(run) {
+  if (run.status && run.status !== "completed") {
+    return `Workflow is still ${run.status}; wait for completion before acting.`;
+  }
+  if (run.conclusion === "failure") {
+    return "Workflow completed with failing jobs; inspect the run logs and fix the first failed job before retrying.";
+  }
+  if (run.conclusion === "timed_out") {
+    return "Workflow timed out; check for hung tests, external services, or jobs with too-low timeout settings.";
+  }
+  if (run.conclusion === "action_required") {
+    return "Workflow needs an approval or manual action before it can continue.";
+  }
+  if (run.conclusion === "cancelled") {
+    return "Workflow was cancelled; usually safe to ignore if superseded by a newer run.";
+  }
+  return "Workflow has no blocking failure signal.";
+}
+
+function buildSummary({ totals, repoCount, health }) {
+  if (health === "ok") {
+    return `GitHub helper checked ${repoCount} repo(s): ${totals.openPullRequests} open PR(s), ${totals.openIssues} open issue(s), no failing workflow runs.`;
+  }
+  return `GitHub helper checked ${repoCount} repo(s): ${totals.openPullRequests} open PR(s), ${totals.openIssues} open issue(s), ${totals.failingWorkflowRuns} failing workflow run(s).`;
+}
+
+function buildRecommendations({ totals, warnings, pullRequestsNeedingAttention, issuesNeedingTriage }) {
+  const recommendations = [];
+  if (totals.failingWorkflowRuns > 0) {
+    recommendations.push("Inspect the newest failing workflow run before merging or retrying.");
+  }
+  if (pullRequestsNeedingAttention.length > 0) {
+    recommendations.push("Review stale or draft PRs and decide whether to merge, close, or unblock them.");
+  }
+  if (issuesNeedingTriage.length > 0) {
+    recommendations.push("Triage old or unanswered issues so agent work has a clear next step.");
+  }
+  if (warnings.some((warning) => warning.status === 401 || warning.status === 403)) {
+    recommendations.push("Check GITHUB_TOKEN permissions and rate limits for the configured repositories.");
+  }
+  return recommendations;
+}
+
+function emptyTotals() {
+  return {
+    openPullRequests: 0,
+    openIssues: 0,
+    failingWorkflowRuns: 0,
+    activeWorkflowRuns: 0
+  };
+}
+
+function ageDays(value, now = Date.now()) {
+  const timestamp = Date.parse(value ?? "");
+  if (!Number.isFinite(timestamp)) return 0;
+  const nowMs = now instanceof Date ? now.getTime() : Number(now);
+  return Math.max(0, Math.floor((nowMs - timestamp) / 86_400_000));
+}

--- a/mcp-server/src/core/github-operator-helper.test.js
+++ b/mcp-server/src/core/github-operator-helper.test.js
@@ -1,0 +1,164 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  collectGithubOperatorStatus,
+  normalizeGithubHelperLimit,
+  parseGithubHelperRepos
+} from "./github-operator-helper.js";
+
+test("parseGithubHelperRepos accepts repo names and GitHub URLs", () => {
+  assert.deepEqual(
+    parseGithubHelperRepos("averray-agent/agent, https://github.com/depre-dev/averray-reference-agent.git, bad"),
+    ["averray-agent/agent", "depre-dev/averray-reference-agent"]
+  );
+});
+
+test("normalizeGithubHelperLimit clamps unsafe values", () => {
+  assert.equal(normalizeGithubHelperLimit("0"), 5);
+  assert.equal(normalizeGithubHelperLimit("3"), 3);
+  assert.equal(normalizeGithubHelperLimit("999"), 20);
+});
+
+test("collectGithubOperatorStatus reports unconfigured helper without mutating", async () => {
+  const status = await collectGithubOperatorStatus({
+    repos: "",
+    githubToken: undefined,
+    now: new Date("2026-05-08T10:00:00.000Z"),
+    fetchImpl: async () => {
+      throw new Error("fetch should not be called");
+    }
+  });
+
+  assert.equal(status.configured, false);
+  assert.equal(status.mutates, false);
+  assert.equal(status.health, "ok");
+  assert.equal(status.repoCount, 0);
+  assert.equal(status.warnings[0].code, "github_helper_not_configured");
+});
+
+test("collectGithubOperatorStatus summarizes PRs, issues, and failing workflows", async () => {
+  const fetchImpl = fakeGithubFetch({
+    "https://api.github.com/repos/acme/widgets": {
+      default_branch: "main",
+      private: false,
+      archived: false,
+      html_url: "https://github.com/acme/widgets"
+    },
+    "https://api.github.com/repos/acme/widgets/pulls?state=open&sort=updated&direction=desc&per_page=2": [
+      {
+        number: 7,
+        title: "Fix flaky widget test",
+        html_url: "https://github.com/acme/widgets/pull/7",
+        draft: true,
+        user: { login: "alice" },
+        head: { ref: "fix-flake" },
+        base: { ref: "main" },
+        created_at: "2026-04-01T00:00:00.000Z",
+        updated_at: "2026-05-07T00:00:00.000Z"
+      }
+    ],
+    "https://api.github.com/repos/acme/widgets/issues?state=open&sort=updated&direction=desc&per_page=4": [
+      {
+        number: 9,
+        title: "Document widget retries",
+        html_url: "https://github.com/acme/widgets/issues/9",
+        user: { login: "bob" },
+        labels: [{ name: "docs" }],
+        comments: 0,
+        created_at: "2026-04-15T00:00:00.000Z",
+        updated_at: "2026-05-06T00:00:00.000Z"
+      },
+      {
+        number: 7,
+        title: "Fix flaky widget test",
+        pull_request: {},
+        html_url: "https://github.com/acme/widgets/pull/7"
+      }
+    ],
+    "https://api.github.com/repos/acme/widgets/actions/runs?per_page=2": {
+      workflow_runs: [
+        {
+          name: "CI",
+          run_number: 42,
+          head_branch: "main",
+          event: "push",
+          status: "completed",
+          conclusion: "failure",
+          html_url: "https://github.com/acme/widgets/actions/runs/42",
+          created_at: "2026-05-08T08:00:00.000Z",
+          updated_at: "2026-05-08T08:10:00.000Z"
+        },
+        {
+          name: "Deploy",
+          run_number: 43,
+          head_branch: "main",
+          event: "workflow_dispatch",
+          status: "in_progress",
+          conclusion: null,
+          html_url: "https://github.com/acme/widgets/actions/runs/43",
+          created_at: "2026-05-08T09:00:00.000Z",
+          updated_at: "2026-05-08T09:00:00.000Z"
+        }
+      ]
+    }
+  });
+
+  const status = await collectGithubOperatorStatus({
+    repos: "acme/widgets",
+    githubToken: "github-token",
+    limit: 2,
+    now: new Date("2026-05-08T10:00:00.000Z"),
+    fetchImpl
+  });
+
+  assert.equal(status.mutates, false);
+  assert.equal(status.configured, true);
+  assert.equal(status.authConfigured, true);
+  assert.equal(status.health, "attention");
+  assert.deepEqual(status.totals, {
+    openPullRequests: 1,
+    openIssues: 1,
+    failingWorkflowRuns: 1,
+    activeWorkflowRuns: 1
+  });
+  assert.equal(status.repositories[0].repo, "acme/widgets");
+  assert.equal(status.repositories[0].openIssues[0].number, 9);
+  assert.equal(status.digest.pullRequestsNeedingAttention[0].reason, "draft");
+  assert.equal(status.digest.issuesNeedingTriage[0].reason, "no_comments");
+  assert.match(status.digest.ciFailures[0].explanation, /failing jobs/u);
+});
+
+test("collectGithubOperatorStatus keeps partial results when a repo fetch fails", async () => {
+  const status = await collectGithubOperatorStatus({
+    repos: "acme/missing",
+    limit: 1,
+    fetchImpl: fakeGithubFetch({}, { missingStatus: 404 })
+  });
+
+  assert.equal(status.health, "attention");
+  assert.equal(status.repositories[0].repo, "acme/missing");
+  assert.equal(status.warnings.length, 4);
+  assert.equal(status.warnings[0].code, "github_fetch_failed");
+});
+
+function fakeGithubFetch(fixtures, { missingStatus = 404 } = {}) {
+  return async (input, init = {}) => {
+    assert.equal(init.headers.accept, "application/vnd.github+json");
+    const url = String(input);
+    if (!Object.hasOwn(fixtures, url)) {
+      return fakeResponse({ message: "not found" }, { ok: false, status: missingStatus });
+    }
+    return fakeResponse(fixtures[url]);
+  };
+}
+
+function fakeResponse(payload, { ok = true, status = 200 } = {}) {
+  return {
+    ok,
+    status,
+    async json() {
+      return payload;
+    }
+  };
+}

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -19,6 +19,7 @@ import { computeClaimEconomics, countClaimedSessions } from "./claim-economics.j
 import { claimStatusFields, isTerminalSession, summarizeJobClaimState } from "./claim-state.js";
 import { capabilityMatrix } from "../auth/capabilities.js";
 import { normalizeAssetSymbol } from "./assets.js";
+import { collectGithubOperatorStatus } from "./github-operator-helper.js";
 
 const TIMELINE_VERSION = "v2";
 
@@ -430,6 +431,10 @@ export class PlatformService {
         updatedAt: undefined
       }
     };
+  }
+
+  async getGithubOperatorStatus(options = {}) {
+    return collectGithubOperatorStatus(options);
   }
 
   getJobDefinition(jobId) {

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -784,3 +784,17 @@ test("getAdminStatus surfaces XCM observation relay status", async () => {
   assert.equal(status.xcmObservationRelay.enabled, true);
   assert.equal(status.xcmObservationRelay.cursor, "cursor-1");
 });
+
+test("getGithubOperatorStatus exposes the read-only GitHub helper", async () => {
+  const service = makePlatformService();
+  const status = await service.getGithubOperatorStatus({
+    repos: "",
+    fetchImpl: async () => {
+      throw new Error("fetch should not be called when no repos are configured");
+    }
+  });
+
+  assert.equal(status.mutates, false);
+  assert.equal(status.configured, false);
+  assert.equal(status.digest.pullRequestsNeedingAttention.length, 0);
+});

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -1359,7 +1359,8 @@ const server = createServer(async (request, response) => {
           "/admin/jobs/resume",
           "/admin/xcm/observe",
           "/admin/xcm/finalize",
-          "/admin/status"
+          "/admin/status",
+          "/admin/github/status"
         ]
       });
     }
@@ -3039,6 +3040,14 @@ const server = createServer(async (request, response) => {
     if (request.method === "GET" && pathname === "/admin/status") {
       const auth = await authMiddleware(request, url, { requireRole: "admin" });
       return respond(response, 200, await service.getAdminStatus({ auth }));
+    }
+
+    if (request.method === "GET" && pathname === "/admin/github/status") {
+      await authMiddleware(request, url, { requireRole: "admin" });
+      return respond(response, 200, await service.getGithubOperatorStatus({
+        repos: url.searchParams.has("repos") ? url.searchParams.get("repos") : undefined,
+        limit: parseLimit(url, 5, 20)
+      }));
     }
 
     if (request.method === "POST" && pathname === "/admin/xcm/observe") {


### PR DESCRIPTION
## Summary
- add a read-only GitHub operator helper for PR, issue, and workflow-run digests
- expose it through the admin-only GET /admin/github/status endpoint
- document GITHUB_HELPER_REPOS/GITHUB_HELPER_LIMIT configuration

## Checks
- node --test mcp-server/src/core/github-operator-helper.test.js mcp-server/src/core/platform-service.test.js
- git diff --check

Note: npm --workspace mcp-server test currently fails in this local worktree because @paraspell/sdk-core is not installed, which breaks unrelated blockchain/XCM tests before this patch is involved.

## Impact
- Backend: yes, read-only admin API
- Frontend: no
- Indexer: no
- Caddy: no
- Contracts: no
- Public site: no

## Env / VPS
- Optional: set GITHUB_HELPER_REPOS=owner/repo[,owner/repo]
- Optional: set GITHUB_HELPER_LIMIT=5
- Reuses GITHUB_TOKEN when present for private repos or higher rate limits; no new write-capable token required.