### PR TITLE
Wire bootstrap instrumentation deploy env

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -55,6 +55,30 @@ on:
         options:
           - "0"
           - "1"
+      bootstrap_self_report_send_on_start:
+        description: One-shot bootstrap self-report send on backend start.
+        required: false
+        default: "0"
+        type: choice
+        options:
+          - "0"
+          - "1"
+      smoke_check_bootstrap_instrumentation:
+        description: Require bootstrap poller + self-report status in hosted smoke.
+        required: false
+        default: "0"
+        type: choice
+        options:
+          - "0"
+          - "1"
+      smoke_check_bootstrap_self_report_sent:
+        description: Require the bootstrap self-report last run to be sent.
+        required: false
+        default: "0"
+        type: choice
+        options:
+          - "0"
+          - "1"
 
 concurrency:
   group: production
@@ -76,6 +100,9 @@ jobs:
       APP_BASIC_AUTH_PASSWORD_HASH: ${{ secrets.APP_BASIC_AUTH_PASSWORD_HASH }}
       APP_ALLOW_PROTECTED_SHELL: ${{ secrets.APP_ALLOW_PROTECTED_SHELL }}
       ADMIN_JWT: ${{ secrets.ADMIN_JWT }}
+      RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+      BOOTSTRAP_SELF_REPORT_TO: ${{ secrets.BOOTSTRAP_SELF_REPORT_TO }}
+      BOOTSTRAP_SELF_REPORT_FROM: ${{ secrets.BOOTSTRAP_SELF_REPORT_FROM }}
       DEPLOY_RUN_INDEXER: ${{ github.event_name == 'workflow_dispatch' && inputs.run_indexer || 'auto' }}
       DEPLOY_WAIT_FOR_READY: ${{ github.event_name == 'workflow_dispatch' && inputs.wait_for_ready || '1' }}
       DEPLOY_HEALTH_STABILITY_SEC: ${{ github.event_name == 'workflow_dispatch' && inputs.health_stability_sec || '0' }}
@@ -83,6 +110,9 @@ jobs:
       DEPLOY_SMOKE_CHECK_INDEXER: ${{ github.event_name == 'workflow_dispatch' && inputs.smoke_check_indexer || 'auto' }}
       DEPLOY_INDEXER_DATABASE_SCHEMA: ${{ github.event_name == 'workflow_dispatch' && inputs.indexer_database_schema || '' }}
       DEPLOY_INDEXER_FRESH_SCHEMA: ${{ github.event_name == 'workflow_dispatch' && inputs.indexer_fresh_schema || '0' }}
+      DEPLOY_BOOTSTRAP_SELF_REPORT_SEND_ON_START: ${{ github.event_name == 'workflow_dispatch' && inputs.bootstrap_self_report_send_on_start || '0' }}
+      DEPLOY_SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION: ${{ github.event_name == 'workflow_dispatch' && inputs.smoke_check_bootstrap_instrumentation || '0' }}
+      DEPLOY_SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT: ${{ github.event_name == 'workflow_dispatch' && inputs.smoke_check_bootstrap_self_report_sent || '0' }}
     steps:
       - name: Validate required secrets
         run: |
@@ -104,17 +134,23 @@ jobs:
       - name: Deploy production
         run: |
           remote_env=$(
-            printf 'APP_BASIC_AUTH_USER=%q APP_BASIC_AUTH_PASSWORD=%q APP_BASIC_AUTH_PASSWORD_HASH=%q APP_ALLOW_PROTECTED_SHELL=%q ADMIN_JWT=%q RUN_INDEXER=%q WAIT_FOR_READY=%q HEALTH_STABILITY_SEC=%q INDEXER_LOG_TAIL=%q SMOKE_CHECK_INDEXER=%q INDEXER_DATABASE_SCHEMA=%q INDEXER_FRESH_SCHEMA=%q ' \
+            printf 'APP_BASIC_AUTH_USER=%q APP_BASIC_AUTH_PASSWORD=%q APP_BASIC_AUTH_PASSWORD_HASH=%q APP_ALLOW_PROTECTED_SHELL=%q ADMIN_JWT=%q RESEND_API_KEY=%q BOOTSTRAP_SELF_REPORT_TO=%q BOOTSTRAP_SELF_REPORT_FROM=%q BOOTSTRAP_SELF_REPORT_SEND_ON_START=%q RUN_INDEXER=%q WAIT_FOR_READY=%q HEALTH_STABILITY_SEC=%q INDEXER_LOG_TAIL=%q SMOKE_CHECK_INDEXER=%q SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION=%q SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT=%q INDEXER_DATABASE_SCHEMA=%q INDEXER_FRESH_SCHEMA=%q ' \
               "$APP_BASIC_AUTH_USER" \
               "$APP_BASIC_AUTH_PASSWORD" \
               "$APP_BASIC_AUTH_PASSWORD_HASH" \
               "$APP_ALLOW_PROTECTED_SHELL" \
               "$ADMIN_JWT" \
+              "$RESEND_API_KEY" \
+              "$BOOTSTRAP_SELF_REPORT_TO" \
+              "$BOOTSTRAP_SELF_REPORT_FROM" \
+              "$DEPLOY_BOOTSTRAP_SELF_REPORT_SEND_ON_START" \
               "$DEPLOY_RUN_INDEXER" \
               "$DEPLOY_WAIT_FOR_READY" \
               "$DEPLOY_HEALTH_STABILITY_SEC" \
               "$DEPLOY_INDEXER_LOG_TAIL" \
               "$DEPLOY_SMOKE_CHECK_INDEXER" \
+              "$DEPLOY_SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION" \
+              "$DEPLOY_SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT" \
               "$DEPLOY_INDEXER_DATABASE_SCHEMA" \
               "$DEPLOY_INDEXER_FRESH_SCHEMA"
           )

--- a/scripts/ops/deploy-production.sh
+++ b/scripts/ops/deploy-production.sh
@@ -28,9 +28,12 @@ RUN_SITE=${RUN_SITE:-auto}
 RUN_CADDY=${RUN_CADDY:-auto}
 RUN_SMOKE=${RUN_SMOKE:-1}
 SMOKE_CHECK_INDEXER=${SMOKE_CHECK_INDEXER:-auto}
+SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION=${SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION:-0}
+SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT=${SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT:-0}
 INDEXER_DATABASE_SCHEMA=${INDEXER_DATABASE_SCHEMA:-}
 INDEXER_FRESH_SCHEMA=${INDEXER_FRESH_SCHEMA:-0}
 INDEXER_ENV_FILE=${INDEXER_ENV_FILE:-"$STACK_ROOT/indexer.env"}
+BACKEND_ENV_FILE=${BACKEND_ENV_FILE:-"$STACK_ROOT/backend.env"}
 
 SITE_BUILD_RUNNER=${SITE_BUILD_RUNNER:-auto}
 SITE_NODE_IMAGE=${SITE_NODE_IMAGE:-node:22-bookworm-slim}
@@ -119,6 +122,71 @@ initialize_component_state() {
       echo "Initialized $component deploy pointer at $OLD_SHA"
     fi
   done
+}
+
+quote_env_value() {
+  local value="$1"
+  value=${value//$'\n'/}
+  value=${value//\\/\\\\}
+  value=${value//\"/\\\"}
+  printf '"%s"' "$value"
+}
+
+upsert_env_values() {
+  local env_file="$1"
+  shift
+  mkdir -p "$(dirname "$env_file")"
+  touch "$env_file"
+
+  local key_pattern=""
+  local pair key
+  for pair in "$@"; do
+    key="${pair%%=*}"
+    if [[ -z "$key_pattern" ]]; then
+      key_pattern="$key"
+    else
+      key_pattern="$key_pattern|$key"
+    fi
+  done
+
+  local tmp="${env_file}.tmp.$$"
+  grep -Ev "^(${key_pattern})=" "$env_file" > "$tmp" || true
+  for pair in "$@"; do
+    key="${pair%%=*}"
+    printf '%s=%s\n' "$key" "$(quote_env_value "${pair#*=}")" >> "$tmp"
+  done
+  mv "$tmp" "$env_file"
+}
+
+configure_bootstrap_instrumentation_env() {
+  if [[ -z "${RESEND_API_KEY:-}" || -z "${BOOTSTRAP_SELF_REPORT_TO:-}" ]]; then
+    echo "Bootstrap self-report secrets are incomplete; leaving backend.env instrumentation settings unchanged."
+    return
+  fi
+
+  local send_on_start="false"
+  case "${BOOTSTRAP_SELF_REPORT_SEND_ON_START:-0}" in
+    1|true|yes) send_on_start="true" ;;
+    0|false|no|"") send_on_start="false" ;;
+    *)
+      echo "Invalid BOOTSTRAP_SELF_REPORT_SEND_ON_START toggle: $BOOTSTRAP_SELF_REPORT_SEND_ON_START" >&2
+      exit 1
+      ;;
+  esac
+
+  echo "Writing bootstrap instrumentation settings to $BACKEND_ENV_FILE"
+  upsert_env_values "$BACKEND_ENV_FILE" \
+    "UPSTREAM_STATUS_POLLER_ENABLED=true" \
+    "UPSTREAM_STATUS_POLLER_INTERVAL_MS=86400000" \
+    "UPSTREAM_STATUS_POLLER_BATCH_SIZE=50" \
+    "BOOTSTRAP_SELF_REPORT_ENABLED=true" \
+    "BOOTSTRAP_SELF_REPORT_INTERVAL_MS=604800000" \
+    "BOOTSTRAP_SELF_REPORT_SEND_ON_START=$send_on_start" \
+    "BOOTSTRAP_SELF_REPORT_FROM=${BOOTSTRAP_SELF_REPORT_FROM:-ops@averray.com}" \
+    "BOOTSTRAP_SELF_REPORT_TO=$BOOTSTRAP_SELF_REPORT_TO" \
+    "BOOTSTRAP_SELF_REPORT_SUBJECT_PREFIX=Averray bootstrap self-report" \
+    "RESEND_API_KEY=$RESEND_API_KEY" \
+    "RESEND_API_BASE_URL=https://api.resend.com"
 }
 
 component_changed_matches() {
@@ -335,6 +403,7 @@ deploy() {
 
   initialize_component_state
   apply_indexer_database_schema
+  configure_bootstrap_instrumentation_env
 
   local run_backend=0
   local run_indexer=0
@@ -413,7 +482,10 @@ deploy() {
     if [[ "$check_indexer" != "1" ]]; then
       echo "Skipping indexer smoke checks because this deploy did not change indexer or Caddy."
     fi
-    CHECK_INDEXER="$check_indexer" "$APP_ROOT/scripts/ops/check-hosted-stack.sh"
+    CHECK_INDEXER="$check_indexer" \
+      CHECK_BOOTSTRAP_INSTRUMENTATION="$SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION" \
+      CHECK_BOOTSTRAP_SELF_REPORT_SENT="$SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT" \
+      "$APP_ROOT/scripts/ops/check-hosted-stack.sh"
   else
     echo "RUN_SMOKE=0 set; skipping hosted smoke check."
   fi

--- a/scripts/ops/deploy-production.test.mjs
+++ b/scripts/ops/deploy-production.test.mjs
@@ -118,6 +118,67 @@ test("deploy wrapper retries frontend after an earlier failed indexer deploy", a
   assert.equal((await readFile(join(stateDir, "frontend.last-good"), "utf8")).trim(), indexerFixSha);
 });
 
+test("deploy wrapper writes bootstrap instrumentation backend env when secrets are present", async () => {
+  const root = await mkdtemp(join(tmpdir(), "deploy-production-bootstrap-"));
+  const appRoot = join(root, "app");
+  const stackRoot = join(root, "stack");
+  const fakeBin = join(root, "bin");
+  const stateDir = join(root, "state");
+  const backendEnv = join(stackRoot, "backend.env");
+
+  await mkdir(join(appRoot, "scripts/ops"), { recursive: true });
+  await mkdir(stackRoot, { recursive: true });
+  await mkdir(fakeBin, { recursive: true });
+  await writeFile(join(stackRoot, "docker-compose.yml"), "services: {}\n");
+  await writeFile(backendEnv, "KEEP_ME=1\nBOOTSTRAP_SELF_REPORT_ENABLED=false\nRESEND_API_KEY=\"old\"\n");
+  await copyFile(DEPLOY_SCRIPT, join(appRoot, "scripts/ops/deploy-production.sh"));
+  await chmod(join(appRoot, "scripts/ops/deploy-production.sh"), 0o755);
+
+  for (const command of ["docker", "curl", "npm", "flock"]) {
+    await writeExecutable(join(fakeBin, command), "#!/usr/bin/env bash\nexit 0\n");
+  }
+
+  git(appRoot, "init");
+  git(appRoot, "config", "user.email", "test@example.com");
+  git(appRoot, "config", "user.name", "Deploy Test");
+  await writeFile(join(appRoot, "README.md"), "base\n");
+  git(appRoot, "add", ".");
+  git(appRoot, "commit", "-m", "base");
+  const baseSha = revParse(appRoot, "HEAD");
+
+  const result = runDeploy(appRoot, {
+    PATH: `${fakeBin}:${process.env.PATH}`,
+    STACK_ROOT: stackRoot,
+    COMPOSE_FILE: join(stackRoot, "docker-compose.yml"),
+    BACKEND_ENV_FILE: backendEnv,
+    DEPLOY_LOCK_FILE: join(root, "deploy.lock"),
+    DEPLOY_STATE_DIR: stateDir,
+    DEPLOY_OLD_SHA: baseSha,
+    DEPLOY_NEW_SHA: baseSha,
+    RESEND_API_KEY: "secret",
+    BOOTSTRAP_SELF_REPORT_TO: "ops@example.com",
+    BOOTSTRAP_SELF_REPORT_FROM: "ops@averray.com",
+    BOOTSTRAP_SELF_REPORT_SEND_ON_START: "1",
+    RUN_BACKEND: "0",
+    RUN_FRONTEND: "0",
+    RUN_INDEXER: "0",
+    RUN_SITE: "0",
+    RUN_CADDY: "0",
+    RUN_SMOKE: "0"
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const contents = await readFile(backendEnv, "utf8");
+  assert.match(contents, /^KEEP_ME=1$/m);
+  assert.match(contents, /^UPSTREAM_STATUS_POLLER_ENABLED="true"$/m);
+  assert.match(contents, /^BOOTSTRAP_SELF_REPORT_ENABLED="true"$/m);
+  assert.match(contents, /^BOOTSTRAP_SELF_REPORT_SEND_ON_START="true"$/m);
+  assert.match(contents, /^BOOTSTRAP_SELF_REPORT_TO="ops@example\.com"$/m);
+  assert.match(contents, /^BOOTSTRAP_SELF_REPORT_FROM="ops@averray\.com"$/m);
+  assert.match(contents, /^RESEND_API_KEY="secret"$/m);
+  assert.equal((contents.match(/^RESEND_API_KEY=/gm) ?? []).length, 1);
+});
+
 async function writeExecutable(path, content) {
   await writeFile(path, `${content}\n`);
   await chmod(path, 0o755);


### PR DESCRIPTION
## What changed
- Forward bootstrap self-report secrets from GitHub Actions to the VPS deploy wrapper.
- Add workflow_dispatch inputs for one-shot send-on-start and bootstrap smoke verification.
- Update deploy-production.sh to upsert only bootstrap instrumentation keys in backend.env when Resend + recipient secrets are present.
- Add an ops regression test for backend.env writing with dummy values.

## Checks
- bash -n scripts/ops/deploy-production.sh
- npm run test:ops
- git diff --check HEAD~1..HEAD

## Impact
- Affects production deployment workflow and ops script only.
- No frontend, indexer, contracts, or public site runtime code changes.
- Requires GitHub secrets: RESEND_API_KEY, BOOTSTRAP_SELF_REPORT_TO, BOOTSTRAP_SELF_REPORT_FROM, and a valid ADMIN_JWT for bootstrap smoke verification.