### PR TITLE
Add PRODUCT_PROOF_REWARD_ASSET workflow_dispatch input (escape hatch for hosted smoke)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -95,6 +95,11 @@ on:
         options:
           - "0"
           - "1"
+      product_proof_reward_asset:
+        description: Reward asset symbol for the hosted product-proof worker loop. Leave blank to keep the deploy-script default (DOT). Set to "USDC" to exercise the v1 USDC settlement path against the on-chain TreasuryPolicy approved-asset list.
+        required: false
+        default: ""
+        type: string
 
 concurrency:
   group: production
@@ -131,6 +136,7 @@ jobs:
       DEPLOY_SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT: ${{ github.event_name == 'workflow_dispatch' && inputs.smoke_check_bootstrap_self_report_sent || '0' }}
       DEPLOY_SMOKE_CHECK_PRODUCT_PROOF_GATE: ${{ github.event_name == 'workflow_dispatch' && inputs.smoke_check_product_proof_gate || '0' }}
       DEPLOY_PRODUCT_PROOF_REQUIRE_WORKER_LOOP: ${{ github.event_name == 'workflow_dispatch' && inputs.product_proof_require_worker_loop || '0' }}
+      DEPLOY_PRODUCT_PROOF_REWARD_ASSET: ${{ github.event_name == 'workflow_dispatch' && inputs.product_proof_reward_asset || '' }}
     steps:
       - name: Validate required secrets
         run: |
@@ -152,7 +158,7 @@ jobs:
       - name: Deploy production
         run: |
           remote_env=$(
-            printf 'APP_BASIC_AUTH_USER=%q APP_BASIC_AUTH_PASSWORD=%q APP_BASIC_AUTH_PASSWORD_HASH=%q APP_ALLOW_PROTECTED_SHELL=%q ADMIN_JWT=%q RESEND_API_KEY=%q BOOTSTRAP_SELF_REPORT_TO=%q BOOTSTRAP_SELF_REPORT_FROM=%q BOOTSTRAP_SELF_REPORT_SEND_ON_START=%q RUN_INDEXER=%q WAIT_FOR_READY=%q HEALTH_STABILITY_SEC=%q INDEXER_LOG_TAIL=%q SMOKE_CHECK_INDEXER=%q SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION=%q SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT=%q SMOKE_CHECK_PRODUCT_PROOF_GATE=%q PRODUCT_PROOF_REQUIRE_WORKER_LOOP=%q INDEXER_DATABASE_SCHEMA=%q INDEXER_FRESH_SCHEMA=%q ' \
+            printf 'APP_BASIC_AUTH_USER=%q APP_BASIC_AUTH_PASSWORD=%q APP_BASIC_AUTH_PASSWORD_HASH=%q APP_ALLOW_PROTECTED_SHELL=%q ADMIN_JWT=%q RESEND_API_KEY=%q BOOTSTRAP_SELF_REPORT_TO=%q BOOTSTRAP_SELF_REPORT_FROM=%q BOOTSTRAP_SELF_REPORT_SEND_ON_START=%q RUN_INDEXER=%q WAIT_FOR_READY=%q HEALTH_STABILITY_SEC=%q INDEXER_LOG_TAIL=%q SMOKE_CHECK_INDEXER=%q SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION=%q SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT=%q SMOKE_CHECK_PRODUCT_PROOF_GATE=%q PRODUCT_PROOF_REQUIRE_WORKER_LOOP=%q PRODUCT_PROOF_REWARD_ASSET=%q INDEXER_DATABASE_SCHEMA=%q INDEXER_FRESH_SCHEMA=%q ' \
               "$APP_BASIC_AUTH_USER" \
               "$APP_BASIC_AUTH_PASSWORD" \
               "$APP_BASIC_AUTH_PASSWORD_HASH" \
@@ -171,6 +177,7 @@ jobs:
               "$DEPLOY_SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT" \
               "$DEPLOY_SMOKE_CHECK_PRODUCT_PROOF_GATE" \
               "$DEPLOY_PRODUCT_PROOF_REQUIRE_WORKER_LOOP" \
+              "$DEPLOY_PRODUCT_PROOF_REWARD_ASSET" \
               "$DEPLOY_INDEXER_DATABASE_SCHEMA" \
               "$DEPLOY_INDEXER_FRESH_SCHEMA"
           )

--- a/scripts/ops/deploy-production.sh
+++ b/scripts/ops/deploy-production.sh
@@ -32,6 +32,11 @@ SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION=${SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION:-0
 SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT=${SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT:-0}
 SMOKE_CHECK_PRODUCT_PROOF_GATE=${SMOKE_CHECK_PRODUCT_PROOF_GATE:-0}
 PRODUCT_PROOF_REQUIRE_WORKER_LOOP=${PRODUCT_PROOF_REQUIRE_WORKER_LOOP:-0}
+# Optional override for the hosted worker-loop's reward asset symbol.
+# Empty string keeps the run-hosted-worker-loop.mjs default (DOT today).
+# Set to "USDC" via the workflow_dispatch input to exercise the v1 USDC
+# settlement path against the on-chain TreasuryPolicy approved-asset list.
+PRODUCT_PROOF_REWARD_ASSET=${PRODUCT_PROOF_REWARD_ASSET:-}
 PRODUCT_PROOF_EVIDENCE_FILE=${PRODUCT_PROOF_EVIDENCE_FILE:-"$STACK_ROOT/product-proof-worker-loop-evidence.json"}
 PRODUCT_PROOF_NODE_IMAGE=${PRODUCT_PROOF_NODE_IMAGE:-node:22-bookworm-slim}
 INDEXER_DATABASE_SCHEMA=${INDEXER_DATABASE_SCHEMA:-}


### PR DESCRIPTION
## Summary
Adds an optional `product_proof_reward_asset` `workflow_dispatch` input on the Deploy Production workflow so the hosted product-proof worker loop can be pointed at any approved escrow asset (USDC for v1) instead of the in-script default of DOT.

## Why this matters
`scripts/ops/run-hosted-worker-loop.mjs:42` currently reads `env.PRODUCT_PROOF_REWARD_ASSET || "DOT"`. DOT is **not** on the on-chain `TreasuryPolicy.approvedAssets` list — USDC (`0x0000053900000000000000000000000001200000`) is. Every recent post-deploy product-proof smoke has failed at `resolveSinglePayout` because of that mismatch.

Until the upstream platform-side guard PR lands (defaulting to USDC + adding strict v1 USDC validation), this gives ops a way to trigger the hosted smoke end-to-end against the real settlement path today.

## Plumbing
```
workflow input (string)
  → DEPLOY_PRODUCT_PROOF_REWARD_ASSET (workflow env)
  → PRODUCT_PROOF_REWARD_ASSET=%q in remote SSH printf line
  → PRODUCT_PROOF_REWARD_ASSET=${…:-} in deploy-production.sh
  → -e PRODUCT_PROOF_REWARD_ASSET="${…:-}" on worker-loop docker run
    (already in place at deploy-production.sh:314)
```

Empty default keeps current behaviour. Once the strict-validator PR lands, this stays useful as an explicit per-run knob.

## Test plan
- [x] `bash -n scripts/ops/deploy-production.sh` clean
- [x] `printf %q` tokens (21) match the args list (21)
- [ ] Trigger the workflow with `smoke_check_product_proof_gate=1`, `product_proof_require_worker_loop=1`, `product_proof_reward_asset=USDC` after merge — expect the hosted worker loop to create+claim+submit+verify a USDC escrow job and pass the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)