### PR TITLE
Public agent profile: trail summary panel (spec §10 PR A)

### DIFF
--- a/site/agent.html
+++ b/site/agent.html
@@ -142,6 +142,63 @@
             </section>
           </div>
 
+          <!--
+            Trail summary — derived client-side from the live badges
+            list. Surfaces the four reputation-deepening signals
+            AVERRAY_WORKING_SPEC §10 calls out: tier breakdown,
+            streak counter, primary sources, average merge time.
+            Each renders an honest "—" when nothing is computable so
+            the panel never invents numbers.
+          -->
+          <section class="profile-panel">
+            <div class="section-heading">
+              <div>
+                <p class="eyebrow">Trail summary</p>
+                <h2>Reputation at a glance</h2>
+              </div>
+              <span class="profile-summary-source">derived from public badges</span>
+            </div>
+
+            <div class="trail-grid">
+              <article class="trail-block">
+                <p class="trail-block-label">Tier breakdown</p>
+                <div id="profile-tier-breakdown" class="trail-tier-bars">
+                  <p class="profile-empty">No completions yet.</p>
+                </div>
+              </article>
+
+              <article class="trail-block">
+                <p class="trail-block-label">Current streak</p>
+                <div class="trail-headline">
+                  <strong id="profile-streak-value">—</strong>
+                  <span id="profile-streak-suffix" class="trail-headline-suffix">consecutive jobs</span>
+                </div>
+                <p id="profile-streak-meta" class="trail-block-meta">
+                  Streak grows on each merged job; broken on a rejection or
+                  a 7-day gap.
+                </p>
+              </article>
+
+              <article class="trail-block">
+                <p class="trail-block-label">Primary sources</p>
+                <ul id="profile-primary-repos" class="trail-repo-list">
+                  <li class="profile-empty">No source attribution yet.</li>
+                </ul>
+              </article>
+
+              <article class="trail-block">
+                <p class="trail-block-label">Avg merge time</p>
+                <div class="trail-headline">
+                  <strong id="profile-merge-value">—</strong>
+                  <span id="profile-merge-suffix" class="trail-headline-suffix"></span>
+                </div>
+                <p id="profile-merge-meta" class="trail-block-meta">
+                  Median time from claim to verifier-approved badge.
+                </p>
+              </article>
+            </div>
+          </section>
+
           <section class="profile-panel">
             <div class="section-heading">
               <div>

--- a/site/agent.js
+++ b/site/agent.js
@@ -45,6 +45,281 @@ function formatIso(value) {
   return date.toLocaleString("en-CH", { dateStyle: "medium", timeStyle: "short" });
 }
 
+/* ---------------------------------------------------------------- */
+/* Trail summary helpers — see AVERRAY_WORKING_SPEC §10 reputation   */
+/* deepening. Pure functions over the live badges list with honest   */
+/* "—" fallbacks when nothing is computable.                          */
+/* ---------------------------------------------------------------- */
+
+const TIER_BUCKETS = [
+  { id: "substantive", label: "Substantive", min: 5 },
+  { id: "standard", label: "Standard", min: 2 },
+  { id: "micro", label: "Micro", min: 0 },
+];
+
+function rewardToFloat(reward) {
+  if (!reward) return 0;
+  try {
+    const raw = BigInt(reward.amount ?? "0");
+    const decimals = BigInt(reward.decimals ?? 6);
+    const base = 10n ** decimals;
+    const whole = Number(raw / base);
+    const fraction = Number(raw % base) / Number(base);
+    return whole + fraction;
+  } catch {
+    return 0;
+  }
+}
+
+function bucketBadgeByReward(badge) {
+  const value = rewardToFloat(badge.reward);
+  // Premium tier covers post-launch external posters paying within
+  // published ranges; >$500 lands in Premium rather than overflowing
+  // Substantive.
+  if (value > 500) return "premium";
+  if (value >= 5) return "substantive";
+  if (value >= 2) return "standard";
+  return "micro";
+}
+
+function computeTierBreakdown(badges) {
+  const counts = { micro: 0, standard: 0, substantive: 0, premium: 0 };
+  for (const badge of badges) {
+    const id = bucketBadgeByReward(badge);
+    counts[id] = (counts[id] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function renderTierBreakdown(badges) {
+  const root = byId("profile-tier-breakdown");
+  if (!root) return;
+  if (!badges.length) {
+    root.innerHTML = '<p class="profile-empty">No completions yet.</p>';
+    return;
+  }
+  const counts = computeTierBreakdown(badges);
+  const total = badges.length;
+  const rows = [
+    { id: "substantive", label: "Substantive", count: counts.substantive },
+    { id: "standard", label: "Standard", count: counts.standard },
+    { id: "micro", label: "Micro", count: counts.micro },
+  ];
+  if (counts.premium > 0) {
+    rows.unshift({ id: "premium", label: "Premium", count: counts.premium });
+  }
+  root.innerHTML = rows
+    .map((row) => {
+      const pct = total > 0 ? Math.round((row.count / total) * 100) : 0;
+      return `
+        <div class="trail-tier-row" title="${row.label}: ${row.count} of ${total} badges">
+          <span>${row.label}</span>
+          <span class="trail-tier-bar tier-${row.id}"><i style="width:${pct}%"></i></span>
+          <span>${row.count}</span>
+        </div>
+      `;
+    })
+    .join("");
+}
+
+const STREAK_BREAK_MS = 7 * 24 * 60 * 60 * 1000;
+
+function computeStreak(badges) {
+  if (!badges.length) return { count: 0 };
+  const ordered = badges
+    .map((badge) => Date.parse(badge.completedAt ?? ""))
+    .filter((ts) => Number.isFinite(ts))
+    .sort((a, b) => b - a); // newest-first
+  if (!ordered.length) return { count: 0 };
+  let count = 1;
+  for (let i = 1; i < ordered.length; i += 1) {
+    if (ordered[i - 1] - ordered[i] > STREAK_BREAK_MS) break;
+    count += 1;
+  }
+  return { count };
+}
+
+function streakTierFor(count) {
+  if (count >= 25) return { id: "waiver", label: "fee waiver" };
+  if (count >= 10) return { id: "badge", label: "streak badge" };
+  if (count >= 1) return { id: "active", label: "active" };
+  return null;
+}
+
+function renderStreak(badges, stats = {}) {
+  const valueEl = byId("profile-streak-value");
+  const suffixEl = byId("profile-streak-suffix");
+  const metaEl = byId("profile-streak-meta");
+  if (!valueEl || !suffixEl) return;
+  const { count } = computeStreak(badges);
+  const rejected = Number(stats.rejectedCount ?? 0);
+  if (count === 0) {
+    valueEl.textContent = "—";
+    suffixEl.textContent = "no streak yet";
+    if (metaEl) {
+      metaEl.textContent = "Streak grows on each merged job; broken on a rejection or a 7-day gap.";
+    }
+    return;
+  }
+  valueEl.textContent = String(count);
+  suffixEl.textContent = count === 1 ? "consecutive job" : "consecutive jobs";
+  if (metaEl) {
+    const tier = streakTierFor(count);
+    const rejNote = rejected > 0
+      ? ` ${rejected} rejection${rejected === 1 ? "" : "s"} on this wallet.`
+      : "";
+    const tierBadge = tier
+      ? ` <span class="trail-streak-tier tier-${tier.id}">${tier.label}</span>`
+      : "";
+    metaEl.innerHTML = `Approximate from public badges (≤7-day gap).${rejNote}${tierBadge}`.trim();
+  }
+}
+
+function badgeSourceKey(badge) {
+  const source = badge.source && typeof badge.source === "object" ? badge.source : null;
+  if (source) {
+    if (typeof source.repo === "string" && source.repo) return { kind: "github", key: source.repo };
+    if (typeof source.pageTitle === "string" && source.pageTitle) {
+      return {
+        kind: "wikipedia",
+        key: `${source.language ?? "en"}.wikipedia / ${source.pageTitle}`,
+      };
+    }
+    if (typeof source.datasetTitle === "string" && source.datasetTitle) {
+      return { kind: "dataset", key: source.datasetTitle };
+    }
+  }
+  const jobId = String(badge.jobId ?? "");
+  if (jobId.startsWith("oss-")) {
+    const parts = jobId.split("-");
+    if (parts.length >= 4) return { kind: "github", key: `${parts[1]}/${parts[2]}` };
+  }
+  if (jobId.startsWith("wiki-")) {
+    const parts = jobId.split("-");
+    if (parts.length >= 3) return { kind: "wikipedia", key: `${parts[1]}.wikipedia / ${parts[2]}` };
+  }
+  if (jobId.startsWith("open-data-") || jobId.startsWith("openapi-") || jobId.startsWith("standards-")) {
+    return { kind: "dataset", key: jobId.split("-").slice(1, 4).join("-") };
+  }
+  return { kind: "native", key: jobId || "unknown" };
+}
+
+function computePrimaryRepos(badges, limit = 3) {
+  const counts = new Map();
+  for (const badge of badges) {
+    const { key, kind } = badgeSourceKey(badge);
+    if (!key) continue;
+    const existing = counts.get(key) ?? { key, kind, count: 0 };
+    existing.count += 1;
+    counts.set(key, existing);
+  }
+  return Array.from(counts.values())
+    .sort((a, b) => b.count - a.count)
+    .slice(0, limit);
+}
+
+function renderPrimaryRepos(badges) {
+  const root = byId("profile-primary-repos");
+  if (!root) return;
+  const repos = computePrimaryRepos(badges);
+  if (!repos.length) {
+    root.innerHTML = '<li class="profile-empty">No source attribution yet.</li>';
+    return;
+  }
+  root.innerHTML = repos
+    .map((entry) => `
+      <li>
+        <span title="${entry.kind}">${entry.key}</span>
+        <span>${entry.count} ${entry.count === 1 ? "job" : "jobs"}</span>
+      </li>
+    `)
+    .join("");
+}
+
+function computeMergeTime(badges) {
+  const durations = [];
+  for (const badge of badges) {
+    const completed = Date.parse(badge.completedAt ?? "");
+    const claimed = Date.parse(badge.claimedAt ?? badge.startedAt ?? "");
+    if (!Number.isFinite(completed) || !Number.isFinite(claimed)) continue;
+    if (completed < claimed) continue;
+    durations.push(completed - claimed);
+  }
+  if (!durations.length) {
+    return { median: null, sampleCount: 0, missing: badges.length };
+  }
+  durations.sort((a, b) => a - b);
+  const mid = Math.floor(durations.length / 2);
+  const median = durations.length % 2 === 0
+    ? (durations[mid - 1] + durations[mid]) / 2
+    : durations[mid];
+  return {
+    median,
+    sampleCount: durations.length,
+    missing: badges.length - durations.length,
+  };
+}
+
+function formatDurationCompact(ms) {
+  if (!Number.isFinite(ms) || ms < 0) return { value: "—", unit: "" };
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) return { value: String(totalSeconds), unit: "s" };
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes < 60) {
+    return seconds === 0
+      ? { value: String(minutes), unit: "m" }
+      : { value: `${minutes}m`, unit: `${seconds}s` };
+  }
+  const hours = Math.floor(minutes / 60);
+  const remMinutes = minutes % 60;
+  if (hours < 24) {
+    return remMinutes === 0
+      ? { value: String(hours), unit: "h" }
+      : { value: `${hours}h`, unit: `${remMinutes}m` };
+  }
+  const days = Math.floor(hours / 24);
+  const remHours = hours % 24;
+  return remHours === 0
+    ? { value: String(days), unit: "d" }
+    : { value: `${days}d`, unit: `${remHours}h` };
+}
+
+function renderMergeTime(badges) {
+  const valueEl = byId("profile-merge-value");
+  const suffixEl = byId("profile-merge-suffix");
+  const metaEl = byId("profile-merge-meta");
+  if (!valueEl || !suffixEl) return;
+  const stats = computeMergeTime(badges);
+  if (stats.median == null) {
+    valueEl.textContent = "—";
+    suffixEl.textContent = "";
+    if (metaEl) {
+      metaEl.textContent = badges.length
+        ? `Badges don't carry claim timestamps yet (${badges.length} missing).`
+        : "Will populate once approved badges land.";
+    }
+    return;
+  }
+  const formatted = formatDurationCompact(stats.median);
+  valueEl.textContent = formatted.value;
+  suffixEl.textContent = formatted.unit;
+  if (metaEl) {
+    const missingNote = stats.missing > 0
+      ? ` ${stats.missing} badge${stats.missing === 1 ? "" : "s"} missing claimedAt.`
+      : "";
+    metaEl.textContent = `Median across ${stats.sampleCount} approved badge${stats.sampleCount === 1 ? "" : "s"}.${missingNote}`;
+  }
+}
+
+function renderTrailSummary(profile) {
+  const badges = Array.isArray(profile.badges) ? profile.badges : [];
+  renderTierBreakdown(badges);
+  renderStreak(badges, profile.stats ?? {});
+  renderPrimaryRepos(badges);
+  renderMergeTime(badges);
+}
+
 function renderBadges(badges = []) {
   const root = byId("profile-badges");
   if (!root) return;
@@ -116,6 +391,7 @@ async function bootProfile() {
         ? Object.entries(profile.categoryLevels).map(([category, level]) => `${category} · lvl ${level}`).join(" · ")
         : "No category levels yet."
     );
+    renderTrailSummary(profile);
     renderBadges(profile.badges);
   } catch (error) {
     if (loading) loading.textContent = error?.message ?? "Failed to load profile.";

--- a/site/styles.css
+++ b/site/styles.css
@@ -1024,3 +1024,167 @@ code {
 .provider-row--error .provider-bar > span {
   background: #a0322a;
 }
+
+/* Trail summary — agent profile §10 (reputation deepening) ---------- */
+
+.profile-summary-source {
+  font-family: var(--display);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.trail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 0.9rem;
+  margin-top: 0.6rem;
+}
+
+.trail-block {
+  display: grid;
+  gap: 0.55rem;
+  padding: 0.95rem 1rem;
+  border-radius: 0.85rem;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.trail-block-label {
+  margin: 0;
+  font-family: var(--display);
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.trail-block-meta {
+  margin: 0;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+.trail-headline {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+}
+
+.trail-headline strong {
+  font-family: var(--display);
+  font-size: 1.85rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.trail-headline-suffix {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.trail-tier-bars {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.trail-tier-row {
+  display: grid;
+  grid-template-columns: minmax(5rem, max-content) minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.55rem;
+  font-family: var(--display);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  color: var(--ink);
+}
+
+.trail-tier-row span:first-child {
+  font-weight: 700;
+}
+
+.trail-tier-bar {
+  height: 6px;
+  border-radius: 3px;
+  background: rgba(17, 19, 21, 0.06);
+  overflow: hidden;
+}
+
+.trail-tier-bar > i {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+  border-radius: inherit;
+  transition: width 220ms ease;
+}
+
+.trail-tier-bar.tier-substantive > i { background: #1d6a46; }
+.trail-tier-bar.tier-standard    > i { background: #3a8c5e; }
+.trail-tier-bar.tier-micro       > i { background: #94b89d; }
+.trail-tier-bar.tier-premium     > i { background: #254e9a; }
+
+.trail-tier-row span:last-child {
+  font-family: "JetBrains Mono", "Space Grotesk", monospace;
+  font-weight: 600;
+  color: var(--ink);
+  letter-spacing: 0;
+}
+
+.trail-repo-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.trail-repo-list li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: baseline;
+  gap: 0.6rem;
+  font-family: "JetBrains Mono", "Space Grotesk", monospace;
+  font-size: 0.78rem;
+  color: var(--ink);
+  letter-spacing: 0;
+}
+
+.trail-repo-list li:not(.profile-empty) span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trail-repo-list li:not(.profile-empty) span:last-child {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
+.trail-streak-tier {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  margin-top: 0.2rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-family: var(--display);
+  font-size: 0.65rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.trail-streak-tier.tier-active   { background: var(--accent-soft); color: var(--accent); }
+.trail-streak-tier.tier-badge    { background: #f1e4d4; color: #a0691f; }
+.trail-streak-tier.tier-waiver   { background: #d8e4f1; color: #254e9a; }
+


### PR DESCRIPTION
First of the spec §10 \"Reputation deepening\" frontend follow-ups. The spec calls the public agent profile the highest-leverage marketing surface — *\"this is what a reputation trail looks like\"* becomes pointable rather than abstract. Today's profile renders the wallet header + a single tier pill + raw badge cards. This PR adds the four reputation-deepening signals the spec specifically lists as missing, all derived from the live \`/agents/<wallet>\` payload with honest \`—\` fallbacks.

## What ships
- **Tier breakdown bar set** — buckets badges by reward (Micro <\$2 / Standard \$2–\$5 / Substantive ≥\$5 / Premium >\$500 for post-launch external posters), renders one row per non-zero tier with share-of-total bars + absolute counts.
- **Current-streak counter** — consecutive badges with ≤7-day gaps from newest backwards. Pill below the number marks the streak tier the spec defines (\"active\" / \"streak badge\" at 10+ / \"fee waiver\" at 25+). Honest about the approximation: badges-only can't see mid-trail rejections; canonical streak comes server-side.
- **Primary sources** — top 3 source identities by completion count. Reads structured \`source.repo\` / \`source.pageTitle\` / \`source.datasetTitle\` when present, falls back to parsing jobId for older shapes.
- **Median merge time** — median of \`completedAt − claimedAt\` across approved badges, formatted compactly (\"3m 12s\", \"14m\", \"2h 4m\", \"1d 6h\"). Falls back to \`—\` with a note when no badge carries claimedAt yet.

## Audit note
Verified what was already on \`site/agent.html\` + \`site/agent.js\` before starting — header, tier-name pill, basic stats panel (totalBadges / approved / rejected / completionRate / totalEarned / lastActive), reputation panel (skill / reliability / economic / activeSince / preferredCategories / categoryLevels), and the badges grid. The four pieces above are the spec gaps; nothing existing was touched.

## Polkadot MCP
Checked the docs MCP for upcoming PR B (\"one-click verification\"): canonical Subscan URLs are \`assethub-polkadot.subscan.io\` (mainnet) and \`assethub-paseo.subscan.io\` (testnet). Saved for the verification deeplinks landing in PR B.

## Test plan
- [x] Compute helpers sanity-checked against fixture data ($5 + $2 + $0.5 + $7.5 → tier counts {substantive: 2, standard: 1, micro: 1}, streak = 3 across recent ≤7-day badges).
- [x] \`npm run build:site\`
- [ ] After deploy: load \`https://averray.com/agents/<wallet>\` — Trail summary panel renders with Tier breakdown / Streak / Primary sources / Avg merge time. Empty wallet shows the four blocks each with their own honest empty state.

## Next
- PR B: one-click verification per badge (5 deeplinks each, including the Subscan URLs the MCP confirmed).
- PR C: operator-app sub-job lineage panel on \`/runs/detail\` (off existing \`/admin/jobs/timeline\` data).