### PR TITLE
Add secrets management playbook (SECRETS.md + migration plan + JWT mint + calendar)

### DIFF
--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -1,0 +1,353 @@
+# Secrets — Inventory and Storage Strategy
+
+This is the canonical map of every key, password, token, and credential
+the Averray platform depends on. Read this first when:
+
+- You need to rotate a secret and want to know which surfaces it touches
+- You're onboarding a new operator and they need access
+- You're preparing for mainnet (see also
+  [`SECRETS_MIGRATION.md`](SECRETS_MIGRATION.md))
+- Something looks suspicious and you need to figure out the blast radius
+
+If you find a secret in the code or config that isn't listed here, **add
+it**. The whole point of this doc is that there's exactly one
+authoritative inventory.
+
+---
+
+## TL;DR
+
+The platform has **~70 secrets across 5 buckets**. Today they live in a
+mix of GitHub Actions, plain-text VPS env files, personal password
+managers, and hardware wallets. For mainnet we're moving most
+human-managed secrets into **1Password Business**, and the hottest
+cryptographic key (`SIGNER_PRIVATE_KEY`) into **AWS KMS** so the backend
+never holds the private bytes in memory.
+
+| Bucket | Count | Today | Target |
+|---|---|---|---|
+| GitHub Actions | 9 | repo settings → secrets | synced from 1Password via `op` CLI |
+| VPS backend env (`/srv/agent-stack/backend.env`) | ~40 | plain-text on disk | rendered at deploy from 1Password via `op inject` |
+| VPS indexer env (`/srv/agent-stack/indexer.env`) | 3 | plain-text on disk | same as backend |
+| Local-machine / human passwords (deployer key, signer seeds, SSH passphrases) | ~7 | personal password manager + Ledger | 1Password Business shared vault (where applicable) + hardware wallet (signers) |
+| External service tokens (Pimlico, Sentry, GitHub PAT, Subscan, alert webhook, RPC provider) | ~8 | mixed (vendor portals + VPS env) | 1Password Business shared vault |
+| **Cryptographic signing key** (`SIGNER_PRIVATE_KEY`) | 1 | plain-text in VPS env | **AWS KMS asymmetric secp256k1 key** (private bytes never exported) |
+
+The 4 highest-risk items, ordered by blast radius:
+
+1. **`SIGNER_PRIVATE_KEY`** — backend signs all on-chain verifications
+   with this. Compromise = forged claims. Migration to AWS KMS is the
+   single biggest pre-mainnet hardening step.
+2. **`VPS_SSH_KEY`** (GitHub Actions secret) — full deploy pipeline
+   access. Compromise = production code overwrite.
+3. **`AUTH_JWT_SECRETS`** — HMAC for SIWE session tokens. Compromise =
+   forge admin JWTs.
+4. **Multisig signer seeds** (Hot/Warm/Cold) — owner ops on
+   TreasuryPolicy. Loss = lose ability to change platform parameters.
+
+---
+
+## Storage strategy
+
+Each secret class has a target home. The rule of thumb is: **one
+canonical source, synced to runtime by automation, never copy-pasted**.
+
+| Secret class | Where it lives | How runtime gets it |
+|---|---|---|
+| App secrets (JWT secret, RPC URLs, Pimlico, Sentry, GH PAT, Subscan, webhooks) | 1Password Business → `Averray/Production/Backend` vault | `op inject` renders the env at deploy time; `op://` URI references in templates, no plain-text on disk |
+| GitHub Actions secrets (`VPS_SSH_KEY`, `ADMIN_JWT`, `APP_BASIC_AUTH_*`) | 1Password Business → `Averray/Production/CI` vault | Synced via `1password/load-secrets-action@v1` per workflow job |
+| Indexer env (DB password, RPC URL) | 1Password Business → `Averray/Production/Indexer` vault | Same pattern as backend |
+| Backend signer key | **AWS KMS** secp256k1 key, region pinned, IAM-controlled | ethers.js `AwsKmsSigner` adapter — backend never sees the private key |
+| Operator passwords (basic auth, personal vault items) | 1Password Business → `Averray/Operators` per-user vault | Manual; only used by humans through the 1Password UI |
+| Multisig signer seeds | Three independent humans/devices (existing pattern, see [`MULTISIG_SETUP.md`](MULTISIG_SETUP.md)) | Hardware wallets + sealed-envelope offline backups |
+| Burnable deployer key (one-time per deploy) | Generated fresh; transferred away from the deployer EOA via `transferOwnership()` to the multisig at the end of `deploy_contracts.sh` | Never persisted long-term |
+
+The one rule that prevents most incidents: **never store a long-lived
+secret in shell history, a `.env` committed to the repo, or a Slack
+DM**. Use the vault, even for ten-second tasks.
+
+---
+
+## Inventory by bucket
+
+### A. GitHub Actions secrets
+
+These secrets are referenced as `${{ secrets.NAME }}` from
+`.github/workflows/*.yml`. Today they're set via the GitHub UI; after
+migration they'll be synced from 1Password.
+
+| Name | What | Where used | Owner | Rotation | Blast radius |
+|---|---|---|---|---|---|
+| `VPS_HOST` | Hostname/IP | `deploy-production.yml` SSH target | Deployer | On infra change | Production VPS reachability |
+| `VPS_PORT` | SSH port | Same | Deployer | Rare | Same |
+| `VPS_USER` | SSH user | Same | Deployer | On account change | Same |
+| `VPS_SSH_KEY` | ED25519 private key | Written to `~/.ssh/id_ed25519` in deploy job | Deployer | **On suspicion of compromise** | Full deploy pipeline access |
+| `APP_BASIC_AUTH_USER` | Username | Caddy basic auth on `app.averray.com` | Operator | On policy change | Operator UI access |
+| `APP_BASIC_AUTH_PASSWORD` | Plain password | Same | Operator | Periodic | Same |
+| `APP_BASIC_AUTH_PASSWORD_HASH` | bcrypt/htpasswd hash | Same (preferred over plain) | Operator | Periodic | Same |
+| `ADMIN_JWT` | Long-lived JWT | Hosted product-proof smoke + ops scripts | Deployer | On expiry (was 30d, expired today) | Backend admin role |
+| `RESEND_API_KEY` | Email API key | Bootstrap self-report / alert emails | Deployer | On vendor rotation | Alert email delivery |
+
+### B. VPS backend env (`/srv/agent-stack/backend.env`)
+
+Loaded by `mcp-server/src/services/bootstrap.js`. Today rendered by
+`scripts/ops/render-caddyfile.sh` + ssh; target is a single
+`op inject -i template.env -o backend.env` step.
+
+**Auth surface** (mcp-server/src/auth/config.js):
+| Name | What | Notes |
+|---|---|---|
+| `AUTH_JWT_SECRETS` | Comma-separated HS256 secrets, newest first | Rotation pattern: prepend new, redeploy, drop old |
+| `AUTH_JWT_SECRET` | Legacy single-secret fallback | Prefer the plural form |
+| `AUTH_DOMAIN` | Domain string for SIWE validation | E.g., `api.averray.com` |
+| `AUTH_CHAIN_ID` | EVM chain ID | 420420417 testnet |
+| `AUTH_ADMIN_WALLETS` | Comma-separated 0x addresses | Role claims at login |
+| `AUTH_VERIFIER_WALLETS` | Comma-separated 0x addresses | Same |
+| `AUTH_MODE` | `strict` \| `permissive` | `strict` in prod |
+
+**Blockchain surface** (mcp-server/src/blockchain/config.js):
+| Name | What | Notes |
+|---|---|---|
+| **`SIGNER_PRIVATE_KEY`** | EVM private key for backend-signed transactions | **Migrating to AWS KMS** (Phase 3) |
+| `TREASURY_POLICY_ADDRESS` | Public contract address | Public, but env-pinned |
+| `AGENT_ACCOUNT_ADDRESS` | Public contract address | Public |
+| `ESCROW_CORE_ADDRESS` | Public contract address | Public |
+| `REPUTATION_SBT_ADDRESS` | Public contract address | Public |
+| `VERIFIER_REGISTRY_ADDRESS` | Public contract address | Public |
+| `RPC_URL` / `POLKADOT_RPC_URL` / `DWELLER_RPC_URL` | Substrate/EVM RPC endpoint | Fallback chain |
+
+**External services**:
+| Name | What | Notes |
+|---|---|---|
+| `REDIS_URL` | Connection string `redis://user:password@host:port/db` | Holds session/nonce state |
+| `REDIS_NAMESPACE` | Key prefix | Default `agent-platform` |
+| `PIMLICO_BUNDLER_URL` | Pimlico ERC-4337 bundler | Vendor-managed |
+| `PIMLICO_PAYMASTER_URL` | Pimlico paymaster | Vendor-managed |
+| `PIMLICO_ENTRY_POINT` | ERC-4337 EntryPoint contract | Public |
+| `PIMLICO_SPONSORSHIP_POLICY_ID` | Pimlico policy UUID | Vendor-managed |
+| `PIMLICO_CHAIN_ID` | Chain ID number | Public |
+| `SENTRY_DSN` | Sentry project URL | Vendor-managed |
+| `SENTRY_ENVIRONMENT` | `production` / `testnet` | Public-ish |
+| `SENTRY_RELEASE` | Git SHA / tag | Public |
+| `SENTRY_TRACES_SAMPLE_RATE` | Float 0-1 | Config |
+| `XCM_OBSERVER_FEED_URL` | XCM event feed endpoint | Vendor-managed |
+| `XCM_OBSERVER_AUTH_TOKEN` | Bearer token for the feed | Vendor-managed |
+| `XCM_OBSERVER_ENABLED` | Boolean toggle | Config |
+| `XCM_SUBSCAN_API_HOST` | Subscan REST host | Vendor-managed |
+| `XCM_SUBSCAN_API_KEY` | Subscan API key | Vendor-managed |
+| `GITHUB_TOKEN` | GitHub PAT for issue ingestion | Vendor-managed; expires per GitHub policy |
+| `GITHUB_ISSUE_QUERY` | Search query string | Config |
+
+**Operations**:
+| Name | What | Notes |
+|---|---|---|
+| `LOG_LEVEL` | Verbosity | Config |
+| `PORT` | Backend listen port | Config (default 8787) |
+| `NODE_ENV` | `production` | Config |
+| `TRUST_PROXY` | Boolean for Caddy reverse proxy | Config |
+| `CORS_ALLOWED_ORIGINS` | Comma-separated origins | Config |
+| `METRICS_BEARER_TOKEN` | Bearer for `/metrics` endpoint | Rotated with redeploy |
+| `PUBLIC_BASE_URL` | Public-facing URL | Config |
+| `ALERT_WEBHOOK_URL` | Slack/Discord/PagerDuty webhook | Vendor-managed |
+| `ALERT_SERVICE_NAME` | Label for alerts | Config |
+| `ALERT_ENVIRONMENT` | Label for alerts | Config |
+| `DISCOVERY_REGISTRY_ADDRESS` | Public contract address (optional) | Public |
+| `DISCLOSURE_LOG_ADDRESS` | Public contract address (optional) | Public |
+| `XCM_WRAPPER_ADDRESS` | Public contract address (optional) | Public |
+
+### C. VPS indexer env (`/srv/agent-stack/indexer.env`)
+
+| Name | What | Notes |
+|---|---|---|
+| `DATABASE_URL` | `postgres://user:password@host/db` | Indexer state store |
+| `DATABASE_SCHEMA` | Postgres schema name | Default `ponder` |
+| `PONDER_RPC_URL_<chainId>` | Per-chain RPC URL | Falls back to `DWELLER_RPC_URL` |
+
+### D. Local-machine / human-managed
+
+Today: deployer's personal password manager + Ledger + (in some cases)
+shell history. Target: same vault structure as the platform (1Password
+Business shared `Averray/Operators/<role>` vaults), except for the three
+hardware-wallet seeds which stay on hardware by design.
+
+| Role | Secret | Where it lives today | Where it should live |
+|---|---|---|---|
+| Deployer | One-shot `PRIVATE_KEY` for `deploy_contracts.sh` | Local env / `.env` | 1Password vault item; rotated per deploy |
+| Deployer | `OWNER_KEY` for `rotate_pauser.sh` | Local env | 1Password vault; mainnet path uses multisig instead of EOA |
+| Operator | `APP_BASIC_AUTH_PASSWORD` | Local password manager | 1Password vault item, rendered by `op inject` |
+| Operator | SSH key passphrase | gpg-agent / SSH agent | Same |
+| Multisig signer A (hot) | Polkadot.js extension seed | Browser extension + offline backup | Same — **do not move to 1Password** |
+| Multisig signer B (warm) | Nova Wallet / SubWallet seed | Mobile wallet + paper backup | Same — **do not move to 1Password** |
+| Multisig signer C (cold) | Ledger recovery seed | Cryptosteel / sealed envelope | Same — **do not move to 1Password** |
+
+Rule: **multisig signer seeds never go into a centralized vault**. The
+whole point of multisig is independent compromise paths; co-locating the
+seeds defeats it.
+
+### E. On-chain identities
+
+Public addresses; the secrets are the *private keys behind them*, which
+live in D.
+
+| Role | Address (testnet) | Key location | Notes |
+|---|---|---|---|
+| Deployer | `0xFd2EAE…6519` | Local one-shot env | Only used during `deploy_contracts.sh`; transferred to multisig at end |
+| Owner (mainnet) | TBD multisig | Three signer set in D | 2-of-3 threshold per `MULTISIG_SETUP.md` |
+| Owner (testnet) | `0x1f8C…b6F9` | Same multisig signer set | |
+| Pauser | `0xFd2EAE…6519` | Local env / hot key | EOA today; can be rotated via `rotate_pauser.sh` |
+| Verifier | `0xFd2EAE…6519` | `SIGNER_PRIVATE_KEY` (current) → AWS KMS (target) | The hottest key |
+| Arbitrator | `0xFd2EAE…6519` | `SIGNER_PRIVATE_KEY` (current) → AWS KMS (target) | Same key as verifier today; consider splitting |
+
+### F. External service tokens (vendor portals)
+
+These are the entries you'll find in 1Password's `Averray/Production/External`
+vault. Each has a vendor-side rotation path.
+
+| Service | What | Vendor portal | Rotation |
+|---|---|---|---|
+| Pimlico | Bundler + paymaster URLs, sponsorship policy ID | dashboard.pimlico.io | On policy change |
+| Sentry | Project DSN | sentry.io | Rare (per project lifetime) |
+| GitHub | Personal access token | github.com/settings/tokens | Per token's `expires_at` (typically 90d) |
+| Subscan | API key | subscan.io | Per their cycle |
+| Resend | API key | resend.com | Periodic |
+| Webhook (alerts) | Slack/Discord/PagerDuty URL | Their respective dashboards | Rare |
+| Dweller / Polkadot RPC | URL (and any auth token) | Provider portal | Rare |
+
+---
+
+## Per-secret runbook (when something breaks)
+
+For each secret class, the canonical mint/rotate/revoke flow.
+
+### `AUTH_JWT_SECRETS` (HMAC for SIWE sessions)
+
+**Mint a new entry**:
+```bash
+openssl rand -hex 32     # 64-char hex string, ≥32 bytes
+```
+Add to 1Password as a new field; do **not** delete the old one yet.
+
+**Rotate**:
+1. Update the 1Password entry: prepend the new secret, keep the old one.
+2. Trigger a redeploy. Backend now signs with new, accepts both.
+3. After 24-48h grace period (allows in-flight tokens to expire),
+   delete the old secret from the 1Password entry.
+4. Trigger a second redeploy. Old tokens now reject.
+
+**Revoke an issued token**:
+- The auth middleware checks `stateStore.isTokenRevoked(jti)`.
+- For one-off revocation: `redis-cli SET revoked:<jti> 1 EX <ttl>`.
+- For a full rotation, use the rotation flow above.
+
+### `ADMIN_JWT` (long-lived JWT for ops scripts)
+
+**Mint with the script**:
+```bash
+AUTH_JWT_SECRETS=$(op read "op://Averray/Production/Backend/AUTH_JWT_SECRETS") \
+  node scripts/ops/mint-admin-jwt.mjs --profile testnet --expires-in-days 30 --quiet \
+  | gh secret set ADMIN_JWT
+```
+
+**Rotate**: Mint a new one with the script before the old expires.
+Add a [`SECRETS_CALENDAR.yml`](SECRETS_CALENDAR.yml) entry so CI warns
+you ~7 days out.
+
+### `SIGNER_PRIVATE_KEY` (backend signer)
+
+**Today** (testnet): plain hex in VPS env. Rotation requires generating
+a new keypair, redeploying contracts (because the verifier address is
+baked into TreasuryPolicy), and updating env. Heavy.
+
+**Target** (after Phase 3 of [`SECRETS_MIGRATION.md`](SECRETS_MIGRATION.md)):
+AWS KMS-managed secp256k1 key. Rotation path:
+1. Create a new KMS key.
+2. Import the new public key as the new verifier on TreasuryPolicy via
+   the multisig (`setVerifier(new, true)`).
+3. Update `KMS_KEY_ID` in the backend env via 1Password; redeploy.
+4. After grace period: `setVerifier(old, false)` and `kms.scheduleKeyDeletion(old)`.
+
+### `VPS_SSH_KEY`
+
+**Mint**: `ssh-keygen -t ed25519 -f ~/.ssh/averray_deploy_<date> -C "averray-deploy-<date>"`.
+Add the **public** key to the VPS's `~/.ssh/authorized_keys`. Update
+the **private** key in the 1Password `Averray/Production/CI` vault so
+GitHub Actions can sync it.
+
+**Rotate**: standard "two keys side-by-side, remove old" pattern. Add
+the new pubkey to authorized_keys, swap the GitHub secret, deploy
+once, remove old pubkey.
+
+**Revoke**: remove from `authorized_keys` and from GitHub secrets.
+
+### Multisig signer seeds
+
+See [`MULTISIG_SETUP.md`](MULTISIG_SETUP.md) and
+[`SIGNER_POLICY.md`](SIGNER_POLICY.md). Seed loss is irrecoverable
+without the other seeds; threshold is 2-of-3 so one loss is survivable.
+Rotation = generate a new seed in a fresh wallet, replace the old signer
+on-chain via a multisig transaction signed by the remaining N-1.
+
+### External vendor tokens (Pimlico, Sentry, etc.)
+
+Each has a vendor-specific UI. The generic flow:
+1. Generate the new token in the vendor portal.
+2. Update the 1Password entry.
+3. Trigger a redeploy.
+4. Revoke the old token in the vendor portal.
+
+The [`SECRETS_CALENDAR.yml`](SECRETS_CALENDAR.yml) file tracks expiry
+dates so CI can warn you N days before each rotation is due.
+
+---
+
+## Mainnet hardening checklist
+
+When you're ready to launch on mainnet, **every secret in the inventory
+above** gets rotated. Use this as the cutover checklist:
+
+- [ ] Generate fresh `AUTH_JWT_SECRETS` (≥32 chars, never derive from testnet)
+- [ ] Generate fresh `SIGNER_PRIVATE_KEY` — **and put it directly in AWS KMS, never on disk**
+- [ ] Generate fresh `VPS_SSH_KEY`
+- [ ] Generate fresh deployer EOA key for the one-shot `deploy_contracts.sh`
+- [ ] Set up new multisig signer seeds (separate seeds from testnet — do **not** reuse)
+- [ ] Mint mainnet-only API keys for Pimlico, Sentry, Subscan, RPC provider
+- [ ] Generate fresh `APP_BASIC_AUTH_PASSWORD` (assuming you keep basic-auth gating)
+- [ ] Generate fresh `METRICS_BEARER_TOKEN`
+- [ ] Generate fresh `RESEND_API_KEY`
+- [ ] Verify zero secrets are shared between testnet and mainnet vaults
+- [ ] Deploy contracts with the multisig as the owner from line 1 (don't use the EOA-then-transfer flow)
+- [ ] After deploy, archive (don't delete) the testnet 1Password vault for forensics
+
+The full migration plan with phased steps, rollback notes, and
+per-phase checks lives in
+[`SECRETS_MIGRATION.md`](SECRETS_MIGRATION.md).
+
+---
+
+## Tooling
+
+| Script | Does | When to use |
+|---|---|---|
+| `scripts/ops/mint-admin-jwt.mjs` | Offline mint of admin JWTs | Rotating `ADMIN_JWT` GitHub secret |
+| `scripts/ops/check-secrets-calendar.mjs` | Reads `SECRETS_CALENDAR.yml`, fails CI if any token expires within 7 days | Run on every CI build to catch drift before tokens die in production |
+| `scripts/ops/audit-launch-readiness.mjs` | Reads on-chain TreasuryPolicy state | Pre-mainnet check; complements but doesn't overlap with this doc |
+| `scripts/ops/fund-signer-usdc-deposit.mjs` | Approve + deposit USDC into AgentAccountCore | Funding flow only; see [`TESTNET_FUND_SIGNER.md`](TESTNET_FUND_SIGNER.md) |
+| `scripts/rotate_pauser.sh` | Rotate pauser hot key | Periodic rotation drill |
+
+---
+
+## Related docs
+
+- [`SECRETS_MIGRATION.md`](SECRETS_MIGRATION.md) — phase-by-phase
+  migration to 1Password Business + AWS KMS
+- [`SECRETS_CALENDAR.yml`](SECRETS_CALENDAR.yml) — declarative source of
+  truth for token expiry tracking
+- [`MULTISIG_SETUP.md`](MULTISIG_SETUP.md) — multisig provisioning and
+  signer separation rules
+- [`SIGNER_POLICY.md`](SIGNER_POLICY.md) — signer roles and key-handling
+  policy
+- [`INCIDENT_RESPONSE.md`](INCIDENT_RESPONSE.md) — what to do when a
+  secret is suspected compromised
+- [`TESTNET_FUND_SIGNER.md`](TESTNET_FUND_SIGNER.md) — how to fund the
+  backend signer with USDC for hosted smoke (separate from secret
+  management proper)

--- a/docs/SECRETS_CALENDAR.yml
+++ b/docs/SECRETS_CALENDAR.yml
@@ -1,0 +1,142 @@
+# Secrets Calendar — declarative source of truth for token expiry tracking
+#
+# Read by `scripts/ops/check-secrets-calendar.mjs`, which warns when
+# any tracked token's `expires_at` is within 7 days of now and fails
+# CI when an entry is past expiry.
+#
+# Each entry should describe a secret whose lifetime is bounded by an
+# external system (vendor token expiry, GitHub PAT scope, etc.) and
+# therefore needs proactive rotation. Long-lived secrets without a
+# vendor expiry don't need entries here — they're tracked by
+# rotation-on-incident, not by calendar.
+#
+# Field reference
+# ---------------
+#   name          (required)  Stable identifier; matches the 1Password
+#                             item name when possible.
+#   description   (required)  One-liner: what the token unlocks.
+#   owner         (required)  Who's responsible for rotating it.
+#   vault_path    (optional)  op:// reference to the 1Password item.
+#   expires_at    (required)  ISO date when the token expires.
+#                             ISO format: YYYY-MM-DD.
+#   warn_days     (optional)  Override the global 7-day warning window.
+#   notes         (optional)  Anything else worth knowing at rotation
+#                             time.
+
+entries:
+
+  # ── GitHub Actions secrets ─────────────────────────────────────────
+
+  - name: ADMIN_JWT
+    description: Long-lived admin JWT used by hosted product-proof smoke and ops scripts.
+    owner: deployer
+    vault_path: op://Averray/Production/CI/admin-jwt
+    expires_at: "2026-06-09"   # 30 days after the mint on 2026-05-10
+    warn_days: 7
+    notes: |
+      Mint a fresh one with:
+        AUTH_JWT_SECRETS=$(op read 'op://Averray/Production/Backend/auth-jwt-secrets/credential') \
+          node scripts/ops/mint-admin-jwt.mjs --profile testnet --expires-in-days 30 --quiet \
+          | gh secret set ADMIN_JWT
+      Update this entry's expires_at after rotation.
+
+  # ── External service tokens (placeholder values — fill in real
+  #    expiry dates after migration to 1Password) ─────────────────────
+
+  - name: github-pat-issue-ingestion
+    description: GitHub Personal Access Token used by the GitHub issue ingestor.
+    owner: deployer
+    vault_path: op://Averray/Production/External/github-pat
+    expires_at: "TBD"   # Set after rotation; GitHub PATs typically default to 90d
+    warn_days: 7
+    notes: |
+      Rotate at https://github.com/settings/tokens.
+      Required scopes: `repo`, `read:org`, `workflow`.
+
+  - name: pimlico-api-key
+    description: Pimlico bundler / paymaster credentials for ERC-4337 sponsorship.
+    owner: deployer
+    vault_path: op://Averray/Production/External/pimlico
+    expires_at: "TBD"   # Pimlico keys don't auto-expire; treat as 90d rotation policy
+    warn_days: 14
+    notes: |
+      Rotate at https://dashboard.pimlico.io/. Update both bundler and
+      paymaster URLs together — they share the same API key.
+
+  - name: subscan-api-key
+    description: Subscan API key for XCM observation.
+    owner: deployer
+    vault_path: op://Averray/Production/External/subscan
+    expires_at: "TBD"   # Subscan: vendor cycle, treat as 90d rotation
+    warn_days: 14
+    notes: |
+      Rotate at https://subscan.io/api. The staging-tier key has a
+      lower rate limit; the production tier requires email request.
+
+  - name: resend-api-key
+    description: Resend.com API key for bootstrap self-report and alert emails.
+    owner: operator
+    vault_path: op://Averray/Production/External/resend
+    expires_at: "TBD"
+    warn_days: 14
+    notes: |
+      Rotate at https://resend.com/api-keys. Token name: `averray-prod`.
+
+  - name: sentry-dsn
+    description: Sentry project DSN for error telemetry.
+    owner: deployer
+    vault_path: op://Averray/Production/External/sentry-dsn
+    expires_at: "never"   # Sentry DSNs are project-lifetime; flag if rotated
+    notes: |
+      Sentry DSNs don't have an expiry; this entry exists so the
+      check script confirms it's still in the inventory. Rotate via
+      project settings if compromise is suspected.
+
+  # ── 1Password service account token ────────────────────────────────
+
+  - name: op-service-account-runtime
+    description: 1Password service account token used by the VPS and CI to fetch secrets.
+    owner: deployer
+    vault_path: op://Personal/1password-runtime-token-production
+    expires_at: "2026-08-08"   # 90d max, set this when token is provisioned in Phase 1
+    warn_days: 14
+    notes: |
+      Rotate in 1Password admin: Integrations → Service Accounts → Rotate.
+      After rotating, update the VPS env (/etc/agent-stack/op.env) and
+      the OP_SERVICE_ACCOUNT_TOKEN GitHub Actions secret.
+
+  # ── AWS IAM keys ──────────────────────────────────────────────────
+
+  - name: aws-kms-signer-iam-keys
+    description: AWS access key + secret for the IAM user that calls KMS.Sign.
+    owner: deployer
+    vault_path: op://Averray/Production/Backend/aws-kms-signer
+    expires_at: "TBD"   # Set after Phase 3; IAM keys don't auto-expire but rotate every 90d
+    warn_days: 14
+    notes: |
+      Rotate at AWS Console → IAM → Users → averray-signer-prod →
+      Security credentials. Mint new key, update 1Password, redeploy
+      backend, then deactivate (don't delete) the old key for 24h
+      grace period.
+
+  # ── VPS SSH key ───────────────────────────────────────────────────
+
+  - name: vps-ssh-key
+    description: ED25519 private key used by GitHub Actions to SSH into the VPS.
+    owner: deployer
+    vault_path: op://Averray/Production/CI/vps-ssh-key
+    expires_at: "TBD"   # Manually rotate every 6 months
+    warn_days: 30
+    notes: |
+      Mint with `ssh-keygen -t ed25519 -f ~/.ssh/averray_deploy_<date>`.
+      Add the public key to /root/.ssh/authorized_keys on the VPS,
+      update 1Password with the private key, redeploy once, then
+      remove the old public key from authorized_keys after 24h.
+
+# Global config
+config:
+  default_warn_days: 7
+  fail_within_days: 1
+  # Entries with expires_at: "never" are tracked but never warn;
+  # entries with expires_at: "TBD" are treated as past-due and
+  # warned aggressively until set.

--- a/docs/SECRETS_MIGRATION.md
+++ b/docs/SECRETS_MIGRATION.md
@@ -1,0 +1,506 @@
+# Secrets Migration — From "Starter Tier" to Pre-Mainnet Hardened
+
+This doc is the operator's checklist for moving from where we are today
+(plain-text env files + GitHub Actions secrets + ad-hoc password
+managers) to where we need to be for mainnet (centralized vault for
+human-managed secrets + AWS KMS for the hottest cryptographic key).
+
+Read [`SECRETS.md`](SECRETS.md) first for the inventory. This doc
+assumes you're convinced *what* needs to move and just need the *how*.
+
+The migration breaks into **5 phases** that can land independently. Each
+phase is mergeable on its own and reversible if something breaks. You
+can pause between any of them.
+
+| Phase | What | Time | Reversible? |
+|---|---|---|---|
+| 1 | 1Password Business setup + secret inventory loaded into vault | ~1 day | Yes — old env files still authoritative |
+| 2 | Sync vault → runtime (CI + VPS) | ~1 day | Yes — fall back to GitHub UI / direct env edit |
+| 3 | AWS KMS for the backend signer | ~2 days | Yes — keep `SIGNER_PRIVATE_KEY` env path until cutover |
+| 4 | Hardening (CI secret scanning, short-lived JWTs, expiry alarms) | ~1 day | Yes — purely additive |
+| 5 | Mainnet cutover | ~1 day | No — new addresses are fresh; testnet stays as testnet |
+
+---
+
+## Phase 1 — 1Password Business setup
+
+### 1a. Sign up
+
+- Plan: **1Password Business** ($7.99/user/mo). Cheaper than Teams
+  Starter for ≤2 users (where you are today), and gives you Watchtower
+  + finer-grained vault sharing for the same money.
+- Use a dedicated email for the team account (e.g. `secrets@averray.com`),
+  not your personal one. This makes future ownership transfers
+  painless.
+
+### 1b. Create the vault structure
+
+Build these vaults in 1Password. Each is a separate access boundary.
+
+```
+Averray/
+├── Production/
+│   ├── Backend           # AUTH_JWT_SECRETS, RPC URLs, external API keys
+│   ├── Indexer           # DATABASE_URL, PONDER_RPC_URL_*
+│   ├── CI                # VPS_SSH_KEY, ADMIN_JWT, APP_BASIC_AUTH_*
+│   └── External          # Pimlico, Sentry, Subscan, GitHub PAT, Resend, RPC provider
+├── Testnet/              # Mirrors Production/ but for testnet keys
+│   ├── Backend
+│   ├── Indexer
+│   ├── CI
+│   └── External
+├── Multisig/             # Signer reference info ONLY — never the seeds themselves
+│   └── Signer addresses, public keys, SS58 forms
+├── Operators/            # Per-operator personal vaults (auto-created by 1Password)
+│   ├── Pascal
+│   └── …
+└── Archive/              # Decommissioned secrets, kept for audit
+```
+
+Why split testnet and production: re-using testnet secrets on mainnet
+is the most common pre-launch mistake. Separate vaults make accidental
+cross-contamination structurally impossible.
+
+### 1c. Migrate secrets
+
+For **every entry** in the inventory in [`SECRETS.md`](SECRETS.md),
+create a corresponding 1Password item. Use the **API Credential** item
+type — it has fields for the credential value, expiration, and notes.
+
+Suggested naming: `<service>-<purpose>-<env>`, e.g.:
+- `pimlico-bundler-url-production`
+- `auth-jwt-secrets-production`
+- `signer-private-key-testnet` (will be deleted after Phase 3)
+
+Required fields per item:
+- The secret value
+- Description: 1–2 sentences on what it unlocks
+- Expiration date (where applicable; use the [`SECRETS_CALENDAR.yml`](SECRETS_CALENDAR.yml) cadence)
+- Tags: `production` / `testnet` / `ci` / `runtime`
+- Notes: link back to the inventory section in `SECRETS.md`
+
+### 1d. Provision a service account for runtime sync
+
+This is the read-only credential that GitHub Actions and the VPS use to
+fetch secrets without a human signing in.
+
+1. In 1Password admin: **Integrations → Service Accounts → New**
+2. Name: `averray-runtime-readonly`
+3. Vault access: **read-only** to `Averray/Production/*` and
+   `Averray/Testnet/*` (NOT to Multisig or Operators)
+4. Save the service account token in your personal 1Password vault as
+   `1password-runtime-token-production` — this is itself a secret
+5. Set up a calendar reminder to rotate this token every 90 days
+   (1Password's max for service accounts)
+
+### Phase 1 done = exit criteria
+
+- [ ] All ~70 secrets from the inventory are in 1Password
+- [ ] Each item has its description and tags
+- [ ] Service account token is provisioned and stored
+- [ ] Migration is **purely additive** — old env files still
+  authoritative; no plumbing changes yet
+- [ ] You can find any secret in <30 seconds via 1Password search
+
+### Rollback
+
+Trivial: nothing depends on 1Password yet. Delete the vault and walk
+away if the team decides to use a different tool.
+
+---
+
+## Phase 2 — Sync vault → runtime
+
+This is where the actual win lives. After this phase, rotating a secret
+= update one entry in 1Password, redeploy. No more "did I update GitHub
+Actions AND the VPS env file?".
+
+### 2a. Install `op` CLI on the VPS
+
+```bash
+# on the VPS, as root or via sudo
+curl -sS https://downloads.1password.com/linux/keys/1password.asc \
+  | gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg
+echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/amd64 stable main' \
+  | tee /etc/apt/sources.list.d/1password.list
+mkdir -p /etc/debsig/policies/AC2D62742012EA22 /usr/share/debsig/keyrings/AC2D62742012EA22
+curl -sS https://downloads.1password.com/linux/debian/debsig/1password.pol \
+  | tee /etc/debsig/policies/AC2D62742012EA22/1password.pol
+curl -sS https://downloads.1password.com/linux/keys/1password.asc \
+  | gpg --dearmor --output /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg
+apt update && apt install -y 1password-cli
+```
+
+Verify: `op --version`.
+
+### 2b. Set the service account token
+
+```bash
+# on the VPS
+echo 'export OP_SERVICE_ACCOUNT_TOKEN="ops_..."' >> /etc/agent-stack/op.env
+chmod 600 /etc/agent-stack/op.env
+```
+
+The `op` CLI auto-detects this env var and uses it for all subsequent
+commands.
+
+### 2c. Convert `backend.env` to a template
+
+Replace plain-text values with `op://` URI references. Save the result
+as `/srv/agent-stack/backend.env.template`.
+
+```diff
+# /srv/agent-stack/backend.env (BEFORE — plain text)
+- AUTH_JWT_SECRETS=abc123def456...
+- SIGNER_PRIVATE_KEY=0x...
+- PIMLICO_BUNDLER_URL=https://api.pimlico.io/...
+
+# /srv/agent-stack/backend.env.template (AFTER)
++ AUTH_JWT_SECRETS=op://Averray/Production/Backend/auth-jwt-secrets/credential
++ SIGNER_PRIVATE_KEY=op://Averray/Production/Backend/signer-private-key/credential
++ PIMLICO_BUNDLER_URL=op://Averray/Production/External/pimlico-bundler-url/credential
+```
+
+### 2d. Render at deploy time
+
+Add to `scripts/ops/deploy-production.sh`, before the docker compose
+restart step:
+
+```bash
+# Source the OP service account token
+source /etc/agent-stack/op.env
+
+# Render env files
+op inject -i /srv/agent-stack/backend.env.template -o /srv/agent-stack/backend.env
+op inject -i /srv/agent-stack/indexer.env.template -o /srv/agent-stack/indexer.env
+chmod 600 /srv/agent-stack/backend.env /srv/agent-stack/indexer.env
+
+# (existing: docker compose pull && up)
+```
+
+After deploy, the rendered `backend.env` looks identical to today.
+Difference: it's regenerated from 1Password every deploy. If you change
+a secret in 1Password and redeploy, the new value lands automatically.
+
+### 2e. Convert GitHub Actions secrets
+
+Use the official 1Password Action:
+
+```yaml
+# .github/workflows/deploy-production.yml
+- uses: 1password/load-secrets-action@v1
+  env:
+    OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+    VPS_SSH_KEY: op://Averray/Production/CI/vps-ssh-key/credential
+    ADMIN_JWT:    op://Averray/Production/CI/admin-jwt/credential
+    APP_BASIC_AUTH_PASSWORD_HASH: op://Averray/Production/CI/app-basic-auth-password-hash/credential
+    RESEND_API_KEY:                op://Averray/Production/CI/resend-api-key/credential
+```
+
+Now the GitHub Actions secret store contains exactly **one** entry:
+`OP_SERVICE_ACCOUNT_TOKEN`. Everything else flows from 1Password.
+
+### 2f. Cutover
+
+1. **Don't delete the old plain-text values yet.** Run a deploy with
+   both paths active in parallel for 24h to confirm the rendered files
+   match what was there before.
+2. Verify with `diff` (compare against an offline backup of the old
+   `backend.env`).
+3. After 24h of clean deploys, delete the legacy GitHub Actions
+   secrets and the plain-text `backend.env` backups. Lock down VPS
+   access so only `op inject` writes the env file.
+
+### Phase 2 done = exit criteria
+
+- [ ] `op` CLI installed on VPS, service account token configured
+- [ ] `backend.env.template` and `indexer.env.template` exist with
+  `op://` references for every secret
+- [ ] Deploy script renders env from template
+- [ ] GitHub Actions workflows reference only `OP_SERVICE_ACCOUNT_TOKEN`
+  + the 1Password load-secrets action
+- [ ] Old plain-text secrets are removed from GitHub Actions / VPS
+- [ ] Test rotation: change one secret in 1Password → redeploy → new
+  value reaches runtime
+
+### Rollback
+
+Per-secret: copy the value out of 1Password into the old plain-text
+location (GitHub Actions secret or VPS env). Per-phase: revert the
+deploy script PR and the workflow changes.
+
+---
+
+## Phase 3 — AWS KMS for the backend signer
+
+This is the big security win. After this phase, no human, no env file,
+no log line, and no backup ever contains the private key for the
+backend signer. Compromise of the VPS or 1Password vault no longer
+implies compromise of the signer.
+
+### 3a. AWS account + IAM policy
+
+1. Create an AWS account (use root only to set up billing + IAM, then
+   never touch root again)
+2. Create an IAM user `averray-signer-prod` with **only** these
+   permissions:
+   - `kms:Sign` on the specific key ARN
+   - `kms:GetPublicKey` on the same
+3. Generate access key + secret for that IAM user
+4. Store the access key + secret as 1Password items
+   `aws-kms-signer-access-key-id` and `aws-kms-signer-secret-access-key`
+   in `Averray/Production/Backend`
+
+### 3b. Create the KMS key
+
+Via AWS Console (Key Management Service) or CLI:
+
+```bash
+aws kms create-key \
+  --description "Averray production backend signer (secp256k1)" \
+  --key-usage SIGN_VERIFY \
+  --customer-master-key-spec ECC_SECG_P256K1 \
+  --region eu-central-1
+```
+
+Save the returned `KeyId` UUID. The key spec `ECC_SECG_P256K1` is the
+Ethereum curve.
+
+### 3c. Derive the EVM address
+
+The EVM address is the keccak256 of the public key, last 20 bytes:
+
+```js
+import { KMSClient, GetPublicKeyCommand } from "@aws-sdk/client-kms";
+import { keccak256 } from "ethers";
+import { secp256k1 } from "@noble/curves/secp256k1";
+
+const kms = new KMSClient({ region: "eu-central-1" });
+const { PublicKey } = await kms.send(new GetPublicKeyCommand({ KeyId: "<uuid>" }));
+// PublicKey is DER-encoded; extract the 64-byte uncompressed point
+const point = PublicKey.subarray(PublicKey.length - 64);
+const address = "0x" + keccak256(point).slice(-40);
+console.log("EVM address:", address);
+```
+
+This becomes the new on-chain verifier address.
+
+### 3d. Wire the backend
+
+Add `KMS_KEY_ID` and `AWS_REGION` env vars to `backend.env.template` (they
+flow through 1Password). Update `mcp-server/src/blockchain/gateway.js`:
+
+```js
+import { AwsKmsSigner } from "@rumblefishdev/eth-signer-kms";
+
+function createSigner(provider, config) {
+  if (config.kmsKeyId) {
+    return new AwsKmsSigner({
+      keyId: config.kmsKeyId,
+      region: config.awsRegion ?? "eu-central-1",
+    }, provider);
+  }
+  // Fallback for testnet / local dev
+  if (config.signerPrivateKey) {
+    return new Wallet(config.signerPrivateKey, provider);
+  }
+  throw new Error("No signer configured (KMS_KEY_ID or SIGNER_PRIVATE_KEY required).");
+}
+```
+
+The `AwsKmsSigner` is a drop-in `ethers.Signer`. All call sites
+(`escrowContract.connect(signer)`, etc.) work unchanged.
+
+### 3e. Test on testnet first
+
+1. Generate a fresh KMS key in AWS for testnet
+2. Deploy fresh testnet contracts using the KMS-derived address as
+   the verifier
+3. Run the full hosted product-proof smoke loop end-to-end with the
+   KMS path
+4. Confirm: `dmesg` / process tree / `cat backend.env` — the
+   private key bytes appear nowhere
+
+### 3f. Cutover
+
+For testnet: just update the `verifier` field in
+`deployments/testnet.json`, deploy fresh, switch.
+
+For mainnet: this is part of Phase 5 — the mainnet deploy is the
+first time the KMS-managed key signs anything.
+
+### Phase 3 done = exit criteria
+
+- [ ] AWS account + IAM user provisioned with minimal-permission policy
+- [ ] KMS key created (one for testnet, one for mainnet)
+- [ ] EVM address derived and matches what's expected on-chain
+- [ ] `AwsKmsSigner` adapter integrated and unit-tested
+- [ ] Hosted product-proof smoke passes end-to-end on testnet using the
+  KMS path
+- [ ] `SIGNER_PRIVATE_KEY` env path retained as fallback for local dev
+  but removed from production env
+
+### Rollback
+
+Easy: revert to `SIGNER_PRIVATE_KEY` env path on the backend. The
+contract-side verifier address would need to be reset on TreasuryPolicy
+via the multisig — irreversible if mainnet deploy already happened, so
+test on testnet first.
+
+---
+
+## Phase 4 — Hardening
+
+Three small additions; each <1h.
+
+### 4a. CI secret scanning
+
+Add a `gitleaks` step to the CI workflow:
+
+```yaml
+# .github/workflows/ci.yml
+- uses: gitleaks/gitleaks-action@v2
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+This fails any PR that accidentally contains a secret pattern (private
+keys, JWTs, AWS keys, etc.). One-time setup; ongoing protection.
+
+### 4b. Short-lived JWTs + refresh tokens
+
+Replace the long-lived `ADMIN_JWT` GitHub secret pattern with a refresh
+token model:
+
+- The hosted worker loop receives a **refresh token** (long-lived,
+  stored in 1Password)
+- On each run, it exchanges the refresh token for a **fresh access
+  token** (1h lifetime) via a new `/auth/refresh` endpoint
+- The access token never sits in env vars long enough to expire
+  unattended
+
+Implementation: add `mcp-server/src/auth/refresh.js` with the
+exchange endpoint; update `run-hosted-worker-loop.mjs` to call it at
+the start of each run.
+
+### 4c. Expiry calendar + CI check
+
+Already in this PR: [`SECRETS_CALENDAR.yml`](SECRETS_CALENDAR.yml) +
+`scripts/ops/check-secrets-calendar.mjs`. Wire into the CI workflow:
+
+```yaml
+# .github/workflows/ci.yml
+- name: Check secrets calendar
+  run: node scripts/ops/check-secrets-calendar.mjs
+```
+
+This warns 7 days before any tracked token expires. Doesn't fail CI on
+warnings (would block legitimate work) but does fail on any token
+already past expiry.
+
+### Phase 4 done = exit criteria
+
+- [ ] `gitleaks` runs on every PR
+- [ ] Hosted worker loop uses refresh-token exchange instead of
+  long-lived `ADMIN_JWT`
+- [ ] CI warns 7 days before any tracked token expires
+- [ ] No secret has been merged into the repo for at least 14 days
+  after `gitleaks` lands (sanity check the scanner is configured right)
+
+---
+
+## Phase 5 — Mainnet cutover
+
+This is the night-of deploy. Treat it as a one-shot ceremony with all
+four prior phases already in production for ≥1 week each.
+
+### Pre-flight checklist
+
+The day before:
+
+- [ ] All four prior phases live and stable on testnet for ≥7 days
+- [ ] Audit script (`scripts/ops/audit-launch-readiness.mjs`) shows
+  zero drift between testnet config and the planned mainnet config
+- [ ] `op` service account token rotated within the last 30 days
+- [ ] AWS KMS key for mainnet created with separate IAM user from
+  testnet
+- [ ] Multisig signer set is established with **fresh seeds** —
+  do not reuse testnet seeds
+- [ ] All vendor accounts (Pimlico, Sentry, Subscan, RPC provider) have
+  separate mainnet API keys minted
+- [ ] On-call rotation defined in `INCIDENT_RESPONSE.md` Section 1
+  (currently a blank template — fill it in)
+
+### Cutover sequence
+
+1. **Generate fresh secrets**: rotate every secret listed in
+   [`SECRETS.md`'s mainnet hardening checklist](SECRETS.md#mainnet-hardening-checklist).
+   Each goes into a fresh 1Password item under
+   `Averray/Production/<vault>/`.
+2. **Provision the multisig** on Polkadot.js Apps with the three new
+   signer addresses (Hot, Warm, Cold per `MULTISIG_SETUP.md`).
+3. **Deploy contracts** with the multisig as the owner from line 1
+   (skip the EOA-then-transfer flow used on testnet — owner is the
+   multisig from genesis).
+4. **Update `deployments/mainnet.json`** with all addresses.
+5. **Update `backend.env.template`** to reference the new mainnet
+   1Password items (or use a separate `backend.mainnet.env.template`).
+6. **Run the smoke** with `product_proof_reward_asset=USDC` against
+   mainnet.
+7. **Archive** the testnet 1Password vault — read-only, kept for
+   forensics. **Do not delete** for at least 90 days.
+
+### Post-cutover verification
+
+- [ ] `audit-launch-readiness.mjs` shows green for mainnet
+- [ ] `check-secrets-calendar.mjs` shows zero entries within 7 days of
+  expiry
+- [ ] Hosted product-proof smoke passes end-to-end three consecutive
+  runs
+- [ ] No secret appears in any log file or process listing on the
+  mainnet VPS (`ps -ef | grep -E '0x[a-f0-9]{60}'` returns nothing)
+- [ ] On-call rotation is live and the first responder has been paged
+  with a test alert successfully
+
+---
+
+## Cost summary
+
+| Item | Monthly cost |
+|---|---|
+| 1Password Business (1 user) | $7.99 |
+| 1Password Business (3 users) | $23.97 |
+| AWS KMS asymmetric key | $1 + $0.15 per 10k signatures (~$1.05/mo at our volume) |
+| AWS minimum (free tier covers most ancillary services) | $0 |
+| **Total at 1 user, current scale** | **~$9/mo** |
+| **Total at 3 users, current scale** | **~$25/mo** |
+
+The cost is rounding error compared to the security improvement. The
+real cost is **engineering time for the migration** (~5 working days
+spread over a few weeks).
+
+---
+
+## When something goes wrong
+
+Each phase has its own rollback noted above. For incidents:
+
+- **Suspected secret compromise**: see [`INCIDENT_RESPONSE.md`](INCIDENT_RESPONSE.md).
+  Per-secret rotation paths are in
+  [`SECRETS.md`'s runbook section](SECRETS.md#per-secret-runbook-when-something-breaks).
+- **Migration step fails halfway**: roll back that step. Old path is
+  still live until you explicitly remove it.
+- **Vault locked / 1Password down**: the rendered env files are still
+  on the VPS. Don't redeploy until 1Password recovers. If urgent, an
+  operator can manually edit the rendered env file as a one-off — but
+  the next deploy will overwrite it from the vault.
+
+---
+
+## Related
+
+- [`SECRETS.md`](SECRETS.md) — the inventory + storage strategy
+- [`SECRETS_CALENDAR.yml`](SECRETS_CALENDAR.yml) — token expiry tracking
+- [`MULTISIG_SETUP.md`](MULTISIG_SETUP.md) — multisig provisioning
+- [`SIGNER_POLICY.md`](SIGNER_POLICY.md) — signer roles and key handling
+- [`INCIDENT_RESPONSE.md`](INCIDENT_RESPONSE.md) — incident playbook

--- a/scripts/ops/check-secrets-calendar.mjs
+++ b/scripts/ops/check-secrets-calendar.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+
+/**
+ * Reads docs/SECRETS_CALENDAR.yml and warns when any tracked token's
+ * `expires_at` is within the warning window of now.
+ *
+ * Designed to run on every CI build — non-zero exit when any entry
+ * is past expiry; otherwise prints a summary and exits zero. Warnings
+ * (within `warn_days` but not yet expired) print but do NOT fail CI,
+ * because failing CI on a 7-day warning would block legitimate work.
+ *
+ * Usage:
+ *   node scripts/ops/check-secrets-calendar.mjs
+ *   node scripts/ops/check-secrets-calendar.mjs --calendar docs/SECRETS_CALENDAR.yml
+ *   node scripts/ops/check-secrets-calendar.mjs --json
+ *
+ * Exit codes:
+ *   0  All entries are healthy or only emitting warnings
+ *   1  Script error (bad YAML, missing file, etc.)
+ *   2  At least one entry is past expiry
+ */
+
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { createRequire } from "node:module";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..", "..");
+
+// js-yaml is hoisted in the repo's node_modules from a transitive dep;
+// require it via createRequire to avoid pulling in a new top-level dep.
+const require = createRequire(import.meta.url);
+let yaml;
+try {
+  yaml = require("js-yaml");
+} catch (error) {
+  console.error("check-secrets-calendar requires js-yaml. Run `npm install` at the repo root and try again.");
+  console.error(`(underlying error: ${error.message})`);
+  process.exitCode = 1;
+  process.exit();
+}
+
+function parseArgs(argv) {
+  const args = {
+    calendarPath: resolve(repoRoot, "docs", "SECRETS_CALENDAR.yml"),
+    jsonOutput: false
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    if (flag === "--calendar") args.calendarPath = resolve(argv[++i]);
+    else if (flag === "--json") args.jsonOutput = true;
+    else if (flag === "--help" || flag === "-h") args.help = true;
+  }
+  return args;
+}
+
+function classify(entry, now, defaults) {
+  const warnDays = Number.isFinite(entry.warn_days) ? entry.warn_days : defaults.default_warn_days;
+  const failWithinDays = defaults.fail_within_days;
+  const expiresAtRaw = entry.expires_at;
+
+  if (expiresAtRaw === "never") {
+    return { status: "skip", reason: "expires_at=never (intentional, no expiry tracking)" };
+  }
+  if (expiresAtRaw === "TBD") {
+    return { status: "warn", reason: "expires_at=TBD — set this after the next rotation" };
+  }
+  if (typeof expiresAtRaw !== "string") {
+    return { status: "error", reason: `expires_at must be a YYYY-MM-DD string, "TBD", or "never"; got ${JSON.stringify(expiresAtRaw)}` };
+  }
+  const expiresAt = new Date(expiresAtRaw);
+  if (Number.isNaN(expiresAt.getTime())) {
+    return { status: "error", reason: `expires_at "${expiresAtRaw}" is not a valid date` };
+  }
+  const msPerDay = 24 * 60 * 60 * 1000;
+  const daysUntilExpiry = Math.ceil((expiresAt.getTime() - now.getTime()) / msPerDay);
+  if (daysUntilExpiry <= 0) {
+    return { status: "fail", reason: `expired ${Math.abs(daysUntilExpiry)} day${Math.abs(daysUntilExpiry) === 1 ? "" : "s"} ago`, daysUntilExpiry };
+  }
+  if (daysUntilExpiry <= failWithinDays) {
+    return { status: "fail", reason: `expires in ${daysUntilExpiry} day${daysUntilExpiry === 1 ? "" : "s"} (within fail_within_days=${failWithinDays})`, daysUntilExpiry };
+  }
+  if (daysUntilExpiry <= warnDays) {
+    return { status: "warn", reason: `expires in ${daysUntilExpiry} day${daysUntilExpiry === 1 ? "" : "s"}`, daysUntilExpiry };
+  }
+  return { status: "ok", reason: `expires in ${daysUntilExpiry} days`, daysUntilExpiry };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(
+      [
+        "Usage: node scripts/ops/check-secrets-calendar.mjs [options]",
+        "",
+        "Options:",
+        "  --calendar <path>   Calendar YAML file. Default: docs/SECRETS_CALENDAR.yml",
+        "  --json              Output a JSON report instead of human-readable lines",
+        "",
+        "Exit codes:",
+        "  0   all healthy / warnings only",
+        "  1   script error (bad YAML, missing file)",
+        "  2   one or more entries past expiry"
+      ].join("\n")
+    );
+    return;
+  }
+
+  let raw;
+  try {
+    raw = await readFile(args.calendarPath, "utf8");
+  } catch (error) {
+    console.error(`could not read calendar at ${args.calendarPath}: ${error.message}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  let parsed;
+  try {
+    parsed = yaml.load(raw);
+  } catch (error) {
+    console.error(`could not parse calendar YAML: ${error.message}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const entries = Array.isArray(parsed?.entries) ? parsed.entries : [];
+  const config = parsed?.config ?? {};
+  const defaults = {
+    default_warn_days: Number.isFinite(config.default_warn_days) ? config.default_warn_days : 7,
+    fail_within_days: Number.isFinite(config.fail_within_days) ? config.fail_within_days : 1
+  };
+  const now = new Date();
+
+  const results = entries.map((entry) => ({
+    name: String(entry.name ?? "(unnamed)"),
+    description: String(entry.description ?? ""),
+    owner: String(entry.owner ?? "unknown"),
+    expiresAt: String(entry.expires_at ?? ""),
+    ...classify(entry, now, defaults)
+  }));
+
+  if (args.jsonOutput) {
+    console.log(JSON.stringify({ now: now.toISOString(), defaults, entries: results }, null, 2));
+  } else {
+    console.log(`# secrets calendar (${args.calendarPath})`);
+    console.log(`now: ${now.toISOString()}`);
+    console.log(`fail_within_days=${defaults.fail_within_days}, default_warn_days=${defaults.default_warn_days}`);
+    console.log("");
+    for (const r of results) {
+      const icon = { ok: "✅", warn: "⚠️", fail: "❌", skip: "—", error: "💥" }[r.status] ?? "?";
+      console.log(`${icon}  ${r.name.padEnd(36, " ")} owner=${r.owner.padEnd(12, " ")} expires=${r.expiresAt.padEnd(12, " ")} ${r.reason}`);
+    }
+  }
+
+  const totals = results.reduce((acc, r) => {
+    acc[r.status] = (acc[r.status] ?? 0) + 1;
+    return acc;
+  }, {});
+  if (!args.jsonOutput) {
+    console.log("");
+    console.log(`summary: ${totals.ok ?? 0} ok · ${totals.warn ?? 0} warn · ${totals.fail ?? 0} fail · ${totals.skip ?? 0} skipped · ${totals.error ?? 0} errors`);
+  }
+
+  if ((totals.fail ?? 0) > 0 || (totals.error ?? 0) > 0) {
+    process.exitCode = 2;
+  }
+}
+
+main().catch((error) => {
+  console.error(`check-secrets-calendar failed: ${error?.stack ?? error?.message ?? error}`);
+  process.exitCode = 1;
+});

--- a/scripts/ops/mint-admin-jwt.mjs
+++ b/scripts/ops/mint-admin-jwt.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+
+/**
+ * Offline mint of an admin / verifier JWT for the Averray backend.
+ *
+ * Closes a gap that bit us in early ops: when the `ADMIN_JWT` GitHub
+ * Actions secret (or any other long-lived ops token) expires, the
+ * only previously-documented mint path was the operator app's SIWE
+ * sign-in flow followed by manual local-storage extraction. That
+ * flow is fine for human operators but breaks any time the deployer
+ * wants to refresh tokens consumed by automation (e.g.
+ * scripts/ops/run-hosted-worker-loop.mjs).
+ *
+ * This script signs a JWT locally using the platform's HS256
+ * secret. It does NOT contact the running backend — the produced
+ * token is verifiable by any backend whose `AUTH_JWT_SECRETS`
+ * environment variable contains the same secret used to sign it.
+ *
+ * Required env (treat as sensitive — source from a vault or
+ * password manager, never paste literals into shell history):
+ *   AUTH_JWT_SECRETS    — comma-separated list of HS256 secrets.
+ *                         The script signs with the first entry,
+ *                         matching the rotation pattern in
+ *                         mcp-server/src/auth/jwt.js (newest first).
+ *   AUTH_JWT_SECRET     — legacy single-secret fallback.
+ *
+ * Usage:
+ *   node scripts/ops/mint-admin-jwt.mjs \
+ *     --wallet 0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519 \
+ *     --roles admin,verifier \
+ *     --expires-in-days 90
+ *
+ *   # short form: takes the wallet from deployments/<profile>.json
+ *   node scripts/ops/mint-admin-jwt.mjs --profile testnet
+ *
+ * Common workflow (hosted product-proof smoke):
+ *   AUTH_JWT_SECRETS=$(op read 'op://Averray/Production/jwt-secret/credential') \
+ *     node scripts/ops/mint-admin-jwt.mjs --profile testnet --expires-in-days 30 \
+ *   | xargs -I {} gh secret set ADMIN_JWT --body '{}'
+ */
+
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+import { signToken } from "../../mcp-server/src/auth/jwt.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..", "..");
+
+function parseArgs(argv) {
+  const args = {
+    wallet: undefined,
+    profile: undefined,
+    roles: ["admin"],
+    expiresInDays: 30,
+    quiet: false
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    if (flag === "--wallet") args.wallet = argv[++i];
+    else if (flag === "--profile") args.profile = argv[++i];
+    else if (flag === "--roles") args.roles = argv[++i].split(",").map((s) => s.trim()).filter(Boolean);
+    else if (flag === "--expires-in-days") args.expiresInDays = Number(argv[++i]);
+    else if (flag === "--quiet" || flag === "-q") args.quiet = true;
+    else if (flag === "--help" || flag === "-h") args.help = true;
+  }
+  return args;
+}
+
+function printUsage() {
+  console.log(
+    [
+      "Usage: node scripts/ops/mint-admin-jwt.mjs [options]",
+      "",
+      "Options:",
+      "  --wallet <0x…>          Subject wallet to sign for. Defaults to deployments/<profile>.json#verifier when --profile is given.",
+      "  --profile <name>        Read default wallet from deployments/<name>.json (e.g. testnet, mainnet).",
+      "  --roles <a,b,c>         Comma-separated role list. Default: admin.",
+      "  --expires-in-days <n>   Token lifetime in days. Default: 30.",
+      "  --quiet, -q             Print only the JWT (no decoded claims summary).",
+      "",
+      "Required env:",
+      "  AUTH_JWT_SECRETS        Comma-separated HS256 secrets. First entry is the signing key.",
+      "  AUTH_JWT_SECRET         Legacy single-secret fallback (only used if AUTH_JWT_SECRETS unset).",
+      "",
+      "Output:",
+      "  When --quiet: stdout is just the JWT (suitable for piping to `gh secret set`, etc.).",
+      "  Otherwise: a short summary block + the JWT on the last line."
+    ].join("\n")
+  );
+}
+
+async function loadDefaultWallet(profile) {
+  if (!profile) return undefined;
+  try {
+    const raw = await readFile(resolve(repoRoot, "deployments", `${profile}.json`), "utf8");
+    const data = JSON.parse(raw);
+    return data.verifier ?? data.deployer ?? undefined;
+  } catch (error) {
+    throw new Error(`Could not read deployments/${profile}.json: ${error.message}`);
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printUsage();
+    return;
+  }
+
+  const wallet = args.wallet ?? (await loadDefaultWallet(args.profile));
+  if (!wallet || !/^0x[a-fA-F0-9]{40}$/u.test(wallet)) {
+    console.error("--wallet (or --profile that resolves to one) is required and must be a 0x-prefixed 40-char hex address.");
+    printUsage();
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!Number.isFinite(args.expiresInDays) || args.expiresInDays <= 0 || args.expiresInDays > 365 * 2) {
+    console.error("--expires-in-days must be between 1 and 730 (~2 years).");
+    process.exitCode = 1;
+    return;
+  }
+  if (!Array.isArray(args.roles) || args.roles.length === 0) {
+    console.error("--roles must be a non-empty comma-separated list (e.g. admin,verifier).");
+    process.exitCode = 1;
+    return;
+  }
+
+  const secretsRaw = String(process.env.AUTH_JWT_SECRETS ?? process.env.AUTH_JWT_SECRET ?? "").trim();
+  if (!secretsRaw) {
+    console.error("AUTH_JWT_SECRETS env (or legacy AUTH_JWT_SECRET) is required.");
+    console.error("Source it from your vault — never paste the secret as a shell literal:");
+    console.error('  AUTH_JWT_SECRETS=$(op read "op://Averray/Production/jwt-secret/credential")');
+    process.exitCode = 1;
+    return;
+  }
+  const secrets = secretsRaw.split(",").map((s) => s.trim()).filter(Boolean);
+  if (secrets.length === 0) {
+    console.error("AUTH_JWT_SECRETS resolved to an empty list after splitting on commas.");
+    process.exitCode = 1;
+    return;
+  }
+  // Sign with the first (newest) secret, mirroring auth/middleware.js
+  // verification order. Old tokens issued by previous secrets remain
+  // valid until those entries are dropped from the live backend's
+  // AUTH_JWT_SECRETS list.
+  const signingSecret = secrets[0];
+  if (signingSecret.length < 32) {
+    console.error(`The first AUTH_JWT_SECRETS entry is ${signingSecret.length} chars long; auth/config.js requires ≥ 32 chars in strict mode. Ensure the env matches the live backend.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const expiresInSeconds = Math.floor(args.expiresInDays * 24 * 60 * 60);
+  const { token, claims } = signToken(
+    {
+      sub: wallet.toLowerCase(),
+      roles: args.roles,
+      // No explicit scopes — admin/verifier roles already grant the
+      // capabilities ops scripts need. If you need finer-grained
+      // scopes for a service token, add them via a fork of this
+      // script or thread `--scopes` through the CLI parser.
+    },
+    { secret: signingSecret, expiresInSeconds }
+  );
+
+  if (args.quiet) {
+    console.log(token);
+    return;
+  }
+
+  const expiresAt = new Date(claims.exp * 1000).toISOString();
+  const issuedAt = new Date(claims.iat * 1000).toISOString();
+  console.error("# admin-jwt mint");
+  console.error(`subject:        ${claims.sub}`);
+  console.error(`roles:          ${claims.roles?.join(", ") ?? "(none)"}`);
+  console.error(`jti:            ${claims.jti}`);
+  console.error(`issued:         ${issuedAt}`);
+  console.error(`expires:        ${expiresAt}  (${args.expiresInDays} days from now)`);
+  console.error(`signed with:    secret index 0 of ${secrets.length} configured secret${secrets.length === 1 ? "" : "s"}`);
+  console.error("");
+  console.error("# JWT (this line below is the token; paste it into ADMIN_JWT or pipe to `gh secret set`):");
+  console.log(token);
+}
+
+main().catch((error) => {
+  console.error(`mint-admin-jwt failed: ${error?.stack ?? error?.message ?? error}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
Five files, one PR. Closes the operator's "I don't have an overview of all the keys, passwords, and tokens we use" ask, with an explicit pre-mainnet hardening path.

## What's in this PR

| File | Purpose |
|---|---|
| `docs/SECRETS.md` | Inventory of ~70 secrets across 5 buckets (GH Actions, VPS backend env, VPS indexer env, local/human-managed, external service tokens). Per-secret runbook. Mainnet hardening checklist. |
| `docs/SECRETS_MIGRATION.md` | Five-phase plan from "Tier 1 starter" → "Tier 2.5" (1Password Business + AWS KMS). Each phase has commands, exit criteria, and rollback notes. |
| `docs/SECRETS_CALENDAR.yml` | Declarative source of truth for token expiry tracking. Fields: name, description, owner, vault_path, expires_at, warn_days, notes. |
| `scripts/ops/mint-admin-jwt.mjs` | Offline mint of admin JWTs. Closes the gap that bit ops today: `ADMIN_JWT` expired, only documented path was the operator-app SIWE flow + manual local-storage extraction. Now a one-liner that pipes cleanly to `gh secret set`. |
| `scripts/ops/check-secrets-calendar.mjs` | Reads the calendar, warns 7 days out, fails CI on past-expiry. Designed to run on every CI build. |

## Smoke-tested
- **`mint-admin-jwt.mjs`**: signs a JWT with a 40-char test secret, resolves wallet from `deployments/testnet.json`, prints a clean summary + token on the last line ✅
- **`check-secrets-calendar.mjs`**: 2 ok / 6 warn / 0 fail / 1 skipped against the seeded calendar (expected — TBD entries warn intentionally until the migration sets real expiry). Confirmed fail path returns exit code 2 on past-expiry ✅

## Why 1Password Business + AWS KMS

Per a [web-search comparison](https://github.com/averray-agent/agent/issues): at this team's current size (1–2 people), 1Password Business at $7.99/user/mo is **cheaper** than Teams Starter Pack ($19.95 flat) and adds Watchtower breach alerts + SSO + finer-grained vault sharing. The `op://` CLI URI is best-in-class for runtime injection.

AWS KMS provides asymmetric secp256k1 sign-only keys for $1/key/mo + $0.15 per 10k operations. The backend never holds the private bytes in memory — calls `kms.sign(messageHash)` and gets a signature. Drop-in `AwsKmsSigner` ethers.js adapter.

Total monthly cost: ~$9/mo at 1 user, ~$25/mo at 3 users.

## Out of scope (deliberate)
- Phase 1–5 execution itself (this PR is the *plan*; the operator does the migration on their own clock)
- 1Password tenant provisioning (operator action; the docs describe what to set up)
- AWS account creation (operator action)
- The `gitleaks` CI integration in Phase 4 (separate small PR after migration starts)

## Closes
- The operator's overview gap (today's ask)
- The `ADMIN_JWT` rotation gap (the script unblocks today's hosted-smoke retrigger after the operator regenerates the secret)

## Test plan
- [x] Both scripts pass their own smoke tests
- [x] Calendar exits with code 2 on a synthetic past-expired entry
- [x] No new top-level deps added (`js-yaml` is transitively available; `signToken` reused from `mcp-server/src/auth/jwt.js`)
- [ ] After merge: operator runs `mint-admin-jwt.mjs` to refresh `ADMIN_JWT`, then re-triggers the hosted smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)