### PR TITLE
Add Hermes post-deploy verification hook

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -100,6 +100,14 @@ on:
         required: false
         default: ""
         type: string
+      run_hermes_post_deploy:
+        description: Run the read-only Hermes post-deploy testbed suite after a successful deploy.
+        required: false
+        default: "1"
+        type: choice
+        options:
+          - "1"
+          - "0"
 
 concurrency:
   group: production
@@ -137,6 +145,8 @@ jobs:
       DEPLOY_SMOKE_CHECK_PRODUCT_PROOF_GATE: ${{ github.event_name == 'workflow_dispatch' && inputs.smoke_check_product_proof_gate || '0' }}
       DEPLOY_PRODUCT_PROOF_REQUIRE_WORKER_LOOP: ${{ github.event_name == 'workflow_dispatch' && inputs.product_proof_require_worker_loop || '0' }}
       DEPLOY_PRODUCT_PROOF_REWARD_ASSET: ${{ github.event_name == 'workflow_dispatch' && inputs.product_proof_reward_asset || '' }}
+      DEPLOY_RUN_HERMES_POST_DEPLOY: ${{ github.event_name == 'workflow_dispatch' && inputs.run_hermes_post_deploy || '1' }}
+      HERMES_POST_DEPLOY_TIMEOUT: 12m
     steps:
       - name: Validate required secrets
         run: |
@@ -214,3 +224,78 @@ jobs:
 
           DEPLOY_OLD_SHA="$old_sha" DEPLOY_NEW_SHA="$new_sha" ./scripts/ops/deploy-production.sh
           REMOTE
+
+      - name: Ask Hermes for post-deploy testbed verification
+        id: hermes_post_deploy
+        if: env.DEPLOY_RUN_HERMES_POST_DEPLOY == '1'
+        continue-on-error: true
+        env:
+          HERMES_DEPLOY_CORRELATION_ID: github-deploy-${{ github.run_id }}-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+          HERMES_DEPLOY_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+          HERMES_DEPLOY_EVENT: ${{ github.event_name }}
+        run: |
+          prompt=$(
+            cat <<PROMPT
+          Use Averray MCP tools only. Run the read-only post-deploy testbed verification suite for repo='averray-agent/agent', sha='${HERMES_DEPLOY_SHA}', correlationId='${HERMES_DEPLOY_CORRELATION_ID}', requester='github-actions', reason='post-production-deploy verification after ${HERMES_DEPLOY_EVENT}'. Prefer averray_invoke_agent_task with intent='testbed_suite', testSuiteId='post_deploy', testCaseIds=['TBE2E-001','TBE2E-002','TBE2E-003','TBE2E-006','TBE2E-007','TBE2E-008','TBE2E-009','TBE2E-010']. If that structured suite intent is unavailable, call averray_handle_operator_command with text='testbed e2e suite' and source='github-actions'. Report finalVerdict, pass/fail/skip counts, requested tests, deployment health, and safety briefly. Do not run guarded live mutation, do not submit work, and do not mutate GitHub.
+          PROMPT
+          )
+
+          remote_env=$(printf 'HERMES_POST_DEPLOY_PROMPT=%q ' "$prompt")
+
+          : > hermes-post-deploy.log
+          set +e
+          timeout "$HERMES_POST_DEPLOY_TIMEOUT" ssh -p "${VPS_PORT:-22}" \
+            -o ServerAliveInterval=30 \
+            -o ServerAliveCountMax=120 \
+            "$VPS_USER@$VPS_HOST" \
+            "${remote_env} bash -s" <<'REMOTE' | tee hermes-post-deploy.log
+          set -euo pipefail
+          cd /srv/averray-reference-agent
+          docker compose --env-file .env.prod \
+            -f ops/compose.yml \
+            -f ops/compose.prod.yml \
+            -p avg \
+            exec -T hermes /opt/hermes/.venv/bin/hermes chat \
+              --provider ollama-cloud \
+              -m deepseek-v4-pro:cloud \
+              -q "$HERMES_POST_DEPLOY_PROMPT"
+          REMOTE
+          status=${PIPESTATUS[0]}
+          set -e
+          outcome=failed
+
+          if [ "$status" -eq 0 ]; then
+            outcome=success
+          elif [ "$status" -eq 124 ]; then
+            outcome=timeout
+            {
+              echo
+              echo "Hermes post-deploy verification timed out after ${HERMES_POST_DEPLOY_TIMEOUT}."
+              echo "The production deploy already completed; inspect the remote Hermes session before relying on the verification result."
+            } | tee -a hermes-post-deploy.log
+          fi
+
+          echo "exit_status=$status" >> "$GITHUB_OUTPUT"
+          echo "outcome=$outcome" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Hermes Post-Deploy Verification"
+            echo
+            echo "- Correlation: \`${HERMES_DEPLOY_CORRELATION_ID}\`"
+            echo "- Commit: \`${HERMES_DEPLOY_SHA}\`"
+            echo "- Outcome: \`${outcome}\`"
+            echo
+            echo '```text'
+            sed -n '1,220p' hermes-post-deploy.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit "$status"
+
+      - name: Fail if Hermes post-deploy verification failed
+        if: always() && env.DEPLOY_RUN_HERMES_POST_DEPLOY == '1' && steps.hermes_post_deploy.outcome != 'skipped' && steps.hermes_post_deploy.outputs.exit_status != '0'
+        run: |
+          echo "Hermes post-deploy verification failed with status ${HERMES_STATUS:-unknown}."
+          exit 1
+        env:
+          HERMES_STATUS: ${{ steps.hermes_post_deploy.outputs.exit_status }}


### PR DESCRIPTION
Adds a read-only Hermes post-deploy verification step to the production deploy workflow.\n\nWhat changed:\n- Adds an opt-out manual deploy input, run_hermes_post_deploy, defaulting to enabled.\n- After a successful production deploy, asks Hermes/Averray to run the post-deploy testbed suite with a correlation id and deployed SHA.\n- Wraps the remote Hermes call in a 12-minute timeout and records output in the GitHub step summary.\n- Fails the deploy workflow if Hermes verification fails or times out, while keeping the suite read-only and non-mutating.\n\nChecks run:\n- git diff --check\n- YAML parse via Ruby YAML.load_file\n\nImpact:\n- GitHub Actions workflow only.\n- No backend, frontend, indexer, Caddy, contracts, or public site source changes.\n- No new repository or VPS secrets required; reuses existing production SSH secrets.