### PR TITLE
Bump hosted product-proof reward default above USDC minBalance (fix TransferFailed at settlement)

### DIFF
--- a/scripts/ops/run-hosted-worker-loop.mjs
+++ b/scripts/ops/run-hosted-worker-loop.mjs
@@ -6,7 +6,17 @@ import { AgentPlatformClient } from "../../sdk/agent-platform-client.js";
 import { DEFAULT_ESCROW_ASSET } from "../../mcp-server/src/core/assets.js";
 
 const DEFAULT_API_BASE_URL = "https://api.averray.com";
-const DEFAULT_REWARD_AMOUNT = 0.000001;
+// Reward must yield at least the asset's `minBalance` (existential
+// deposit on the Polkadot Hub Assets pallet) once converted to base
+// units, otherwise EscrowCore.resolveSinglePayout will revert with
+// SafeTransfer.TransferFailed when settling to a worker whose asset
+// account has been destroyed (balance dropped to 0). Trust-Backed
+// assets on Asset Hub Paseo carry non-trivial minBalance values — for
+// USDC asset id 1337 the value is 70_000 base units (0.07 USDC). Pick
+// a default well above any common minBalance: 0.1 USDC = 100_000 base
+// units. Operators running with cheaper assets (DOT-decimals) can set
+// PRODUCT_PROOF_REWARD_AMOUNT explicitly to a smaller number.
+const DEFAULT_REWARD_AMOUNT = 0.1;
 const REQUIRED_ESCROW_ASSET = {
   symbol: DEFAULT_ESCROW_ASSET.symbol,
   address: DEFAULT_ESCROW_ASSET.address.toLowerCase(),

--- a/scripts/ops/run-hosted-worker-loop.test.mjs
+++ b/scripts/ops/run-hosted-worker-loop.test.mjs
@@ -63,7 +63,13 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
     env: {
       API_BASE_URL: "https://api.example.test/",
       ADMIN_JWT: "token",
-      PRODUCT_PROOF_EVIDENCE_FILE: evidenceFile
+      PRODUCT_PROOF_EVIDENCE_FILE: evidenceFile,
+      // Pin the reward to the original test value so this test's assertions
+      // (rewardAmount === 0.000001, requiredRaw === "1") remain independent
+      // of DEFAULT_REWARD_AMOUNT. The default was bumped to clear USDC's
+      // existential deposit; this test still exercises the small-reward
+      // configuration path explicitly.
+      PRODUCT_PROOF_REWARD_AMOUNT: "0.000001"
     }
   });
 
@@ -179,7 +185,9 @@ test("runHostedWorkerLoop fails closed before mutation when AgentAccountCore USD
       },
       now: () => 1700000000000,
       log: () => {},
-      env: { ADMIN_JWT: "token" }
+      // Pinning the reward keeps the assertion regex stable across changes
+      // to DEFAULT_REWARD_AMOUNT.
+      env: { ADMIN_JWT: "token", PRODUCT_PROOF_REWARD_AMOUNT: "0.000001" }
     }),
     /requires funded USDC liquidity before mutation; wallet=0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519; account=0x3333333333333333333333333333333333333333; required=0\.000001 USDC \(raw 1\); available=0 USDC \(raw 0\)/u
   );


### PR DESCRIPTION
## Summary
The hosted product-proof worker loop's default reward (`DEFAULT_REWARD_AMOUNT = 0.000001`) yielded **1 USDC base unit** at 6 decimals — well below Polkadot Hub's Assets-pallet existential deposit of **70 000 base units (0.07 USDC)** for trust-backed asset id 1337. Settlement reverted with `SafeTransfer.TransferFailed` (selector `0x90b8ec18`) when the worker's asset account had been destroyed (balance hit zero after the deposit step) and the 1-base-unit transfer couldn't recreate it.

Bumps the default to **`0.1` USDC = 100 000 base units**, comfortably above any reasonable `minBalance` for trust-backed assets on Asset Hub. Operators running with cheaper assets (DOT-decimals, where `0.000001` is `10^12` base units) can still override via `PRODUCT_PROOF_REWARD_AMOUNT`.

## Diagnosis trail
1. Hosted smoke ran on USDC for the first time after PRs #209/#213/#215/#216 lined up the asset path + deposited liquidity
2. Failed at `resolveSinglePayout: execution reverted (unknown custom error)`
3. Replayed via `eth_call` → revert selector `0x90b8ec18` → `SafeTransfer.TransferFailed()`
4. Read `Assets.Asset(1337)` storage on Paseo Asset Hub via Substrate RPC → `minBalance = 70000`
5. Math checks out: `0.000001 USDC × 10^6 decimals = 1 base unit < 70000 minBalance`

Per [Polkadot ERC20 precompile docs](https://docs.polkadot.com/smart-contracts/precompiles/erc20/), the precompile delegates to the underlying Assets pallet, which enforces `minBalance` on every transfer destination. There is no metadata function on the precompile to discover this at runtime; it must be queried via Substrate state or hard-coded.

## What this PR doesn't do
A more robust fix would preflight the reward against the asset's actual `minBalance` for **any** asset, not just rely on a hard-coded default. Filed separately as a follow-up issue.

## Test plan
- [x] `node --test scripts/ops/run-hosted-worker-loop.test.mjs` — 11/11 green (two tests had to pin `PRODUCT_PROOF_REWARD_AMOUNT` env to keep their assertions stable across this default change; behavior is identical)
- [ ] After merge + deploy, re-trigger hosted smoke with `product_proof_reward_asset=USDC` — expecting end-to-end USDC settlement to finally complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)