### PR TITLE
Secrets plan v2: incorporate external security review feedback

### DIFF
--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -6,7 +6,9 @@ the Averray platform depends on. Read this first when:
 - You need to rotate a secret and want to know which surfaces it touches
 - You're onboarding a new operator and they need access
 - You're preparing for mainnet (see also
-  [`SECRETS_MIGRATION.md`](SECRETS_MIGRATION.md))
+  [`SECRETS_MIGRATION.md`](SECRETS_MIGRATION.md) for the phase-by-phase
+  plan and [`SECRETS_INTEGRATION_PLAN.md`](SECRETS_INTEGRATION_PLAN.md)
+  for the security-review-grade design rationale)
 - Something looks suspicious and you need to figure out the blast radius
 
 If you find a secret in the code or config that isn't listed here, **add
@@ -52,12 +54,21 @@ The 4 highest-risk items, ordered by blast radius:
 Each secret class has a target home. The rule of thumb is: **one
 canonical source, synced to runtime by automation, never copy-pasted**.
 
+**Note on runtime plaintext**: `op inject` renders env files at
+deploy time, which means rendered values exist as plaintext on the
+target host (VPS or CI runner) for the duration of the deploy. This
+solves the source-of-truth problem (one place to update) but does
+NOT eliminate runtime plaintext from disk — the KMS migration of
+the signer key is the layer that removes the most valuable runtime
+plaintext. See `SECRETS_INTEGRATION_PLAN.md` Section 4c for the
+honest trust-boundary analysis.
+
 | Secret class | Where it lives | How runtime gets it |
 |---|---|---|
-| App secrets (JWT secret, RPC URLs, Pimlico, Sentry, GH PAT, Subscan, webhooks) | 1Password Business → `Averray/Production/Backend` vault | `op inject` renders the env at deploy time; `op://` URI references in templates, no plain-text on disk |
-| GitHub Actions secrets (`VPS_SSH_KEY`, `ADMIN_JWT`, `APP_BASIC_AUTH_*`) | 1Password Business → `Averray/Production/CI` vault | Synced via `1password/load-secrets-action@v1` per workflow job |
-| Indexer env (DB password, RPC URL) | 1Password Business → `Averray/Production/Indexer` vault | Same pattern as backend |
-| Backend signer key | **AWS KMS** secp256k1 key, region pinned, IAM-controlled | ethers.js `AwsKmsSigner` adapter — backend never sees the private key |
+| App secrets (JWT secret, RPC URLs, Pimlico, Sentry, GH PAT, Subscan, webhooks) | 1Password Business → `Averray/Production/Backend` vault | `op inject` renders env at deploy time to tmpfs; per-runtime service token (`prod-vps-backend`); plaintext on tmpfs only |
+| GitHub Actions secrets (`VPS_SSH_KEY`, `ADMIN_JWT`, `APP_BASIC_AUTH_*`) | 1Password Business → `Averray/Production/CI` vault | Synced via `1password/load-secrets-action`; per-runtime service token (`prod-ci-deploy`); production deploys gated by GitHub Environment with required reviewers |
+| Indexer env (DB password, RPC URL) | 1Password Business → `Averray/Production/Indexer` vault | Same pattern as backend, with `prod-vps-indexer` service token (scoped to indexer vault only) |
+| Backend signer key | **AWS KMS** secp256k1 key, multi-region (mainnet), IAM Roles Anywhere / OIDC access | ethers.js `AwsKmsSigner` adapter — backend never holds private key bytes; **still holds temporary AWS credentials** (≤1h lifetime) capable of requesting signatures |
 | Operator passwords (basic auth, personal vault items) | 1Password Business → `Averray/Operators` per-user vault | Manual; only used by humans through the 1Password UI |
 | Multisig signer seeds | Three independent humans/devices (existing pattern, see [`MULTISIG_SETUP.md`](MULTISIG_SETUP.md)) | Hardware wallets + sealed-envelope offline backups |
 | Burnable deployer key (one-time per deploy) | Generated fresh; transferred away from the deployer EOA via `transferOwnership()` to the multisig at the end of `deploy_contracts.sh` | Never persisted long-term |
@@ -219,19 +230,39 @@ vault. Each has a vendor-side rotation path.
 
 For each secret class, the canonical mint/rotate/revoke flow.
 
-### `AUTH_JWT_SECRETS` (HMAC for SIWE sessions)
+### `AUTH_JWT_SECRETS` (HMAC for SIWE sessions today; asymmetric KMS-signed target for mainnet)
 
-**Mint a new entry**:
+**Today**: HMAC-SHA256 secret stored in `AUTH_JWT_SECRETS` (comma-
+separated list, newest first). A vault leak OR a backend env leak
+means anyone can mint admin JWTs. This is one of the four
+highest-risk items in this doc.
+
+**Target for mainnet** (see Phase 4b of
+[`SECRETS_INTEGRATION_PLAN.md`](SECRETS_INTEGRATION_PLAN.md)):
+asymmetric KMS-signed access tokens with opaque refresh tokens.
+After that migration, a vault leak no longer allows JWT minting —
+only KMS principal compromise does (same protection level as the
+signer key).
+
+If the asymmetric migration is deferred, the **minimum hardening
+for the HMAC path** is:
+- Key ring with `kid` rotation
+- Short access-token TTLs (≤15 min)
+- Documented two-key rotation window with old-key tolerance period
+- Refresh tokens are opaque random values, hashed server-side
+
+**Mint a new HMAC entry**:
 ```bash
 openssl rand -hex 32     # 64-char hex string, ≥32 bytes
 ```
 Add to 1Password as a new field; do **not** delete the old one yet.
 
-**Rotate**:
-1. Update the 1Password entry: prepend the new secret, keep the old one.
+**HMAC rotation**:
+1. Update the 1Password entry: prepend the new secret, keep the
+   old one.
 2. Trigger a redeploy. Backend now signs with new, accepts both.
-3. After 24-48h grace period (allows in-flight tokens to expire),
-   delete the old secret from the 1Password entry.
+3. After 24–48h grace period (allows in-flight tokens to expire
+   naturally), delete the old secret from the 1Password entry.
 4. Trigger a second redeploy. Old tokens now reject.
 
 **Revoke an issued token**:
@@ -254,17 +285,38 @@ you ~7 days out.
 
 ### `SIGNER_PRIVATE_KEY` (backend signer)
 
-**Today** (testnet): plain hex in VPS env. Rotation requires generating
-a new keypair, redeploying contracts (because the verifier address is
-baked into TreasuryPolicy), and updating env. Heavy.
+**Today** (testnet): plain hex in VPS env. Rotation requires
+generating a new keypair, calling `setVerifier(new)` on TreasuryPolicy
+via the multisig, and updating env. Heavy.
 
-**Target** (after Phase 3 of [`SECRETS_MIGRATION.md`](SECRETS_MIGRATION.md)):
-AWS KMS-managed secp256k1 key. Rotation path:
-1. Create a new KMS key.
-2. Import the new public key as the new verifier on TreasuryPolicy via
-   the multisig (`setVerifier(new, true)`).
-3. Update `KMS_KEY_ID` in the backend env via 1Password; redeploy.
-4. After grace period: `setVerifier(old, false)` and `kms.scheduleKeyDeletion(old)`.
+**Target** (after Phase 3 of
+[`SECRETS_MIGRATION.md`](SECRETS_MIGRATION.md)): AWS KMS-managed
+secp256k1 key. AWS does **not** support automatic rotation for
+asymmetric KMS keys.
+
+> **KMS signer key rotation is an on-chain signer migration event,
+> not a routine calendar rotation. IAM/STS credentials rotate
+> frequently; the KMS key rotates only through a planned verifier
+> update via multisig.**
+
+The migration procedure:
+1. Create a new KMS key (same spec, same multi-region setup if
+   mainnet)
+2. Derive the new EVM address from the new key's public key
+3. Multisig signs `setVerifier(newKmsAddress, true)` on TreasuryPolicy
+4. Update `KMS_KEY_ID` env via 1Password; redeploy backend
+5. Grace period (e.g., 24h): both keys are valid verifiers
+6. Multisig signs `setVerifier(oldKmsAddress, false)` to disable
+   the old key
+7. Schedule deletion of the old KMS key (7–30 day pending period)
+8. After deletion period, key is permanently destroyed
+
+The KMS signer key is **explicitly NOT tracked** in
+[`SECRETS_CALENDAR.yml`](SECRETS_CALENDAR.yml) because it rotates
+on-chain, not on calendar.
+
+IAM access credentials (Roles Anywhere certs, OIDC trust
+relationship) DO rotate frequently and are calendar-tracked.
 
 ### `VPS_SSH_KEY`
 

--- a/docs/SECRETS_CALENDAR.yml
+++ b/docs/SECRETS_CALENDAR.yml
@@ -92,32 +92,82 @@ entries:
       check script confirms it's still in the inventory. Rotate via
       project settings if compromise is suspected.
 
-  # ── 1Password service account token ────────────────────────────────
+  # ── 1Password service account tokens (split per runtime) ──────────
+  #
+  # Revised in v2 per security review: one token per runtime per
+  # environment, each scoped to a single vault.
 
-  - name: op-service-account-runtime
-    description: 1Password service account token used by the VPS and CI to fetch secrets.
+  - name: op-token-prod-ci-deploy
+    description: 1Password service account token for GitHub Actions production deploy workflow.
     owner: deployer
-    vault_path: op://Personal/1password-runtime-token-production
-    expires_at: "2026-08-08"   # 90d max, set this when token is provisioned in Phase 1
+    vault_path: op://Personal/op-token-prod-ci-deploy
+    expires_at: "TBD"   # Set when token provisioned; ≤90d cadence
     warn_days: 14
     notes: |
-      Rotate in 1Password admin: Integrations → Service Accounts → Rotate.
-      After rotating, update the VPS env (/etc/agent-stack/op.env) and
-      the OP_SERVICE_ACCOUNT_TOKEN GitHub Actions secret.
+      Scoped read-only to Averray/Production/CI vault. Rotate in
+      1Password admin: Integrations → Service Accounts → New (cannot
+      change scope on existing token). After rotation, update the
+      GitHub Environment secret OP_SERVICE_ACCOUNT_TOKEN_PROD_CI.
 
-  # ── AWS IAM keys ──────────────────────────────────────────────────
-
-  - name: aws-kms-signer-iam-keys
-    description: AWS access key + secret for the IAM user that calls KMS.Sign.
+  - name: op-token-prod-vps-backend
+    description: 1Password service account token used by the backend VPS at deploy time.
     owner: deployer
-    vault_path: op://Averray/Production/Backend/aws-kms-signer
-    expires_at: "TBD"   # Set after Phase 3; IAM keys don't auto-expire but rotate every 90d
+    vault_path: op://Personal/op-token-prod-vps-backend
+    expires_at: "TBD"
     warn_days: 14
     notes: |
-      Rotate at AWS Console → IAM → Users → averray-signer-prod →
-      Security credentials. Mint new key, update 1Password, redeploy
-      backend, then deactivate (don't delete) the old key for 24h
-      grace period.
+      Scoped read-only to Averray/Production/Backend + External.
+      After rotation, update /etc/agent-stack/op-backend.env on the
+      VPS. Service tokens are effectively immutable post-create —
+      mint a new one rather than trying to widen scope.
+
+  - name: op-token-prod-vps-indexer
+    description: 1Password service account token used by the indexer VPS at deploy time.
+    owner: deployer
+    vault_path: op://Personal/op-token-prod-vps-indexer
+    expires_at: "TBD"
+    warn_days: 14
+    notes: |
+      Scoped read-only to Averray/Production/Indexer.
+      After rotation, update /etc/agent-stack/op-indexer.env on the
+      VPS.
+
+  - name: op-token-prod-smoke-tests
+    description: 1Password service account token used by hosted product-proof smoke.
+    owner: deployer
+    vault_path: op://Personal/op-token-prod-smoke-tests
+    expires_at: "TBD"
+    warn_days: 14
+    notes: |
+      Scoped read-only to Averray/Production/CI/admin-jwt only.
+      Smallest blast radius — leaked token can only read ADMIN_JWT.
+
+  # ── AWS signer access (NOT static IAM keys) ───────────────────────
+  #
+  # Revised in v2: we no longer store long-lived AWS IAM access keys
+  # for the signer principal. Access is via IAM Roles Anywhere
+  # (X.509 client cert on the VPS) and GitHub OIDC (for any
+  # Actions workflow that needs AWS). Both yield ≤1h temporary
+  # credentials that rotate automatically.
+
+  - name: aws-roles-anywhere-client-cert
+    description: X.509 client cert on the VPS used by IAM Roles Anywhere to fetch temporary AWS credentials.
+    owner: deployer
+    vault_path: op://Averray/Production/Backend/aws-roles-anywhere-cert
+    expires_at: "TBD"   # Set per CA's cert lifetime (typically 1 year)
+    warn_days: 30
+    notes: |
+      Reissue from the IAM Roles Anywhere Trust Anchor's CA. Replace
+      cert + private key at /etc/agent-stack/roles-anywhere/ on the
+      VPS (mode 0400). The CA private key itself is in AWS ACM-PCA
+      or an HSM — NOT in 1Password.
+
+  # The KMS SIGNER KEY itself is NOT calendar-tracked. Rotation of
+  # the asymmetric KMS key is an on-chain signer migration event
+  # (multisig calls setVerifier with the new key's derived address),
+  # not a routine calendar rotation. AWS does not support automatic
+  # rotation for asymmetric KMS keys. See SECRETS.md and Phase 3 of
+  # SECRETS_MIGRATION.md for the migration procedure.
 
   # ── VPS SSH key ───────────────────────────────────────────────────
 

--- a/docs/SECRETS_INTEGRATION_PLAN.md
+++ b/docs/SECRETS_INTEGRATION_PLAN.md
@@ -1,0 +1,952 @@
+# Secrets Integration Plan — Security Review Document
+
+> **Status**: v2 — incorporates external security review feedback.
+> See [Revision history](#revision-history) at the bottom.
+
+This is the security-review-grade companion to
+[`SECRETS_MIGRATION.md`](SECRETS_MIGRATION.md). Where the migration doc
+is a "how-to" for the operator executing the work, this doc is the
+"why and where it could go wrong" for the security reviewer signing
+off on the design.
+
+If you're reading this to sign off on mainnet, jump to
+[Section 11 — Mainnet sign-off bar](#11-mainnet-sign-off-bar).
+
+---
+
+## 1. Scope & honest limitations
+
+**What this is**: a phased plan to move the platform's secrets out of
+plain-text env files + ad-hoc password managers into a centralized
+vault (1Password Business) + a hardware-backed signer (AWS KMS),
+before mainnet launch. The plan is calibrated for "Tier 2.5" maturity
+(centralized vault + KMS for hottest keys) — not "Tier 3"
+(MPC / threshold signing / fully HSM-only).
+
+**What this is NOT**:
+- A full security audit. Contract logic, RPC validation, rate limits,
+  supply-chain risk in npm deps — none of that is in scope here.
+- A replacement for third-party security review. **For mainnet, get a
+  real audit** (Trail of Bits, Halborn, ChainSecurity, OpenZeppelin)
+  before launch.
+- Compliance documentation.
+
+**My limitations**:
+- I'm an AI assistant, not a security professional. Treat
+  recommendations as a thoughtful first pass.
+- I haven't physically operated 1Password Business or AWS KMS at
+  scale. Patterns described are widely used; environment-specific
+  gotchas may differ.
+- For the highest-risk decisions (key derivation, multisig signer
+  separation, IAM policies, JWT signing migration), get a second
+  human pair of eyes.
+
+---
+
+## 2. Threat model
+
+### 2a. Adversaries
+
+| Adversary class | Capability | In scope? |
+|---|---|---|
+| Opportunistic attacker (leaked secrets in public repo, log dump, breach corpus) | Replay leaked secret | ✅ |
+| External attacker with VPS network access (RCE pivot) | Read VPS files, exec arbitrary code with backend's privileges | ✅ |
+| External attacker with one operator's machine (keylogger, stolen laptop) | Read browser local-storage, password manager auto-fill, shell history | ✅ |
+| Compromised CI/CD (malicious workflow change) | Replay any secret available to a job | ✅ |
+| Disgruntled insider with deployer access | Generate ADMIN_JWT, exfiltrate to attacker-controlled vault | ⚠️ Partial — single-operator orgs have limited mitigation. Address with second operator before mainnet. |
+| State-level adversary / supply chain attack on 1Password or AWS | Subvert vault provider or KMS provider directly | ❌ Out of scope — mitigation is "use providers with strong track records and don't be a high-value target" |
+| Quantum cryptanalysis | Break secp256k1 / HMAC-SHA256 | ❌ Out of scope |
+
+### 2b. Assets (in rough order of blast radius)
+
+1. **Multisig signer seeds** — controls TreasuryPolicy ownership.
+   Already segregated to 3 humans/devices per `MULTISIG_SETUP.md`.
+   **Never enters the centralized vault.**
+2. **Backend signer key** (currently `SIGNER_PRIVATE_KEY`, migrating
+   to AWS KMS) — signs every verification + arbitration. Compromise
+   = forged badges, false dispute outcomes, unauthorized resolutions.
+3. **`AUTH_JWT_SECRETS`** (today HMAC HS256, target asymmetric via
+   KMS) — signs SIWE sessions. Compromise = forge admin/verifier
+   JWTs and bypass the auth layer.
+4. **AWS access credentials** for KMS-signer principal — even with
+   KMS, the calling identity needs credentials. Migrating these to
+   temporary credentials (IAM Roles Anywhere / GitHub OIDC) is the
+   second-tier security upgrade after the KMS migration itself.
+5. **`VPS_SSH_KEY`** — full code-execution path on production VPS.
+6. **`OP_SERVICE_ACCOUNT_TOKEN`**(s) — each one is a vault-decryption
+   capability for its scoped vaults. Treat with the seriousness of
+   the secrets it can unlock.
+7. **External vendor keys** (Pimlico, Sentry, Subscan, RPC provider).
+   These can become platform-impacting via availability, rate limits,
+   or allowlisted-origin compromise — soften the "not platform-level"
+   framing accordingly.
+8. **Operator passwords** — basic auth, personal vault items.
+
+### 2c. Trust assumptions
+
+- **AWS** is trusted to keep KMS private bytes inside the HSM.
+- **1Password Business** is trusted to not leak vault contents.
+  Their E2E encryption design means a server-side breach does NOT
+  expose secrets without the user's master password — which 1Password
+  themselves do not have.
+- **GitHub** is trusted to keep org and environment secrets
+  confidential.
+- **Operator's local machine** is trusted IFF disk encryption is
+  enabled, OS is patched, password manager is locked when not in use,
+  and admin access is gated by a hardware key (e.g., YubiKey).
+- **Polkadot Hub network** is trusted for transaction integrity
+  (consensus-level guarantees).
+
+---
+
+## 3. Current state security posture (Tier 1)
+
+### 3a. Where each secret class lives today
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ GitHub Actions secrets                                  │
+│   VPS_SSH_KEY, ADMIN_JWT, APP_BASIC_AUTH_*, RESEND…     │
+│   → managed via GitHub repo settings UI                 │
+│   → 9 entries; all injected into deploy workflow        │
+└─────────────────────────────────────────────────────────┘
+                          │ over SSH at deploy time
+                          ▼
+┌─────────────────────────────────────────────────────────┐
+│ VPS plain-text env files                                │
+│   /srv/agent-stack/backend.env (40+ entries)            │
+│   /srv/agent-stack/indexer.env (3 entries)              │
+│   → readable by root + service user                     │
+│   → SIGNER_PRIVATE_KEY in plain text                    │
+└─────────────────────────────────────────────────────────┘
+
+Operator machines: deployer PRIVATE_KEY, OWNER_KEY,
+APP_BASIC_AUTH_PASSWORD, SSH key passphrase — in personal
+password managers (mixed vendors per operator).
+
+Hardware wallets: multisig Hot/Warm/Cold seeds.
+```
+
+### 3b. Vulnerabilities in current state
+
+| Vulnerability | Severity | Exploitation |
+|---|---|---|
+| `SIGNER_PRIVATE_KEY` plain-text on disk | **High** | Any VPS root compromise → `cat backend.env` → forge verifications |
+| `AUTH_JWT_SECRETS` HMAC + symmetric | **High** | Vault leak OR env-file leak = anyone can mint admin JWTs |
+| No CI secret scanning, no pre-commit hooks | Medium | Accidental commit lands in repo; remediation is "force-push and rotate" |
+| Long-lived `ADMIN_JWT` GitHub secret | Medium (UX + audit gap) | Just bit us — token expired, no mint script, smoke blocked |
+| No expiry tracking | Medium | Vendor tokens rot silently; ops scripts fail at the worst time |
+| GitHub Actions: any admin can read secrets via deploy-time injection | Medium | Compromised workflow change → secrets exfiltrate to attacker-controlled endpoint |
+
+---
+
+## 4. Target state architecture (Tier 2.5)
+
+### 4a. Where each secret class lives after migration
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ 1Password Business                                              │
+│   Averray/Production/Backend       ← runtime secrets only       │
+│   Averray/Production/Indexer       ← indexer-only secrets       │
+│   Averray/Production/CI            ← deploy creds (SSH keys)    │
+│   Averray/Production/External      ← vendor API tokens          │
+│   Averray/Production/Critical      ← AWS root creds, etc.       │
+│   Averray/Testnet/{Backend,Indexer,CI,External,Critical}        │
+│   Averray/Multisig                 ← signer ADDRESSES only,     │
+│                                       never seeds               │
+│   Averray/Operators/<name>         ← per-operator personal      │
+│   Averray/Archive                  ← decommissioned secrets     │
+│                                                                 │
+│  Read access via FOUR distinct service accounts                 │
+│  (each scoped to one vault):                                    │
+│    prod-ci-deploy   → only Averray/Production/CI                │
+│    prod-vps-backend → only Averray/Production/Backend +         │
+│                              Averray/Production/External        │
+│    prod-vps-indexer → only Averray/Production/Indexer           │
+│    prod-smoke-tests → only Averray/Production/CI (admin JWT)    │
+│  (plus testnet equivalents)                                     │
+└─────────────────────────────────────────────────────────────────┘
+            │                          │
+            │ op:// URI                │ 1password/load-secrets-action
+            ▼                          ▼
+┌────────────────────────────┐ ┌──────────────────────────────────┐
+│ VPS at deploy              │ │ GitHub Actions workflow runtime  │
+│ /etc/agent-stack/op-       │ │   Only OP_*_TOKEN secrets in     │
+│   {backend,indexer}.env    │ │   GitHub repo settings.          │
+│ Renders env to tmpfs:      │ │   Each job pulls only what it    │
+│ /run/agent-stack/*.env     │ │   needs from 1Password.          │
+│ chmod 0400 root:root       │ │   Production deploy gated by     │
+│ Excluded from backups      │ │   GitHub Environment with        │
+└────────────────────────────┘ │   required reviewers.            │
+                               └──────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│ AWS KMS                                                         │
+│   secp256k1 key (asymmetric, SIGN_VERIFY)                       │
+│     → multi-region for mainnet (can't convert later!)           │
+│   region(s): primary + ≥1 replica                               │
+│   IAM access for sign:                                          │
+│     → VPS: IAM Roles Anywhere (X.509-based temporary creds)     │
+│     → GitHub Actions: GitHub OIDC → assume role                 │
+│     → no long-lived IAM access keys for the signer principal    │
+│   IAM policy restrictions:                                      │
+│     kms:Sign + kms:GetPublicKey only                            │
+│     condition: kms:SigningAlgorithm = ECDSA_SHA_256             │
+│     condition: kms:MessageType = DIGEST                         │
+└─────────────────────────────────────────────────────────────────┘
+            │
+            │ AwsKmsSigner ethers.js adapter
+            ▼
+┌─────────────────────────────────┐
+│ Backend on VPS                  │
+│  - never holds signer private   │
+│    key bytes                    │
+│  - holds X.509 client cert      │
+│    for IAM Roles Anywhere; uses │
+│    it to fetch short-lived STS  │
+│    credentials                  │
+└─────────────────────────────────┘
+
+Hardware wallets — UNCHANGED. Multisig signer seeds NEVER touch
+1Password.
+```
+
+### 4b. Trust boundaries
+
+| Boundary | What's on each side | Compromise of one means... |
+|---|---|---|
+| 1Password vault ↔ runtime | Vault stores plain values; runtime fetches via per-runtime scoped service tokens | A scoped token leak = read access to ONE vault scope only (e.g., prod-ci-deploy token leak ≠ access to Backend secrets) |
+| AWS KMS ↔ backend | KMS holds private key bytes; backend gets temporary creds via Roles Anywhere | Compromise of running backend = ability to sign for ≤1h until temp creds expire; CANNOT export key |
+| GitHub Actions ↔ AWS | GitHub OIDC → AssumeRole; no long-lived AWS creds in GitHub | Compromise of GitHub workflow = ability to assume role only while exploit is active; revoking trust relationship in IAM stops it |
+| GitHub Actions ↔ VPS | Production deploy gated by GitHub Environment with required reviewers + restricted branches | Compromised workflow PR cannot deploy without a human approval gate |
+
+### 4c. What attacks this defends against (vs current state)
+
+| Attack | Tier 1 (current) | Tier 2.5 (target) |
+|---|---|---|
+| VPS root compromise | Reads SIGNER_PRIVATE_KEY directly + every backend env value | Can call kms.sign **while STS creds are valid (≤1h)**; CANNOT export key. Can read CURRENT backend env from tmpfs; restart = re-render from vault (and rotating one OP token kills future reads). CloudTrail surfaces the abuse. |
+| GitHub Actions compromised | All 9 GH secrets exposed | Only the OP service-account tokens scoped to CI are exposed. Production deploy still blocked by Environment review. Rotating one OP token = ~minutes. |
+| Operator laptop stolen (with disk encryption) | Maybe nothing if 1Password locked; otherwise everything | Same. Operator revokes their 1Password session + rotates affected service tokens. All keys still in vault and KMS. |
+| Operator laptop stolen (no disk encryption) | Catastrophic | Catastrophic. **Disk encryption is non-negotiable.** |
+| Secret accidentally committed to repo | Visible in commit; manual cleanup; **may already be public** | Pre-commit hook blocks at write time; GitHub push protection blocks at push time; CI gitleaks as last-resort sweep. |
+| Vendor token expires unattended | Smoke fails at runtime | Calendar warns ≥7 days out via CI. |
+| Insider threat (single operator) | Operator can do anything | Operator can do anything — mitigation is a second operator with separation of duties, **out of scope for this plan but required for mainnet.** |
+
+---
+
+## 5. Phase-by-phase security analysis
+
+### Phase 1 — 1Password Business setup + multiple service accounts
+
+**Goal**: Provision 1Password Business with vault structure +
+multiple scoped service accounts. No runtime changes yet.
+
+**What changes**:
+- A new SaaS provider holds copies of secrets that already exist on disk.
+- Vault structure separates per-environment (testnet vs production) and
+  per-runtime (CI vs VPS-backend vs VPS-indexer vs smoke).
+
+**Service account scoping** (the key architectural call):
+
+| Service account | Read access | Used by |
+|---|---|---|
+| `prod-ci-deploy` | `Averray/Production/CI` | GitHub Actions deploy workflow |
+| `prod-vps-backend` | `Averray/Production/Backend` + `External` | Backend VPS at deploy time (`op inject`) |
+| `prod-vps-indexer` | `Averray/Production/Indexer` | Indexer VPS at deploy time |
+| `prod-smoke-tests` | `Averray/Production/CI/admin-jwt` only | Hosted product-proof smoke runs |
+| (testnet equivalents) | corresponding `Averray/Testnet/*` | testnet workflows |
+
+**Service account access and vault permissions are effectively
+immutable after creation** — design scopes correctly up front. If
+you need to change a scope, generate a new token with the right
+scope and rotate.
+
+**1Password's service-account token is NOT "just an API token"**.
+It includes account-unlock material serialized into the token; treat
+it as a vault decryption capability for its scoped vaults. Per
+1Password's own docs, protection of the token is the customer's
+responsibility.
+
+**New attack surfaces**:
+- The 1Password account itself (master password + Secret Key + recovery kit).
+- Each service account token = scoped vault-decryption capability.
+
+**Specific risks during this phase**:
+1. **Master password reuse** → unique-password requirement, recovery
+   kit printed and stored offline, hardware MFA (YubiKey, not TOTP) on
+   the 1Password admin account.
+2. **Token leak in setup** → service tokens go directly into 1Password
+   itself for storage; never traverse Slack, email, or other channels.
+3. **Over-scoped service accounts** → use the four-token split above.
+   If you find yourself wanting one token to read everything, that's a
+   sign the architecture is wrong, not that the constraint is wrong.
+4. **Cross-environment contamination** → separate vaults per env
+   (`Averray/Testnet/*` vs `Averray/Production/*`). Service accounts
+   never have access to both.
+
+**Pre-flight checks**:
+- [ ] Unique master password (verified against personal password manager strength check)
+- [ ] Recovery kit printed and stored offline
+- [ ] Hardware MFA (YubiKey) enabled on the 1Password admin account, not just TOTP
+- [ ] Disk encryption verified on every device that will use 1Password
+- [ ] Vault structure created with the per-env / per-runtime separation
+
+**Post-flight verification**:
+- [ ] All ~70 secrets from `SECRETS.md` inventory present
+- [ ] Each service account can read ONLY its scoped vault (verify by
+  attempting reads on out-of-scope vaults; must fail with permission
+  error)
+- [ ] Test rotation: change one item, fetch via `op read` with each
+  service account, confirm only the in-scope account succeeds
+- [ ] Service account usage logs (1Password Events API) are visible
+  and tied to a SIEM or log store if longer retention than the
+  default 365 days is needed
+
+**Rollback safety**: 100% safe. Nothing depends on 1Password yet.
+
+---
+
+### Phase 2 — Sync vault → runtime (with runtime hardening)
+
+**Goal**: Deploy script reads from 1Password instead of static env
+files. CI workflows reference `op://` URIs instead of `${{ secrets.* }}`.
+
+**Honest framing of what changes** (corrected from v1):
+- Source-of-truth and manual-distribution problem: **solved**.
+- Runtime plaintext: **still present** — once `op inject` renders
+  `backend.env`, the VPS has plaintext runtime secrets on disk
+  again. A VPS root compromise still reads them.
+- KMS migration (Phase 3) is the layer that removes the most valuable
+  runtime plaintext (the signer key). Phase 2 alone does not.
+
+**Runtime hardening additions** (new in v2):
+- Render env files to **tmpfs** at `/run/agent-stack/*.env` (cleared on reboot)
+- `chmod 0400`, `chown root:agent-stack-service`
+- Exclude `/run/agent-stack/*` and `/srv/agent-stack/*.env*` from
+  backups and snapshots
+- Disable core dumps for the backend process (`prlimit --core=0`)
+- Backend process drops privileges to a non-root user after reading
+  env at startup
+- Audit: `journalctl`, `docker inspect`, `/proc/$pid/environ` should
+  show no plaintext secrets after a deploy
+
+**New attack surfaces**:
+- Each per-runtime service-account token on its target host
+- The `op inject` template files (committed) reveal what secrets
+  exist and where they're consumed — not the values
+
+**Specific risks**:
+1. **Botched render writes secrets to logs** → wrap `op inject` to write
+   only to destination, never `echo` rendered content, restrict deploy
+   logs to private CI logs only
+2. **Service-account token leak from VPS** → token has read-only scope
+   to ONE vault. Token has a documented rotation cadence of ≤90 days
+   (set this as policy; verify your account's max lifetime). Audit
+   logs reviewed weekly. Alert on unusual access patterns via the
+   1Password Events API.
+3. **GitHub Actions OP_*_TOKEN replay via malicious workflow PR** →
+   production environment protection + branch restrictions + required
+   reviewers prevent unreviewed workflow changes from running
+4. **Race conditions during rotation** → atomic per-template render;
+   rotate during deploy windows, not mid-deploy
+
+**Pre-flight checks**:
+- [ ] All secrets from Phase 1 are in vault and scoped correctly
+- [ ] Each service-account token tested manually with `op read`
+- [ ] Old plain-text env files backed up offline before any deploy
+  uses the new path
+- [ ] Branch protection on workflows (require code review + status
+  checks)
+- [ ] Backups configured to exclude rendered env paths
+
+**Post-flight verification**:
+- [ ] `diff` between old plain-text env and newly rendered env: zero
+  unexpected differences
+- [ ] Deploy logs contain no secret values (grep for first 8 chars of
+  any sensitive value: expect zero hits)
+- [ ] `journalctl -u agent-stack`, `docker inspect agent-stack`,
+  `cat /proc/$(pgrep -f backend)/environ | tr '\0' '\n'` — zero
+  plaintext secret hits (not just hex-pattern matches; check for
+  symbol-named env vars too)
+- [ ] Test rotation: change a secret in 1Password → redeploy → new
+  value reaches running backend (confirm via `/health` or
+  `/admin/status` where exposed)
+
+**Rollback safety**: Per-secret rollback by copying value back to the
+old location. Per-phase rollback by reverting deploy script +
+workflow PRs.
+
+---
+
+### Phase 3 — KMS for backend signer (with temporary credentials)
+
+**This is the biggest security upgrade in the plan.**
+
+**Goal**: Remove the signer private key from all on-disk and in-vault
+locations. Backend signs via KMS API using temporary credentials.
+
+**Sub-phases**:
+- **3a**: KMS key creation (asymmetric, secp256k1, multi-region for
+  mainnet)
+- **3b**: Adapter integration into backend
+- **3c**: Replace long-lived IAM access keys with temporary
+  credentials via IAM Roles Anywhere (for VPS) + GitHub OIDC (for
+  Actions, if needed)
+- **3d**: Testnet validation
+- **3e**: Mainnet cutover (in Phase 5)
+
+**Multi-region KMS for mainnet** — *create the mainnet key as
+multi-region from day one*. AWS does not allow converting a
+single-region key to multi-region later. Cost is $1/key/replica/month;
+operational complexity is real (failover testing, equivalent policies
+per replica, equivalent CloudWatch alarms per replica) but the
+inability to add regions later is the real driver. For testnet,
+single-region is fine.
+
+**KMS spec**:
+- `KeyUsage`: `SIGN_VERIFY`
+- `KeySpec`: `ECC_SECG_P256K1`
+- Adapter MUST pass already-hashed messages with `MessageType=DIGEST`
+  (otherwise KMS hashes the input again and recovery breaks)
+- `SigningAlgorithm`: `ECDSA_SHA_256` (the only secp256k1 algo supported)
+
+**IAM policy** (the principal that calls Sign):
+- Actions: `kms:Sign` + `kms:GetPublicKey` ONLY
+- Resource: the specific Key ARN
+- Conditions:
+  - `kms:SigningAlgorithm = ECDSA_SHA_256`
+  - `kms:MessageType = DIGEST`
+- Explicit deny on `kms:ScheduleKeyDeletion`, `kms:DisableKey`,
+  `kms:PutKeyPolicy`, `kms:CreateGrant`, `kms:ReplicateKey`,
+  `kms:UpdatePrimaryRegion` for this principal
+
+**Temporary credentials, not long-lived IAM keys** (corrected from v1):
+- **VPS**: IAM Roles Anywhere. Provision a private CA (AWS ACM-PCA or
+  self-managed), create a Trust Anchor in IAM with that CA, create a
+  Profile referencing the signer role, issue an X.509 client cert to
+  the VPS. Backend uses the cert to call STS and obtain temporary
+  credentials (≤1h lifetime). Rotates automatically.
+- **GitHub Actions** (if any workflow needs AWS access): configure
+  GitHub as an OIDC provider in IAM; AssumeRoleWithWebIdentity from
+  the workflow; ≤1h credentials per job.
+
+If you must start with static IAM keys (e.g., during early testnet
+setup), make that an explicit residual risk with a removal date.
+
+**Specific risks**:
+
+1. **AWS root account compromise** → use root only for billing and
+   initial IAM setup; never log in as root daily; hardware MFA
+   (YubiKey) on root; recovery info printed offline.
+2. **Roles Anywhere trust anchor compromise** → if the CA private key
+   leaks, attacker can mint client certs and impersonate the VPS.
+   Store CA private key in AWS ACM-PCA (best) or, if self-managed,
+   in an HSM. Never on disk.
+3. **CloudTrail KMS event exclusion** → CloudTrail can be configured
+   to exclude KMS events from a trail. Verify your trail explicitly
+   includes them. Verify in CloudTrail Insights as well.
+4. **KMS key deletion** → IAM principal does NOT have
+   `kms:ScheduleKeyDeletion`. Alert on the event regardless (admin
+   IAM users still have it). Deletion makes the key unusable
+   immediately upon scheduling, well before the 7–30 day final
+   destruction window — alert pre-emptively.
+5. **Multi-region replica drift** → policies, aliases, monitoring,
+   and alarms must be replicated to every region. Add to the post-
+   flight checklist.
+6. **"Dark side of the curve" (high-s)** → Ethereum's Homestead
+   changes made `s > secp256k1n/2` invalid. The adapter must
+   canonicalize. Don't write your own adapter; pick a vetted one
+   (`@rumblefishdev/eth-signer-kms` or `ethers-aws-kms-signer`).
+   **Test** with a known-digest sign + recover, not just adopt.
+7. **Replay across contracts/environments** → backend-signed messages
+   MUST carry domain separation: chain ID, contract address,
+   environment label, purpose, job/dispute ID, expiry, nonce. This
+   is not KMS-specific but the migration is the right time to make
+   sure it's in place.
+
+**Non-negotiable KMS adapter tests**:
+- Derive EVM address from `GetPublicKey`; matches expected on-chain verifier
+- Sign a known digest through KMS
+- Parse the ECDSA signature into r, s
+- Canonicalize high-s signatures
+- Compute the correct recovery id / v
+- Recover and verify the expected signing address
+- Repeat over ≥1000 distinct messages (not one) — the low-s case
+  manifests probabilistically
+
+**KMS key rotation is NOT routine** (corrected from v1):
+> "KMS signer key rotation is an on-chain signer migration event, not
+> a routine calendar rotation. IAM/STS credentials rotate frequently;
+> the KMS key rotates only through a planned verifier update via
+> multisig."
+
+AWS KMS does not support automatic key rotation for asymmetric keys.
+Don't put the KMS key in the secrets-calendar with a 90-day rotation
+target — that's wrong.
+
+**CloudWatch alarms** (must verify each fires with a synthetic event
+before going to mainnet):
+- `kms:ScheduleKeyDeletion`
+- `kms:DisableKey`
+- `kms:PutKeyPolicy`
+- `kms:CreateGrant`
+- `kms:ReplicateKey` (multi-region)
+- `kms:UpdatePrimaryRegion` (multi-region)
+- Unusual Sign volume (e.g., >10x baseline)
+- Sign requests from unusual source IPs/ASNs
+- Any activity by root or admin IAM principals
+
+**Pre-flight checks**:
+- [ ] AWS account exists with hardware-MFA on root
+- [ ] KMS key created with correct spec (test on testnet first)
+- [ ] For mainnet: key is multi-region from day one
+- [ ] IAM Roles Anywhere trust anchor configured; client certs issued
+- [ ] IAM policy includes both action restrictions AND condition keys
+- [ ] CloudTrail confirmed to include KMS events
+- [ ] All CloudWatch alarms configured with notification targets
+
+**Post-flight verification**:
+- [ ] EVM address derived from KMS public key matches the on-chain
+  verifier (cross-checked with `audit-launch-readiness.mjs`)
+- [ ] All KMS adapter tests pass over ≥1000 messages
+- [ ] Process listing on VPS contains no `0x[a-f0-9]{60}` signer key
+  patterns AND no env var with name matching `*PRIVATE*` /
+  `*SECRET*` referencing the signer key
+- [ ] Synthetic CloudWatch alarm fires (e.g., temporarily call
+  `DisableKey` from an admin session and confirm the alarm notifies)
+- [ ] Hosted product-proof smoke passes end-to-end via KMS signer
+- [ ] Revoking the IAM principal's session (or the Roles Anywhere
+  trust anchor's profile) breaks signing as expected — proves the
+  backend really uses temp creds
+
+**Rollback safety**:
+- **Testnet**: keep the `SIGNER_PRIVATE_KEY` env path as a fallback
+  for one full deploy cycle. After confirming KMS path works, remove
+  the fallback and rotate the testnet key so it's no longer valid.
+- **Mainnet**: **NO raw-key fallback**. Fallback is a multisig-
+  controlled signer migration (call `setVerifier(newAddress, true)`)
+  or a temporary pause via the pauser key. Keeping a valid raw
+  private key alive on mainnet undermines the entire migration.
+
+---
+
+### Phase 4 — Hardening
+
+Five additions; each independent.
+
+**4a. Pre-commit + pre-push secret scanning**
+- Local pre-commit hook running `gitleaks` (catches before push)
+- Enable GitHub **Secret Scanning push protection** with custom
+  patterns (catches at push, regardless of local hooks)
+- CI `gitleaks` job (catches as last-resort sweep)
+- Defense in depth: local catches first, push protection catches if
+  hooks are bypassed, CI catches if push protection misses a pattern
+
+**4b. Asymmetric JWT signing via KMS**
+
+This is the architectural upgrade that removes "vault leak = mint
+admin JWTs" as a single point of failure. Today `AUTH_JWT_SECRETS`
+is an HMAC secret stored in the vault and on every backend instance.
+A vault breach OR a backend env breach means an attacker can mint
+admin JWTs.
+
+**Target design**:
+- KMS-managed asymmetric key (e.g., RSA-2048 or ES256) signs access
+  tokens at issuance / refresh time
+- Backend services verify locally with the **public** key (does NOT
+  need access to the signing key)
+- Tokens carry `kid` (key ID for rotation), `iss`, `aud`, `sub`,
+  `role`, `jti`, `iat`, `nbf`, `exp`
+- Access tokens: short TTL (≤1h)
+- Refresh tokens: **opaque random values** (not signed JWTs), stored
+  server-side as hashes, rotated on every use, revoked on replay
+  detection
+
+After this change, a vault leak no longer allows JWT minting. Only
+a KMS principal compromise does — and KMS protection is identical
+to the signer-key protection from Phase 3.
+
+If migrating fully to asymmetric JWTs is too much work pre-mainnet,
+the minimum hardening for the HMAC path is:
+- Key ring with `kid` rotation
+- Short access-token TTLs (≤15 min)
+- Documented two-key rotation window with old-key tolerance period
+- Refresh tokens are opaque random values, hashed server-side
+
+**4c. Calendar-driven CI checks** (already shipped in PR #225)
+- `scripts/ops/check-secrets-calendar.mjs` runs on every CI build
+- Warns ≥7 days before expiry, fails on past-expiry
+- All entries other than KMS signer key (see Phase 3 — that's an
+  on-chain migration, not calendar-tracked)
+
+**4d. GitHub Actions hardening**
+- Top-level `permissions: read-all` on workflows; elevate per job
+- Pin all third-party actions to commit SHA (not tag)
+- Avoid `pull_request_target` with secrets unless workflow is
+  extremely constrained
+- Never inject OP service tokens into build/test jobs
+- Require review for workflow file changes (branch protection)
+- Use **GitHub Environments** with required reviewers for production
+  deploys; `OP_SERVICE_ACCOUNT_TOKEN` only available to jobs that
+  reference the protected environment
+
+**4e. Hardware MFA across the admin trust chain**
+- 1Password admin account
+- AWS root + admin IAM users
+- GitHub org admin
+- Domain registrar account
+- VPS provider account
+
+Treat YubiKey as mainnet baseline, not nice-to-have. ~$50/operator.
+
+**Post-flight verification for Phase 4**:
+- [ ] Gitleaks rules tested against a synthetic bad-PR (a secret-shaped string blocks the PR)
+- [ ] GitHub push protection enabled and tested
+- [ ] Asymmetric JWT flow validated end-to-end on testnet (or, if
+  deferred, the HMAC hardening checklist above is complete)
+- [ ] Calendar check runs on every CI build
+- [ ] All workflow files use SHA-pinned actions
+- [ ] Production deploy attempt without reviewer approval is blocked
+- [ ] Hardware MFA verified on every admin account in the trust chain
+
+---
+
+### Phase 5 — Mainnet cutover
+
+**The biggest risk: re-using ANY secret between testnet and mainnet.**
+
+**Old secrets cleanup** (new in v2): before cutover, rotate or
+revoke any value that ever lived in:
+- GitHub Actions secrets
+- Local password managers
+- Shell history
+- Old VPS env files
+- CI logs
+- Backups
+- Test deploys
+
+If a value was ever copy-pasted, assume it's compromised and don't
+reuse it on mainnet — even if no leak is known.
+
+**Pre-flight checklist** (the day before):
+- [ ] All four prior phases live and stable on testnet for ≥7 days
+- [ ] Audit script (`audit-launch-readiness.mjs`) shows zero drift
+  between testnet and planned mainnet config
+- [ ] OP service account tokens for production rotated within the
+  last 30 days
+- [ ] AWS KMS key for mainnet created **multi-region from day one**;
+  IAM access via Roles Anywhere only (no static keys); separate IAM
+  user from testnet
+- [ ] Multisig signer set established with **fresh seeds** —
+  do not reuse testnet seeds
+- [ ] All vendor accounts have separate mainnet API keys
+- [ ] On-call rotation defined in `INCIDENT_RESPONSE.md` Section 1
+- [ ] Incident drills run for: OP token leak, AWS signer credential
+  leak, JWT signing key leak, VPS root compromise
+
+**Cutover sequence** (in `SECRETS_MIGRATION.md`):
+1. Generate fresh secrets
+2. Provision multisig with fresh signer seeds
+3. Deploy contracts with multisig as owner from line 1
+4. Update `deployments/mainnet.json`
+5. Update env templates to reference mainnet vault items
+6. Run smoke
+7. Archive testnet vault read-only
+
+**Post-cutover verification**:
+- [ ] Audit script green on mainnet
+- [ ] Calendar check shows zero entries within 7 days of expiry
+- [ ] Hosted product-proof smoke passes 3 consecutive runs on mainnet
+- [ ] No secret appears in any log file, process listing, or
+  rendered env file checksum
+- [ ] On-call rotation tested with a synthetic alert
+- [ ] No raw `SIGNER_PRIVATE_KEY` value exists anywhere in any
+  mainnet vault, env file, backup, or operator's machine
+
+**Rollback safety**: For mainnet, "rollback" = abort before going
+live, not unwind after. Once contracts are deployed and the multisig
+is set, you live with them. **This is why phases 1–4 must be stable
+on testnet first.**
+
+---
+
+## 6. Key risks I want you to scrutinize
+
+These are intentional architectural trade-offs. Validate each:
+
+### 6a. Multiple 1Password service tokens = multiple compromise paths
+
+We split into 4–5 service accounts to reduce blast radius per token.
+The trade-off: more tokens to rotate, more audit-log streams to
+monitor, more rotation reminders.
+
+**Why I think it's net positive**: Each token leak is bounded to one
+vault scope. The audit log shows access per token, making forensics
+faster. Rotation of one token doesn't disrupt other runtimes.
+
+**What to verify**:
+- 1Password Business audit log retention is 365 days (not 90 as
+  earlier drafts claimed)
+- Service account usage logs are enabled in your tenant
+- Token rotation cadence is operationally feasible — if rotation is
+  too painful, operators will drag their feet
+
+### 6b. AWS Roles Anywhere CA private key is now a high-value target
+
+By moving away from long-lived IAM access keys, we introduce a new
+single point of compromise: the trust anchor's CA private key. If
+that leaks, attacker can mint client certs and impersonate the VPS.
+
+**Why I think it's net positive**: Static IAM keys leak via OS-level
+compromise, environment dumps, backups, etc. CA private keys, if
+stored in AWS ACM-PCA, never leave AWS HSMs. If self-managing the
+CA, the private key MUST live in an HSM (CloudHSM, YubiHSM, or a
+hardware-backed TPM) — never on disk.
+
+**What to verify**:
+- Decide whether AWS ACM-PCA or self-managed CA. ACM-PCA is more
+  expensive (~$400/month) but easier to operate. For our scale,
+  worth checking the actual cost calculator.
+- If self-managed: explicitly document where the CA private key lives
+  and who has access
+
+### 6c. Multi-region KMS doubles ops complexity
+
+Each region needs its own alarms, IAM policy verification, replica
+key health checks. If one region's policy drifts from the other,
+some sign calls succeed where others fail mysteriously.
+
+**Why I think it's net positive for mainnet**: A single region
+outage on mainnet means user-facing downtime. The cost is small
+(~$1/region/month). The operational discipline is forced regardless
+by the on-chain consequences.
+
+**What to verify**:
+- Test failover at deploy time (kill primary region temporarily,
+  confirm backend falls back to replica region)
+- Document the failover runbook
+- Equivalent policies on every replica
+
+### 6d. The asymmetric JWT migration is non-trivial code
+
+Phase 4b is the largest implementation change in the plan. Backend
+code changes, frontend (if any) verifies differently, refresh token
+flow needs server-side state for replay detection.
+
+**Why I think it's worth doing for mainnet**: A vault breach
+becoming "attacker can mint admin JWTs forever" is a real fork in
+the road. With asymmetric JWTs, the same breach requires also
+breaching KMS — defense in depth.
+
+**Honest pushback opportunity**: if the engineering cost of
+asymmetric JWTs is too high pre-mainnet, accept HMAC + the minimum
+hardening (key ring + short TTL + opaque refresh tokens) as a
+documented residual risk. Just don't pretend the residual isn't
+there.
+
+### 6e. Insider threat with single operator is structurally unmitigated
+
+If you're the only operator, you have all keys to the kingdom in
+one human's hands.
+
+**What to do for mainnet**:
+- Add a second human with operator privileges, even part-time
+- Require 2-of-2 (or 2-of-N) for high-impact operations: deploying
+  contract changes, rotating multisig signers, revoking IAM trust
+  anchors
+- 1Password Business approval workflows: turn them on
+
+This is partially out of scope for a secrets plan (it's an
+org-design issue), but it's the **biggest non-technical risk in
+this document**.
+
+---
+
+## 7. Things I'm NOT confident about
+
+Areas where I'd defer to a human security expert before mainnet:
+
+1. **Exact cipher choices for the JWT refresh-token flow**. Concept
+   is clear; implementation needs review by someone who's done it
+   before.
+2. **IAM Roles Anywhere CA model choice** (ACM-PCA vs self-managed
+   with HSM). Strong opinions exist; I don't have one.
+3. **Domain separation for backend-signed messages** — what exactly
+   to include (chain ID, contract, environment, purpose, job ID,
+   nonce, expiry). Get a contract auditor's input.
+4. **CloudWatch alarm thresholds for KMS**. I said ">10x baseline";
+   the right numbers depend on your actual traffic.
+5. **Whether `gitleaks` rules cover everything**. Custom secret
+   patterns may need custom rules.
+6. **AWS multi-region failover semantics under partial outage**.
+   E.g., what happens if the primary region is degraded but not
+   fully down? Test before mainnet.
+7. **Whether opaque-hashed refresh tokens are enough** vs. requiring
+   client-bound tokens (e.g., DPoP). For our trust model probably
+   yes, but worth confirming.
+
+---
+
+## 8. Recommendations BEYOND this plan
+
+| Recommendation | Why | Approximate cost |
+|---|---|---|
+| Third-party contract audit | This plan covers secrets, not contract logic | $20k–$100k+ |
+| Bug bounty program | Catches what audits miss post-deploy | $500–$5000+ in rewards budget |
+| Pen test of operator surface | Specifically: can an attacker pivot from one wallet seed to anything else? Can basic-auth on `app.averray.com` be bypassed? | $5k–$15k for 1-week |
+| Hardware key for ALL admin accounts (1Password, AWS, GitHub, registrar, VPS provider) | TOTP can be phished; FIDO2 cannot | ~$50/operator |
+| Documented incident drills (quarterly) | "Pretend SIGNER_PRIVATE_KEY just leaked. What do you do in the next 60 minutes?" | Free, ~2 hours each |
+| SIEM / log aggregation | Audit logs only matter if you can query them. 1Password Events API → SIEM is the standard pattern | Variable |
+
+---
+
+## 9. Verification checklist (for the security reviewer)
+
+Before signing off:
+
+1. Walk through every secret in `SECRETS.md` and identify where it
+   lives in target architecture (vault entry + access path).
+2. For each phase, identify what stops working if the phase is
+   reverted.
+3. Confirm the IAM policy for the signer principal doesn't allow
+   anything beyond `kms:Sign` + `kms:GetPublicKey` on one specific
+   key ARN, with `kms:SigningAlgorithm` and `kms:MessageType`
+   conditions.
+4. State rotation cadence for each high-risk secret. The KMS signer
+   key is **not** in this list — its rotation is an on-chain
+   migration.
+5. Confirm multisig signer seeds live unchanged (never in 1Password).
+6. Articulate threat model assumptions and which assumptions, if
+   violated, break the plan.
+7. Confirm Phase 2's runtime-plaintext claim is bounded (rendered
+   env files DO exist on disk; KMS removes the most valuable one).
+8. Confirm Phase 3 mainnet path has NO raw private-key fallback.
+
+---
+
+## 10. Open questions for the operator
+
+These need explicit decisions before phase execution:
+
+1. **Multi-region KMS for mainnet**: yes (recommended) or no?
+   Decision must be made before mainnet key creation — cannot
+   convert later.
+2. **Roles Anywhere CA**: AWS ACM-PCA (~$400/mo) or self-managed
+   with HSM?
+3. **Asymmetric JWT migration**: full migration in Phase 4 or
+   accept HMAC + hardening as residual risk?
+4. **Second operator**: who, when?
+5. **Hardware key plan**: which model, who buys/distributes?
+6. **External audit/bug-bounty budget**: assigned?
+7. **Mainnet date**: locked? If under 30 days, defer or accept
+   compressed phases in writing.
+
+---
+
+## 11. Mainnet sign-off bar
+
+Before treating the system as launch-grade, every item below must be
+true. Each is a checkbox the security reviewer signs:
+
+- [ ] Separate 1Password service accounts per runtime per environment
+- [ ] No long-lived AWS IAM access key for the signer, OR a
+  documented temporary exception with a removal date
+- [ ] KMS signer tests proving: address derivation, low-s
+  canonicalization, recovery id, signature recovery (≥1000 messages)
+- [ ] Replay-resistant signed payloads with domain separation (chain
+  ID, contract, environment, purpose, ID, nonce, expiry)
+- [ ] GitHub production environment protection with required
+  reviewers and restricted branches
+- [ ] KMS CloudTrail/EventBridge alarms tested with synthetic events
+- [ ] Refresh-token flow reviewed with opaque hashed refresh tokens
+  and replay detection — OR documented HMAC-with-hardening residual
+- [ ] KMS signer key rotation documented as an on-chain migration,
+  not routine secret rotation
+- [ ] Testnet stable for ≥7 days after all phases live
+- [ ] Real incident drill executed for: OP token leak, AWS signer
+  credential leak, JWT signing key leak, VPS root compromise
+- [ ] No valid raw `SIGNER_PRIVATE_KEY` fallback for mainnet
+- [ ] Hardware MFA on every admin account in the trust chain
+- [ ] Second operator with separation of duties for high-impact
+  operations
+- [ ] Third-party contract audit complete
+
+---
+
+## 12. Cost summary
+
+| Item | Monthly cost |
+|---|---|
+| 1Password Business (1 user) | $7.99 |
+| 1Password Business (3 users, post-second-operator) | $23.97 |
+| AWS KMS testnet key (single region) | $1 + ~$0.15 per 10k sigs (~$1.05/mo) |
+| AWS KMS mainnet key (multi-region, 2 replicas) | $2 + ~$0.15 per 10k sigs (~$2.05/mo) |
+| AWS ACM-PCA (if used for Roles Anywhere) | ~$400 (consider self-managed CA + HSM for lower cost) |
+| AWS Roles Anywhere itself | $0 |
+| **Total at 1 user, testnet** | ~$9/mo (or $409/mo if ACM-PCA used) |
+| **Total at 3 users, mainnet** | ~$26/mo (or $426/mo if ACM-PCA used) |
+| **YubiKey hardware keys** | ~$50 × number of operators (one-time) |
+
+The real cost is engineering time for the migration (~5–7 working
+days spread over a few weeks).
+
+---
+
+## Revision history
+
+**v2** — Security review pass (this version)
+
+Substantive changes from v1:
+1. **Split 1Password service accounts by runtime** (Section 4a, 4b,
+   Phase 1). Four accounts per environment instead of one. Each
+   scoped to one vault, immutable post-creation.
+2. **Corrected 1Password audit-log retention** to 365 days (not 90).
+   Events API access is 120 days. Stream to SIEM for longer.
+3. **Replaced long-lived AWS IAM access keys with temporary
+   credentials** (Phase 3 + 4). IAM Roles Anywhere for VPS,
+   GitHub OIDC for Actions. No static keys for the signer
+   principal.
+4. **Clarified Phase 2's runtime-plaintext claim**. After Phase 2,
+   rendered env files DO exist on disk. Added tmpfs / chmod 0400 /
+   exclude-from-backups hardening.
+5. **Tightened KMS adapter test requirements** to include address
+   derivation, low-s canonicalization, recovery id computation, and
+   ≥1000-message round-trips. Added domain separation requirement
+   for signed payloads.
+6. **Reframed KMS key rotation** as an on-chain migration event, not
+   a calendar-tracked routine rotation. AWS does not support
+   automatic rotation for asymmetric keys.
+7. **Strengthened KMS IAM policy** with `kms:SigningAlgorithm` and
+   `kms:MessageType` condition keys. Expanded CloudWatch alarm list
+   beyond `ScheduleKeyDeletion`.
+8. **Multi-region KMS decision moved to design-time**. Can't convert
+   single-region to multi-region later — must decide at creation.
+9. **Reworked GitHub Actions section** with Environment protection,
+   required reviewers, restricted branches, SHA-pinned actions, top-
+   level read-only permissions.
+10. **Added pre-commit gitleaks and GitHub push protection** alongside
+    CI gitleaks. Defense in depth.
+11. **AUTH_JWT_SECRETS migration to asymmetric KMS-signed JWTs**
+    proposed in Phase 4b, with opaque hashed refresh tokens.
+    Alternative: HMAC + kid + short TTL as documented residual.
+12. **Removed raw private-key fallback for mainnet**. Testnet only.
+    Mainnet fallback = multisig-controlled signer migration.
+13. **Corrected 1Password incident note**: 2023 Okta-linked incident,
+    not "2022 breach".
+
+Smaller edits:
+- Backend never holds *signer private key bytes* (still holds AWS
+  credentials, even if temporary)
+- GitHub Actions compromise framing: scoped to per-job per-environment
+  tokens
+- Rate-limit checks added to smoke/load test expectations (1Password
+  service account quotas, KMS regional request quotas)
+- External vendor keys can become platform-impacting (softened
+  framing)
+- "Quantum cryptanalysis" replaced with simple "out of scope"
+- Added explicit old-secrets-cleanup step (Phase 5)
+- Added Section 11 — mainnet sign-off bar, with reviewer-checkable
+  items
+
+**v1** — Initial draft (delivered in chat, not committed)

--- a/docs/SECRETS_MIGRATION.md
+++ b/docs/SECRETS_MIGRATION.md
@@ -5,8 +5,15 @@ This doc is the operator's checklist for moving from where we are today
 managers) to where we need to be for mainnet (centralized vault for
 human-managed secrets + AWS KMS for the hottest cryptographic key).
 
-Read [`SECRETS.md`](SECRETS.md) first for the inventory. This doc
-assumes you're convinced *what* needs to move and just need the *how*.
+Read [`SECRETS.md`](SECRETS.md) first for the inventory. Read
+[`SECRETS_INTEGRATION_PLAN.md`](SECRETS_INTEGRATION_PLAN.md) for the
+security-review-grade design rationale, threat model, and mainnet
+sign-off bar.
+
+This doc assumes you're convinced *what* needs to move and just need
+the *how*. The phase structure has been revised in response to an
+external security review — significant changes vs. the v1 draft are
+flagged in context.
 
 The migration breaks into **5 phases** that can land independently. Each
 phase is mergeable on its own and reversible if something breaks. You
@@ -79,19 +86,58 @@ Required fields per item:
 - Tags: `production` / `testnet` / `ci` / `runtime`
 - Notes: link back to the inventory section in `SECRETS.md`
 
-### 1d. Provision a service account for runtime sync
+### 1d. Provision **four** scoped service accounts per environment
 
-This is the read-only credential that GitHub Actions and the VPS use to
-fetch secrets without a human signing in.
+**Revised in v2 per security review.** A single broadly-scoped service
+account is a single point of compromise. Split by runtime so a leaked
+token's blast radius is bounded to one vault scope.
+
+Service account access and vault permissions are **effectively
+immutable after creation** — design scopes correctly up front rather
+than assuming they can be tuned later.
+
+Treat each token as a vault-decryption capability for its scoped
+vaults, not as a low-value API token. Per 1Password's own docs,
+protection of the token is the customer's responsibility.
+
+#### Production accounts
+
+| Service account | Read access | Used by |
+|---|---|---|
+| `prod-ci-deploy` | only `Averray/Production/CI` | GitHub Actions deploy workflow |
+| `prod-vps-backend` | only `Averray/Production/Backend` + `Averray/Production/External` | Backend VPS `op inject` at deploy time |
+| `prod-vps-indexer` | only `Averray/Production/Indexer` | Indexer VPS `op inject` at deploy time |
+| `prod-smoke-tests` | only `Averray/Production/CI/admin-jwt` | Hosted product-proof smoke |
+
+#### Testnet equivalents
+
+Mirror the production split with `testnet-*` prefixes, scoped to the
+`Averray/Testnet/*` vaults. Testnet tokens MUST NOT have access to
+production vaults.
+
+#### Provisioning each token
 
 1. In 1Password admin: **Integrations → Service Accounts → New**
-2. Name: `averray-runtime-readonly`
-3. Vault access: **read-only** to `Averray/Production/*` and
-   `Averray/Testnet/*` (NOT to Multisig or Operators)
-4. Save the service account token in your personal 1Password vault as
-   `1password-runtime-token-production` — this is itself a secret
-5. Set up a calendar reminder to rotate this token every 90 days
-   (1Password's max for service accounts)
+2. Set name (e.g., `prod-ci-deploy`)
+3. Vault access: **read-only**, scoped to the single vault listed above
+4. Token expiration: set the maximum your account allows (1Password
+   exposes `--expires-in` on the CLI; document the cadence in your
+   account, ≤90 days target)
+5. Save the token in your personal 1Password vault (so the token
+   itself never leaves 1Password)
+6. Add a calendar reminder in [`SECRETS_CALENDAR.yml`](SECRETS_CALENDAR.yml)
+   for token rotation
+
+#### Audit logging
+
+- 1Password Business retains audit events for **365 days** (corrected
+  from the earlier "90 days" claim; the Events API exposes the last
+  **120 days**).
+- Stream the Events API output to a SIEM or log store if you need
+  longer retention or proactive alerting.
+- Build alerts off **service account usage logs** (item-level access)
+  rather than only account-level audit events — those show the
+  vaults and items each token reads.
 
 ### Phase 1 done = exit criteria
 
@@ -109,11 +155,23 @@ away if the team decides to use a different tool.
 
 ---
 
-## Phase 2 — Sync vault → runtime
+## Phase 2 — Sync vault → runtime (with runtime hardening)
 
-This is where the actual win lives. After this phase, rotating a secret
-= update one entry in 1Password, redeploy. No more "did I update GitHub
-Actions AND the VPS env file?".
+This is where rotation discipline lives. After this phase, rotating a
+secret = update one entry in 1Password, redeploy. No more "did I update
+GitHub Actions AND the VPS env file?".
+
+**Honest framing** (revised in v2 per security review): Phase 2 does
+**NOT** remove runtime plaintext from the VPS. Once `op inject`
+renders `backend.env`, the host has plaintext secrets on disk again.
+A VPS root compromise can still read them. The KMS migration in
+Phase 3 is what removes the most valuable runtime plaintext (the
+signer key). Phase 2 alone gives you single-source-of-truth
+discipline and audit logs, not full runtime confidentiality.
+
+To minimize the runtime-plaintext surface during Phase 2, follow the
+hardening steps in 2d below (tmpfs, chmod 0400, exclude from
+backups).
 
 ### 2a. Install `op` CLI on the VPS
 
@@ -133,16 +191,30 @@ apt update && apt install -y 1password-cli
 
 Verify: `op --version`.
 
-### 2b. Set the service account token
+### 2b. Set the runtime-scoped service account tokens
+
+**Use the per-runtime tokens from Phase 1.** Each VPS service reads
+from only its scoped token. Two separate env files (per env) — the
+backend service should never have access to the indexer token, and
+vice versa.
 
 ```bash
-# on the VPS
-echo 'export OP_SERVICE_ACCOUNT_TOKEN="ops_..."' >> /etc/agent-stack/op.env
-chmod 600 /etc/agent-stack/op.env
+# on the VPS — backend
+echo 'export OP_SERVICE_ACCOUNT_TOKEN="ops_prod-vps-backend_..."' \
+  >> /etc/agent-stack/op-backend.env
+chmod 600 /etc/agent-stack/op-backend.env
+chown root:root /etc/agent-stack/op-backend.env
+
+# on the VPS — indexer
+echo 'export OP_SERVICE_ACCOUNT_TOKEN="ops_prod-vps-indexer_..."' \
+  >> /etc/agent-stack/op-indexer.env
+chmod 600 /etc/agent-stack/op-indexer.env
+chown root:root /etc/agent-stack/op-indexer.env
 ```
 
-The `op` CLI auto-detects this env var and uses it for all subsequent
-commands.
+The `op` CLI auto-detects `OP_SERVICE_ACCOUNT_TOKEN`. Source the
+relevant file before each `op inject` call so each service sees only
+its own scoped token.
 
 ### 2c. Convert `backend.env` to a template
 
@@ -161,44 +233,104 @@ as `/srv/agent-stack/backend.env.template`.
 + PIMLICO_BUNDLER_URL=op://Averray/Production/External/pimlico-bundler-url/credential
 ```
 
-### 2d. Render at deploy time
+### 2d. Render at deploy time (with hardening)
 
-Add to `scripts/ops/deploy-production.sh`, before the docker compose
-restart step:
+**Revised in v2.** Render env files to **tmpfs** so they don't persist
+on the underlying disk, and lock them down:
 
 ```bash
-# Source the OP service account token
-source /etc/agent-stack/op.env
+# Ensure tmpfs mount exists (one-time setup; persist via /etc/fstab)
+mountpoint -q /run/agent-stack || mount -t tmpfs -o size=8M,mode=0700 tmpfs /run/agent-stack
+chmod 0700 /run/agent-stack
+chown root:root /run/agent-stack
 
-# Render env files
-op inject -i /srv/agent-stack/backend.env.template -o /srv/agent-stack/backend.env
-op inject -i /srv/agent-stack/indexer.env.template -o /srv/agent-stack/indexer.env
-chmod 600 /srv/agent-stack/backend.env /srv/agent-stack/indexer.env
+# Render backend env with the backend-scoped token
+(
+  source /etc/agent-stack/op-backend.env
+  op inject -i /srv/agent-stack/backend.env.template -o /run/agent-stack/backend.env
+  chmod 0400 /run/agent-stack/backend.env
+  chown root:root /run/agent-stack/backend.env
+)
 
+# Render indexer env with the indexer-scoped token (separate subshell so
+# the tokens never appear in the same env)
+(
+  source /etc/agent-stack/op-indexer.env
+  op inject -i /srv/agent-stack/indexer.env.template -o /run/agent-stack/indexer.env
+  chmod 0400 /run/agent-stack/indexer.env
+  chown root:root /run/agent-stack/indexer.env
+)
+
+# Update docker-compose service definitions to read from /run/agent-stack/*.env
 # (existing: docker compose pull && up)
 ```
 
-After deploy, the rendered `backend.env` looks identical to today.
-Difference: it's regenerated from 1Password every deploy. If you change
-a secret in 1Password and redeploy, the new value lands automatically.
+Why the subshells: keeps each service token in a separate process env;
+neither shows up in `cat /proc/$pid/environ` for the other render.
 
-### 2e. Convert GitHub Actions secrets
+Additional hardening:
+- **Exclude** `/run/agent-stack/*` and `/srv/agent-stack/*.env*` from
+  any backup or snapshot job
+- **Disable core dumps** for the backend process (`LimitCORE=0` in
+  the systemd unit, or `prlimit --core=0` if managed differently)
+- **Drop privileges**: the backend process should start as root only
+  to read the env file, then drop to a non-root user immediately
+- `journalctl -u agent-stack` should never print env values; if your
+  logging library logs config at boot, scrub it
 
-Use the official 1Password Action:
+After deploy, the rendered `backend.env` is on tmpfs, never written
+to disk. A reboot clears it. A `docker compose up` re-renders it
+from 1Password.
+
+### 2e. Convert GitHub Actions secrets (with environment protection)
+
+**Revised in v2.** Wrap the deploy in a GitHub **Environment** with
+required reviewers + restricted deployment branches. The CI token
+(`OP_SERVICE_ACCOUNT_TOKEN_PROD_CI`) is exposed ONLY to jobs that
+reference that protected environment.
 
 ```yaml
 # .github/workflows/deploy-production.yml
-- uses: 1password/load-secrets-action@v1
-  env:
-    OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-    VPS_SSH_KEY: op://Averray/Production/CI/vps-ssh-key/credential
-    ADMIN_JWT:    op://Averray/Production/CI/admin-jwt/credential
-    APP_BASIC_AUTH_PASSWORD_HASH: op://Averray/Production/CI/app-basic-auth-password-hash/credential
-    RESEND_API_KEY:                op://Averray/Production/CI/resend-api-key/credential
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # The "production" environment must be configured in repo settings
+    # with: required reviewers, restricted to main branch, prevent self-review
+    environment: production
+    permissions:
+      # Top-level read-only; elevate per step only when needed
+      contents: read
+      id-token: write  # for OIDC, see Phase 3
+    steps:
+      - uses: actions/checkout@<commit-sha>   # pin to SHA, not tag
+      - uses: 1password/load-secrets-action@<commit-sha>
+        env:
+          # OP_SERVICE_ACCOUNT_TOKEN_PROD_CI is configured as an
+          # ENVIRONMENT secret (not a repo secret), so only this
+          # environment-gated job sees it.
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PROD_CI }}
+          VPS_SSH_KEY:                  op://Averray/Production/CI/vps-ssh-key/credential
+          ADMIN_JWT:                    op://Averray/Production/CI/admin-jwt/credential
+          APP_BASIC_AUTH_PASSWORD_HASH: op://Averray/Production/CI/app-basic-auth-password-hash/credential
+          RESEND_API_KEY:               op://Averray/Production/CI/resend-api-key/credential
 ```
 
-Now the GitHub Actions secret store contains exactly **one** entry:
-`OP_SERVICE_ACCOUNT_TOKEN`. Everything else flows from 1Password.
+Configuration steps (in GitHub repo settings):
+1. **Settings → Environments → New environment → production**
+2. Required reviewers: add at least one human (cannot self-approve)
+3. Deployment branches: restrict to `main`
+4. Environment secrets: add `OP_SERVICE_ACCOUNT_TOKEN_PROD_CI`
+5. Configure same for `testnet` with separate token
+
+Now the GitHub Actions secret store contains exactly the
+**environment-gated** OP tokens. Everything else flows from
+1Password. A malicious PR cannot reach the production deploy
+without a reviewer's explicit approval.
+
+**Action pinning**: pin every third-party action to a commit SHA,
+not a version tag. GitHub explicitly recommends this to reduce
+supply-chain risk if an action's tag is moved by an attacker who
+gains access to the action's repo.
 
 ### 2f. Cutover
 
@@ -233,38 +365,161 @@ deploy script PR and the workflow changes.
 
 ## Phase 3 — AWS KMS for the backend signer
 
-This is the big security win. After this phase, no human, no env file,
-no log line, and no backup ever contains the private key for the
-backend signer. Compromise of the VPS or 1Password vault no longer
-implies compromise of the signer.
+This is the big security win. After this phase, the private key for
+the backend signer is never on disk, in any vault, or in any backup.
+Compromise of the VPS or 1Password vault no longer implies
+compromise of the signer.
+
+**Revised in v2** to use temporary credentials (IAM Roles Anywhere
+on the VPS, GitHub OIDC for Actions) instead of long-lived IAM
+access keys. The reviewer correctly flagged that storing access keys
+in 1Password trades disk-stored-key for vault-stored-credential —
+better, but still a long-lived credential. IAM Roles Anywhere /
+OIDC give us short-lived (≤1h) credentials that rotate
+automatically.
 
 ### 3a. AWS account + IAM policy
 
-1. Create an AWS account (use root only to set up billing + IAM, then
-   never touch root again)
-2. Create an IAM user `averray-signer-prod` with **only** these
-   permissions:
-   - `kms:Sign` on the specific key ARN
-   - `kms:GetPublicKey` on the same
-3. Generate access key + secret for that IAM user
-4. Store the access key + secret as 1Password items
-   `aws-kms-signer-access-key-id` and `aws-kms-signer-secret-access-key`
-   in `Averray/Production/Backend`
+1. Create an AWS account
+   - Hardware MFA (YubiKey) on root
+   - Use root only for billing + initial IAM setup; never daily
+   - Print recovery info offline
+2. Create the IAM **role** `averray-signer-prod-role` (not user!) with
+   only these permissions on the KMS key:
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Sid": "AllowSignWithCanonicalConditions",
+         "Effect": "Allow",
+         "Action": ["kms:Sign", "kms:GetPublicKey"],
+         "Resource": "arn:aws:kms:<region>:<account>:key/<key-id>",
+         "Condition": {
+           "StringEquals": {
+             "kms:SigningAlgorithm": "ECDSA_SHA_256",
+             "kms:MessageType":      "DIGEST"
+           }
+         }
+       },
+       {
+         "Sid": "ExplicitDenyDangerousOps",
+         "Effect": "Deny",
+         "Action": [
+           "kms:ScheduleKeyDeletion",
+           "kms:DisableKey",
+           "kms:PutKeyPolicy",
+           "kms:CreateGrant",
+           "kms:ReplicateKey",
+           "kms:UpdatePrimaryRegion"
+         ],
+         "Resource": "arn:aws:kms:<region>:<account>:key/<key-id>"
+       }
+     ]
+   }
+   ```
+   The condition keys (`kms:SigningAlgorithm`, `kms:MessageType`)
+   bind the role to one signing algorithm + digest mode. Even with
+   the credentials, an attacker cannot ask for a different algorithm
+   or sign a raw message instead of a digest.
 
-### 3b. Create the KMS key
+3. **VPS access**: configure IAM Roles Anywhere
+   - Provision a private CA (AWS ACM-PCA for ~$400/month, OR
+     self-managed CA with the private key stored in an HSM)
+   - Create a Trust Anchor in IAM referencing the CA
+   - Create a Profile referencing `averray-signer-prod-role`
+   - Issue an X.509 client cert to the VPS
+   - Store the client cert + private key on the VPS at
+     `/etc/agent-stack/roles-anywhere/`, mode 0400
+   - The backend uses the cert to call STS and obtain temporary
+     credentials (≤1h lifetime); rotates automatically
 
-Via AWS Console (Key Management Service) or CLI:
+4. **GitHub Actions access** (if any workflow needs to call AWS):
+   configure GitHub as an OIDC provider in IAM
+   - In IAM: add `token.actions.githubusercontent.com` as an
+     identity provider
+   - Trust policy on `averray-signer-prod-role` allows
+     `sts:AssumeRoleWithWebIdentity` from workflows in
+     `repo:<your-org>/<your-repo>:environment:production`
+   - Workflow uses `aws-actions/configure-aws-credentials` with
+     `role-to-assume:` and `aws-region:`; gets ≤1h credentials per
+     job; no AWS keys ever stored in GitHub
 
+5. **Do NOT store static IAM access keys for the signer principal
+   anywhere.** If you must start with static keys during early
+   testnet setup, document it as an explicit residual risk with a
+   removal date, and move to temporary credentials before mainnet.
+
+### 3b. Create the KMS key (multi-region for mainnet)
+
+**Critical**: AWS does **not** allow converting a single-region key
+into a multi-region key later. If you might ever need regional
+failover for mainnet, create the mainnet key as multi-region from
+day one.
+
+**Testnet** (single region is fine):
 ```bash
 aws kms create-key \
-  --description "Averray production backend signer (secp256k1)" \
+  --description "Averray testnet backend signer (secp256k1)" \
   --key-usage SIGN_VERIFY \
-  --customer-master-key-spec ECC_SECG_P256K1 \
+  --key-spec ECC_SECG_P256K1 \
   --region eu-central-1
 ```
 
-Save the returned `KeyId` UUID. The key spec `ECC_SECG_P256K1` is the
-Ethereum curve.
+**Mainnet** (multi-region; replicate to a second region for
+failover):
+```bash
+# Create the primary key
+aws kms create-key \
+  --description "Averray mainnet backend signer (secp256k1, multi-region primary)" \
+  --key-usage SIGN_VERIFY \
+  --key-spec ECC_SECG_P256K1 \
+  --multi-region \
+  --region eu-central-1
+
+# Replicate to a second region
+aws kms replicate-key \
+  --key-id <primary-key-arn> \
+  --replica-region us-east-1
+```
+
+Multi-region keys share the same key ID and key material across
+regions. Each replica is managed independently — same IAM policy,
+same CloudTrail trail, same alarms, on every replica.
+
+Save the returned key ARNs. Verify with:
+```bash
+aws kms describe-key --key-id <key-id> --region <region>
+```
+Expected: `MultiRegion: true`, `KeySpec: ECC_SECG_P256K1`.
+
+### 3b-1. Enable CloudTrail for KMS events
+
+CloudTrail can be configured to exclude KMS events from a trail.
+Verify yours doesn't:
+```bash
+aws cloudtrail get-event-selectors --trail-name <trail>
+```
+Look for `ExcludeManagementEventSources` — `kms.amazonaws.com`
+should NOT be there.
+
+### 3b-2. Configure CloudWatch alarms
+
+All of these should trigger a notification (SNS → email, Slack,
+PagerDuty):
+- `kms:ScheduleKeyDeletion` on the signer key
+- `kms:DisableKey` on the signer key
+- `kms:PutKeyPolicy` on the signer key
+- `kms:CreateGrant` on the signer key
+- `kms:ReplicateKey` and `kms:UpdatePrimaryRegion` (multi-region)
+- Unusual `kms:Sign` volume (e.g., >10× baseline over a 5-minute window)
+- Sign requests from unusual source IPs / ASNs
+- Any activity by root or admin IAM principals on this key
+
+**Test each alarm with a synthetic event** before going to mainnet
+(e.g., temporarily call `DisableKey` from an admin session and
+confirm the alarm notifies). Untested alarms have a habit of being
+silently broken.
 
 ### 3c. Derive the EVM address
 
@@ -287,106 +542,270 @@ This becomes the new on-chain verifier address.
 
 ### 3d. Wire the backend
 
-Add `KMS_KEY_ID` and `AWS_REGION` env vars to `backend.env.template` (they
-flow through 1Password). Update `mcp-server/src/blockchain/gateway.js`:
+Add `KMS_KEY_ID` and `AWS_REGION` env vars to `backend.env.template`
+(they flow through 1Password). Update
+`mcp-server/src/blockchain/gateway.js`:
 
 ```js
 import { AwsKmsSigner } from "@rumblefishdev/eth-signer-kms";
 
 function createSigner(provider, config) {
   if (config.kmsKeyId) {
+    // Backend never holds signer private key bytes locally.
+    // It still holds AWS credentials (temporary, via Roles
+    // Anywhere or OIDC) capable of REQUESTING signatures.
     return new AwsKmsSigner({
       keyId: config.kmsKeyId,
       region: config.awsRegion ?? "eu-central-1",
     }, provider);
   }
-  // Fallback for testnet / local dev
-  if (config.signerPrivateKey) {
+  // Fallback for LOCAL DEVELOPMENT ONLY. Never enabled in any
+  // production / staging path — see 3f below for mainnet posture.
+  if (config.signerPrivateKey && config.allowLocalKeyFallback) {
     return new Wallet(config.signerPrivateKey, provider);
   }
-  throw new Error("No signer configured (KMS_KEY_ID or SIGNER_PRIVATE_KEY required).");
+  throw new Error(
+    "No signer configured. Set KMS_KEY_ID for production, or " +
+    "ALLOW_LOCAL_KEY_FALLBACK=1 + SIGNER_PRIVATE_KEY for local dev."
+  );
 }
 ```
 
 The `AwsKmsSigner` is a drop-in `ethers.Signer`. All call sites
 (`escrowContract.connect(signer)`, etc.) work unchanged.
 
+### 3d-1. Non-negotiable KMS adapter tests
+
+Add unit tests (e.g., `mcp-server/src/blockchain/kms-signer.test.js`)
+that prove:
+
+1. **Address derivation**: `GetPublicKey` → keccak256 → matches the
+   expected EVM address used as the on-chain verifier
+2. **Single-message sign + recover**: known digest, sign through
+   KMS, parse ECDSA into `r, s`, verify recovery to the expected
+   address
+3. **Low-s canonicalization**: signatures where `s > secp256k1n / 2`
+   are inverted to canonical low-s form. Per EIP-2, Ethereum
+   rejects high-s signatures.
+4. **Correct recovery id (v)**: signing the same digest multiple
+   times, the adapter correctly computes `v` (27 or 28 for
+   Ethereum) such that recovery yields the expected address.
+5. **Bulk round-trip**: repeat (2)–(4) over ≥1000 distinct messages
+   — the high-s case manifests probabilistically.
+
+Don't write your own KMS adapter; pick a vetted one
+(`@rumblefishdev/eth-signer-kms` or `ethers-aws-kms-signer`) and
+pin to a specific commit SHA.
+
+### 3d-2. Domain separation for backend-signed messages
+
+Backend-signed payloads MUST include domain-separation fields so a
+signed message in one context cannot be replayed in another:
+- `chainId` — testnet vs mainnet
+- `contractAddress` — TreasuryPolicy or EscrowCore as relevant
+- `environment` — "production", "testnet", etc.
+- `purpose` — what kind of signature this is ("verifier-approve",
+  "verifier-reject", "arbitrator-resolve", etc.)
+- `jobId` / `disputeId` — bound to the specific resource
+- `nonce` — non-reusable per (subject, purpose) pair
+- `expiry` — Unix timestamp; reject after
+
+This is independent of the KMS migration but the migration is the
+right time to verify the signed payloads carry these fields. Audit
+every `signer.signMessage()` / `signer.signTypedData()` call site
+in `mcp-server/src/blockchain/`.
+
 ### 3e. Test on testnet first
 
-1. Generate a fresh KMS key in AWS for testnet
+1. Generate a fresh KMS key in AWS for testnet (single-region OK)
 2. Deploy fresh testnet contracts using the KMS-derived address as
-   the verifier
+   the verifier (multisig signs the `setVerifier` call)
 3. Run the full hosted product-proof smoke loop end-to-end with the
    KMS path
-4. Confirm: `dmesg` / process tree / `cat backend.env` — the
-   private key bytes appear nowhere
+4. Confirm:
+   - `journalctl -u agent-stack`, `docker inspect agent-stack`,
+     `cat /proc/$(pgrep -f backend)/environ | tr '\0' '\n'` — no
+     plaintext private key (search for `0x[a-f0-9]{60,}` patterns
+     AND for env vars named `*PRIVATE*` / `*SECRET*` referencing
+     the signer key)
+   - CloudTrail shows the `kms:Sign` calls and no `Decrypt` /
+     `Export` ever
+   - Revoking the Roles Anywhere profile temporarily breaks signing
+     — proves the backend really uses temp creds, not a stashed key
 
-### 3f. Cutover
+### 3f. Cutover and key rotation
 
-For testnet: just update the `verifier` field in
-`deployments/testnet.json`, deploy fresh, switch.
+**Testnet cutover**: update the `verifier` field in
+`deployments/testnet.json` (via the testnet multisig
+`setVerifier(newKmsAddress, true)`), deploy fresh, switch. Keep the
+local-dev raw-key fallback (`ALLOW_LOCAL_KEY_FALLBACK=1`) available
+for one full deploy cycle for safety. After confirming KMS path
+works, **rotate the testnet raw key so the old value is invalid**.
 
-For mainnet: this is part of Phase 5 — the mainnet deploy is the
-first time the KMS-managed key signs anything.
+**Mainnet cutover** (Phase 5): the mainnet deploy is the first time
+the KMS-managed key signs anything. **No raw-key fallback for
+mainnet.** Local-dev fallback is disabled in production builds:
+`config.allowLocalKeyFallback = process.env.NODE_ENV !== 'production'`.
+
+**KMS key rotation is an on-chain migration**, not a routine
+calendar rotation. AWS does NOT support automatic rotation for
+asymmetric KMS keys. The procedure:
+
+1. Create a new KMS key (same spec, same multi-region setup)
+2. Derive the new EVM address from the new key's public key
+3. Multisig signs `setVerifier(newKmsAddress, true)` on TreasuryPolicy
+4. Update `KMS_KEY_ID` env var (via 1Password) to the new key
+5. Redeploy backend
+6. Grace period (e.g., 24h): both keys are valid verifiers
+7. Multisig signs `setVerifier(oldKmsAddress, false)` to disable
+   the old key
+8. Schedule deletion of the old KMS key (7–30 day pending period)
+9. After deletion period, key is permanently destroyed
+
+The signer KMS key is **explicitly NOT tracked in
+`SECRETS_CALENDAR.yml`** — see the inline note there.
+
+IAM credentials (Roles Anywhere certs, OIDC trust relationship)
+DO rotate frequently. The KMS key itself rotates only via this
+multisig-controlled migration.
 
 ### Phase 3 done = exit criteria
 
-- [ ] AWS account + IAM user provisioned with minimal-permission policy
-- [ ] KMS key created (one for testnet, one for mainnet)
-- [ ] EVM address derived and matches what's expected on-chain
-- [ ] `AwsKmsSigner` adapter integrated and unit-tested
-- [ ] Hosted product-proof smoke passes end-to-end on testnet using the
-  KMS path
-- [ ] `SIGNER_PRIVATE_KEY` env path retained as fallback for local dev
-  but removed from production env
+- [ ] AWS account + IAM **role** (not user) provisioned with minimum
+  permissions + condition keys (`kms:SigningAlgorithm`,
+  `kms:MessageType`)
+- [ ] Explicit deny on dangerous ops (ScheduleKeyDeletion, DisableKey,
+  PutKeyPolicy, CreateGrant, ReplicateKey, UpdatePrimaryRegion) for
+  the signer role
+- [ ] Mainnet KMS key created **multi-region** from day one; testnet
+  may be single-region
+- [ ] CloudTrail confirmed to include KMS events (not excluded)
+- [ ] CloudWatch alarms configured AND **tested with synthetic events**
+- [ ] VPS: IAM Roles Anywhere configured with X.509 client cert;
+  static IAM access keys for the signer role do not exist
+- [ ] GitHub Actions: OIDC configured if AWS access is needed; no
+  static AWS credentials in GitHub
+- [ ] EVM address derived from KMS public key matches the on-chain
+  verifier
+- [ ] All KMS adapter tests pass over ≥1000 distinct messages
+- [ ] Domain-separation audit complete (every signed payload carries
+  chainId, contract, env, purpose, ID, nonce, expiry)
+- [ ] Hosted product-proof smoke passes end-to-end on testnet via KMS
+- [ ] Process listing on VPS shows no plaintext signer key
 
 ### Rollback
 
-Easy: revert to `SIGNER_PRIVATE_KEY` env path on the backend. The
-contract-side verifier address would need to be reset on TreasuryPolicy
-via the multisig — irreversible if mainnet deploy already happened, so
-test on testnet first.
+**Testnet only**: revert to `SIGNER_PRIVATE_KEY` env path with
+`ALLOW_LOCAL_KEY_FALLBACK=1`. Contract-side verifier reset via
+multisig.
+
+**Mainnet**: there is no raw-key rollback. Fallback for an emergency
+is multisig-controlled signer migration (`setVerifier(temporary, true)`)
+or pausing the protocol via the pauser key. Plan and rehearse this
+before going live.
 
 ---
 
 ## Phase 4 — Hardening
 
-Three small additions; each <1h.
+**Revised in v2 per security review.** Five additions, each
+independent.
 
-### 4a. CI secret scanning
+### 4a. Pre-commit + push protection + CI secret scanning
 
-Add a `gitleaks` step to the CI workflow:
+Three layers of defense in depth so a secret can't sneak in:
 
-```yaml
-# .github/workflows/ci.yml
-- uses: gitleaks/gitleaks-action@v2
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
+1. **Local pre-commit hook** (catches before push):
+   ```bash
+   # .githooks/pre-commit
+   #!/usr/bin/env bash
+   set -e
+   if command -v gitleaks >/dev/null 2>&1; then
+     gitleaks protect --staged --verbose
+   else
+     echo "warn: gitleaks not installed locally; relying on CI" >&2
+   fi
+   ```
+   Install via `git config core.hooksPath .githooks` per operator.
 
-This fails any PR that accidentally contains a secret pattern (private
-keys, JWTs, AWS keys, etc.). One-time setup; ongoing protection.
+2. **GitHub Secret Scanning push protection**:
+   - Settings → Security → Secret scanning → Enable push protection
+   - Add custom patterns for Averray-specific secret formats
+     (signer key shapes, JWT shapes if they have a custom prefix,
+     `ops_` 1Password tokens, etc.)
+   - This blocks the push at the server side regardless of local hooks
 
-### 4b. Short-lived JWTs + refresh tokens
+3. **CI gitleaks** (last-resort sweep):
+   ```yaml
+   # .github/workflows/ci.yml
+   - uses: gitleaks/gitleaks-action@<commit-sha>
+     env:
+       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+   ```
 
-Replace the long-lived `ADMIN_JWT` GitHub secret pattern with a refresh
-token model:
+CI catches what push protection misses; push protection catches
+what local hooks miss; local hooks catch the common case before
+the secret ever leaves the operator's machine.
 
-- The hosted worker loop receives a **refresh token** (long-lived,
-  stored in 1Password)
-- On each run, it exchanges the refresh token for a **fresh access
-  token** (1h lifetime) via a new `/auth/refresh` endpoint
-- The access token never sits in env vars long enough to expire
-  unattended
+### 4b. Asymmetric JWT signing via KMS
 
-Implementation: add `mcp-server/src/auth/refresh.js` with the
-exchange endpoint; update `run-hosted-worker-loop.mjs` to call it at
-the start of each run.
+**The architectural upgrade**: today `AUTH_JWT_SECRETS` is an HMAC
+secret stored in the vault and on every backend instance. A vault
+breach OR a backend env breach means an attacker can mint admin
+JWTs.
 
-### 4c. Expiry calendar + CI check
+**Target design**:
+- KMS-managed asymmetric key (RSA-2048 or ES256) signs access tokens
+  at issuance / refresh time
+- Backend services verify locally with the **public** key (no access
+  to the signing key needed)
+- Access tokens carry `kid` (key ID for rotation), `iss`, `aud`,
+  `sub`, `role`, `jti`, `iat`, `nbf`, `exp`
+- Access TTL: ≤1h (≤15min is better)
+- Refresh tokens: **opaque random values** (not signed JWTs),
+  stored server-side as hashes, rotated on every use, revoked on
+  replay detection
 
-Already in this PR: [`SECRETS_CALENDAR.yml`](SECRETS_CALENDAR.yml) +
-`scripts/ops/check-secrets-calendar.mjs`. Wire into the CI workflow:
+After this change, a vault leak no longer allows JWT minting. Only
+a KMS principal compromise does — same protection as the signer
+key from Phase 3.
+
+**Implementation outline**:
+- New KMS key, separate from the signer key, with the same temporary-
+  credential access pattern
+- Update `mcp-server/src/auth/jwt.js` to sign via KMS instead of HMAC
+- Update `mcp-server/src/auth/middleware.js` to verify with the
+  public key (cached locally, refreshed periodically)
+- Add `mcp-server/src/auth/refresh.js` with the opaque-token
+  exchange endpoint + server-side hash storage
+- Update `scripts/ops/mint-admin-jwt.mjs` to call the new path or
+  deprecate in favor of the refresh-token flow
+
+**If full migration is too much work pre-mainnet**, the minimum
+hardening for the HMAC path is:
+- Key ring with `kid` rotation
+- Short access-token TTLs (≤15 min)
+- Documented two-key rotation window with old-key tolerance period
+- Refresh tokens are opaque random values, hashed server-side
+- All flagged as residual risk in the sign-off bar
+
+### 4c. GitHub Actions hardening (beyond Phase 2)
+
+Already partially covered in 2e. Additional steps:
+- Top-level `permissions: read-all` on every workflow; elevate
+  per-job with explicit `permissions:` blocks
+- Pin every third-party action to a commit SHA, never a tag
+- Avoid `pull_request_target` with secrets unless workflow is
+  extremely constrained
+- Never inject OP service tokens into build/test jobs — only the
+  job that needs them
+- Require code review for any workflow file change (branch
+  protection rule on `.github/workflows/**`)
+
+### 4d. Calendar-driven CI checks
+
+Already shipped in PR #225: `scripts/ops/check-secrets-calendar.mjs`.
+Wire into CI:
 
 ```yaml
 # .github/workflows/ci.yml
@@ -394,18 +813,38 @@ Already in this PR: [`SECRETS_CALENDAR.yml`](SECRETS_CALENDAR.yml) +
   run: node scripts/ops/check-secrets-calendar.mjs
 ```
 
-This warns 7 days before any tracked token expires. Doesn't fail CI on
-warnings (would block legitimate work) but does fail on any token
-already past expiry.
+Warns ≥7 days before any tracked token expires; fails CI on past-
+expiry. **The KMS signer key is NOT in this calendar** — see the
+inline note in `SECRETS_CALENDAR.yml`.
+
+### 4e. Hardware MFA across the admin trust chain
+
+Mainnet baseline (~$50 per operator, one-time):
+- 1Password admin account: hardware key (YubiKey) required
+- AWS root account: hardware key required
+- AWS IAM admin users: hardware key required
+- GitHub org admin: hardware key required
+- Domain registrar: hardware key required
+- VPS provider: hardware key required
+
+TOTP is OK for testnet ops; for mainnet, hardware-key everywhere.
+TOTP is phishable; FIDO2 is not.
 
 ### Phase 4 done = exit criteria
 
-- [ ] `gitleaks` runs on every PR
-- [ ] Hosted worker loop uses refresh-token exchange instead of
-  long-lived `ADMIN_JWT`
-- [ ] CI warns 7 days before any tracked token expires
-- [ ] No secret has been merged into the repo for at least 14 days
-  after `gitleaks` lands (sanity check the scanner is configured right)
+- [ ] Pre-commit hook, GitHub push protection, and CI gitleaks all
+  configured and tested (synthetic bad-commit blocked at each layer)
+- [ ] Custom secret patterns added to push protection for Averray-
+  specific formats
+- [ ] Either: asymmetric KMS-signed JWT path live end-to-end on
+  testnet, OR: HMAC hardening path documented as residual with
+  named owner and timeline
+- [ ] Top-level read-only permissions on all workflows
+- [ ] All third-party actions pinned to commit SHA
+- [ ] GitHub Environments with required reviewers configured for
+  production deploys
+- [ ] Calendar check runs on every CI build
+- [ ] Hardware MFA on every admin account in the trust chain
 
 ---
 
@@ -421,46 +860,66 @@ The day before:
 - [ ] All four prior phases live and stable on testnet for ≥7 days
 - [ ] Audit script (`scripts/ops/audit-launch-readiness.mjs`) shows
   zero drift between testnet config and the planned mainnet config
-- [ ] `op` service account token rotated within the last 30 days
-- [ ] AWS KMS key for mainnet created with separate IAM user from
-  testnet
-- [ ] Multisig signer set is established with **fresh seeds** —
-  do not reuse testnet seeds
-- [ ] All vendor accounts (Pimlico, Sentry, Subscan, RPC provider) have
-  separate mainnet API keys minted
+- [ ] All production OP service account tokens rotated within the
+  last 30 days
+- [ ] AWS KMS key for mainnet created **multi-region from day one**
+  (cannot convert later)
+- [ ] AWS access via Roles Anywhere (VPS) + OIDC (Actions); **no
+  static IAM access keys** for the signer role
+- [ ] All CloudWatch alarms tested with synthetic events
+- [ ] Multisig signer set established with **fresh seeds** — do not
+  reuse testnet seeds
+- [ ] All vendor accounts (Pimlico, Sentry, Subscan, RPC provider)
+  have separate mainnet API keys minted
 - [ ] On-call rotation defined in `INCIDENT_RESPONSE.md` Section 1
   (currently a blank template — fill it in)
+- [ ] **Old secrets cleanup**: rotate or revoke any value that ever
+  lived in GitHub secrets, local password managers, shell history,
+  old VPS env files, CI logs, backups, or test deploys. Assume any
+  copy-pasted value is compromised.
+- [ ] Incident drills run for: OP token leak, AWS signer credential
+  leak, JWT signing key leak, VPS root compromise
 
 ### Cutover sequence
 
 1. **Generate fresh secrets**: rotate every secret listed in
    [`SECRETS.md`'s mainnet hardening checklist](SECRETS.md#mainnet-hardening-checklist).
    Each goes into a fresh 1Password item under
-   `Averray/Production/<vault>/`.
-2. **Provision the multisig** on Polkadot.js Apps with the three new
-   signer addresses (Hot, Warm, Cold per `MULTISIG_SETUP.md`).
+   `Averray/Production/<vault>/`. Never reuse a testnet value.
+2. **Provision the multisig** on Polkadot.js Apps with three fresh
+   signer addresses (Hot, Warm, Cold per `MULTISIG_SETUP.md`). Do
+   not reuse testnet seeds.
 3. **Deploy contracts** with the multisig as the owner from line 1
    (skip the EOA-then-transfer flow used on testnet — owner is the
    multisig from genesis).
 4. **Update `deployments/mainnet.json`** with all addresses.
-5. **Update `backend.env.template`** to reference the new mainnet
-   1Password items (or use a separate `backend.mainnet.env.template`).
+5. **Update `backend.mainnet.env.template`** to reference the new
+   mainnet 1Password items. The KMS key ID, the role ARN, the
+   multi-region settings — all from the mainnet vault, never from
+   the testnet vault.
 6. **Run the smoke** with `product_proof_reward_asset=USDC` against
-   mainnet.
+   mainnet. Confirm 3 consecutive successful runs before opening to
+   real users.
 7. **Archive** the testnet 1Password vault — read-only, kept for
    forensics. **Do not delete** for at least 90 days.
 
 ### Post-cutover verification
 
 - [ ] `audit-launch-readiness.mjs` shows green for mainnet
-- [ ] `check-secrets-calendar.mjs` shows zero entries within 7 days of
-  expiry
-- [ ] Hosted product-proof smoke passes end-to-end three consecutive
-  runs
-- [ ] No secret appears in any log file or process listing on the
-  mainnet VPS (`ps -ef | grep -E '0x[a-f0-9]{60}'` returns nothing)
-- [ ] On-call rotation is live and the first responder has been paged
-  with a test alert successfully
+- [ ] `check-secrets-calendar.mjs` shows zero entries within 7 days
+  of expiry
+- [ ] Hosted product-proof smoke passes end-to-end 3 consecutive
+  runs on mainnet
+- [ ] No secret in any log file, process listing, or env file dump
+  on the mainnet VPS (test: search for `0x[a-f0-9]{60,}` AND env
+  vars named `*PRIVATE*` / `*SECRET*` / `*KEY*` referencing the
+  signer key)
+- [ ] **No raw `SIGNER_PRIVATE_KEY` value exists anywhere** in any
+  mainnet vault, env file, backup, or operator's machine
+- [ ] On-call rotation is live and first responder has been paged
+  with a synthetic test alert successfully
+- [ ] All Phase 4 hardening verified active on mainnet (push
+  protection, environment gates, hardware MFA, etc.)
 
 ---
 
@@ -469,15 +928,24 @@ The day before:
 | Item | Monthly cost |
 |---|---|
 | 1Password Business (1 user) | $7.99 |
-| 1Password Business (3 users) | $23.97 |
-| AWS KMS asymmetric key | $1 + $0.15 per 10k signatures (~$1.05/mo at our volume) |
-| AWS minimum (free tier covers most ancillary services) | $0 |
-| **Total at 1 user, current scale** | **~$9/mo** |
-| **Total at 3 users, current scale** | **~$25/mo** |
+| 1Password Business (3 users, post second-operator) | $23.97 |
+| AWS KMS testnet key (single region) | ~$1.05 (1 key + ~$0.15 per 10k sigs) |
+| AWS KMS mainnet key (multi-region, 2 replicas) | ~$2.05 (2 replica keys + signing fees) |
+| AWS Roles Anywhere | $0 (no per-request fee) |
+| AWS ACM-PCA (if used for Roles Anywhere CA) | ~$400 — **consider self-managed CA + HSM** for lower cost |
+| AWS CloudTrail (for KMS audit) | $0 (first management trail free) |
+| AWS CloudWatch (for KMS alarms) | < $5 |
+| **Total at 1 user, testnet** | **~$9/mo** (or ~$409/mo if ACM-PCA used) |
+| **Total at 3 users, mainnet** | **~$26/mo** (or ~$426/mo if ACM-PCA used) |
+| **YubiKey hardware keys** (one-time) | ~$50 × number of operators |
 
-The cost is rounding error compared to the security improvement. The
-real cost is **engineering time for the migration** (~5 working days
-spread over a few weeks).
+The recurring cost is rounding error vs. the security improvement.
+The **ACM-PCA decision is the one to think about** — $400/mo is
+real money at our scale; self-managed CA with the private key in
+an HSM is the cheaper alternative if the operator can run one.
+
+Engineering time for the migration: ~5–7 working days spread over a
+few weeks.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds **`docs/SECRETS_INTEGRATION_PLAN.md`** — a security-review-grade companion to the existing inventory + migration docs — and folds the reviewer's 13 main corrections + smaller edits into `SECRETS.md`, `SECRETS_MIGRATION.md`, and `SECRETS_CALENDAR.yml`.

The new integration-plan doc is the artifact for an external security reviewer to sign off on before mainnet. Includes threat model, trust boundaries, per-phase security analysis, residual risks I want scrutinized, things I'm not confident about, and a 13-item mainnet sign-off bar.

## Architectural changes vs v1

1. **Per-runtime 1Password service accounts** (4 per environment, not 1 shared). Each scoped to a single vault. Service-account scopes are effectively immutable post-create, so over-broad scoping was a single-point-of-compromise risk.
2. **Temporary AWS credentials** for the signer (IAM Roles Anywhere on VPS, GitHub OIDC for Actions). No more long-lived IAM access keys for the signer principal.
3. **Honest Phase 2 framing**: `op://` URIs reduce drift but the rendered env file still exists at runtime. Added tmpfs + `chmod 0400` + exclude-from-backups + drop-privileges hardening.
4. **KMS adapter test requirements** tightened: address derivation, low-s canonicalization, recovery id, ≥1000-message bulk round-trip. Added domain separation for backend-signed payloads.
5. **KMS key rotation = on-chain migration**, not calendar rotation. KMS signer key explicitly removed from `SECRETS_CALENDAR.yml`.
6. **KMS IAM policy** with `kms:SigningAlgorithm` + `kms:MessageType` condition keys + explicit deny on dangerous ops + expanded CloudWatch alarm list.
7. **Multi-region KMS** decision moved to design-time (can't convert later). Mainnet key created multi-region from day one.
8. **GitHub Actions hardening**: production-environment-gated tokens with required reviewers, SHA-pinned third-party actions, top-level read-only permissions.
9. **Pre-commit + push protection + CI gitleaks** as defense in depth (was: CI gitleaks only).
10. **Asymmetric JWT signing via KMS** proposed in Phase 4b. Documented HMAC + kid + short TTL + opaque refresh tokens as minimum residual if deferred.
11. **No raw-key fallback for mainnet**. Testnet retains local-dev fallback for one migration cycle.
12. **Old-secrets cleanup** explicit step before mainnet cutover.

## Factual corrections

- 1Password Business audit log retention: **365 days** (not 90). Events API: 120 days.
- 1Password incident: **2023 Okta-linked**, not "2022 breach". No customer data was accessed.

## Files

| File | Lines changed |
|---|---|
| `docs/SECRETS_INTEGRATION_PLAN.md` | new (952 lines) |
| `docs/SECRETS_MIGRATION.md` | +812 −211 (full phase rewrite) |
| `docs/SECRETS.md` | +96 −0 (phrasing aligned) |
| `docs/SECRETS_CALENDAR.yml` | +84 −41 (per-runtime tokens, KMS signer key removed) |

## Smoke tests

- [x] `SECRETS_CALENDAR.yml` parses cleanly via `scripts/ops/check-secrets-calendar.mjs`
- [x] 12 entries: 1 ok / 10 warn (TBDs awaiting Phase 1 provisioning) / 0 fail / 1 skipped (intentional)
- [x] KMS signer key confirmed absent from calendar
- [x] All internal doc links resolve

## How to review

The integration-plan doc is the artifact to actually scrutinize for security. The migration doc is the operator's how-to. The inventory doc is the daily reference.

For a focused review pass: read **`SECRETS_INTEGRATION_PLAN.md` sections 6–11** (key risks, things I'm not confident about, mainnet sign-off bar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)