### PR TITLE
Publish discovery manifest hashes after deploy

### DIFF
--- a/.github/workflows/publish-discovery-manifest.yml
+++ b/.github/workflows/publish-discovery-manifest.yml
@@ -1,0 +1,49 @@
+name: Publish Discovery Manifest
+
+on:
+  workflow_run:
+    workflows: ["Deploy Production"]
+    branches: [main]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      manifest_url:
+        description: Manifest URL to hash and publish.
+        required: false
+        default: https://averray.com/.well-known/agent-tools.json
+        type: string
+
+concurrency:
+  group: discovery-registry-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish discovery hash
+    runs-on: ubuntu-latest
+    environment: production
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    env:
+      DISCOVERY_MANIFEST_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.manifest_url || 'https://averray.com/.well-known/agent-tools.json' }}
+      DISCOVERY_REGISTRY_ADDRESS: ${{ secrets.DISCOVERY_REGISTRY_ADDRESS }}
+      DISCOVERY_PUBLISH_RPC_URL: ${{ secrets.DISCOVERY_PUBLISH_RPC_URL }}
+      POLKADOT_RPC_URL: ${{ secrets.POLKADOT_RPC_URL }}
+      RPC_URL: ${{ secrets.RPC_URL }}
+      DISCOVERY_PUBLISHER_PRIVATE_KEY: ${{ secrets.DISCOVERY_PUBLISHER_PRIVATE_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install workspace dependencies
+        run: npm ci
+
+      - name: Publish manifest hash
+        run: |
+          node scripts/ops/publish-discovery-manifest.mjs \
+            --manifest-url "$DISCOVERY_MANIFEST_URL" \
+            --skip-missing-config

--- a/docs/AVERRAY_WORKING_SPEC.md
+++ b/docs/AVERRAY_WORKING_SPEC.md
@@ -945,6 +945,12 @@ Stripe Link's launch and Stripe Sessions 2026 announcements positioned agents as
 
 For traceability.
 
+### v2.6 (DiscoveryRegistry publish automation)
+
+1. **Canonical manifest publisher added:** `scripts/ops/publish-discovery-manifest.mjs` loads the served or local discovery manifest, canonicalizes JSON with sorted keys, computes the keccak256 hash, checks `DiscoveryRegistry.currentManifestHash()`, and only calls `publish(bytes32)` when the chain hash is stale.
+2. **Production workflow added:** `.github/workflows/publish-discovery-manifest.yml` runs after successful production deploys and can also be dispatched manually. It is safe before registry rollout: missing registry/RPC/publisher secrets produce an explicit skip, not a failed deploy.
+3. **Launch checklist remains deployment-gated:** the workflow exists, but `DiscoveryRegistry deployed, CI publishing on directory updates` should only be marked complete after the registry address and publisher key are configured in production and a real publish or already-current check is observed.
+
 ### v2.5 (bootstrap self-report scheduler)
 
 1. **Weekly bootstrap self-report email path added:** backend now has a disabled-by-default scheduler that generates the existing funded-jobs weekly report and sends it through a Resend-compatible HTTP email provider.

--- a/docs/DISCOVERY.md
+++ b/docs/DISCOVERY.md
@@ -52,6 +52,22 @@ Do not add a tool here just because it exists internally. If it moves
 funds, posts jobs, triggers verification, or mutates account state,
 document it separately and make an explicit distribution decision first.
 
+After production deploy, `.github/workflows/publish-discovery-manifest.yml`
+hashes the served `/.well-known/agent-tools.json` with canonical JSON key
+ordering and publishes that hash to `DiscoveryRegistry` when these production
+secrets are configured: `DISCOVERY_REGISTRY_ADDRESS`,
+`DISCOVERY_PUBLISHER_PRIVATE_KEY`, and either `DISCOVERY_PUBLISH_RPC_URL`,
+`POLKADOT_RPC_URL`, or `RPC_URL`. Missing secrets produce a no-op skip so
+deployment is not blocked before the registry is deployed.
+
+To rehearse locally without a transaction:
+
+```bash
+npm run publish:discovery-manifest -- \
+  --manifest-path discovery/.well-known/agent-tools.json \
+  --dry-run
+```
+
 ### 2. MCP registries
 
 Three registries matter as of April 2026:

--- a/docs/FRAMEWORK_AGENT_HANDOFF.md
+++ b/docs/FRAMEWORK_AGENT_HANDOFF.md
@@ -70,7 +70,7 @@ These prevent silent 10^12 scaling bugs at deploy time.
 The following can proceed in parallel (gated only by item B above for anything mainnet-adjacent):
 
 **Contract changes:**
-- `DiscoveryRegistry` — new contract for manifest hash anchoring
+- `DiscoveryRegistry` — contract exists for manifest hash anchoring; publish automation now runs after production deploy when `DISCOVERY_REGISTRY_ADDRESS`, `DISCOVERY_PUBLISHER_PRIVATE_KEY`, and RPC secrets are configured. Treat the launch checklist item as open until the deployed registry is configured and the workflow records a real publish/already-current result.
 - Verifier mapping extension — `authorizedSince`/`authorizedUntil`/`wasAuthorizedAt`
 - `ReputationSBT` non-transferable hardening — `revert(Soulbound)` on transfer/transferFrom (load-bearing per spec §10 wallet-linkage subsection — non-negotiable)
 - Hash fields on session events — `JobCreated(..., specHash)`, `Submitted(..., payloadHash)`, `Verified(..., reasoningHash)`

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -47,6 +47,11 @@ Restore drills are documented in [VPS_RUNBOOK.md](../VPS_RUNBOOK.md).
 
 - [ ] Public site loads at `https://averray.com/`.
 - [ ] Discovery manifest loads at `https://averray.com/.well-known/agent-tools.json`.
+- [ ] Discovery manifest publish workflow reports `published` or
+  `already_current` for the deployed `DiscoveryRegistry` hash. Required
+  production secrets: `DISCOVERY_REGISTRY_ADDRESS`,
+  `DISCOVERY_PUBLISHER_PRIVATE_KEY`, and `DISCOVERY_PUBLISH_RPC_URL`
+  (or `POLKADOT_RPC_URL` / `RPC_URL`).
 - [ ] Operator app loads at `https://app.averray.com/`.
 - [ ] API health is green at `https://api.averray.com/health`.
 - [ ] Indexer readiness is green at `https://index.averray.com/ready`.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:indexer:api": "npm --workspace indexer run test:api",
     "test:ops": "node --test scripts/ops/*.test.mjs",
     "test:contracts": "forge test",
+    "publish:discovery-manifest": "node scripts/ops/publish-discovery-manifest.mjs",
     "dev:app": "npm --workspace averray-app run dev",
     "build:app": "npm --workspace averray-app run build",
     "build:frontend": "NEXT_OUTPUT=export NEXT_PUBLIC_API_BASE_URL=https://api.averray.com npm --workspace averray-app run build && node scripts/sync-operator-frontend.mjs",

--- a/scripts/ops/publish-discovery-manifest.mjs
+++ b/scripts/ops/publish-discovery-manifest.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { keccak256, toUtf8Bytes, Contract, JsonRpcProvider, Wallet, getAddress } from "ethers";
+
+const DEFAULT_MANIFEST_URL = "https://averray.com/.well-known/agent-tools.json";
+const DISCOVERY_REGISTRY_ABI = [
+  "function publisher() view returns (address)",
+  "function currentManifestHash() view returns (bytes32)",
+  "function currentVersion() view returns (uint64)",
+  "function publish(bytes32 newHash)",
+  "event ManifestPublished(uint64 indexed version, bytes32 indexed hash, uint64 timestamp, address publisher)"
+];
+
+export function canonicalizeJson(value) {
+  if (value === null) return "null";
+  if (typeof value === "string") return JSON.stringify(value);
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new Error("Cannot canonicalize non-finite JSON number.");
+    return JSON.stringify(value);
+  }
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalizeJson(entry)).join(",")}]`;
+  }
+  if (typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalizeJson(value[key])}`)
+      .join(",")}}`;
+  }
+  throw new Error(`Cannot canonicalize JSON value of type ${typeof value}.`);
+}
+
+export function hashDiscoveryManifest(manifest) {
+  const canonical = canonicalizeJson(manifest);
+  return {
+    canonical,
+    hash: keccak256(toUtf8Bytes(canonical))
+  };
+}
+
+export async function loadDiscoveryManifest({ manifestPath, manifestUrl, fetchImpl = fetch } = {}) {
+  if (manifestPath) {
+    return JSON.parse(await readFile(manifestPath, "utf8"));
+  }
+  const url = manifestUrl || DEFAULT_MANIFEST_URL;
+  const response = await fetchImpl(url, {
+    headers: {
+      accept: "application/json",
+      "user-agent": "averray-discovery-registry-publisher"
+    }
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Discovery manifest fetch failed (${response.status}) for ${url}: ${body}`);
+  }
+  return response.json();
+}
+
+export async function publishManifestHash({
+  registryAddress,
+  rpcUrl,
+  privateKey,
+  hash,
+  wait = true
+} = {}) {
+  const provider = new JsonRpcProvider(rpcUrl);
+  const wallet = new Wallet(privateKey, provider);
+  const registry = new Contract(registryAddress, DISCOVERY_REGISTRY_ABI, wallet);
+  const publisher = await registry.publisher();
+  if (getAddress(publisher) !== getAddress(wallet.address)) {
+    throw new Error(`Publisher key mismatch: signer ${wallet.address} is not registry publisher ${publisher}.`);
+  }
+  const currentHash = await registry.currentManifestHash();
+  const currentVersion = await registry.currentVersion();
+  if (String(currentHash).toLowerCase() === String(hash).toLowerCase()) {
+    return {
+      status: "already_current",
+      hash,
+      currentHash,
+      currentVersion: currentVersion.toString(),
+      publisher
+    };
+  }
+  const tx = await registry.publish(hash);
+  const receipt = wait ? await tx.wait() : undefined;
+  const nextVersion = await registry.currentVersion();
+  return {
+    status: "published",
+    hash,
+    previousHash: currentHash,
+    previousVersion: currentVersion.toString(),
+    currentVersion: nextVersion.toString(),
+    publisher,
+    txHash: tx.hash,
+    blockNumber: receipt?.blockNumber
+  };
+}
+
+export function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const raw = argv[index];
+    if (!raw.startsWith("--")) continue;
+    const key = raw.slice(2);
+    if (["dry-run", "skip-missing-config", "no-wait"].includes(key)) {
+      args[toCamelCase(key)] = true;
+      continue;
+    }
+    const value = argv[index + 1];
+    if (value && !value.startsWith("--")) {
+      args[toCamelCase(key)] = value;
+      index += 1;
+    } else {
+      args[toCamelCase(key)] = true;
+    }
+  }
+  return args;
+}
+
+export async function runPublishDiscoveryManifestCli({
+  argv = process.argv.slice(2),
+  env = process.env,
+  stdout = process.stdout,
+  fetchImpl = fetch
+} = {}) {
+  const args = parseArgs(argv);
+  const manifest = await loadDiscoveryManifest({
+    manifestPath: args.manifestPath || env.DISCOVERY_MANIFEST_PATH,
+    manifestUrl: args.manifestUrl || env.DISCOVERY_MANIFEST_URL || DEFAULT_MANIFEST_URL,
+    fetchImpl
+  });
+  const { canonical, hash } = hashDiscoveryManifest(manifest);
+  const registryAddress = args.registry || env.DISCOVERY_REGISTRY_ADDRESS;
+  const rpcUrl = args.rpcUrl || env.DISCOVERY_PUBLISH_RPC_URL || env.POLKADOT_RPC_URL || env.RPC_URL;
+  const privateKey = args.privateKey || env.DISCOVERY_PUBLISHER_PRIVATE_KEY;
+  const base = {
+    manifestUrl: args.manifestUrl || env.DISCOVERY_MANIFEST_URL || DEFAULT_MANIFEST_URL,
+    manifestPath: args.manifestPath || env.DISCOVERY_MANIFEST_PATH,
+    hash,
+    canonicalBytes: Buffer.byteLength(canonical, "utf8")
+  };
+  if (args.dryRun) {
+    const result = { status: "dry_run", ...base };
+    stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return result;
+  }
+  if (!registryAddress || !rpcUrl || !privateKey) {
+    if (!args.skipMissingConfig) {
+      throw new Error(
+        "Publishing requires DISCOVERY_REGISTRY_ADDRESS, DISCOVERY_PUBLISH_RPC_URL/POLKADOT_RPC_URL/RPC_URL, and DISCOVERY_PUBLISHER_PRIVATE_KEY."
+      );
+    }
+    const result = {
+      status: "skipped",
+      reason: "missing_publish_config",
+      ...base,
+      configured: {
+        registryAddress: Boolean(registryAddress),
+        rpcUrl: Boolean(rpcUrl),
+        privateKey: Boolean(privateKey)
+      }
+    };
+    stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return result;
+  }
+  const publish = await publishManifestHash({
+    registryAddress,
+    rpcUrl,
+    privateKey,
+    hash,
+    wait: !args.noWait
+  });
+  const result = { ...base, ...publish, registryAddress };
+  stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  return result;
+}
+
+function toCamelCase(value) {
+  return value.replace(/-([a-z])/gu, (_, char) => char.toUpperCase());
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runPublishDiscoveryManifestCli().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ops/publish-discovery-manifest.test.mjs
+++ b/scripts/ops/publish-discovery-manifest.test.mjs
@@ -1,0 +1,106 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  canonicalizeJson,
+  hashDiscoveryManifest,
+  loadDiscoveryManifest,
+  parseArgs,
+  runPublishDiscoveryManifestCli
+} from "./publish-discovery-manifest.mjs";
+
+test("canonicalizeJson sorts object keys recursively", () => {
+  const left = { b: 2, a: { d: true, c: ["z", "a"] } };
+  const right = { a: { c: ["z", "a"], d: true }, b: 2 };
+
+  assert.equal(canonicalizeJson(left), '{"a":{"c":["z","a"],"d":true},"b":2}');
+  assert.equal(canonicalizeJson(left), canonicalizeJson(right));
+});
+
+test("hashDiscoveryManifest is stable across key order", () => {
+  const first = hashDiscoveryManifest({ z: 1, a: "manifest" });
+  const second = hashDiscoveryManifest({ a: "manifest", z: 1 });
+
+  assert.match(first.hash, /^0x[a-f0-9]{64}$/u);
+  assert.equal(first.hash, second.hash);
+});
+
+test("loadDiscoveryManifest can fetch a remote manifest", async () => {
+  const manifest = await loadDiscoveryManifest({
+    manifestUrl: "https://example.test/.well-known/agent-tools.json",
+    fetchImpl: async (url, options) => {
+      assert.equal(String(url), "https://example.test/.well-known/agent-tools.json");
+      assert.equal(options.headers["user-agent"], "averray-discovery-registry-publisher");
+      return {
+        ok: true,
+        async json() {
+          return { name: "Averray", version: "test" };
+        }
+      };
+    }
+  });
+
+  assert.deepEqual(manifest, { name: "Averray", version: "test" });
+});
+
+test("runPublishDiscoveryManifestCli dry-runs without chain config", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "averray-discovery-"));
+  const path = join(dir, "agent-tools.json");
+  await writeFile(path, JSON.stringify({ b: 2, a: 1 }), "utf8");
+  let output = "";
+
+  const result = await runPublishDiscoveryManifestCli({
+    argv: ["--manifest-path", path, "--dry-run"],
+    stdout: {
+      write(chunk) {
+        output += chunk;
+      }
+    }
+  });
+
+  assert.equal(result.status, "dry_run");
+  assert.equal(result.canonicalBytes, 13);
+  assert.equal(JSON.parse(output).hash, result.hash);
+});
+
+test("runPublishDiscoveryManifestCli skips when publish config is absent and explicitly allowed", async () => {
+  let output = "";
+  const result = await runPublishDiscoveryManifestCli({
+    argv: ["--skip-missing-config"],
+    env: {
+      DISCOVERY_MANIFEST_URL: "https://example.test/agent-tools.json"
+    },
+    fetchImpl: async () => ({
+      ok: true,
+      async json() {
+        return { name: "Averray" };
+      }
+    }),
+    stdout: {
+      write(chunk) {
+        output += chunk;
+      }
+    }
+  });
+
+  assert.equal(result.status, "skipped");
+  assert.equal(result.reason, "missing_publish_config");
+  assert.equal(result.configured.privateKey, false);
+  assert.equal(JSON.parse(output).status, "skipped");
+});
+
+test("parseArgs normalizes kebab-case flags", () => {
+  assert.deepEqual(parseArgs([
+    "--manifest-url",
+    "https://example.test/manifest.json",
+    "--skip-missing-config",
+    "--no-wait"
+  ]), {
+    manifestUrl: "https://example.test/manifest.json",
+    skipMissingConfig: true,
+    noWait: true
+  });
+});


### PR DESCRIPTION
## Summary
- add a canonical JSON + keccak256 publisher for the served discovery manifest
- add a production workflow that runs after successful deploys and publishes/skips safely based on configured registry/RPC/publisher secrets
- document the rollout caveat so the DiscoveryRegistry checklist stays open until a real publish or already_current result is observed

## Checks
- npm run test:ops
- node --test mcp-server/src/core/discovery-manifest.test.js
- npm run publish:discovery-manifest -- --manifest-path discovery/.well-known/agent-tools.json --dry-run
- forge test
- git diff --check
- npm --workspace mcp-server test (fails in this local worktree because @paraspell/sdk-core is not installed; unrelated xcm import failure before four tests run)

## Impact
- GitHub Actions / ops scripts / docs
- No frontend, indexer runtime, backend runtime, Caddy, or contract source changes

## Production follow-up
To actually anchor manifests on-chain, production needs DISCOVERY_REGISTRY_ADDRESS, DISCOVERY_PUBLISHER_PRIVATE_KEY, and DISCOVERY_PUBLISH_RPC_URL or POLKADOT_RPC_URL/RPC_URL. The checklist item should remain open until the deployed registry is configured and the workflow logs published or already_current.