### PR TITLE
Use Hermes PR handoff intent

### DIFF
--- a/.github/workflows/hermes-pr-handoff.yml
+++ b/.github/workflows/hermes-pr-handoff.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           prompt=$(
             cat <<PROMPT
-          Use Averray MCP tools only. Call averray_invoke_agent_task with requester='github-actions', intent='testbed_case', testCaseId='TBE2E-004', correlationId='${HANDOFF_CORRELATION_ID}', reason='post-CI PR handoff for ${HANDOFF_REPO}#${HANDOFF_PR_NUMBER}'. Report finalVerdict, mergeRecommendation, requested tests, and safety briefly.
+          Use Averray MCP tools only. Call averray_invoke_agent_task with requester='github-actions', intent='pr_handoff', repo='${HANDOFF_REPO}', pullRequestNumber=${HANDOFF_PR_NUMBER}, testCaseIds=['TBE2E-004'], correlationId='${HANDOFF_CORRELATION_ID}', reason='post-CI PR handoff'. Report finalVerdict, mergeRecommendation, requested tests, GitHub risk findings, and safety briefly. Do not merge or mutate GitHub; this handoff is recommendation-only.
           PROMPT
           )
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,21 +56,20 @@ CI is the merge gate. Do not bypass failing checks.
 ## Hermes PR Handoff
 
 - After PR CI passes, `.github/workflows/hermes-pr-handoff.yml` asks the
-  Averray/Hermes operator to run the configured testbed check set. Treat that
-  workflow as the automated test runner handoff between code agents and the
-  operator agent.
+  Averray/Hermes operator to review the PR and run the configured testbed check
+  set. Treat that workflow as the automated review and test handoff between
+  code agents and the operator agent.
 - The handoff currently invokes Hermes with `averray_invoke_agent_task`,
-  `intent='testbed_case'`, and `testCaseId='TBE2E-004'` as the default safe
-  dry-run testbed case. It is read-only from GitHub's side and reports its
-  verdict in the GitHub Actions summary.
-- Full PR-review semantics, such as code/logic review, changed-file analysis,
-  and merge recommendations, should be added as a first-class Averray/Hermes
-  `pr_handoff` intent before this workflow switches to that broader mode.
+  `intent='pr_handoff'`, the PR repository/number, and `TBE2E-004` as the
+  default safe dry-run testbed case. Hermes checks PR metadata, GitHub checks,
+  changed-file risk signals, and requested testbed cases, then reports its
+  verdict and merge recommendation in the GitHub Actions summary.
 - If a PR needs a specific Hermes test, mention the desired testbed case in the
   PR notes so the next agent/operator can route it explicitly through
   `averray_invoke_agent_task`.
-- Do not merge only because Hermes reports ok. CI remains the merge gate, and a
-  human or explicitly authorized merge workflow still owns the final merge.
+- Hermes PR handoff is recommendation-only. It does not merge, approve, comment,
+  or otherwise mutate GitHub. CI remains the merge gate, and a human or
+  explicitly authorized merge workflow still owns the final merge.
 
 ## Deployment
 


### PR DESCRIPTION
## Summary
- Switch the Hermes PR handoff workflow from the temporary testbed_case call to the first-class pr_handoff intent
- Pass repo, pull request number, correlation id, and requested TBE2E-004 testbed check to Hermes
- Update AGENTS.md so future agents know Hermes now performs recommendation-only PR review plus testbed handoff

## Checks
- git diff --check

## Impact
- GitHub Actions workflow/docs only
- No backend, frontend, indexer, Caddy, contracts, public site, environment, or VPS secret changes

Note: this is recommendation-only. Hermes does not merge, approve, comment, or otherwise mutate GitHub.