### PR TITLE
Report policy settlement read errors

### DIFF
--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -290,18 +290,27 @@ export class BlockchainGateway {
             signerIsVerifier: false,
             escrowIsServiceOperator: false
           },
+          readErrors: [],
           risk: {}
         };
       }
 
       const signerAddress = await this.signer?.getAddress?.();
-      const optionalBool = async (promise, fallback = false) => {
+      const readErrors = [];
+      const optionalRead = async (field, promise, fallback) => {
         try {
-          return Boolean(await promise);
-        } catch {
+          return await promise;
+        } catch (error) {
+          readErrors.push({
+            field,
+            message: error?.shortMessage ?? error?.message ?? "read failed"
+          });
           return fallback;
         }
       };
+      const optionalBool = async (field, promise, fallback = false) => Boolean(
+        await optionalRead(field, promise, fallback)
+      );
       const [
         owner,
         pauser,
@@ -320,33 +329,33 @@ export class BlockchainGateway {
         disputeLossSkillPenalty,
         disputeLossReliabilityPenalty
       ] = await Promise.all([
-        this.policyContract.owner(),
-        this.policyContract.pauser(),
-        this.policyContract.paused(),
-        signerAddress ? optionalBool(this.policyContract.verifiers(signerAddress)) : false,
+        optionalRead("owner", this.policyContract.owner(), undefined),
+        optionalRead("pauser", this.policyContract.pauser(), undefined),
+        optionalRead("paused", this.policyContract.paused(), undefined),
+        signerAddress ? optionalBool("verifiers(signer)", this.policyContract.verifiers(signerAddress)) : false,
         this.config.escrowCoreAddress
-          ? optionalBool(this.policyContract.serviceOperators(this.config.escrowCoreAddress))
+          ? optionalBool("serviceOperators(escrowCore)", this.policyContract.serviceOperators(this.config.escrowCoreAddress))
           : false,
-        this.policyContract.dailyOutflowCap(),
-        this.policyContract.perAccountBorrowCap(),
-        this.policyContract.minimumCollateralRatioBps(),
-        this.policyContract.defaultClaimStakeBps(),
-        this.policyContract.claimFeeBps().catch(() => 0),
-        this.policyContract.claimFeeVerifierBps().catch(() => 7000),
-        this.policyContract.onboardingWaiverClaimCount().catch(() => 0),
-        this.policyContract.rejectionSkillPenalty(),
-        this.policyContract.rejectionReliabilityPenalty(),
-        this.policyContract.disputeLossSkillPenalty(),
-        this.policyContract.disputeLossReliabilityPenalty()
+        optionalRead("dailyOutflowCap", this.policyContract.dailyOutflowCap(), 0),
+        optionalRead("perAccountBorrowCap", this.policyContract.perAccountBorrowCap(), 0),
+        optionalRead("minimumCollateralRatioBps", this.policyContract.minimumCollateralRatioBps(), 0),
+        optionalRead("defaultClaimStakeBps", this.policyContract.defaultClaimStakeBps(), 0),
+        optionalRead("claimFeeBps", this.policyContract.claimFeeBps(), 0),
+        optionalRead("claimFeeVerifierBps", this.policyContract.claimFeeVerifierBps(), 7000),
+        optionalRead("onboardingWaiverClaimCount", this.policyContract.onboardingWaiverClaimCount(), 0),
+        optionalRead("rejectionSkillPenalty", this.policyContract.rejectionSkillPenalty(), 0),
+        optionalRead("rejectionReliabilityPenalty", this.policyContract.rejectionReliabilityPenalty(), 0),
+        optionalRead("disputeLossSkillPenalty", this.policyContract.disputeLossSkillPenalty(), 0),
+        optionalRead("disputeLossReliabilityPenalty", this.policyContract.disputeLossReliabilityPenalty(), 0)
       ]);
 
       return {
         enabled: true,
         policyAddress: this.config.treasuryPolicyAddress,
-        paused: Boolean(paused),
+        paused: paused === undefined ? undefined : Boolean(paused),
         owner,
         pauser,
-        settlementReady: Boolean(signerIsVerifier && escrowIsServiceOperator && !paused),
+        settlementReady: Boolean(signerIsVerifier && escrowIsServiceOperator && paused === false),
         contracts: {
           escrowCoreAddress: this.config.escrowCoreAddress,
           agentAccountAddress: this.config.agentAccountAddress,
@@ -358,6 +367,7 @@ export class BlockchainGateway {
           signerIsVerifier,
           escrowIsServiceOperator
         },
+        readErrors,
         risk: {
           dailyOutflowCap: Number(dailyOutflowCap),
           perAccountBorrowCap: Number(perAccountBorrowCap),

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -249,11 +249,87 @@ test("getTreasuryPolicyStatus surfaces settlement readiness roles", async () => 
   assert.equal(status.roles.signerAddress, signerAddress);
   assert.equal(status.roles.signerIsVerifier, true);
   assert.equal(status.roles.escrowIsServiceOperator, true);
+  assert.deepEqual(status.readErrors, []);
   assert.deepEqual(status.contracts.supportedAssets, [{
     symbol: "DOT",
     address: DOT_ASSET.address,
     assetClass: "custom",
     decimals: 18
+  }]);
+});
+
+test("getTreasuryPolicyStatus records individual read errors without hiding roles", async () => {
+  const gateway = new BlockchainGateway({
+    enabled: true,
+    rpcUrl: "http://127.0.0.1:8545",
+    signerPrivateKey: `0x${"11".repeat(32)}`,
+    treasuryPolicyAddress: "0x1111111111111111111111111111111111111111",
+    agentAccountAddress: "0x3333333333333333333333333333333333333333",
+    escrowCoreAddress: "0x2222222222222222222222222222222222222222",
+    reputationSbtAddress: "0x4444444444444444444444444444444444444444",
+    supportedAssets: [DOT_ASSET]
+  });
+  gateway.policyContract = {
+    async owner() {
+      return "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    },
+    async pauser() {
+      return "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    },
+    async paused() {
+      return false;
+    },
+    async verifiers() {
+      return true;
+    },
+    async serviceOperators() {
+      const error = new Error("require(false)");
+      error.shortMessage = "execution reverted";
+      throw error;
+    },
+    async dailyOutflowCap() {
+      return 100n;
+    },
+    async perAccountBorrowCap() {
+      return 200n;
+    },
+    async minimumCollateralRatioBps() {
+      return 300n;
+    },
+    async defaultClaimStakeBps() {
+      return 400n;
+    },
+    async claimFeeBps() {
+      return 5n;
+    },
+    async claimFeeVerifierBps() {
+      return 6000n;
+    },
+    async onboardingWaiverClaimCount() {
+      return 7n;
+    },
+    async rejectionSkillPenalty() {
+      return 8n;
+    },
+    async rejectionReliabilityPenalty() {
+      return 9n;
+    },
+    async disputeLossSkillPenalty() {
+      return 10n;
+    },
+    async disputeLossReliabilityPenalty() {
+      return 11n;
+    }
+  };
+
+  const status = await gateway.getTreasuryPolicyStatus();
+
+  assert.equal(status.roles.signerIsVerifier, true);
+  assert.equal(status.roles.escrowIsServiceOperator, false);
+  assert.equal(status.settlementReady, false);
+  assert.deepEqual(status.readErrors, [{
+    field: "serviceOperators(escrowCore)",
+    message: "execution reverted"
   }]);
 });
 

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -58,6 +58,7 @@ const DEFAULT_TREASURY_POLICY_STATUS = {
     signerIsVerifier: false,
     escrowIsServiceOperator: false
   },
+  readErrors: [],
   risk: {}
 };
 

--- a/scripts/ops/run-hosted-worker-loop.mjs
+++ b/scripts/ops/run-hosted-worker-loop.mjs
@@ -159,6 +159,9 @@ function formatSettlementReadiness(policy) {
   if (policy?.paused) reasons.push("policyPaused=true");
   if (!policy?.roles?.signerIsVerifier) reasons.push("signerIsVerifier=false");
   if (!policy?.roles?.escrowIsServiceOperator) reasons.push("escrowIsServiceOperator=false");
+  if (Array.isArray(policy?.readErrors) && policy.readErrors.length > 0) {
+    reasons.push(`policyReadErrors=${policy.readErrors.map((entry) => entry.field).join("|")}`);
+  }
   if (policy?.error?.message) reasons.push(`policyError=${policy.error.message}`);
   return reasons.length ? reasons.join(", ") : "settlementReady=false";
 }

--- a/scripts/ops/run-hosted-worker-loop.test.mjs
+++ b/scripts/ops/run-hosted-worker-loop.test.mjs
@@ -157,6 +157,7 @@ test("runHostedWorkerLoop fails closed before mutation when settlement is not re
           calls.push(["getAdminStatus"]);
           return settlementReadyStatus({
             settlementReady: false,
+            readErrors: [{ field: "serviceOperators(escrowCore)", message: "execution reverted" }],
             roles: {
               signerAddress: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
               signerIsVerifier: false,
@@ -173,7 +174,7 @@ test("runHostedWorkerLoop fails closed before mutation when settlement is not re
       log: () => {},
       env: { ADMIN_JWT: "token" }
     }),
-    /signerIsVerifier=false/u
+    /signerIsVerifier=false, policyReadErrors=serviceOperators\(escrowCore\)/u
   );
 
   assert.deepEqual(calls.map(([name]) => name), ["getAuthSession", "getAdminStatus"]);


### PR DESCRIPTION
## Summary
- keep TreasuryPolicy admin status alive when individual contract getters revert
- expose per-field policy readErrors so hosted product-proof preflight can name the failing getter
- include policyReadErrors in the worker-loop fail-closed message

## Checks
- node --test mcp-server/src/blockchain/gateway.test.js
- node --test scripts/ops/run-hosted-worker-loop.test.mjs
- npm --workspace mcp-server test

## Impact
- Backend/admin status and hosted worker-loop diagnostics only
- No frontend, indexer, Caddy, contracts, or public-site changes
- No environment changes required