### PR TITLE
Add multisig owner record tooling

### DIFF
--- a/docs/MULTISIG_SETUP.md
+++ b/docs/MULTISIG_SETUP.md
@@ -76,16 +76,25 @@ to "create" the multisig — it exists as soon as you commit to the signer set.
 4. Apps shows the derived address. **Copy this address** — it's your
    multisig's Substrate-native SS58 form.
 
-### Option B: CLI
+### Option B: repo helper
 
 ```bash
-npx @polkadot/api-cli --ws <HUB_WSS> \
-  derive.multisig \
+node scripts/ops/prepare-multisig-owner-record.mjs \
+  --profile testnet \
+  --threshold 2 \
   --signatories <HOT_SS58>,<WARM_SS58>,<COLD_SS58> \
-  --threshold 2
+  --out deployments/testnet-multisig-owner.json
 ```
 
-(Order matters — sort the addresses lexicographically before calling.)
+The helper sorts the signers, derives the deterministic pallet-multisig
+SS58/accountId, computes the H160 owner candidate used as `OWNER`, and writes
+a public operator record. It does **not** prove the account is safe to use as a
+contract owner yet — the initial record is `status: "draft"` until the
+`map_account` and testnet rehearsal evidence below are filled in.
+
+Do not put seeds or private labels in the record. Signer addresses, transaction
+hashes, workflow run ids, and the mapped owner address are public launch
+metadata.
 
 ---
 
@@ -119,6 +128,22 @@ testnet rehearsal succeeds.
 > **Important**: if the owner address is wrong, the contract is not
 > "partially degraded" — it is effectively frozen out of admin control.
 > Treat owner-address verification as a launch gate, not a clerical step.
+
+After the multisig account has called `pallet_revive.map_account()` on Hub
+TestNet, update the record with the mapping transaction:
+
+```bash
+node scripts/ops/prepare-multisig-owner-record.mjs \
+  --profile testnet \
+  --threshold 2 \
+  --signatories <HOT_SS58>,<WARM_SS58>,<COLD_SS58> \
+  --map-account-tx 0x<tx-hash> \
+  --out deployments/testnet-multisig-owner.json
+```
+
+The record should stay `draft` at this point. It becomes `verified` only after
+ownership transfer, `verify_deployment.sh testnet`, and one owner-only admin
+rehearsal are all recorded.
 
 ---
 
@@ -199,6 +224,25 @@ On Polkadot.js Apps:
 
 If this flow completes cleanly on testnet, your signer set + EVM mapping
 are correct. Revert the pauser back to the original hot key afterwards.
+
+Now finalize the owner record:
+
+```bash
+node scripts/ops/prepare-multisig-owner-record.mjs \
+  --profile testnet \
+  --threshold 2 \
+  --signatories <HOT_SS58>,<WARM_SS58>,<COLD_SS58> \
+  --map-account-tx 0x<map-account-tx> \
+  --ownership-transfer-tx 0x<deploy-or-transfer-tx> \
+  --admin-rehearsal-tx 0x<set-pauser-rehearsal-tx> \
+  --verify-deployment-run <workflow-run-or-terminal-log-id> \
+  --final \
+  --out deployments/testnet-multisig-owner.json
+```
+
+`./scripts/verify_deployment.sh testnet` automatically reads
+`deployments/testnet-multisig-owner.json` when present and fails if the manifest
+owner differs from the record owner or the record is still draft.
 
 ---
 

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -17,6 +17,7 @@ If this checklist is not green, the answer is "not ready yet".
 ## 1. Control plane
 
 - [ ] `TreasuryPolicy.owner` is the intended multisig address.
+- [ ] `deployments/testnet-multisig-owner.json` is `status: "verified"` and matches the deployment manifest owner.
 - [ ] `TreasuryPolicy.pauser` is a hot key that only holds pause power.
 - [ ] `./scripts/verify_deployment.sh testnet` passes cleanly.
 - [ ] Pause and unpause were rehearsed from the pauser key.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "@acala-network/chopsticks": "^1.3.1",
         "@paraspell/sdk": "^13.4.0",
         "@paraspell/sdk-core": "^13.4.0",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
         "polkadot-api": "^2.1.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "@acala-network/chopsticks": "^1.3.1",
     "@paraspell/sdk": "^13.4.0",
     "@paraspell/sdk-core": "^13.4.0",
+    "@polkadot/util": "^14.0.3",
+    "@polkadot/util-crypto": "^14.0.3",
     "polkadot-api": "^2.1.1"
   }
 }

--- a/scripts/ops/prepare-multisig-owner-record.mjs
+++ b/scripts/ops/prepare-multisig-owner-record.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+import { writeFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  createKeyMulti,
+  cryptoWaitReady,
+  decodeAddress,
+  encodeAddress,
+  keccakAsU8a,
+  sortAddresses
+} from "@polkadot/util-crypto";
+import { u8aToHex } from "@polkadot/util";
+
+const DEFAULT_SS58_PREFIX = 0;
+
+export async function buildMultisigOwnerRecord({
+  profile = "testnet",
+  threshold = 2,
+  signatories,
+  ss58Prefix = DEFAULT_SS58_PREFIX,
+  mapAccountTxHash = null,
+  ownershipTransferTxHash = null,
+  adminRehearsalTxHash = null,
+  verifyDeploymentRun = null,
+  final = false
+} = {}) {
+  await cryptoWaitReady();
+  const normalizedSignatories = normalizeSignatories(signatories);
+  const numericThreshold = normalizePositiveInteger(threshold, "threshold");
+  const numericSs58Prefix = normalizeNonNegativeInteger(ss58Prefix, "ss58Prefix");
+  if (numericThreshold > normalizedSignatories.length) {
+    throw new Error(`threshold (${numericThreshold}) cannot exceed signatory count (${normalizedSignatories.length})`);
+  }
+
+  const sortedSignatories = sortAddresses(normalizedSignatories, numericSs58Prefix);
+  const decodedSignatories = sortedSignatories.map((address) => decodeAddress(address));
+  const accountIds = decodedSignatories.map((accountId) => u8aToHex(accountId));
+  if (new Set(accountIds).size !== accountIds.length) {
+    throw new Error("signatories must be unique accounts");
+  }
+
+  const multisigAccountId = createKeyMulti(decodedSignatories, numericThreshold);
+  const ownerEnvValue = u8aToHex(keccakAsU8a(multisigAccountId).slice(-20));
+  const evidence = {
+    mapAccountTxHash: normalizeNullableString(mapAccountTxHash),
+    ownershipTransferTxHash: normalizeNullableString(ownershipTransferTxHash),
+    adminRehearsalTxHash: normalizeNullableString(adminRehearsalTxHash),
+    verifyDeploymentRun: normalizeNullableString(verifyDeploymentRun)
+  };
+  const status = evidence.mapAccountTxHash
+    && evidence.ownershipTransferTxHash
+    && evidence.adminRehearsalTxHash
+    && evidence.verifyDeploymentRun
+    ? "verified"
+    : "draft";
+  if (final && status !== "verified") {
+    throw new Error(
+      "--final requires --map-account-tx, --ownership-transfer-tx, --admin-rehearsal-tx, and --verify-deployment-run"
+    );
+  }
+
+  return {
+    schemaVersion: 1,
+    kind: "averray.multisigOwnerRecord",
+    status,
+    profile: String(profile),
+    threshold: numericThreshold,
+    ss58Prefix: numericSs58Prefix,
+    signatories: sortedSignatories.map((address, index) => ({
+      index: index + 1,
+      address,
+      accountId32: accountIds[index]
+    })),
+    multisig: {
+      ss58Address: encodeAddress(multisigAccountId, numericSs58Prefix),
+      accountId32: u8aToHex(multisigAccountId),
+      ownerEnvValue,
+      ownerEnvVar: "OWNER"
+    },
+    mapAccount: {
+      required: true,
+      extrinsic: "pallet_revive.map_account()",
+      status: evidence.mapAccountTxHash ? "recorded" : "pending",
+      txHash: evidence.mapAccountTxHash
+    },
+    testnetRehearsal: {
+      ownershipTransferTxHash: evidence.ownershipTransferTxHash,
+      adminRehearsalTxHash: evidence.adminRehearsalTxHash,
+      verifyDeploymentRun: evidence.verifyDeploymentRun
+    },
+    launchGate: {
+      readyForOwnerUse: status === "verified",
+      reason: status === "verified"
+        ? "map_account, ownership transfer, verify_deployment, and multisig admin rehearsal are recorded"
+        : "do not use multisig.ownerEnvValue as OWNER until map_account and testnet ownership/admin rehearsals are recorded"
+    },
+    polkadotDocsCheck: {
+      source: "https://docs.polkadot.com/smart-contracts/for-eth-devs/accounts/#account-mapping-for-native-polkadot-accounts",
+      note: "Native AccountId32 accounts need pallet_revive.map_account() before Ethereum-compatible smart-contract tooling can safely control them."
+    }
+  };
+}
+
+export function normalizeSignatories(value) {
+  const signatories = Array.isArray(value)
+    ? value
+    : String(value ?? "").split(",");
+  const normalized = signatories.map((entry) => String(entry).trim()).filter(Boolean);
+  if (normalized.length < 2) {
+    throw new Error("at least two signatories are required");
+  }
+  for (const address of normalized) {
+    decodeAddress(address);
+  }
+  return normalized;
+}
+
+function normalizePositiveInteger(value, label) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function normalizeNonNegativeInteger(value, label) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${label} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
+function normalizeNullableString(value) {
+  const normalized = String(value ?? "").trim();
+  return normalized || null;
+}
+
+function parseArgs(argv) {
+  const args = {
+    profile: "testnet",
+    threshold: 2,
+    ss58Prefix: DEFAULT_SS58_PREFIX,
+    final: false
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = () => {
+      index += 1;
+      if (index >= argv.length) throw new Error(`${arg} requires a value`);
+      return argv[index];
+    };
+    switch (arg) {
+      case "--profile":
+        args.profile = next();
+        break;
+      case "--threshold":
+        args.threshold = next();
+        break;
+      case "--ss58-prefix":
+        args.ss58Prefix = next();
+        break;
+      case "--signatories":
+        args.signatories = next();
+        break;
+      case "--map-account-tx":
+        args.mapAccountTxHash = next();
+        break;
+      case "--ownership-transfer-tx":
+        args.ownershipTransferTxHash = next();
+        break;
+      case "--admin-rehearsal-tx":
+        args.adminRehearsalTxHash = next();
+        break;
+      case "--verify-deployment-run":
+        args.verifyDeploymentRun = next();
+        break;
+      case "--out":
+        args.out = next();
+        break;
+      case "--final":
+        args.final = true;
+        break;
+      case "--help":
+      case "-h":
+        args.help = true;
+        break;
+      default:
+        throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function usage() {
+  return `Usage:
+  node scripts/ops/${basename(fileURLToPath(import.meta.url))} \\
+    --signatories <HOT_SS58>,<WARM_SS58>,<COLD_SS58> \\
+    [--threshold 2] [--ss58-prefix 0] [--profile testnet] \\
+    [--map-account-tx 0x...] [--ownership-transfer-tx 0x...] \\
+    [--admin-rehearsal-tx 0x...] [--verify-deployment-run <url-or-id>] \\
+    [--final] [--out deployments/testnet-multisig-owner.json]
+
+The output is a public operator record. It does not contain private keys or seeds.
+Use --final only after map_account, ownership transfer, verify_deployment, and
+one multisig admin rehearsal have all completed on Polkadot Hub TestNet.`;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(usage());
+    return;
+  }
+  const record = await buildMultisigOwnerRecord(args);
+  const json = `${JSON.stringify(record, null, 2)}\n`;
+  if (args.out) {
+    await writeFile(args.out, json, { mode: 0o644 });
+  }
+  process.stdout.write(json);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error.message);
+    console.error("");
+    console.error(usage());
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ops/prepare-multisig-owner-record.test.mjs
+++ b/scripts/ops/prepare-multisig-owner-record.test.mjs
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildMultisigOwnerRecord,
+  normalizeSignatories
+} from "./prepare-multisig-owner-record.mjs";
+
+const SIGNATORIES = [
+  "0x3333333333333333333333333333333333333333333333333333333333333333",
+  "0x1111111111111111111111111111111111111111111111111111111111111111",
+  "0x2222222222222222222222222222222222222222222222222222222222222222"
+];
+
+test("buildMultisigOwnerRecord derives a stable multisig owner record", async () => {
+  const record = await buildMultisigOwnerRecord({
+    profile: "testnet",
+    threshold: 2,
+    signatories: SIGNATORIES
+  });
+
+  assert.equal(record.status, "draft");
+  assert.equal(record.threshold, 2);
+  assert.deepEqual(record.signatories.map((entry) => entry.accountId32), [
+    "0x1111111111111111111111111111111111111111111111111111111111111111",
+    "0x2222222222222222222222222222222222222222222222222222222222222222",
+    "0x3333333333333333333333333333333333333333333333333333333333333333"
+  ]);
+  assert.equal(record.multisig.ss58Address, "1pEnJbesJVDcSG7TixQvkZoDYkCXsp4afj2rNgLREsc94eD");
+  assert.equal(record.multisig.accountId32, "0x2406ece07636b132f3091e772b0408c7aa0d1543f5df80881a69fd518a4b0034");
+  assert.equal(record.multisig.ownerEnvValue, "0x6fa3fa64bba94777ea5b938cc59c0316d3335730");
+  assert.equal(record.mapAccount.required, true);
+  assert.equal(record.launchGate.readyForOwnerUse, false);
+});
+
+test("buildMultisigOwnerRecord fails closed for final records without live evidence", async () => {
+  await assert.rejects(
+    () => buildMultisigOwnerRecord({
+      threshold: 2,
+      signatories: SIGNATORIES,
+      final: true,
+      mapAccountTxHash: "0xmap"
+    }),
+    /--final requires/u
+  );
+});
+
+test("buildMultisigOwnerRecord marks complete evidence as verified", async () => {
+  const record = await buildMultisigOwnerRecord({
+    threshold: 2,
+    signatories: SIGNATORIES,
+    mapAccountTxHash: "0xmap",
+    ownershipTransferTxHash: "0xowner",
+    adminRehearsalTxHash: "0xadmin",
+    verifyDeploymentRun: "25500000000",
+    final: true
+  });
+
+  assert.equal(record.status, "verified");
+  assert.equal(record.mapAccount.status, "recorded");
+  assert.equal(record.launchGate.readyForOwnerUse, true);
+});
+
+test("normalizeSignatories rejects duplicate accounts", async () => {
+  await assert.rejects(
+    () => buildMultisigOwnerRecord({
+      threshold: 2,
+      signatories: [
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+        "0x1111111111111111111111111111111111111111111111111111111111111111"
+      ]
+    }),
+    /unique/u
+  );
+
+  assert.deepEqual(
+    normalizeSignatories(SIGNATORIES.join(",")),
+    SIGNATORIES
+  );
+});

--- a/scripts/verify_deployment.sh
+++ b/scripts/verify_deployment.sh
@@ -5,6 +5,7 @@
 # that:
 #   - each contract address responds to a known function selector
 #   - TreasuryPolicy.owner() matches the expected owner (multisig on prod)
+#   - optional deployments/<profile>-multisig-owner.json matches owner and is verified
 #   - TreasuryPolicy.pauser() matches the expected pauser hot-key
 #   - TreasuryPolicy.verifiers(VERIFIER) and TreasuryPolicy.arbitrators(ARBITRATOR) are true
 #   - TreasuryPolicy.serviceOperators({escrow,account}) are true
@@ -26,6 +27,7 @@ PROFILE="${1:-${PROFILE:-dev}}"
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "${script_dir}/.." && pwd)"
 manifest_path="${repo_root}/deployments/${PROFILE}.json"
+owner_record_path="${repo_root}/deployments/${PROFILE}-multisig-owner.json"
 
 require_command() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -156,6 +158,17 @@ if [[ "$ALLOW_PAUSED" == "1" ]]; then
   printf "  [skip] paused check (--allow-paused)\n"
 else
   check_bool "not paused" "false" "$paused_raw"
+fi
+
+if [[ -f "$owner_record_path" ]]; then
+  echo ""
+  echo "Multisig owner record:"
+  record_owner="$(jq -r '.multisig.ownerEnvValue // empty' "$owner_record_path")"
+  record_status="$(jq -r '.status // empty' "$owner_record_path")"
+  record_ready="$(jq -r '.launchGate.readyForOwnerUse // false' "$owner_record_path")"
+  check "record owner" "$EXPECTED_OWNER" "$record_owner"
+  check "record status" "verified" "$record_status"
+  check_bool "record readyForOwnerUse" "true" "$record_ready"
 fi
 
 echo ""


### PR DESCRIPTION
## What changed
- Added `scripts/ops/prepare-multisig-owner-record.mjs` to derive the pallet-multisig SS58/accountId and H160 owner candidate from public signer addresses.
- The generated owner record stays `draft` until `map_account`, ownership transfer, deployment verification, and one multisig admin rehearsal are all recorded.
- `verify_deployment.sh` now checks `deployments/<profile>-multisig-owner.json` when present, failing if it does not match the manifest owner or remains draft.
- Updated the multisig runbook and production checklist to use the new record flow.

## Polkadot docs check
- Confirmed with Polkadot docs MCP that native AccountId32 accounts require `pallet_revive.map_account()` before Ethereum-compatible smart-contract tooling can safely control them.

## Checks run
- `node --test scripts/ops/prepare-multisig-owner-record.test.mjs`
- `npm run test:ops`
- `bash -n scripts/verify_deployment.sh`

## Impact
- Backend: no
- Frontend: no
- Indexer: no
- Contracts: no
- Ops/docs: yes

## Env / VPS secrets
- None. This does not execute live ownership transfer or require private keys.