### PR TITLE
Dispute history on public agent profile (spec §3 + §10)

### DIFF
--- a/mcp-server/src/core/agent-profile.js
+++ b/mcp-server/src/core/agent-profile.js
@@ -4,6 +4,11 @@ import {
   DEFAULT_ESCROW_ASSET_SYMBOL,
   decimalsForAssetSymbol
 } from "./assets.js";
+import {
+  ARBITRATOR_SLA_SECONDS,
+  addSecondsIso,
+  disputeIdForSession,
+} from "./dispute-resolution.js";
 
 /**
  * Build a v1 agent profile document from in-memory platform state.
@@ -28,7 +33,23 @@ import {
  */
 export const AGENT_PROFILE_SCHEMA_VERSION = "v1";
 
-export function buildAgentProfile({ wallet, reputation, sessions, getJobDefinition, publicBaseUrl, fetchedAt }) {
+export function buildAgentProfile({
+  wallet,
+  reputation,
+  sessions,
+  getJobDefinition,
+  publicBaseUrl,
+  fetchedAt,
+  // Optional dispute-receipt lookup. The HTTP layer pre-fetches
+  // `dispute_verdict` + `dispute_release` mutation receipts for every
+  // session that's flagged as disputed (status === "disputed" or
+  // disputedAt set), then passes a sync `(sessionId) → { verdict?,
+  // release? } | undefined` so this builder can emit the
+  // `disputes[]` block + dispute counts on the profile without
+  // reaching into the store itself. Callers that don't need
+  // dispute history can omit it.
+  getDisputeReceipts,
+} = {}) {
   requireAddress(wallet, "wallet");
   const normalizedWallet = wallet.toLowerCase();
   const rep = normaliseReputation(reputation);
@@ -122,6 +143,34 @@ export function buildAgentProfile({ wallet, reputation, sessions, getJobDefiniti
   const totalTerminal = approved.length + rejected.length;
   const completionRate = totalTerminal === 0 ? null : approved.length / totalTerminal;
 
+  // Dispute history. Walks every session (not just approved /
+  // rejected) so we surface in-flight disputes too. Sessions are
+  // candidates for the disputes[] list when:
+  //   - status === "disputed" (active dispute), or
+  //   - they have any kind of dispute receipt registered against
+  //     them (resolved or stake-released)
+  // Sessions that are merely rejected without a contest don't
+  // become disputes; the spec treats arbitration as the
+  // contested-rejection path.
+  const disputes = buildDisputeHistory(
+    safeSessions,
+    definitionOf,
+    typeof getDisputeReceipts === "function" ? getDisputeReceipts : () => undefined
+  );
+  const disputeOutcomes = disputes.reduce(
+    (acc, dispute) => {
+      acc.total += 1;
+      if (dispute.status === "open") acc.open += 1;
+      else if (dispute.verdict === "upheld") acc.lost += 1;
+      else if (dispute.verdict === "dismissed") acc.won += 1;
+      else if (dispute.verdict === "split") acc.split += 1;
+      else if (dispute.verdict === "timeout") acc.timeout += 1;
+      else acc.resolved += 1;
+      return acc;
+    },
+    { total: 0, open: 0, lost: 0, won: 0, split: 0, timeout: 0, resolved: 0 }
+  );
+
   return {
     schemaVersion: AGENT_PROFILE_SCHEMA_VERSION,
     wallet: normalizedWallet,
@@ -140,11 +189,13 @@ export function buildAgentProfile({ wallet, reputation, sessions, getJobDefiniti
       githubSignals,
       activeSince: activeSinceMs ? new Date(activeSinceMs).toISOString() : null,
       lastActive: lastActiveMs ? new Date(lastActiveMs).toISOString() : null,
-      preferredCategories
+      preferredCategories,
+      disputes: disputeOutcomes,
     },
     ...(currentActivity ? { currentActivity } : {}),
     categoryLevels,
-    badges
+    badges,
+    disputes,
   };
 }
 
@@ -344,4 +395,80 @@ function stringOrUndefined(value) {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Walk session history and emit a slim dispute record per session
+ * that's either currently disputed or has a verdict / release
+ * receipt against it. Newest-first, capped at 25 entries to keep
+ * the public profile payload bounded — the frontend's "Open full
+ * dispute log" link routes to /disputes for the unbounded view.
+ */
+function buildDisputeHistory(sessions, definitionOf, getDisputeReceipts) {
+  if (!Array.isArray(sessions) || sessions.length === 0) return [];
+  const candidates = [];
+  for (const session of sessions) {
+    if (!session || typeof session !== "object") continue;
+    const status = String(session.status ?? "").toLowerCase();
+    const receipts = getDisputeReceipts(session.sessionId) ?? {};
+    const verdictReceipt = receipts.verdict ?? receipts.verdictReceipt;
+    const releaseReceipt = receipts.release ?? receipts.releaseReceipt;
+    const hasDisputeMarker =
+      status === "disputed" ||
+      Boolean(session.disputedAt) ||
+      Boolean(verdictReceipt) ||
+      Boolean(releaseReceipt);
+    if (!hasDisputeMarker) continue;
+    candidates.push(buildProfileDispute(session, definitionOf, verdictReceipt, releaseReceipt));
+  }
+  candidates.sort((a, b) => Date.parse(b.openedAt) - Date.parse(a.openedAt));
+  return candidates.slice(0, 25);
+}
+
+/**
+ * Slim dispute record for the public profile. Mirrors the shape
+ * `/disputes/<id>` returns but trimmed to the fields a profile
+ * reader cares about — id, sessionId, jobId, status, openedAt,
+ * windowEndsAt, verdict, reasonCode, workerPayout, txHash. Heavy
+ * fields (full evidence blob, signed receipt body) live behind
+ * `/disputes/<id>` and require auth.
+ */
+function buildProfileDispute(session, definitionOf, verdictReceipt, releaseReceipt) {
+  const sessionId = String(session.sessionId ?? "");
+  const id = sessionId ? disputeIdForSession(sessionId) : undefined;
+  const openedAt = stringOrUndefined(session.disputedAt)
+    ?? stringOrUndefined(session.updatedAt)
+    ?? new Date().toISOString();
+  const windowEndsAt = addSecondsIso(openedAt, ARBITRATOR_SLA_SECONDS) ?? openedAt;
+  const status = verdictReceipt || releaseReceipt ? "resolved" : "open";
+  const job = (() => {
+    try {
+      return definitionOf(session.jobId);
+    } catch {
+      return undefined;
+    }
+  })();
+  const verdict = stringOrUndefined(verdictReceipt?.verdict);
+  const reasonCode = stringOrUndefined(verdictReceipt?.reasonCode);
+  const workerPayout = verdictReceipt?.workerPayout;
+  const txHash = stringOrUndefined(verdictReceipt?.txHash);
+  return {
+    ...(id ? { id } : {}),
+    sessionId,
+    jobId: stringOrUndefined(session.jobId) ?? "unknown-job",
+    ...(stringOrUndefined(job?.title) ? { jobTitle: job.title } : {}),
+    status,
+    openedAt,
+    windowEndsAt,
+    slaSeconds: ARBITRATOR_SLA_SECONDS,
+    ...(verdict ? { verdict } : {}),
+    ...(reasonCode ? { reasonCode } : {}),
+    ...(workerPayout !== undefined && workerPayout !== null
+      ? { workerPayout: String(workerPayout) }
+      : {}),
+    ...(txHash ? { txHash } : {}),
+    ...(stringOrUndefined(releaseReceipt?.releasedAt)
+      ? { releasedAt: releaseReceipt.releasedAt }
+      : {}),
+  };
 }

--- a/mcp-server/src/core/agent-profile.test.js
+++ b/mcp-server/src/core/agent-profile.test.js
@@ -392,3 +392,106 @@ test("buildAgentProfile omits the verification block when nothing is computable"
   assert.equal(profile.badges.length, 1);
   assert.ok(!("verification" in profile.badges[0]));
 });
+
+test("buildAgentProfile surfaces dispute history with verdict outcomes", () => {
+  // Three sessions:
+  //   - one currently disputed with no verdict yet (open)
+  //   - one disputed with an "upheld" verdict (worker lost)
+  //   - one disputed with a "dismissed" verdict (worker won)
+  const sessions = [
+    {
+      sessionId: "s-open",
+      wallet: WALLET,
+      jobId: "starter-coding-001",
+      status: "disputed",
+      disputedAt: "2026-05-08T10:00:00Z",
+      updatedAt: "2026-05-08T10:00:00Z",
+      verification: { outcome: "rejected", reasonCode: "REJECTED" },
+    },
+    {
+      sessionId: "s-lost",
+      wallet: WALLET,
+      jobId: "starter-coding-001",
+      status: "rejected",
+      disputedAt: "2026-04-30T10:00:00Z",
+      updatedAt: "2026-05-02T12:00:00Z",
+      verification: { outcome: "rejected", reasonCode: "DISPUTE_LOST" },
+    },
+    {
+      sessionId: "s-won",
+      wallet: WALLET,
+      jobId: "governance-pro-001",
+      status: "resolved",
+      disputedAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-22T12:00:00Z",
+      verification: { outcome: "approved", reasonCode: "DISPUTE_OVERTURNED" },
+    },
+  ];
+  const receiptsBySession = new Map([
+    ["s-lost", {
+      verdict: { verdict: "upheld", reasonCode: "DISPUTE_LOST", txHash: "0xab" },
+    }],
+    ["s-won", {
+      verdict: { verdict: "dismissed", reasonCode: "DISPUTE_OVERTURNED", workerPayout: "5000000" },
+    }],
+  ]);
+
+  const profile = buildAgentProfile({
+    wallet: WALLET,
+    reputation: { skill: 200, reliability: 200, economic: 200, tier: "pro" },
+    sessions,
+    getJobDefinition: makeGetJob(),
+    getDisputeReceipts: (sessionId) => receiptsBySession.get(sessionId),
+  });
+
+  assert.equal(profile.disputes.length, 3);
+  // Newest-first ordering by openedAt.
+  assert.equal(profile.disputes[0].sessionId, "s-open");
+  assert.equal(profile.disputes[0].status, "open");
+  assert.ok(!("verdict" in profile.disputes[0]));
+  assert.equal(profile.disputes[1].sessionId, "s-lost");
+  assert.equal(profile.disputes[1].status, "resolved");
+  assert.equal(profile.disputes[1].verdict, "upheld");
+  assert.equal(profile.disputes[1].reasonCode, "DISPUTE_LOST");
+  assert.equal(profile.disputes[2].verdict, "dismissed");
+  assert.equal(profile.disputes[2].workerPayout, "5000000");
+
+  // Outcome counts surface on stats.disputes for the strip view.
+  assert.equal(profile.stats.disputes.total, 3);
+  assert.equal(profile.stats.disputes.open, 1);
+  assert.equal(profile.stats.disputes.lost, 1);
+  assert.equal(profile.stats.disputes.won, 1);
+  assert.equal(profile.stats.disputes.split, 0);
+  assert.equal(profile.stats.disputes.timeout, 0);
+
+  // Each dispute carries a stable id derived from the session id.
+  for (const dispute of profile.disputes) {
+    assert.match(dispute.id, /^dispute-[a-f0-9]{12}$/u);
+    assert.equal(typeof dispute.openedAt, "string");
+    assert.equal(typeof dispute.windowEndsAt, "string");
+    assert.equal(dispute.slaSeconds, 14 * 24 * 60 * 60);
+  }
+});
+
+test("buildAgentProfile leaves disputes empty when no contested sessions exist", () => {
+  const sessions = [
+    approvedSession({ jobId: "starter-coding-001", sessionId: "s1", updatedAt: "2026-04-10T10:00:00Z" }),
+    rejectedSession({ jobId: "starter-coding-001", sessionId: "s2", updatedAt: "2026-04-12T10:00:00Z" }),
+  ];
+  const profile = buildAgentProfile({
+    wallet: WALLET,
+    reputation: { skill: 100, reliability: 100, economic: 100, tier: "pro" },
+    sessions,
+    getJobDefinition: makeGetJob(),
+  });
+  assert.deepEqual(profile.disputes, []);
+  assert.deepEqual(profile.stats.disputes, {
+    total: 0,
+    open: 0,
+    lost: 0,
+    won: 0,
+    split: 0,
+    timeout: 0,
+    resolved: 0,
+  });
+});

--- a/mcp-server/src/core/dispute-resolution.js
+++ b/mcp-server/src/core/dispute-resolution.js
@@ -1,6 +1,31 @@
+import { keccak256, toUtf8Bytes } from "ethers";
 import { ValidationError } from "./errors.js";
 
 export const ARBITRATOR_SLA_SECONDS = 14 * 24 * 60 * 60;
+
+/**
+ * Stable id for the dispute associated with a session. Hashed from
+ * the session id so the same dispute id is computed everywhere
+ * (HTTP route, state-store mutation receipts, profile dispute
+ * history). Stays usable as a public identifier without leaking the
+ * raw session id.
+ */
+export function disputeIdForSession(sessionId) {
+  return `dispute-${keccak256(toUtf8Bytes(String(sessionId))).slice(2, 14)}`;
+}
+
+/**
+ * Add a fixed seconds offset to an ISO timestamp, returning the
+ * same ISO format. Used to derive the SLA window end for a dispute
+ * (`openedAt + ARBITRATOR_SLA_SECONDS`). Treats unparseable inputs
+ * as undefined so the caller can render `—` rather than `NaN`.
+ */
+export function addSecondsIso(iso, seconds) {
+  if (typeof iso !== "string") return undefined;
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return undefined;
+  return new Date(t + seconds * 1000).toISOString();
+}
 
 export const DISPUTE_REASON_CODES = Object.freeze({
   upheld: "DISPUTE_LOST",

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -18,7 +18,11 @@ import { getAddress, keccak256, toUtf8Bytes } from "ethers";
 import { buildBadgeFromSession } from "../../core/badge-metadata.js";
 import { buildAgentProfile } from "../../core/agent-profile.js";
 import { buildDiscoveryManifest } from "../../core/discovery-manifest.js";
-import { buildDisputeResolution, ARBITRATOR_SLA_SECONDS } from "../../core/dispute-resolution.js";
+import {
+  ARBITRATOR_SLA_SECONDS,
+  buildDisputeResolution,
+  disputeIdForSession,
+} from "../../core/dispute-resolution.js";
 import {
   assertContentHashMatches,
   buildContentRecord,
@@ -238,6 +242,20 @@ function buildAgentDirectoryRow(profile) {
   const approvedCount = Number(profile.stats?.approvedCount ?? 0);
   const rejectedCount = Number(profile.stats?.rejectedCount ?? 0);
   const totalJobs = approvedCount + rejectedCount;
+  // Slash events are upheld disputes — the verdict went against the
+  // worker. Map straight off the profile's dispute history so the
+  // agents directory exposes the same slashed-state the operator
+  // app rail already gates on.
+  const slashEvents = (profile.disputes ?? [])
+    .filter((dispute) => dispute.verdict === "upheld")
+    .map((dispute) => ({
+      disputeId: dispute.id ?? null,
+      jobId: dispute.jobId,
+      sessionId: dispute.sessionId,
+      reasonCode: dispute.reasonCode ?? null,
+      txHash: dispute.txHash ?? null,
+      at: dispute.openedAt,
+    }));
   return {
     wallet: profile.wallet,
     handle: handleForWallet(profile.wallet),
@@ -251,8 +269,51 @@ function buildAgentDirectoryRow(profile) {
     currentActivity: profile.currentActivity ?? null,
     activeStake: 0,
     badges: profile.badges ?? [],
-    slashEvents: []
+    slashEvents,
   };
+}
+
+/**
+ * For each session in the history, fetch any dispute receipts the
+ * state store carries against it. Builds the sync lookup
+ * `buildAgentProfile` expects via its `getDisputeReceipts` arg so
+ * the profile can emit dispute history without reaching into the
+ * store itself. Skips sessions that aren't dispute candidates
+ * (status !== "disputed" and no disputedAt) so the average wallet
+ * with no contested submissions pays no extra fetches.
+ */
+async function preloadDisputeReceipts(sessions) {
+  if (!Array.isArray(sessions) || sessions.length === 0) {
+    return () => undefined;
+  }
+  const candidates = sessions.filter((session) => {
+    if (!session || typeof session !== "object") return false;
+    const status = String(session.status ?? "").toLowerCase();
+    return status === "disputed" || Boolean(session.disputedAt);
+  });
+  if (candidates.length === 0) return () => undefined;
+  const receiptsBySession = new Map();
+  await Promise.all(
+    candidates.map(async (session) => {
+      const id = disputeIdForSession(session.sessionId);
+      const [verdict, release] = await Promise.all([
+        stateStore.getMutationReceipt?.("dispute_verdict", id),
+        stateStore.getMutationReceipt?.("dispute_release", id),
+      ]);
+      if (verdict || release) {
+        receiptsBySession.set(session.sessionId, {
+          ...(verdict ? { verdict } : {}),
+          ...(release ? { release } : {}),
+        });
+      } else {
+        // Session is in the disputed state but no receipt landed
+        // yet. Still register it so buildAgentProfile picks it up
+        // as an "open" dispute.
+        receiptsBySession.set(session.sessionId, {});
+      }
+    })
+  );
+  return (sessionId) => receiptsBySession.get(sessionId);
 }
 
 async function buildAgentDirectory(limit = 50) {
@@ -264,6 +325,10 @@ async function buildAgentDirectory(limit = 50) {
       service.getReputation(checksummed),
       service.collectSessionHistory(checksummed, { logger })
     ]);
+    // Pre-fetch dispute receipts so directory rows correctly mark
+    // slashed (upheld-verdict) wallets. Skips wallets with no
+    // disputed sessions, so this is free in the common case.
+    const getDisputeReceipts = await preloadDisputeReceipts(history);
     const profile = buildAgentProfile({
       wallet: wallet.toLowerCase(),
       reputation,
@@ -275,7 +340,8 @@ async function buildAgentDirectory(limit = 50) {
           return undefined;
         }
       },
-      publicBaseUrl: process.env.PUBLIC_BASE_URL
+      publicBaseUrl: process.env.PUBLIC_BASE_URL,
+      getDisputeReceipts,
     });
     return buildAgentDirectoryRow(profile);
   }));
@@ -327,10 +393,6 @@ async function listBadgeReceipts(limit = 100) {
     receipts.push(buildBadgeReceipt(badge));
   }
   return receipts;
-}
-
-function disputeIdForSession(sessionId) {
-  return `dispute-${keccak256(toUtf8Bytes(String(sessionId))).slice(2, 14)}`;
 }
 
 function compactObject(value) {
@@ -1625,6 +1687,12 @@ const server = createServer(async (request, response) => {
         service.getReputation(checksummed),
         service.collectSessionHistory(checksummed, { logger: requestLogger })
       ]);
+      // Pre-fetch dispute receipts so the public profile carries
+      // dispute history (status, verdict, reasonCode) without the
+      // frontend needing a separate /disputes call. Free for wallets
+      // with no contested sessions — `preloadDisputeReceipts` short-
+      // circuits when there's nothing to fetch.
+      const getDisputeReceipts = await preloadDisputeReceipts(sessions);
       const profile = buildAgentProfile({
         wallet: rawWallet.toLowerCase(),
         reputation,
@@ -1636,7 +1704,8 @@ const server = createServer(async (request, response) => {
             return undefined;
           }
         },
-        publicBaseUrl: process.env.PUBLIC_BASE_URL
+        publicBaseUrl: process.env.PUBLIC_BASE_URL,
+        getDisputeReceipts,
       });
       return respond(response, 200, profile, { "cache-control": "public, max-age=30" });
     }

--- a/site/agent.html
+++ b/site/agent.html
@@ -199,6 +199,30 @@
             </div>
           </section>
 
+          <!--
+            Dispute history — surfaces every session this wallet had
+            arbitrated, hydrated from `profile.disputes` (slim shape:
+            id, sessionId, jobId, status, openedAt, windowEndsAt,
+            verdict, reasonCode, workerPayout, txHash). Stays empty
+            (with an honest note) until at least one session has been
+            disputed. See AVERRAY_WORKING_SPEC §3 (verifier and
+            arbitrator model) and §10 (reputation deepening).
+          -->
+          <section class="profile-panel">
+            <div class="section-heading">
+              <div>
+                <p class="eyebrow">Dispute history</p>
+                <h2>Arbitration outcomes</h2>
+              </div>
+              <span id="profile-dispute-count" class="profile-summary-source">no disputes yet</span>
+            </div>
+
+            <div id="profile-dispute-outcomes" class="dispute-outcomes" hidden></div>
+            <div id="profile-disputes" class="dispute-list">
+              <p class="profile-empty">No arbitrated sessions on this wallet yet.</p>
+            </div>
+          </section>
+
           <section class="profile-panel">
             <div class="section-heading">
               <div>

--- a/site/agent.js
+++ b/site/agent.js
@@ -321,6 +321,184 @@ function renderTrailSummary(profile) {
 }
 
 /* ---------------------------------------------------------------- */
+/* Dispute history — see AVERRAY_WORKING_SPEC §3 (arbitrator model)  */
+/* and §10 (reputation deepening). Renders the slim disputes[] block */
+/* from the wallet profile JSON: status pill, opened/window-ends     */
+/* timestamps, verdict + reason code, and an on-chain link when the  */
+/* arbitrator's release receipt has a tx hash. Public read; heavy    */
+/* fields (full evidence, signed receipt body) live behind           */
+/* `/disputes/<id>` and require auth.                                 */
+/* ---------------------------------------------------------------- */
+
+const DISPUTE_VERDICT_PILL = {
+  upheld:    { variant: "lost",   label: "Worker lost" },
+  dismissed: { variant: "won",    label: "Worker won" },
+  split:     { variant: "split",  label: "Split award" },
+  timeout:   { variant: "timeout", label: "Arbitrator timeout" },
+};
+
+const DISPUTE_REASON_LABEL = {
+  DISPUTE_LOST:        "Dispute upheld — escrow slashed to treasury",
+  DISPUTE_OVERTURNED:  "Dispute dismissed — escrow returned to depositor",
+  DISPUTE_PARTIAL:     "Split verdict — partial payout to worker",
+  ARB_TIMEOUT:         "Arbitrator SLA elapsed — escrow auto-released",
+};
+
+function disputeStatusPill(dispute) {
+  if (dispute.status === "open") {
+    return { variant: "open", label: "Open" };
+  }
+  const verdict = String(dispute.verdict ?? "").toLowerCase();
+  if (DISPUTE_VERDICT_PILL[verdict]) {
+    return DISPUTE_VERDICT_PILL[verdict];
+  }
+  return { variant: "resolved", label: "Resolved" };
+}
+
+function formatSlaWindow(slaSeconds) {
+  if (!Number.isFinite(slaSeconds) || slaSeconds <= 0) return "—";
+  const days = Math.round(slaSeconds / 86400);
+  return `${days}-day SLA`;
+}
+
+function formatPayoutString(value) {
+  if (value === undefined || value === null || value === "") return "—";
+  const text = String(value);
+  // Heuristic: when the raw integer looks like a base-unit balance
+  // (≥7 digits) we don't try to scale it without decimals metadata —
+  // we render as-is so we never misrepresent the amount.
+  return text;
+}
+
+function renderDisputeRow(dispute) {
+  const pill = disputeStatusPill(dispute);
+  const reasonLine = dispute.reasonCode && DISPUTE_REASON_LABEL[dispute.reasonCode]
+    ? DISPUTE_REASON_LABEL[dispute.reasonCode]
+    : null;
+  const title = dispute.jobTitle ? `${dispute.jobTitle}` : dispute.jobId;
+  const detailRows = [];
+  detailRows.push(`
+    <div class="verify-row">
+      <span class="verify-label">Opened</span>
+      <span class="verify-value" title="${escapeHtml(dispute.openedAt ?? "")}">${escapeHtml(formatIso(dispute.openedAt))}</span>
+    </div>
+  `);
+  if (dispute.windowEndsAt) {
+    detailRows.push(`
+      <div class="verify-row">
+        <span class="verify-label">Window ends</span>
+        <span class="verify-value" title="${escapeHtml(dispute.windowEndsAt)}">${escapeHtml(formatIso(dispute.windowEndsAt))} · ${escapeHtml(formatSlaWindow(dispute.slaSeconds))}</span>
+      </div>
+    `);
+  }
+  if (dispute.verdict) {
+    detailRows.push(`
+      <div class="verify-row">
+        <span class="verify-label">Verdict</span>
+        <span class="verify-value">${escapeHtml(dispute.verdict)}${dispute.reasonCode ? ` · <code>${escapeHtml(dispute.reasonCode)}</code>` : ""}</span>
+      </div>
+    `);
+  }
+  if (dispute.workerPayout !== undefined && dispute.workerPayout !== null && dispute.workerPayout !== "") {
+    detailRows.push(`
+      <div class="verify-row">
+        <span class="verify-label">Worker payout</span>
+        <code class="verify-value">${escapeHtml(formatPayoutString(dispute.workerPayout))}</code>
+      </div>
+    `);
+  }
+  if (dispute.releasedAt) {
+    detailRows.push(`
+      <div class="verify-row">
+        <span class="verify-label">Released</span>
+        <span class="verify-value" title="${escapeHtml(dispute.releasedAt)}">${escapeHtml(formatIso(dispute.releasedAt))}</span>
+      </div>
+    `);
+  }
+  if (dispute.txHash) {
+    detailRows.push(`
+      <div class="verify-row">
+        <span class="verify-label">On-chain receipt</span>
+        <a class="verify-link" href="${escapeHtml(subscanExtrinsicSearchUrl(dispute.txHash))}" target="_blank" rel="noreferrer">
+          <code>${escapeHtml(shortHash(dispute.txHash))}</code> ↗
+        </a>
+      </div>
+    `);
+  }
+
+  return `
+    <article class="dispute-row dispute-row-${escapeHtml(pill.variant)}">
+      <header class="dispute-row-header">
+        <div class="dispute-row-title">
+          <p class="eyebrow">${escapeHtml(dispute.id ?? "dispute")}</p>
+          <h3>${escapeHtml(title)}</h3>
+          <p class="dispute-row-job"><code>${escapeHtml(dispute.jobId)}</code> · session <code>${escapeHtml(dispute.sessionId)}</code></p>
+        </div>
+        <span class="dispute-pill dispute-pill-${escapeHtml(pill.variant)}">${escapeHtml(pill.label)}</span>
+      </header>
+      ${reasonLine ? `<p class="dispute-row-reason">${escapeHtml(reasonLine)}</p>` : ""}
+      <div class="verify-rows dispute-row-rows">${detailRows.join("")}</div>
+    </article>
+  `;
+}
+
+function renderDisputeOutcomes(outcomes, total) {
+  const root = byId("profile-dispute-outcomes");
+  if (!root) return;
+  if (!total || total <= 0) {
+    root.hidden = true;
+    root.innerHTML = "";
+    return;
+  }
+  const cells = [
+    { id: "open",    label: "Open",      count: outcomes.open ?? 0 },
+    { id: "won",     label: "Won",       count: outcomes.won ?? 0 },
+    { id: "lost",    label: "Lost",      count: outcomes.lost ?? 0 },
+    { id: "split",   label: "Split",     count: outcomes.split ?? 0 },
+    { id: "timeout", label: "Timeout",   count: outcomes.timeout ?? 0 },
+  ].filter((cell) => cell.count > 0);
+  if (cells.length === 0) {
+    root.hidden = true;
+    root.innerHTML = "";
+    return;
+  }
+  root.hidden = false;
+  root.innerHTML = cells
+    .map((cell) => `
+      <div class="dispute-outcome dispute-outcome-${escapeHtml(cell.id)}">
+        <span class="dispute-outcome-label">${escapeHtml(cell.label)}</span>
+        <strong class="dispute-outcome-count">${cell.count}</strong>
+      </div>
+    `)
+    .join("");
+}
+
+function renderDisputeHistory(profile) {
+  const root = byId("profile-disputes");
+  const countEl = byId("profile-dispute-count");
+  if (!root) return;
+  const disputes = Array.isArray(profile.disputes) ? profile.disputes : [];
+  const outcomes = profile.stats?.disputes ?? {};
+  const total = Number(outcomes.total ?? disputes.length ?? 0);
+
+  renderDisputeOutcomes(outcomes, total);
+
+  if (countEl) {
+    if (total <= 0) {
+      countEl.textContent = "no disputes yet";
+    } else {
+      countEl.textContent = `${total} arbitrated session${total === 1 ? "" : "s"}`;
+    }
+  }
+
+  if (!disputes.length) {
+    root.innerHTML = '<p class="profile-empty">No arbitrated sessions on this wallet yet.</p>';
+    return;
+  }
+  root.innerHTML = disputes.map((dispute) => renderDisputeRow(dispute)).join("");
+}
+
+/* ---------------------------------------------------------------- */
 /* One-click verification — spec §10 PR B. Each badge card carries  */
 /* a "Verify receipt" disclosure exposing the source URL, on-chain  */
 /* hash, verifier verdict timestamp, verifier address, and Subscan  */
@@ -516,6 +694,7 @@ async function bootProfile() {
         : "No category levels yet."
     );
     renderTrailSummary(profile);
+    renderDisputeHistory(profile);
     renderBadges(profile.badges);
   } catch (error) {
     if (loading) loading.textContent = error?.message ?? "Failed to load profile.";

--- a/site/styles.css
+++ b/site/styles.css
@@ -1279,3 +1279,140 @@ code {
   font-size: 0.78rem;
 }
 
+/* Dispute history (spec §3 + §10) ---------------------------------- */
+
+.dispute-outcomes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin: 0.6rem 0 0.85rem;
+}
+
+.dispute-outcome {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.45rem;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.dispute-outcome-label {
+  font-family: var(--display);
+  font-size: 0.65rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.dispute-outcome-count {
+  font-family: var(--display);
+  font-size: 0.95rem;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  color: var(--ink);
+}
+
+.dispute-outcome-open    { border-color: #d6c2a0; background: #fbf3df; }
+.dispute-outcome-open    .dispute-outcome-count { color: #9a5d1b; }
+.dispute-outcome-won     { border-color: #bcd9c5; background: #e8f3ec; }
+.dispute-outcome-won     .dispute-outcome-count { color: #1d6a46; }
+.dispute-outcome-lost    { border-color: #e7c0bf; background: #fbeae9; }
+.dispute-outcome-lost    .dispute-outcome-count { color: #9a2a26; }
+.dispute-outcome-split   { border-color: #c8d3e7; background: #ecf1fa; }
+.dispute-outcome-split   .dispute-outcome-count { color: #254e9a; }
+.dispute-outcome-timeout { border-color: #d4d2cd; background: #efece5; }
+.dispute-outcome-timeout .dispute-outcome-count { color: #5a544a; }
+
+.dispute-list {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 0.4rem;
+}
+
+.dispute-row {
+  display: grid;
+  gap: 0.55rem;
+  padding: 0.95rem 1rem;
+  border-radius: 0.85rem;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.55);
+}
+
+.dispute-row-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.65rem;
+}
+
+.dispute-row-title {
+  display: grid;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.dispute-row-title .eyebrow {
+  margin: 0;
+}
+
+.dispute-row-title h3 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: -0.005em;
+}
+
+.dispute-row-job {
+  margin: 0;
+  font-size: 0.72rem;
+  color: var(--muted);
+  letter-spacing: 0;
+  word-break: break-all;
+}
+
+.dispute-row-job code {
+  font-size: 0.72rem;
+  padding: 0.05rem 0.3rem;
+}
+
+.dispute-row-reason {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--ink);
+  line-height: 1.5;
+}
+
+.dispute-row-rows {
+  margin-top: 0;
+}
+
+.dispute-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.7rem;
+  border-radius: 999px;
+  font-family: var(--display);
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.dispute-pill-open     { background: #fbf3df; color: #9a5d1b; }
+.dispute-pill-won      { background: #e8f3ec; color: #1d6a46; }
+.dispute-pill-lost     { background: #fbeae9; color: #9a2a26; }
+.dispute-pill-split    { background: #ecf1fa; color: #254e9a; }
+.dispute-pill-timeout  { background: #efece5; color: #5a544a; }
+.dispute-pill-resolved { background: var(--accent-soft); color: var(--accent); }
+
+.dispute-row-open     { border-left: 3px solid #d6a35a; }
+.dispute-row-won      { border-left: 3px solid #3a8c5e; }
+.dispute-row-lost     { border-left: 3px solid #c54a44; }
+.dispute-row-split    { border-left: 3px solid #4a73c2; }
+.dispute-row-timeout  { border-left: 3px solid #8c857a; }
+.dispute-row-resolved { border-left: 3px solid var(--accent); }
+


### PR DESCRIPTION
## Summary
- Surface a slim `disputes[]` block + `stats.disputes` outcome counts on `GET /agents/<wallet>`, populated from the live `dispute_verdict` / `dispute_release` mutation receipts (one async pre-fetch per directory or wallet request, short-circuits when no disputed sessions exist).
- Render an arbitration-outcomes section on the public agent profile page with an outcome strip (open / won / lost / split / timeout), per-dispute rows with status pills, SLA window, verdict + reason code, worker payout, and a Subscan deeplink when the on-chain release tx is known.
- Share `disputeIdForSession` and `addSecondsIso` from `core/dispute-resolution.js` so HTTP routes and the profile builder agree on dispute id derivation; `buildAgentDirectoryRow` now derives `slashEvents` from upheld disputes instead of a hardcoded empty array.

Spec refs: AVERRAY_WORKING_SPEC §3 (verifier and arbitrator model) and §10 (reputation deepening — dispute history surface).

## Test plan
- [x] `npm --workspace mcp-server test` — 384/388 pass (same 4 chronic env-dependent failures as `main`: gateway, xcm-message-builder, http-config, strategies-config)
- [x] `node --check site/agent.js`
- [x] HTML balance check on `site/agent.html`
- [ ] Open `/agents/<wallet>` on a wallet with no disputes — outcome strip hidden, "no disputes yet" copy, empty list note
- [ ] Open `/agents/<wallet>` on a wallet with at least one disputed session — rows render newest-first, verdict pill matches, Subscan link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)