### PR TITLE
Reconcile contract surface spec checklist

### DIFF
--- a/docs/AVERRAY_WORKING_SPEC.md
+++ b/docs/AVERRAY_WORKING_SPEC.md
@@ -705,14 +705,14 @@ Before public v1.0.0-rc1 launch:
 
 **Contract surface:**
 - [x] `DiscoveryRegistry` deployed, CI publishing on directory updates
-- [ ] Verifier mapping extended with `wasAuthorizedAt` (no new contract)
-- [ ] `ReputationSBT` non-transferable at contract level
-- [ ] Hash fields live on `JobCreated` / `Submitted` / `Verified`
-- [ ] `Disclosed` / `AutoDisclosed` events live on session lifecycle contract
-- [ ] `EscrowCore.openDispute` enforces deadline window (`block.timestamp <= rejectedAt + DISPUTE_WINDOW`)
-- [ ] `DISPUTE_WINDOW` bumped from 1 day to 7 days
-- [ ] `EscrowCore.autoResolveOnTimeout(jobId)` shipped with `ARBITRATOR_SLA = 14 days`
-- [ ] `disputedAt` timestamp present on job state and emitted in `Disputed` event
+- [x] Verifier mapping extended with `wasAuthorizedAt` (no new contract)
+- [x] `ReputationSBT` non-transferable at contract level
+- [x] Hash fields live on `JobCreated` / `Submitted` / `Verified`
+- [x] `Disclosed` / `AutoDisclosed` events live on session lifecycle contract
+- [x] `EscrowCore.openDispute` enforces deadline window (`block.timestamp <= rejectedAt + DISPUTE_WINDOW`)
+- [x] `DISPUTE_WINDOW` bumped from 1 day to 7 days
+- [x] `EscrowCore.autoResolveOnTimeout(jobId)` shipped with `ARBITRATOR_SLA = 14 days`
+- [x] `disputedAt` timestamp present on job state and emitted in `DisputeOpened` event
 
 **Content storage:**
 - [ ] `/content/:hash` serving with visibility-resolved-at-read-time

--- a/docs/RC1_WORKING_SPEC.md
+++ b/docs/RC1_WORKING_SPEC.md
@@ -553,15 +553,15 @@ Before public v1.0.0-rc1 launch:
 - [ ] Weekly self-report email scheduled
 
 **Contract surface:**
-- [ ] `DiscoveryRegistry` deployed, CI publishing on directory updates
-- [ ] Verifier mapping extended with `wasAuthorizedAt` (no new contract)
-- [ ] `ReputationSBT` non-transferable at contract level
-- [ ] Hash fields live on `JobCreated` / `Submitted` / `Verified`
-- [ ] `Disclosed` / `AutoDisclosed` events live on session lifecycle contract
-- [ ] `EscrowCore.openDispute` enforces deadline window (`block.timestamp <= rejectedAt + DISPUTE_WINDOW`)
-- [ ] `DISPUTE_WINDOW` bumped from 1 day to 7 days
-- [ ] `EscrowCore.autoResolveOnTimeout(jobId)` shipped with `ARBITRATOR_SLA = 14 days`
-- [ ] `disputedAt` timestamp present on job state and emitted in `Disputed` event
+- [x] `DiscoveryRegistry` deployed, CI publishing on directory updates
+- [x] Verifier mapping extended with `wasAuthorizedAt` (no new contract)
+- [x] `ReputationSBT` non-transferable at contract level
+- [x] Hash fields live on `JobCreated` / `Submitted` / `Verified`
+- [x] `Disclosed` / `AutoDisclosed` events live on session lifecycle contract
+- [x] `EscrowCore.openDispute` enforces deadline window (`block.timestamp <= rejectedAt + DISPUTE_WINDOW`)
+- [x] `DISPUTE_WINDOW` bumped from 1 day to 7 days
+- [x] `EscrowCore.autoResolveOnTimeout(jobId)` shipped with `ARBITRATOR_SLA = 14 days`
+- [x] `disputedAt` timestamp present on job state and emitted in `DisputeOpened` event
 
 **Content storage:**
 - [ ] `/content/:hash` serving with visibility-resolved-at-read-time

--- a/test/AgentPlatform.t.sol
+++ b/test/AgentPlatform.t.sol
@@ -11,7 +11,13 @@ import {EscrowCore} from "../contracts/EscrowCore.sol";
 import {ReputationSBT} from "../contracts/ReputationSBT.sol";
 import {MockVDotAdapter} from "../contracts/strategies/MockVDotAdapter.sol";
 
+interface VmEvent {
+    function expectEmit(bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData, address emitter) external;
+}
+
 contract AgentPlatformTest is Test {
+    VmEvent internal constant vmEvent = VmEvent(address(uint160(uint256(keccak256("hevm cheat code")))));
+
     TreasuryPolicy internal policy;
     StrategyAdapterRegistry internal registry;
     AgentAccountCore internal accounts;
@@ -28,6 +34,8 @@ contract AgentPlatformTest is Test {
     uint256 internal constant WORKER_DEPOSIT = 200 ether;
     bytes32 internal constant SPEC_HASH = bytes32("SPEC_HASH");
     bytes32 internal constant REASONING_HASH = bytes32("REASONING_HASH");
+
+    event DisputeOpened(bytes32 indexed jobId, address indexed opener, uint256 disputedAt);
 
     function setUp() public {
         policy = new TreasuryPolicy();
@@ -94,6 +102,11 @@ contract AgentPlatformTest is Test {
         assertEq(workerJobStake, 0);
         assertEq(dot.balanceOf(worker), startingWorkerBalance + 100 ether);
         assertEq(reputation.balanceOf(worker), 1);
+    }
+
+    function testDisputeWindowAndArbitratorSlaMatchSpec() public view {
+        assertEq(escrow.DISPUTE_WINDOW(), 7 days);
+        assertEq(escrow.ARBITRATOR_SLA(), 14 days);
     }
 
     function testRecurringTemplateReserveFundsDerivativeWithoutFreshPosterLiquid() public {
@@ -458,6 +471,8 @@ contract AgentPlatformTest is Test {
         vm.prank(verifier);
         escrow.resolveSinglePayout(jobId, false, bytes32("REJECTED"), "ipfs://badge/rejected", REASONING_HASH);
 
+        vmEvent.expectEmit(true, true, false, true, address(escrow));
+        emit DisputeOpened(jobId, worker, block.timestamp);
         vm.prank(worker);
         escrow.openDispute(jobId);
         EscrowCore.JobEscrow memory disputedJob = escrow.jobs(jobId);


### PR DESCRIPTION
## Summary
- mark the contract-surface checklist items complete in both working specs after verifying the implemented contract surface
- align the disputed timestamp checklist wording with the actual DisputeOpened event name
- add contract tests for the exact dispute window/SLA constants and DisputeOpened disputedAt payload

## Checks
- forge test

## Impact
- Contracts: test-only coverage change
- Docs: spec checklist reconciliation
- Backend/frontend/indexer/public site/Caddy: no runtime changes
- Env/VPS secrets: none