### PR TITLE
Use Docker fallback for settlement env derivation

### DIFF
--- a/scripts/ops/deploy-production.sh
+++ b/scripts/ops/deploy-production.sh
@@ -209,79 +209,21 @@ configure_settlement_env() {
     return
   fi
 
-  if ! command -v node >/dev/null 2>&1; then
-    echo "node is required to derive settlement env from $manifest." >&2
-    exit 1
+  local derive_script="$APP_ROOT/scripts/ops/derive-settlement-env.mjs"
+  local generated
+  if command -v node >/dev/null 2>&1; then
+    generated=$(node "$derive_script" "$manifest")
+  else
+    local relative_manifest="${manifest#$APP_ROOT/}"
+    local relative_script="${derive_script#$APP_ROOT/}"
+    generated=$(docker run --rm \
+      -v "$APP_ROOT:/workspace" \
+      -w /workspace \
+      "$PRODUCT_PROOF_NODE_IMAGE" \
+      node "$relative_script" "$relative_manifest")
   fi
 
-  local generated
-  if ! generated=$(node - "$manifest" <<'NODE'
-const { readFileSync } = require("node:fs");
-
-const manifestPath = process.argv[2];
-const deployment = JSON.parse(readFileSync(manifestPath, "utf8"));
-
-function requireAddress(value, label) {
-  if (typeof value !== "string" || !/^0x[a-fA-F0-9]{40}$/.test(value)) {
-    throw new Error(`${label} must be a 0x + 20-byte EVM address.`);
-  }
-  return value;
-}
-
-function requireString(value, label) {
-  if (typeof value !== "string" || value.trim() === "") {
-    throw new Error(`${label} must be present.`);
-  }
-  return value.trim();
-}
-
-const rpcUrl = requireString(deployment.rpcUrl, "rpcUrl");
-const contracts = deployment.contracts ?? {};
-const treasuryPolicy = requireAddress(contracts.treasuryPolicy, "contracts.treasuryPolicy");
-const agentAccountCore = requireAddress(contracts.agentAccountCore, "contracts.agentAccountCore");
-const escrowCore = requireAddress(contracts.escrowCore, "contracts.escrowCore");
-const reputationSbt = requireAddress(contracts.reputationSbt, "contracts.reputationSbt");
-const discoveryRegistry = contracts.discoveryRegistry
-  ? requireAddress(contracts.discoveryRegistry, "contracts.discoveryRegistry")
-  : "";
-const xcmWrapper = contracts.xcmWrapper
-  ? requireAddress(contracts.xcmWrapper, "contracts.xcmWrapper")
-  : "";
-const usdc = requireAddress(contracts.token, "contracts.token");
-const usdcLower = usdc.toLowerCase();
-const canonicalUsdc = "0x0000053900000000000000000000000001200000";
-
-if (usdcLower !== canonicalUsdc) {
-  throw new Error(`contracts.token must be canonical Hub USDC (${canonicalUsdc}), got ${usdc}.`);
-}
-
-const supportedAssets = JSON.stringify([{
-  symbol: "USDC",
-  assetClass: "trust_backed",
-  assetId: 1337,
-  address: usdc,
-  decimals: 6
-}]);
-
-const entries = {
-  DWELLER_RPC_URL: rpcUrl,
-  POLKADOT_RPC_URL: rpcUrl,
-  RPC_URL: rpcUrl,
-  TREASURY_POLICY_ADDRESS: treasuryPolicy,
-  AGENT_ACCOUNT_ADDRESS: agentAccountCore,
-  ESCROW_CORE_ADDRESS: escrowCore,
-  REPUTATION_SBT_ADDRESS: reputationSbt,
-  DISCOVERY_REGISTRY_ADDRESS: discoveryRegistry,
-  XCM_WRAPPER_ADDRESS: xcmWrapper,
-  SUPPORTED_ASSETS_JSON: supportedAssets,
-  SUPPORTED_ASSETS: ""
-};
-
-for (const [key, value] of Object.entries(entries)) {
-  console.log(`${key}=${value}`);
-}
-NODE
-  ); then
+  if [[ -z "$generated" ]]; then
     echo "Failed to derive settlement env from $manifest." >&2
     exit 1
   fi

--- a/scripts/ops/deploy-production.test.mjs
+++ b/scripts/ops/deploy-production.test.mjs
@@ -8,6 +8,7 @@ import { execFileSync, spawnSync } from "node:child_process";
 
 const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
 const DEPLOY_SCRIPT = join(REPO_ROOT, "scripts/ops/deploy-production.sh");
+const DERIVE_SETTLEMENT_ENV_SCRIPT = join(REPO_ROOT, "scripts/ops/derive-settlement-env.mjs");
 
 test("deploy wrapper retries frontend after an earlier failed indexer deploy", async () => {
   const root = await mkdtemp(join(tmpdir(), "deploy-production-"));
@@ -24,6 +25,7 @@ test("deploy wrapper retries frontend after an earlier failed indexer deploy", a
   await mkdir(fakeBin, { recursive: true });
   await writeFile(join(stackRoot, "docker-compose.yml"), "services: {}\n");
   await copyFile(DEPLOY_SCRIPT, join(appRoot, "scripts/ops/deploy-production.sh"));
+  await copyFile(DERIVE_SETTLEMENT_ENV_SCRIPT, join(appRoot, "scripts/ops/derive-settlement-env.mjs"));
   await chmod(join(appRoot, "scripts/ops/deploy-production.sh"), 0o755);
 
   await writeExecutable(join(appRoot, "scripts/ops/redeploy-indexer.sh"), [
@@ -222,6 +224,7 @@ test("deploy wrapper refreshes settlement backend env from testnet deployment ma
     }
   }), "utf8");
   await copyFile(DEPLOY_SCRIPT, join(appRoot, "scripts/ops/deploy-production.sh"));
+  await copyFile(DERIVE_SETTLEMENT_ENV_SCRIPT, join(appRoot, "scripts/ops/derive-settlement-env.mjs"));
   await chmod(join(appRoot, "scripts/ops/deploy-production.sh"), 0o755);
   await writeExecutable(join(appRoot, "scripts/ops/redeploy-backend.sh"), [
     "#!/usr/bin/env bash",
@@ -273,6 +276,91 @@ test("deploy wrapper refreshes settlement backend env from testnet deployment ma
   assert.match(contents, /^SUPPORTED_ASSETS=""$/m);
   assert.match(contents, /^SUPPORTED_ASSETS_JSON="\[{\\"symbol\\":\\"USDC\\",\\"assetClass\\":\\"trust_backed\\",\\"assetId\\":1337,\\"address\\":\\"0x0000053900000000000000000000000001200000\\",\\"decimals\\":6}\]"$/m);
   assert.match(await readFile(deployLog, "utf8"), /^backend$/m);
+});
+
+test("deploy wrapper derives settlement env through docker when host node is unavailable", async () => {
+  const root = await mkdtemp(join(tmpdir(), "deploy-production-settlement-docker-"));
+  const appRoot = join(root, "app");
+  const stackRoot = join(root, "stack");
+  const fakeBin = join(root, "bin");
+  const stateDir = join(root, "state");
+  const deployLog = join(root, "deploy.log");
+  const backendEnv = join(stackRoot, "backend.env");
+
+  await mkdir(join(appRoot, "scripts/ops"), { recursive: true });
+  await mkdir(join(appRoot, "deployments"), { recursive: true });
+  await mkdir(stackRoot, { recursive: true });
+  await mkdir(fakeBin, { recursive: true });
+  await writeFile(join(stackRoot, "docker-compose.yml"), "services: {}\n");
+  await writeFile(backendEnv, "KEEP_ME=1\nSUPPORTED_ASSETS=\"DOT:0x5555555555555555555555555555555555555555\"\n");
+  await writeFile(join(appRoot, "deployments/testnet.json"), JSON.stringify({
+    profile: "testnet",
+    rpcUrl: "https://eth-rpc-testnet.polkadot.io/",
+    contracts: {
+      treasuryPolicy: "0x648Cc5fdE94435992296C4e5ac642d18bB64c12B",
+      agentAccountCore: "0x71B111d8c9DF84Be26cb9067D27dAd7A2d5E7e08",
+      reputationSbt: "0x68Db90db715Be59E5800Bea08c058E4CFd88e27c",
+      discoveryRegistry: "0x0a1b78F8A2A3C28dB47f35Cb3E6b3b83412dad57",
+      escrowCore: "0x7BB8fea44bDeE9870cF27c1dB616E7017BC38b0a",
+      xcmWrapper: null,
+      token: "0x0000053900000000000000000000000001200000"
+    }
+  }), "utf8");
+  await copyFile(DEPLOY_SCRIPT, join(appRoot, "scripts/ops/deploy-production.sh"));
+  await copyFile(DERIVE_SETTLEMENT_ENV_SCRIPT, join(appRoot, "scripts/ops/derive-settlement-env.mjs"));
+  await chmod(join(appRoot, "scripts/ops/deploy-production.sh"), 0o755);
+  await writeExecutable(join(appRoot, "scripts/ops/redeploy-backend.sh"), [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    "echo backend >> \"$DEPLOY_LOG\""
+  ].join("\n"));
+
+  await writeExecutable(join(fakeBin, "docker"), [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    "echo docker \"$@\" >> \"$DEPLOY_LOG\"",
+    "while [[ \"$#\" -gt 0 && \"$1\" != \"node\" ]]; do shift; done",
+    "if [[ \"$#\" -eq 0 ]]; then echo 'node command not found in docker args' >&2; exit 1; fi",
+    "shift",
+    "\"$HOST_NODE\" \"$@\""
+  ].join("\n"));
+  for (const command of ["curl", "npm", "flock"]) {
+    await writeExecutable(join(fakeBin, command), "#!/usr/bin/env bash\nexit 0\n");
+  }
+
+  git(appRoot, "init");
+  git(appRoot, "config", "user.email", "test@example.com");
+  git(appRoot, "config", "user.name", "Deploy Test");
+  await writeFile(join(appRoot, "README.md"), "base\n");
+  git(appRoot, "add", ".");
+  git(appRoot, "commit", "-m", "base");
+  const baseSha = revParse(appRoot, "HEAD");
+
+  const result = runDeploy(appRoot, {
+    PATH: `${fakeBin}:/usr/bin:/bin`,
+    STACK_ROOT: stackRoot,
+    COMPOSE_FILE: join(stackRoot, "docker-compose.yml"),
+    BACKEND_ENV_FILE: backendEnv,
+    DEPLOY_LOCK_FILE: join(root, "deploy.lock"),
+    DEPLOY_STATE_DIR: stateDir,
+    DEPLOY_OLD_SHA: baseSha,
+    DEPLOY_NEW_SHA: baseSha,
+    DEPLOY_LOG: deployLog,
+    HOST_NODE: process.execPath,
+    RUN_FRONTEND: "0",
+    RUN_INDEXER: "0",
+    RUN_SITE: "0",
+    RUN_CADDY: "0",
+    RUN_SMOKE: "0"
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const log = await readFile(deployLog, "utf8");
+  assert.match(log, /^docker .* node scripts\/ops\/derive-settlement-env\.mjs deployments\/testnet\.json$/m);
+  assert.match(log, /^backend$/m);
+  const contents = await readFile(backendEnv, "utf8");
+  assert.match(contents, /^SUPPORTED_ASSETS_JSON="\[{\\"symbol\\":\\"USDC\\"/m);
+  assert.match(contents, /^SUPPORTED_ASSETS=""$/m);
 });
 
 async function writeExecutable(path, content) {

--- a/scripts/ops/derive-settlement-env.mjs
+++ b/scripts/ops/derive-settlement-env.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+
+const manifestPath = process.argv[2];
+if (!manifestPath) {
+  throw new Error("usage: derive-settlement-env.mjs <deployments/testnet.json>");
+}
+
+const deployment = JSON.parse(readFileSync(manifestPath, "utf8"));
+
+function requireAddress(value, label) {
+  if (typeof value !== "string" || !/^0x[a-fA-F0-9]{40}$/.test(value)) {
+    throw new Error(`${label} must be a 0x + 20-byte EVM address.`);
+  }
+  return value;
+}
+
+function requireString(value, label) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${label} must be present.`);
+  }
+  return value.trim();
+}
+
+const rpcUrl = requireString(deployment.rpcUrl, "rpcUrl");
+const contracts = deployment.contracts ?? {};
+const treasuryPolicy = requireAddress(contracts.treasuryPolicy, "contracts.treasuryPolicy");
+const agentAccountCore = requireAddress(contracts.agentAccountCore, "contracts.agentAccountCore");
+const escrowCore = requireAddress(contracts.escrowCore, "contracts.escrowCore");
+const reputationSbt = requireAddress(contracts.reputationSbt, "contracts.reputationSbt");
+const discoveryRegistry = contracts.discoveryRegistry
+  ? requireAddress(contracts.discoveryRegistry, "contracts.discoveryRegistry")
+  : "";
+const xcmWrapper = contracts.xcmWrapper
+  ? requireAddress(contracts.xcmWrapper, "contracts.xcmWrapper")
+  : "";
+const usdc = requireAddress(contracts.token, "contracts.token");
+const canonicalUsdc = "0x0000053900000000000000000000000001200000";
+
+if (usdc.toLowerCase() !== canonicalUsdc) {
+  throw new Error(`contracts.token must be canonical Hub USDC (${canonicalUsdc}), got ${usdc}.`);
+}
+
+const supportedAssets = JSON.stringify([{
+  symbol: "USDC",
+  assetClass: "trust_backed",
+  assetId: 1337,
+  address: usdc,
+  decimals: 6
+}]);
+
+const entries = {
+  DWELLER_RPC_URL: rpcUrl,
+  POLKADOT_RPC_URL: rpcUrl,
+  RPC_URL: rpcUrl,
+  TREASURY_POLICY_ADDRESS: treasuryPolicy,
+  AGENT_ACCOUNT_ADDRESS: agentAccountCore,
+  ESCROW_CORE_ADDRESS: escrowCore,
+  REPUTATION_SBT_ADDRESS: reputationSbt,
+  DISCOVERY_REGISTRY_ADDRESS: discoveryRegistry,
+  XCM_WRAPPER_ADDRESS: xcmWrapper,
+  SUPPORTED_ASSETS_JSON: supportedAssets,
+  SUPPORTED_ASSETS: ""
+};
+
+for (const [key, value] of Object.entries(entries)) {
+  console.log(`${key}=${value}`);
+}


### PR DESCRIPTION
## Summary
- move manifest-to-backend-env derivation into scripts/ops/derive-settlement-env.mjs
- let deploy-production.sh use local node when available, otherwise run the helper through the existing Docker Node image
- keeps the PR #210 behavior: all RPC aliases converge to the manifest URL, canonical Hub USDC is required, and backend redeploy is forced on settlement env drift

## Checks
- node scripts/ops/derive-settlement-env.mjs deployments/testnet.json
- node --test scripts/ops/deploy-production.test.mjs
- node --test scripts/ops/run-hosted-worker-loop.test.mjs
- git diff --check

## Impact
- Deploy wrapper/backend config convergence only
- Fixes the production deploy failure where the VPS shell lacked node before product-proof smoke could run