### PR TITLE
Harden product-proof USDC readiness gate

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1442,6 +1442,117 @@
         },
         "additionalProperties": true
       },
+      "AdminSettlementAssetStatus": {
+        "type": "object",
+        "description": "Configured settlement asset and live TreasuryPolicy approval state.",
+        "properties": {
+          "symbol": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
+          },
+          "assetClass": {
+            "type": "string"
+          },
+          "assetId": {
+            "type": "integer"
+          },
+          "foreignAssetIndex": {
+            "type": "integer"
+          },
+          "decimals": {
+            "type": "integer"
+          },
+          "approved": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": true
+      },
+      "AdminPolicyStatus": {
+        "type": "object",
+        "description": "Live TreasuryPolicy contract readiness for settlement mutations.",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "policyAddress": {
+            "type": "string"
+          },
+          "paused": {
+            "type": "boolean"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "pauser": {
+            "type": "string"
+          },
+          "settlementReady": {
+            "type": "boolean"
+          },
+          "contracts": {
+            "type": "object",
+            "properties": {
+              "escrowCoreAddress": {
+                "type": "string"
+              },
+              "agentAccountAddress": {
+                "type": "string"
+              },
+              "reputationSbtAddress": {
+                "type": "string"
+              },
+              "supportedAssets": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AdminSettlementAssetStatus"
+                }
+              }
+            },
+            "additionalProperties": true
+          },
+          "roles": {
+            "type": "object",
+            "properties": {
+              "signerAddress": {
+                "type": "string"
+              },
+              "signerIsVerifier": {
+                "type": "boolean"
+              },
+              "escrowIsServiceOperator": {
+                "type": "boolean"
+              },
+              "agentAccountIsServiceOperator": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": true
+          },
+          "readErrors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "field": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": true
+            }
+          },
+          "risk": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      },
       "AdminStatus": {
         "type": "object",
         "description": "Admin-only platform status. The shape includes provider scheduler state and may grow as new operational views are added.",
@@ -1458,6 +1569,15 @@
           "jobStaleSweeper": {
             "type": "object",
             "description": "Automatic stale-job sweeper status, including dry-run/live mode, action, limits, and lastRun summary.",
+            "additionalProperties": true
+          },
+          "maintenance": {
+            "type": "object",
+            "properties": {
+              "policy": {
+                "$ref": "#/components/schemas/AdminPolicyStatus"
+              }
+            },
             "additionalProperties": true
           },
           "githubIngestion": {

--- a/mcp-server/src/blockchain/abis.js
+++ b/mcp-server/src/blockchain/abis.js
@@ -94,6 +94,7 @@ export const TREASURY_POLICY_ABI = [
   "function claimFeeVerifierBps() view returns (uint16)",
   "function onboardingWaiverClaimCount() view returns (uint256)",
   "function minClaimFeeByAsset(address asset) view returns (uint256)",
+  "function approvedAssets(address asset) view returns (bool)",
   "function rejectionSkillPenalty() view returns (uint256)",
   "function rejectionReliabilityPenalty() view returns (uint256)",
   "function disputeLossSkillPenalty() view returns (uint256)",

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -40,12 +40,18 @@ const abiCoder = AbiCoder.defaultAbiCoder();
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 function summarizeSupportedAssets(assets = []) {
-  return assets.map((asset) => ({
+  return assets.map(summarizeSupportedAsset);
+}
+
+function summarizeSupportedAsset(asset) {
+  return {
     symbol: asset.symbol,
     address: asset.address,
     assetClass: asset.assetClass ?? "custom",
+    assetId: asset.assetId,
+    foreignAssetIndex: asset.foreignAssetIndex,
     decimals: asset.decimals
-  }));
+  };
 }
 
 export class BlockchainGateway {
@@ -288,7 +294,8 @@ export class BlockchainGateway {
           roles: {
             signerAddress: undefined,
             signerIsVerifier: false,
-            escrowIsServiceOperator: false
+            escrowIsServiceOperator: false,
+            agentAccountIsServiceOperator: false
           },
           readErrors: [],
           risk: {}
@@ -317,6 +324,7 @@ export class BlockchainGateway {
         paused,
         signerIsVerifier,
         escrowIsServiceOperator,
+        agentAccountIsServiceOperator,
         dailyOutflowCap,
         perAccountBorrowCap,
         minimumCollateralRatioBps,
@@ -336,6 +344,9 @@ export class BlockchainGateway {
         this.config.escrowCoreAddress
           ? optionalBool("serviceOperators(escrowCore)", this.policyContract.serviceOperators(this.config.escrowCoreAddress))
           : false,
+        this.config.agentAccountAddress
+          ? optionalBool("serviceOperators(agentAccount)", this.policyContract.serviceOperators(this.config.agentAccountAddress))
+          : false,
         optionalRead("dailyOutflowCap", this.policyContract.dailyOutflowCap(), 0),
         optionalRead("perAccountBorrowCap", this.policyContract.perAccountBorrowCap(), 0),
         optionalRead("minimumCollateralRatioBps", this.policyContract.minimumCollateralRatioBps(), 0),
@@ -348,6 +359,14 @@ export class BlockchainGateway {
         optionalRead("disputeLossSkillPenalty", this.policyContract.disputeLossSkillPenalty(), 0),
         optionalRead("disputeLossReliabilityPenalty", this.policyContract.disputeLossReliabilityPenalty(), 0)
       ]);
+      const supportedAssets = await Promise.all((this.config.supportedAssets ?? []).map(async (asset) => ({
+        ...summarizeSupportedAsset(asset),
+        approved: asset.address
+          ? await optionalBool(`approvedAssets(${asset.symbol ?? asset.address})`, this.policyContract.approvedAssets(asset.address))
+          : false
+      })));
+      const supportedAssetsReady = supportedAssets.length > 0
+        && supportedAssets.every((asset) => asset.approved === true);
 
       return {
         enabled: true,
@@ -355,17 +374,24 @@ export class BlockchainGateway {
         paused: paused === undefined ? undefined : Boolean(paused),
         owner,
         pauser,
-        settlementReady: Boolean(signerIsVerifier && escrowIsServiceOperator && paused === false),
+        settlementReady: Boolean(
+          signerIsVerifier
+            && escrowIsServiceOperator
+            && agentAccountIsServiceOperator
+            && supportedAssetsReady
+            && paused === false
+        ),
         contracts: {
           escrowCoreAddress: this.config.escrowCoreAddress,
           agentAccountAddress: this.config.agentAccountAddress,
           reputationSbtAddress: this.config.reputationSbtAddress,
-          supportedAssets: summarizeSupportedAssets(this.config.supportedAssets)
+          supportedAssets
         },
         roles: {
           signerAddress,
           signerIsVerifier,
-          escrowIsServiceOperator
+          escrowIsServiceOperator,
+          agentAccountIsServiceOperator
         },
         readErrors,
         risk: {

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -205,7 +205,14 @@ test("getTreasuryPolicyStatus surfaces settlement readiness roles", async () => 
       return true;
     },
     async serviceOperators(address) {
-      assert.equal(address, "0x2222222222222222222222222222222222222222");
+      assert.ok([
+        "0x2222222222222222222222222222222222222222",
+        "0x3333333333333333333333333333333333333333"
+      ].includes(address));
+      return true;
+    },
+    async approvedAssets(address) {
+      assert.equal(address, DOT_ASSET.address);
       return true;
     },
     async dailyOutflowCap() {
@@ -249,12 +256,16 @@ test("getTreasuryPolicyStatus surfaces settlement readiness roles", async () => 
   assert.equal(status.roles.signerAddress, signerAddress);
   assert.equal(status.roles.signerIsVerifier, true);
   assert.equal(status.roles.escrowIsServiceOperator, true);
+  assert.equal(status.roles.agentAccountIsServiceOperator, true);
   assert.deepEqual(status.readErrors, []);
   assert.deepEqual(status.contracts.supportedAssets, [{
     symbol: "DOT",
     address: DOT_ASSET.address,
     assetClass: "custom",
-    decimals: 18
+    assetId: undefined,
+    foreignAssetIndex: undefined,
+    decimals: 18,
+    approved: true
   }]);
 });
 
@@ -286,6 +297,9 @@ test("getTreasuryPolicyStatus records individual read errors without hiding role
       const error = new Error("require(false)");
       error.shortMessage = "execution reverted";
       throw error;
+    },
+    async approvedAssets() {
+      return false;
     },
     async dailyOutflowCap() {
       return 100n;
@@ -326,11 +340,18 @@ test("getTreasuryPolicyStatus records individual read errors without hiding role
 
   assert.equal(status.roles.signerIsVerifier, true);
   assert.equal(status.roles.escrowIsServiceOperator, false);
+  assert.equal(status.roles.agentAccountIsServiceOperator, false);
   assert.equal(status.settlementReady, false);
-  assert.deepEqual(status.readErrors, [{
-    field: "serviceOperators(escrowCore)",
-    message: "execution reverted"
-  }]);
+  assert.deepEqual(status.readErrors, [
+    {
+      field: "serviceOperators(escrowCore)",
+      message: "execution reverted"
+    },
+    {
+      field: "serviceOperators(agentAccount)",
+      message: "execution reverted"
+    }
+  ]);
 });
 
 test("previewClaimEconomics returns display values while preserving raw chain amounts", async () => {

--- a/scripts/ops/run-hosted-worker-loop.mjs
+++ b/scripts/ops/run-hosted-worker-loop.mjs
@@ -3,9 +3,17 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
 import { AgentPlatformClient } from "../../sdk/agent-platform-client.js";
+import { DEFAULT_ESCROW_ASSET } from "../../mcp-server/src/core/assets.js";
 
 const DEFAULT_API_BASE_URL = "https://api.averray.com";
 const DEFAULT_REWARD_AMOUNT = 0.000001;
+const REQUIRED_ESCROW_ASSET = {
+  symbol: DEFAULT_ESCROW_ASSET.symbol,
+  address: DEFAULT_ESCROW_ASSET.address.toLowerCase(),
+  assetClass: DEFAULT_ESCROW_ASSET.assetClass,
+  assetId: DEFAULT_ESCROW_ASSET.assetId,
+  decimals: DEFAULT_ESCROW_ASSET.decimals
+};
 
 export async function runHostedWorkerLoop({
   env = process.env,
@@ -25,6 +33,12 @@ export async function runHostedWorkerLoop({
   const idempotencyKey = env.PRODUCT_PROOF_IDEMPOTENCY_KEY || `product-proof:${jobId}`;
   const evidence = env.PRODUCT_PROOF_SUBMISSION || `complete verified output for ${jobId}`;
   const rewardAmount = parsePositiveNumber(env.PRODUCT_PROOF_REWARD_AMOUNT, DEFAULT_REWARD_AMOUNT);
+  const rewardAsset = normalizeAssetSymbol(env.PRODUCT_PROOF_REWARD_ASSET || REQUIRED_ESCROW_ASSET.symbol);
+  if (rewardAsset !== REQUIRED_ESCROW_ASSET.symbol) {
+    throw new Error(
+      `Hosted product-proof worker loop requires ${REQUIRED_ESCROW_ASSET.symbol} settlement; got PRODUCT_PROOF_REWARD_ASSET=${rewardAsset}.`
+    );
+  }
 
   const authSession = await platform.getAuthSession();
   const wallet = authSession?.wallet;
@@ -32,14 +46,14 @@ export async function runHostedWorkerLoop({
     throw new Error("/auth/session did not return a wallet for the worker token.");
   }
 
-  const settlementReadiness = await assertSettlementReadiness(platform);
+  const settlementReadiness = await assertSettlementReadiness(platform, rewardAsset);
 
   log(`Creating hosted product-proof job ${jobId}`);
   const created = await platform.createJob({
     id: jobId,
     category: "coding",
     tier: "starter",
-    rewardAsset: env.PRODUCT_PROOF_REWARD_ASSET || "DOT",
+    rewardAsset,
     rewardAmount,
     verifierMode: "benchmark",
     verifierTerms: ["complete", "verified", "output"],
@@ -114,6 +128,10 @@ export async function runHostedWorkerLoop({
   return evidenceDoc;
 }
 
+function normalizeAssetSymbol(value) {
+  return String(value ?? "").trim().toUpperCase();
+}
+
 function stripTrailingSlash(value) {
   return String(value).replace(/\/+$/u, "");
 }
@@ -129,7 +147,7 @@ function parsePositiveNumber(value, fallback) {
   return parsed;
 }
 
-async function assertSettlementReadiness(platform) {
+async function assertSettlementReadiness(platform, rewardAsset) {
   if (typeof platform.getAdminStatus !== "function") {
     throw new Error("Hosted product-proof worker loop requires /admin/status settlement readiness.");
   }
@@ -141,17 +159,58 @@ async function assertSettlementReadiness(platform) {
   if (policy.settlementReady !== true) {
     throw new Error(`Hosted product-proof worker loop requires on-chain settlement readiness; ${formatSettlementReadiness(policy)}`);
   }
+  const settlementAsset = (policy.contracts?.supportedAssets ?? []).find(
+    (asset) => normalizeAssetSymbol(asset.symbol) === rewardAsset
+  );
+  if (!settlementAsset) {
+    throw new Error(
+      `Hosted product-proof worker loop requires ${rewardAsset} as the configured settlement asset; ${formatSettlementReadiness(policy)}`
+    );
+  }
+  const assetMismatch = describeRequiredAssetMismatch(settlementAsset);
+  if (assetMismatch) {
+    throw new Error(
+      `Hosted product-proof worker loop requires canonical v1 ${REQUIRED_ESCROW_ASSET.symbol} settlement asset; ${assetMismatch}; ${formatSettlementReadiness(policy)}`
+    );
+  }
+  if (settlementAsset.approved !== true) {
+    throw new Error(
+      `Hosted product-proof worker loop requires approved ${rewardAsset} settlement asset; ${formatSettlementReadiness(policy)}`
+    );
+  }
   return {
     policyAddress: policy.policyAddress,
     paused: Boolean(policy.paused),
     settlementReady: true,
+    asset: settlementAsset,
     roles: {
       signerAddress: policy.roles?.signerAddress,
       signerIsVerifier: Boolean(policy.roles?.signerIsVerifier),
-      escrowIsServiceOperator: Boolean(policy.roles?.escrowIsServiceOperator)
+      escrowIsServiceOperator: Boolean(policy.roles?.escrowIsServiceOperator),
+      agentAccountIsServiceOperator: Boolean(policy.roles?.agentAccountIsServiceOperator)
     },
     contracts: policy.contracts
   };
+}
+
+function describeRequiredAssetMismatch(asset) {
+  const mismatches = [];
+  if (normalizeAssetSymbol(asset.symbol) !== REQUIRED_ESCROW_ASSET.symbol) {
+    mismatches.push(`symbol=${asset.symbol ?? "missing"}`);
+  }
+  if (String(asset.address ?? "").toLowerCase() !== REQUIRED_ESCROW_ASSET.address) {
+    mismatches.push(`address=${asset.address ?? "missing"}`);
+  }
+  if (String(asset.assetClass ?? "") !== REQUIRED_ESCROW_ASSET.assetClass) {
+    mismatches.push(`assetClass=${asset.assetClass ?? "missing"}`);
+  }
+  if (Number(asset.assetId) !== REQUIRED_ESCROW_ASSET.assetId) {
+    mismatches.push(`assetId=${asset.assetId ?? "missing"}`);
+  }
+  if (Number(asset.decimals) !== REQUIRED_ESCROW_ASSET.decimals) {
+    mismatches.push(`decimals=${asset.decimals ?? "missing"}`);
+  }
+  return mismatches.join(", ");
 }
 
 function formatSettlementReadiness(policy) {
@@ -159,6 +218,11 @@ function formatSettlementReadiness(policy) {
   if (policy?.paused) reasons.push("policyPaused=true");
   if (!policy?.roles?.signerIsVerifier) reasons.push("signerIsVerifier=false");
   if (!policy?.roles?.escrowIsServiceOperator) reasons.push("escrowIsServiceOperator=false");
+  if (!policy?.roles?.agentAccountIsServiceOperator) reasons.push("agentAccountIsServiceOperator=false");
+  const unapprovedAssets = (policy?.contracts?.supportedAssets ?? [])
+    .filter((asset) => asset.approved !== true)
+    .map((asset) => asset.symbol ?? asset.address ?? "unknown");
+  if (unapprovedAssets.length > 0) reasons.push(`unapprovedAssets=${unapprovedAssets.join("|")}`);
   if (Array.isArray(policy?.readErrors) && policy.readErrors.length > 0) {
     reasons.push(`policyReadErrors=${policy.readErrors.map((entry) => entry.field).join("|")}`);
   }

--- a/scripts/ops/run-hosted-worker-loop.test.mjs
+++ b/scripts/ops/run-hosted-worker-loop.test.mjs
@@ -80,7 +80,7 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
     "getAgentProfile"
   ]);
   assert.equal(calls[2][1].verifierMode, "benchmark");
-  assert.equal(calls[2][1].rewardAsset, "DOT");
+  assert.equal(calls[2][1].rewardAsset, "USDC");
   assert.equal(calls[2][1].rewardAmount, 0.000001);
   assert.equal(calls[3][2], `product-proof:${jobId}`);
 
@@ -161,7 +161,8 @@ test("runHostedWorkerLoop fails closed before mutation when settlement is not re
             roles: {
               signerAddress: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
               signerIsVerifier: false,
-              escrowIsServiceOperator: true
+              escrowIsServiceOperator: true,
+              agentAccountIsServiceOperator: true
             }
           });
         },
@@ -175,6 +176,146 @@ test("runHostedWorkerLoop fails closed before mutation when settlement is not re
       env: { ADMIN_JWT: "token" }
     }),
     /signerIsVerifier=false, policyReadErrors=serviceOperators\(escrowCore\)/u
+  );
+
+  assert.deepEqual(calls.map(([name]) => name), ["getAuthSession", "getAdminStatus"]);
+});
+
+test("runHostedWorkerLoop rejects non-USDC product-proof reward assets before mutation", async () => {
+  const calls = [];
+  await assert.rejects(
+    runHostedWorkerLoop({
+      client: {
+        async getAuthSession() {
+          calls.push(["getAuthSession"]);
+          return { wallet: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519" };
+        },
+        async createJob() {
+          calls.push(["createJob"]);
+          throw new Error("should not mutate with non-USDC reward asset");
+        }
+      },
+      now: () => 1700000000000,
+      log: () => {},
+      env: { ADMIN_JWT: "token", PRODUCT_PROOF_REWARD_ASSET: "DOT" }
+    }),
+    /requires USDC settlement; got PRODUCT_PROOF_REWARD_ASSET=DOT/u
+  );
+
+  assert.deepEqual(calls, []);
+});
+
+test("runHostedWorkerLoop rejects USDC symbol with non-canonical asset metadata", async () => {
+  const calls = [];
+  await assert.rejects(
+    runHostedWorkerLoop({
+      client: {
+        async getAuthSession() {
+          calls.push(["getAuthSession"]);
+          return { wallet: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519" };
+        },
+        async getAdminStatus() {
+          calls.push(["getAdminStatus"]);
+          return settlementReadyStatus({
+            contracts: {
+              supportedAssets: [{
+                symbol: "USDC",
+                address: "0x5555555555555555555555555555555555555555",
+                assetClass: "custom",
+                assetId: 999,
+                decimals: 18,
+                approved: true
+              }]
+            }
+          });
+        },
+        async createJob() {
+          calls.push(["createJob"]);
+          throw new Error("should not mutate with non-canonical USDC asset metadata");
+        }
+      },
+      now: () => 1700000000000,
+      log: () => {},
+      env: { ADMIN_JWT: "token" }
+    }),
+    /requires canonical v1 USDC settlement asset; address=0x5555555555555555555555555555555555555555, assetClass=custom, assetId=999, decimals=18/u
+  );
+
+  assert.deepEqual(calls.map(([name]) => name), ["getAuthSession", "getAdminStatus"]);
+});
+
+test("runHostedWorkerLoop rejects missing matching USDC settlement asset", async () => {
+  const calls = [];
+  await assert.rejects(
+    runHostedWorkerLoop({
+      client: {
+        async getAuthSession() {
+          calls.push(["getAuthSession"]);
+          return { wallet: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519" };
+        },
+        async getAdminStatus() {
+          calls.push(["getAdminStatus"]);
+          return settlementReadyStatus({
+            contracts: {
+              supportedAssets: [{
+                symbol: "DOT",
+                address: "0x5555555555555555555555555555555555555555",
+                assetClass: "custom",
+                decimals: 18,
+                approved: true
+              }]
+            }
+          });
+        },
+        async createJob() {
+          calls.push(["createJob"]);
+          throw new Error("should not mutate without USDC");
+        }
+      },
+      now: () => 1700000000000,
+      log: () => {},
+      env: { ADMIN_JWT: "token" }
+    }),
+    /requires USDC as the configured settlement asset/u
+  );
+
+  assert.deepEqual(calls.map(([name]) => name), ["getAuthSession", "getAdminStatus"]);
+});
+
+test("runHostedWorkerLoop rejects unapproved canonical USDC settlement asset", async () => {
+  const calls = [];
+  await assert.rejects(
+    runHostedWorkerLoop({
+      client: {
+        async getAuthSession() {
+          calls.push(["getAuthSession"]);
+          return { wallet: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519" };
+        },
+        async getAdminStatus() {
+          calls.push(["getAdminStatus"]);
+          return settlementReadyStatus({
+            contracts: {
+              supportedAssets: [{
+                symbol: "USDC",
+                address: "0x0000053900000000000000000000000001200000",
+                assetClass: "trust_backed",
+                assetId: 1337,
+                decimals: 6,
+                approved: false
+              }]
+            }
+          });
+        },
+        async createJob() {
+          calls.push(["createJob"]);
+          throw new Error("should not mutate with unapproved USDC");
+        }
+      },
+      now: () => 1700000000000,
+      log: () => {},
+      env: { ADMIN_JWT: "token" }
+    }),
+    /requires approved USDC settlement asset/u
   );
 
   assert.deepEqual(calls.map(([name]) => name), ["getAuthSession", "getAdminStatus"]);
@@ -205,14 +346,22 @@ function settlementReadyStatus(overrides = {}) {
         settlementReady: true,
         roles: {
           signerAddress: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
-          signerIsVerifier: true,
-          escrowIsServiceOperator: true
-        },
+            signerIsVerifier: true,
+            escrowIsServiceOperator: true,
+            agentAccountIsServiceOperator: true
+          },
         contracts: {
           escrowCoreAddress: "0x2222222222222222222222222222222222222222",
           agentAccountAddress: "0x3333333333333333333333333333333333333333",
           reputationSbtAddress: "0x4444444444444444444444444444444444444444",
-          supportedAssets: [{ symbol: "DOT", address: "0x5555555555555555555555555555555555555555" }]
+          supportedAssets: [{
+            symbol: "USDC",
+            address: "0x0000053900000000000000000000000001200000",
+            assetClass: "trust_backed",
+            assetId: 1337,
+            decimals: 6,
+            approved: true
+          }]
         }
       }
     }

--- a/sdk/agent-platform-client.d.ts
+++ b/sdk/agent-platform-client.d.ts
@@ -858,6 +858,45 @@ export interface AdminJobCreateInput extends ApiEnvelope {
   recurringPolicy?: RecurringPolicy;
 }
 
+export interface AdminSettlementAssetStatus extends ApiEnvelope {
+  symbol?: AssetSymbol;
+  address?: string;
+  assetClass?: string;
+  assetId?: number;
+  foreignAssetIndex?: number;
+  decimals?: number;
+  approved?: boolean;
+}
+
+export interface AdminPolicyStatus extends ApiEnvelope {
+  enabled?: boolean;
+  policyAddress?: string;
+  paused?: boolean;
+  owner?: string;
+  pauser?: string;
+  settlementReady?: boolean;
+  contracts?: {
+    escrowCoreAddress?: string;
+    agentAccountAddress?: string;
+    reputationSbtAddress?: string;
+    supportedAssets?: AdminSettlementAssetStatus[];
+    [key: string]: unknown;
+  };
+  roles?: {
+    signerAddress?: string;
+    signerIsVerifier?: boolean;
+    escrowIsServiceOperator?: boolean;
+    agentAccountIsServiceOperator?: boolean;
+    [key: string]: unknown;
+  };
+  readErrors?: Array<{
+    field?: string;
+    message?: string;
+    [key: string]: unknown;
+  }>;
+  risk?: ApiEnvelope;
+}
+
 export interface AdminStatusResponse extends ApiEnvelope {
   jobLifecycle?: {
     total?: number;
@@ -870,6 +909,10 @@ export interface AdminStatusResponse extends ApiEnvelope {
   };
   recurringJobs?: ApiEnvelope;
   providerOperations?: ApiEnvelope;
+  maintenance?: {
+    policy?: AdminPolicyStatus;
+    [key: string]: unknown;
+  };
 }
 
 export class AgentPlatformApiError extends Error {

--- a/sdk/api-surface-model.mjs
+++ b/sdk/api-surface-model.mjs
@@ -519,6 +519,45 @@ export interface AdminJobCreateInput extends ApiEnvelope {
   recurringPolicy?: RecurringPolicy;
 }
 
+export interface AdminSettlementAssetStatus extends ApiEnvelope {
+  symbol?: AssetSymbol;
+  address?: string;
+  assetClass?: string;
+  assetId?: number;
+  foreignAssetIndex?: number;
+  decimals?: number;
+  approved?: boolean;
+}
+
+export interface AdminPolicyStatus extends ApiEnvelope {
+  enabled?: boolean;
+  policyAddress?: string;
+  paused?: boolean;
+  owner?: string;
+  pauser?: string;
+  settlementReady?: boolean;
+  contracts?: {
+    escrowCoreAddress?: string;
+    agentAccountAddress?: string;
+    reputationSbtAddress?: string;
+    supportedAssets?: AdminSettlementAssetStatus[];
+    [key: string]: unknown;
+  };
+  roles?: {
+    signerAddress?: string;
+    signerIsVerifier?: boolean;
+    escrowIsServiceOperator?: boolean;
+    agentAccountIsServiceOperator?: boolean;
+    [key: string]: unknown;
+  };
+  readErrors?: Array<{
+    field?: string;
+    message?: string;
+    [key: string]: unknown;
+  }>;
+  risk?: ApiEnvelope;
+}
+
 export interface AdminStatusResponse extends ApiEnvelope {
   jobLifecycle?: {
     total?: number;
@@ -531,6 +570,10 @@ export interface AdminStatusResponse extends ApiEnvelope {
   };
   recurringJobs?: ApiEnvelope;
   providerOperations?: ApiEnvelope;
+  maintenance?: {
+    policy?: AdminPolicyStatus;
+    [key: string]: unknown;
+  };
 }
 
 export class AgentPlatformApiError extends Error {


### PR DESCRIPTION
## What changed
- Default the hosted product-proof worker loop to the canonical v1 USDC escrow asset and reject non-USDC overrides before any platform call.
- Require the live admin policy status to expose approved canonical USDC metadata: trust-backed asset 1337, 6 decimals, and precompile address 0x0000053900000000000000000000000001200000.
- Expand policy readiness to include AgentAccountCore service-operator status and per-asset TreasuryPolicy approval reads.
- Surface the new readiness fields in SDK types and OpenAPI docs.

## Checks run
- node --test scripts/ops/run-hosted-worker-loop.test.mjs
- node --test mcp-server/src/blockchain/gateway.test.js
- npm --workspace mcp-server test
- npm run check:sdk-types
- npm run typecheck:sdk
- JSON parse check for docs/api/openapi.json
- git diff --check

## Impact
- Backend: yes
- SDK/OpenAPI docs: yes
- Frontend/indexer/contracts/Caddy/public site: no

## Env / live notes
- Product-proof live gate now expects SUPPORTED_ASSETS_JSON to include canonical USDC and TreasuryPolicy.approvedAssets(USDC) to be true.
- Live contract roles still need operator verification/configuration before PRODUCT_PROOF_REQUIRE_WORKER_LOOP=1 can pass.