### PR TITLE
Sub-contracting history on the public agent profile (closes roadmap §8)

### DIFF
--- a/mcp-server/src/core/agent-profile.js
+++ b/mcp-server/src/core/agent-profile.js
@@ -49,6 +49,14 @@ export function buildAgentProfile({
   // reaching into the store itself. Callers that don't need
   // dispute history can omit it.
   getDisputeReceipts,
+  // Optional sub-contracting lineage lookup. The HTTP layer
+  // pre-walks each session's parent (via `job.parentSessionId`) and
+  // children (via `listJobsByParentSession(session.sessionId)`),
+  // then passes a sync `(sessionId) → { parent?, children? } |
+  // undefined` so this builder can emit the `lineage` block +
+  // `stats.lineage` counters without reaching into the catalog
+  // itself. Callers that don't need lineage can omit it. Roadmap §8.
+  getLineage,
 } = {}) {
   requireAddress(wallet, "wallet");
   const normalizedWallet = wallet.toLowerCase();
@@ -171,6 +179,21 @@ export function buildAgentProfile({
     { total: 0, open: 0, lost: 0, won: 0, split: 0, timeout: 0, resolved: 0 }
   );
 
+  // Sub-contracting history. Each session can be a parent (this
+  // wallet posted a sub-job from it), a child (this wallet worked
+  // on a sub-job posted by another session), or both for a middle
+  // node in a chain. Roadmap §8.
+  const lineage = buildLineageHistory(
+    safeSessions,
+    normalizedWallet,
+    definitionOf,
+    typeof getLineage === "function" ? getLineage : () => undefined
+  );
+  const lineageOutcomes = {
+    delegated: lineage.delegated.length,
+    subcontracted: lineage.subcontracted.length
+  };
+
   return {
     schemaVersion: AGENT_PROFILE_SCHEMA_VERSION,
     wallet: normalizedWallet,
@@ -191,11 +214,13 @@ export function buildAgentProfile({
       lastActive: lastActiveMs ? new Date(lastActiveMs).toISOString() : null,
       preferredCategories,
       disputes: disputeOutcomes,
+      lineage: lineageOutcomes,
     },
     ...(currentActivity ? { currentActivity } : {}),
     categoryLevels,
     badges,
     disputes,
+    lineage,
   };
 }
 
@@ -433,6 +458,121 @@ function buildDisputeHistory(sessions, definitionOf, getDisputeReceipts) {
  * fields (full evidence blob, signed receipt body) live behind
  * `/disputes/<id>` and require auth.
  */
+/**
+ * Walk session history and split each entry into the wallet's two
+ * sub-contracting roles:
+ *
+ *   - delegated:   sessions where THIS wallet posted at least one
+ *                  child job (parent role).
+ *   - subcontracted: sessions where THIS wallet worked on a job
+ *                  that was itself a child of another session
+ *                  (child role).
+ *
+ * Both lists are newest-first and capped at 25 entries to keep the
+ * public profile bounded. The frontend can deep-link to /runs for
+ * the unbounded view. Each entry stays slim: id, jobId, jobTitle?,
+ * status, completedAt, plus a compact counterparty + lineage
+ * summary. Heavy lineage payloads (full child timelines, budget
+ * accounting) live behind /admin/jobs/timeline.
+ *
+ * Skips any session whose lineage lookup returns nothing — the
+ * common case for a wallet that hasn't done any sub-contracting.
+ */
+function buildLineageHistory(sessions, normalizedWallet, definitionOf, getLineage) {
+  const delegated = [];
+  const subcontracted = [];
+  if (!Array.isArray(sessions) || sessions.length === 0) {
+    return { delegated, subcontracted };
+  }
+
+  for (const session of sessions) {
+    if (!session || typeof session !== "object") continue;
+    const lineage = getLineage(session.sessionId);
+    if (!lineage || typeof lineage !== "object") continue;
+
+    const job = (() => {
+      try {
+        return definitionOf(session.jobId);
+      } catch {
+        return undefined;
+      }
+    })();
+
+    if (Array.isArray(lineage.children) && lineage.children.length > 0) {
+      delegated.push(buildDelegatedEntry(session, job, lineage.children));
+    }
+    if (lineage.parent && typeof lineage.parent === "object") {
+      subcontracted.push(buildSubcontractedEntry(session, job, lineage.parent, normalizedWallet));
+    }
+  }
+
+  delegated.sort((a, b) => Date.parse(b.updatedAt ?? "") - Date.parse(a.updatedAt ?? ""));
+  subcontracted.sort((a, b) => Date.parse(b.updatedAt ?? "") - Date.parse(a.updatedAt ?? ""));
+  return {
+    delegated: delegated.slice(0, 25),
+    subcontracted: subcontracted.slice(0, 25)
+  };
+}
+
+function buildDelegatedEntry(session, job, children) {
+  const childJobIds = [];
+  const childSessionIds = [];
+  const childWallets = new Set();
+  for (const child of children) {
+    if (!child || typeof child !== "object") continue;
+    const jobId = stringOrUndefined(child.jobId);
+    if (jobId) childJobIds.push(jobId);
+    if (Array.isArray(child.sessionIds)) {
+      for (const sid of child.sessionIds) {
+        if (typeof sid === "string" && sid) childSessionIds.push(sid);
+      }
+    }
+    const childWallet = stringOrUndefined(child.wallet);
+    if (childWallet) childWallets.add(childWallet.toLowerCase());
+  }
+  return {
+    sessionId: String(session.sessionId ?? ""),
+    jobId: stringOrUndefined(session.jobId) ?? "unknown-job",
+    ...(stringOrUndefined(job?.title) ? { jobTitle: job.title } : {}),
+    status: stringOrUndefined(session.status) ?? "unknown",
+    role: "parent",
+    updatedAt: stringOrUndefined(session.updatedAt) ?? new Date().toISOString(),
+    children: {
+      count: childJobIds.length,
+      ...(childJobIds.length ? { jobIds: childJobIds } : {}),
+      ...(childSessionIds.length ? { sessionIds: childSessionIds } : {}),
+      ...(childWallets.size ? { wallets: [...childWallets] } : {})
+    }
+  };
+}
+
+function buildSubcontractedEntry(session, job, parent, normalizedWallet) {
+  const parentWallet = stringOrUndefined(parent.wallet);
+  const parentSessionId = stringOrUndefined(parent.sessionId);
+  const parentJobId = stringOrUndefined(parent.jobId);
+  return {
+    sessionId: String(session.sessionId ?? ""),
+    jobId: stringOrUndefined(session.jobId) ?? "unknown-job",
+    ...(stringOrUndefined(job?.title) ? { jobTitle: job.title } : {}),
+    status: stringOrUndefined(session.status) ?? "unknown",
+    role: "child",
+    updatedAt: stringOrUndefined(session.updatedAt) ?? new Date().toISOString(),
+    parent: {
+      ...(parentSessionId ? { sessionId: parentSessionId } : {}),
+      ...(parentJobId ? { jobId: parentJobId } : {}),
+      ...(parentWallet
+        ? {
+            wallet: parentWallet.toLowerCase(),
+            // Convenience flag so the renderer can mark "self-
+            // delegation" (a wallet posting a sub-job to itself)
+            // distinctly from a true cross-wallet subcontract.
+            isSelf: parentWallet.toLowerCase() === normalizedWallet
+          }
+        : {})
+    }
+  };
+}
+
 function buildProfileDispute(session, definitionOf, verdictReceipt, releaseReceipt) {
   const sessionId = String(session.sessionId ?? "");
   const id = sessionId ? disputeIdForSession(sessionId) : undefined;

--- a/mcp-server/src/core/agent-profile.test.js
+++ b/mcp-server/src/core/agent-profile.test.js
@@ -495,3 +495,101 @@ test("buildAgentProfile leaves disputes empty when no contested sessions exist",
     resolved: 0,
   });
 });
+
+test("buildAgentProfile surfaces sub-contracting lineage when getLineage returns a parent or children", () => {
+  const PARENT_WALLET = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  const sessions = [
+    approvedSession({
+      jobId: "starter-coding-001",
+      sessionId: "session-parent",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    }),
+    approvedSession({
+      jobId: "governance-pro-001",
+      sessionId: "session-child",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    }),
+  ];
+  // session-parent posted one sub-job; session-child worked on a
+  // sub-job whose parent belonged to PARENT_WALLET.
+  const lineageBySession = {
+    "session-parent": {
+      children: [{ jobId: "child-job-1", parentWallet: WALLET.toLowerCase() }],
+    },
+    "session-child": {
+      parent: {
+        sessionId: "remote-session",
+        jobId: "remote-job",
+        wallet: PARENT_WALLET,
+      },
+    },
+  };
+  const profile = buildAgentProfile({
+    wallet: WALLET,
+    reputation: { skill: 70, reliability: 60, economic: 40 },
+    sessions,
+    getJobDefinition: makeGetJob(),
+    getLineage: (sessionId) => lineageBySession[sessionId],
+  });
+
+  assert.equal(profile.stats.lineage.delegated, 1);
+  assert.equal(profile.stats.lineage.subcontracted, 1);
+  assert.equal(profile.lineage.delegated.length, 1);
+  assert.equal(profile.lineage.subcontracted.length, 1);
+
+  const delegated = profile.lineage.delegated[0];
+  assert.equal(delegated.role, "parent");
+  assert.equal(delegated.sessionId, "session-parent");
+  assert.equal(delegated.children.count, 1);
+  assert.deepEqual(delegated.children.jobIds, ["child-job-1"]);
+
+  const subcontracted = profile.lineage.subcontracted[0];
+  assert.equal(subcontracted.role, "child");
+  assert.equal(subcontracted.sessionId, "session-child");
+  assert.equal(subcontracted.parent.sessionId, "remote-session");
+  assert.equal(subcontracted.parent.jobId, "remote-job");
+  assert.equal(subcontracted.parent.wallet, PARENT_WALLET.toLowerCase());
+  assert.equal(subcontracted.parent.isSelf, false);
+});
+
+test("buildAgentProfile flags a session whose parent wallet equals its own wallet as self-delegated", () => {
+  const sessions = [
+    approvedSession({
+      jobId: "governance-pro-001",
+      sessionId: "session-self",
+      updatedAt: "2026-01-03T00:00:00.000Z",
+    }),
+  ];
+  const profile = buildAgentProfile({
+    wallet: WALLET,
+    reputation: { skill: 50, reliability: 50, economic: 50 },
+    sessions,
+    getJobDefinition: makeGetJob(),
+    getLineage: () => ({
+      parent: { sessionId: "self-parent", jobId: "self-job", wallet: WALLET },
+    }),
+  });
+  assert.equal(profile.lineage.subcontracted[0].parent.isSelf, true);
+});
+
+test("buildAgentProfile leaves lineage empty when no sessions carry sub-contracting markers", () => {
+  const sessions = [
+    approvedSession({
+      jobId: "starter-coding-001",
+      sessionId: "session-plain",
+      updatedAt: "2026-01-04T00:00:00.000Z",
+    }),
+  ];
+  const profile = buildAgentProfile({
+    wallet: WALLET,
+    reputation: { skill: 50, reliability: 50, economic: 50 },
+    sessions,
+    getJobDefinition: makeGetJob(),
+    // Lookup returns nothing — same as the common case where the
+    // HTTP layer's preloadLineage short-circuits because no session
+    // has a parent or children.
+    getLineage: () => undefined,
+  });
+  assert.deepEqual(profile.lineage, { delegated: [], subcontracted: [] });
+  assert.deepEqual(profile.stats.lineage, { delegated: 0, subcontracted: 0 });
+});

--- a/mcp-server/src/core/badge-metadata.js
+++ b/mcp-server/src/core/badge-metadata.js
@@ -73,6 +73,11 @@ const DESCRIPTION_MAX = 1024;
  * @param {string} [input.image]              Badge image URL (optional)
  * @param {string} [input.externalUrl]        Profile page URL override
  * @param {string} [input.publicBaseUrl]      Falls back to external_url = <base>/agents/<worker>
+ * @param {object} [input.lineage]            Optional sub-contracting lineage:
+ *                                            { parent?: { sessionId, jobId, wallet },
+ *                                              children?: { count, jobIds?, sessionIds? } }
+ *                                            See docs/schemas/agent-badge-v1.md and
+ *                                            CORE_FRAMEWORK_ROADMAP §8 for the rule.
  * @returns {object} metadata document
  */
 export function buildBadgeMetadata(input) {
@@ -93,7 +98,8 @@ export function buildBadgeMetadata(input) {
     metadataURI,
     image,
     externalUrl,
-    publicBaseUrl
+    publicBaseUrl,
+    lineage
   } = input;
 
   const canonicalCategory = String(category ?? "").trim().toLowerCase() || "unknown";
@@ -135,11 +141,65 @@ export function buildBadgeMetadata(input) {
   if (metadataURI) {
     doc.averray.metadataURI = metadataURI;
   }
+  const normalizedLineage = normalizeBadgeLineage(lineage);
+  if (normalizedLineage) {
+    doc.averray.lineage = normalizedLineage;
+  }
 
   // Re-validate before handing back to the caller so we fail fast at the
   // construction site, not when the endpoint serves it.
   validateBadgeMetadata(doc);
   return doc;
+}
+
+/**
+ * Strip noise / canonicalise the lineage block so only the keys we
+ * accept survive. Returns `undefined` when nothing meaningful is
+ * left, so the badge omits the lineage field entirely (the schema
+ * treats lineage as optional rather than empty).
+ */
+function normalizeBadgeLineage(raw) {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const lineage = {};
+  if (raw.parent && typeof raw.parent === "object" && !Array.isArray(raw.parent)) {
+    const parent = {};
+    if (typeof raw.parent.sessionId === "string" && raw.parent.sessionId) {
+      parent.sessionId = raw.parent.sessionId;
+    }
+    if (typeof raw.parent.jobId === "string" && raw.parent.jobId) {
+      parent.jobId = raw.parent.jobId;
+    }
+    if (typeof raw.parent.wallet === "string" && ADDRESS_RE.test(raw.parent.wallet)) {
+      parent.wallet = raw.parent.wallet.toLowerCase();
+    }
+    if (Object.keys(parent).length > 0) {
+      lineage.parent = parent;
+    }
+  }
+  if (raw.children && typeof raw.children === "object" && !Array.isArray(raw.children)) {
+    const children = {};
+    const count = Number(raw.children.count);
+    if (Number.isFinite(count) && count >= 0) {
+      children.count = Math.floor(count);
+    }
+    if (Array.isArray(raw.children.jobIds)) {
+      const jobIds = raw.children.jobIds.filter((id) => typeof id === "string" && id);
+      if (jobIds.length > 0) children.jobIds = jobIds;
+    }
+    if (Array.isArray(raw.children.sessionIds)) {
+      const sessionIds = raw.children.sessionIds.filter((id) => typeof id === "string" && id);
+      if (sessionIds.length > 0) children.sessionIds = sessionIds;
+    }
+    if (Object.keys(children).length > 0) {
+      // If a count wasn't supplied, derive it from the lists so the
+      // surface always carries an explicit "how many" value.
+      if (children.count === undefined && Array.isArray(children.jobIds)) {
+        children.count = children.jobIds.length;
+      }
+      lineage.children = children;
+    }
+  }
+  return Object.keys(lineage).length > 0 ? lineage : undefined;
 }
 
 /**
@@ -220,8 +280,14 @@ function requireAverray(averray) {
     requireString(averray, "metadataURI", { parent: "averray", urlLike: true });
   }
 
+  if ("lineage" in averray) {
+    validateLineage(averray.lineage);
+  }
+
   // Disallow unknown keys in `averray` so producers don't drift the schema
-  // without bumping schemaVersion.
+  // without bumping schemaVersion. `lineage` was added under v1 as a
+  // purely-additive field — see docs/schemas/agent-badge-v1.md and
+  // CORE_FRAMEWORK_ROADMAP §8.
   const allowed = new Set([
     "schemaVersion",
     "jobId",
@@ -237,11 +303,80 @@ function requireAverray(averray) {
     "worker",
     "poster",
     "verifier",
-    "metadataURI"
+    "metadataURI",
+    "lineage"
   ]);
   for (const key of Object.keys(averray)) {
     if (!allowed.has(key)) {
       throw new ValidationError(`averray.${key} is not a recognised field for schemaVersion ${BADGE_SCHEMA_VERSION}`);
+    }
+  }
+}
+
+function validateLineage(lineage) {
+  if (!lineage || typeof lineage !== "object" || Array.isArray(lineage)) {
+    throw new ValidationError("averray.lineage must be an object");
+  }
+  const allowed = new Set(["parent", "children"]);
+  for (const key of Object.keys(lineage)) {
+    if (!allowed.has(key)) {
+      throw new ValidationError(`averray.lineage.${key} is not a recognised lineage field`);
+    }
+  }
+  if ("parent" in lineage) {
+    const parent = lineage.parent;
+    if (!parent || typeof parent !== "object" || Array.isArray(parent)) {
+      throw new ValidationError("averray.lineage.parent must be an object");
+    }
+    const parentAllowed = new Set(["sessionId", "jobId", "wallet"]);
+    for (const key of Object.keys(parent)) {
+      if (!parentAllowed.has(key)) {
+        throw new ValidationError(`averray.lineage.parent.${key} is not a recognised parent field`);
+      }
+    }
+    if ("sessionId" in parent) {
+      requireString(parent, "sessionId", { parent: "averray.lineage.parent" });
+    }
+    if ("jobId" in parent) {
+      requireString(parent, "jobId", { parent: "averray.lineage.parent" });
+    }
+    if ("wallet" in parent && !ADDRESS_RE.test(parent.wallet ?? "")) {
+      throw new ValidationError("averray.lineage.parent.wallet must be a 0x-prefixed 20-byte EVM address");
+    }
+  }
+  if ("children" in lineage) {
+    const children = lineage.children;
+    if (!children || typeof children !== "object" || Array.isArray(children)) {
+      throw new ValidationError("averray.lineage.children must be an object");
+    }
+    const childrenAllowed = new Set(["count", "jobIds", "sessionIds"]);
+    for (const key of Object.keys(children)) {
+      if (!childrenAllowed.has(key)) {
+        throw new ValidationError(`averray.lineage.children.${key} is not a recognised children field`);
+      }
+    }
+    if (!Number.isInteger(children.count) || children.count < 0) {
+      throw new ValidationError("averray.lineage.children.count must be a non-negative integer");
+    }
+    if ("jobIds" in children) {
+      if (!Array.isArray(children.jobIds)) {
+        throw new ValidationError("averray.lineage.children.jobIds must be an array of strings");
+      }
+      for (const id of children.jobIds) {
+        if (typeof id !== "string" || id.length === 0) {
+          throw new ValidationError("averray.lineage.children.jobIds entries must be non-empty strings");
+        }
+      }
+    }
+    if ("sessionIds" in children) {
+      if (!Array.isArray(children.sessionIds)) {
+        throw new ValidationError("averray.lineage.children.sessionIds must be an array of strings");
+      }
+      for (const id of children.sessionIds) {
+        if (typeof id !== "string" || id.length === 0) {
+          throw new ValidationError("averray.lineage.children.sessionIds entries must be non-empty strings");
+        }
+      }
     }
   }
 }
@@ -334,7 +469,14 @@ function stripTrailingSlash(value) {
  * @param {object} params.session                 Session object from the state store
  * @param {object} params.job                     Canonical job definition
  * @param {object} [params.verification]          Verification result, if any
- * @param {object} [params.context]               { publicBaseUrl, posterAddress, verifierAddress, image }
+ * @param {object} [params.context]               { publicBaseUrl, posterAddress, verifierAddress, image, lineage }
+ *                                                 `context.lineage` (optional) is the slim
+ *                                                 sub-contracting block: `{ parent?, children? }`.
+ *                                                 The HTTP layer assembles it by walking
+ *                                                 `job.parentSessionId` (parent) and
+ *                                                 `listJobsByParentSession(session.sessionId)`
+ *                                                 (children) so this builder doesn't need
+ *                                                 to reach into the catalog. Roadmap §8.
  */
 export function buildBadgeFromSession({ session, job, verification, context = {} }) {
   if (!session) {
@@ -385,7 +527,8 @@ export function buildBadgeFromSession({ session, job, verification, context = {}
     verifier: requireLowerAddress(context.verifierAddress ?? UNKNOWN_ADDRESS, "context.verifierAddress"),
     metadataURI: selfUrl,
     image: context.image,
-    publicBaseUrl
+    publicBaseUrl,
+    lineage: context.lineage
   });
 }
 

--- a/mcp-server/src/core/badge-metadata.test.js
+++ b/mcp-server/src/core/badge-metadata.test.js
@@ -259,3 +259,52 @@ test("buildBadgeFromSession never attributes poster/verifier back to the worker"
   assert.notEqual(doc.averray.poster, doc.averray.worker);
   assert.notEqual(doc.averray.verifier, doc.averray.worker);
 });
+
+test("buildBadgeMetadata accepts an optional lineage block (parent only)", () => {
+  const doc = buildBadgeMetadata({
+    ...validInput(),
+    lineage: {
+      parent: {
+        sessionId: "remote-session",
+        jobId: "remote-job",
+        wallet: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      }
+    }
+  });
+  assert.deepEqual(doc.averray.lineage, {
+    parent: {
+      sessionId: "remote-session",
+      jobId: "remote-job",
+      wallet: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  });
+});
+
+test("buildBadgeMetadata accepts a children-only lineage block and derives count from jobIds", () => {
+  const doc = buildBadgeMetadata({
+    ...validInput(),
+    lineage: {
+      children: { jobIds: ["child-1", "child-2"] }
+    }
+  });
+  assert.deepEqual(doc.averray.lineage, {
+    children: { count: 2, jobIds: ["child-1", "child-2"] }
+  });
+});
+
+test("buildBadgeMetadata omits the lineage block when nothing meaningful was supplied", () => {
+  const doc = buildBadgeMetadata({ ...validInput(), lineage: { parent: {} } });
+  assert.equal("lineage" in doc.averray, false);
+});
+
+test("validateBadgeMetadata rejects an unknown lineage subfield", () => {
+  const doc = buildBadgeMetadata(validInput());
+  doc.averray.lineage = { parent: { sessionId: "s1", rogue: "x" } };
+  assert.throws(() => validateBadgeMetadata(doc), ValidationError);
+});
+
+test("validateBadgeMetadata rejects a malformed parent wallet", () => {
+  const doc = buildBadgeMetadata(validInput());
+  doc.averray.lineage = { parent: { wallet: "not-a-wallet" } };
+  assert.throws(() => validateBadgeMetadata(doc), ValidationError);
+});

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -470,6 +470,16 @@ export class PlatformService {
     return this.jobCatalogService.getJobDefinition(jobId);
   }
 
+  /**
+   * Synchronous lookup of every child job posted from a given parent
+   * session. Used by HTTP routes that need a slim sub-contracting
+   * view (public agent profile, badge lineage block) without paying
+   * for `getSubJobLineage`'s session-history fetches. Roadmap §8.
+   */
+  listChildJobsByParentSession(parentSessionId) {
+    return this.jobCatalogService.listJobsByParentSession(parentSessionId);
+  }
+
   async getPublicJobDefinition(jobId, options = {}) {
     const { wallet, currentWallet, now = new Date() } = options;
     return this.attachClaimState(

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -316,6 +316,68 @@ async function preloadDisputeReceipts(sessions) {
   return (sessionId) => receiptsBySession.get(sessionId);
 }
 
+/**
+ * Walk the wallet's session history and pre-build the slim
+ * sub-contracting lookup `buildAgentProfile` consumes via its
+ * `getLineage` arg. For each session we record:
+ *   - `parent`  if the job this session is on was itself a child of
+ *               another session (`job.parentSessionId` set; the
+ *               parent wallet lives on `job.lineage.parentWallet`).
+ *   - `children` if any sub-jobs were posted from this session
+ *               (`listChildJobsByParentSession`).
+ * Sessions with neither role are skipped so a wallet that's never
+ * sub-contracted pays no extra cost. Roadmap §8.
+ */
+function preloadLineage(sessions) {
+  if (!Array.isArray(sessions) || sessions.length === 0) {
+    return () => undefined;
+  }
+  const lookup = new Map();
+  for (const session of sessions) {
+    if (!session || typeof session !== "object") continue;
+    const sessionId = String(session.sessionId ?? "");
+    if (!sessionId) continue;
+
+    const entry = {};
+    let job;
+    try {
+      job = service.getJobDefinition(session.jobId);
+    } catch {
+      job = undefined;
+    }
+    if (job?.parentSessionId) {
+      const parent = {
+        sessionId: String(job.parentSessionId),
+        ...(job.lineage?.parentJobId ? { jobId: String(job.lineage.parentJobId) } : {}),
+        ...(typeof job.lineage?.parentWallet === "string"
+          ? { wallet: job.lineage.parentWallet }
+          : {})
+      };
+      if (Object.keys(parent).length > 0) entry.parent = parent;
+    }
+    let childJobs;
+    try {
+      childJobs = service.listChildJobsByParentSession?.(sessionId) ?? [];
+    } catch {
+      childJobs = [];
+    }
+    if (childJobs.length > 0) {
+      entry.children = childJobs.map((childJob) => ({
+        jobId: String(childJob.id ?? ""),
+        ...(typeof childJob.lineage?.parentWallet === "string"
+          ? { parentWallet: childJob.lineage.parentWallet }
+          : {})
+      })).filter((child) => child.jobId);
+    }
+
+    if (entry.parent || (entry.children && entry.children.length > 0)) {
+      lookup.set(sessionId, entry);
+    }
+  }
+  if (lookup.size === 0) return () => undefined;
+  return (sessionId) => lookup.get(sessionId);
+}
+
 async function buildAgentDirectory(limit = 50) {
   const sessions = await service.listRecentSessions(limit);
   const wallets = [...new Set(sessions.map((session) => session.wallet).filter(Boolean))];
@@ -329,6 +391,10 @@ async function buildAgentDirectory(limit = 50) {
     // slashed (upheld-verdict) wallets. Skips wallets with no
     // disputed sessions, so this is free in the common case.
     const getDisputeReceipts = await preloadDisputeReceipts(history);
+    // Walk job lineage so directory rows can surface a "delegated"
+    // / "subcontracted" counter alongside the rest. Free for wallets
+    // that haven't sub-contracted.
+    const getLineage = preloadLineage(history);
     const profile = buildAgentProfile({
       wallet: wallet.toLowerCase(),
       reputation,
@@ -342,6 +408,7 @@ async function buildAgentDirectory(limit = 50) {
       },
       publicBaseUrl: process.env.PUBLIC_BASE_URL,
       getDisputeReceipts,
+      getLineage,
     });
     return buildAgentDirectoryRow(profile);
   }));
@@ -369,6 +436,40 @@ function buildBadgeReceipt(badge) {
     blockRef: averray.chainJobId,
     badge
   };
+}
+
+/**
+ * Derive the badge `lineage` block at fetch time from the session +
+ * job pair. Mirrors what `preloadLineage` does for the agent
+ * profile but for a single badge: parent (if the job was a sub-job)
+ * and children (if the session itself spawned sub-jobs). Returns
+ * `undefined` when there's nothing to surface so the badge stays
+ * clean. Roadmap §8.
+ */
+function deriveBadgeLineage(session, job) {
+  if (!session || !job) return undefined;
+  const lineage = {};
+  if (job.parentSessionId) {
+    const parent = {
+      sessionId: String(job.parentSessionId),
+      ...(job.lineage?.parentJobId ? { jobId: String(job.lineage.parentJobId) } : {}),
+      ...(typeof job.lineage?.parentWallet === "string" ? { wallet: job.lineage.parentWallet } : {})
+    };
+    if (Object.keys(parent).length > 0) lineage.parent = parent;
+  }
+  let childJobs = [];
+  try {
+    childJobs = service.listChildJobsByParentSession?.(session.sessionId) ?? [];
+  } catch {
+    childJobs = [];
+  }
+  if (childJobs.length > 0) {
+    lineage.children = {
+      count: childJobs.length,
+      jobIds: childJobs.map((childJob) => String(childJob.id ?? "")).filter(Boolean)
+    };
+  }
+  return Object.keys(lineage).length > 0 ? lineage : undefined;
 }
 
 async function listBadgeReceipts(limit = 100) {
@@ -1693,6 +1794,11 @@ const server = createServer(async (request, response) => {
       // with no contested sessions — `preloadDisputeReceipts` short-
       // circuits when there's nothing to fetch.
       const getDisputeReceipts = await preloadDisputeReceipts(sessions);
+      // Pre-walk sub-contracting lineage so the profile carries a
+      // delegated / subcontracted history block + counters without
+      // a separate /jobs/sub or /admin/jobs/timeline call. Free for
+      // wallets that haven't sub-contracted. Roadmap §8.
+      const getLineage = preloadLineage(sessions);
       const profile = buildAgentProfile({
         wallet: rawWallet.toLowerCase(),
         reputation,
@@ -1706,6 +1812,7 @@ const server = createServer(async (request, response) => {
         },
         publicBaseUrl: process.env.PUBLIC_BASE_URL,
         getDisputeReceipts,
+        getLineage,
       });
       return respond(response, 200, profile, { "cache-control": "public, max-age=30" });
     }
@@ -1746,7 +1853,8 @@ const server = createServer(async (request, response) => {
           context: {
             publicBaseUrl: process.env.PUBLIC_BASE_URL,
             posterAddress: process.env.DEFAULT_POSTER_ADDRESS,
-            verifierAddress: process.env.DEFAULT_VERIFIER_ADDRESS
+            verifierAddress: process.env.DEFAULT_VERIFIER_ADDRESS,
+            lineage: deriveBadgeLineage(session, job)
           }
         });
         // Keep badge JSON browser-cacheable for a minute — it's deterministic

--- a/site/agent.html
+++ b/site/agent.html
@@ -223,6 +223,41 @@
             </div>
           </section>
 
+          <!--
+            Sub-contracting history — derived from the live `lineage`
+            block on the profile JSON. Two columns: jobs this wallet
+            posted as a parent (delegated) and jobs this wallet
+            worked as a child of someone else's session
+            (subcontracted). Empty until at least one sub-job lands.
+            Roadmap §8: "extend profile and operator UI surfaces
+            around sub-contracting history".
+          -->
+          <section class="profile-panel">
+            <div class="section-heading">
+              <div>
+                <p class="eyebrow">Sub-contracting</p>
+                <h2>Delegation history</h2>
+              </div>
+              <span id="profile-lineage-summary" class="profile-summary-source">no sub-contracting yet</span>
+            </div>
+
+            <div class="lineage-grid">
+              <article class="lineage-block">
+                <p class="trail-block-label">Delegated <span id="profile-lineage-delegated-count">(0)</span></p>
+                <div id="profile-lineage-delegated" class="lineage-list">
+                  <p class="profile-empty">No sub-jobs posted from this wallet yet.</p>
+                </div>
+              </article>
+
+              <article class="lineage-block">
+                <p class="trail-block-label">Worked as sub-contractor <span id="profile-lineage-subcontracted-count">(0)</span></p>
+                <div id="profile-lineage-subcontracted" class="lineage-list">
+                  <p class="profile-empty">No sub-jobs claimed by this wallet yet.</p>
+                </div>
+              </article>
+            </div>
+          </section>
+
           <section class="profile-panel">
             <div class="section-heading">
               <div>

--- a/site/agent.js
+++ b/site/agent.js
@@ -616,6 +616,136 @@ function renderVerifyPanel(badge) {
   return `<div class="verify-rows">${rows.join("")}</div>`;
 }
 
+/* ---------------------------------------------------------------- */
+/* Sub-contracting history — see CORE_FRAMEWORK_ROADMAP §8. Reads    */
+/* the live `profile.lineage` block emitted by the agent profile    */
+/* builder (delegated[] + subcontracted[]) and renders two columns: */
+/* parent jobs this wallet posted, and child jobs this wallet       */
+/* worked on someone else's behalf. Each row stays compact: jobId,  */
+/* counterparty wallet, status, updatedAt. Empty state speaks       */
+/* honestly ("no sub-contracting yet") rather than inventing rows.  */
+/* ---------------------------------------------------------------- */
+
+const LINEAGE_STATUS_TONE = {
+  resolved: "won",
+  rejected: "lost",
+  disputed: "open",
+  open: "open",
+  paused: "open",
+  archived: "split",
+  stale: "split"
+};
+
+function renderLineageStatusPill(status) {
+  const key = String(status ?? "").toLowerCase();
+  const variant = LINEAGE_STATUS_TONE[key] ?? "resolved";
+  return `<span class="dispute-pill dispute-pill-${escapeHtml(variant)}">${escapeHtml(key || "unknown")}</span>`;
+}
+
+function renderDelegatedRow(entry) {
+  const childCount = entry?.children?.count ?? 0;
+  const jobIds = Array.isArray(entry?.children?.jobIds) ? entry.children.jobIds : [];
+  return `
+    <article class="lineage-row lineage-row-parent">
+      <header class="lineage-row-header">
+        <div class="lineage-row-title">
+          <p class="eyebrow">Parent</p>
+          <h3>${escapeHtml(entry.jobTitle ?? entry.jobId)}</h3>
+          <p class="lineage-row-meta">
+            <code>${escapeHtml(entry.jobId)}</code> · session
+            <code>${escapeHtml(entry.sessionId)}</code>
+          </p>
+        </div>
+        ${renderLineageStatusPill(entry.status)}
+      </header>
+      <p class="lineage-row-summary">
+        Delegated <strong>${childCount}</strong>
+        sub-job${childCount === 1 ? "" : "s"} on
+        <span title="${escapeHtml(entry.updatedAt ?? "")}">${escapeHtml(formatIso(entry.updatedAt))}</span>.
+      </p>
+      ${jobIds.length
+        ? `<ul class="lineage-row-jobs">${jobIds
+            .slice(0, 5)
+            .map((id) => `<li><code>${escapeHtml(id)}</code></li>`)
+            .join("")}${jobIds.length > 5 ? `<li class="lineage-row-jobs-more">+${jobIds.length - 5} more</li>` : ""}</ul>`
+        : ""}
+    </article>
+  `;
+}
+
+function renderSubcontractedRow(entry) {
+  const parent = entry?.parent ?? {};
+  const counterparty = parent.wallet
+    ? `<a class="verify-link" href="/agents/${escapeHtml(parent.wallet)}"><code>${escapeHtml(shortHash(parent.wallet, 6, 4))}</code> ↗</a>`
+    : '<span class="verify-value">—</span>';
+  return `
+    <article class="lineage-row lineage-row-child">
+      <header class="lineage-row-header">
+        <div class="lineage-row-title">
+          <p class="eyebrow">Sub-contractor</p>
+          <h3>${escapeHtml(entry.jobTitle ?? entry.jobId)}</h3>
+          <p class="lineage-row-meta">
+            <code>${escapeHtml(entry.jobId)}</code> · session
+            <code>${escapeHtml(entry.sessionId)}</code>
+          </p>
+        </div>
+        ${renderLineageStatusPill(entry.status)}
+      </header>
+      <p class="lineage-row-summary">
+        ${parent.isSelf ? "Self-delegated from" : "Posted by"}
+        ${counterparty}
+        ${parent.jobId ? `· parent job <code>${escapeHtml(parent.jobId)}</code>` : ""}
+        on <span title="${escapeHtml(entry.updatedAt ?? "")}">${escapeHtml(formatIso(entry.updatedAt))}</span>.
+      </p>
+    </article>
+  `;
+}
+
+function renderLineageHistory(profile) {
+  const summary = byId("profile-lineage-summary");
+  const delegatedRoot = byId("profile-lineage-delegated");
+  const subcontractedRoot = byId("profile-lineage-subcontracted");
+  const delegatedCount = byId("profile-lineage-delegated-count");
+  const subcontractedCount = byId("profile-lineage-subcontracted-count");
+
+  const lineage = profile.lineage ?? {};
+  const delegated = Array.isArray(lineage.delegated) ? lineage.delegated : [];
+  const subcontracted = Array.isArray(lineage.subcontracted) ? lineage.subcontracted : [];
+  const stats = profile.stats?.lineage ?? {};
+  const totalDelegated = Number(stats.delegated ?? delegated.length ?? 0);
+  const totalSubcontracted = Number(stats.subcontracted ?? subcontracted.length ?? 0);
+
+  if (delegatedCount) delegatedCount.textContent = `(${totalDelegated})`;
+  if (subcontractedCount) subcontractedCount.textContent = `(${totalSubcontracted})`;
+
+  if (summary) {
+    if (totalDelegated <= 0 && totalSubcontracted <= 0) {
+      summary.textContent = "no sub-contracting yet";
+    } else {
+      const parts = [];
+      if (totalDelegated > 0) parts.push(`${totalDelegated} delegated`);
+      if (totalSubcontracted > 0) parts.push(`${totalSubcontracted} subcontracted`);
+      summary.textContent = parts.join(" · ");
+    }
+  }
+
+  if (delegatedRoot) {
+    if (delegated.length === 0) {
+      delegatedRoot.innerHTML = '<p class="profile-empty">No sub-jobs posted from this wallet yet.</p>';
+    } else {
+      delegatedRoot.innerHTML = delegated.map(renderDelegatedRow).join("");
+    }
+  }
+
+  if (subcontractedRoot) {
+    if (subcontracted.length === 0) {
+      subcontractedRoot.innerHTML = '<p class="profile-empty">No sub-jobs claimed by this wallet yet.</p>';
+    } else {
+      subcontractedRoot.innerHTML = subcontracted.map(renderSubcontractedRow).join("");
+    }
+  }
+}
+
 function renderBadges(badges = []) {
   const root = byId("profile-badges");
   if (!root) return;
@@ -695,6 +825,7 @@ async function bootProfile() {
     );
     renderTrailSummary(profile);
     renderDisputeHistory(profile);
+    renderLineageHistory(profile);
     renderBadges(profile.badges);
   } catch (error) {
     if (loading) loading.textContent = error?.message ?? "Failed to load profile.";

--- a/site/styles.css
+++ b/site/styles.css
@@ -1416,3 +1416,114 @@ code {
 .dispute-row-timeout  { border-left: 3px solid #8c857a; }
 .dispute-row-resolved { border-left: 3px solid var(--accent); }
 
+/* Sub-contracting history (roadmap §8) ----------------------------- */
+
+.lineage-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+  gap: 0.9rem;
+  margin-top: 0.6rem;
+}
+
+.lineage-block {
+  display: grid;
+  gap: 0.55rem;
+  padding: 0.95rem 1rem;
+  border-radius: 0.85rem;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.55);
+}
+
+.lineage-block .trail-block-label span {
+  margin-left: 0.35rem;
+  font-family: "JetBrains Mono", "Space Grotesk", monospace;
+  font-weight: 600;
+  color: var(--ink);
+  letter-spacing: 0;
+}
+
+.lineage-list {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.lineage-row {
+  display: grid;
+  gap: 0.4rem;
+  padding: 0.7rem 0.85rem;
+  border-radius: 0.65rem;
+  border: 1px solid var(--line);
+  background: rgba(255, 253, 247, 0.6);
+}
+
+.lineage-row-parent { border-left: 3px solid #3a8c5e; }
+.lineage-row-child  { border-left: 3px solid #4a73c2; }
+
+.lineage-row-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.55rem;
+}
+
+.lineage-row-title {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.lineage-row-title .eyebrow {
+  margin: 0;
+}
+
+.lineage-row-title h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: -0.005em;
+}
+
+.lineage-row-meta {
+  margin: 0;
+  font-size: 0.7rem;
+  color: var(--muted);
+  letter-spacing: 0;
+  word-break: break-all;
+}
+
+.lineage-row-meta code {
+  font-size: 0.7rem;
+  padding: 0.05rem 0.25rem;
+}
+
+.lineage-row-summary {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--ink);
+  line-height: 1.5;
+}
+
+.lineage-row-summary code {
+  font-size: 0.72rem;
+  padding: 0.05rem 0.3rem;
+}
+
+.lineage-row-jobs {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  list-style: none;
+}
+
+.lineage-row-jobs li {
+  font-family: "JetBrains Mono", "Space Grotesk", monospace;
+  font-size: 0.7rem;
+  color: var(--ink);
+}
+
+.lineage-row-jobs-more {
+  color: var(--muted);
+}
+


### PR DESCRIPTION
## Summary
- Closes the remaining roadmap §8 item: _"extend profile and operator UI surfaces around sub-contracting history"_. PR #192 shipped the operator-side `/runs/detail` `JobLineagePanel`; this PR closes the profile half.
- Extends the badge schema (additively, under v1) with an optional `averray.lineage` block carrying `parent` and/or `children` references, so a single badge fetch tells you whether the session was a parent, a child, or a middle node in a chain.
- Surfaces a "Delegation history" section on `averray.com/agents/<wallet>` with two columns — sub-jobs this wallet posted (delegated) and sub-jobs this wallet worked on someone else's behalf (subcontracted).

## Backend
- `core/badge-metadata.js` — optional `averray.lineage`; `buildBadgeFromSession` accepts `context.lineage`; `validateBadgeMetadata` allows the new block and rejects unknown subfields.
- `core/agent-profile.js` — new `getLineage` callback mirrors the `getDisputeReceipts` pattern. Emits a top-level `lineage` block (delegated[] + subcontracted[], capped at 25 newest-first each) plus `stats.lineage` counters. Self-delegation flagged via `parent.isSelf`.
- `core/platform-service.js` — thin `listChildJobsByParentSession` wrapper.
- `protocols/http/server.js` — `preloadLineage` walks each session in one sync pass, wired into both `/agents` directory and `/agents/:wallet` routes. `/badges/:sessionId` derives the badge lineage block at fetch time. Both helpers short-circuit when the session has neither parent nor children.

## Frontend (public profile)
- `site/agent.html` — "Delegation history" panel between Dispute history and Badges.
- `site/agent.js` — `renderLineageHistory` consumes `profile.lineage` + `profile.stats.lineage`. Counterparty wallet links to `/agents/<wallet>`. Self-delegation rendered distinctly.
- `site/styles.css` — lineage grid + row styles, parent/child color stripes matching the operator-side `JobLineagePanel`.

## Test plan
- [x] `npm --workspace mcp-server test` — 392/396 pass (8 new; same 4 chronic env-dependent failures as `main`)
- [x] `node --check site/agent.js`, HTML balance check
- [x] `npm run check:sdk-types`
- [ ] Open `/agents/<wallet>` for a wallet with no sub-contracting — section shows empty states ("no sub-contracting yet")
- [ ] Open `/agents/<wallet>` for a wallet that posted a sub-job — Delegated column lists rows with child jobIds
- [ ] Open `/agents/<wallet>` for a wallet that worked on a sub-job — Subcontracted column lists rows linking to the parent wallet

🤖 Generated with [Claude Code](https://claude.com/claude-code)