### PR TITLE
Record testnet multisig map_account evidence

### DIFF
--- a/deployments/testnet-multisig-owner.json
+++ b/deployments/testnet-multisig-owner.json
@@ -1,0 +1,50 @@
+{
+  "schemaVersion": 1,
+  "kind": "averray.multisigOwnerRecord",
+  "status": "draft",
+  "profile": "testnet",
+  "threshold": 2,
+  "ss58Prefix": 0,
+  "signatories": [
+    {
+      "index": 1,
+      "address": "13pav6xpfdapyCAqfRhWZXxUnqDhjrF92dJr3FBwVfBKUKSM",
+      "accountId32": "0x7cc32bbee82258e9302721a93de10cc95bd1def2af0762223ee22dbb18f1da67"
+    },
+    {
+      "index": 2,
+      "address": "148tqwhGxeCva7ZX8RwvaLjCS7HvDJJaSbxfTUwE9Zyc5Xtm",
+      "accountId32": "0x8ab9f0ac44ca825a1111b5b0233fccd2f16560293aae7bb7f438802582433b63"
+    },
+    {
+      "index": 3,
+      "address": "14ruuTeh5cXMTr9SLNuLt1NiroQZgt5ZQnwYrhg7K5LHiXQb",
+      "accountId32": "0xaac5d1481fc3a294d1a1ce333e1bcfde364d625adf0a98ca855940ca7a3d156c"
+    }
+  ],
+  "multisig": {
+    "ss58Address": "12nHTKYfV64pnxsVRB6Cjn6kQPPH64Ehnr8zgqZxvfa8hJvQ",
+    "accountId32": "0x4ec5aa4011eebe946766fba4b0581a4435d145bc7e26377d2df25e508b25c5eb",
+    "ownerEnvValue": "0x1f8c4da4aaac79916350f1fabf1221309591b6f9",
+    "ownerEnvVar": "OWNER"
+  },
+  "mapAccount": {
+    "required": true,
+    "extrinsic": "pallet_revive.map_account()",
+    "status": "recorded",
+    "txHash": "0x9b34733972de857f5973f486c8b62ae1be5f41317f1dc9825605c5452eeb3a38"
+  },
+  "testnetRehearsal": {
+    "ownershipTransferTxHash": null,
+    "adminRehearsalTxHash": null,
+    "verifyDeploymentRun": null
+  },
+  "launchGate": {
+    "readyForOwnerUse": false,
+    "reason": "do not use multisig.ownerEnvValue as OWNER until map_account and testnet ownership/admin rehearsals are recorded"
+  },
+  "polkadotDocsCheck": {
+    "source": "https://docs.polkadot.com/smart-contracts/for-eth-devs/accounts/#account-mapping-for-native-polkadot-accounts",
+    "note": "Native AccountId32 accounts need pallet_revive.map_account() before Ethereum-compatible smart-contract tooling can safely control them."
+  }
+}


### PR DESCRIPTION
## What changed
- Added deployments/testnet-multisig-owner.json for the testnet 2-of-3 Averray multisig.
- Recorded the successful pallet_revive.map_account() transaction hash: 0x6c77862210a8653bcb8e38be43448bc145b08ceaed6a8a6183c8c61310df43f0.
- Kept the record status as draft and launchGate.readyForOwnerUse as false until ownership transfer, verify_deployment, and admin rehearsal evidence are recorded.

## Checks
- npm run test:ops

## Impact
- Affects ops/deployment evidence only.
- No backend, frontend, indexer, Caddy, contracts, or public site runtime changes.

## Required env / VPS changes
- None from this PR.
- OWNER should not be switched to the multisig ownerEnvValue until the record is verified.