### PR TITLE
Capability grant/revoke flow (roadmap §6)

### DIFF
--- a/app/app/(authed)/capabilities/page.tsx
+++ b/app/app/(authed)/capabilities/page.tsx
@@ -1,0 +1,590 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { mutate } from "swr";
+import { useAuthSession, useCapabilityGrants } from "@/lib/api/hooks";
+import { ApiError } from "@/lib/api/client";
+import {
+  buildAuthSession,
+  canUseControl,
+  type AuthSession,
+} from "@/lib/auth/capabilities";
+import {
+  createCapabilityGrant,
+  revokeCapabilityGrant,
+  type CapabilityGrant,
+} from "@/lib/api/capability-grants";
+
+const GRANTS_PATH = "/admin/capability-grants?limit=200";
+
+/*
+ * Capability grants admin page (roadmap §6).
+ *
+ * Modelled after Polkadot's Staking Operator Proxy: an admin can
+ * delegate a strict subset of platform capabilities to a service
+ * wallet (an automation bot, a co-operator, etc.), and revoke the
+ * grant at any time. Capability-management capabilities themselves
+ * are reserved — the backend rejects any attempt to grant
+ * `admin:capabilities:*`, preventing delegation chains.
+ *
+ * The page reads `/admin/capability-grants` and gates its controls
+ * via `canUseControl(session, "admin.capabilities.*")`, so a viewer
+ * without the relevant capability sees disabled buttons with a hint
+ * instead of hitting a 403 from the backend.
+ */
+export default function CapabilitiesPage() {
+  const sessionRequest = useAuthSession();
+  const grantsRequest = useCapabilityGrants();
+  const session = useMemo(() => buildAuthSession(sessionRequest.data), [sessionRequest.data]);
+
+  const grants = extractGrants(grantsRequest.data);
+  const known = useMemo(() => listKnownCapabilities(session), [session]);
+
+  const viewGate = canUseControl(session, "admin.capabilities.view");
+  const grantGate = canUseControl(session, "admin.capabilities.grant");
+  const revokeGate = canUseControl(session, "admin.capabilities.revoke");
+
+  const unauthorized =
+    grantsRequest.error instanceof ApiError &&
+    (grantsRequest.error.status === 401 || grantsRequest.error.status === 403);
+
+  const [active, revoked] = useMemo(() => {
+    const a: CapabilityGrant[] = [];
+    const r: CapabilityGrant[] = [];
+    for (const grant of grants) {
+      if (grant.status === "active") a.push(grant);
+      else r.push(grant);
+    }
+    return [a, r];
+  }, [grants]);
+
+  return (
+    <div className="flex w-full max-w-[1100px] flex-col gap-5">
+      <header className="flex flex-col gap-1.5">
+        <span
+          className="font-[family-name:var(--font-display)] text-[11.5px] font-extrabold uppercase text-[var(--avy-accent)]"
+          style={{ letterSpacing: "0.12em" }}
+        >
+          Operator delegation
+        </span>
+        <h1 className="m-0 font-[family-name:var(--font-display)] text-[2.4rem] font-bold leading-none text-[var(--avy-ink)]">
+          Capability grants
+        </h1>
+        <p className="m-0 mt-0.5 max-w-[62ch] font-[family-name:var(--font-body)] text-[16px] leading-[1.55] text-[var(--avy-muted)]">
+          Issue scoped capabilities to a service wallet — automation
+          bots, hosted operators, or co-signers — without granting
+          full admin. Modelled after Polkadot&rsquo;s Staking Operator
+          Proxy: a strict subset, no further delegation, revocable at
+          any time. Every grant and revoke writes an audit event.
+        </p>
+      </header>
+
+      {unauthorized ? (
+        <Notice tone="warn">
+          Sign in with an admin wallet to view and manage capability grants.
+        </Notice>
+      ) : null}
+
+      {!unauthorized && session && !viewGate.allowed ? (
+        <Notice tone="warn">
+          {viewGate.reason ?? "Your wallet does not have the admin:capabilities:read capability."}
+        </Notice>
+      ) : null}
+
+      <IssueGrantPanel
+        gate={grantGate}
+        knownCapabilities={known}
+        onIssued={() => mutate(GRANTS_PATH)}
+      />
+
+      <GrantList
+        title="Active grants"
+        emptyHint="No active grants. Use the form above to issue one."
+        grants={active}
+        revokeGate={revokeGate}
+        onRevoke={() => mutate(GRANTS_PATH)}
+        showRevoke
+      />
+
+      <GrantList
+        title="Revoked grants"
+        emptyHint="No revoked grants on file."
+        grants={revoked}
+        revokeGate={revokeGate}
+        onRevoke={() => mutate(GRANTS_PATH)}
+        showRevoke={false}
+      />
+
+      <p
+        className="font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]"
+        style={{ letterSpacing: 0 }}
+      >
+        Capability merging takes effect on the next request after the
+        15-second middleware cache lapses. The audit log
+        (<span className="text-[var(--avy-accent)]">/audit-log</span>)
+        records every grant and revoke with the issuing admin wallet.
+      </p>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Issue panel                                                        */
+/* ------------------------------------------------------------------ */
+
+function IssueGrantPanel({
+  gate,
+  knownCapabilities,
+  onIssued,
+}: {
+  gate: ReturnType<typeof canUseControl>;
+  knownCapabilities: string[];
+  onIssued: () => void;
+}) {
+  const [subject, setSubject] = useState("");
+  const [scope, setScope] = useState("");
+  const [note, setNote] = useState("");
+  const [expiresAt, setExpiresAt] = useState("");
+  const [selected, setSelected] = useState<string[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const subjectValid = /^0x[a-fA-F0-9]{40}$/u.test(subject.trim());
+  const canSubmit = gate.allowed && subjectValid && selected.length > 0 && !submitting;
+
+  function toggle(capability: string) {
+    setSelected((prev) =>
+      prev.includes(capability)
+        ? prev.filter((entry) => entry !== capability)
+        : [...prev, capability]
+    );
+  }
+
+  async function submit() {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await createCapabilityGrant({
+        subject: subject.trim().toLowerCase(),
+        capabilities: selected,
+        scope: scope.trim() || undefined,
+        note: note.trim() || undefined,
+        expiresAt: expiresAt ? new Date(expiresAt).toISOString() : undefined,
+      });
+      setSubject("");
+      setScope("");
+      setNote("");
+      setExpiresAt("");
+      setSelected([]);
+      onIssued();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not issue grant.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="flex flex-col gap-4 rounded-[var(--radius-lg)] border border-[var(--line)] bg-[var(--paper-solid)] p-5 shadow-[var(--shadow-sm)]">
+      <header className="flex items-baseline justify-between gap-3">
+        <span
+          className="font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase text-[var(--avy-accent)]"
+          style={{ letterSpacing: "0.12em" }}
+        >
+          Issue grant
+        </span>
+        {!gate.allowed ? (
+          <span
+            className="font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]"
+            style={{ letterSpacing: 0 }}
+            title={gate.reason ?? ""}
+          >
+            {gate.reason ?? "Insufficient capability to issue grants"}
+          </span>
+        ) : null}
+      </header>
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <Field label="Subject wallet (0x…)">
+          <input
+            type="text"
+            spellCheck={false}
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            placeholder="0x0000000000000000000000000000000000000000"
+            disabled={!gate.allowed}
+            className="h-9 w-full rounded-[8px] border border-[var(--line)] bg-[var(--paper-solid)] px-3 font-[family-name:var(--font-mono)] text-[12.5px] text-[var(--ink)] placeholder:text-[var(--muted)] focus:border-[color:rgba(30,102,66,0.45)] focus:outline focus:outline-2 focus:outline-[color:rgba(30,102,66,0.22)] disabled:opacity-50"
+            style={{ letterSpacing: 0 }}
+          />
+        </Field>
+
+        <Field label="Scope label (optional)">
+          <input
+            type="text"
+            value={scope}
+            onChange={(e) => setScope(e.target.value)}
+            placeholder="ops-bot"
+            maxLength={60}
+            disabled={!gate.allowed}
+            className="h-9 w-full rounded-[8px] border border-[var(--line)] bg-[var(--paper-solid)] px-3 font-[family-name:var(--font-body)] text-[13px] text-[var(--ink)] placeholder:text-[var(--muted)] focus:border-[color:rgba(30,102,66,0.45)] focus:outline focus:outline-2 focus:outline-[color:rgba(30,102,66,0.22)] disabled:opacity-50"
+          />
+        </Field>
+
+        <Field label="Note (optional)">
+          <input
+            type="text"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="Why is this delegation in place?"
+            maxLength={500}
+            disabled={!gate.allowed}
+            className="h-9 w-full rounded-[8px] border border-[var(--line)] bg-[var(--paper-solid)] px-3 font-[family-name:var(--font-body)] text-[13px] text-[var(--ink)] placeholder:text-[var(--muted)] focus:border-[color:rgba(30,102,66,0.45)] focus:outline focus:outline-2 focus:outline-[color:rgba(30,102,66,0.22)] disabled:opacity-50"
+          />
+        </Field>
+
+        <Field label="Expires (optional)">
+          <input
+            type="datetime-local"
+            value={expiresAt}
+            onChange={(e) => setExpiresAt(e.target.value)}
+            disabled={!gate.allowed}
+            className="h-9 w-full rounded-[8px] border border-[var(--line)] bg-[var(--paper-solid)] px-3 font-[family-name:var(--font-mono)] text-[12.5px] text-[var(--ink)] focus:border-[color:rgba(30,102,66,0.45)] focus:outline focus:outline-2 focus:outline-[color:rgba(30,102,66,0.22)] disabled:opacity-50"
+            style={{ letterSpacing: 0 }}
+          />
+        </Field>
+      </div>
+
+      <Field label={`Capabilities (${selected.length} selected)`}>
+        <div className="flex max-h-[16rem] flex-col gap-1 overflow-y-auto rounded-[8px] border border-[var(--line)] bg-[var(--paper)] p-2">
+          {knownCapabilities.length === 0 ? (
+            <p className="m-0 p-2 text-[12px] text-[var(--muted)]">
+              Sign in to load the capability matrix.
+            </p>
+          ) : (
+            knownCapabilities.map((capability) => {
+              const on = selected.includes(capability);
+              return (
+                <label
+                  key={capability}
+                  className={`flex cursor-pointer items-center gap-2 rounded-[6px] px-2 py-1 transition-colors ${
+                    on ? "bg-[var(--accent-soft)]" : "hover:bg-[var(--paper-solid)]"
+                  } ${gate.allowed ? "" : "cursor-not-allowed opacity-60"}`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={on}
+                    onChange={() => toggle(capability)}
+                    disabled={!gate.allowed}
+                    className="h-4 w-4 accent-[var(--avy-accent)]"
+                  />
+                  <code className="font-[family-name:var(--font-mono)] text-[12px] text-[var(--ink)]">
+                    {capability}
+                  </code>
+                </label>
+              );
+            })
+          )}
+        </div>
+      </Field>
+
+      {error ? <Notice tone="warn">{error}</Notice> : null}
+
+      <footer className="flex items-center justify-between gap-3 border-t border-[var(--line-soft)] pt-3">
+        <span
+          className="font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--muted)]"
+          style={{ letterSpacing: 0 }}
+        >
+          {subjectValid
+            ? `Granting ${selected.length} capabilit${selected.length === 1 ? "y" : "ies"} to ${shortWallet(subject)}.`
+            : "Enter a 0x-prefixed 40-character wallet to enable issue."}
+        </span>
+        <button
+          type="button"
+          disabled={!canSubmit}
+          onClick={submit}
+          title={gate.allowed ? "" : (gate.reason ?? "")}
+          className="inline-flex h-9 items-center gap-1.5 rounded-[8px] bg-[var(--avy-accent)] px-3.5 font-[family-name:var(--font-display)] text-[11.5px] font-bold uppercase text-[var(--fg-invert)] transition-transform hover:-translate-y-px hover:bg-[var(--avy-accent-2)] disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:translate-y-0"
+          style={{ letterSpacing: "0.04em" }}
+        >
+          {submitting ? "Issuing…" : "Issue grant"}
+        </button>
+      </footer>
+    </section>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Grant list                                                         */
+/* ------------------------------------------------------------------ */
+
+function GrantList({
+  title,
+  emptyHint,
+  grants,
+  revokeGate,
+  onRevoke,
+  showRevoke,
+}: {
+  title: string;
+  emptyHint: string;
+  grants: CapabilityGrant[];
+  revokeGate: ReturnType<typeof canUseControl>;
+  onRevoke: () => void;
+  showRevoke: boolean;
+}) {
+  return (
+    <section className="flex flex-col gap-3 rounded-[var(--radius-lg)] border border-[var(--line)] bg-[var(--paper-solid)] p-5 shadow-[var(--shadow-sm)]">
+      <header className="flex items-baseline justify-between gap-3">
+        <span
+          className="font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase text-[var(--avy-accent)]"
+          style={{ letterSpacing: "0.12em" }}
+        >
+          {title}
+        </span>
+        <span
+          className="font-[family-name:var(--font-mono)] text-[11px] text-[var(--muted)]"
+          style={{ letterSpacing: 0 }}
+        >
+          {grants.length}
+        </span>
+      </header>
+
+      {grants.length === 0 ? (
+        <p
+          className="m-0 font-[family-name:var(--font-body)] text-[13px] text-[var(--muted)]"
+          style={{ letterSpacing: 0 }}
+        >
+          {emptyHint}
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-2 p-0" style={{ listStyle: "none" }}>
+          {grants.map((grant) => (
+            <GrantRow
+              key={grant.id}
+              grant={grant}
+              revokeGate={revokeGate}
+              onRevoke={onRevoke}
+              showRevoke={showRevoke}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function GrantRow({
+  grant,
+  revokeGate,
+  onRevoke,
+  showRevoke,
+}: {
+  grant: CapabilityGrant;
+  revokeGate: ReturnType<typeof canUseControl>;
+  onRevoke: () => void;
+  showRevoke: boolean;
+}) {
+  const [revoking, setRevoking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function revoke() {
+    if (!revokeGate.allowed) return;
+    if (!window.confirm(`Revoke ${grant.id}? This takes effect immediately.`)) return;
+    setRevoking(true);
+    setError(null);
+    try {
+      await revokeCapabilityGrant(grant.id);
+      onRevoke();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not revoke grant.");
+    } finally {
+      setRevoking(false);
+    }
+  }
+
+  return (
+    <li className="flex flex-col gap-2 rounded-[8px] border border-[var(--line)] bg-[var(--paper)] p-3">
+      <header className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-col gap-0.5">
+          <code className="font-[family-name:var(--font-mono)] text-[12px] text-[var(--ink)]">
+            {grant.id}
+          </code>
+          <span className="font-[family-name:var(--font-body)] text-[12.5px] text-[var(--muted)]">
+            {grant.scope ? `${grant.scope} · ` : ""}
+            <code className="font-[family-name:var(--font-mono)] text-[11.5px]">
+              {shortWallet(grant.subject)}
+            </code>
+          </span>
+        </div>
+        <StatusPill status={grant.status} />
+      </header>
+
+      <ul className="flex flex-wrap gap-1.5 p-0" style={{ listStyle: "none" }}>
+        {grant.capabilities.map((capability) => (
+          <li
+            key={capability}
+            className="rounded-full border border-[var(--line)] bg-[var(--paper-solid)] px-2 py-0.5 font-[family-name:var(--font-mono)] text-[11px] text-[var(--ink)]"
+          >
+            {capability}
+          </li>
+        ))}
+      </ul>
+
+      <dl className="grid grid-cols-1 gap-x-4 gap-y-0.5 text-[12px] sm:grid-cols-[max-content_1fr]">
+        <Detail label="Issued by">
+          <code className="font-[family-name:var(--font-mono)] text-[11.5px]">
+            {shortWallet(grant.issuedBy)}
+          </code>
+        </Detail>
+        <Detail label="Issued at">{formatIso(grant.issuedAt)}</Detail>
+        {grant.expiresAt ? <Detail label="Expires">{formatIso(grant.expiresAt)}</Detail> : null}
+        {grant.note ? <Detail label="Note">{grant.note}</Detail> : null}
+        {grant.status === "revoked" ? (
+          <>
+            <Detail label="Revoked at">{formatIso(grant.revokedAt)}</Detail>
+            {grant.revokedBy ? (
+              <Detail label="Revoked by">
+                <code className="font-[family-name:var(--font-mono)] text-[11.5px]">
+                  {shortWallet(grant.revokedBy)}
+                </code>
+              </Detail>
+            ) : null}
+            {grant.revokeNote ? <Detail label="Revoke note">{grant.revokeNote}</Detail> : null}
+          </>
+        ) : null}
+      </dl>
+
+      {error ? <Notice tone="warn">{error}</Notice> : null}
+
+      {showRevoke ? (
+        <footer className="flex items-center justify-end gap-3 border-t border-[var(--line-soft)] pt-2">
+          <button
+            type="button"
+            onClick={revoke}
+            disabled={!revokeGate.allowed || revoking}
+            title={revokeGate.allowed ? "" : (revokeGate.reason ?? "")}
+            className="inline-flex h-8 items-center rounded-[8px] border border-[var(--line)] bg-[var(--paper-solid)] px-3 font-[family-name:var(--font-display)] text-[11px] font-bold uppercase text-[var(--ink)] transition-colors hover:border-[color:rgba(167,97,34,0.35)] disabled:cursor-not-allowed disabled:opacity-40"
+            style={{ letterSpacing: "0.04em" }}
+          >
+            {revoking ? "Revoking…" : "Revoke"}
+          </button>
+        </footer>
+      ) : null}
+    </li>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <span
+        className="font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--muted)]"
+        style={{ letterSpacing: "0.14em" }}
+      >
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+function Detail({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <>
+      <dt
+        className="font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--muted)]"
+        style={{ letterSpacing: "0.12em" }}
+      >
+        {label}
+      </dt>
+      <dd className="m-0 font-[family-name:var(--font-body)] text-[12.5px] text-[var(--ink)]">
+        {children}
+      </dd>
+    </>
+  );
+}
+
+function StatusPill({ status }: { status: CapabilityGrant["status"] }) {
+  const tone = status === "active"
+    ? { bg: "var(--accent-soft)", color: "var(--avy-accent)" }
+    : { bg: "rgba(167,97,34,0.12)", color: "#9a5d1b" };
+  return (
+    <span
+      className="rounded-full px-2 py-0.5 font-[family-name:var(--font-display)] text-[10.5px] font-extrabold uppercase"
+      style={{ background: tone.bg, color: tone.color, letterSpacing: "0.1em" }}
+    >
+      {status}
+    </span>
+  );
+}
+
+function Notice({ tone, children }: { tone: "warn"; children: React.ReactNode }) {
+  return (
+    <p
+      className="m-0 rounded-[8px] border p-3 font-[family-name:var(--font-body)] text-[12.5px] leading-[1.55]"
+      style={
+        tone === "warn"
+          ? {
+              borderColor: "rgba(167,97,34,0.35)",
+              background: "rgba(244,227,207,0.35)",
+              color: "var(--avy-muted)",
+            }
+          : undefined
+      }
+    >
+      {children}
+    </p>
+  );
+}
+
+function shortWallet(value: string | undefined): string {
+  if (!value) return "—";
+  const v = String(value).trim();
+  if (v.length <= 12) return v;
+  return `${v.slice(0, 6)}…${v.slice(-4)}`;
+}
+
+function formatIso(value: string | undefined): string {
+  if (!value) return "—";
+  const t = Date.parse(value);
+  if (!Number.isFinite(t)) return value;
+  return new Date(t).toLocaleString("en-CH", { dateStyle: "medium", timeStyle: "short" });
+}
+
+function extractGrants(data: unknown): CapabilityGrant[] {
+  if (!data || typeof data !== "object") return [];
+  const items = (data as Record<string, unknown>).items;
+  if (!Array.isArray(items)) return [];
+  return items.filter((entry): entry is CapabilityGrant => {
+    if (!entry || typeof entry !== "object") return false;
+    const r = entry as Record<string, unknown>;
+    return typeof r.id === "string" && typeof r.subject === "string" && Array.isArray(r.capabilities);
+  });
+}
+
+/**
+ * Build the list of capabilities the operator can offer in the form.
+ * Sourced from the live capabilityMatrix so it always matches the
+ * backend, with capability-management capabilities filtered out
+ * (the backend rejects them anyway, but the UI shouldn't tempt
+ * admins to try). When no session has loaded yet the list is empty —
+ * the form disables itself in that state.
+ */
+function listKnownCapabilities(session: AuthSession | undefined): string[] {
+  if (!session) return [];
+  const matrix = session.capabilityMatrix;
+  const all = new Set<string>(matrix.base);
+  for (const expansion of Object.values(matrix.roles)) {
+    for (const capability of expansion) {
+      all.add(capability);
+    }
+  }
+  return [...all]
+    .filter((capability) => !capability.startsWith("admin:capabilities:"))
+    .sort();
+}

--- a/app/components/shell/OperatorRail.tsx
+++ b/app/components/shell/OperatorRail.tsx
@@ -9,6 +9,7 @@ import {
   FileCheck2,
   Gauge,
   History,
+  KeyRound,
   LayoutDashboard,
   ScrollText,
   ShieldCheck,
@@ -61,6 +62,7 @@ const NAV_GROUPS: NavGroup[] = [
     label: "Governance",
     items: [
       { href: "/policies", label: "Policies", icon: ShieldCheck },
+      { href: "/capabilities", label: "Capabilities", icon: KeyRound },
       { href: "/disputes", label: "Disputes", icon: AlertTriangle },
       { href: "/audit-log", label: "Audit log", icon: FileCheck2 },
     ],

--- a/app/lib/api/capability-grants.ts
+++ b/app/lib/api/capability-grants.ts
@@ -1,0 +1,75 @@
+"use client";
+
+/**
+ * Operator-app helpers for the capability grant/revoke surface
+ * introduced in roadmap §6. The backend exposes:
+ *
+ *   GET    /admin/capability-grants[?subject=&status=]
+ *   POST   /admin/capability-grants               { subject, capabilities, scope?, note?, expiresAt?, idempotencyKey? }
+ *   POST   /admin/capability-grants/:id/revoke    { note?, idempotencyKey? }
+ *
+ * Each grant is persisted alongside an audit-event mutation receipt
+ * so /audit-log surfaces every change. Revocation has immediate
+ * effect (next request after the 15s middleware cache lapses; the
+ * UI invalidates the SWR cache so the panel reflects the new state
+ * instantly).
+ */
+
+import { swrFetcher } from "./client";
+
+export interface CapabilityGrant {
+  id: string;
+  subject: string;
+  capabilities: string[];
+  scope?: string;
+  note?: string;
+  issuedBy: string;
+  issuedAt: string;
+  expiresAt?: string;
+  status: "active" | "revoked";
+  revokedAt?: string;
+  revokedBy?: string;
+  revokeNote?: string;
+}
+
+export interface CapabilityGrantListResponse {
+  items: CapabilityGrant[];
+  limit: number;
+  offset: number;
+}
+
+export interface CreateCapabilityGrantInput {
+  subject: string;
+  capabilities: string[];
+  scope?: string;
+  note?: string;
+  expiresAt?: string;
+  idempotencyKey?: string;
+}
+
+export async function createCapabilityGrant(
+  input: CreateCapabilityGrantInput
+): Promise<CapabilityGrant> {
+  return swrFetcher<CapabilityGrant>([
+    "/admin/capability-grants",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(input),
+    },
+  ]);
+}
+
+export async function revokeCapabilityGrant(
+  id: string,
+  options: { note?: string; idempotencyKey?: string } = {}
+): Promise<CapabilityGrant> {
+  return swrFetcher<CapabilityGrant>([
+    `/admin/capability-grants/${encodeURIComponent(id)}/revoke`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(options),
+    },
+  ]);
+}

--- a/app/lib/api/hooks.ts
+++ b/app/lib/api/hooks.ts
@@ -108,3 +108,11 @@ export const useJobTimeline = (jobId: string | null) =>
 export const useOnboarding = () => useApi("/onboarding");
 export const useVerifierHandlers = () => useApi("/verifier/handlers");
 export const useSessionStateMachine = () => useApi("/session/state-machine");
+
+/**
+ * Operator-issued capability grants (roadmap §6). Lists every grant
+ * — active and revoked — newest-first. Polls every 15s so a
+ * just-issued grant lands in the panel without a manual refresh.
+ */
+export const useCapabilityGrants = () =>
+  useApi("/admin/capability-grants?limit=200", { refreshInterval: 15_000 });

--- a/mcp-server/src/auth/auth.test.js
+++ b/mcp-server/src/auth/auth.test.js
@@ -487,3 +487,88 @@ test("MemoryStateStore isTokenRevoked is false for unknown jti", async () => {
   const store = new MemoryStateStore();
   assert.equal(await store.isTokenRevoked("never-seen"), false);
 });
+
+test("MemoryStateStore capability grants round-trip + filter by subject and status", async () => {
+  const store = new MemoryStateStore();
+  const subjectA = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  const subjectB = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+  await store.upsertCapabilityGrant({ id: "g-a1", subject: subjectA, status: "active", capabilities: ["jobs:lifecycle"], issuedAt: "2026-01-01T00:00:00.000Z" });
+  await store.upsertCapabilityGrant({ id: "g-a2", subject: subjectA, status: "revoked", capabilities: ["jobs:lifecycle"], issuedAt: "2026-01-02T00:00:00.000Z" });
+  await store.upsertCapabilityGrant({ id: "g-b1", subject: subjectB, status: "active", capabilities: ["policies:propose"], issuedAt: "2026-01-03T00:00:00.000Z" });
+
+  const all = await store.listCapabilityGrants({});
+  assert.equal(all.length, 3);
+  // Newest-first ordering.
+  assert.deepEqual(all.map((g) => g.id), ["g-b1", "g-a2", "g-a1"]);
+
+  const onlyA = await store.listCapabilityGrants({ subject: subjectA });
+  assert.deepEqual(onlyA.map((g) => g.id).sort(), ["g-a1", "g-a2"]);
+
+  const onlyActive = await store.listCapabilityGrants({ status: "active" });
+  assert.deepEqual(onlyActive.map((g) => g.id).sort(), ["g-a1", "g-b1"]);
+
+  const aActive = await store.listCapabilityGrants({ subject: subjectA, status: "active" });
+  assert.deepEqual(aActive.map((g) => g.id), ["g-a1"]);
+});
+
+test("requireAuth merges active capability grants for the subject", async () => {
+  const subject = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  const stateStore = new MemoryStateStore();
+  await stateStore.upsertCapabilityGrant({
+    id: "grant-x",
+    subject,
+    status: "active",
+    capabilities: ["jobs:lifecycle"],
+    issuedAt: new Date().toISOString(),
+    issuedBy: "0x1111111111111111111111111111111111111111"
+  });
+  const authConfig = {
+    secrets: [LONG_SECRET],
+    signingSecret: LONG_SECRET,
+    permissive: false,
+    strict: true
+  };
+  const middleware = createAuthMiddleware({ authConfig, stateStore, logger: silentLogger() });
+  const { token } = signToken({ sub: subject, roles: [] }, {
+    secret: LONG_SECRET,
+    expiresInSeconds: 60
+  });
+  const request = { method: "POST", headers: { authorization: `Bearer ${token}` } };
+  const url = new URL("http://localhost/admin/jobs/lifecycle");
+  // Without the grant the request would fail capability enforcement
+  // because base capabilities do not include jobs:lifecycle. The
+  // grant promotes the subject above the route requirement.
+  const result = await middleware(request, url);
+  assert.ok(result.capabilities.includes("jobs:lifecycle"));
+});
+
+test("requireAuth ignores revoked grants when expanding capabilities", async () => {
+  const subject = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+  const stateStore = new MemoryStateStore();
+  await stateStore.upsertCapabilityGrant({
+    id: "grant-y",
+    subject,
+    status: "revoked",
+    capabilities: ["jobs:lifecycle"],
+    issuedAt: new Date().toISOString(),
+    revokedAt: new Date().toISOString(),
+    issuedBy: "0x1111111111111111111111111111111111111111"
+  });
+  const authConfig = {
+    secrets: [LONG_SECRET],
+    signingSecret: LONG_SECRET,
+    permissive: false,
+    strict: true
+  };
+  const middleware = createAuthMiddleware({ authConfig, stateStore, logger: silentLogger() });
+  const { token } = signToken({ sub: subject, roles: [] }, {
+    secret: LONG_SECRET,
+    expiresInSeconds: 60
+  });
+  const request = { method: "POST", headers: { authorization: `Bearer ${token}` } };
+  const url = new URL("http://localhost/admin/jobs/lifecycle");
+  await assert.rejects(
+    () => middleware(request, url),
+    (error) => error instanceof AuthorizationError && error.code === "missing_capability"
+  );
+});

--- a/mcp-server/src/auth/capabilities.js
+++ b/mcp-server/src/auth/capabilities.js
@@ -31,6 +31,9 @@ const BASE_CAPABILITIES = [
 
 const ROLE_CAPABILITIES = {
   admin: [
+    "admin:capabilities:read",
+    "admin:capabilities:grant",
+    "admin:capabilities:revoke",
     "admin:status",
     "disputes:release",
     "jobs:ingest",
@@ -94,6 +97,9 @@ const ROUTE_CAPABILITY_RULES = [
   { method: "GET", path: "/admin/jobs/timeline", capabilities: ["jobs:timeline"] },
   { method: "GET", path: "/admin/sessions", capabilities: ["ops:view"] },
   { method: "GET", path: "/admin/status", capabilities: ["admin:status", "ops:view"] },
+  { method: "GET", path: "/admin/capability-grants", capabilities: ["admin:capabilities:read"] },
+  { method: "POST", path: "/admin/capability-grants", capabilities: ["admin:capabilities:grant"] },
+  { method: "POST", path: "/admin/capability-grants/:id/revoke", capabilities: ["admin:capabilities:revoke"] },
   { method: "POST", path: "/admin/xcm/observe", capabilities: ["xcm:observe"] },
   { method: "POST", path: "/admin/xcm/finalize", capabilities: ["xcm:finalize"] },
   { method: "POST", path: "/verifier/replay", capabilities: ["verifier:replay"] },
@@ -110,6 +116,9 @@ const UI_CONTROLS = {
   "admin.jobs.timeline": ["jobs:timeline"],
   "admin.sessions.view": ["ops:view"],
   "admin.status.view": ["admin:status", "ops:view"],
+  "admin.capabilities.view": ["admin:capabilities:read"],
+  "admin.capabilities.grant": ["admin:capabilities:grant"],
+  "admin.capabilities.revoke": ["admin:capabilities:revoke"],
   "policies.propose": ["policies:propose"],
   "verifier.run": ["verifier:run"],
   "xcm.observe": ["xcm:observe"],
@@ -127,8 +136,27 @@ const AUTOMATION_ACTIONS = {
   "policy.propose": ["policies:propose"],
   "verifier.run": ["verifier:run"],
   "xcm.observe": ["xcm:observe"],
-  "xcm.finalize": ["xcm:finalize"]
+  "xcm.finalize": ["xcm:finalize"],
+  "capability.grant": ["admin:capabilities:grant"],
+  "capability.revoke": ["admin:capabilities:revoke"]
 };
+
+/**
+ * Set of every capability the platform recognises — the union of
+ * BASE_CAPABILITIES and every role's expansion. Used by the
+ * capability-grant validator (`buildCapabilityGrant`) so an admin
+ * cannot delegate a capability the platform itself has never heard
+ * of (typo prevention).
+ */
+export function listAllKnownCapabilities() {
+  const all = new Set(BASE_CAPABILITIES);
+  for (const capabilities of Object.values(ROLE_CAPABILITIES)) {
+    for (const capability of capabilities) {
+      all.add(capability);
+    }
+  }
+  return new Set([...all].sort());
+}
 
 export function resolveCapabilities(claims = {}) {
   const capabilities = new Set(BASE_CAPABILITIES);

--- a/mcp-server/src/auth/capabilities.test.js
+++ b/mcp-server/src/auth/capabilities.test.js
@@ -72,3 +72,37 @@ test("missingCapabilities reports the exact capability gap", () => {
     ["ops:view"]
   );
 });
+
+test("capabilityMatrix surfaces the capability-grant routes and UI controls (roadmap §6)", () => {
+  const matrix = capabilityMatrix();
+  assert.ok(matrix.roles.admin.includes("admin:capabilities:read"));
+  assert.ok(matrix.roles.admin.includes("admin:capabilities:grant"));
+  assert.ok(matrix.roles.admin.includes("admin:capabilities:revoke"));
+  assert.deepEqual(matrix.routes["/admin/capability-grants"], [
+    "admin:capabilities:grant",
+    "admin:capabilities:read"
+  ]);
+  assert.deepEqual(matrix.routes["/admin/capability-grants/:id/revoke"], [
+    "admin:capabilities:revoke"
+  ]);
+  assert.deepEqual(matrix.uiControls["admin.capabilities.view"], ["admin:capabilities:read"]);
+  assert.deepEqual(matrix.uiControls["admin.capabilities.grant"], ["admin:capabilities:grant"]);
+  assert.deepEqual(matrix.uiControls["admin.capabilities.revoke"], ["admin:capabilities:revoke"]);
+  assert.deepEqual(matrix.automationActions["capability.grant"], ["admin:capabilities:grant"]);
+  assert.deepEqual(matrix.automationActions["capability.revoke"], ["admin:capabilities:revoke"]);
+});
+
+test("getRouteCapabilityRequirements resolves capability-grant routes by method", () => {
+  assert.deepEqual(
+    getRouteCapabilityRequirements("GET", "/admin/capability-grants"),
+    ["admin:capabilities:read"]
+  );
+  assert.deepEqual(
+    getRouteCapabilityRequirements("POST", "/admin/capability-grants"),
+    ["admin:capabilities:grant"]
+  );
+  assert.deepEqual(
+    getRouteCapabilityRequirements("POST", "/admin/capability-grants/grant-abc/revoke"),
+    ["admin:capabilities:revoke"]
+  );
+});

--- a/mcp-server/src/auth/middleware.js
+++ b/mcp-server/src/auth/middleware.js
@@ -7,7 +7,10 @@ import {
   missingCapabilities,
   resolveCapabilities
 } from "./capabilities.js";
+import { mergeGrantCapabilities } from "../core/capability-grants.js";
 import { buildAuthRequirementDetails } from "../core/discovery-manifest.js";
+
+const GRANT_CACHE_TTL_MS = 15_000;
 
 /**
  * Create an auth middleware bound to a specific auth configuration.
@@ -30,7 +33,49 @@ import { buildAuthRequirementDetails } from "../core/discovery-manifest.js";
  * A `stateStore` with `isTokenRevoked(jti)` is optional. When supplied the
  * middleware rejects tokens whose `jti` is in the revocation list.
  */
-export function createAuthMiddleware({ authConfig, stateStore, logger = console }) {
+export function createAuthMiddleware({ authConfig, stateStore, logger = console, now = () => new Date() }) {
+  // Per-subject grant cache. The grant list is stable for the
+  // lifetime of a JWT and lookups happen on every authed request,
+  // so a 15s in-process cache keeps the steady-state cost of
+  // capability merging at zero. Revokes invalidate via TTL — admins
+  // should expect up to 15s lag from revoke-call to enforcement.
+  const grantCache = new Map();
+
+  async function loadActiveGrantsFor(wallet) {
+    if (!wallet) return [];
+    if (typeof stateStore?.listCapabilityGrants !== "function") return [];
+    const cacheKey = String(wallet).toLowerCase();
+    const cached = grantCache.get(cacheKey);
+    const nowMs = now().getTime();
+    if (cached && cached.expiresAt > nowMs) {
+      return cached.grants;
+    }
+    let grants = [];
+    try {
+      grants = await stateStore.listCapabilityGrants({
+        subject: cacheKey,
+        status: "active",
+        limit: 50
+      });
+    } catch (error) {
+      logger.warn?.({ wallet: cacheKey, error: error?.message }, "auth.grant_lookup_failed");
+      grants = [];
+    }
+    grantCache.set(cacheKey, {
+      grants: Array.isArray(grants) ? grants : [],
+      expiresAt: nowMs + GRANT_CACHE_TTL_MS
+    });
+    return grantCache.get(cacheKey).grants;
+  }
+
+  async function expandCapabilities(claims, baseCapabilities) {
+    const subject = String(claims?.sub ?? "").trim();
+    if (!subject) return baseCapabilities;
+    const grants = await loadActiveGrantsFor(subject);
+    if (!grants.length) return baseCapabilities;
+    return mergeGrantCapabilities(baseCapabilities, grants, { now });
+  }
+
   return async function requireAuth(
     request,
     url,
@@ -73,7 +118,8 @@ export function createAuthMiddleware({ authConfig, stateStore, logger = console 
               verifierWallets: authConfig.verifierWallets ?? new Set()
             })
           };
-          const capabilities = resolveCapabilities(permissiveClaims);
+          const baseCapabilities = resolveCapabilities(permissiveClaims);
+          const capabilities = await expandCapabilities(permissiveClaims, baseCapabilities);
           enforceRole(permissiveClaims, requireRole, authDetails);
           enforceCapabilities(capabilities, requiredCapabilities, authDetails);
           return {
@@ -107,7 +153,8 @@ export function createAuthMiddleware({ authConfig, stateStore, logger = console 
       }
     }
 
-    const capabilities = resolveCapabilities(claims);
+    const baseCapabilities = resolveCapabilities(claims);
+    const capabilities = await expandCapabilities(claims, baseCapabilities);
     enforceRole(claims, requireRole, authDetails);
     enforceCapabilities(capabilities, requiredCapabilities, authDetails);
 

--- a/mcp-server/src/core/capability-grants.js
+++ b/mcp-server/src/core/capability-grants.js
@@ -1,0 +1,219 @@
+import { keccak256, toUtf8Bytes } from "ethers";
+import { ValidationError } from "./errors.js";
+
+/**
+ * Capability grants — operator-issued, scoped delegations of
+ * platform capabilities to a subject wallet (a service token, an
+ * automation bot, or a co-operator). Modelled after Polkadot's
+ * Staking Operator Proxy: a strict subset of the issuer's
+ * capabilities, no further delegation, revocable at any time.
+ *
+ * Grants live in the state store (`capability_grants` bucket) and
+ * are merged into a subject's resolved capabilities at request time
+ * by the auth middleware. Each grant + revoke writes a mutation
+ * receipt so the audit log surfaces every change.
+ */
+
+export const GRANT_STATUS = Object.freeze({
+  active: "active",
+  revoked: "revoked"
+});
+
+const RESERVED_GRANT_CAPABILITIES = Object.freeze([
+  // A grant cannot extend the grantor's permissions — explicit deny
+  // on capability-management capabilities prevents delegation chains.
+  "admin:capabilities:read",
+  "admin:capabilities:grant",
+  "admin:capabilities:revoke"
+]);
+
+export function isReservedCapability(capability) {
+  return RESERVED_GRANT_CAPABILITIES.includes(String(capability ?? "").trim());
+}
+
+/**
+ * Stable id for a grant. Hashed from `subject + scope + issuedAt +
+ * nonce` so re-issuing a grant with the same shape generates a new
+ * id and keeps the audit trail honest. The hash is truncated to 12
+ * hex chars — same convention as `dispute-<hex12>`.
+ */
+export function grantIdForRecord({ subject, scope, issuedAt, nonce }) {
+  const seed = [subject, scope ?? "", issuedAt, nonce ?? ""].join("|");
+  return `grant-${keccak256(toUtf8Bytes(String(seed))).slice(2, 14)}`;
+}
+
+function normalizeWallet(value) {
+  const trimmed = String(value ?? "").trim();
+  if (!/^0x[a-fA-F0-9]{40}$/u.test(trimmed)) {
+    throw new ValidationError("subject must be a 0x-prefixed 40-character wallet address.");
+  }
+  return trimmed.toLowerCase();
+}
+
+function normalizeCapabilityList(value, { knownCapabilities, label = "capabilities" } = {}) {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new ValidationError(`${label} must be a non-empty array of capability strings.`);
+  }
+  const seen = new Set();
+  const normalized = [];
+  for (const entry of value) {
+    const capability = String(entry ?? "").trim();
+    if (!capability) {
+      throw new ValidationError(`${label} entries must be non-empty capability strings.`);
+    }
+    if (isReservedCapability(capability)) {
+      throw new ValidationError(`${label} cannot include capability-management capabilities (${capability}).`);
+    }
+    if (knownCapabilities && !knownCapabilities.has(capability)) {
+      throw new ValidationError(`${label} includes unknown capability "${capability}".`, {
+        capability
+      });
+    }
+    if (!seen.has(capability)) {
+      seen.add(capability);
+      normalized.push(capability);
+    }
+  }
+  return normalized.sort();
+}
+
+function normalizeOptionalString(value, label, { maxLength = 200 } = {}) {
+  if (value === undefined || value === null) return undefined;
+  const text = String(value).trim();
+  if (!text) return undefined;
+  if (text.length > maxLength) {
+    throw new ValidationError(`${label} must be ${maxLength} characters or fewer.`);
+  }
+  return text;
+}
+
+function normalizeIssuedAt(value) {
+  if (value === undefined || value === null || value === "") {
+    return new Date().toISOString();
+  }
+  const t = Date.parse(String(value));
+  if (!Number.isFinite(t)) {
+    throw new ValidationError("issuedAt must be a valid ISO timestamp.");
+  }
+  return new Date(t).toISOString();
+}
+
+function normalizeExpiresAt(value, { issuedAt }) {
+  if (value === undefined || value === null || value === "") return undefined;
+  const t = Date.parse(String(value));
+  if (!Number.isFinite(t)) {
+    throw new ValidationError("expiresAt must be a valid ISO timestamp.");
+  }
+  if (t <= Date.parse(issuedAt)) {
+    throw new ValidationError("expiresAt must be later than issuedAt.");
+  }
+  return new Date(t).toISOString();
+}
+
+/**
+ * Build a brand-new grant record from operator input. Validates
+ * subject + capability subset + optional expiry, fills in issuedAt
+ * and a stable id. Throws `ValidationError` on any malformed field.
+ */
+export function buildCapabilityGrant(input = {}, { knownCapabilities, issuerWallet, now = () => new Date() } = {}) {
+  const subject = normalizeWallet(input.subject);
+  const capabilities = normalizeCapabilityList(input.capabilities, { knownCapabilities });
+  const scope = normalizeOptionalString(input.scope, "scope", { maxLength: 60 });
+  const note = normalizeOptionalString(input.note, "note", { maxLength: 500 });
+  const issuedAt = normalizeIssuedAt(input.issuedAt ?? now().toISOString());
+  const expiresAt = normalizeExpiresAt(input.expiresAt, { issuedAt });
+  const issuedBy = issuerWallet ? normalizeWallet(issuerWallet) : normalizeWallet(input.issuedBy);
+  const nonce = String(input.nonce ?? `${issuedAt}-${Math.random().toString(36).slice(2, 10)}`);
+  const id = grantIdForRecord({ subject, scope, issuedAt, nonce });
+  return {
+    id,
+    subject,
+    capabilities,
+    ...(scope ? { scope } : {}),
+    ...(note ? { note } : {}),
+    issuedBy,
+    issuedAt,
+    ...(expiresAt ? { expiresAt } : {}),
+    status: GRANT_STATUS.active
+  };
+}
+
+/**
+ * Apply a revocation to an existing grant. Idempotent — calling
+ * revoke twice is allowed (the second call is a no-op on the
+ * record, but the caller still gets a stable receipt).
+ */
+export function applyRevocation(grant, { revokedBy, revokeNote, now = () => new Date() } = {}) {
+  if (!grant || typeof grant !== "object") {
+    throw new ValidationError("grant record is required for revocation.");
+  }
+  if (grant.status === GRANT_STATUS.revoked) {
+    return { record: grant, alreadyRevoked: true };
+  }
+  const note = normalizeOptionalString(revokeNote, "revokeNote", { maxLength: 500 });
+  const wallet = revokedBy ? normalizeWallet(revokedBy) : undefined;
+  const record = {
+    ...grant,
+    status: GRANT_STATUS.revoked,
+    revokedAt: now().toISOString(),
+    ...(wallet ? { revokedBy: wallet } : {}),
+    ...(note ? { revokeNote: note } : {})
+  };
+  return { record, alreadyRevoked: false };
+}
+
+/**
+ * Treat grants whose `expiresAt` has passed as inactive. Storage
+ * keeps them for audit, but middleware should not merge their
+ * capabilities into a request.
+ */
+export function isGrantActive(grant, { now = () => new Date() } = {}) {
+  if (!grant || typeof grant !== "object") return false;
+  if (grant.status !== GRANT_STATUS.active) return false;
+  if (!grant.expiresAt) return true;
+  return Date.parse(grant.expiresAt) > now().getTime();
+}
+
+/**
+ * Merge active, non-expired grants into a base capability list.
+ * Used by the middleware to expand a subject's resolved
+ * capabilities at request time. Returns a sorted, de-duplicated
+ * array.
+ */
+export function mergeGrantCapabilities(baseCapabilities, grants, options = {}) {
+  const merged = new Set(Array.isArray(baseCapabilities) ? baseCapabilities : []);
+  if (Array.isArray(grants)) {
+    for (const grant of grants) {
+      if (!isGrantActive(grant, options)) continue;
+      for (const capability of grant.capabilities ?? []) {
+        if (typeof capability === "string" && capability && !isReservedCapability(capability)) {
+          merged.add(capability);
+        }
+      }
+    }
+  }
+  return [...merged].sort();
+}
+
+/**
+ * Public projection of a grant — what we surface in /admin/...
+ * responses and audit events. Hides internal-only fields (none
+ * today, but keeps the projection a single source of truth).
+ */
+export function projectGrant(grant) {
+  if (!grant || typeof grant !== "object") return undefined;
+  return {
+    id: grant.id,
+    subject: grant.subject,
+    capabilities: Array.isArray(grant.capabilities) ? [...grant.capabilities] : [],
+    ...(grant.scope ? { scope: grant.scope } : {}),
+    ...(grant.note ? { note: grant.note } : {}),
+    issuedBy: grant.issuedBy,
+    issuedAt: grant.issuedAt,
+    ...(grant.expiresAt ? { expiresAt: grant.expiresAt } : {}),
+    status: grant.status,
+    ...(grant.revokedAt ? { revokedAt: grant.revokedAt } : {}),
+    ...(grant.revokedBy ? { revokedBy: grant.revokedBy } : {}),
+    ...(grant.revokeNote ? { revokeNote: grant.revokeNote } : {})
+  };
+}

--- a/mcp-server/src/core/capability-grants.test.js
+++ b/mcp-server/src/core/capability-grants.test.js
@@ -1,0 +1,190 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  applyRevocation,
+  buildCapabilityGrant,
+  GRANT_STATUS,
+  isGrantActive,
+  isReservedCapability,
+  mergeGrantCapabilities,
+  projectGrant
+} from "./capability-grants.js";
+import { ValidationError } from "./errors.js";
+import { listAllKnownCapabilities } from "../auth/capabilities.js";
+
+const ADMIN = "0x1111111111111111111111111111111111111111";
+const SUBJECT = "0x2222222222222222222222222222222222222222";
+const KNOWN = listAllKnownCapabilities();
+
+test("buildCapabilityGrant produces a stable id and active status", () => {
+  const grant = buildCapabilityGrant(
+    {
+      subject: SUBJECT,
+      capabilities: ["jobs:lifecycle", "policies:propose"],
+      scope: "ops-bot",
+      issuedAt: "2026-01-01T00:00:00.000Z",
+      nonce: "test-nonce"
+    },
+    { knownCapabilities: KNOWN, issuerWallet: ADMIN }
+  );
+  assert.match(grant.id, /^grant-[a-f0-9]{12}$/u);
+  assert.equal(grant.status, GRANT_STATUS.active);
+  assert.deepEqual(grant.capabilities, ["jobs:lifecycle", "policies:propose"]);
+  assert.equal(grant.subject, SUBJECT.toLowerCase());
+  assert.equal(grant.issuedBy, ADMIN.toLowerCase());
+  assert.equal(grant.scope, "ops-bot");
+  assert.equal(grant.issuedAt, "2026-01-01T00:00:00.000Z");
+});
+
+test("buildCapabilityGrant rejects unknown capabilities (typo guard)", () => {
+  assert.throws(
+    () =>
+      buildCapabilityGrant(
+        { subject: SUBJECT, capabilities: ["jobs:nonsense"] },
+        { knownCapabilities: KNOWN, issuerWallet: ADMIN }
+      ),
+    ValidationError
+  );
+});
+
+test("buildCapabilityGrant rejects capability-management capabilities (no delegation chain)", () => {
+  assert.throws(
+    () =>
+      buildCapabilityGrant(
+        { subject: SUBJECT, capabilities: ["admin:capabilities:grant"] },
+        { knownCapabilities: KNOWN, issuerWallet: ADMIN }
+      ),
+    ValidationError
+  );
+});
+
+test("buildCapabilityGrant rejects malformed subject", () => {
+  assert.throws(
+    () =>
+      buildCapabilityGrant(
+        { subject: "not-a-wallet", capabilities: ["jobs:lifecycle"] },
+        { knownCapabilities: KNOWN, issuerWallet: ADMIN }
+      ),
+    ValidationError
+  );
+});
+
+test("buildCapabilityGrant rejects expiresAt before issuedAt", () => {
+  assert.throws(
+    () =>
+      buildCapabilityGrant(
+        {
+          subject: SUBJECT,
+          capabilities: ["jobs:lifecycle"],
+          issuedAt: "2026-01-02T00:00:00.000Z",
+          expiresAt: "2026-01-01T00:00:00.000Z"
+        },
+        { knownCapabilities: KNOWN, issuerWallet: ADMIN }
+      ),
+    ValidationError
+  );
+});
+
+test("applyRevocation marks the grant revoked once and is idempotent", () => {
+  const grant = buildCapabilityGrant(
+    { subject: SUBJECT, capabilities: ["jobs:lifecycle"], nonce: "nonce-2" },
+    { knownCapabilities: KNOWN, issuerWallet: ADMIN }
+  );
+  const first = applyRevocation(grant, { revokedBy: ADMIN, revokeNote: "rotated key" });
+  assert.equal(first.alreadyRevoked, false);
+  assert.equal(first.record.status, GRANT_STATUS.revoked);
+  assert.equal(first.record.revokedBy, ADMIN.toLowerCase());
+  assert.equal(first.record.revokeNote, "rotated key");
+  assert.ok(first.record.revokedAt);
+
+  const second = applyRevocation(first.record, { revokedBy: ADMIN });
+  assert.equal(second.alreadyRevoked, true);
+  assert.equal(second.record, first.record);
+});
+
+test("isGrantActive treats expired grants as inactive without mutating", () => {
+  const past = "2020-01-01T00:00:00.000Z";
+  const expired = {
+    id: "grant-expired",
+    status: GRANT_STATUS.active,
+    capabilities: ["jobs:lifecycle"],
+    issuedAt: past,
+    expiresAt: past
+  };
+  assert.equal(isGrantActive(expired), false);
+
+  const future = new Date(Date.now() + 60_000).toISOString();
+  const live = {
+    id: "grant-live",
+    status: GRANT_STATUS.active,
+    capabilities: ["jobs:lifecycle"],
+    issuedAt: new Date().toISOString(),
+    expiresAt: future
+  };
+  assert.equal(isGrantActive(live), true);
+});
+
+test("mergeGrantCapabilities adds active grant capabilities to the base set", () => {
+  const base = ["jobs:claim", "session:read"];
+  const grants = [
+    {
+      id: "g1",
+      status: GRANT_STATUS.active,
+      capabilities: ["jobs:lifecycle", "policies:propose"],
+      issuedAt: new Date().toISOString()
+    },
+    {
+      id: "g2",
+      status: GRANT_STATUS.revoked,
+      capabilities: ["xcm:observe"],
+      issuedAt: new Date().toISOString()
+    }
+  ];
+  const merged = mergeGrantCapabilities(base, grants);
+  assert.ok(merged.includes("jobs:lifecycle"));
+  assert.ok(merged.includes("policies:propose"));
+  assert.ok(merged.includes("jobs:claim"));
+  assert.ok(merged.includes("session:read"));
+  assert.ok(!merged.includes("xcm:observe"));
+});
+
+test("mergeGrantCapabilities never propagates capability-management capabilities", () => {
+  const merged = mergeGrantCapabilities(
+    ["jobs:claim"],
+    [
+      {
+        id: "rogue",
+        status: GRANT_STATUS.active,
+        capabilities: ["admin:capabilities:grant"],
+        issuedAt: new Date().toISOString()
+      }
+    ]
+  );
+  assert.ok(!merged.includes("admin:capabilities:grant"));
+});
+
+test("projectGrant returns a stable public shape", () => {
+  const grant = buildCapabilityGrant(
+    { subject: SUBJECT, capabilities: ["jobs:lifecycle"], nonce: "p" },
+    { knownCapabilities: KNOWN, issuerWallet: ADMIN }
+  );
+  const projected = projectGrant(grant);
+  assert.equal(projected.id, grant.id);
+  assert.deepEqual(Object.keys(projected).sort(), [
+    "capabilities",
+    "id",
+    "issuedAt",
+    "issuedBy",
+    "status",
+    "subject"
+  ].sort());
+});
+
+test("isReservedCapability flags only capability-management capabilities", () => {
+  assert.equal(isReservedCapability("admin:capabilities:grant"), true);
+  assert.equal(isReservedCapability("admin:capabilities:revoke"), true);
+  assert.equal(isReservedCapability("admin:capabilities:read"), true);
+  assert.equal(isReservedCapability("jobs:lifecycle"), false);
+  assert.equal(isReservedCapability(""), false);
+});

--- a/mcp-server/src/core/state-store.js
+++ b/mcp-server/src/core/state-store.js
@@ -46,6 +46,7 @@ export class MemoryStateStore {
     this.serviceStates = new Map();
     this.content = new Map();
     this.fundedJobs = new Map();
+    this.capabilityGrants = new Map();
   }
 
   async getSession(sessionId) {
@@ -296,6 +297,30 @@ export class MemoryStateStore {
     };
     this.serviceStates.set(scope, merged);
     return merged;
+  }
+
+  async getCapabilityGrant(id) {
+    return this.capabilityGrants.get(String(id ?? ""));
+  }
+
+  async upsertCapabilityGrant(record) {
+    const id = String(record?.id ?? "");
+    if (!id) return record;
+    this.capabilityGrants.set(id, record);
+    return record;
+  }
+
+  async listCapabilityGrants({ subject, status, limit = 100, offset = 0 } = {}) {
+    const subjectKey = subject ? String(subject).toLowerCase() : undefined;
+    const statusKey = status ? String(status).toLowerCase() : undefined;
+    return [...this.capabilityGrants.values()]
+      .filter((grant) => {
+        if (subjectKey && String(grant.subject ?? "").toLowerCase() !== subjectKey) return false;
+        if (statusKey && grant.status !== statusKey) return false;
+        return true;
+      })
+      .sort((left, right) => String(right.issuedAt ?? "").localeCompare(String(left.issuedAt ?? "")))
+      .slice(Math.max(offset, 0), Math.max(offset, 0) + Math.max(limit, 0));
   }
 
   async revokeToken(jti, ttlSeconds) {
@@ -634,6 +659,49 @@ export class RedisStateStore {
     };
     await this.client.set(this.key("service-state", scope), JSON.stringify(merged));
     return merged;
+  }
+
+  async getCapabilityGrant(id) {
+    await this.connect();
+    const raw = await this.client.get(this.key("capability-grant", String(id ?? "")));
+    return raw ? JSON.parse(raw) : undefined;
+  }
+
+  async upsertCapabilityGrant(record) {
+    await this.connect();
+    const id = String(record?.id ?? "");
+    if (!id) return record;
+    await this.client.set(this.key("capability-grant", id), JSON.stringify(record));
+    // Sorted set indices so list queries by subject and by status are
+    // O(log n + k) instead of scanning every grant key.
+    await this.client.zAdd(this.key("capability-grants", "all"), {
+      score: Date.parse(record?.issuedAt ?? "") || Date.now(),
+      value: id
+    });
+    if (record?.subject) {
+      await this.client.zAdd(
+        this.key("capability-grants-by-subject", String(record.subject).toLowerCase()),
+        { score: Date.parse(record?.issuedAt ?? "") || Date.now(), value: id }
+      );
+    }
+    return record;
+  }
+
+  async listCapabilityGrants({ subject, status, limit = 100, offset = 0 } = {}) {
+    await this.connect();
+    const start = Math.max(offset, 0);
+    const stop = start + Math.max(limit - 1, 0);
+    const indexKey = subject
+      ? this.key("capability-grants-by-subject", String(subject).toLowerCase())
+      : this.key("capability-grants", "all");
+    const ids = await this.client.zRange(indexKey, start, stop, { REV: true });
+    const records = await Promise.all(ids.map((id) => this.getCapabilityGrant(id)));
+    const statusKey = status ? String(status).toLowerCase() : undefined;
+    return records.filter((record) => {
+      if (!record) return false;
+      if (statusKey && record.status !== statusKey) return false;
+      return true;
+    });
   }
 
   async revokeToken(jti, ttlSeconds) {

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -20,6 +20,13 @@ import { buildAgentProfile } from "../../core/agent-profile.js";
 import { buildDiscoveryManifest } from "../../core/discovery-manifest.js";
 import { buildDisputeResolution, ARBITRATOR_SLA_SECONDS } from "../../core/dispute-resolution.js";
 import {
+  applyRevocation,
+  buildCapabilityGrant,
+  GRANT_STATUS,
+  projectGrant
+} from "../../core/capability-grants.js";
+import { listAllKnownCapabilities } from "../../auth/capabilities.js";
+import {
   assertContentHashMatches,
   buildContentRecord,
   contentResponse,
@@ -655,6 +662,42 @@ async function listAuditEvents(limit = 100) {
       tone: policy.state === "Pending" ? "warn" : "neutral",
       link: { label: "Open policy ->", href: "/policies" }
     }));
+  }
+  // Surface capability grant/revoke audit events alongside policy
+  // and run lifecycle ones so the audit log has a single feed for
+  // governance changes. Read-only — no state mutation.
+  if (typeof stateStore?.listCapabilityGrants === "function") {
+    const grants = await stateStore.listCapabilityGrants({ limit: Math.min(limit, 100) }).catch(() => []);
+    for (const grant of grants) {
+      const issuer = compactWallet(grant.issuedBy);
+      const subject = compactWallet(grant.subject);
+      events.push(auditEvent({
+        id: `audit-capability-grant-${grant.id}`,
+        at: grant.issuedAt,
+        source: "operator",
+        category: "policy",
+        action: "capability.grant",
+        actor: auditActor("operator", issuer, "ink"),
+        summary: `Granted ${grant.capabilities.length} capabilit${grant.capabilities.length === 1 ? "y" : "ies"} to ${subject}${grant.scope ? ` (${grant.scope})` : ""}.`,
+        target: grant.id,
+        tone: "neutral",
+        link: { label: "Open grants ->", href: "/capabilities" }
+      }));
+      if (grant.status === "revoked" && grant.revokedAt) {
+        events.push(auditEvent({
+          id: `audit-capability-revoke-${grant.id}`,
+          at: grant.revokedAt,
+          source: "operator",
+          category: "policy",
+          action: "capability.revoke",
+          actor: auditActor("operator", compactWallet(grant.revokedBy), "warn"),
+          summary: `Revoked grant ${grant.id} for ${subject}${grant.revokeNote ? ` — ${grant.revokeNote}` : ""}.`,
+          target: grant.id,
+          tone: "warn",
+          link: { label: "Open grants ->", href: "/capabilities" }
+        }));
+      }
+    }
   }
   return events
     .sort((left, right) => String(right.day + right.at).localeCompare(String(left.day + left.at)))
@@ -3040,6 +3083,118 @@ const server = createServer(async (request, response) => {
     if (request.method === "GET" && pathname === "/admin/status") {
       const auth = await authMiddleware(request, url, { requireRole: "admin" });
       return respond(response, 200, await service.getAdminStatus({ auth }));
+    }
+
+    /*
+     * Capability grants — operator-issued, scoped delegations of
+     * platform capabilities to a subject wallet (a service token,
+     * an automation bot, or a co-operator). Modelled after
+     * Polkadot's Staking Operator Proxy: a strict subset of the
+     * issuer's capabilities, no further delegation, revocable at
+     * any time. Roadmap §6.
+     */
+    if (request.method === "GET" && pathname === "/admin/capability-grants") {
+      await authMiddleware(request, url, { requireRole: "admin" });
+      const subject = (url.searchParams.get("subject") ?? "").trim().toLowerCase() || undefined;
+      const status = (url.searchParams.get("status") ?? "").trim().toLowerCase() || undefined;
+      const limit = parseLimit(url, 50, 200);
+      const offset = Math.max(0, Number(url.searchParams.get("offset") ?? 0) || 0);
+      const grants = (await stateStore.listCapabilityGrants?.({ subject, status, limit, offset })) ?? [];
+      return respond(response, 200, {
+        items: grants.map((grant) => projectGrant(grant)).filter(Boolean),
+        limit,
+        offset
+      });
+    }
+
+    if (request.method === "POST" && pathname === "/admin/capability-grants") {
+      const auth = await authMiddleware(request, url, { requireRole: "admin" });
+      await enforceLimit("admin_jobs", auth.wallet, rateLimitConfig.adminJobs);
+      const payload = await readJsonBody(request);
+      const idempotencyKey = typeof payload?.idempotencyKey === "string" && payload.idempotencyKey.trim()
+        ? payload.idempotencyKey.trim()
+        : undefined;
+      const mutationKey = idempotencyKey ? `${auth.wallet}:${idempotencyKey}` : undefined;
+      const existing = mutationKey
+        ? await stateStore.getMutationReceipt?.("capability_grant", mutationKey)
+        : undefined;
+      if (existing) {
+        return respond(response, 200, existing);
+      }
+      const knownCapabilities = listAllKnownCapabilities();
+      const grant = buildCapabilityGrant(payload ?? {}, {
+        knownCapabilities,
+        issuerWallet: auth.wallet
+      });
+      await stateStore.upsertCapabilityGrant?.(grant);
+      const projection = projectGrant(grant);
+      if (mutationKey) {
+        await stateStore.upsertMutationReceipt?.("capability_grant", mutationKey, projection);
+      }
+      eventBus?.publish({
+        id: `capability-grant-${grant.id}-${Date.now()}`,
+        topic: "capability.grant",
+        wallet: auth.wallet,
+        wallets: [auth.wallet, grant.subject],
+        timestamp: new Date().toISOString(),
+        data: {
+          grantId: grant.id,
+          subject: grant.subject,
+          capabilities: grant.capabilities,
+          scope: grant.scope ?? null
+        }
+      });
+      return respond(response, 201, projection);
+    }
+
+    if (request.method === "POST" && pathname.startsWith("/admin/capability-grants/") && pathname.endsWith("/revoke")) {
+      const auth = await authMiddleware(request, url, { requireRole: "admin" });
+      await enforceLimit("admin_jobs", auth.wallet, rateLimitConfig.adminJobs);
+      const grantId = decodeURIComponent(pathname.slice("/admin/capability-grants/".length, -"/revoke".length));
+      if (!grantId) {
+        throw new ValidationError("grantId is required.");
+      }
+      const payload = (await readJsonBody(request).catch(() => undefined)) ?? {};
+      const idempotencyKey = typeof payload?.idempotencyKey === "string" && payload.idempotencyKey.trim()
+        ? payload.idempotencyKey.trim()
+        : undefined;
+      const mutationKey = idempotencyKey ? `${auth.wallet}:${grantId}:${idempotencyKey}` : undefined;
+      const existing = mutationKey
+        ? await stateStore.getMutationReceipt?.("capability_revoke", mutationKey)
+        : undefined;
+      if (existing) {
+        return respond(response, 200, existing);
+      }
+      const current = await stateStore.getCapabilityGrant?.(grantId);
+      if (!current) {
+        throw new ValidationError("Unknown grant id.", { grantId });
+      }
+      const { record, alreadyRevoked } = applyRevocation(current, {
+        revokedBy: auth.wallet,
+        revokeNote: payload?.note
+      });
+      if (!alreadyRevoked) {
+        await stateStore.upsertCapabilityGrant?.(record);
+      }
+      const projection = projectGrant(record);
+      if (mutationKey) {
+        await stateStore.upsertMutationReceipt?.("capability_revoke", mutationKey, projection);
+      }
+      if (!alreadyRevoked) {
+        eventBus?.publish({
+          id: `capability-revoke-${record.id}-${Date.now()}`,
+          topic: "capability.revoke",
+          wallet: auth.wallet,
+          wallets: [auth.wallet, record.subject],
+          timestamp: new Date().toISOString(),
+          data: {
+            grantId: record.id,
+            subject: record.subject,
+            revokedBy: record.revokedBy ?? auth.wallet
+          }
+        });
+      }
+      return respond(response, 200, projection);
     }
 
     if (request.method === "GET" && pathname === "/admin/github/status") {


### PR DESCRIPTION
## Summary
- Operator-facing scoped capability delegation: an admin can issue a strict subset of platform capabilities to a service wallet (automation bot, hosted operator, co-signer), and revoke at any time.
- Modelled after Polkadot's [Staking Operator Proxy](https://docs.polkadot.com/node-infrastructure/run-a-validator/operational-tasks/staking-operator-proxy): strict subset, no further delegation, revocable, with audit trail.
- Capability-management capabilities (`admin:capabilities:*`) are reserved — a grant cannot delegate the right to issue further grants.

## Backend
- `core/capability-grants.js` — build/validate/revoke helpers, capability-subset validation, public projection.
- `core/state-store.js` — `capabilityGrants` bucket on memory + redis with subject and status secondary indices.
- `auth/capabilities.js` — three new admin caps (`admin:capabilities:read|grant|revoke`), UI controls (`admin.capabilities.{view,grant,revoke}`), automation actions, route rules, and `listAllKnownCapabilities()` for grant validation.
- `auth/middleware.js` — subject-keyed grant lookup with 15-second in-process cache, merged into resolved capabilities so a granted wallet passes route-capability enforcement on the next request after the cache lapses.
- `protocols/http/server.js` — three new routes:
  - `GET  /admin/capability-grants[?subject=&status=]`
  - `POST /admin/capability-grants` (idempotent via `idempotencyKey`)
  - `POST /admin/capability-grants/:id/revoke` (idempotent)
  - Plus `capability.grant` / `capability.revoke` audit-log entries and an event-bus topic per change.

## Frontend
- `app/lib/api/capability-grants.ts` — typed list/create/revoke helpers.
- `app/lib/api/hooks.ts` — `useCapabilityGrants()` with 15s refresh.
- `app/app/(authed)/capabilities/page.tsx` — issue form + active/revoked grant lists, gated via `canUseControl` on `admin.capabilities.{view,grant,revoke}`.
- `app/components/shell/OperatorRail.tsx` — "Capabilities" entry under Governance.

## Test plan
- [x] `npm --workspace mcp-server test` — 398/402 pass (16 new; same 4 chronic env-dependent failures as `main`)
- [x] `npm --workspace averray-app run typecheck` — clean
- [x] `npm --workspace averray-app run build` — `/capabilities` route 4.93 kB
- [x] `npm run check:sdk-types` + `npm run typecheck:sdk` — clean
- [ ] As an admin, issue a grant for a 0x wallet — appears in active list, audit log records `capability.grant`
- [ ] Sign in as the granted wallet — capability-required route succeeds within 15s
- [ ] Revoke the grant — appears in revoked list, audit log records `capability.revoke`, route enforcement returns within 15s

🤖 Generated with [Claude Code](https://claude.com/claude-code)