### PR TITLE
Enforce maintainer surface guards

### DIFF
--- a/docs/AVERRAY_WORKING_SPEC.md
+++ b/docs/AVERRAY_WORKING_SPEC.md
@@ -719,9 +719,9 @@ Before public v1.0.0-rc1 launch:
 - [ ] Append-only recovery log writing to object storage
 
 **Agent/maintainer surface:**
-- [ ] Disclosure footer auto-injected into every PR/edit
-- [ ] Per-repo 3-PR cap enforced at platform layer
-- [ ] Denylist live, with security/standards repos pre-populated
+- [x] Disclosure footer auto-injected into every PR/edit
+- [x] Per-repo 3-PR cap enforced at platform layer
+- [x] Denylist live, with security/standards repos pre-populated
 
 **Multisig and ops (per `MULTISIG_SETUP.md`):**
 - [ ] All three signer keys generated, backups in distinct locations per `SIGNER_POLICY.md`

--- a/docs/RC1_WORKING_SPEC.md
+++ b/docs/RC1_WORKING_SPEC.md
@@ -568,9 +568,9 @@ Before public v1.0.0-rc1 launch:
 - [ ] Append-only recovery log writing to object storage
 
 **Agent/maintainer surface:**
-- [ ] Disclosure footer auto-injected into every PR/edit
-- [ ] Per-repo 3-PR cap enforced at platform layer
-- [ ] Denylist live, with security/standards repos pre-populated
+- [x] Disclosure footer auto-injected into every PR/edit
+- [x] Per-repo 3-PR cap enforced at platform layer
+- [x] Denylist live, with security/standards repos pre-populated
 
 **Multisig and ops (per `MULTISIG_SETUP.md`):**
 - [ ] All three signer keys generated, backups in distinct locations per `SIGNER_POLICY.md`

--- a/mcp-server/src/core/job-execution-service.js
+++ b/mcp-server/src/core/job-execution-service.js
@@ -21,6 +21,7 @@ import {
 import { computeClaimEconomics, countClaimedSessions } from "./claim-economics.js";
 import {
   DEFAULT_OPEN_PR_CAP_PER_REPO,
+  appendAverrayDisclosureFooter,
   countOpenGithubPullRequestsForRepo
 } from "./maintainer-surface-policy.js";
 import { claimExpiresAt, countClaimAttempts, isExpiredClaim, isTerminalSession } from "./claim-state.js";
@@ -235,14 +236,16 @@ export class JobExecutionService {
     const submission = normalizeSubmission(normalizeSubmitPayloadShape(job.outputSchemaRef, submissionInput));
     validateSubmissionContract(job.outputSchemaRef, submission);
     await this.enforceMaintainerOpenPrCap(job, submission);
+    const guardedSubmission = this.applyMaintainerSubmissionGuards(job, refreshed, submission);
+    validateSubmissionContract(job.outputSchemaRef, guardedSubmission);
     if (this.blockchainGateway?.isEnabled()) {
-      await this.blockchainGateway.submitWork(session.chainJobId ?? session.jobId, hashSubmission(submission));
+      await this.blockchainGateway.submitWork(session.chainJobId ?? session.jobId, hashSubmission(guardedSubmission));
     }
     const protocolHistory = [...new Set([...refreshed.protocolHistory, protocol])];
     const transitioned = transitionSession({
       ...refreshed,
       protocolHistory,
-      submission,
+      submission: guardedSubmission,
       outputSchemaBuiltin: Boolean(getBuiltinJobSchema(job.outputSchemaRef))
     }, "submitted", {
       reason: "work_submitted",
@@ -427,6 +430,29 @@ export class JobExecutionService {
         { repo, openCount, openPrCap: this.openPrCap }
       );
     }
+  }
+
+  applyMaintainerSubmissionGuards(job, session, submission) {
+    if (job?.source?.type !== "github_issue" || submission.kind !== "structured") {
+      return submission;
+    }
+    if (job.source?.maintainerPolicy?.disclosureRequired === false) {
+      return submission;
+    }
+    const prUrl = submission.structured?.prUrl ?? submission.structured?.pullRequestUrl;
+    if (!parseGithubPullRequestUrl(prUrl)) {
+      return submission;
+    }
+    return {
+      ...submission,
+      structured: {
+        ...submission.structured,
+        prBody: appendAverrayDisclosureFooter(submission.structured.prBody, {
+          agentWallet: session.wallet,
+          jobSpecUrl: job.definitionUrl ?? `https://api.averray.com/jobs/${encodeURIComponent(job.id ?? session.jobId)}`
+        })
+      }
+    };
   }
 
   isTerminalSession(session) {

--- a/mcp-server/src/core/job-execution-service.test.js
+++ b/mcp-server/src/core/job-execution-service.test.js
@@ -5,6 +5,7 @@ import { ValidationError } from "./errors.js";
 import { JobExecutionService } from "./job-execution-service.js";
 import { MemoryStateStore } from "./state-store.js";
 import { computeClaimEconomics } from "./claim-economics.js";
+import { buildAverrayDisclosureFooter } from "./maintainer-surface-policy.js";
 
 const WALLET = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const WALLET_2 = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
@@ -397,4 +398,63 @@ test("submitWork enforces per-repo open PR cap for GitHub issue jobs", async () 
     }),
     (error) => error.code === "maintainer_open_pr_cap_reached"
   );
+});
+
+test("submitWork injects Averray disclosure footer into GitHub PR evidence", async () => {
+  const stateStore = new MemoryStateStore();
+  const job = makeJob({
+    id: "github-issue-job-disclosure",
+    outputSchemaRef: "schema://jobs/github-pr-evidence-output",
+    source: {
+      type: "github_issue",
+      repo: "example/project",
+      issueNumber: 42,
+      maintainerPolicy: {
+        disclosureRequired: true,
+        openPrCap: 3
+      }
+    }
+  });
+  const service = new JobExecutionService(stateStore, undefined, () => job);
+  const claimed = await service.claimJob(WALLET, job.id, "http", "idemp-disclosure");
+
+  const submitted = await service.submitWork(claimed.sessionId, "http", {
+    prUrl: "https://github.com/example/project/pull/7",
+    summary: "Adds the requested parser regression test.",
+    tests: "npm test"
+  });
+
+  assert.match(submitted.submission.structured.prBody, /This contribution was prepared by an autonomous agent/u);
+  assert.match(submitted.submission.structured.prBody, /Averray platform/u);
+  assert.match(submitted.submission.structured.prBody, new RegExp(WALLET, "u"));
+  assert.match(submitted.submission.structured.prBody, /https:\/\/api\.averray\.com\/jobs\/github-issue-job-disclosure/u);
+});
+
+test("submitWork does not duplicate an existing Averray disclosure footer", async () => {
+  const stateStore = new MemoryStateStore();
+  const footer = buildAverrayDisclosureFooter({
+    agentWallet: WALLET,
+    jobSpecUrl: "https://api.averray.com/jobs/github-issue-job-disclosure-once"
+  });
+  const prBody = `Fixes #42\n\n${footer}`;
+  const job = makeJob({
+    id: "github-issue-job-disclosure-once",
+    outputSchemaRef: "schema://jobs/github-pr-evidence-output",
+    source: {
+      type: "github_issue",
+      repo: "example/project",
+      issueNumber: 42
+    }
+  });
+  const service = new JobExecutionService(stateStore, undefined, () => job);
+  const claimed = await service.claimJob(WALLET, job.id, "http", "idemp-disclosure-once");
+
+  const submitted = await service.submitWork(claimed.sessionId, "http", {
+    prUrl: "https://github.com/example/project/pull/8",
+    summary: "Adds the requested parser regression test.",
+    tests: "npm test",
+    prBody
+  });
+
+  assert.equal(submitted.submission.structured.prBody, prBody);
 });

--- a/mcp-server/src/jobs/ingest-github-issues.test.js
+++ b/mcp-server/src/jobs/ingest-github-issues.test.js
@@ -93,6 +93,31 @@ test("ingestGithubIssues skips denylisted repos", async () => {
   assert.equal(payload.skippedDetails[0].reason, "repo_denylisted");
 });
 
+test("ingestGithubIssues skips default security and standards denylist repos", async () => {
+  const payload = await ingestGithubIssues({
+    query: "is:issue is:open label:good-first-issue",
+    limit: 5,
+    minScore: 55,
+    fetchImpl: async () => ({
+      ok: true,
+      async json() {
+        return {
+          items: [{
+            ...GOOD_ISSUE,
+            html_url: "https://github.com/w3c/csswg-drafts/issues/42",
+            repository_url: "https://api.github.com/repos/w3c/csswg-drafts"
+          }]
+        };
+      }
+    })
+  });
+
+  assert.equal(payload.count, 0);
+  assert.equal(payload.jobs.length, 0);
+  assert.equal(payload.skippedDetails[0].repo, "w3c/csswg-drafts");
+  assert.equal(payload.skippedDetails[0].reason, "repo_denylisted");
+});
+
 test("ingestGithubIssues scans repository policy files when enabled", async () => {
   const payload = await ingestGithubIssues({
     query: "is:issue is:open label:good-first-issue",


### PR DESCRIPTION
## What changed
- Auto-inject the Averray disclosure footer into GitHub issue PR submissions before hashing, chain submit, persistence, and verification.
- Keep the footer injection idempotent so agents that already include the disclosure are not rewritten twice.
- Add regression coverage for default security/standards denylist ingestion and mark the agent/maintainer surface checklist complete in the working specs.

## Checks run
- npm --workspace mcp-server test

## Impact
- Backend: yes
- Frontend: no
- Indexer: no
- Contracts: no
- Public site: no

## Env / VPS secrets
- None required.

Note: the first local test run failed because this fresh worktree had not installed the already-declared @paraspell packages. After running npm install, the full backend suite passed.