### PR TITLE
Allow protected operator app smoke checks

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -74,6 +74,7 @@ jobs:
       APP_BASIC_AUTH_USER: ${{ secrets.APP_BASIC_AUTH_USER }}
       APP_BASIC_AUTH_PASSWORD: ${{ secrets.APP_BASIC_AUTH_PASSWORD }}
       APP_BASIC_AUTH_PASSWORD_HASH: ${{ secrets.APP_BASIC_AUTH_PASSWORD_HASH }}
+      APP_ALLOW_PROTECTED_SHELL: ${{ secrets.APP_ALLOW_PROTECTED_SHELL }}
       ADMIN_JWT: ${{ secrets.ADMIN_JWT }}
       DEPLOY_RUN_INDEXER: ${{ github.event_name == 'workflow_dispatch' && inputs.run_indexer || 'auto' }}
       DEPLOY_WAIT_FOR_READY: ${{ github.event_name == 'workflow_dispatch' && inputs.wait_for_ready || '1' }}
@@ -103,10 +104,11 @@ jobs:
       - name: Deploy production
         run: |
           remote_env=$(
-            printf 'APP_BASIC_AUTH_USER=%q APP_BASIC_AUTH_PASSWORD=%q APP_BASIC_AUTH_PASSWORD_HASH=%q ADMIN_JWT=%q RUN_INDEXER=%q WAIT_FOR_READY=%q HEALTH_STABILITY_SEC=%q INDEXER_LOG_TAIL=%q SMOKE_CHECK_INDEXER=%q INDEXER_DATABASE_SCHEMA=%q INDEXER_FRESH_SCHEMA=%q ' \
+            printf 'APP_BASIC_AUTH_USER=%q APP_BASIC_AUTH_PASSWORD=%q APP_BASIC_AUTH_PASSWORD_HASH=%q APP_ALLOW_PROTECTED_SHELL=%q ADMIN_JWT=%q RUN_INDEXER=%q WAIT_FOR_READY=%q HEALTH_STABILITY_SEC=%q INDEXER_LOG_TAIL=%q SMOKE_CHECK_INDEXER=%q INDEXER_DATABASE_SCHEMA=%q INDEXER_FRESH_SCHEMA=%q ' \
               "$APP_BASIC_AUTH_USER" \
               "$APP_BASIC_AUTH_PASSWORD" \
               "$APP_BASIC_AUTH_PASSWORD_HASH" \
+              "$APP_ALLOW_PROTECTED_SHELL" \
               "$ADMIN_JWT" \
               "$DEPLOY_RUN_INDEXER" \
               "$DEPLOY_WAIT_FOR_READY" \

--- a/docs/INCIDENT_RESPONSE.md
+++ b/docs/INCIDENT_RESPONSE.md
@@ -109,6 +109,10 @@ relay that accepts JSON POSTs.
    cd /srv/agent-stack/app
    ./scripts/ops/check-hosted-stack.sh
 
+   # If the operator app is deliberately behind browser auth and no app-shell
+   # credentials are available in this shell:
+   APP_ALLOW_PROTECTED_SHELL=1 ./scripts/ops/check-hosted-stack.sh
+
    # If an admin JWT is available, include async XCM operator status too:
    ADMIN_JWT='<admin-jwt>' ./scripts/ops/check-hosted-stack.sh
    ```

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -64,6 +64,11 @@ Run:
 ```bash
 ./scripts/ops/check-hosted-stack.sh
 
+# If the operator app is intentionally protected by Caddy, Cloudflare Access,
+# or another browser auth layer and you do not have app-shell credentials in the
+# current shell:
+APP_ALLOW_PROTECTED_SHELL=1 ./scripts/ops/check-hosted-stack.sh
+
 # Optional: include the async XCM operator lane in the smoke check
 ADMIN_JWT='<admin-jwt>' ./scripts/ops/check-hosted-stack.sh
 
@@ -71,6 +76,10 @@ ADMIN_JWT='<admin-jwt>' ./scripts/ops/check-hosted-stack.sh
 # touched, while scheduled/full-stack smoke should keep the default.
 CHECK_INDEXER=0 ./scripts/ops/check-hosted-stack.sh
 ```
+
+For the GitHub production deploy workflow, set the repository/environment secret
+`APP_ALLOW_PROTECTED_SHELL=1` when `app.averray.com` should return an auth
+challenge instead of the public operator shell.
 
 ---
 

--- a/scripts/ops/check-hosted-stack.sh
+++ b/scripts/ops/check-hosted-stack.sh
@@ -19,6 +19,8 @@ TIMEOUT_SEC=${TIMEOUT_SEC:-20}
 APP_BASIC_AUTH_USER=${APP_BASIC_AUTH_USER:-}
 APP_BASIC_AUTH_PASSWORD=${APP_BASIC_AUTH_PASSWORD:-}
 APP_EXPECTED_MARKER=${APP_EXPECTED_MARKER:-Opening the operator control room.}
+APP_ALLOW_PROTECTED_SHELL=${APP_ALLOW_PROTECTED_SHELL:-0}
+APP_PROTECTED_STATUS_CODES=${APP_PROTECTED_STATUS_CODES:-401}
 ADMIN_JWT=${ADMIN_JWT:-}
 
 require_command() {
@@ -78,6 +80,43 @@ enabled() {
   esac
 }
 
+status_allowed() {
+  local status="$1"
+  local allowed
+  IFS=',' read -ra allowed <<<"$APP_PROTECTED_STATUS_CODES"
+  for code in "${allowed[@]}"; do
+    if [[ "$status" == "${code//[[:space:]]/}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+check_operator_app_shell() {
+  if app_html="$(fetch "$APP_URL" 2>/dev/null)" && grep -Fq "$APP_EXPECTED_MARKER" <<<"$app_html"; then
+    return 0
+  fi
+
+  if ! enabled "$APP_ALLOW_PROTECTED_SHELL"; then
+    echo "Operator app did not return the expected shell" >&2
+    exit 1
+  fi
+
+  local curl_args=(-sS --max-time "$TIMEOUT_SEC" -o /dev/null -w "%{http_code}")
+  if [[ -n "$APP_BASIC_AUTH_USER" && -n "$APP_BASIC_AUTH_PASSWORD" ]]; then
+    curl_args+=(-u "$APP_BASIC_AUTH_USER:$APP_BASIC_AUTH_PASSWORD")
+  fi
+  local status
+  status="$(curl "${curl_args[@]}" "$APP_URL")"
+  if status_allowed "$status"; then
+    echo "Operator app returned protected status $status as expected."
+    return 0
+  fi
+
+  echo "Operator app did not return the expected shell or an allowed protected status (got HTTP $status)." >&2
+  exit 1
+}
+
 echo "Checking public site"
 public_html="$(fetch "$PUBLIC_SITE_URL")"
 grep -q "<title>Averray" <<<"$public_html" || {
@@ -91,11 +130,7 @@ jq -e '.discoveryUrl == "https://averray.com/.well-known/agent-tools.json"' >/de
 jq -e '.baseUrl == "https://api.averray.com"' >/dev/null <<<"$discovery_json"
 
 echo "Checking operator app shell"
-app_html="$(fetch "$APP_URL")"
-grep -Fq "$APP_EXPECTED_MARKER" <<<"$app_html" || {
-  echo "Operator app did not return the expected shell" >&2
-  exit 1
-}
+check_operator_app_shell
 
 echo "Checking API health"
 api_health_json="$(fetch "$API_HEALTH_URL")"


### PR DESCRIPTION
## Summary
- add an explicit APP_ALLOW_PROTECTED_SHELL smoke-check mode for intentionally protected operator app shells
- pass the optional setting through the production deploy workflow
- document manual and GitHub deploy usage

## Checks
- bash -n scripts/ops/check-hosted-stack.sh scripts/ops/deploy-production.sh
- git diff --check

## Impact
- Affects production smoke/deploy scripts and docs only
- No backend, frontend, indexer, contracts, Caddy, or public site runtime changes