### PR TITLE
Add hosted product proof worker loop

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -87,6 +87,14 @@ on:
         options:
           - "0"
           - "1"
+      product_proof_require_worker_loop:
+        description: Run one real hosted worker loop, write evidence, and require it in the product-proof gate.
+        required: false
+        default: "0"
+        type: choice
+        options:
+          - "0"
+          - "1"
 
 concurrency:
   group: production
@@ -122,6 +130,7 @@ jobs:
       DEPLOY_SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION: ${{ github.event_name == 'workflow_dispatch' && inputs.smoke_check_bootstrap_instrumentation || '0' }}
       DEPLOY_SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT: ${{ github.event_name == 'workflow_dispatch' && inputs.smoke_check_bootstrap_self_report_sent || '0' }}
       DEPLOY_SMOKE_CHECK_PRODUCT_PROOF_GATE: ${{ github.event_name == 'workflow_dispatch' && inputs.smoke_check_product_proof_gate || '0' }}
+      DEPLOY_PRODUCT_PROOF_REQUIRE_WORKER_LOOP: ${{ github.event_name == 'workflow_dispatch' && inputs.product_proof_require_worker_loop || '0' }}
     steps:
       - name: Validate required secrets
         run: |
@@ -143,7 +152,7 @@ jobs:
       - name: Deploy production
         run: |
           remote_env=$(
-            printf 'APP_BASIC_AUTH_USER=%q APP_BASIC_AUTH_PASSWORD=%q APP_BASIC_AUTH_PASSWORD_HASH=%q APP_ALLOW_PROTECTED_SHELL=%q ADMIN_JWT=%q RESEND_API_KEY=%q BOOTSTRAP_SELF_REPORT_TO=%q BOOTSTRAP_SELF_REPORT_FROM=%q BOOTSTRAP_SELF_REPORT_SEND_ON_START=%q RUN_INDEXER=%q WAIT_FOR_READY=%q HEALTH_STABILITY_SEC=%q INDEXER_LOG_TAIL=%q SMOKE_CHECK_INDEXER=%q SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION=%q SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT=%q SMOKE_CHECK_PRODUCT_PROOF_GATE=%q INDEXER_DATABASE_SCHEMA=%q INDEXER_FRESH_SCHEMA=%q ' \
+            printf 'APP_BASIC_AUTH_USER=%q APP_BASIC_AUTH_PASSWORD=%q APP_BASIC_AUTH_PASSWORD_HASH=%q APP_ALLOW_PROTECTED_SHELL=%q ADMIN_JWT=%q RESEND_API_KEY=%q BOOTSTRAP_SELF_REPORT_TO=%q BOOTSTRAP_SELF_REPORT_FROM=%q BOOTSTRAP_SELF_REPORT_SEND_ON_START=%q RUN_INDEXER=%q WAIT_FOR_READY=%q HEALTH_STABILITY_SEC=%q INDEXER_LOG_TAIL=%q SMOKE_CHECK_INDEXER=%q SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION=%q SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT=%q SMOKE_CHECK_PRODUCT_PROOF_GATE=%q PRODUCT_PROOF_REQUIRE_WORKER_LOOP=%q INDEXER_DATABASE_SCHEMA=%q INDEXER_FRESH_SCHEMA=%q ' \
               "$APP_BASIC_AUTH_USER" \
               "$APP_BASIC_AUTH_PASSWORD" \
               "$APP_BASIC_AUTH_PASSWORD_HASH" \
@@ -161,6 +170,7 @@ jobs:
               "$DEPLOY_SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION" \
               "$DEPLOY_SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT" \
               "$DEPLOY_SMOKE_CHECK_PRODUCT_PROOF_GATE" \
+              "$DEPLOY_PRODUCT_PROOF_REQUIRE_WORKER_LOOP" \
               "$DEPLOY_INDEXER_DATABASE_SCHEMA" \
               "$DEPLOY_INDEXER_FRESH_SCHEMA"
           )

--- a/docs/PRODUCT_PROOF_GATE.md
+++ b/docs/PRODUCT_PROOF_GATE.md
@@ -36,6 +36,24 @@ learning one contract from the public site and another from the API host.
 
 ## Worker-Loop Evidence
 
+The deploy workflow can generate this evidence itself when run manually with:
+
+- `smoke_check_product_proof_gate=1`
+- `product_proof_require_worker_loop=1`
+
+That path uses the production `ADMIN_JWT` secret, creates a tiny benchmark job,
+claims it as the token wallet, submits matching evidence, runs the verifier, and
+writes the evidence file before running the required gate. It does not print the
+token.
+
+For a local/manual run, first complete one hosted loop and write evidence:
+
+```bash
+PRODUCT_PROOF_EVIDENCE_FILE=/tmp/product-proof-evidence.json \
+ADMIN_JWT="$ADMIN_TOKEN" \
+npm run product-proof:worker-loop
+```
+
 After a real hosted worker loop completes, write a local evidence file:
 
 ```json

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "sync:discovery-manifest": "node scripts/ops/sync-discovery-manifest.mjs",
     "check:discovery-manifest": "node scripts/ops/sync-discovery-manifest.mjs --check",
     "check:product-proof": "node scripts/ops/check-product-proof-gate.mjs",
+    "product-proof:worker-loop": "node scripts/ops/run-hosted-worker-loop.mjs",
     "dev:app": "npm --workspace averray-app run dev",
     "build:app": "npm --workspace averray-app run build",
     "build:frontend": "NEXT_OUTPUT=export NEXT_PUBLIC_API_BASE_URL=https://api.averray.com npm --workspace averray-app run build && node scripts/sync-operator-frontend.mjs",

--- a/scripts/ops/check-hosted-stack.sh
+++ b/scripts/ops/check-hosted-stack.sh
@@ -18,6 +18,9 @@ CHECK_INDEXER=${CHECK_INDEXER:-1}
 CHECK_BOOTSTRAP_INSTRUMENTATION=${CHECK_BOOTSTRAP_INSTRUMENTATION:-0}
 CHECK_BOOTSTRAP_SELF_REPORT_SENT=${CHECK_BOOTSTRAP_SELF_REPORT_SENT:-0}
 CHECK_PRODUCT_PROOF_GATE=${CHECK_PRODUCT_PROOF_GATE:-0}
+PRODUCT_PROOF_NODE_IMAGE=${PRODUCT_PROOF_NODE_IMAGE:-node:22-bookworm-slim}
+PRODUCT_PROOF_EVIDENCE_FILE=${PRODUCT_PROOF_EVIDENCE_FILE:-}
+PRODUCT_PROOF_REQUIRE_WORKER_LOOP=${PRODUCT_PROOF_REQUIRE_WORKER_LOOP:-0}
 TIMEOUT_SEC=${TIMEOUT_SEC:-20}
 APP_BASIC_AUTH_USER=${APP_BASIC_AUTH_USER:-}
 APP_BASIC_AUTH_PASSWORD=${APP_BASIC_AUTH_PASSWORD:-}
@@ -36,9 +39,6 @@ require_command() {
 
 require_command curl
 require_command jq
-case "$CHECK_PRODUCT_PROOF_GATE" in
-  1|true|yes) require_command node ;;
-esac
 
 fetch() {
   local url="$1"
@@ -93,6 +93,10 @@ enabled() {
     *) return 1 ;;
   esac
 }
+
+if enabled "$CHECK_PRODUCT_PROOF_GATE" && ! command -v node >/dev/null 2>&1; then
+  require_command docker
+fi
 
 status_allowed() {
   local status="$1"
@@ -228,10 +232,26 @@ fi
 if enabled "$CHECK_PRODUCT_PROOF_GATE"; then
   echo "Checking product-proof gate"
   script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-  PUBLIC_SITE_URL="$PUBLIC_SITE_URL" \
-    PUBLIC_DISCOVERY_URL="$DISCOVERY_URL" \
-    API_BASE_URL="${API_HEALTH_URL%/health}" \
-    node "$script_dir/check-product-proof-gate.mjs"
+  repo_root="$(cd "$script_dir/../.." && pwd)"
+  if command -v node >/dev/null 2>&1; then
+    PUBLIC_SITE_URL="$PUBLIC_SITE_URL" \
+      PUBLIC_DISCOVERY_URL="$DISCOVERY_URL" \
+      API_BASE_URL="${API_HEALTH_URL%/health}" \
+      PRODUCT_PROOF_EVIDENCE_FILE="$PRODUCT_PROOF_EVIDENCE_FILE" \
+      PRODUCT_PROOF_REQUIRE_WORKER_LOOP="$PRODUCT_PROOF_REQUIRE_WORKER_LOOP" \
+      node "$script_dir/check-product-proof-gate.mjs"
+  else
+    docker run --rm \
+      -v "$repo_root:/workspace" \
+      -w /workspace \
+      -e PUBLIC_SITE_URL="$PUBLIC_SITE_URL" \
+      -e PUBLIC_DISCOVERY_URL="$DISCOVERY_URL" \
+      -e API_BASE_URL="${API_HEALTH_URL%/health}" \
+      -e PRODUCT_PROOF_EVIDENCE_FILE="$PRODUCT_PROOF_EVIDENCE_FILE" \
+      -e PRODUCT_PROOF_REQUIRE_WORKER_LOOP="$PRODUCT_PROOF_REQUIRE_WORKER_LOOP" \
+      "$PRODUCT_PROOF_NODE_IMAGE" \
+      node scripts/ops/check-product-proof-gate.mjs
+  fi
 fi
 
 echo "Hosted stack smoke check passed."

--- a/scripts/ops/deploy-production.sh
+++ b/scripts/ops/deploy-production.sh
@@ -31,6 +31,9 @@ SMOKE_CHECK_INDEXER=${SMOKE_CHECK_INDEXER:-auto}
 SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION=${SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION:-0}
 SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT=${SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT:-0}
 SMOKE_CHECK_PRODUCT_PROOF_GATE=${SMOKE_CHECK_PRODUCT_PROOF_GATE:-0}
+PRODUCT_PROOF_REQUIRE_WORKER_LOOP=${PRODUCT_PROOF_REQUIRE_WORKER_LOOP:-0}
+PRODUCT_PROOF_EVIDENCE_FILE=${PRODUCT_PROOF_EVIDENCE_FILE:-"$STACK_ROOT/product-proof-worker-loop-evidence.json"}
+PRODUCT_PROOF_NODE_IMAGE=${PRODUCT_PROOF_NODE_IMAGE:-node:22-bookworm-slim}
 INDEXER_DATABASE_SCHEMA=${INDEXER_DATABASE_SCHEMA:-}
 INDEXER_FRESH_SCHEMA=${INDEXER_FRESH_SCHEMA:-0}
 INDEXER_ENV_FILE=${INDEXER_ENV_FILE:-"$STACK_ROOT/indexer.env"}
@@ -290,6 +293,51 @@ build_site() {
     sh -lc "npm ci && npm run build:site"
 }
 
+run_node_script() {
+  local script="$1"
+  shift
+
+  if command -v node >/dev/null 2>&1; then
+    node "$script" "$@"
+    return
+  fi
+
+  local relative_script="${script#$APP_ROOT/}"
+  docker run --rm \
+    -v "$APP_ROOT:/workspace" \
+    -w /workspace \
+    -e API_BASE_URL="${API_BASE_URL:-https://api.averray.com}" \
+    -e ADMIN_JWT="${ADMIN_JWT:-}" \
+    -e AVERRAY_TOKEN="${AVERRAY_TOKEN:-}" \
+    -e PRODUCT_PROOF_WORKER_TOKEN="${PRODUCT_PROOF_WORKER_TOKEN:-}" \
+    -e PRODUCT_PROOF_EVIDENCE_FILE="$PRODUCT_PROOF_EVIDENCE_FILE" \
+    -e PRODUCT_PROOF_JOB_ID="${PRODUCT_PROOF_JOB_ID:-}" \
+    -e PRODUCT_PROOF_IDEMPOTENCY_KEY="${PRODUCT_PROOF_IDEMPOTENCY_KEY:-}" \
+    -e PRODUCT_PROOF_SUBMISSION="${PRODUCT_PROOF_SUBMISSION:-}" \
+    "$PRODUCT_PROOF_NODE_IMAGE" \
+    node "$relative_script" "$@"
+}
+
+run_product_proof_worker_loop() {
+  case "$PRODUCT_PROOF_REQUIRE_WORKER_LOOP" in
+    1|true|yes) ;;
+    0|false|no|"") return 0 ;;
+    *)
+      echo "Invalid PRODUCT_PROOF_REQUIRE_WORKER_LOOP toggle: $PRODUCT_PROOF_REQUIRE_WORKER_LOOP" >&2
+      exit 1
+      ;;
+  esac
+
+  if [[ -z "${PRODUCT_PROOF_WORKER_TOKEN:-}" && -z "${AVERRAY_TOKEN:-}" && -z "${ADMIN_JWT:-}" ]]; then
+    echo "PRODUCT_PROOF_REQUIRE_WORKER_LOOP=1 requires PRODUCT_PROOF_WORKER_TOKEN, AVERRAY_TOKEN, or ADMIN_JWT." >&2
+    exit 1
+  fi
+
+  echo "Running hosted product-proof worker loop"
+  API_BASE_URL="${API_BASE_URL:-https://api.averray.com}" \
+    run_node_script "$APP_ROOT/scripts/ops/run-hosted-worker-loop.mjs"
+}
+
 apply_caddy() {
   if [[ -z "${APP_BASIC_AUTH_USER:-}" ]]; then
     echo "Skipping Caddy render: APP_BASIC_AUTH_USER is not set." >&2
@@ -489,6 +537,10 @@ deploy() {
   fi
 
   if [[ "$RUN_SMOKE" == "1" ]]; then
+    if [[ "$SMOKE_CHECK_PRODUCT_PROOF_GATE" == "1" || "$SMOKE_CHECK_PRODUCT_PROOF_GATE" == "true" || "$SMOKE_CHECK_PRODUCT_PROOF_GATE" == "yes" ]]; then
+      run_product_proof_worker_loop
+    fi
+
     echo "Running hosted stack smoke check"
     local check_indexer
     check_indexer=$(resolve_smoke_check_indexer "$run_indexer" "$run_caddy")
@@ -499,6 +551,9 @@ deploy() {
       CHECK_BOOTSTRAP_INSTRUMENTATION="$SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION" \
       CHECK_BOOTSTRAP_SELF_REPORT_SENT="$SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT" \
       CHECK_PRODUCT_PROOF_GATE="$SMOKE_CHECK_PRODUCT_PROOF_GATE" \
+      PRODUCT_PROOF_REQUIRE_WORKER_LOOP="$PRODUCT_PROOF_REQUIRE_WORKER_LOOP" \
+      PRODUCT_PROOF_EVIDENCE_FILE="$PRODUCT_PROOF_EVIDENCE_FILE" \
+      PRODUCT_PROOF_NODE_IMAGE="$PRODUCT_PROOF_NODE_IMAGE" \
       "$APP_ROOT/scripts/ops/check-hosted-stack.sh"
   else
     echo "RUN_SMOKE=0 set; skipping hosted smoke check."

--- a/scripts/ops/run-hosted-worker-loop.mjs
+++ b/scripts/ops/run-hosted-worker-loop.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import { AgentPlatformClient } from "../../sdk/agent-platform-client.js";
+
+const DEFAULT_API_BASE_URL = "https://api.averray.com";
+
+export async function runHostedWorkerLoop({
+  env = process.env,
+  client = undefined,
+  now = () => Date.now(),
+  log = console.log
+} = {}) {
+  const apiBaseUrl = stripTrailingSlash(env.API_BASE_URL || DEFAULT_API_BASE_URL);
+  const token = env.PRODUCT_PROOF_WORKER_TOKEN || env.AVERRAY_TOKEN || env.ADMIN_JWT;
+  if (!token) {
+    throw new Error("PRODUCT_PROOF_WORKER_TOKEN, AVERRAY_TOKEN, or ADMIN_JWT is required.");
+  }
+
+  const platform = client ?? new AgentPlatformClient({ baseUrl: apiBaseUrl, token });
+  const timestamp = now();
+  const jobId = env.PRODUCT_PROOF_JOB_ID || `product-proof-worker-loop-${timestamp}`;
+  const idempotencyKey = env.PRODUCT_PROOF_IDEMPOTENCY_KEY || `product-proof:${jobId}`;
+  const evidence = env.PRODUCT_PROOF_SUBMISSION || `complete verified output for ${jobId}`;
+
+  const authSession = await platform.getAuthSession();
+  const wallet = authSession?.wallet;
+  if (!wallet) {
+    throw new Error("/auth/session did not return a wallet for the worker token.");
+  }
+
+  log(`Creating hosted product-proof job ${jobId}`);
+  const created = await platform.createJob({
+    id: jobId,
+    category: "coding",
+    tier: "starter",
+    rewardAmount: 1,
+    verifierMode: "benchmark",
+    verifierTerms: ["complete", "verified", "output"],
+    verifierMinimumMatches: 2,
+    requiresSponsoredGas: true,
+    claimTtlSeconds: 3600,
+    retryLimit: 1,
+    outputSchemaRef: "schema://jobs/product-proof-worker-loop"
+  });
+  if (created?.id !== jobId) {
+    throw new Error(`created job id mismatch: expected ${jobId}, got ${created?.id ?? "missing"}`);
+  }
+
+  log(`Claiming hosted product-proof job ${jobId}`);
+  const claim = await platform.claimJob(jobId, idempotencyKey);
+  const sessionId = claim?.sessionId;
+  if (!sessionId) {
+    throw new Error("claim response did not include sessionId.");
+  }
+
+  log(`Submitting hosted product-proof session ${sessionId}`);
+  const submit = await platform.submitWork(sessionId, evidence);
+  if (submit?.status !== "submitted") {
+    throw new Error(`expected submitted status, got ${submit?.status ?? "missing"}`);
+  }
+
+  log(`Verifying hosted product-proof session ${sessionId}`);
+  const verification = await platform.runVerifier(sessionId, evidence);
+  if (verification?.outcome !== "approved") {
+    throw new Error(`expected approved verifier outcome, got ${verification?.outcome ?? "missing"}`);
+  }
+
+  const session = await platform.getSession(sessionId);
+  if (session?.status !== "resolved") {
+    throw new Error(`expected resolved session, got ${session?.status ?? "missing"}`);
+  }
+
+  const badgeUrl = `${apiBaseUrl}/badges/${encodeURIComponent(sessionId)}`;
+  const profileUrl = `${apiBaseUrl}/agents/${encodeURIComponent(wallet)}`;
+  const [badge, profile] = await Promise.all([
+    platform.getAgentBadge(sessionId),
+    platform.getAgentProfile(wallet)
+  ]);
+
+  if (badge?.averray?.sessionId !== sessionId || badge?.averray?.jobId !== jobId) {
+    throw new Error("badge did not reference the product-proof session and job.");
+  }
+  if (!Array.isArray(profile?.badges) || !profile.badges.some((entry) => entry.sessionId === sessionId && entry.jobId === jobId)) {
+    throw new Error("agent profile did not include the product-proof badge.");
+  }
+
+  const evidenceDoc = {
+    apiBaseUrl,
+    wallet,
+    jobId,
+    sessionId,
+    badgeUrl,
+    profileUrl,
+    verificationOutcome: verification.outcome,
+    verificationReasonCode: verification.reasonCode ?? null,
+    sessionStatus: session.status,
+    completedAt: new Date(timestamp).toISOString()
+  };
+
+  if (env.PRODUCT_PROOF_EVIDENCE_FILE) {
+    await mkdir(dirname(env.PRODUCT_PROOF_EVIDENCE_FILE), { recursive: true });
+    await writeFile(env.PRODUCT_PROOF_EVIDENCE_FILE, `${JSON.stringify(evidenceDoc, null, 2)}\n`);
+    log(`Wrote product-proof evidence to ${env.PRODUCT_PROOF_EVIDENCE_FILE}`);
+  }
+
+  return evidenceDoc;
+}
+
+function stripTrailingSlash(value) {
+  return String(value).replace(/\/+$/u, "");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runHostedWorkerLoop()
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2));
+    })
+    .catch((error) => {
+      console.error(error.message);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/ops/run-hosted-worker-loop.test.mjs
+++ b/scripts/ops/run-hosted-worker-loop.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import test from "node:test";
+
+import { runHostedWorkerLoop } from "./run-hosted-worker-loop.mjs";
+
+test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidence", async () => {
+  const calls = [];
+  const wallet = "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519";
+  const sessionId = "session-product-proof";
+  const jobId = "product-proof-worker-loop-1700000000000";
+  const tmp = await mkdtemp(join(tmpdir(), "product-proof-"));
+  const evidenceFile = join(tmp, "evidence.json");
+  const client = {
+    async getAuthSession() {
+      calls.push(["getAuthSession"]);
+      return { wallet };
+    },
+    async createJob(payload) {
+      calls.push(["createJob", payload]);
+      return { id: payload.id };
+    },
+    async claimJob(id, idempotencyKey) {
+      calls.push(["claimJob", id, idempotencyKey]);
+      return { status: "claimed", sessionId };
+    },
+    async submitWork(id, evidence) {
+      calls.push(["submitWork", id, evidence]);
+      return { status: "submitted", sessionId: id };
+    },
+    async runVerifier(id, evidence) {
+      calls.push(["runVerifier", id, evidence]);
+      return { outcome: "approved", reasonCode: "BENCHMARK_THRESHOLD_MET" };
+    },
+    async getSession(id) {
+      calls.push(["getSession", id]);
+      return { status: "resolved", sessionId: id };
+    },
+    async getAgentBadge(id) {
+      calls.push(["getAgentBadge", id]);
+      return { averray: { sessionId: id, jobId } };
+    },
+    async getAgentProfile(profileWallet) {
+      calls.push(["getAgentProfile", profileWallet]);
+      return { wallet: profileWallet.toLowerCase(), badges: [{ sessionId, jobId }] };
+    }
+  };
+
+  const result = await runHostedWorkerLoop({
+    client,
+    now: () => 1700000000000,
+    log: () => {},
+    env: {
+      API_BASE_URL: "https://api.example.test/",
+      ADMIN_JWT: "token",
+      PRODUCT_PROOF_EVIDENCE_FILE: evidenceFile
+    }
+  });
+
+  assert.equal(result.jobId, jobId);
+  assert.equal(result.sessionId, sessionId);
+  assert.equal(result.wallet, wallet);
+  assert.equal(result.badgeUrl, `https://api.example.test/badges/${sessionId}`);
+  assert.equal(result.profileUrl, `https://api.example.test/agents/${wallet}`);
+  assert.deepEqual(calls.map(([name]) => name), [
+    "getAuthSession",
+    "createJob",
+    "claimJob",
+    "submitWork",
+    "runVerifier",
+    "getSession",
+    "getAgentBadge",
+    "getAgentProfile"
+  ]);
+  assert.equal(calls[1][1].verifierMode, "benchmark");
+  assert.equal(calls[2][2], `product-proof:${jobId}`);
+
+  const written = JSON.parse(await readFile(evidenceFile, "utf8"));
+  assert.equal(written.jobId, jobId);
+  assert.equal(written.sessionId, sessionId);
+  assert.equal(written.verificationOutcome, "approved");
+});
+
+test("runHostedWorkerLoop fails closed without a token", async () => {
+  await assert.rejects(
+    runHostedWorkerLoop({ env: {}, log: () => {} }),
+    /PRODUCT_PROOF_WORKER_TOKEN, AVERRAY_TOKEN, or ADMIN_JWT is required/u
+  );
+});


### PR DESCRIPTION
## What changed
- Add a hosted product-proof worker-loop runner that creates a tiny benchmark job, claims it, submits evidence, runs verifier, and writes gate evidence JSON.
- Allow hosted stack product-proof checks to run through Docker when host node is unavailable on the VPS smoke-only path.
- Add a manual deploy workflow input to require a real worker loop before the product-proof gate passes.

## Checks
- npm run test:ops
- npm run check:product-proof
- bash -n scripts/ops/check-hosted-stack.sh
- bash -n scripts/ops/deploy-production.sh

## Impact
- Deployment workflow / ops scripts only.
- Uses existing ADMIN_JWT/AVERRAY_TOKEN/PRODUCT_PROOF_WORKER_TOKEN; no new secret required.