### PR TITLE
Redeploy backend after bootstrap env update

### DIFF
--- a/scripts/ops/deploy-production.sh
+++ b/scripts/ops/deploy-production.sh
@@ -37,6 +37,7 @@ BACKEND_ENV_FILE=${BACKEND_ENV_FILE:-"$STACK_ROOT/backend.env"}
 
 SITE_BUILD_RUNNER=${SITE_BUILD_RUNNER:-auto}
 SITE_NODE_IMAGE=${SITE_NODE_IMAGE:-node:22-bookworm-slim}
+BOOTSTRAP_INSTRUMENTATION_ENV_UPDATED=0
 
 require_command() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -187,6 +188,17 @@ configure_bootstrap_instrumentation_env() {
     "BOOTSTRAP_SELF_REPORT_SUBJECT_PREFIX=Averray bootstrap self-report" \
     "RESEND_API_KEY=$RESEND_API_KEY" \
     "RESEND_API_BASE_URL=https://api.resend.com"
+  BOOTSTRAP_INSTRUMENTATION_ENV_UPDATED=1
+}
+
+backend_env_requires_deploy() {
+  if [[ "$BOOTSTRAP_INSTRUMENTATION_ENV_UPDATED" != "1" ]]; then
+    return 1
+  fi
+  case "$RUN_BACKEND" in
+    0|false|no) return 1 ;;
+    *) return 0 ;;
+  esac
 }
 
 component_changed_matches() {
@@ -411,7 +423,7 @@ deploy() {
   local run_site=0
   local run_caddy=0
 
-  if should_run backend "$RUN_BACKEND" '^(mcp-server/|sdk/|examples/|docs/schemas/|package(-lock)?\.json|scripts/ops/redeploy-backend\.sh)'; then
+  if backend_env_requires_deploy || should_run backend "$RUN_BACKEND" '^(mcp-server/|sdk/|examples/|docs/schemas/|package(-lock)?\.json|scripts/ops/redeploy-backend\.sh)'; then
     run_backend=1
     echo "Deploying backend"
     SKIP_GIT_UPDATE=1 PRE_DEPLOY_SHA="$OLD_SHA" "$APP_ROOT/scripts/ops/redeploy-backend.sh"

--- a/scripts/ops/deploy-production.test.mjs
+++ b/scripts/ops/deploy-production.test.mjs
@@ -124,6 +124,7 @@ test("deploy wrapper writes bootstrap instrumentation backend env when secrets a
   const stackRoot = join(root, "stack");
   const fakeBin = join(root, "bin");
   const stateDir = join(root, "state");
+  const deployLog = join(root, "deploy.log");
   const backendEnv = join(stackRoot, "backend.env");
 
   await mkdir(join(appRoot, "scripts/ops"), { recursive: true });
@@ -133,6 +134,11 @@ test("deploy wrapper writes bootstrap instrumentation backend env when secrets a
   await writeFile(backendEnv, "KEEP_ME=1\nBOOTSTRAP_SELF_REPORT_ENABLED=false\nRESEND_API_KEY=\"old\"\n");
   await copyFile(DEPLOY_SCRIPT, join(appRoot, "scripts/ops/deploy-production.sh"));
   await chmod(join(appRoot, "scripts/ops/deploy-production.sh"), 0o755);
+  await writeExecutable(join(appRoot, "scripts/ops/redeploy-backend.sh"), [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    "echo backend >> \"$DEPLOY_LOG\""
+  ].join("\n"));
 
   for (const command of ["docker", "curl", "npm", "flock"]) {
     await writeExecutable(join(fakeBin, command), "#!/usr/bin/env bash\nexit 0\n");
@@ -155,11 +161,11 @@ test("deploy wrapper writes bootstrap instrumentation backend env when secrets a
     DEPLOY_STATE_DIR: stateDir,
     DEPLOY_OLD_SHA: baseSha,
     DEPLOY_NEW_SHA: baseSha,
+    DEPLOY_LOG: deployLog,
     RESEND_API_KEY: "secret",
     BOOTSTRAP_SELF_REPORT_TO: "ops@example.com",
     BOOTSTRAP_SELF_REPORT_FROM: "ops@averray.com",
     BOOTSTRAP_SELF_REPORT_SEND_ON_START: "1",
-    RUN_BACKEND: "0",
     RUN_FRONTEND: "0",
     RUN_INDEXER: "0",
     RUN_SITE: "0",
@@ -177,6 +183,7 @@ test("deploy wrapper writes bootstrap instrumentation backend env when secrets a
   assert.match(contents, /^BOOTSTRAP_SELF_REPORT_FROM="ops@averray\.com"$/m);
   assert.match(contents, /^RESEND_API_KEY="secret"$/m);
   assert.equal((contents.match(/^RESEND_API_KEY=/gm) ?? []).length, 1);
+  assert.match(await readFile(deployLog, "utf8"), /^backend$/m);
 });
 
 async function writeExecutable(path, content) {


### PR DESCRIPTION
## What changed
- Treat bootstrap instrumentation env writes as a backend redeploy trigger.
- Preserve explicit RUN_BACKEND=0 for manual recovery cases.
- Extend the ops regression test to prove backend redeploy happens after bootstrap env update.

## Checks
- bash -n scripts/ops/deploy-production.sh
- npm run test:ops
- git diff --check HEAD~1..HEAD

## Impact
- Affects production deploy orchestration only.
- No frontend, indexer, contracts, or public site runtime code changes.
- Follow-up after merge: production deploy should restart backend with the already configured bootstrap self-report env.