### PR TITLE
Converge settlement env during production deploy

### DIFF
--- a/scripts/ops/deploy-production.sh
+++ b/scripts/ops/deploy-production.sh
@@ -47,6 +47,7 @@ BACKEND_ENV_FILE=${BACKEND_ENV_FILE:-"$STACK_ROOT/backend.env"}
 SITE_BUILD_RUNNER=${SITE_BUILD_RUNNER:-auto}
 SITE_NODE_IMAGE=${SITE_NODE_IMAGE:-node:22-bookworm-slim}
 BOOTSTRAP_INSTRUMENTATION_ENV_UPDATED=0
+SETTLEMENT_ENV_UPDATED=0
 
 require_command() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -168,6 +169,141 @@ upsert_env_values() {
   mv "$tmp" "$env_file"
 }
 
+upsert_env_values_if_changed() {
+  local env_file="$1"
+  shift
+  mkdir -p "$(dirname "$env_file")"
+  touch "$env_file"
+
+  local key_pattern=""
+  local pair key
+  for pair in "$@"; do
+    key="${pair%%=*}"
+    if [[ -z "$key_pattern" ]]; then
+      key_pattern="$key"
+    else
+      key_pattern="$key_pattern|$key"
+    fi
+  done
+
+  local tmp="${env_file}.tmp.$$"
+  grep -Ev "^(${key_pattern})=" "$env_file" > "$tmp" || true
+  for pair in "$@"; do
+    key="${pair%%=*}"
+    printf '%s=%s\n' "$key" "$(quote_env_value "${pair#*=}")" >> "$tmp"
+  done
+
+  if cmp -s "$tmp" "$env_file"; then
+    rm -f "$tmp"
+    return 1
+  fi
+
+  mv "$tmp" "$env_file"
+  return 0
+}
+
+configure_settlement_env() {
+  local manifest="$APP_ROOT/deployments/testnet.json"
+  if [[ ! -f "$manifest" ]]; then
+    echo "No testnet deployment manifest found; leaving backend.env settlement settings unchanged."
+    return
+  fi
+
+  if ! command -v node >/dev/null 2>&1; then
+    echo "node is required to derive settlement env from $manifest." >&2
+    exit 1
+  fi
+
+  local generated
+  if ! generated=$(node - "$manifest" <<'NODE'
+const { readFileSync } = require("node:fs");
+
+const manifestPath = process.argv[2];
+const deployment = JSON.parse(readFileSync(manifestPath, "utf8"));
+
+function requireAddress(value, label) {
+  if (typeof value !== "string" || !/^0x[a-fA-F0-9]{40}$/.test(value)) {
+    throw new Error(`${label} must be a 0x + 20-byte EVM address.`);
+  }
+  return value;
+}
+
+function requireString(value, label) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${label} must be present.`);
+  }
+  return value.trim();
+}
+
+const rpcUrl = requireString(deployment.rpcUrl, "rpcUrl");
+const contracts = deployment.contracts ?? {};
+const treasuryPolicy = requireAddress(contracts.treasuryPolicy, "contracts.treasuryPolicy");
+const agentAccountCore = requireAddress(contracts.agentAccountCore, "contracts.agentAccountCore");
+const escrowCore = requireAddress(contracts.escrowCore, "contracts.escrowCore");
+const reputationSbt = requireAddress(contracts.reputationSbt, "contracts.reputationSbt");
+const discoveryRegistry = contracts.discoveryRegistry
+  ? requireAddress(contracts.discoveryRegistry, "contracts.discoveryRegistry")
+  : "";
+const xcmWrapper = contracts.xcmWrapper
+  ? requireAddress(contracts.xcmWrapper, "contracts.xcmWrapper")
+  : "";
+const usdc = requireAddress(contracts.token, "contracts.token");
+const usdcLower = usdc.toLowerCase();
+const canonicalUsdc = "0x0000053900000000000000000000000001200000";
+
+if (usdcLower !== canonicalUsdc) {
+  throw new Error(`contracts.token must be canonical Hub USDC (${canonicalUsdc}), got ${usdc}.`);
+}
+
+const supportedAssets = JSON.stringify([{
+  symbol: "USDC",
+  assetClass: "trust_backed",
+  assetId: 1337,
+  address: usdc,
+  decimals: 6
+}]);
+
+const entries = {
+  DWELLER_RPC_URL: rpcUrl,
+  POLKADOT_RPC_URL: rpcUrl,
+  RPC_URL: rpcUrl,
+  TREASURY_POLICY_ADDRESS: treasuryPolicy,
+  AGENT_ACCOUNT_ADDRESS: agentAccountCore,
+  ESCROW_CORE_ADDRESS: escrowCore,
+  REPUTATION_SBT_ADDRESS: reputationSbt,
+  DISCOVERY_REGISTRY_ADDRESS: discoveryRegistry,
+  XCM_WRAPPER_ADDRESS: xcmWrapper,
+  SUPPORTED_ASSETS_JSON: supportedAssets,
+  SUPPORTED_ASSETS: ""
+};
+
+for (const [key, value] of Object.entries(entries)) {
+  console.log(`${key}=${value}`);
+}
+NODE
+  ); then
+    echo "Failed to derive settlement env from $manifest." >&2
+    exit 1
+  fi
+
+  local pairs=()
+  local line
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    pairs+=("$line")
+  done <<< "$generated"
+
+  if [[ "${#pairs[@]}" -eq 0 ]]; then
+    echo "Settlement env derivation returned no values." >&2
+    exit 1
+  fi
+
+  echo "Ensuring backend settlement settings in $BACKEND_ENV_FILE match $manifest"
+  if upsert_env_values_if_changed "$BACKEND_ENV_FILE" "${pairs[@]}"; then
+    SETTLEMENT_ENV_UPDATED=1
+  fi
+}
+
 configure_bootstrap_instrumentation_env() {
   if [[ -z "${RESEND_API_KEY:-}" || -z "${BOOTSTRAP_SELF_REPORT_TO:-}" ]]; then
     echo "Bootstrap self-report secrets are incomplete; leaving backend.env instrumentation settings unchanged."
@@ -201,7 +337,7 @@ configure_bootstrap_instrumentation_env() {
 }
 
 backend_env_requires_deploy() {
-  if [[ "$BOOTSTRAP_INSTRUMENTATION_ENV_UPDATED" != "1" ]]; then
+  if [[ "$BOOTSTRAP_INSTRUMENTATION_ENV_UPDATED" != "1" && "$SETTLEMENT_ENV_UPDATED" != "1" ]]; then
     return 1
   fi
   case "$RUN_BACKEND" in
@@ -471,6 +607,7 @@ deploy() {
 
   initialize_component_state
   apply_indexer_database_schema
+  configure_settlement_env
   configure_bootstrap_instrumentation_env
 
   local run_backend=0

--- a/scripts/ops/deploy-production.test.mjs
+++ b/scripts/ops/deploy-production.test.mjs
@@ -186,6 +186,95 @@ test("deploy wrapper writes bootstrap instrumentation backend env when secrets a
   assert.match(await readFile(deployLog, "utf8"), /^backend$/m);
 });
 
+test("deploy wrapper refreshes settlement backend env from testnet deployment manifest", async () => {
+  const root = await mkdtemp(join(tmpdir(), "deploy-production-settlement-"));
+  const appRoot = join(root, "app");
+  const stackRoot = join(root, "stack");
+  const fakeBin = join(root, "bin");
+  const stateDir = join(root, "state");
+  const deployLog = join(root, "deploy.log");
+  const backendEnv = join(stackRoot, "backend.env");
+
+  await mkdir(join(appRoot, "scripts/ops"), { recursive: true });
+  await mkdir(join(appRoot, "deployments"), { recursive: true });
+  await mkdir(stackRoot, { recursive: true });
+  await mkdir(fakeBin, { recursive: true });
+  await writeFile(join(stackRoot, "docker-compose.yml"), "services: {}\n");
+  await writeFile(backendEnv, [
+    "KEEP_ME=1",
+    "DWELLER_RPC_URL=\"https://old-dweller.example\"",
+    "POLKADOT_RPC_URL=\"https://old-polkadot.example\"",
+    "RPC_URL=\"https://old.example\"",
+    "SUPPORTED_ASSETS=\"DOT:0x5555555555555555555555555555555555555555\"",
+    "SUPPORTED_ASSETS_JSON=\"[]\""
+  ].join("\n") + "\n");
+  await writeFile(join(appRoot, "deployments/testnet.json"), JSON.stringify({
+    profile: "testnet",
+    rpcUrl: "https://eth-rpc-testnet.polkadot.io/",
+    contracts: {
+      treasuryPolicy: "0x648Cc5fdE94435992296C4e5ac642d18bB64c12B",
+      agentAccountCore: "0x71B111d8c9DF84Be26cb9067D27dAd7A2d5E7e08",
+      reputationSbt: "0x68Db90db715Be59E5800Bea08c058E4CFd88e27c",
+      discoveryRegistry: "0x0a1b78F8A2A3C28dB47f35Cb3E6b3b83412dad57",
+      escrowCore: "0x7BB8fea44bDeE9870cF27c1dB616E7017BC38b0a",
+      xcmWrapper: null,
+      token: "0x0000053900000000000000000000000001200000"
+    }
+  }), "utf8");
+  await copyFile(DEPLOY_SCRIPT, join(appRoot, "scripts/ops/deploy-production.sh"));
+  await chmod(join(appRoot, "scripts/ops/deploy-production.sh"), 0o755);
+  await writeExecutable(join(appRoot, "scripts/ops/redeploy-backend.sh"), [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    "echo backend >> \"$DEPLOY_LOG\""
+  ].join("\n"));
+
+  for (const command of ["docker", "curl", "npm", "flock"]) {
+    await writeExecutable(join(fakeBin, command), "#!/usr/bin/env bash\nexit 0\n");
+  }
+
+  git(appRoot, "init");
+  git(appRoot, "config", "user.email", "test@example.com");
+  git(appRoot, "config", "user.name", "Deploy Test");
+  await writeFile(join(appRoot, "README.md"), "base\n");
+  git(appRoot, "add", ".");
+  git(appRoot, "commit", "-m", "base");
+  const baseSha = revParse(appRoot, "HEAD");
+
+  const result = runDeploy(appRoot, {
+    PATH: `${fakeBin}:${process.env.PATH}`,
+    STACK_ROOT: stackRoot,
+    COMPOSE_FILE: join(stackRoot, "docker-compose.yml"),
+    BACKEND_ENV_FILE: backendEnv,
+    DEPLOY_LOCK_FILE: join(root, "deploy.lock"),
+    DEPLOY_STATE_DIR: stateDir,
+    DEPLOY_OLD_SHA: baseSha,
+    DEPLOY_NEW_SHA: baseSha,
+    DEPLOY_LOG: deployLog,
+    RUN_FRONTEND: "0",
+    RUN_INDEXER: "0",
+    RUN_SITE: "0",
+    RUN_CADDY: "0",
+    RUN_SMOKE: "0"
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const contents = await readFile(backendEnv, "utf8");
+  assert.match(contents, /^KEEP_ME=1$/m);
+  assert.match(contents, /^DWELLER_RPC_URL="https:\/\/eth-rpc-testnet\.polkadot\.io\/"$/m);
+  assert.match(contents, /^POLKADOT_RPC_URL="https:\/\/eth-rpc-testnet\.polkadot\.io\/"$/m);
+  assert.match(contents, /^RPC_URL="https:\/\/eth-rpc-testnet\.polkadot\.io\/"$/m);
+  assert.match(contents, /^TREASURY_POLICY_ADDRESS="0x648Cc5fdE94435992296C4e5ac642d18bB64c12B"$/m);
+  assert.match(contents, /^AGENT_ACCOUNT_ADDRESS="0x71B111d8c9DF84Be26cb9067D27dAd7A2d5E7e08"$/m);
+  assert.match(contents, /^ESCROW_CORE_ADDRESS="0x7BB8fea44bDeE9870cF27c1dB616E7017BC38b0a"$/m);
+  assert.match(contents, /^REPUTATION_SBT_ADDRESS="0x68Db90db715Be59E5800Bea08c058E4CFd88e27c"$/m);
+  assert.match(contents, /^DISCOVERY_REGISTRY_ADDRESS="0x0a1b78F8A2A3C28dB47f35Cb3E6b3b83412dad57"$/m);
+  assert.match(contents, /^XCM_WRAPPER_ADDRESS=""$/m);
+  assert.match(contents, /^SUPPORTED_ASSETS=""$/m);
+  assert.match(contents, /^SUPPORTED_ASSETS_JSON="\[{\\"symbol\\":\\"USDC\\",\\"assetClass\\":\\"trust_backed\\",\\"assetId\\":1337,\\"address\\":\\"0x0000053900000000000000000000000001200000\\",\\"decimals\\":6}\]"$/m);
+  assert.match(await readFile(deployLog, "utf8"), /^backend$/m);
+});
+
 async function writeExecutable(path, content) {
   await writeFile(path, `${content}\n`);
   await chmod(path, 0o755);


### PR DESCRIPTION
## Summary
- derive non-secret backend settlement env from deployments/testnet.json during production deploy
- upsert canonical Hub TestNet USDC metadata and clear legacy SUPPORTED_ASSETS drift
- force backend redeploy when settlement env changes so /admin/status reflects the manifest before product-proof smoke

## Checks
- node --test scripts/ops/deploy-production.test.mjs
- node --test scripts/ops/run-hosted-worker-loop.test.mjs
- git diff --check

## Impact
- Backend/deploy wrapper only
- No secrets are written; existing SIGNER_PRIVATE_KEY and tokens remain untouched
- Required to complete hosted product-proof worker-loop readiness after the live chain audit passed but /admin/status still reported stale settlement config

## Polkadot docs check
- Confirmed with Polkadot docs MCP: USDC is Trust-Backed asset id 1337, 6 decimals, ERC20 precompile 0x0000053900000000000000000000000001200000; metadata methods are not implemented on the precompile.