### PR TITLE
Add GitHub operator digest views

### DIFF
--- a/docs/READY_TO_POST_JOBS.md
+++ b/docs/READY_TO_POST_JOBS.md
@@ -579,12 +579,34 @@ Configure it with:
 
 ```bash
 GITHUB_HELPER_REPOS=averray-agent/agent,depre-dev/averray-reference-agent
+# Single-repo installs may use this friendlier alias instead:
+GITHUB_DEFAULT_REPO=averray-agent/agent
 GITHUB_HELPER_LIMIT=5
 ```
 
 It reuses `GITHUB_TOKEN` when present for private repositories or higher rate
 limits. Keep this token read-only unless a separate write-capable workflow is
 explicitly introduced.
+
+Assistant/operator surfaces can request focused read-only views with the
+`view` query parameter:
+
+- `GET /admin/github/status?view=status` for the overall summary.
+- `GET /admin/github/status?view=prs` for open pull requests.
+- `GET /admin/github/status?view=ci` for failing or active workflow runs.
+- `GET /admin/github/status?view=issues` for open issues.
+- `GET /admin/github/status?view=digest` for the combined "needs attention"
+  queue.
+
+Suggested natural-language command routing:
+
+- `github status` -> `view=status`
+- `github open prs` -> `view=prs`
+- `github ci failures` -> `view=ci`
+- `github issue digest` -> `view=issues`
+
+All views are read-only. They never merge, rerun CI, comment, close issues, or
+push commits.
 
 ---
 

--- a/mcp-server/src/core/github-operator-helper.js
+++ b/mcp-server/src/core/github-operator-helper.js
@@ -1,8 +1,15 @@
 const DEFAULT_GITHUB_API_BASE_URL = "https://api.github.com";
 const DEFAULT_LIMIT = 5;
 const MAX_LIMIT = 20;
+const DEFAULT_VIEW = "status";
+const VALID_VIEWS = new Set(["status", "prs", "ci", "issues", "digest"]);
 
-export function parseGithubHelperRepos(value = process.env.GITHUB_HELPER_REPOS ?? process.env.GITHUB_REPOSITORY ?? "") {
+export function parseGithubHelperRepos(
+  value = process.env.GITHUB_HELPER_REPOS
+    ?? process.env.GITHUB_DEFAULT_REPO
+    ?? process.env.GITHUB_REPOSITORY
+    ?? ""
+) {
   return String(value)
     .split(",")
     .map((entry) => entry.trim())
@@ -19,16 +26,23 @@ export function normalizeGithubHelperLimit(value = process.env.GITHUB_HELPER_LIM
   return Math.min(Math.trunc(parsed), MAX_LIMIT);
 }
 
+export function normalizeGithubHelperView(value = DEFAULT_VIEW) {
+  const normalized = String(value ?? "").trim().toLowerCase();
+  return VALID_VIEWS.has(normalized) ? normalized : DEFAULT_VIEW;
+}
+
 export async function collectGithubOperatorStatus({
   repos = undefined,
   githubToken = process.env.GITHUB_TOKEN,
   apiBaseUrl = process.env.GITHUB_API_BASE_URL ?? DEFAULT_GITHUB_API_BASE_URL,
   limit = undefined,
+  view = DEFAULT_VIEW,
   fetchImpl = fetch,
   now = new Date()
 } = {}) {
   const normalizedRepos = parseGithubHelperRepos(Array.isArray(repos) ? repos.join(",") : repos);
   const normalizedLimit = normalizeGithubHelperLimit(limit);
+  const normalizedView = normalizeGithubHelperView(view);
   const warnings = [];
 
   if (normalizedRepos.length === 0) {
@@ -39,6 +53,7 @@ export async function collectGithubOperatorStatus({
       configured: false,
       authConfigured: Boolean(githubToken),
       health: "ok",
+      view: normalizedView,
       repoCount: 0,
       totals: emptyTotals(),
       repositories: [],
@@ -47,6 +62,11 @@ export async function collectGithubOperatorStatus({
         pullRequestsNeedingAttention: [],
         issuesNeedingTriage: [],
         ciFailures: []
+      },
+      views: emptyViews(),
+      selectedView: {
+        name: normalizedView,
+        items: []
       },
       warnings: [{
         severity: "low",
@@ -85,6 +105,21 @@ export async function collectGithubOperatorStatus({
         updatedAt: pr.updatedAt
       }))
   ).slice(0, normalizedLimit);
+  const openPullRequests = repositories.flatMap((repo) =>
+    repo.openPullRequests.map((pr) => ({
+      repo: repo.repo,
+      number: pr.number,
+      title: pr.title,
+      url: pr.url,
+      author: pr.author,
+      branch: pr.branch,
+      base: pr.base,
+      isDraft: pr.isDraft,
+      reviewState: pr.reviewState,
+      ageDays: pr.ageDays,
+      updatedAt: pr.updatedAt
+    }))
+  ).slice(0, normalizedLimit);
   const issuesNeedingTriage = repositories.flatMap((repo) =>
     repo.openIssues
       .filter((issue) => issue.commentCount === 0 || issue.ageDays >= 14)
@@ -96,6 +131,19 @@ export async function collectGithubOperatorStatus({
         reason: issue.commentCount === 0 ? "no_comments" : "stale",
         updatedAt: issue.updatedAt
       }))
+  ).slice(0, normalizedLimit);
+  const issueDigest = repositories.flatMap((repo) =>
+    repo.openIssues.map((issue) => ({
+      repo: repo.repo,
+      number: issue.number,
+      title: issue.title,
+      url: issue.url,
+      author: issue.author,
+      labels: issue.labels,
+      commentCount: issue.commentCount,
+      ageDays: issue.ageDays,
+      updatedAt: issue.updatedAt
+    }))
   ).slice(0, normalizedLimit);
   const ciFailures = repositories.flatMap((repo) =>
     repo.workflowRuns.failed.map((run) => ({
@@ -109,9 +157,38 @@ export async function collectGithubOperatorStatus({
       updatedAt: run.updatedAt
     }))
   ).slice(0, normalizedLimit);
+  const activeWorkflowRuns = repositories.flatMap((repo) =>
+    repo.workflowRuns.active.map((run) => ({
+      repo: repo.repo,
+      workflowName: run.workflowName,
+      runNumber: run.runNumber,
+      branch: run.branch,
+      status: run.status,
+      url: run.url,
+      updatedAt: run.updatedAt
+    }))
+  ).slice(0, normalizedLimit);
   const health = warnings.some((warning) => warning.severity === "high")
     ? "degraded"
     : (totals.failingWorkflowRuns > 0 || warnings.length > 0 ? "attention" : "ok");
+  const recommendations = buildRecommendations({ totals, warnings, pullRequestsNeedingAttention, issuesNeedingTriage });
+  const summary = buildSummary({ totals, repoCount: normalizedRepos.length, health });
+  const views = {
+    status: [{
+      health,
+      summary,
+      totals,
+      recommendations
+    }],
+    prs: openPullRequests,
+    ci: [...ciFailures, ...activeWorkflowRuns],
+    issues: issueDigest,
+    digest: [
+      ...pullRequestsNeedingAttention.map((item) => ({ ...item, kind: "pull_request" })),
+      ...issuesNeedingTriage.map((item) => ({ ...item, kind: "issue" })),
+      ...ciFailures.map((item) => ({ ...item, kind: "workflow_failure" }))
+    ].slice(0, normalizedLimit)
+  };
 
   return {
     schemaVersion: 1,
@@ -120,17 +197,23 @@ export async function collectGithubOperatorStatus({
     configured: true,
     authConfigured: Boolean(githubToken),
     health,
+    view: normalizedView,
     repoCount: normalizedRepos.length,
     totals,
     repositories,
     digest: {
-      summary: buildSummary({ totals, repoCount: normalizedRepos.length, health }),
+      summary,
       pullRequestsNeedingAttention,
       issuesNeedingTriage,
       ciFailures
     },
+    views,
+    selectedView: {
+      name: normalizedView,
+      items: views[normalizedView]
+    },
     warnings,
-    recommendations: buildRecommendations({ totals, warnings, pullRequestsNeedingAttention, issuesNeedingTriage })
+    recommendations
   };
 }
 
@@ -321,6 +404,16 @@ function emptyTotals() {
     openIssues: 0,
     failingWorkflowRuns: 0,
     activeWorkflowRuns: 0
+  };
+}
+
+function emptyViews() {
+  return {
+    status: [],
+    prs: [],
+    ci: [],
+    issues: [],
+    digest: []
   };
 }
 

--- a/mcp-server/src/core/github-operator-helper.test.js
+++ b/mcp-server/src/core/github-operator-helper.test.js
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   collectGithubOperatorStatus,
   normalizeGithubHelperLimit,
+  normalizeGithubHelperView,
   parseGithubHelperRepos
 } from "./github-operator-helper.js";
 
@@ -14,15 +15,39 @@ test("parseGithubHelperRepos accepts repo names and GitHub URLs", () => {
   );
 });
 
+test("parseGithubHelperRepos falls back to GITHUB_DEFAULT_REPO", () => {
+  const previousRepos = process.env.GITHUB_HELPER_REPOS;
+  const previousDefaultRepo = process.env.GITHUB_DEFAULT_REPO;
+  const previousRepository = process.env.GITHUB_REPOSITORY;
+  delete process.env.GITHUB_HELPER_REPOS;
+  process.env.GITHUB_DEFAULT_REPO = "averray-agent/agent";
+  process.env.GITHUB_REPOSITORY = "other/repo";
+  try {
+    assert.deepEqual(parseGithubHelperRepos(), ["averray-agent/agent"]);
+  } finally {
+    restoreEnv("GITHUB_HELPER_REPOS", previousRepos);
+    restoreEnv("GITHUB_DEFAULT_REPO", previousDefaultRepo);
+    restoreEnv("GITHUB_REPOSITORY", previousRepository);
+  }
+});
+
 test("normalizeGithubHelperLimit clamps unsafe values", () => {
   assert.equal(normalizeGithubHelperLimit("0"), 5);
   assert.equal(normalizeGithubHelperLimit("3"), 3);
   assert.equal(normalizeGithubHelperLimit("999"), 20);
 });
 
+test("normalizeGithubHelperView accepts the operator command views", () => {
+  assert.equal(normalizeGithubHelperView("prs"), "prs");
+  assert.equal(normalizeGithubHelperView("ci"), "ci");
+  assert.equal(normalizeGithubHelperView("issues"), "issues");
+  assert.equal(normalizeGithubHelperView("wat"), "status");
+});
+
 test("collectGithubOperatorStatus reports unconfigured helper without mutating", async () => {
   const status = await collectGithubOperatorStatus({
     repos: "",
+    view: "ci",
     githubToken: undefined,
     now: new Date("2026-05-08T10:00:00.000Z"),
     fetchImpl: async () => {
@@ -33,6 +58,9 @@ test("collectGithubOperatorStatus reports unconfigured helper without mutating",
   assert.equal(status.configured, false);
   assert.equal(status.mutates, false);
   assert.equal(status.health, "ok");
+  assert.equal(status.view, "ci");
+  assert.equal(status.selectedView.name, "ci");
+  assert.deepEqual(status.selectedView.items, []);
   assert.equal(status.repoCount, 0);
   assert.equal(status.warnings[0].code, "github_helper_not_configured");
 });
@@ -45,7 +73,7 @@ test("collectGithubOperatorStatus summarizes PRs, issues, and failing workflows"
       archived: false,
       html_url: "https://github.com/acme/widgets"
     },
-    "https://api.github.com/repos/acme/widgets/pulls?state=open&sort=updated&direction=desc&per_page=2": [
+    "https://api.github.com/repos/acme/widgets/pulls?state=open&sort=updated&direction=desc&per_page=3": [
       {
         number: 7,
         title: "Fix flaky widget test",
@@ -58,7 +86,7 @@ test("collectGithubOperatorStatus summarizes PRs, issues, and failing workflows"
         updated_at: "2026-05-07T00:00:00.000Z"
       }
     ],
-    "https://api.github.com/repos/acme/widgets/issues?state=open&sort=updated&direction=desc&per_page=4": [
+    "https://api.github.com/repos/acme/widgets/issues?state=open&sort=updated&direction=desc&per_page=6": [
       {
         number: 9,
         title: "Document widget retries",
@@ -76,7 +104,7 @@ test("collectGithubOperatorStatus summarizes PRs, issues, and failing workflows"
         html_url: "https://github.com/acme/widgets/pull/7"
       }
     ],
-    "https://api.github.com/repos/acme/widgets/actions/runs?per_page=2": {
+    "https://api.github.com/repos/acme/widgets/actions/runs?per_page=3": {
       workflow_runs: [
         {
           name: "CI",
@@ -107,7 +135,8 @@ test("collectGithubOperatorStatus summarizes PRs, issues, and failing workflows"
   const status = await collectGithubOperatorStatus({
     repos: "acme/widgets",
     githubToken: "github-token",
-    limit: 2,
+    limit: 3,
+    view: "digest",
     now: new Date("2026-05-08T10:00:00.000Z"),
     fetchImpl
   });
@@ -127,6 +156,14 @@ test("collectGithubOperatorStatus summarizes PRs, issues, and failing workflows"
   assert.equal(status.digest.pullRequestsNeedingAttention[0].reason, "draft");
   assert.equal(status.digest.issuesNeedingTriage[0].reason, "no_comments");
   assert.match(status.digest.ciFailures[0].explanation, /failing jobs/u);
+  assert.equal(status.view, "digest");
+  assert.equal(status.views.prs[0].number, 7);
+  assert.equal(status.views.issues[0].number, 9);
+  assert.equal(status.views.ci.length, 2);
+  assert.deepEqual(
+    status.selectedView.items.map((item) => item.kind),
+    ["pull_request", "issue", "workflow_failure"]
+  );
 });
 
 test("collectGithubOperatorStatus keeps partial results when a repo fetch fails", async () => {
@@ -161,4 +198,12 @@ function fakeResponse(payload, { ok = true, status = 200 } = {}) {
       return payload;
     }
   };
+}
+
+function restoreEnv(name, value) {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
 }

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -807,6 +807,7 @@ test("getGithubOperatorStatus exposes the read-only GitHub helper", async () => 
   const service = makePlatformService();
   const status = await service.getGithubOperatorStatus({
     repos: "",
+    view: "prs",
     fetchImpl: async () => {
       throw new Error("fetch should not be called when no repos are configured");
     }
@@ -814,5 +815,6 @@ test("getGithubOperatorStatus exposes the read-only GitHub helper", async () => 
 
   assert.equal(status.mutates, false);
   assert.equal(status.configured, false);
+  assert.equal(status.selectedView.name, "prs");
   assert.equal(status.digest.pullRequestsNeedingAttention.length, 0);
 });

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -3046,7 +3046,8 @@ const server = createServer(async (request, response) => {
       await authMiddleware(request, url, { requireRole: "admin" });
       return respond(response, 200, await service.getGithubOperatorStatus({
         repos: url.searchParams.has("repos") ? url.searchParams.get("repos") : undefined,
-        limit: parseLimit(url, 5, 20)
+        limit: parseLimit(url, 5, 20),
+        view: url.searchParams.get("view") ?? undefined
       }));
     }
 


### PR DESCRIPTION
## Summary
- add focused read-only GitHub helper views for status, PRs, CI, issues, and digest
- accept GITHUB_DEFAULT_REPO as a single-repo alias for GitHub helper configuration
- expose the view selector through /admin/github/status and document natural-language routing

## Checks
- node --test src/core/github-operator-helper.test.js src/core/platform-service.test.js
- git diff --check

## Impact
- Backend: yes, read-only admin GitHub status endpoint
- Frontend: no
- Indexer: no
- Caddy: no
- Contracts: no
- Public site: no

## Env / VPS
- Optional: set GITHUB_DEFAULT_REPO=owner/repo or GITHUB_HELPER_REPOS=owner/repo[,owner/repo]
- Optional: set read-only GITHUB_TOKEN for private repos or higher GitHub API rate limits