### PR TITLE
Record live DiscoveryRegistry publish

### DIFF
--- a/deployments/discovery-registry-testnet.json
+++ b/deployments/discovery-registry-testnet.json
@@ -1,0 +1,19 @@
+{
+  "profile": "testnet",
+  "network": "Polkadot Hub TestNet",
+  "chainId": 420420417,
+  "rpcUrl": "https://services.polkadothub-rpc.com/testnet",
+  "contract": "DiscoveryRegistry",
+  "address": "0x9B1aDD0Dcd0AF57d8549307C27fc24555F8E293d",
+  "publisher": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+  "deployTxHash": "0xb4080929eb298c562107de56221ccfbb1079bc357dce83ce0b07798adcaa93da",
+  "deployBlockNumber": 8583585,
+  "firstManifestPublish": {
+    "workflowRunId": 25546750360,
+    "manifestUrl": "https://averray.com/.well-known/agent-tools.json",
+    "manifestHash": "0xddded191d8d70f5a3033d54d94165bee1a613e1a6e4f63d8cf52d667f54a6bf8",
+    "txHash": "0xe1f242d4b1aece3e18811367bd5d381f4cdc4133d0537597a81b7ece7a371b33",
+    "blockNumber": 8584322,
+    "registryVersion": 1
+  }
+}

--- a/docs/AVERRAY_WORKING_SPEC.md
+++ b/docs/AVERRAY_WORKING_SPEC.md
@@ -704,7 +704,7 @@ Before public v1.0.0-rc1 launch:
 - [ ] Weekly self-report email scheduled
 
 **Contract surface:**
-- [ ] `DiscoveryRegistry` deployed, CI publishing on directory updates
+- [x] `DiscoveryRegistry` deployed, CI publishing on directory updates
 - [ ] Verifier mapping extended with `wasAuthorizedAt` (no new contract)
 - [ ] `ReputationSBT` non-transferable at contract level
 - [ ] Hash fields live on `JobCreated` / `Submitted` / `Verified`
@@ -949,7 +949,7 @@ For traceability.
 
 1. **Canonical manifest publisher added:** `scripts/ops/publish-discovery-manifest.mjs` loads the served or local discovery manifest, canonicalizes JSON with sorted keys, computes the keccak256 hash, checks `DiscoveryRegistry.currentManifestHash()`, and only calls `publish(bytes32)` when the chain hash is stale.
 2. **Production workflow added:** `.github/workflows/publish-discovery-manifest.yml` runs after successful production deploys and can also be dispatched manually. It is safe before registry rollout: missing registry/RPC/publisher secrets produce an explicit skip, not a failed deploy.
-3. **Launch checklist remains deployment-gated:** the workflow exists, but `DiscoveryRegistry deployed, CI publishing on directory updates` should only be marked complete after the registry address and publisher key are configured in production and a real publish or already-current check is observed.
+3. **Launch checklist gate cleared:** `DiscoveryRegistry` is deployed on Polkadot Hub TestNet at `0x9B1aDD0Dcd0AF57d8549307C27fc24555F8E293d`, GitHub production secrets are configured, and workflow run `25546750360` published manifest hash `0xddded191d8d70f5a3033d54d94165bee1a613e1a6e4f63d8cf52d667f54a6bf8` at registry version `1`.
 
 ### v2.5 (bootstrap self-report scheduler)
 

--- a/docs/DISCOVERY.md
+++ b/docs/DISCOVERY.md
@@ -60,6 +60,11 @@ secrets are configured: `DISCOVERY_REGISTRY_ADDRESS`,
 `POLKADOT_RPC_URL`, or `RPC_URL`. Missing secrets produce a no-op skip so
 deployment is not blocked before the registry is deployed.
 
+Current Polkadot Hub TestNet registry: `0x9B1aDD0Dcd0AF57d8549307C27fc24555F8E293d`.
+The first production workflow publish was run `25546750360`, which wrote
+manifest hash `0xddded191d8d70f5a3033d54d94165bee1a6e4f63d8cf52d667f54a6bf8`
+as registry version `1`.
+
 To rehearse locally without a transaction:
 
 ```bash

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -47,11 +47,14 @@ Restore drills are documented in [VPS_RUNBOOK.md](../VPS_RUNBOOK.md).
 
 - [ ] Public site loads at `https://averray.com/`.
 - [ ] Discovery manifest loads at `https://averray.com/.well-known/agent-tools.json`.
-- [ ] Discovery manifest publish workflow reports `published` or
+- [x] Discovery manifest publish workflow reports `published` or
   `already_current` for the deployed `DiscoveryRegistry` hash. Required
   production secrets: `DISCOVERY_REGISTRY_ADDRESS`,
   `DISCOVERY_PUBLISHER_PRIVATE_KEY`, and `DISCOVERY_PUBLISH_RPC_URL`
-  (or `POLKADOT_RPC_URL` / `RPC_URL`).
+  (or `POLKADOT_RPC_URL` / `RPC_URL`). First observed publish:
+  workflow run `25546750360`, tx
+  `0xe1f242d4b1aece3e18811367bd5d381f4cdc4133d0537597a81b7ece7a371b33`,
+  registry version `1`.
 - [ ] Operator app loads at `https://app.averray.com/`.
 - [ ] API health is green at `https://api.averray.com/health`.
 - [ ] Indexer readiness is green at `https://index.averray.com/ready`.


### PR DESCRIPTION
## Summary
- mark the DiscoveryRegistry checklist item complete now that the registry is deployed and the publish workflow has produced a real on-chain publish
- record the Polkadot Hub TestNet registry address, deployment tx, manifest hash, and first publish tx in a non-secret deployment evidence file
- update discovery/production docs with the observed workflow run and registry version

## Checks
- git diff --check
- node -e "JSON.parse(require('fs').readFileSync('deployments/discovery-registry-testnet.json','utf8')); console.log('deployment json ok')"
- Polkadot MCP docs cross-check: official Foundry docs confirm Hub TestNet chain id/RPC and deploy/publish model

## Impact
- docs/deployment evidence only
- no backend, frontend, indexer, Caddy, contracts, or public site runtime changes

## Live evidence
- DiscoveryRegistry: 0x9B1aDD0Dcd0AF57d8549307C27fc24555F8E293d
- Deploy tx: 0xb4080929eb298c562107de56221ccfbb1079bc357dce83ce0b07798adcaa93da
- Publish workflow run: 25546750360
- Publish tx: 0xe1f242d4b1aece3e18811367bd5d381f4cdc4133d0537597a81b7ece7a371b33