### PR TITLE
Decouple product proof evidence gate

### DIFF
--- a/scripts/ops/check-product-proof-gate.mjs
+++ b/scripts/ops/check-product-proof-gate.mjs
@@ -83,14 +83,14 @@ export async function checkProductProofGate({
   const sample = await fetchJson(fetchImpl, `${apiBaseUrl}/schemas/jobs/${sampleSchema}.json`);
   assert.equal(sample.$id, sampleRef);
 
-  if (evidenceFile) {
+  if (requireWorkerLoop && evidenceFile) {
     log(`Checking hosted worker-loop evidence: ${evidenceFile}`);
     const evidence = JSON.parse(await readFile(evidenceFile, "utf8"));
     await checkWorkerLoopEvidence(fetchImpl, evidence, { apiBaseUrl });
   } else if (requireWorkerLoop) {
     throw new Error("PRODUCT_PROOF_REQUIRE_WORKER_LOOP=1 requires PRODUCT_PROOF_EVIDENCE_FILE.");
   } else {
-    log("Worker-loop evidence file not provided; skipping mutation-loop evidence check.");
+    log("Worker-loop evidence is not required; skipping mutation-loop evidence check.");
   }
 
   log("Product-proof gate passed.");

--- a/scripts/ops/check-product-proof-gate.test.mjs
+++ b/scripts/ops/check-product-proof-gate.test.mjs
@@ -40,11 +40,13 @@ test("checkProductProofGate validates public discovery, pages, and schemas", asy
 
   const seen = [];
   await checkProductProofGate({
+    env: { PRODUCT_PROOF_EVIDENCE_FILE: "/tmp/product-proof-evidence-not-required.json" },
     fetchImpl: fakeFetch(responses),
     log: (line) => seen.push(line)
   });
 
   assert.ok(seen.includes("Product-proof gate passed."));
+  assert.ok(seen.includes("Worker-loop evidence is not required; skipping mutation-loop evidence check."));
 });
 
 test("checkProductProofGate fails when the public manifest drifts from the API mirror", async () => {


### PR DESCRIPTION
## Summary
- let the product-proof discovery/schema/trust gate run without requiring worker-loop evidence
- only validate the evidence file when PRODUCT_PROOF_REQUIRE_WORKER_LOOP=1
- cover the gate-only path when PRODUCT_PROOF_EVIDENCE_FILE is set by deploy defaults

## Checks
- node --test scripts/ops/check-product-proof-gate.test.mjs

## Impact
- Hosted smoke script only
- No backend runtime, frontend, indexer, Caddy, contracts, or public-site changes
- No environment changes required