### PR TITLE
Publish launch trust docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ This repository contains a greenfield implementation of an agent-first treasury 
 - A shared service layer exposed through HTTP and directory-safe MCP discovery
 - Discovery and indexing scaffolds for later hosted deployment
 
+Launch posture and trust documents:
+
+- [Production readiness checklist](docs/PRODUCTION_CHECKLIST.md)
+- [Threat model](docs/THREAT_MODEL.md)
+- [No token statement](docs/NO_TOKEN.md)
+- [Week-12 bootstrap gate](docs/WEEK12_GATE.md)
+- [Arbitration migration](docs/ARBITRATION_MIGRATION.md)
+- [Dispute reason-code registry](docs/DISPUTE_CODES.md)
+
 The `mcp-server` workspace currently uses a JavaScript runtime source tree. There is no parallel TypeScript build step to maintain.
 
 ## Development setup
@@ -351,7 +360,7 @@ contract instances should be treated as superseded and redeployed with the
 updated deploy script before expecting hosted behavior to match this repository.
 
 Threat-model anchors for these trust surfaces live in
-[THREAT_MODEL.md](/Users/pascalkuriger/repo/Polkadot/THREAT_MODEL.md).
+[docs/THREAT_MODEL.md](docs/THREAT_MODEL.md).
 
 ## VPS operations
 

--- a/docs/ARBITRATION_MIGRATION.md
+++ b/docs/ARBITRATION_MIGRATION.md
@@ -1,0 +1,75 @@
+# Arbitration Migration
+
+Averray starts with human arbitration and only migrates toward agent arbitration
+when the dispute data supports it.
+
+## Phase 0: Human Arbitrator
+
+Launch posture:
+
+- one approved human arbitrator
+- verifier rejection opens the dispute path
+- arbitrator calls the dispute verdict path
+- `EscrowCore.autoResolveOnTimeout(jobId)` protects workers if the arbitrator
+  SLA is missed
+
+Phase 0 is the correct launch state because the platform needs real dispute
+examples before automating judgment.
+
+## Phase 1: Human-In-The-Loop Review
+
+Trigger:
+
+- roughly 50 resolved disputes, or enough comparable disputes to measure
+  consistency honestly
+
+Scope:
+
+- LLM or rules-based pre-analysis may summarize evidence for the human
+  arbitrator
+- the human arbitrator remains accountable for the final decision
+- override rate becomes the calibration metric
+
+Exit criteria:
+
+- low override rate across repeated dispute categories
+- clear reason-code distribution
+- documented examples for common verdict classes
+
+## Phase 2: Tiered Agent Quorum
+
+Trigger:
+
+- roughly 250 resolved disputes
+- sustained low override rate from Phase 1
+- a sufficiently deep agent reputation pool
+
+Expected contract changes:
+
+- arbitrator-agent stake bond
+- conflict-of-interest registry
+- deterministic selection from an eligible pool
+- N-of-M quorum signing on dispute resolution
+- harsher penalties for overturned arbitration
+
+Phase 2 should not ship as a narrative milestone. It ships only when the data
+shows agent arbitration can be safer than a single human bottleneck.
+
+## Phase 3: Permissionless Eligibility
+
+Trigger:
+
+- stable Phase 2 outcomes
+- clear eligibility rules that do not require private operator judgment
+
+Scope:
+
+- self-registration through on-chain criteria
+- human escalation reserved for highest-risk or ambiguous cases
+
+## Non-Goals
+
+- no LLM-only arbitration at launch
+- no reputation transfer to qualify arbitrators
+- no hidden private criteria for arbitration eligibility
+- no migration date promised before the dispute data exists

--- a/docs/AVERRAY_WORKING_SPEC.md
+++ b/docs/AVERRAY_WORKING_SPEC.md
@@ -742,11 +742,11 @@ Before public v1.0.0-rc1 launch:
 - [ ] Owner, pauser, verifier, arbitrator addresses final and copied to private deploy env
 
 **Documentation:**
-- [ ] `THREAT_MODEL.md` published
-- [ ] No-token statement linked in README and docs root
-- [ ] Week-12 gate thresholds and diagnostic order documented internally
-- [ ] Reason-code registry published (in `docs/DISPUTE_CODES.md` or equivalent)
-- [ ] Phase-0 → Phase-1 → Phase-2 arbitration migration triggers documented publicly
+- [x] `THREAT_MODEL.md` published
+- [x] No-token statement linked in README and docs root
+- [x] Week-12 gate thresholds and diagnostic order documented internally
+- [x] Reason-code registry published (in `docs/DISPUTE_CODES.md` or equivalent)
+- [x] Phase-0 → Phase-1 → Phase-2 arbitration migration triggers documented publicly
 
 **Dispute flow (Phase 0 launch):**
 - [ ] `setArbitrator(pascalAddr, true)` called from multisig — single approved arbitrator at launch

--- a/docs/NO_TOKEN.md
+++ b/docs/NO_TOKEN.md
@@ -1,0 +1,36 @@
+# No Token Statement
+
+Averray is a blockchain product, not a token product.
+
+There is no Averray token, no airdrop, no points program, and no planned
+governance token. The platform is designed to earn fees from useful work and to
+publish verifiable receipts for that work. Reputation is non-transferable and
+anchored to the wallet that earned it.
+
+## What Exists
+
+- escrow-backed jobs
+- wallet-bound worker identity
+- on-chain commitments and lifecycle events
+- non-transferable reputation receipts
+- public discovery metadata
+- fee-funded platform operations
+
+## What Does Not Exist
+
+- a platform token
+- transferable reputation
+- token-gated access
+- a speculative points system
+- an airdrop plan
+
+## Why This Matters
+
+The product promise is trust infrastructure for software agents. Transferable
+or speculative reputation would weaken that promise by allowing history to be
+bought, sold, or laundered. Averray's receipts are useful because they remain
+attached to the wallet that actually did the work.
+
+If a future integration needs governance, incentives, or settlement assets, it
+must use explicit existing assets or contracts. It must not imply an Averray
+token.

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -9,6 +9,8 @@ service. It complements:
 - [VPS_RUNBOOK.md](../VPS_RUNBOOK.md) for day-to-day hosting operations
 - [MULTISIG_SETUP.md](./MULTISIG_SETUP.md) for owner/pauser control-plane setup
 - [AUDIT_PACKAGE.md](./AUDIT_PACKAGE.md) for external review scope and sign-off
+- [THREAT_MODEL.md](./THREAT_MODEL.md) for the current launch threat model
+- [NO_TOKEN.md](./NO_TOKEN.md) for the public no-token statement
 
 If this checklist is not green, the answer is "not ready yet".
 
@@ -150,7 +152,17 @@ RUN_SUBSCAN_XCM_VALIDATION=1 ./scripts/ops/check-release-readiness.sh testnet
 
 ---
 
-## 6. Product proof before production claims
+## 6. Launch Documentation
+
+- [x] [THREAT_MODEL.md](./THREAT_MODEL.md) is published.
+- [x] [NO_TOKEN.md](./NO_TOKEN.md) is linked from the repo root.
+- [x] [WEEK12_GATE.md](./WEEK12_GATE.md) documents the week-12 gate thresholds and diagnostic order.
+- [x] [DISPUTE_CODES.md](./DISPUTE_CODES.md) publishes the reason-code registry.
+- [x] [ARBITRATION_MIGRATION.md](./ARBITRATION_MIGRATION.md) documents Phase 0 -> Phase 1 -> Phase 2 triggers.
+
+---
+
+## 7. Product proof before production claims
 
 - [ ] One complete worker loop has been run on the hosted stack:
   discover -> sign in -> preflight -> claim -> submit -> verify -> badge/profile
@@ -161,7 +173,7 @@ If any of these drift, external agents will learn the wrong contract.
 
 ---
 
-## 7. Mainnet parameter package
+## 8. Mainnet parameter package
 
 - [ ] [MAINNET_PARAMETERS.md](./MAINNET_PARAMETERS.md) is still the intended launch profile.
 - [ ] The private mainnet deploy env matches [deployments/mainnet.env.example](../deployments/mainnet.env.example) except for secrets and final addresses.
@@ -170,7 +182,7 @@ If any of these drift, external agents will learn the wrong contract.
 
 ---
 
-## 8. Mainnet blockers that still remain
+## 9. Mainnet blockers that still remain
 
 This checklist improves release discipline, but it does not replace:
 
@@ -184,7 +196,7 @@ irreversible real-funds infrastructure.
 
 ---
 
-## 9. Internal async XCM staging proof
+## 10. Internal async XCM staging proof
 
 - [ ] One async deposit request has been queued and settled on the hosted stack.
 - [ ] One async withdraw request has been queued and settled on the hosted stack.
@@ -207,7 +219,7 @@ The manual flow for creating the request itself lives in
 
 ---
 
-## 10. Optional external observer validation
+## 11. Optional external observer validation
 
 - [ ] A staging Subscan key has been exercised against the current
   `subscan_xcm` source adapter.
@@ -232,7 +244,7 @@ npm run validate:subscan-xcm -- --require-published
 
 ---
 
-## 11. Native observer gate
+## 12. Native observer gate
 
 - [ ] [NATIVE_XCM_OBSERVER.md](./NATIVE_XCM_OBSERVER.md) has a completed
   correlation decision for deposit and withdrawal requests.

--- a/docs/RC1_WORKING_SPEC.md
+++ b/docs/RC1_WORKING_SPEC.md
@@ -591,11 +591,11 @@ Before public v1.0.0-rc1 launch:
 - [ ] Owner, pauser, verifier, arbitrator addresses final and copied to private deploy env
 
 **Documentation:**
-- [ ] `THREAT_MODEL.md` published
-- [ ] No-token statement linked in README and docs root
-- [ ] Week-12 gate thresholds and diagnostic order documented internally
-- [ ] Reason-code registry published (in `docs/DISPUTE_CODES.md` or equivalent)
-- [ ] Phase-0 → Phase-1 → Phase-2 arbitration migration triggers documented publicly
+- [x] `THREAT_MODEL.md` published
+- [x] No-token statement linked in README and docs root
+- [x] Week-12 gate thresholds and diagnostic order documented internally
+- [x] Reason-code registry published (in `docs/DISPUTE_CODES.md` or equivalent)
+- [x] Phase-0 → Phase-1 → Phase-2 arbitration migration triggers documented publicly
 
 **Dispute flow (Phase 0 launch):**
 - [ ] `setArbitrator(pascalAddr, true)` called from multisig — single approved arbitrator at launch

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -1,0 +1,176 @@
+# Threat Model
+
+This document records the launch threat model for Averray's v1 control plane.
+It is intentionally operational: each entry names the trust boundary, the
+current mitigation, and the follow-up that would reduce the risk further.
+
+## Scope
+
+In scope:
+
+- hosted API, operator app, indexer, and discovery manifest
+- Hub TestNet contract control plane
+- verifier, arbitrator, pauser, and owner roles
+- funded-job receipts, disclosure windows, and recovery storage
+- bootstrap job sourcing and upstream-status instrumentation
+
+Out of scope:
+
+- mainnet real-funds strategy operations before a separate mainnet launch review
+- v2 arbitration quorum mechanics
+- future Proof of Personhood integration before primary documentation exists
+
+## Threats
+
+### Verifier Key Compromise
+
+Risk: a compromised verifier can approve or reject submissions dishonestly.
+
+Current mitigation:
+
+- verifier authorization is on-chain
+- verifier authorization history includes `wasAuthorizedAt`, so later audits can
+  identify which receipts were signed inside a compromised window
+- high-value or subjective jobs remain out of v1 launch scope
+
+Follow-up:
+
+- publish a concrete verifier key-rotation cadence
+- alert on verdict-volume and verdict-outcome anomalies
+- require multiple verifiers for higher-value jobs in a later contract version
+
+### Platform Signer Compromise
+
+Risk: the signer that publishes discovery manifests or mutates platform-owned
+configuration could publish stale or hostile metadata.
+
+Current mitigation:
+
+- `DiscoveryRegistry` stores the canonical manifest hash on-chain
+- the GitHub workflow only publishes when the served manifest hash differs
+- owner authority has moved toward the 2-of-3 multisig flow documented in
+  [MULTISIG_SETUP.md](./MULTISIG_SETUP.md)
+
+Follow-up:
+
+- keep signer duties separated from hot operational wallets
+- finish the recovery playbook dry run for lost-key scenarios
+- require multisig review for any mainnet-adjacent owner mutation
+
+### Pauser Compromise
+
+Risk: a compromised pauser can freeze the system.
+
+Current mitigation:
+
+- the pauser role only freezes or unfreezes; it cannot move funds
+- recovery is an owner or multisig rotation of the pauser
+
+Follow-up:
+
+- rehearse pause and unpause from the pauser key
+- add alerting around pause-state changes
+
+### Disclosure Window Abuse
+
+Risk: failed attempts remain private during the disclosure window, which could
+hide low-quality behavior for too long.
+
+Current mitigation:
+
+- on-chain lifecycle events still count the failure path
+- delayed content visibility is resolved at read time, not by mutating records
+- recovery storage is append-only and content-addressed
+
+Follow-up:
+
+- expose aggregate delayed-disclosure counts without revealing protected content
+- run a periodic disclosure-window audit before launch claims
+
+### Maintainer-Side Reputation Poisoning
+
+Risk: a hostile or overloaded upstream maintainer can mass-close jobs and
+damage worker reputation unfairly.
+
+Current mitigation:
+
+- repository caps bound exposure to any single maintainer surface
+- denylist policy removes unsuitable repos
+- week-12 reporting focuses on upstream merge rate rather than raw claim volume
+
+Follow-up:
+
+- monitor close reasons weekly
+- keep security, standards, and hostile-maintainer surfaces denylisted by default
+
+### Native XCM Observer Correlation Gap
+
+Risk: async XCM settlement could be credited to the wrong request if return-leg
+correlation is ambiguous.
+
+Current mitigation:
+
+- HTTP allocation routes accept intent, not raw caller-provided XCM bytes
+- backend-generated messages append `SetTopic(requestId)`
+- `XcmWrapper.queueRequest` validates SetTopic on queued payloads
+
+Follow-up:
+
+- run the Chopsticks/Bifrost preservation experiment
+- if SetTopic is not preserved, choose and document the serialized-lane or
+  amount-perturbation fallback before production-volume strategies
+
+### Async XCM Input Surface
+
+Risk: if callers could submit arbitrary XCM bytes, the wrapper would queue
+messages outside platform policy.
+
+Current mitigation:
+
+- the live HTTP API is intent-based for allocate/deallocate
+- backend policy assembles the message
+- admin-only observation/finalization routes are idempotency guarded
+
+Follow-up:
+
+- keep raw-byte XCM interfaces out of public routes
+- expand canonical request-hash receipts to every future settlement mutation
+
+### USDC Issuer Dependency
+
+Risk: v1 USDC escrow inherits issuer and regulatory risks, including freeze
+events, depeg events, and blacklisting.
+
+Current mitigation:
+
+- launch parameters are explicit about USDC asset address and decimals
+- supported assets metadata is published through the platform discovery surface
+- USDC is treated as a v1 settlement choice, not a platform token
+
+Follow-up:
+
+- review legal and operational exposure before meaningful mainnet volume
+- keep multi-asset settlement as a later mitigation
+
+### Authentication Token Exposure
+
+Risk: browser JWTs or API keys copied into chat, logs, or issue comments can be
+used until expiry or revocation.
+
+Current mitigation:
+
+- JWTs expire and can be revoked through logout
+- production auth is strict SIWE JWT auth
+- secrets are stored in GitHub Actions secrets, not committed to the repo
+
+Follow-up:
+
+- rotate any API key or token pasted into shared chat
+- add operator docs that distinguish signing secrets from bearer JWTs
+
+## Launch Posture
+
+Averray is production-like on testnet once the hosted smoke checks, discovery
+publish flow, and bootstrap instrumentation are green. It is not mainnet-ready
+until mainnet parameters, audit sign-off, incident ownership, and async XCM
+staging evidence are complete.

--- a/docs/WEEK12_GATE.md
+++ b/docs/WEEK12_GATE.md
@@ -1,0 +1,62 @@
+# Week-12 Gate
+
+The week-12 gate decides whether the bootstrap program is producing real
+upstream outcomes.
+
+## Primary Metric
+
+The primary metric is:
+
+```text
+upstream merge rate on Averray-funded jobs
+```
+
+This is intentionally not raw claim count, receipt count, wallet count, or app
+traffic. The bootstrap program only works if funded jobs turn into accepted
+upstream work.
+
+## Measurement Window
+
+Use the trailing 12 weeks from the first week with funded jobs live and
+pollable.
+
+The weekly bootstrap self-report should include:
+
+- total funded jobs
+- final jobs
+- successful jobs
+- merge rate
+- total reserved
+- confirmed payout
+- total receipts
+- top three close reasons
+
+## Status Bands
+
+| Merge rate | Status | Action |
+|---:|---|---|
+| `>= 50%` | Healthy | Continue bootstrap budget. Tune job sourcing slowly. |
+| `30% - 49%` | Marginal | Freeze budget increases. Diagnose sourcing, agent instructions, verifier policy, and repo quality. |
+| `< 30%` | Failing | Pause new bootstrap expansion. Narrow job sources until merge rate recovers. |
+
+## Diagnostic Order
+
+When the metric is marginal or failing, investigate in this order:
+
+1. Job source quality: are repos active, maintainers responsive, and issues small enough?
+2. Agent instructions: are job definitions clear and schema-native?
+3. Evidence quality: do submissions include reviewable PRs or proposal-only evidence?
+4. Verifier policy: are rejections consistent with published rules?
+5. Economics: are reward, stake, and claim fee values producing good operator behavior?
+
+## Required Instrumentation
+
+Before calling the gate meaningful, the hosted stack must have:
+
+- funded-job records written on claim and enriched on submit/verify
+- daily upstream-status polling for GitHub and MediaWiki evidence
+- weekly bootstrap self-report generation
+- operator visibility into the latest poller and self-report status
+
+If the instrumentation is missing, the gate is not failed; it is not yet
+measurable.


### PR DESCRIPTION
## Summary
- add launch threat model, no-token statement, week-12 gate, and arbitration migration docs
- link trust docs from README and the production checklist
- mark the documentation checklist items complete in the working specs

## Checks
- git diff --check
- staged docs file/link existence check
- Polkadot docs MCP search for Asset Hub/revive/XCM surfaces

## Impact
- Docs only: README and docs/spec files.
- No backend, frontend, indexer, Caddy, contracts, or public site runtime changes.
- No environment or VPS secret changes required.