### PR TITLE
Harden Hermes PR code review handoff

### DIFF
--- a/.github/workflows/hermes-pr-handoff.yml
+++ b/.github/workflows/hermes-pr-handoff.yml
@@ -75,7 +75,27 @@ jobs:
         run: |
           prompt=$(
             cat <<PROMPT
-          Use Averray MCP tools only. Call averray_invoke_agent_task with requester='github-actions', intent='pr_handoff', repo='${HANDOFF_REPO}', pullRequestNumber=${HANDOFF_PR_NUMBER}, testCaseIds=['TBE2E-004'], correlationId='${HANDOFF_CORRELATION_ID}', reason='post-CI PR handoff'. Report finalVerdict, mergeRecommendation, requested tests, GitHub risk findings, and safety briefly. Do not merge or mutate GitHub; this handoff is recommendation-only.
+          Use Averray MCP tools only. Call averray_invoke_agent_task with requester='github-actions', intent='pr_handoff', repo='${HANDOFF_REPO}', pullRequestNumber=${HANDOFF_PR_NUMBER}, testCaseIds=['TBE2E-004'], correlationId='${HANDOFF_CORRELATION_ID}', reason='post-CI PR handoff'.
+
+          Before giving the merge recommendation, perform a PR code and logic review:
+          - Inspect PR metadata, changed files, diff/risk summary, CI status, and requested testbed results.
+          - Look for logic bugs, unsafe defaults, missing guards, missing tests, race/idempotency problems, timeout/retry problems, secret exposure, and deployment risk.
+          - Pay extra attention to deploy workflows, auth, secrets, payments/settlement, indexer, contracts, Caddy, database migrations, and external agent hooks.
+          - Verify that CI coverage matches the touched areas. If it does not, list the missing checks.
+          - If you cannot inspect the diff or changed files, say so clearly and mark the code review verdict as needs_human_review.
+
+          Report these sections briefly:
+          - finalVerdict
+          - codeReviewVerdict: approve, conditional_approve, needs_human_review, or block
+          - blockingFindings
+          - nonBlockingFindings
+          - missingTests
+          - requestedTests
+          - GitHub risk findings
+          - mergeRecommendation
+          - safety
+
+          Do not merge or mutate GitHub; this handoff is recommendation-only.
           PROMPT
           )
 
@@ -126,7 +146,7 @@ jobs:
             echo "- Outcome: \`${outcome}\`"
             echo
             echo '```text'
-            sed -n '1,220p' hermes-handoff.log
+            tail -n 260 hermes-handoff.log
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -143,7 +163,7 @@ jobs:
         run: |
           {
             echo "<!-- hermes-pr-handoff:${HANDOFF_CORRELATION_ID} -->"
-            echo "### Hermes PR Handoff"
+            echo "### Hermes PR Handoff and Code Review"
             echo
             echo "- Outcome: \`${HERMES_OUTCOME}\`"
             echo "- Correlation: \`${HANDOFF_CORRELATION_ID}\`"
@@ -153,26 +173,55 @@ jobs:
             echo "<summary>Hermes output</summary>"
             echo
             echo '```text'
-            sed -n '1,120p' hermes-handoff.log
+            tail -n 180 hermes-handoff.log
             echo '```'
             echo
             echo "</details>"
           } > hermes-comment.md
 
+          set +e
           comment_id=$(
             gh api "repos/${HANDOFF_REPO}/issues/${HANDOFF_PR_NUMBER}/comments" \
-              --jq ".[] | select(.body | contains(\"hermes-pr-handoff:${HANDOFF_CORRELATION_ID}\")) | .id" \
-              | tail -n 1
+              --jq "map(select(.body | contains(\"hermes-pr-handoff:${HANDOFF_CORRELATION_ID}\")) | .id) | last // \"\"" \
+              2>hermes-comment-api.err
           )
+          lookup_status=$?
 
+          if [ "$lookup_status" -ne 0 ]; then
+            {
+              echo "### Hermes PR comment skipped"
+              echo
+              echo "Hermes completed, but GitHub did not allow this workflow to read PR comments."
+              echo
+              echo '```text'
+              cat hermes-comment-api.err
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          body=$(cat hermes-comment.md)
           if [ -n "$comment_id" ]; then
-            body=$(cat hermes-comment.md)
             gh api -X PATCH "repos/${HANDOFF_REPO}/issues/comments/${comment_id}" \
-              -f body="$body" >/dev/null
+              -f body="$body" >/dev/null 2>hermes-comment-api.err
+            comment_status=$?
           else
-            gh pr comment "$HANDOFF_PR_NUMBER" \
-              --repo "$HANDOFF_REPO" \
-              --body-file hermes-comment.md
+            gh api -X POST "repos/${HANDOFF_REPO}/issues/${HANDOFF_PR_NUMBER}/comments" \
+              -f body="$body" >/dev/null 2>hermes-comment-api.err
+            comment_status=$?
+          fi
+
+          if [ "$comment_status" -ne 0 ]; then
+            {
+              echo "### Hermes PR comment skipped"
+              echo
+              echo "Hermes completed, but GitHub did not allow this workflow to write a PR comment."
+              echo
+              echo '```text'
+              cat hermes-comment-api.err
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
 
       - name: Fail if Hermes handoff failed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,14 +62,22 @@ CI is the merge gate. Do not bypass failing checks.
 - The handoff currently invokes Hermes with `averray_invoke_agent_task`,
   `intent='pr_handoff'`, the PR repository/number, and `TBE2E-004` as the
   default safe dry-run testbed case. Hermes checks PR metadata, GitHub checks,
-  changed-file risk signals, and requested testbed cases, then reports its
+  changed-file risk signals, changed files/diff context, CI coverage against
+  touched areas, and requested testbed cases, then reports its code-review
   verdict and merge recommendation in the GitHub Actions summary.
+- Hermes should flag blocking findings, non-blocking findings, missing tests,
+  and higher-risk areas such as deploy workflows, auth, secrets,
+  payments/settlement, indexer, contracts, Caddy, database migrations, and
+  external agent hooks. If it cannot inspect the diff, treat the handoff as
+  needing human review.
 - If a PR needs a specific Hermes test, mention the desired testbed case in the
   PR notes so the next agent/operator can route it explicitly through
   `averray_invoke_agent_task`.
-- Hermes PR handoff is recommendation-only. It does not merge, approve, comment,
-  or otherwise mutate GitHub. CI remains the merge gate, and a human or
-  explicitly authorized merge workflow still owns the final merge.
+- Hermes PR handoff is recommendation-only. It does not merge, approve, or
+  otherwise mutate GitHub. The workflow may best-effort post a summary comment,
+  but comment permission failures must not hide the Hermes verdict in the
+  GitHub Actions summary. CI remains the merge gate, and a human or explicitly
+  authorized merge workflow still owns the final merge.
 
 ## Deployment
 


### PR DESCRIPTION
## Summary
- ask Hermes to perform a PR code/logic review before giving a merge recommendation
- require explicit sections for blocking findings, missing tests, risk areas, and safety
- make PR comment publishing best-effort so GitHub token comment permissions cannot hide a successful Hermes verdict
- show the useful tail of Hermes output instead of the startup banner

## Checks
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/hermes-pr-handoff.yml"); puts "yaml ok"'

## Impact
- GitHub Actions workflow only
- Agent collaboration docs only
- no backend, frontend, indexer, contracts, Caddy, or public site runtime changes