### PR TITLE
Back content recovery log with object storage

### DIFF
--- a/docs/AVERRAY_WORKING_SPEC.md
+++ b/docs/AVERRAY_WORKING_SPEC.md
@@ -715,8 +715,8 @@ Before public v1.0.0-rc1 launch:
 - [x] `disputedAt` timestamp present on job state and emitted in `DisputeOpened` event
 
 **Content storage:**
-- [ ] `/content/:hash` serving with visibility-resolved-at-read-time
-- [ ] Append-only recovery log writing to object storage
+- [x] `/content/:hash` serving with visibility-resolved-at-read-time
+- [x] Append-only recovery log writing to object storage
 
 **Agent/maintainer surface:**
 - [ ] Disclosure footer auto-injected into every PR/edit

--- a/docs/CONTENT_RECOVERY_RUNBOOK.md
+++ b/docs/CONTENT_RECOVERY_RUNBOOK.md
@@ -4,9 +4,10 @@ This runbook covers recovery of Averray content-addressed blobs served by
 `/content/:hash`.
 
 The current production path stores content records in the configured state
-store and appends every write to a private JSONL recovery log. If Redis loses
-or corrupts content records, operators can replay that log back into the state
-store.
+store and appends every write to a private JSONL recovery log. Production can
+also mirror each append to S3-compatible object storage. If Redis loses or
+corrupts content records, operators can replay the local log or reconstruct it
+from the object mirror back into the state store.
 
 ## Scope Boundary
 
@@ -32,13 +33,32 @@ CONTENT_RECOVERY_LOG_ENABLED=1
 CONTENT_RECOVERY_LOG_DIR=/srv/agent-stack/content-recovery-log
 ```
 
+The optional object-store mirror is controlled by:
+
+```bash
+CONTENT_RECOVERY_OBJECT_ENABLED=1
+CONTENT_RECOVERY_OBJECT_ENDPOINT=https://s3.example.com
+CONTENT_RECOVERY_OBJECT_BUCKET=averray-content-recovery
+CONTENT_RECOVERY_OBJECT_REGION=eu-west-1
+CONTENT_RECOVERY_OBJECT_ACCESS_KEY_ID=...
+CONTENT_RECOVERY_OBJECT_SECRET_ACCESS_KEY=...
+CONTENT_RECOVERY_OBJECT_PREFIX=content-recovery-log
+```
+
 If `CONTENT_RECOVERY_LOG_DIR` is unset, the backend defaults to
 `.content-recovery-log` under its working directory. Production should keep the
 directory on durable private storage and include it in host backups.
 
-Each log file is named `YYYY-MM-DD.jsonl`. Each line is a canonical
-`content.upserted` record. Replay validates the payload hash before it writes
-anything back to the state store.
+Each local log file is named `YYYY-MM-DD.jsonl`. Each line is a canonical
+`content.upserted` record. Object-store mirror keys are immutable per-entry
+objects under:
+
+```text
+$CONTENT_RECOVERY_OBJECT_PREFIX/YYYY-MM-DD/<loggedAt>-<hash>.jsonl
+```
+
+Replay validates the payload hash before it writes anything back to the state
+store.
 
 ## When To Use
 
@@ -148,6 +168,11 @@ If apply succeeds but `/content/:hash` still returns 404:
 If Redis is unstable, stop risky deploys and treat the incident as a storage
 integrity problem before continuing normal operations.
 
+If the host-local log is missing but the object mirror is intact, download the
+objects for the affected day or prefix, concatenate them in key order into a
+temporary `YYYY-MM-DD.jsonl`, then run the same dry-run/apply replay command
+against that directory.
+
 ## Current Roadmap Position
 
 This runbook completes the operator drill portion of the rc1 content-addressing
@@ -155,6 +180,7 @@ slice:
 
 - `/content/:hash` content store: shipped
 - append-only recovery log: shipped
+- optional S3-compatible object-store mirror: shipped
 - early owner/admin publish: shipped
 - replay command: shipped
 - operator replay runbook: this document

--- a/docs/RC1_WORKING_SPEC.md
+++ b/docs/RC1_WORKING_SPEC.md
@@ -564,8 +564,8 @@ Before public v1.0.0-rc1 launch:
 - [x] `disputedAt` timestamp present on job state and emitted in `DisputeOpened` event
 
 **Content storage:**
-- [ ] `/content/:hash` serving with visibility-resolved-at-read-time
-- [ ] Append-only recovery log writing to object storage
+- [x] `/content/:hash` serving with visibility-resolved-at-read-time
+- [x] Append-only recovery log writing to object storage
 
 **Agent/maintainer surface:**
 - [ ] Disclosure footer auto-injected into every PR/edit

--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -24,6 +24,16 @@ REDIS_NAMESPACE=agent-platform
 # under the app working directory. Keep this path on durable private storage.
 # CONTENT_RECOVERY_LOG_DIR=/srv/agent-stack/content-recovery-log
 # CONTENT_RECOVERY_LOG_ENABLED=1
+# Optional S3-compatible object-store mirror for the same recovery entries.
+# Writes one immutable JSONL object per content write, under:
+#   $CONTENT_RECOVERY_OBJECT_PREFIX/YYYY-MM-DD/<loggedAt>-<hash>.jsonl
+# CONTENT_RECOVERY_OBJECT_ENABLED=0
+# CONTENT_RECOVERY_OBJECT_ENDPOINT=https://s3.example.com
+# CONTENT_RECOVERY_OBJECT_BUCKET=averray-content-recovery
+# CONTENT_RECOVERY_OBJECT_REGION=eu-west-1
+# CONTENT_RECOVERY_OBJECT_ACCESS_KEY_ID=...
+# CONTENT_RECOVERY_OBJECT_SECRET_ACCESS_KEY=...
+# CONTENT_RECOVERY_OBJECT_PREFIX=content-recovery-log
 
 # --- Authentication -----------------------------------------------------------
 # AUTH_MODE controls whether signed-in JWTs are required on protected routes.

--- a/mcp-server/src/core/content-recovery-log.js
+++ b/mcp-server/src/core/content-recovery-log.js
@@ -1,3 +1,4 @@
+import { createHash, createHmac } from "node:crypto";
 import { appendFile, mkdir, readFile, readdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
 
@@ -8,10 +9,11 @@ import { ConfigError, ExternalServiceError } from "./errors.js";
 export const DEFAULT_CONTENT_RECOVERY_LOG_DIR = ".content-recovery-log";
 
 export class ContentRecoveryLog {
-  constructor({ dir = DEFAULT_CONTENT_RECOVERY_LOG_DIR, enabled = true, logger = console } = {}) {
+  constructor({ dir = DEFAULT_CONTENT_RECOVERY_LOG_DIR, enabled = true, logger = console, objectStore = undefined } = {}) {
     this.dir = resolve(dir);
     this.enabled = Boolean(enabled);
     this.logger = logger;
+    this.objectStore = objectStore;
   }
 
   async append(record, { loggedAt = new Date().toISOString() } = {}) {
@@ -31,17 +33,98 @@ export class ContentRecoveryLog {
       autoPublicAt: record.autoPublicAt,
       payload: record.payload
     };
+    const line = `${canonicalizeContent(entry)}\n`;
 
     try {
+      const objectWrite = await this.objectStore?.putEntry?.(entry, line);
       await mkdir(this.dir, { recursive: true, mode: 0o700 });
       const file = join(this.dir, `${loggedAt.slice(0, 10)}.jsonl`);
-      await appendFile(file, `${canonicalizeContent(entry)}\n`, { encoding: "utf8", mode: 0o600 });
-      return { enabled: true, file, hash: record.hash };
+      await appendFile(file, line, { encoding: "utf8", mode: 0o600 });
+      return {
+        enabled: true,
+        file,
+        hash: record.hash,
+        objectKey: objectWrite?.key
+      };
     } catch (error) {
       throw new ExternalServiceError(`Content recovery log append failed: ${error?.message ?? "unknown_error"}`);
     }
   }
 
+}
+
+export class S3ContentRecoveryObjectStore {
+  constructor({
+    endpoint,
+    bucket,
+    region = "auto",
+    accessKeyId,
+    secretAccessKey,
+    prefix = "content-recovery-log",
+    fetchImpl = globalThis.fetch
+  } = {}) {
+    if (!endpoint) throw new ConfigError("CONTENT_RECOVERY_OBJECT_ENDPOINT is required when object recovery is enabled.");
+    if (!bucket) throw new ConfigError("CONTENT_RECOVERY_OBJECT_BUCKET is required when object recovery is enabled.");
+    if (!accessKeyId) throw new ConfigError("CONTENT_RECOVERY_OBJECT_ACCESS_KEY_ID is required when object recovery is enabled.");
+    if (!secretAccessKey) throw new ConfigError("CONTENT_RECOVERY_OBJECT_SECRET_ACCESS_KEY is required when object recovery is enabled.");
+    if (typeof fetchImpl !== "function") throw new ConfigError("Object recovery requires fetch support.");
+    this.endpoint = String(endpoint).replace(/\/+$/u, "");
+    this.bucket = String(bucket).trim();
+    this.region = String(region || "auto").trim();
+    this.accessKeyId = String(accessKeyId).trim();
+    this.secretAccessKey = String(secretAccessKey);
+    this.prefix = String(prefix || "").replace(/^\/+|\/+$/gu, "");
+    this.fetchImpl = fetchImpl;
+  }
+
+  async putEntry(entry, body) {
+    const key = this.objectKey(entry);
+    const url = new URL(`${this.endpoint}/${encodePathSegment(this.bucket)}/${encodeObjectKey(key)}`);
+    const payloadHash = sha256Hex(body);
+    const now = new Date(entry.loggedAt);
+    const amzDate = toAmzDate(now);
+    const dateStamp = amzDate.slice(0, 8);
+    const headers = {
+      "content-type": "application/jsonl; charset=utf-8",
+      "if-none-match": "*",
+      host: url.host,
+      "x-amz-content-sha256": payloadHash,
+      "x-amz-date": amzDate
+    };
+    headers.authorization = signS3Put({
+      method: "PUT",
+      url,
+      headers,
+      payloadHash,
+      region: this.region,
+      accessKeyId: this.accessKeyId,
+      secretAccessKey: this.secretAccessKey,
+      dateStamp,
+      amzDate
+    });
+
+    const response = await this.fetchImpl(url, {
+      method: "PUT",
+      headers,
+      body
+    });
+    if (!response?.ok) {
+      const status = response?.status ?? "unknown";
+      const detail = typeof response?.text === "function" ? await response.text().catch(() => "") : "";
+      throw new ExternalServiceError(`Object recovery write failed with status ${status}${detail ? `: ${detail}` : ""}`);
+    }
+    return { key };
+  }
+
+  objectKey(entry) {
+    const day = String(entry?.loggedAt ?? "").slice(0, 10);
+    if (!/^\d{4}-\d{2}-\d{2}$/u.test(day)) {
+      throw new ConfigError("content recovery object entry requires ISO loggedAt.");
+    }
+    const loggedAt = String(entry.loggedAt).replace(/[^0-9A-Za-z._-]/gu, "-");
+    const hash = String(entry.hash ?? "").replace(/^0x/u, "");
+    return [this.prefix, day, `${loggedAt}-${hash}.jsonl`].filter(Boolean).join("/");
+  }
 }
 
 export async function replayContentRecoveryLog({
@@ -142,14 +225,88 @@ function contentVersionTime(record) {
 export function createContentRecoveryLog(env = process.env, { logger = console } = {}) {
   const enabled = env.CONTENT_RECOVERY_LOG_ENABLED === undefined
     ? true
-    : parseBooleanEnv(env.CONTENT_RECOVERY_LOG_ENABLED);
+    : parseBooleanEnv(env.CONTENT_RECOVERY_LOG_ENABLED, "CONTENT_RECOVERY_LOG_ENABLED");
   const dir = env.CONTENT_RECOVERY_LOG_DIR?.trim() || DEFAULT_CONTENT_RECOVERY_LOG_DIR;
-  return new ContentRecoveryLog({ dir, enabled, logger });
+  const objectStore = parseBooleanEnv(env.CONTENT_RECOVERY_OBJECT_ENABLED ?? "0", "CONTENT_RECOVERY_OBJECT_ENABLED")
+    ? createContentRecoveryObjectStore(env)
+    : undefined;
+  return new ContentRecoveryLog({ dir, enabled, logger, objectStore });
 }
 
-function parseBooleanEnv(value) {
+function parseBooleanEnv(value, label = "boolean env") {
   const normalized = String(value ?? "").trim().toLowerCase();
   if (["1", "true", "yes", "on"].includes(normalized)) return true;
   if (["0", "false", "no", "off"].includes(normalized)) return false;
-  throw new ConfigError("CONTENT_RECOVERY_LOG_ENABLED must be a boolean-like value.");
+  throw new ConfigError(`${label} must be a boolean-like value.`);
+}
+
+export function createContentRecoveryObjectStore(env = process.env) {
+  return new S3ContentRecoveryObjectStore({
+    endpoint: env.CONTENT_RECOVERY_OBJECT_ENDPOINT?.trim(),
+    bucket: env.CONTENT_RECOVERY_OBJECT_BUCKET?.trim(),
+    region: env.CONTENT_RECOVERY_OBJECT_REGION?.trim() || "auto",
+    accessKeyId: env.CONTENT_RECOVERY_OBJECT_ACCESS_KEY_ID?.trim(),
+    secretAccessKey: env.CONTENT_RECOVERY_OBJECT_SECRET_ACCESS_KEY,
+    prefix: env.CONTENT_RECOVERY_OBJECT_PREFIX?.trim() || "content-recovery-log"
+  });
+}
+
+function signS3Put({ method, url, headers, payloadHash, region, accessKeyId, secretAccessKey, dateStamp, amzDate }) {
+  const signedHeaderNames = Object.keys(headers)
+    .map((name) => name.toLowerCase())
+    .sort();
+  const canonicalHeaders = signedHeaderNames
+    .map((name) => `${name}:${String(headers[name] ?? headers[Object.keys(headers).find((key) => key.toLowerCase() === name)] ?? "").trim()}\n`)
+    .join("");
+  const signedHeaders = signedHeaderNames.join(";");
+  const canonicalRequest = [
+    method,
+    url.pathname,
+    "",
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash
+  ].join("\n");
+  const credentialScope = `${dateStamp}/${region}/s3/aws4_request`;
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    amzDate,
+    credentialScope,
+    sha256Hex(canonicalRequest)
+  ].join("\n");
+  const signingKey = hmac(
+    hmac(
+      hmac(
+        hmac(`AWS4${secretAccessKey}`, dateStamp),
+        region
+      ),
+      "s3"
+    ),
+    "aws4_request"
+  );
+  const signature = createHmac("sha256", signingKey).update(stringToSign).digest("hex");
+  return `AWS4-HMAC-SHA256 Credential=${accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
+}
+
+function hmac(key, value) {
+  return createHmac("sha256", key).update(value).digest();
+}
+
+function sha256Hex(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function toAmzDate(date) {
+  return date.toISOString().replace(/[:-]|\.\d{3}/gu, "");
+}
+
+function encodePathSegment(value) {
+  return encodeURIComponent(value).replace(/%2F/giu, "/");
+}
+
+function encodeObjectKey(value) {
+  return String(value)
+    .split("/")
+    .map((segment) => encodePathSegment(segment))
+    .join("/");
 }

--- a/mcp-server/src/core/content-recovery-log.test.js
+++ b/mcp-server/src/core/content-recovery-log.test.js
@@ -9,7 +9,8 @@ import {
   ContentRecoveryLog,
   createContentRecoveryLog,
   recordFromRecoveryLine,
-  replayContentRecoveryLog
+  replayContentRecoveryLog,
+  S3ContentRecoveryObjectStore
 } from "./content-recovery-log.js";
 import { ConfigError } from "./errors.js";
 import { MemoryStateStore } from "./state-store.js";
@@ -70,6 +71,82 @@ test("createContentRecoveryLog parses boolean env", () => {
   assert.throws(
     () => createContentRecoveryLog({ CONTENT_RECOVERY_LOG_ENABLED: "sometimes" }),
     ConfigError
+  );
+});
+
+test("createContentRecoveryLog configures optional object recovery sink", () => {
+  const recoveryLog = createContentRecoveryLog({
+    CONTENT_RECOVERY_OBJECT_ENABLED: "1",
+    CONTENT_RECOVERY_OBJECT_ENDPOINT: "https://objects.example.test",
+    CONTENT_RECOVERY_OBJECT_BUCKET: "averray-private",
+    CONTENT_RECOVERY_OBJECT_REGION: "eu-west-1",
+    CONTENT_RECOVERY_OBJECT_ACCESS_KEY_ID: "key-id",
+    CONTENT_RECOVERY_OBJECT_SECRET_ACCESS_KEY: "secret",
+    CONTENT_RECOVERY_OBJECT_PREFIX: "recovery"
+  });
+
+  assert.ok(recoveryLog.objectStore instanceof S3ContentRecoveryObjectStore);
+  assert.equal(recoveryLog.objectStore.bucket, "averray-private");
+  assert.equal(recoveryLog.objectStore.prefix, "recovery");
+});
+
+test("S3ContentRecoveryObjectStore writes immutable per-entry JSONL objects", async () => {
+  const calls = [];
+  const objectStore = new S3ContentRecoveryObjectStore({
+    endpoint: "https://objects.example.test",
+    bucket: "averray-private",
+    region: "eu-west-1",
+    accessKeyId: "key-id",
+    secretAccessKey: "secret",
+    prefix: "recovery",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return { ok: true, status: 200 };
+    }
+  });
+  const recoveryLog = new ContentRecoveryLog({
+    dir: await mkdtemp(join(tmpdir(), "averray-content-log-")),
+    objectStore
+  });
+  const record = buildContentRecord({
+    ownerWallet: OWNER,
+    payload: { ok: true },
+    createdAt: "2026-04-27T12:00:00.000Z"
+  });
+
+  const result = await recoveryLog.append(record, { loggedAt: "2026-04-27T12:01:02.000Z" });
+
+  assert.equal(calls.length, 1);
+  assert.match(calls[0].url, /^https:\/\/objects\.example\.test\/averray-private\/recovery\/2026-04-27\/2026-04-27T12-01-02\.000Z-/u);
+  assert.equal(calls[0].init.method, "PUT");
+  assert.equal(calls[0].init.headers["if-none-match"], "*");
+  assert.equal(calls[0].init.headers["x-amz-content-sha256"].length, 64);
+  assert.match(calls[0].init.headers.authorization, /^AWS4-HMAC-SHA256 Credential=key-id\/20260427\/eu-west-1\/s3\/aws4_request/u);
+  assert.match(calls[0].init.body, /"kind":"content.upserted"/u);
+  assert.match(result.objectKey, /^recovery\/2026-04-27\/2026-04-27T12-01-02\.000Z-/u);
+});
+
+test("S3ContentRecoveryObjectStore failures fail the recovery append", async () => {
+  const objectStore = new S3ContentRecoveryObjectStore({
+    endpoint: "https://objects.example.test",
+    bucket: "averray-private",
+    region: "eu-west-1",
+    accessKeyId: "key-id",
+    secretAccessKey: "secret",
+    fetchImpl: async () => ({ ok: false, status: 503, text: async () => "slow down" })
+  });
+  const recoveryLog = new ContentRecoveryLog({
+    dir: await mkdtemp(join(tmpdir(), "averray-content-log-")),
+    objectStore
+  });
+  const record = buildContentRecord({
+    ownerWallet: OWNER,
+    payload: { ok: true }
+  });
+
+  await assert.rejects(
+    () => recoveryLog.append(record, { loggedAt: "2026-04-27T12:01:02.000Z" }),
+    /Object recovery write failed with status 503/u
   );
 });
 


### PR DESCRIPTION
## Summary
- add an optional S3-compatible object-store mirror for content recovery log entries
- keep the existing local JSONL recovery log as the default fallback and write immutable per-entry JSONL objects when configured
- document the object-store env vars, recovery layout, and mark the content-storage spec items complete

## Checks
- npm --workspace mcp-server test
- RUN_HTTP_SMOKE=1 node --test src/protocols/http/server.smoke.test.js

## Impact
- Backend: content recovery log durability only; /content route behavior unchanged
- Docs: content recovery runbook, env example, spec checklist
- Frontend/indexer/contracts/Caddy/public site: no changes
- Required env/secrets: optional CONTENT_RECOVERY_OBJECT_* vars to enable the object-store mirror in production