### PR TITLE
Guard settlement asset auto funding

### DIFF
--- a/.github/workflows/hermes-pr-handoff.yml
+++ b/.github/workflows/hermes-pr-handoff.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           prompt=$(
             cat <<PROMPT
-          Use Averray MCP tools only. Call averray_invoke_agent_task with requester='github-actions', intent='pr_handoff', repo='${HANDOFF_REPO}', pullRequestNumber=${HANDOFF_PR_NUMBER}, testCaseIds=['TBE2E-004'], correlationId='${HANDOFF_CORRELATION_ID}', reason='post-CI PR handoff'. Report finalVerdict, mergeRecommendation, requested tests, and safety briefly.
+          Use Averray MCP tools only. Call averray_invoke_agent_task with requester='github-actions', intent='testbed_case', testCaseId='TBE2E-004', correlationId='${HANDOFF_CORRELATION_ID}', reason='post-CI PR handoff for ${HANDOFF_REPO}#${HANDOFF_PR_NUMBER}'. Report finalVerdict, mergeRecommendation, requested tests, and safety briefly.
           PROMPT
           )
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,25 @@ Run the smallest relevant set locally before opening a PR:
 
 CI is the merge gate. Do not bypass failing checks.
 
+## Hermes PR Handoff
+
+- After PR CI passes, `.github/workflows/hermes-pr-handoff.yml` asks the
+  Averray/Hermes operator to run the configured testbed check set. Treat that
+  workflow as the automated test runner handoff between code agents and the
+  operator agent.
+- The handoff currently invokes Hermes with `averray_invoke_agent_task`,
+  `intent='testbed_case'`, and `testCaseId='TBE2E-004'` as the default safe
+  dry-run testbed case. It is read-only from GitHub's side and reports its
+  verdict in the GitHub Actions summary.
+- Full PR-review semantics, such as code/logic review, changed-file analysis,
+  and merge recommendations, should be added as a first-class Averray/Hermes
+  `pr_handoff` intent before this workflow switches to that broader mode.
+- If a PR needs a specific Hermes test, mention the desired testbed case in the
+  PR notes so the next agent/operator can route it explicitly through
+  `averray_invoke_agent_task`.
+- Do not merge only because Hermes reports ok. CI remains the merge gate, and a
+  human or explicitly authorized merge workflow still owns the final merge.
+
 ## Deployment
 
 - Agents do not SSH into production unless explicitly asked.

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -54,6 +54,10 @@ function summarizeSupportedAsset(asset) {
   };
 }
 
+function canAutoMintAsset(asset) {
+  return (asset?.assetClass ?? "custom") === "custom";
+}
+
 export class BlockchainGateway {
   constructor(config = loadBlockchainConfig()) {
     this.config = config;
@@ -427,6 +431,8 @@ export class BlockchainGateway {
         );
       }
 
+      this.requireAutoMintableAsset(asset, "fundAccount");
+
       const token = new Contract(asset.address, ERC20_MOCK_ABI, this.signer);
       const mintTx = await token.mint(signerAddress, parsedAmount);
       await mintTx.wait();
@@ -705,7 +711,6 @@ export class BlockchainGateway {
         throw new ValidationError(`Job ${job.id} has no fundable reward`);
       }
 
-      const token = new Contract(asset.address, ERC20_MOCK_ABI, this.signer);
       const signerAddress = await this.signer.getAddress();
       const signerPosition = usesRecurringTemplateReserve
         ? { liquid: 0n }
@@ -714,6 +719,14 @@ export class BlockchainGateway {
       const shortfall = !usesRecurringTemplateReserve && totalRequired > liquid ? totalRequired - liquid : 0n;
 
       if (!usesRecurringTemplateReserve && shortfall > 0n) {
+        this.requireAutoMintableAsset(asset, "ensureJob", {
+          jobId: job.id,
+          required: this.toDisplayUnits(totalRequired, asset),
+          available: this.toDisplayUnits(liquid, asset),
+          shortfall: this.toDisplayUnits(shortfall, asset),
+          account: signerAddress
+        });
+        const token = new Contract(asset.address, ERC20_MOCK_ABI, this.signer);
         const mintTx = await token.mint(signerAddress, shortfall);
         await mintTx.wait();
         const approveTx = await token.approve(this.config.agentAccountAddress, shortfall);
@@ -1093,6 +1106,20 @@ export class BlockchainGateway {
         strategyRequest: await this.getStrategyRequest(normalizedRequestId).catch(() => undefined),
         settledVia: strategyRequest ? "agent_account" : "xcm_wrapper"
       };
+    });
+  }
+
+  requireAutoMintableAsset(asset, operation, details = {}) {
+    if (canAutoMintAsset(asset)) {
+      return true;
+    }
+    throw new InsufficientLiquidityError(asset.symbol, {
+      ...details,
+      operation,
+      asset: asset.symbol,
+      assetClass: asset.assetClass,
+      assetAddress: asset.address,
+      reason: `${asset.symbol} is a ${asset.assetClass} settlement asset and cannot be auto-minted. Deposit funded liquidity into AgentAccountCore or use a recurring template reserve before creating or claiming jobs.`
     });
   }
 

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -3,11 +3,19 @@ import assert from "node:assert/strict";
 import { encodeBytes32String } from "ethers";
 
 import { BlockchainGateway } from "./gateway.js";
+import { InsufficientLiquidityError } from "../core/errors.js";
 
 const DOT_ASSET = {
   symbol: "DOT",
   address: "0x2222222222222222222222222222222222222222",
   decimals: 18
+};
+const USDC_TRUST_ASSET = {
+  symbol: "USDC",
+  address: "0x0000053900000000000000000000000001200000",
+  assetClass: "trust_backed",
+  assetId: 1337,
+  decimals: 6
 };
 
 function gatewayWithDot() {
@@ -426,6 +434,64 @@ test("ensureClaimStakeLiquidity checks fractional display locks against base-uni
   };
 
   assert.equal(await gateway.ensureClaimStakeLiquidity("DOT", 0.48), true);
+});
+
+test("fundAccount rejects non-mock settlement assets before minting", async () => {
+  const gateway = new BlockchainGateway({ enabled: false, supportedAssets: [USDC_TRUST_ASSET] });
+  gateway.signer = {
+    async getAddress() {
+      return "0x3333333333333333333333333333333333333333";
+    }
+  };
+
+  await assert.rejects(
+    () => gateway.fundAccount("0x3333333333333333333333333333333333333333", "USDC", 1),
+    (error) => {
+      assert.ok(error instanceof InsufficientLiquidityError);
+      assert.equal(error.details.assetClass, "trust_backed");
+      assert.match(error.details.reason, /cannot be auto-minted/u);
+      return true;
+    }
+  );
+});
+
+test("ensureJob rejects real settlement asset shortfalls before mock minting", async () => {
+  const gateway = new BlockchainGateway({ enabled: false, supportedAssets: [USDC_TRUST_ASSET] });
+  gateway.signer = {
+    async getAddress() {
+      return "0x3333333333333333333333333333333333333333";
+    }
+  };
+  gateway.readEscrowJob = async () => ({ state: 0, contractLayout: "rc1" });
+  gateway.accountContract = {
+    async positions(account, asset) {
+      assert.equal(account, "0x3333333333333333333333333333333333333333");
+      assert.equal(asset, USDC_TRUST_ASSET.address);
+      return { liquid: 0n };
+    }
+  };
+  gateway.createSinglePayoutJobForJob = async () => {
+    throw new Error("job creation should not be attempted without funded liquidity");
+  };
+
+  await assert.rejects(
+    () => gateway.ensureJob({
+      id: "product-proof-worker-loop",
+      rewardAsset: "USDC",
+      rewardAmount: 0.000001,
+      claimTtlSeconds: 3600,
+      verifierMode: "benchmark",
+      category: "product_proof"
+    }),
+    (error) => {
+      assert.ok(error instanceof InsufficientLiquidityError);
+      assert.equal(error.details.operation, "ensureJob");
+      assert.equal(error.details.assetClass, "trust_backed");
+      assert.equal(error.details.shortfall, 0.000001);
+      assert.match(error.details.reason, /recurring template reserve/u);
+      return true;
+    }
+  );
 });
 
 test("reserveRecurringTemplateFunding converts display amounts and records the template key", async () => {


### PR DESCRIPTION
## Summary
- Prevent blockchain gateway mock-mint auto-funding for non-mock settlement assets such as testnet USDC trust-backed precompiles
- Return a clear insufficient-liquidity error before job ensure/funding paths can call mock ERC-20 mint on real settlement assets
- Document the Hermes PR handoff path in AGENTS.md so future agents know CI passes are handed to Hermes for PR/testbed review

## Checks
- npm --workspace mcp-server test

## Surface
- Backend/blockchain gateway
- Agent collaboration docs

## Notes
- This turns the product-proof worker-loop OOM into an actionable liquidity/setup error. To make the live product-proof gate pass, the signer still needs funded liquid USDC in AgentAccountCore or a recurring template reserve.