### PR TITLE
Add bootstrap instrumentation smoke gate

### DIFF
--- a/VPS_RUNBOOK.md
+++ b/VPS_RUNBOOK.md
@@ -547,6 +547,36 @@ Required authentication env vars (backend, strict mode):
 - `AUTH_DOMAIN=api.averray.com`
 - `AUTH_CHAIN_ID=420420417`
 
+Required bootstrap instrumentation env vars before marking the week-1
+instrumentation checklist complete:
+
+- `UPSTREAM_STATUS_POLLER_ENABLED=true`
+- `UPSTREAM_STATUS_POLLER_INTERVAL_MS=86400000`
+- `UPSTREAM_STATUS_POLLER_BATCH_SIZE=50`
+- `BOOTSTRAP_SELF_REPORT_ENABLED=true`
+- `BOOTSTRAP_SELF_REPORT_INTERVAL_MS=604800000`
+- `BOOTSTRAP_SELF_REPORT_SEND_ON_START=false`
+- `BOOTSTRAP_SELF_REPORT_FROM="Averray <ops@averray.com>"`
+- `BOOTSTRAP_SELF_REPORT_TO=<comma-separated report recipients>`
+- `BOOTSTRAP_SELF_REPORT_SUBJECT_PREFIX=Averray bootstrap self-report`
+- `RESEND_API_KEY=<resend-api-key>`
+- `RESEND_API_BASE_URL=https://api.resend.com`
+
+For the first production verification only, set
+`BOOTSTRAP_SELF_REPORT_SEND_ON_START=true`, redeploy the backend, then run:
+
+```bash
+cd /srv/agent-stack/app
+ADMIN_JWT='<admin-jwt>' \
+CHECK_BOOTSTRAP_INSTRUMENTATION=1 \
+CHECK_BOOTSTRAP_SELF_REPORT_SENT=1 \
+./scripts/ops/check-hosted-stack.sh
+```
+
+After a successful first-delivery check, set
+`BOOTSTRAP_SELF_REPORT_SEND_ON_START=false` and redeploy so later sends follow
+the weekly cadence.
+
 ### JWT secret rotation
 
 Zero-downtime rotation uses the multi-secret list — the **first** entry signs

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -76,6 +76,18 @@ APP_ALLOW_PROTECTED_SHELL=1 ./scripts/ops/check-hosted-stack.sh
 # Optional: include the async XCM operator lane in the smoke check
 ADMIN_JWT='<admin-jwt>' ./scripts/ops/check-hosted-stack.sh
 
+# Optional: include bootstrap instrumentation once backend.env has the poller,
+# self-report recipient list, and email provider configured.
+ADMIN_JWT='<admin-jwt>' \
+CHECK_BOOTSTRAP_INSTRUMENTATION=1 \
+./scripts/ops/check-hosted-stack.sh
+
+# First-delivery verification: require that the weekly report has actually sent.
+ADMIN_JWT='<admin-jwt>' \
+CHECK_BOOTSTRAP_INSTRUMENTATION=1 \
+CHECK_BOOTSTRAP_SELF_REPORT_SENT=1 \
+./scripts/ops/check-hosted-stack.sh
+
 # Component-scoped deploys can skip indexer checks when the indexer was not
 # touched, while scheduled/full-stack smoke should keep the default.
 CHECK_INDEXER=0 ./scripts/ops/check-hosted-stack.sh

--- a/docs/RC1_IMPLEMENTATION_PLAN.md
+++ b/docs/RC1_IMPLEMENTATION_PLAN.md
@@ -193,6 +193,8 @@ generation are implemented as backend foundations.
   `reverted`.
 - [x] Add weekly self-report generation with merge rate, spend, receipts, and top
   close reasons.
+- [x] Add an opt-in hosted smoke gate that proves the daily poller and weekly
+  self-report scheduler are enabled, running, and provider-configured.
 - [ ] Wire scheduled email delivery once report recipients and cadence are
   finalized.
 

--- a/scripts/ops/check-hosted-stack.sh
+++ b/scripts/ops/check-hosted-stack.sh
@@ -15,6 +15,8 @@ INDEXER_MAX_STALENESS_SEC=${INDEXER_MAX_STALENESS_SEC:-1800}
 INDEXER_RETRY_ATTEMPTS=${INDEXER_RETRY_ATTEMPTS:-12}
 INDEXER_RETRY_SLEEP_SEC=${INDEXER_RETRY_SLEEP_SEC:-5}
 CHECK_INDEXER=${CHECK_INDEXER:-1}
+CHECK_BOOTSTRAP_INSTRUMENTATION=${CHECK_BOOTSTRAP_INSTRUMENTATION:-0}
+CHECK_BOOTSTRAP_SELF_REPORT_SENT=${CHECK_BOOTSTRAP_SELF_REPORT_SENT:-0}
 TIMEOUT_SEC=${TIMEOUT_SEC:-20}
 APP_BASIC_AUTH_USER=${APP_BASIC_AUTH_USER:-}
 APP_BASIC_AUTH_PASSWORD=${APP_BASIC_AUTH_PASSWORD:-}
@@ -22,6 +24,7 @@ APP_EXPECTED_MARKER=${APP_EXPECTED_MARKER:-Opening the operator control room.}
 APP_ALLOW_PROTECTED_SHELL=${APP_ALLOW_PROTECTED_SHELL:-0}
 APP_PROTECTED_STATUS_CODES=${APP_PROTECTED_STATUS_CODES:-401}
 ADMIN_JWT=${ADMIN_JWT:-}
+admin_status_json=""
 
 require_command() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -48,6 +51,13 @@ fetch_admin_json() {
     -H "accept: application/json" \
     -H "authorization: Bearer $ADMIN_JWT" \
     "$url"
+}
+
+fetch_admin_status_once() {
+  if [[ -z "$admin_status_json" ]]; then
+    admin_status_json="$(fetch_admin_json "$API_ADMIN_STATUS_URL")"
+  fi
+  printf '%s' "$admin_status_json"
 }
 
 fetch_indexer_with_retries() {
@@ -166,7 +176,7 @@ fi
 
 if [[ -n "$ADMIN_JWT" ]]; then
   echo "Checking admin async XCM status"
-  admin_status_json="$(fetch_admin_json "$API_ADMIN_STATUS_URL")"
+  admin_status_json="$(fetch_admin_status_once)"
   jq -e '.maintenance.policy.enabled == true' >/dev/null <<<"$admin_status_json"
   jq -e '.xcmSettlementWatcher.enabled == true' >/dev/null <<<"$admin_status_json"
   jq -e '.xcmSettlementWatcher.pendingCount >= 0' >/dev/null <<<"$admin_status_json"
@@ -174,6 +184,41 @@ if [[ -n "$ADMIN_JWT" ]]; then
     (.xcmObservationRelay | type) == "object" and
     (.xcmObservationRelay.enabled | type) == "boolean"
   ' >/dev/null <<<"$admin_status_json"
+fi
+
+if enabled "$CHECK_BOOTSTRAP_INSTRUMENTATION"; then
+  if [[ -z "$ADMIN_JWT" ]]; then
+    echo "CHECK_BOOTSTRAP_INSTRUMENTATION=1 requires ADMIN_JWT for /admin/status." >&2
+    exit 1
+  fi
+
+  echo "Checking bootstrap instrumentation"
+  admin_status_json="$(fetch_admin_status_once)"
+  jq -e '
+    .upstreamStatus.enabled == true and
+    .upstreamStatus.running == true and
+    (.upstreamStatus.intervalMs | type) == "number" and
+    .upstreamStatus.intervalMs <= 86400000 and
+    (.upstreamStatus.batchSize | type) == "number" and
+    .upstreamStatus.batchSize > 0
+  ' >/dev/null <<<"$admin_status_json"
+  jq -e '
+    .bootstrapSelfReport.enabled == true and
+    .bootstrapSelfReport.running == true and
+    .bootstrapSelfReport.providerConfigured == true and
+    (.bootstrapSelfReport.recipientCount | type) == "number" and
+    .bootstrapSelfReport.recipientCount > 0 and
+    (.bootstrapSelfReport.intervalMs | type) == "number" and
+    .bootstrapSelfReport.intervalMs <= 604800000
+  ' >/dev/null <<<"$admin_status_json"
+
+  if enabled "$CHECK_BOOTSTRAP_SELF_REPORT_SENT"; then
+    jq -e '
+      .bootstrapSelfReport.lastRun.status == "sent" and
+      (.bootstrapSelfReport.lastRun.email.providerId | type) == "string" and
+      (.bootstrapSelfReport.lastRun.email.providerId | length) > 0
+    ' >/dev/null <<<"$admin_status_json"
+  fi
 fi
 
 echo "Hosted stack smoke check passed."


### PR DESCRIPTION
## What changed
- Add opt-in hosted-stack checks for bootstrap instrumentation via CHECK_BOOTSTRAP_INSTRUMENTATION=1.
- Require /admin/status to show the upstream status poller and bootstrap self-report scheduler enabled/running/provider-configured.
- Add first-delivery verification with CHECK_BOOTSTRAP_SELF_REPORT_SENT=1.
- Document required VPS backend.env values and production checklist commands.

## Checks
- bash -n scripts/ops/check-hosted-stack.sh
- npm run test:ops
- git diff --check

## Impact
- Affects ops scripts and docs only.
- No backend runtime, frontend, indexer, contracts, or public site behavior changes.
- Production env still needs explicit BOOTSTRAP_SELF_REPORT_* and RESEND_API_KEY values before the checklist item can be marked complete.