### PR TITLE
Preflight product proof settlement readiness

### DIFF
--- a/mcp-server/src/blockchain/abis.js
+++ b/mcp-server/src/blockchain/abis.js
@@ -98,6 +98,7 @@ export const TREASURY_POLICY_ABI = [
   "function rejectionReliabilityPenalty() view returns (uint256)",
   "function disputeLossSkillPenalty() view returns (uint256)",
   "function disputeLossReliabilityPenalty() view returns (uint256)",
+  "function serviceOperators(address operator) view returns (bool)",
   "function verifiers(address verifier) view returns (bool)",
   "function authorizedSince(address verifier) view returns (uint64)",
   "function authorizedUntil(address verifier) view returns (uint64)",

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -39,6 +39,15 @@ const REQUEST_STATUS_LABELS = ["unknown", "pending", "succeeded", "failed", "can
 const abiCoder = AbiCoder.defaultAbiCoder();
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
+function summarizeSupportedAssets(assets = []) {
+  return assets.map((asset) => ({
+    symbol: asset.symbol,
+    address: asset.address,
+    assetClass: asset.assetClass ?? "custom",
+    decimals: asset.decimals
+  }));
+}
+
 export class BlockchainGateway {
   constructor(config = loadBlockchainConfig()) {
     this.config = config;
@@ -269,14 +278,36 @@ export class BlockchainGateway {
           paused: undefined,
           owner: undefined,
           pauser: undefined,
+          settlementReady: false,
+          contracts: {
+            escrowCoreAddress: this.config.escrowCoreAddress || undefined,
+            agentAccountAddress: this.config.agentAccountAddress || undefined,
+            reputationSbtAddress: this.config.reputationSbtAddress || undefined,
+            supportedAssets: summarizeSupportedAssets(this.config.supportedAssets)
+          },
+          roles: {
+            signerAddress: undefined,
+            signerIsVerifier: false,
+            escrowIsServiceOperator: false
+          },
           risk: {}
         };
       }
 
+      const signerAddress = await this.signer?.getAddress?.();
+      const optionalBool = async (promise, fallback = false) => {
+        try {
+          return Boolean(await promise);
+        } catch {
+          return fallback;
+        }
+      };
       const [
         owner,
         pauser,
         paused,
+        signerIsVerifier,
+        escrowIsServiceOperator,
         dailyOutflowCap,
         perAccountBorrowCap,
         minimumCollateralRatioBps,
@@ -292,6 +323,10 @@ export class BlockchainGateway {
         this.policyContract.owner(),
         this.policyContract.pauser(),
         this.policyContract.paused(),
+        signerAddress ? optionalBool(this.policyContract.verifiers(signerAddress)) : false,
+        this.config.escrowCoreAddress
+          ? optionalBool(this.policyContract.serviceOperators(this.config.escrowCoreAddress))
+          : false,
         this.policyContract.dailyOutflowCap(),
         this.policyContract.perAccountBorrowCap(),
         this.policyContract.minimumCollateralRatioBps(),
@@ -311,6 +346,18 @@ export class BlockchainGateway {
         paused: Boolean(paused),
         owner,
         pauser,
+        settlementReady: Boolean(signerIsVerifier && escrowIsServiceOperator && !paused),
+        contracts: {
+          escrowCoreAddress: this.config.escrowCoreAddress,
+          agentAccountAddress: this.config.agentAccountAddress,
+          reputationSbtAddress: this.config.reputationSbtAddress,
+          supportedAssets: summarizeSupportedAssets(this.config.supportedAssets)
+        },
+        roles: {
+          signerAddress,
+          signerIsVerifier,
+          escrowIsServiceOperator
+        },
         risk: {
           dailyOutflowCap: Number(dailyOutflowCap),
           perAccountBorrowCap: Number(perAccountBorrowCap),

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -178,6 +178,85 @@ test("getClaimEconomicsConfig converts chain min fees back to display units", as
   });
 });
 
+test("getTreasuryPolicyStatus surfaces settlement readiness roles", async () => {
+  const gateway = new BlockchainGateway({
+    enabled: true,
+    rpcUrl: "http://127.0.0.1:8545",
+    signerPrivateKey: `0x${"11".repeat(32)}`,
+    treasuryPolicyAddress: "0x1111111111111111111111111111111111111111",
+    agentAccountAddress: "0x3333333333333333333333333333333333333333",
+    escrowCoreAddress: "0x2222222222222222222222222222222222222222",
+    reputationSbtAddress: "0x4444444444444444444444444444444444444444",
+    supportedAssets: [DOT_ASSET]
+  });
+  const signerAddress = await gateway.signer.getAddress();
+  gateway.policyContract = {
+    async owner() {
+      return "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    },
+    async pauser() {
+      return "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    },
+    async paused() {
+      return false;
+    },
+    async verifiers(address) {
+      assert.equal(address, signerAddress);
+      return true;
+    },
+    async serviceOperators(address) {
+      assert.equal(address, "0x2222222222222222222222222222222222222222");
+      return true;
+    },
+    async dailyOutflowCap() {
+      return 100n;
+    },
+    async perAccountBorrowCap() {
+      return 200n;
+    },
+    async minimumCollateralRatioBps() {
+      return 300n;
+    },
+    async defaultClaimStakeBps() {
+      return 400n;
+    },
+    async claimFeeBps() {
+      return 5n;
+    },
+    async claimFeeVerifierBps() {
+      return 6000n;
+    },
+    async onboardingWaiverClaimCount() {
+      return 7n;
+    },
+    async rejectionSkillPenalty() {
+      return 8n;
+    },
+    async rejectionReliabilityPenalty() {
+      return 9n;
+    },
+    async disputeLossSkillPenalty() {
+      return 10n;
+    },
+    async disputeLossReliabilityPenalty() {
+      return 11n;
+    }
+  };
+
+  const status = await gateway.getTreasuryPolicyStatus();
+
+  assert.equal(status.settlementReady, true);
+  assert.equal(status.roles.signerAddress, signerAddress);
+  assert.equal(status.roles.signerIsVerifier, true);
+  assert.equal(status.roles.escrowIsServiceOperator, true);
+  assert.deepEqual(status.contracts.supportedAssets, [{
+    symbol: "DOT",
+    address: DOT_ASSET.address,
+    assetClass: "custom",
+    decimals: 18
+  }]);
+});
+
 test("previewClaimEconomics returns display values while preserving raw chain amounts", async () => {
   const gateway = gatewayWithDot();
   gateway.escrowContract = {

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -46,6 +46,18 @@ const DEFAULT_TREASURY_POLICY_STATUS = {
   paused: undefined,
   owner: undefined,
   pauser: undefined,
+  settlementReady: false,
+  contracts: {
+    escrowCoreAddress: undefined,
+    agentAccountAddress: undefined,
+    reputationSbtAddress: undefined,
+    supportedAssets: []
+  },
+  roles: {
+    signerAddress: undefined,
+    signerIsVerifier: false,
+    escrowIsServiceOperator: false
+  },
   risk: {}
 };
 

--- a/scripts/ops/run-hosted-worker-loop.mjs
+++ b/scripts/ops/run-hosted-worker-loop.mjs
@@ -32,6 +32,8 @@ export async function runHostedWorkerLoop({
     throw new Error("/auth/session did not return a wallet for the worker token.");
   }
 
+  const settlementReadiness = await assertSettlementReadiness(platform);
+
   log(`Creating hosted product-proof job ${jobId}`);
   const created = await platform.createJob({
     id: jobId,
@@ -98,6 +100,7 @@ export async function runHostedWorkerLoop({
     profileUrl,
     verificationOutcome: verification.outcome,
     verificationReasonCode: verification.reasonCode ?? null,
+    settlementReadiness,
     sessionStatus: session.status,
     completedAt: new Date(timestamp).toISOString()
   };
@@ -124,6 +127,40 @@ function parsePositiveNumber(value, fallback) {
     throw new Error(`PRODUCT_PROOF_REWARD_AMOUNT must be greater than zero; got ${JSON.stringify(value)}.`);
   }
   return parsed;
+}
+
+async function assertSettlementReadiness(platform) {
+  if (typeof platform.getAdminStatus !== "function") {
+    throw new Error("Hosted product-proof worker loop requires /admin/status settlement readiness.");
+  }
+  const status = await platform.getAdminStatus();
+  const policy = status?.maintenance?.policy;
+  if (!policy?.enabled) {
+    throw new Error("Hosted product-proof worker loop requires blockchain policy status to be enabled.");
+  }
+  if (policy.settlementReady !== true) {
+    throw new Error(`Hosted product-proof worker loop requires on-chain settlement readiness; ${formatSettlementReadiness(policy)}`);
+  }
+  return {
+    policyAddress: policy.policyAddress,
+    paused: Boolean(policy.paused),
+    settlementReady: true,
+    roles: {
+      signerAddress: policy.roles?.signerAddress,
+      signerIsVerifier: Boolean(policy.roles?.signerIsVerifier),
+      escrowIsServiceOperator: Boolean(policy.roles?.escrowIsServiceOperator)
+    },
+    contracts: policy.contracts
+  };
+}
+
+function formatSettlementReadiness(policy) {
+  const reasons = [];
+  if (policy?.paused) reasons.push("policyPaused=true");
+  if (!policy?.roles?.signerIsVerifier) reasons.push("signerIsVerifier=false");
+  if (!policy?.roles?.escrowIsServiceOperator) reasons.push("escrowIsServiceOperator=false");
+  if (policy?.error?.message) reasons.push(`policyError=${policy.error.message}`);
+  return reasons.length ? reasons.join(", ") : "settlementReady=false";
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/scripts/ops/run-hosted-worker-loop.test.mjs
+++ b/scripts/ops/run-hosted-worker-loop.test.mjs
@@ -18,6 +18,10 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
       calls.push(["getAuthSession"]);
       return { wallet };
     },
+    async getAdminStatus() {
+      calls.push(["getAdminStatus"]);
+      return settlementReadyStatus();
+    },
     async createJob(payload) {
       calls.push(["createJob", payload]);
       return { id: payload.id };
@@ -66,6 +70,7 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
   assert.equal(result.profileUrl, `https://api.example.test/agents/${wallet}`);
   assert.deepEqual(calls.map(([name]) => name), [
     "getAuthSession",
+    "getAdminStatus",
     "createJob",
     "claimJob",
     "submitWork",
@@ -74,15 +79,16 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
     "getAgentBadge",
     "getAgentProfile"
   ]);
-  assert.equal(calls[1][1].verifierMode, "benchmark");
-  assert.equal(calls[1][1].rewardAsset, "DOT");
-  assert.equal(calls[1][1].rewardAmount, 0.000001);
-  assert.equal(calls[2][2], `product-proof:${jobId}`);
+  assert.equal(calls[2][1].verifierMode, "benchmark");
+  assert.equal(calls[2][1].rewardAsset, "DOT");
+  assert.equal(calls[2][1].rewardAmount, 0.000001);
+  assert.equal(calls[3][2], `product-proof:${jobId}`);
 
   const written = JSON.parse(await readFile(evidenceFile, "utf8"));
   assert.equal(written.jobId, jobId);
   assert.equal(written.sessionId, sessionId);
   assert.equal(written.verificationOutcome, "approved");
+  assert.equal(written.settlementReadiness.settlementReady, true);
 });
 
 test("runHostedWorkerLoop fails closed without a token", async () => {
@@ -97,6 +103,9 @@ test("runHostedWorkerLoop accepts an explicit positive reward amount", async () 
   const client = {
     async getAuthSession() {
       return { wallet: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519" };
+    },
+    async getAdminStatus() {
+      return settlementReadyStatus();
     },
     async createJob(payload) {
       calls.push(["createJob", payload]);
@@ -135,6 +144,41 @@ test("runHostedWorkerLoop accepts an explicit positive reward amount", async () 
   assert.equal(calls[0][1].rewardAmount, 0.01);
 });
 
+test("runHostedWorkerLoop fails closed before mutation when settlement is not ready", async () => {
+  const calls = [];
+  await assert.rejects(
+    runHostedWorkerLoop({
+      client: {
+        async getAuthSession() {
+          calls.push(["getAuthSession"]);
+          return { wallet: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519" };
+        },
+        async getAdminStatus() {
+          calls.push(["getAdminStatus"]);
+          return settlementReadyStatus({
+            settlementReady: false,
+            roles: {
+              signerAddress: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+              signerIsVerifier: false,
+              escrowIsServiceOperator: true
+            }
+          });
+        },
+        async createJob() {
+          calls.push(["createJob"]);
+          throw new Error("should not mutate when settlement is not ready");
+        }
+      },
+      now: () => 1700000000000,
+      log: () => {},
+      env: { ADMIN_JWT: "token" }
+    }),
+    /signerIsVerifier=false/u
+  );
+
+  assert.deepEqual(calls.map(([name]) => name), ["getAuthSession", "getAdminStatus"]);
+});
+
 test("runHostedWorkerLoop rejects invalid reward amounts", async () => {
   await assert.rejects(
     runHostedWorkerLoop({
@@ -149,3 +193,47 @@ test("runHostedWorkerLoop rejects invalid reward amounts", async () => {
     /PRODUCT_PROOF_REWARD_AMOUNT must be greater than zero/u
   );
 });
+
+function settlementReadyStatus(overrides = {}) {
+  const base = {
+    maintenance: {
+      policy: {
+        enabled: true,
+        policyAddress: "0x1111111111111111111111111111111111111111",
+        paused: false,
+        settlementReady: true,
+        roles: {
+          signerAddress: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+          signerIsVerifier: true,
+          escrowIsServiceOperator: true
+        },
+        contracts: {
+          escrowCoreAddress: "0x2222222222222222222222222222222222222222",
+          agentAccountAddress: "0x3333333333333333333333333333333333333333",
+          reputationSbtAddress: "0x4444444444444444444444444444444444444444",
+          supportedAssets: [{ symbol: "DOT", address: "0x5555555555555555555555555555555555555555" }]
+        }
+      }
+    }
+  };
+
+  return {
+    ...base,
+    maintenance: {
+      ...base.maintenance,
+      ...(overrides.maintenance ?? {}),
+      policy: {
+        ...base.maintenance.policy,
+        ...(overrides.maintenance?.policy ?? overrides),
+        roles: {
+          ...base.maintenance.policy.roles,
+          ...((overrides.maintenance?.policy ?? overrides).roles ?? {})
+        },
+        contracts: {
+          ...base.maintenance.policy.contracts,
+          ...((overrides.maintenance?.policy ?? overrides).contracts ?? {})
+        }
+      }
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- expose TreasuryPolicy settlement readiness roles in admin status
- fail the hosted product-proof worker loop before create/claim/submit when on-chain settlement wiring is not ready
- include settlement readiness in product-proof evidence when the loop succeeds

## Checks
- node --test scripts/ops/run-hosted-worker-loop.test.mjs
- node --test mcp-server/src/blockchain/gateway.test.js
- npm --workspace mcp-server test
- bash -n scripts/ops/deploy-production.sh

## Impact
- Backend/admin status and hosted smoke scripts only
- No frontend, indexer, Caddy, contracts, or public-site changes
- No environment changes required