### PR TITLE
Public agent profile: one-click verification per badge (spec §10 PR B)

### DIFF
--- a/mcp-server/src/core/agent-profile.js
+++ b/mcp-server/src/core/agent-profile.js
@@ -86,6 +86,12 @@ export function buildAgentProfile({ wallet, reputation, sessions, getJobDefiniti
       activeSinceMs = ts;
     }
 
+    // Verification block — supports the public profile's
+    // "one-click verification" affordance from spec §10. Each
+    // field is optional, and the whole block is dropped when
+    // nothing is computable so older sessions don't ship an
+    // empty stub.
+    const verification = buildBadgeVerification(session, job);
     badges.push({
       sessionId: session.sessionId,
       jobId: session.jobId,
@@ -97,6 +103,7 @@ export function buildAgentProfile({ wallet, reputation, sessions, getJobDefiniti
         amount: toBaseUnits(rewardAmount, decimals).toString(),
         decimals
       },
+      ...(verification ? { verification } : {}),
       ...(publicBaseUrl
         ? { badgeUrl: `${stripTrailingSlash(publicBaseUrl)}/badges/${encodeURIComponent(session.sessionId)}` }
         : {})
@@ -268,4 +275,73 @@ function compact(value) {
   return Object.fromEntries(
     Object.entries(value).filter(([, entry]) => entry !== undefined)
   );
+}
+
+/**
+ * Verification block attached to each approved-session badge entry.
+ * Mirrors the structured fields the canonical badge JSON already
+ * exposes (`agent-badge-v1` / `averray.*` namespace), plus a source
+ * URL pulled off the job definition so the public profile page can
+ * render a "one-click verification" affordance without a per-badge
+ * fetch.
+ *
+ * Every field is optional. Older sessions that predate the chain
+ * hash or evidence binding simply omit the missing keys so the
+ * profile schema stays additive.
+ */
+function buildBadgeVerification(session, job) {
+  const verification = session?.verification ?? session?.verificationSummary;
+  const verifierAddress = stringOrUndefined(verification?.verifier ?? verification?.signer ?? session?.verifierAddress);
+  const evidenceHash = stringOrUndefined(
+    session?.evidenceHash ?? session?.submission?.evidenceHash ?? verification?.evidenceHash
+  );
+  const chainJobId = stringOrUndefined(session?.chainJobId ?? job?.chainJobId);
+  const verifierMode = stringOrUndefined(job?.verifierMode ?? session?.verifierMode);
+  const sourceUrl = pickSourceUrl(job);
+  const sourceKind = stringOrUndefined(job?.source?.type);
+  const result = compact({
+    chainJobId,
+    evidenceHash,
+    verifier: verifierAddress,
+    verifierMode,
+    sourceUrl,
+    sourceKind,
+  });
+  return Object.keys(result).length === 0 ? undefined : result;
+}
+
+/**
+ * Pick the most useful upstream URL for a job's source — the one a
+ * human or browser agent should follow to inspect the original work.
+ * GitHub issues link to the issue, Wikipedia jobs link to the
+ * pinned revision so the diff is always reproducible, OSV jobs link
+ * to the consumer repo's PR (recorded on the session if present)
+ * with a fallback to the OSV advisory page, and open-data jobs link
+ * to the dataset landing page.
+ */
+function pickSourceUrl(job) {
+  const source = job?.source;
+  if (!source || typeof source !== "object") return undefined;
+  switch (source.type) {
+    case "github_issue":
+      return stringOrUndefined(source.issueUrl ?? source.pageUrl);
+    case "wikipedia_article":
+      return stringOrUndefined(source.pinnedRevisionUrl ?? source.articleUrl ?? source.pageUrl);
+    case "osv_advisory":
+      return stringOrUndefined(source.advisoryUrl ?? source.referenceUrl);
+    case "open_data_dataset":
+      return stringOrUndefined(source.resourceUrl ?? source.datasetUrl);
+    case "openapi_spec":
+      return stringOrUndefined(source.specUrl ?? source.finalUrl);
+    case "standards_spec":
+      return stringOrUndefined(source.canonicalUrl ?? source.specUrl);
+    default:
+      return undefined;
+  }
+}
+
+function stringOrUndefined(value) {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }

--- a/mcp-server/src/core/agent-profile.test.js
+++ b/mcp-server/src/core/agent-profile.test.js
@@ -270,3 +270,125 @@ test("buildAgentProfile omits badgeUrl when publicBaseUrl is not provided", () =
   assert.equal(profile.badges[0].sessionId, "s1");
   assert.ok(!("badgeUrl" in profile.badges[0]));
 });
+
+test("buildAgentProfile attaches verification block per source kind", () => {
+  // GitHub session: chainJobId, evidenceHash, verifier, verifierMode,
+  // sourceUrl from job.source.issueUrl.
+  const githubJob = {
+    id: "oss-acme-repo-1",
+    category: "coding",
+    rewardAsset: "USDC",
+    rewardAmount: 5,
+    verifierMode: "github_pr",
+    source: { type: "github_issue", issueUrl: "https://github.com/acme/repo/issues/1" },
+  };
+  // Wikipedia session: pinnedRevisionUrl is preferred over articleUrl
+  // because the revision URL is reproducible.
+  const wikiJob = {
+    id: "wiki-en-12345-citation-repair",
+    category: "wikipedia",
+    rewardAsset: "USDC",
+    rewardAmount: 2,
+    verifierMode: "wikipedia_proposal_review",
+    source: {
+      type: "wikipedia_article",
+      pinnedRevisionUrl: "https://en.wikipedia.org/w/index.php?title=Foo&oldid=42",
+      articleUrl: "https://en.wikipedia.org/wiki/Foo",
+    },
+  };
+  // OSV session with no source URL fields — verification block still
+  // populates with chainJobId/evidenceHash/verifier so the badge isn't
+  // unverifiable end-to-end.
+  const osvJob = {
+    id: "osv-npm-foo-1",
+    category: "security",
+    rewardAsset: "USDC",
+    rewardAmount: 7,
+    verifierMode: "osv_dependency_pr",
+    source: { type: "osv_advisory" },
+  };
+
+  const baseSession = (overrides) => ({
+    wallet: WALLET,
+    status: "resolved",
+    verification: {
+      outcome: "approved",
+      reasonCode: "OK",
+      verifier: "0xVerifier000000000000000000000000000000F0",
+    },
+    chainJobId: "0xchainjob000000000000000000000000000000000000000000000000000000aa",
+    evidenceHash: "0xevidence0000000000000000000000000000000000000000000000000000000bb",
+    ...overrides,
+  });
+
+  const sessions = [
+    baseSession({ sessionId: "g1", jobId: "oss-acme-repo-1", updatedAt: "2026-05-08T10:00:00Z" }),
+    baseSession({ sessionId: "w1", jobId: "wiki-en-12345-citation-repair", updatedAt: "2026-05-09T10:00:00Z" }),
+    baseSession({ sessionId: "o1", jobId: "osv-npm-foo-1", updatedAt: "2026-05-10T10:00:00Z" }),
+  ];
+  const catalog = new Map([
+    [githubJob.id, githubJob],
+    [wikiJob.id, wikiJob],
+    [osvJob.id, osvJob],
+  ]);
+
+  const profile = buildAgentProfile({
+    wallet: WALLET,
+    reputation: { skill: 200, reliability: 200, economic: 200, tier: "pro" },
+    sessions,
+    getJobDefinition: makeGetJob(catalog),
+    publicBaseUrl: "https://api.averray.com",
+    fetchedAt: "2026-05-11T00:00:00Z",
+  });
+
+  // Badges sorted newest-first: o1, w1, g1.
+  const [osvBadge, wikiBadge, githubBadge] = profile.badges;
+  assert.deepEqual(githubBadge.verification, {
+    chainJobId: "0xchainjob000000000000000000000000000000000000000000000000000000aa",
+    evidenceHash: "0xevidence0000000000000000000000000000000000000000000000000000000bb",
+    verifier: "0xVerifier000000000000000000000000000000F0",
+    verifierMode: "github_pr",
+    sourceUrl: "https://github.com/acme/repo/issues/1",
+    sourceKind: "github_issue",
+  });
+  assert.equal(
+    wikiBadge.verification.sourceUrl,
+    "https://en.wikipedia.org/w/index.php?title=Foo&oldid=42",
+    "wikipedia source url prefers pinned revision over article"
+  );
+  // OSV with no source URL: the field is dropped entirely so the
+  // frontend can render a "no source link" state without parsing a
+  // null.
+  assert.ok(!("sourceUrl" in osvBadge.verification));
+  assert.equal(osvBadge.verification.verifierMode, "osv_dependency_pr");
+});
+
+test("buildAgentProfile omits the verification block when nothing is computable", () => {
+  // Session without chainJobId / evidenceHash / verifier and a job
+  // without source.* — no verification fields can be derived. The
+  // block is dropped entirely so the frontend renders an honest "no
+  // verification details" state instead of an empty object.
+  const job = {
+    id: "starter-coding-001",
+    category: "coding",
+    rewardAsset: "USDC",
+    rewardAmount: 5,
+    // verifierMode intentionally absent
+  };
+  const session = {
+    sessionId: "n1",
+    wallet: WALLET,
+    jobId: job.id,
+    status: "resolved",
+    updatedAt: "2026-05-08T10:00:00Z",
+    verification: { outcome: "approved", reasonCode: "OK" },
+  };
+  const profile = buildAgentProfile({
+    wallet: WALLET,
+    reputation: { skill: 50, reliability: 50, economic: 50, tier: "starter" },
+    sessions: [session],
+    getJobDefinition: makeGetJob(new Map([[job.id, job]])),
+  });
+  assert.equal(profile.badges.length, 1);
+  assert.ok(!("verification" in profile.badges[0]));
+});

--- a/site/agent.js
+++ b/site/agent.js
@@ -320,6 +320,124 @@ function renderTrailSummary(profile) {
   renderMergeTime(badges);
 }
 
+/* ---------------------------------------------------------------- */
+/* One-click verification — spec §10 PR B. Each badge card carries  */
+/* a "Verify receipt" disclosure exposing the source URL, on-chain  */
+/* hash, verifier verdict timestamp, verifier address, and Subscan  */
+/* deeplinks so the receipt is auditable in two clicks.             */
+/* Subscan URLs from Polkadot docs MCP:                              */
+/*   - mainnet: https://assethub-polkadot.subscan.io                 */
+/*   - testnet: https://assethub-paseo.subscan.io                    */
+/* ---------------------------------------------------------------- */
+
+const SUBSCAN_BASE_URL = "https://assethub-polkadot.subscan.io";
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function shortHash(value, head = 8, tail = 6) {
+  if (!value) return "—";
+  const s = String(value);
+  if (s.length <= head + tail + 3) return s;
+  return `${s.slice(0, head)}…${s.slice(-tail)}`;
+}
+
+function subscanAddressUrl(address) {
+  return `${SUBSCAN_BASE_URL}/account/${encodeURIComponent(address)}`;
+}
+
+function subscanExtrinsicSearchUrl(hash) {
+  // For arbitrary bytes32 hashes (chainJobId / evidenceHash) the
+  // canonical search endpoint accepts the value as a query and
+  // resolves to the matching block / extrinsic / event when it
+  // exists on-chain.
+  return `${SUBSCAN_BASE_URL}/search?q=${encodeURIComponent(hash)}`;
+}
+
+function verifySourceLabel(kind) {
+  switch (kind) {
+    case "wikipedia_article": return "Wikipedia revision";
+    case "github_issue": return "GitHub issue";
+    case "osv_advisory": return "OSV advisory";
+    case "open_data_dataset": return "Data.gov resource";
+    case "openapi_spec": return "OpenAPI spec";
+    case "standards_spec": return "Standards spec";
+    default: return "Source";
+  }
+}
+
+function renderVerifyPanel(badge) {
+  const v = badge.verification;
+  if (!v) {
+    return '<p class="profile-empty verify-empty">No verification details yet for this badge.</p>';
+  }
+  const rows = [];
+  if (v.sourceUrl) {
+    rows.push(`
+      <div class="verify-row">
+        <span class="verify-label">${escapeHtml(verifySourceLabel(v.sourceKind))}</span>
+        <a class="verify-link" href="${escapeHtml(v.sourceUrl)}" target="_blank" rel="noreferrer">Open upstream ↗</a>
+      </div>
+    `);
+  }
+  if (badge.completedAt) {
+    rows.push(`
+      <div class="verify-row">
+        <span class="verify-label">Verifier verdict</span>
+        <span class="verify-value" title="${escapeHtml(badge.completedAt)}">${escapeHtml(formatIso(badge.completedAt))}</span>
+      </div>
+    `);
+  }
+  if (v.verifierMode) {
+    rows.push(`
+      <div class="verify-row">
+        <span class="verify-label">Mode</span>
+        <code class="verify-value">${escapeHtml(v.verifierMode)}</code>
+      </div>
+    `);
+  }
+  if (v.verifier) {
+    rows.push(`
+      <div class="verify-row">
+        <span class="verify-label">Verifier wallet</span>
+        <a class="verify-link" href="${escapeHtml(subscanAddressUrl(v.verifier))}" target="_blank" rel="noreferrer">
+          <code>${escapeHtml(shortHash(v.verifier, 6, 4))}</code> ↗
+        </a>
+      </div>
+    `);
+  }
+  if (v.chainJobId) {
+    rows.push(`
+      <div class="verify-row">
+        <span class="verify-label">On-chain job</span>
+        <a class="verify-link" href="${escapeHtml(subscanExtrinsicSearchUrl(v.chainJobId))}" target="_blank" rel="noreferrer">
+          <code>${escapeHtml(shortHash(v.chainJobId))}</code> ↗
+        </a>
+      </div>
+    `);
+  }
+  if (v.evidenceHash) {
+    rows.push(`
+      <div class="verify-row">
+        <span class="verify-label">Evidence hash</span>
+        <a class="verify-link" href="${escapeHtml(subscanExtrinsicSearchUrl(v.evidenceHash))}" target="_blank" rel="noreferrer">
+          <code>${escapeHtml(shortHash(v.evidenceHash))}</code> ↗
+        </a>
+      </div>
+    `);
+  }
+  if (rows.length === 0) {
+    return '<p class="profile-empty verify-empty">No verification details yet for this badge.</p>';
+  }
+  return `<div class="verify-rows">${rows.join("")}</div>`;
+}
+
 function renderBadges(badges = []) {
   const root = byId("profile-badges");
   if (!root) return;
@@ -328,20 +446,26 @@ function renderBadges(badges = []) {
     return;
   }
 
-  root.innerHTML = badges.map((badge) => `
+  root.innerHTML = badges
+    .map((badge) => `
     <article class="badge-card">
       <p class="eyebrow">Badge</p>
-      <h3>${badge.jobId}</h3>
+      <h3>${escapeHtml(badge.jobId)}</h3>
       <div class="badge-meta">
-        <span>${badge.category} · level ${badge.level}</span>
-        <span>${formatAmountFromBase(badge.reward)}</span>
-        <span>${formatIso(badge.completedAt)}</span>
+        <span>${escapeHtml(badge.category)} · level ${escapeHtml(badge.level)}</span>
+        <span>${escapeHtml(formatAmountFromBase(badge.reward))}</span>
+        <span>${escapeHtml(formatIso(badge.completedAt))}</span>
       </div>
+      <details class="verify-disclosure">
+        <summary>Verify receipt</summary>
+        ${renderVerifyPanel(badge)}
+      </details>
       <div class="link-row">
-        <a class="button-ghost" href="${badge.badgeUrl ?? "#"}" target="_blank" rel="noreferrer">Open badge JSON</a>
+        <a class="button-ghost" href="${escapeHtml(badge.badgeUrl ?? "#")}" target="_blank" rel="noreferrer">Open badge JSON</a>
       </div>
     </article>
-  `).join("");
+  `)
+    .join("");
 }
 
 async function bootProfile() {

--- a/site/styles.css
+++ b/site/styles.css
@@ -1188,3 +1188,94 @@ code {
 .trail-streak-tier.tier-badge    { background: #f1e4d4; color: #a0691f; }
 .trail-streak-tier.tier-waiver   { background: #d8e4f1; color: #254e9a; }
 
+/* Verify receipt disclosure on each badge card (spec §10 PR B) ----- */
+
+.verify-disclosure {
+  margin-top: 0.65rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--line);
+  border-radius: 0.6rem;
+  background: rgba(255, 253, 247, 0.6);
+}
+
+.verify-disclosure summary {
+  cursor: pointer;
+  font-family: var(--display);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent);
+  list-style: none;
+}
+
+.verify-disclosure summary::-webkit-details-marker {
+  display: none;
+}
+
+.verify-disclosure summary::after {
+  content: "▾";
+  display: inline-block;
+  margin-left: 0.4rem;
+  transition: transform 180ms ease;
+  color: var(--muted);
+}
+
+.verify-disclosure[open] summary::after {
+  transform: rotate(180deg);
+}
+
+.verify-rows {
+  display: grid;
+  gap: 0.35rem;
+  margin-top: 0.55rem;
+}
+
+.verify-row {
+  display: grid;
+  grid-template-columns: minmax(7rem, max-content) minmax(0, 1fr);
+  align-items: baseline;
+  gap: 0.65rem;
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
+.verify-label {
+  font-family: var(--display);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.verify-value {
+  font-family: "JetBrains Mono", "Space Grotesk", monospace;
+  font-size: 0.78rem;
+  color: var(--ink);
+  letter-spacing: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.verify-link {
+  font-family: "JetBrains Mono", "Space Grotesk", monospace;
+  font-size: 0.78rem;
+  color: var(--accent);
+  text-decoration: none;
+  letter-spacing: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.verify-link:hover {
+  text-decoration: underline;
+}
+
+.verify-empty {
+  margin-top: 0.55rem;
+  font-size: 0.78rem;
+}
+


### PR DESCRIPTION
PR B of the §10 reputation-deepening series. Each badge card on \`averray.com/agent/<wallet>\` now carries a \"Verify receipt\" disclosure that surfaces the five fields the spec calls out — original source URL, verifier verdict timestamp, verifier wallet, on-chain job hash, evidence hash — with deeplinks straight to the upstream PR / Wikipedia revision and to Polkadot Hub Subscan.

## Backend
- \`/agents/<wallet>.badges[]\` entries now carry an optional \`verification\` block: \`{ chainJobId, evidenceHash, verifier, verifierMode, sourceUrl, sourceKind }\`.
- Source URL is picked per source kind so the link always lands on the most useful upstream — Wikipedia prefers the **pinned revision URL** (reproducible) over the article URL; OSV/OpenData/OpenAPI/Standards each have their own preference order.
- Every field is optional; the whole block is dropped when nothing is computable so older sessions render an honest \"no verification details yet\" state on the frontend.
- Three new tests in \`agent-profile.test.js\` (per-source-kind URL picking, Wikipedia revision preference, no-data-omits-block). All 11 pass.

## Frontend
- \`<details class=\"verify-disclosure\">\` per badge card with a \"Verify receipt\" summary. Closed by default to keep the badge grid scannable.
- One row per available field with the right deeplink:
  - Source → opens the upstream PR / pinned revision / dataset
  - Verifier wallet → Subscan address page
  - On-chain job + Evidence hash → Subscan search by hash
- All user-supplied strings escaped before interpolation; hashes truncated with \`shortHash\` for layout, full value on \`href\`/\`title\` so deeplinks resolve correctly and operators can copy from the tooltip.

## Polkadot MCP confirmation
Subscan URLs (\`assethub-polkadot.subscan.io\` for mainnet, \`assethub-paseo.subscan.io\` for testnet) taken from the Polkadot docs MCP \`smart-contracts/explorers.md\` page. Single constant in agent.js so a testnet flip is one-line later.

## Test plan
- [x] \`node --test mcp-server/src/core/agent-profile.test.js\` — 11 / 11 pass
- [x] \`npm --workspace mcp-server test\` — 382 / 386 pass (4 chronic env-dependent failures unchanged from main: gateway, xcm-message-builder, http-config, strategies-config)
- [x] \`npm run build:site\`
- [ ] After deploy: load \`https://averray.com/agent/<wallet>\` for a wallet with approved badges. Each badge card shows a \"Verify receipt\" disclosure; expanding it lists the available fields, each with a deeplink that opens upstream / Subscan in a new tab.