### PR TITLE
Secrets plan v3: fold in second security review pass

### DIFF
--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -65,9 +65,13 @@ honest trust-boundary analysis.
 
 | Secret class | Where it lives | How runtime gets it |
 |---|---|---|
-| App secrets (JWT secret, RPC URLs, Pimlico, Sentry, GH PAT, Subscan, webhooks) | 1Password Business → `Averray/Production/Backend` vault | `op inject` renders env at deploy time to tmpfs; per-runtime service token (`prod-vps-backend`); plaintext on tmpfs only |
-| GitHub Actions secrets (`VPS_SSH_KEY`, `ADMIN_JWT`, `APP_BASIC_AUTH_*`) | 1Password Business → `Averray/Production/CI` vault | Synced via `1password/load-secrets-action`; per-runtime service token (`prod-ci-deploy`); production deploys gated by GitHub Environment with required reviewers |
+| Backend app secrets (JWT secret, RPC URLs, KMS key id) | 1Password Business → `Averray/Production/Backend` vault | `op inject` renders env at deploy time to tmpfs; per-runtime service token (`prod-vps-backend`); plaintext on tmpfs only |
+| Backend vendor tokens (Pimlico, Sentry DSN, Subscan, RPC provider, webhook) | 1Password Business → `Averray/Production/BackendExternal` vault | Same `prod-vps-backend` service token (it has read on Backend + BackendExternal only) |
+| GitHub Actions deploy secrets (`VPS_SSH_KEY`, `APP_BASIC_AUTH_PASSWORD_HASH`) | 1Password Business → `Averray/Production/CI` vault | Synced via `1password/load-secrets-action`; per-runtime service token (`prod-ci-deploy`); production deploys gated by GitHub Environment with required reviewers |
+| CI vendor tokens (issue-ingestion PAT, CI-side Resend if used) | 1Password Business → `Averray/Production/CIExternal` vault | Same `prod-ci-deploy` token (CI + CIExternal scope) |
+| Hosted smoke `ADMIN_JWT` | 1Password Business → `Averray/Production/Smoke` vault (dedicated) | `prod-smoke-tests` service token (Smoke vault only) |
 | Indexer env (DB password, RPC URL) | 1Password Business → `Averray/Production/Indexer` vault | Same pattern as backend, with `prod-vps-indexer` service token (scoped to indexer vault only) |
+| Service-account tokens themselves + 1Password recovery + AWS root + Roles Anywhere cert metadata + basic-auth RAW password + pauser seed | 1Password Business → `Averray/Production/Critical` vault | **Human-only.** No runtime service account can read Critical. |
 | Backend signer key | **AWS KMS** secp256k1 key, multi-region (mainnet), IAM Roles Anywhere / OIDC access | ethers.js `AwsKmsSigner` adapter — backend never holds private key bytes; **still holds temporary AWS credentials** (≤1h lifetime) capable of requesting signatures |
 | Operator passwords (basic auth, personal vault items) | 1Password Business → `Averray/Operators` per-user vault | Manual; only used by humans through the 1Password UI |
 | Multisig signer seeds | Three independent humans/devices (existing pattern, see [`MULTISIG_SETUP.md`](MULTISIG_SETUP.md)) | Hardware wallets + sealed-envelope offline backups |
@@ -94,8 +98,16 @@ migration they'll be synced from 1Password.
 | `VPS_USER` | SSH user | Same | Deployer | On account change | Same |
 | `VPS_SSH_KEY` | ED25519 private key | Written to `~/.ssh/id_ed25519` in deploy job | Deployer | **On suspicion of compromise** | Full deploy pipeline access |
 | `APP_BASIC_AUTH_USER` | Username | Caddy basic auth on `app.averray.com` | Operator | On policy change | Operator UI access |
-| `APP_BASIC_AUTH_PASSWORD` | Plain password | Same | Operator | Periodic | Same |
-| `APP_BASIC_AUTH_PASSWORD_HASH` | bcrypt/htpasswd hash | Same (preferred over plain) | Operator | Periodic | Same |
+| `APP_BASIC_AUTH_PASSWORD` | **Raw** password — stored only in `Averray/Production/Critical` (human-only). Never injected by a service-account token. Used by operators to log in via the browser. | Operator vault item only | Periodic | Operator UI access |
+| `APP_BASIC_AUTH_PASSWORD_HASH` | bcrypt/htpasswd hash — this is what CI injects into the Caddy config at deploy time. The raw password is NOT needed in CI. | `Averray/Production/CI` (CI-readable) | Periodic | Same |
+
+**Why split**: the Caddy basic-auth check only needs the hash at
+runtime. The raw password is for humans typing it into a browser
+login dialog. Storing the raw password in the CI-readable vault
+would mean a compromised CI service-account token could read a
+credential that operators use to authenticate — a real privilege
+escalation against the operator UI. Keep raw passwords out of any
+vault a service-account can read.
 | `ADMIN_JWT` | Long-lived JWT | Hosted product-proof smoke + ops scripts | Deployer | On expiry (was 30d, expired today) | Backend admin role |
 | `RESEND_API_KEY` | Email API key | Bootstrap self-report / alert emails | Deployer | On vendor rotation | Alert email delivery |
 
@@ -205,24 +217,33 @@ live in D.
 | Deployer | `0xFd2EAE…6519` | Local one-shot env | Only used during `deploy_contracts.sh`; transferred to multisig at end |
 | Owner (mainnet) | TBD multisig | Three signer set in D | 2-of-3 threshold per `MULTISIG_SETUP.md` |
 | Owner (testnet) | `0x1f8C…b6F9` | Same multisig signer set | |
-| Pauser | `0xFd2EAE…6519` | Local env / hot key | EOA today; can be rotated via `rotate_pauser.sh` |
+| Pauser | `0xFd2EAE…6519` | Local env / hot key (testnet); **multisig-controlled on mainnet** | EOA on testnet, rotated via `rotate_pauser.sh`. **Mainnet**: the pauser must be a separate multisig (or at minimum a separate hardware-protected EOA that is NOT the verifier/arbitrator key). Reusing the verifier key for pause defeats the purpose — a leaked verifier signing capability would otherwise also be able to pause/un-pause arbitrarily. |
 | Verifier | `0xFd2EAE…6519` | `SIGNER_PRIVATE_KEY` (current) → AWS KMS (target) | The hottest key |
-| Arbitrator | `0xFd2EAE…6519` | `SIGNER_PRIVATE_KEY` (current) → AWS KMS (target) | Same key as verifier today; consider splitting |
+| Arbitrator | `0xFd2EAE…6519` | `SIGNER_PRIVATE_KEY` (current) → AWS KMS (target) | **Currently the SAME key as verifier — this is an accepted risk on testnet, NOT acceptable for mainnet.** Mainnet must split verifier and arbitrator into two distinct KMS keys (different IAM roles, different alarm thresholds, different on-chain addresses). A compromised verifier key should not also be able to resolve disputes. Track the split as a Phase 5 prerequisite. |
 
 ### F. External service tokens (vendor portals)
 
-These are the entries you'll find in 1Password's `Averray/Production/External`
-vault. Each has a vendor-side rotation path.
+Revised in v3 per security review: the single `External` vault is
+split into **two** vaults so a leaked CI service-account token
+cannot read backend-runtime vendor tokens, and vice versa.
 
-| Service | What | Vendor portal | Rotation |
-|---|---|---|---|
-| Pimlico | Bundler + paymaster URLs, sponsorship policy ID | dashboard.pimlico.io | On policy change |
-| Sentry | Project DSN | sentry.io | Rare (per project lifetime) |
-| GitHub | Personal access token | github.com/settings/tokens | Per token's `expires_at` (typically 90d) |
-| Subscan | API key | subscan.io | Per their cycle |
-| Resend | API key | resend.com | Periodic |
-| Webhook (alerts) | Slack/Discord/PagerDuty URL | Their respective dashboards | Rare |
-| Dweller / Polkadot RPC | URL (and any auth token) | Provider portal | Rare |
+| Service | What | Vault | Used by | Vendor portal | Rotation |
+|---|---|---|---|---|---|
+| Pimlico | Bundler + paymaster URLs, sponsorship policy ID | `Averray/Production/BackendExternal` | Backend runtime | dashboard.pimlico.io | On policy change |
+| Sentry | Project DSN | `Averray/Production/BackendExternal` | Backend runtime | sentry.io | Rare (per project lifetime) |
+| GitHub | **Fine-grained PAT** for issue ingestion (or GitHub App installation token) — see calendar entry for required scopes | `Averray/Production/CIExternal` | CI / ingestor | github.com/settings/tokens | Per token's `expires_at` (typically 90d) |
+| Subscan | API key | `Averray/Production/BackendExternal` | Backend / indexer | subscan.io | Per their cycle |
+| Resend (backend) | API key for backend self-report mail | `Averray/Production/BackendExternal` | Backend runtime | resend.com | Periodic |
+| Resend (CI) | OPTIONAL: separate API key for CI/deploy notifications | `Averray/Production/CIExternal` | CI | resend.com | Periodic |
+| Webhook (alerts) | Slack/Discord/PagerDuty URL | `Averray/Production/BackendExternal` | Backend alerting | Their respective dashboards | Rare |
+| Dweller / Polkadot RPC | URL (and any auth token) | `Averray/Production/BackendExternal` | Backend / indexer | Provider portal | Rare |
+
+**GitHub PAT scope reduction**: do NOT use a classic PAT with
+`repo`, `read:org`, `workflow`. The issue ingestor needs `Issues:
+Read` (and possibly `Issues: Write`) on a single repository.
+Generate a **fine-grained PAT** restricted to that one repo with
+those minimum permissions. For >1 repo or longer-lived needs, a
+GitHub App installation token is preferred over any PAT.
 
 ---
 
@@ -270,14 +291,32 @@ Add to 1Password as a new field; do **not** delete the old one yet.
 - For one-off revocation: `redis-cli SET revoked:<jti> 1 EX <ttl>`.
 - For a full rotation, use the rotation flow above.
 
-### `ADMIN_JWT` (long-lived JWT for ops scripts)
+### `ADMIN_JWT` (long-lived JWT for ops scripts — TRANSITIONAL)
 
-**Mint with the script**:
+**Transitional**: This long-lived admin JWT exists because the
+hosted smoke and ops scripts predate the asymmetric-KMS JWT work.
+Phase 4b (`SECRETS_INTEGRATION_PLAN.md`) replaces this with
+short-lived JWTs minted per-run from a CI OIDC → KMS path, after
+which this entry retires.
+
+**Mint with the script** (current procedure):
 ```bash
-AUTH_JWT_SECRETS=$(op read "op://Averray/Production/Backend/AUTH_JWT_SECRETS") \
-  node scripts/ops/mint-admin-jwt.mjs --profile testnet --expires-in-days 30 --quiet \
-  | gh secret set ADMIN_JWT
+AUTH_JWT_SECRETS=$(op read "op://Averray/Production/Backend/auth-jwt-secrets/credential") \
+  node scripts/ops/mint-admin-jwt.mjs --profile production --expires-in-days 30 --quiet \
+  | op item edit "op://Averray/Production/Smoke/admin-jwt" credential[password]=-
 ```
+
+Notes:
+- `--profile production` (not `testnet`) for the production smoke target.
+  Earlier instructions referenced `testnet` — that was wrong for
+  the prod smoke loop.
+- Output goes back into **1Password** at
+  `op://Averray/Production/Smoke/admin-jwt`, not directly to a
+  GitHub Actions secret. The smoke workflow reads from that
+  op:// path via the `prod-smoke-tests` service-account token.
+- The op:// path is lowercase. 1Password is case-sensitive for
+  item/section/field names; the earlier `AUTH_JWT_SECRETS`
+  uppercase reference would have failed.
 
 **Rotate**: Mint a new one with the script before the old expires.
 Add a [`SECRETS_CALENDAR.yml`](SECRETS_CALENDAR.yml) entry so CI warns
@@ -358,7 +397,15 @@ When you're ready to launch on mainnet, **every secret in the inventory
 above** gets rotated. Use this as the cutover checklist:
 
 - [ ] Generate fresh `AUTH_JWT_SECRETS` (≥32 chars, never derive from testnet)
-- [ ] Generate fresh `SIGNER_PRIVATE_KEY` — **and put it directly in AWS KMS, never on disk**
+- [ ] **Create a fresh mainnet AWS KMS asymmetric secp256k1 signer
+  key** (`KeySpec=ECC_SECG_P256K1`, `KeyUsage=SIGN_VERIFY`,
+  `Origin=AWS_KMS`, multi-region from creation). **Do NOT generate,
+  export, paste, or store a raw `SIGNER_PRIVATE_KEY` value anywhere
+  for mainnet** — the key material is created inside the HSM and
+  never leaves it; only the public key and its derived EVM
+  address ever appear outside KMS. Mainnet builds set
+  `config.allowLocalKeyFallback = false` so a stray
+  `SIGNER_PRIVATE_KEY` env var cannot be loaded as a fallback.
 - [ ] Generate fresh `VPS_SSH_KEY`
 - [ ] Generate fresh deployer EOA key for the one-shot `deploy_contracts.sh`
 - [ ] Set up new multisig signer seeds (separate seeds from testnet — do **not** reuse)

--- a/docs/SECRETS_CALENDAR.yml
+++ b/docs/SECRETS_CALENDAR.yml
@@ -28,35 +28,56 @@ entries:
   # ── GitHub Actions secrets ─────────────────────────────────────────
 
   - name: ADMIN_JWT
-    description: Long-lived admin JWT used by hosted product-proof smoke and ops scripts.
+    description: Long-lived admin JWT used by hosted product-proof smoke and ops scripts. TRANSITIONAL — replaced by short-lived asymmetric JWTs in Phase 4b.
     owner: deployer
-    vault_path: op://Averray/Production/CI/admin-jwt
+    vault_path: op://Averray/Production/Smoke/admin-jwt
     expires_at: "2026-06-09"   # 30 days after the mint on 2026-05-10
     warn_days: 7
     notes: |
-      Mint a fresh one with:
+      Mint a fresh one and store it back in 1Password (NOT directly
+      into the GitHub secret — the smoke workflow now reads from
+      op://Averray/Production/Smoke/admin-jwt via the
+      smoke-tests service-account token):
+
         AUTH_JWT_SECRETS=$(op read 'op://Averray/Production/Backend/auth-jwt-secrets/credential') \
-          node scripts/ops/mint-admin-jwt.mjs --profile testnet --expires-in-days 30 --quiet \
-          | gh secret set ADMIN_JWT
-      Update this entry's expires_at after rotation.
+          node scripts/ops/mint-admin-jwt.mjs --profile production --expires-in-days 30 --quiet \
+          | op item edit 'op://Averray/Production/Smoke/admin-jwt' credential[password]=-
+
+      Then update this entry's `expires_at`. Profile MUST be
+      `production` for the prod smoke target; `testnet` was an
+      earlier transitional value that should no longer be used
+      against the production smoke loop.
+
+      This entry is **transitional**. Phase 4b (asymmetric JWTs
+      signed by KMS) makes the long-lived admin JWT obsolete —
+      the smoke loop will mint a short-lived JWT (≤15 min) per
+      run from a CI OIDC → KMS signing path, and this calendar
+      entry can be retired. Track that in
+      SECRETS_INTEGRATION_PLAN.md Phase 4b.
 
   # ── External service tokens (placeholder values — fill in real
   #    expiry dates after migration to 1Password) ─────────────────────
 
   - name: github-pat-issue-ingestion
-    description: GitHub Personal Access Token used by the GitHub issue ingestor.
+    description: GitHub fine-grained PAT (or GitHub App installation token) used by the GitHub issue ingestor.
     owner: deployer
-    vault_path: op://Averray/Production/External/github-pat
+    vault_path: op://Averray/Production/CIExternal/github-pat
     expires_at: "TBD"   # Set after rotation; GitHub PATs typically default to 90d
     warn_days: 7
     notes: |
       Rotate at https://github.com/settings/tokens.
-      Required scopes: `repo`, `read:org`, `workflow`.
+      Prefer a **fine-grained PAT** restricted to the SINGLE repo
+      that holds the issue ingestion target, with the minimum
+      permissions: `Issues: Read` (and `Issues: Write` only if the
+      ingestor closes/comments). DO NOT use a classic PAT with
+      `repo`/`read:org`/`workflow` — those scopes are far broader
+      than needed. For >1 repo or longer-lived needs, prefer a
+      GitHub App installation token over any PAT.
 
   - name: pimlico-api-key
     description: Pimlico bundler / paymaster credentials for ERC-4337 sponsorship.
     owner: deployer
-    vault_path: op://Averray/Production/External/pimlico
+    vault_path: op://Averray/Production/BackendExternal/pimlico
     expires_at: "TBD"   # Pimlico keys don't auto-expire; treat as 90d rotation policy
     warn_days: 14
     notes: |
@@ -66,7 +87,7 @@ entries:
   - name: subscan-api-key
     description: Subscan API key for XCM observation.
     owner: deployer
-    vault_path: op://Averray/Production/External/subscan
+    vault_path: op://Averray/Production/BackendExternal/subscan
     expires_at: "TBD"   # Subscan: vendor cycle, treat as 90d rotation
     warn_days: 14
     notes: |
@@ -76,16 +97,20 @@ entries:
   - name: resend-api-key
     description: Resend.com API key for bootstrap self-report and alert emails.
     owner: operator
-    vault_path: op://Averray/Production/External/resend
+    vault_path: op://Averray/Production/BackendExternal/resend
     expires_at: "TBD"
     warn_days: 14
     notes: |
       Rotate at https://resend.com/api-keys. Token name: `averray-prod`.
+      The backend self-report key lives in BackendExternal. If CI
+      also needs to send mail (e.g. a deploy notifier), mint a
+      SEPARATE token in CIExternal so a leaked backend token can't
+      send "from CI" and vice versa.
 
   - name: sentry-dsn
     description: Sentry project DSN for error telemetry.
     owner: deployer
-    vault_path: op://Averray/Production/External/sentry-dsn
+    vault_path: op://Averray/Production/BackendExternal/sentry-dsn
     expires_at: "never"   # Sentry DSNs are project-lifetime; flag if rotated
     notes: |
       Sentry DSNs don't have an expiry; this entry exists so the
@@ -97,50 +122,66 @@ entries:
   # Revised in v2 per security review: one token per runtime per
   # environment, each scoped to a single vault.
 
+  # Service-account tokens are stored in a SHARED, human-only vault
+  # (Averray/Production/Critical) — NOT in any operator's Personal
+  # vault. 1Password's docs also note service accounts cannot be
+  # granted access to built-in Personal vaults, so Personal vault
+  # references are operationally fragile for team continuity.
+  # Critical is human-only and explicitly NOT readable by any
+  # runtime service account.
+
   - name: op-token-prod-ci-deploy
     description: 1Password service account token for GitHub Actions production deploy workflow.
     owner: deployer
-    vault_path: op://Personal/op-token-prod-ci-deploy
+    vault_path: op://Averray/Production/Critical/op-token-prod-ci-deploy
     expires_at: "TBD"   # Set when token provisioned; ≤90d cadence
     warn_days: 14
     notes: |
-      Scoped read-only to Averray/Production/CI vault. Rotate in
-      1Password admin: Integrations → Service Accounts → New (cannot
-      change scope on existing token). After rotation, update the
+      Scoped read-only to Averray/Production/CI + CIExternal vaults
+      (deploy-time credentials only, no backend runtime secrets).
+      Rotate in 1Password admin: Integrations → Service Accounts →
+      New (scope is effectively immutable post-create — mint a new
+      one rather than trying to widen). After rotation, update the
       GitHub Environment secret OP_SERVICE_ACCOUNT_TOKEN_PROD_CI.
 
   - name: op-token-prod-vps-backend
     description: 1Password service account token used by the backend VPS at deploy time.
     owner: deployer
-    vault_path: op://Personal/op-token-prod-vps-backend
+    vault_path: op://Averray/Production/Critical/op-token-prod-vps-backend
     expires_at: "TBD"
     warn_days: 14
     notes: |
-      Scoped read-only to Averray/Production/Backend + External.
+      Scoped read-only to the MINIMAL VAULT SET the backend needs at
+      runtime: Averray/Production/Backend + BackendExternal.
+      A leaked token reads those two vaults only — not Indexer, not
+      CI, not Critical, not Smoke.
       After rotation, update /etc/agent-stack/op-backend.env on the
-      VPS. Service tokens are effectively immutable post-create —
-      mint a new one rather than trying to widen scope.
+      VPS.
 
   - name: op-token-prod-vps-indexer
     description: 1Password service account token used by the indexer VPS at deploy time.
     owner: deployer
-    vault_path: op://Personal/op-token-prod-vps-indexer
+    vault_path: op://Averray/Production/Critical/op-token-prod-vps-indexer
     expires_at: "TBD"
     warn_days: 14
     notes: |
-      Scoped read-only to Averray/Production/Indexer.
+      Scoped read-only to Averray/Production/Indexer (single vault).
       After rotation, update /etc/agent-stack/op-indexer.env on the
       VPS.
 
   - name: op-token-prod-smoke-tests
     description: 1Password service account token used by hosted product-proof smoke.
     owner: deployer
-    vault_path: op://Personal/op-token-prod-smoke-tests
+    vault_path: op://Averray/Production/Critical/op-token-prod-smoke-tests
     expires_at: "TBD"
     warn_days: 14
     notes: |
-      Scoped read-only to Averray/Production/CI/admin-jwt only.
-      Smallest blast radius — leaked token can only read ADMIN_JWT.
+      Scoped read-only to Averray/Production/Smoke (dedicated vault
+      created specifically because 1Password does not support
+      item-level scoping inside a vault — must be a whole-vault
+      grant). The Smoke vault contains only the admin-jwt item.
+      Smallest blast radius — leaked token can read the Smoke vault
+      only.
 
   # ── AWS signer access (NOT static IAM keys) ───────────────────────
   #
@@ -153,14 +194,35 @@ entries:
   - name: aws-roles-anywhere-client-cert
     description: X.509 client cert on the VPS used by IAM Roles Anywhere to fetch temporary AWS credentials.
     owner: deployer
-    vault_path: op://Averray/Production/Backend/aws-roles-anywhere-cert
-    expires_at: "TBD"   # Set per CA's cert lifetime (typically 1 year)
+    # The calendar tracks the cert's PUBLIC metadata (issuer, SAN,
+    # expiry) only. The private key NEVER goes into any 1Password
+    # vault that a service account can read — that would break the
+    # threat model (backend service token + cert+key = AWS temp
+    # creds = kms:Sign capability).
+    vault_path: op://Averray/Production/Critical/aws-roles-anywhere-cert-metadata
+    expires_at: "TBD"   # 1y general-purpose ACM-PCA; ≤7d short-lived mode
     warn_days: 30
     notes: |
-      Reissue from the IAM Roles Anywhere Trust Anchor's CA. Replace
-      cert + private key at /etc/agent-stack/roles-anywhere/ on the
-      VPS (mode 0400). The CA private key itself is in AWS ACM-PCA
-      or an HSM — NOT in 1Password.
+      Reissue procedure (revised in v3 per security review):
+        1. Generate a new keypair ON THE VPS (do not generate
+           remotely and copy).
+        2. Submit the CSR to the IAM Roles Anywhere Trust Anchor's
+           CA (ACM-PCA or your self-managed CA).
+        3. Install the new cert at /etc/agent-stack/roles-anywhere/
+           on the VPS (mode 0400, owner root).
+        4. Update this calendar entry with the new expires_at.
+
+      What lives where:
+        - Public certificate (PEM, metadata): Critical vault for
+          audit + expiry tracking. Human-only access; service
+          accounts cannot read Critical.
+        - Client private key: VPS only. Generated on VPS. Never
+          written to any vault readable by a service account.
+          Optional emergency escrow in Averray/Production/Critical
+          (human-only) is documented as residual risk in
+          SECRETS_INTEGRATION_PLAN.md.
+        - CA private key: AWS ACM-PCA, OR a hardware-backed HSM.
+          Never on disk.
 
   # The KMS SIGNER KEY itself is NOT calendar-tracked. Rotation of
   # the asymmetric KMS key is an on-chain signer migration event

--- a/docs/SECRETS_INTEGRATION_PLAN.md
+++ b/docs/SECRETS_INTEGRATION_PLAN.md
@@ -1,7 +1,8 @@
 # Secrets Integration Plan — Security Review Document
 
-> **Status**: v2 — incorporates external security review feedback.
-> See [Revision history](#revision-history) at the bottom.
+> **Status**: v3 — incorporates a SECOND external security review
+> pass on top of v2. See [Revision history](#revision-history) at
+> the bottom.
 
 This is the security-review-grade companion to
 [`SECRETS_MIGRATION.md`](SECRETS_MIGRATION.md). Where the migration doc
@@ -147,25 +148,43 @@ Hardware wallets: multisig Hot/Warm/Cold seeds.
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │ 1Password Business                                              │
-│   Averray/Production/Backend       ← runtime secrets only       │
-│   Averray/Production/Indexer       ← indexer-only secrets       │
-│   Averray/Production/CI            ← deploy creds (SSH keys)    │
-│   Averray/Production/External      ← vendor API tokens          │
-│   Averray/Production/Critical      ← AWS root creds, etc.       │
-│   Averray/Testnet/{Backend,Indexer,CI,External,Critical}        │
-│   Averray/Multisig                 ← signer ADDRESSES only,     │
-│                                       never seeds               │
-│   Averray/Operators/<name>         ← per-operator personal      │
-│   Averray/Archive                  ← decommissioned secrets     │
+│   Averray/Production/Backend         ← backend runtime secrets  │
+│   Averray/Production/BackendExternal ← vendor tokens used by    │
+│                                         backend (Pimlico,       │
+│                                         Subscan, RPC, Sentry,   │
+│                                         Resend backend key)     │
+│   Averray/Production/Indexer         ← indexer-only secrets     │
+│   Averray/Production/CI              ← deploy creds (SSH key,   │
+│                                         basic-auth HASH)        │
+│   Averray/Production/CIExternal      ← vendor tokens used only  │
+│                                         in CI (GitHub PAT for   │
+│                                         issue ingestion, CI-    │
+│                                         scoped Resend key)      │
+│   Averray/Production/Smoke           ← admin-jwt + smoke-only   │
+│                                         credentials             │
+│   Averray/Production/Critical        ← human-only: service-     │
+│                                         account tokens, AWS     │
+│                                         root, Roles Anywhere    │
+│                                         cert metadata, basic-   │
+│                                         auth RAW password,      │
+│                                         pauser EOA seed         │
+│   Averray/Production/Observability   ← OPTIONAL: dashboards     │
+│                                         and metrics tokens      │
+│   Averray/Testnet/* (same shape, separate vaults)               │
+│   Averray/Multisig                   ← signer ADDRESSES only,   │
+│                                         never seeds             │
+│   Averray/Operators/<name>           ← per-operator personal    │
+│   Averray/Archive                    ← REVOKED/EXPIRED ONLY —   │
+│                                         retained 90d for        │
+│                                         forensics, then deleted │
 │                                                                 │
 │  Read access via FOUR distinct service accounts                 │
-│  (each scoped to one vault):                                    │
-│    prod-ci-deploy   → only Averray/Production/CI                │
-│    prod-vps-backend → only Averray/Production/Backend +         │
-│                              Averray/Production/External        │
-│    prod-vps-indexer → only Averray/Production/Indexer           │
-│    prod-smoke-tests → only Averray/Production/CI (admin JWT)    │
-│  (plus testnet equivalents)                                     │
+│  (each scoped to its minimum vault set):                        │
+│    prod-ci-deploy   → CI + CIExternal                           │
+│    prod-vps-backend → Backend + BackendExternal                 │
+│    prod-vps-indexer → Indexer                                   │
+│    prod-smoke-tests → Smoke                                     │
+│  (plus testnet equivalents; NONE can read Critical)             │
 └─────────────────────────────────────────────────────────────────┘
             │                          │
             │ op:// URI                │ 1password/load-secrets-action
@@ -218,7 +237,7 @@ Hardware wallets — UNCHANGED. Multisig signer seeds NEVER touch
 |---|---|---|
 | 1Password vault ↔ runtime | Vault stores plain values; runtime fetches via per-runtime scoped service tokens | A scoped token leak = read access to ONE vault scope only (e.g., prod-ci-deploy token leak ≠ access to Backend secrets) |
 | AWS KMS ↔ backend | KMS holds private key bytes; backend gets temporary creds via Roles Anywhere | Compromise of running backend = ability to sign for ≤1h until temp creds expire; CANNOT export key |
-| GitHub Actions ↔ AWS | GitHub OIDC → AssumeRole; no long-lived AWS creds in GitHub | Compromise of GitHub workflow = ability to assume role only while exploit is active; revoking trust relationship in IAM stops it |
+| GitHub Actions ↔ AWS | GitHub OIDC → AssumeRole. Separate `averray-ci-deploy-role` (NO `kms:Sign`) from `averray-signer-prod-role` (Roles Anywhere only). | Compromise of CI workflow can NOT assume the signer role — the signer role's trust policy doesn't include GitHub OIDC. Workflow-level compromise gets at most CI-scoped permissions (read-only ECR/S3, optionally `kms:GetPublicKey`). Revoke trust relationship in IAM to stop. |
 | GitHub Actions ↔ VPS | Production deploy gated by GitHub Environment with required reviewers + restricted branches | Compromised workflow PR cannot deploy without a human approval gate |
 
 ### 4c. What attacks this defends against (vs current state)
@@ -251,11 +270,19 @@ multiple scoped service accounts. No runtime changes yet.
 
 | Service account | Read access | Used by |
 |---|---|---|
-| `prod-ci-deploy` | `Averray/Production/CI` | GitHub Actions deploy workflow |
-| `prod-vps-backend` | `Averray/Production/Backend` + `External` | Backend VPS at deploy time (`op inject`) |
+| `prod-ci-deploy` | `Averray/Production/CI` + `Averray/Production/CIExternal` | GitHub Actions deploy workflow |
+| `prod-vps-backend` | `Averray/Production/Backend` + `Averray/Production/BackendExternal` | Backend VPS at deploy time (`op inject`) |
 | `prod-vps-indexer` | `Averray/Production/Indexer` | Indexer VPS at deploy time |
-| `prod-smoke-tests` | `Averray/Production/CI/admin-jwt` only | Hosted product-proof smoke runs |
+| `prod-smoke-tests` | `Averray/Production/Smoke` (dedicated vault) | Hosted product-proof smoke runs |
 | (testnet equivalents) | corresponding `Averray/Testnet/*` | testnet workflows |
+
+**None of these tokens can read `Averray/Production/Critical`** —
+the Critical vault holds the service-account tokens themselves,
+the AWS root, the Roles Anywhere cert metadata, the basic-auth
+RAW password, and the pauser EOA seed. Critical is human-only.
+This is the firebreak: a leaked runtime token cannot read its own
+replacement, cannot read the next layer of credentials, cannot
+escalate.
 
 **Service account access and vault permissions are effectively
 immutable after creation** — design scopes correctly up front. If
@@ -328,8 +355,17 @@ files. CI workflows reference `op://` URIs instead of `${{ secrets.* }}`.
 - Disable core dumps for the backend process (`prlimit --core=0`)
 - Backend process drops privileges to a non-root user after reading
   env at startup
-- Audit: `journalctl`, `docker inspect`, `/proc/$pid/environ` should
-  show no plaintext secrets after a deploy
+- Audit scope after Phase 2 (honest framing): runtime secrets
+  **will** appear in the container environment and in
+  `docker inspect` / `/proc/$pid/environ` for the backend and
+  indexer processes — that's how Docker Compose's `env_file`
+  works, and it's expected. The Phase-2 check is therefore
+  narrower: confirm that **deploy logs** never print rendered
+  values, that the **rendered env files live on tmpfs** with
+  mode 0400 (not on a persistent disk), and that
+  **`journalctl -u agent-stack`** doesn't echo env values at
+  service start. Eliminating the in-container plaintext for the
+  **signer key specifically** is Phase 3's job, not Phase 2's.
 
 **New attack surfaces**:
 - Each per-runtime service-account token on its target host
@@ -365,10 +401,21 @@ files. CI workflows reference `op://` URIs instead of `${{ secrets.* }}`.
   unexpected differences
 - [ ] Deploy logs contain no secret values (grep for first 8 chars of
   any sensitive value: expect zero hits)
-- [ ] `journalctl -u agent-stack`, `docker inspect agent-stack`,
-  `cat /proc/$(pgrep -f backend)/environ | tr '\0' '\n'` — zero
-  plaintext secret hits (not just hex-pattern matches; check for
-  symbol-named env vars too)
+- [ ] Rendered env files live on tmpfs at `/run/agent-stack/*.env`
+  (verify with `findmnt /run/agent-stack` → `tmpfs`), mode 0400,
+  owned by `root:agent-stack-service`
+- [ ] `/run/agent-stack/*` is excluded from every backup / snapshot
+  / image-export job (grep the backup config; do a test restore
+  and confirm the path is missing)
+- [ ] `journalctl -u agent-stack` from a fresh deploy does **not**
+  print env values (start-up config dump is scrubbed or
+  disabled)
+- [ ] **Note (not a pass/fail)**: `docker inspect agent-stack` and
+  `cat /proc/$(pgrep -f backend)/environ` **will** show runtime
+  secrets after Phase 2 — that's expected behaviour for
+  `env_file`-style Compose. The matching Phase-3 verification
+  re-checks these and requires `SIGNER_PRIVATE_KEY` (specifically)
+  to be absent.
 - [ ] Test rotation: change a secret in 1Password → redeploy → new
   value reaches running backend (confirm via `/health` or
   `/admin/status` where exposed)
@@ -411,15 +458,28 @@ single-region is fine.
   (otherwise KMS hashes the input again and recovery breaks)
 - `SigningAlgorithm`: `ECDSA_SHA_256` (the only secp256k1 algo supported)
 
-**IAM policy** (the principal that calls Sign):
-- Actions: `kms:Sign` + `kms:GetPublicKey` ONLY
-- Resource: the specific Key ARN
-- Conditions:
-  - `kms:SigningAlgorithm = ECDSA_SHA_256`
-  - `kms:MessageType = DIGEST`
-- Explicit deny on `kms:ScheduleKeyDeletion`, `kms:DisableKey`,
+**IAM policy** (the principal that calls Sign). The policy MUST split
+`Sign` and `GetPublicKey` into separate statements — the condition
+keys `kms:SigningAlgorithm` and `kms:MessageType` only apply to
+`Sign`/`Verify`, and AWS IAM treats absent condition keys in a
+request context as "no match" unless `IfExists` is used. A combined
+statement implicitly denies `GetPublicKey` (revised in v3):
+
+- Statement 1 — `AllowGetPublicKey`: action `kms:GetPublicKey` on the
+  specific key ARN(s). No conditions.
+- Statement 2 — `AllowSignDigestOnly`: action `kms:Sign` on the
+  specific key ARN(s), with `kms:SigningAlgorithm = ECDSA_SHA_256`
+  AND `kms:MessageType = DIGEST` as `StringEquals` conditions.
+- Statement 3 — `ExplicitDenyDangerousOpsForSignerRole`: explicit
+  `Deny` for `kms:ScheduleKeyDeletion`, `kms:DisableKey`,
   `kms:PutKeyPolicy`, `kms:CreateGrant`, `kms:ReplicateKey`,
-  `kms:UpdatePrimaryRegion` for this principal
+  `kms:UpdatePrimaryRegion` on the same ARN(s).
+
+The explicit deny applies to the signer role only. It does NOT
+constrain AWS root or admin principals — admin-path protection
+requires key-policy constraints, SCPs, permission boundaries, an
+approval process, and CloudTrail monitoring. See `SECRETS_MIGRATION.md`
+§3a for the full JSON policy.
 
 **Temporary credentials, not long-lived IAM keys** (corrected from v1):
 - **VPS**: IAM Roles Anywhere. Provision a private CA (AWS ACM-PCA or
@@ -513,8 +573,12 @@ before going to mainnet):
 - [ ] Process listing on VPS contains no `0x[a-f0-9]{60}` signer key
   patterns AND no env var with name matching `*PRIVATE*` /
   `*SECRET*` referencing the signer key
-- [ ] Synthetic CloudWatch alarm fires (e.g., temporarily call
-  `DisableKey` from an admin session and confirm the alarm notifies)
+- [ ] Synthetic CloudWatch alarm fires — tested via EventBridge
+  `PutEvents` for CloudTrail-driven rules, and via a dedicated
+  non-production KMS key for destructive-API rules. **Do NOT** call
+  `DisableKey` / `ScheduleKeyDeletion` against the live production
+  signer key as a test (see `SECRETS_MIGRATION.md` §3b-2 for the
+  full safe-test procedure)
 - [ ] Hosted product-proof smoke passes end-to-end via KMS signer
 - [ ] Revoking the IAM principal's session (or the Roles Anywhere
   trust anchor's profile) breaks signing as expected — proves the
@@ -895,7 +959,93 @@ days spread over a few weeks).
 
 ## Revision history
 
-**v2** — Security review pass (this version)
+**v3** — Second security review pass (this version)
+
+Substantive changes from v2 (all driven by external review):
+
+1. **IAM policy for the signer role split into three statements**
+   (Phase 3a). The combined-statement form in v2 would have
+   implicitly denied `kms:GetPublicKey` because the
+   `kms:SigningAlgorithm` / `kms:MessageType` condition keys only
+   apply to Sign/Verify. New shape:
+   `AllowGetPublicKey` (no conditions) + `AllowSignDigestOnly`
+   (with conditions) + `ExplicitDenyDangerousOpsForSignerRole`
+   (covers ScheduleKeyDeletion, DisableKey, PutKeyPolicy,
+   CreateGrant, ReplicateKey, UpdatePrimaryRegion).
+2. **Roles Anywhere client cert / private key removed from any
+   service-account-readable vault** (Phase 3a + SECRETS_CALENDAR).
+   Private key is now generated **on the VPS**, never copied
+   anywhere; only public cert metadata lives in
+   `Averray/Production/Critical` (human-only) for expiry tracking.
+   The v2 wording would have allowed a leaked `prod-vps-backend`
+   token to retrieve AWS temp creds with `kms:Sign` capability —
+   the entire point of the migration.
+3. **Vault structure split per-runtime**: added `BackendExternal`,
+   `CIExternal`, dedicated `Smoke`, dedicated `Critical`
+   (human-only), optional `Observability`. The single `External`
+   vault from v2 was too coarse; one leaked CI token could read
+   all vendor keys.
+4. **Phase 2 "runtime plaintext" verification softened** to match
+   reality. Once `env_file` is wired, runtime secrets live in
+   container env by design; `docker inspect` / `/proc/$pid/environ`
+   will show them. Phase 2 now checks tmpfs + backup exclusion +
+   deploy-log scrubbing only. The aggressive
+   `SIGNER_PRIVATE_KEY`-must-be-absent-everywhere check is Phase 3's
+   exit criterion (where it correctly applies).
+5. **ADMIN_JWT runbook** updated: mint with `--profile production`
+   (not testnet); store back into 1Password via `op item edit`
+   (not `gh secret set`); reference
+   `op://Averray/Production/Smoke/admin-jwt` (correct vault, correct
+   casing); flagged as transitional until Phase 4b makes it
+   obsolete.
+6. **Mainnet KMS wording** corrected — there is no "generate fresh
+   SIGNER_PRIVATE_KEY" step on mainnet. KMS key material is created
+   inside the HSM (`Origin=AWS_KMS`) and never exists as raw bytes
+   anywhere. Mainnet builds set
+   `config.allowLocalKeyFallback = false`.
+7. **Roles Anywhere session duration tightened**: ≤1h enforced at
+   Profile + CreateSession + MaxSessionDuration; production signer
+   prefers 15–30 min. Trust policy adds cert identity constraints
+   (`aws:PrincipalTag` / `aws:SourceIdentity`) so only the expected
+   VPS cert can assume the role.
+8. **GitHub OIDC role separated from the production signer role**.
+   `averray-ci-deploy-role` (for Actions) has NO `kms:Sign` by
+   default; only the Roles-Anywhere-trusting
+   `averray-signer-prod-role` does. A compromised workflow cannot
+   pivot to signing capability.
+9. **Alarm testing procedure rewritten** to not call `DisableKey`
+   on production. Use EventBridge `PutEvents` for CloudTrail-driven
+   rules, and a dedicated non-production KMS key for destructive-API
+   rules.
+10. **Cost summary corrected**: multi-region KMS is "primary + 1
+    replica = 2 keys total" (not "2 replicas of one key").
+    Added ACM-PCA short-lived certificate mode at ~$50/mo as the
+    recommended Roles Anywhere CA option.
+
+Smaller v3 edits:
+- KMS public-key derivation uses a real DER/ASN.1 SPKI parser
+  (`@peculiar/asn1-x509`) instead of byte-offset arithmetic.
+- npm dependency pinning clarified: exact version + lockfile +
+  provenance, NOT git-SHA pins (which bypass registry integrity).
+- GitHub PAT for issue ingestion: require fine-grained PAT (or
+  GitHub App installation token) restricted to one repo with
+  minimum permissions; classic PATs are out.
+- Archive vault explicitly restricted to revoked/expired values
+  only.
+- Mainnet pauser must be a separate multisig (or hardware-protected
+  separate EOA), NOT the verifier key.
+- Mainnet verifier and arbitrator must be split into two distinct
+  KMS keys; reusing one key for both is testnet-only.
+- Named 1Password users (not shared logins); the
+  `secrets@averray.com` mailbox is the account-owner address, not
+  a daily sign-in identity.
+- `APP_BASIC_AUTH_PASSWORD` raw password moves to
+  `Averray/Production/Critical` (human-only); only the bcrypt hash
+  lives in CI-readable vaults.
+
+---
+
+**v2** — Security review pass
 
 Substantive changes from v1:
 1. **Split 1Password service accounts by runtime** (Section 4a, 4b,

--- a/docs/SECRETS_MIGRATION.md
+++ b/docs/SECRETS_MIGRATION.md
@@ -11,9 +11,13 @@ security-review-grade design rationale, threat model, and mainnet
 sign-off bar.
 
 This doc assumes you're convinced *what* needs to move and just need
-the *how*. The phase structure has been revised in response to an
-external security review — significant changes vs. the v1 draft are
-flagged in context.
+the *how*. The phase structure has been revised in response to **two
+rounds** of external security review; v2 deltas are flagged
+"(revised in v2)" and v3 deltas are flagged "(revised in v3)" in
+context. The companion
+[`SECRETS_INTEGRATION_PLAN.md`](SECRETS_INTEGRATION_PLAN.md)
+revision history at the bottom is the canonical list of substantive
+changes.
 
 The migration breaks into **5 phases** that can land independently. Each
 phase is mergeable on its own and reversible if something breaks. You
@@ -23,7 +27,7 @@ can pause between any of them.
 |---|---|---|---|
 | 1 | 1Password Business setup + secret inventory loaded into vault | ~1 day | Yes — old env files still authoritative |
 | 2 | Sync vault → runtime (CI + VPS) | ~1 day | Yes — fall back to GitHub UI / direct env edit |
-| 3 | AWS KMS for the backend signer | ~2 days | Yes — keep `SIGNER_PRIVATE_KEY` env path until cutover |
+| 3 | AWS KMS for the backend signer | ~2 days | **Testnet only**: yes — keep `SIGNER_PRIVATE_KEY` env path until cutover. **Mainnet**: no raw-key fallback. Rollback = multisig-controlled signer migration. |
 | 4 | Hardening (CI secret scanning, short-lived JWTs, expiry alarms) | ~1 day | Yes — purely additive |
 | 5 | Mainnet cutover | ~1 day | No — new addresses are fresh; testnet stays as testnet |
 
@@ -39,34 +43,90 @@ can pause between any of them.
 - Use a dedicated email for the team account (e.g. `secrets@averray.com`),
   not your personal one. This makes future ownership transfers
   painless.
+- **Each human gets their own named 1Password user account**, NOT a
+  shared login. Audit logs must attribute every action to a real
+  person. A shared login is incompatible with the
+  "named-individual rotation cadence" the calendar assumes, and
+  with any future SOC 2 / external-audit posture. The dedicated
+  `secrets@averray.com` mailbox is only the ACCOUNT owner address
+  used for billing and recovery — it is not a sign-in identity for
+  daily use. Day-to-day work is done as
+  `pascal@averray.com`, `<second-operator>@averray.com`, etc.,
+  each with their own hardware MFA and recovery kit.
 
 ### 1b. Create the vault structure
 
 Build these vaults in 1Password. Each is a separate access boundary.
+**Revised in v3** to split `External` per-runtime and add dedicated
+`Smoke` and `Critical` vaults (1Password's service-account scoping
+is whole-vault, not item-level).
 
 ```
 Averray/
 ├── Production/
-│   ├── Backend           # AUTH_JWT_SECRETS, RPC URLs, external API keys
+│   ├── Backend           # Runtime backend secrets ONLY:
+│   │                     #   AUTH_JWT_SECRETS, RPC URLs, KMS_KEY_ID,
+│   │                     #   AWS_REGION, blockchain config
+│   ├── BackendExternal   # Vendor keys the backend needs at runtime:
+│   │                     #   Pimlico bundler/paymaster, RPC provider
+│   │                     #   creds, Sentry DSN, XCM observer auth.
+│   │                     #   Splitting from CI-side vendor keys
+│   │                     #   prevents one leaked token from reaching
+│   │                     #   all vendor accounts.
 │   ├── Indexer           # DATABASE_URL, PONDER_RPC_URL_*
-│   ├── CI                # VPS_SSH_KEY, ADMIN_JWT, APP_BASIC_AUTH_*
-│   └── External          # Pimlico, Sentry, Subscan, GitHub PAT, Resend, RPC provider
-├── Testnet/              # Mirrors Production/ but for testnet keys
-│   ├── Backend
-│   ├── Indexer
-│   ├── CI
-│   └── External
-├── Multisig/             # Signer reference info ONLY — never the seeds themselves
-│   └── Signer addresses, public keys, SS58 forms
-├── Operators/            # Per-operator personal vaults (auto-created by 1Password)
+│   ├── CI                # Deploy-time creds:
+│   │                     #   VPS_SSH_KEY, APP_BASIC_AUTH_PASSWORD_HASH
+│   │                     #   (note: the bcrypt HASH only; raw password
+│   │                     #   lives in an operator vault)
+│   ├── CIExternal        # Vendor keys CI needs at deploy time:
+│   │                     #   Resend (alert emails), webhooks
+│   ├── Smoke             # Hosted product-proof smoke test secrets:
+│   │                     #   admin-jwt only. Dedicated vault because
+│   │                     #   1Password doesn't support item-level
+│   │                     #   service-account scoping — must be whole
+│   │                     #   vault.
+│   ├── Critical          # Human-only, NOT readable by any runtime
+│   │                     # service account. Holds:
+│   │                     #   - OP service-account tokens themselves
+│   │                     #   - AWS root account recovery
+│   │                     #   - 1Password account recovery kit
+│   │                     #   - Roles Anywhere cert metadata (public)
+│   │                     #   - Optional Roles Anywhere private-key
+│   │                     #     escrow (documented as residual risk)
+│   └── Observability     # Optional: dedicated vault for monitoring
+│                         # secrets if you want even tighter blast
+│                         # radius. Otherwise rolls into BackendExternal.
+├── Testnet/              # Mirrors Production/ structure for testnet
+│   ├── Backend, BackendExternal, Indexer, CI, CIExternal, Smoke, Critical
+├── Multisig/             # Signer ADDRESSES + public-key reference info
+│                         # ONLY. Multisig seeds NEVER enter 1Password.
+├── Operators/            # Per-operator personal vaults
 │   ├── Pascal
 │   └── …
-└── Archive/              # Decommissioned secrets, kept for audit
+└── Archive/              # ONLY revoked / expired / cryptographically
+                          # unusable values. Never archive a still-valid
+                          # reusable secret. Metadata + dead values for
+                          # audit trail.
 ```
 
-Why split testnet and production: re-using testnet secrets on mainnet
-is the most common pre-launch mistake. Separate vaults make accidental
-cross-contamination structurally impossible.
+Why each separation matters:
+- **Testnet vs Production**: re-using testnet secrets on mainnet is
+  the most common pre-launch mistake. Separate vaults make accidental
+  cross-contamination structurally impossible.
+- **Backend vs BackendExternal**: limits which secrets one leaked
+  runtime token can reach. Backend runtime token compromised? Vendor
+  keys for CIExternal (Resend, webhooks) are not in scope.
+- **Smoke vault**: dedicated so the smoke-test token can be scoped
+  there with smallest blast radius. 1Password doesn't allow item-
+  level service-account scoping, so the smallest scope IS a vault.
+- **Critical**: holds the OP service-account tokens themselves +
+  account-recovery material. Human-only by design; no service
+  account ever reads Critical. If it did, a service-account
+  compromise would yield other service-account tokens — bootstrapped
+  privilege escalation.
+- **Archive**: ONLY for revoked or expired values. Storing
+  still-valid values here defeats the purpose; they're still in
+  scope of any vault search and any vault-level access grant.
 
 ### 1c. Migrate secrets
 
@@ -104,10 +164,10 @@ protection of the token is the customer's responsibility.
 
 | Service account | Read access | Used by |
 |---|---|---|
-| `prod-ci-deploy` | only `Averray/Production/CI` | GitHub Actions deploy workflow |
-| `prod-vps-backend` | only `Averray/Production/Backend` + `Averray/Production/External` | Backend VPS `op inject` at deploy time |
-| `prod-vps-indexer` | only `Averray/Production/Indexer` | Indexer VPS `op inject` at deploy time |
-| `prod-smoke-tests` | only `Averray/Production/CI/admin-jwt` | Hosted product-proof smoke |
+| `prod-ci-deploy` | `Averray/Production/CI` + `Averray/Production/CIExternal` | GitHub Actions deploy workflow |
+| `prod-vps-backend` | `Averray/Production/Backend` + `Averray/Production/BackendExternal` | Backend VPS `op inject` at deploy time |
+| `prod-vps-indexer` | `Averray/Production/Indexer` | Indexer VPS `op inject` at deploy time |
+| `prod-smoke-tests` | `Averray/Production/Smoke` (dedicated vault — currently holds only `admin-jwt`) | Hosted product-proof smoke |
 
 #### Testnet equivalents
 
@@ -230,7 +290,7 @@ as `/srv/agent-stack/backend.env.template`.
 # /srv/agent-stack/backend.env.template (AFTER)
 + AUTH_JWT_SECRETS=op://Averray/Production/Backend/auth-jwt-secrets/credential
 + SIGNER_PRIVATE_KEY=op://Averray/Production/Backend/signer-private-key/credential
-+ PIMLICO_BUNDLER_URL=op://Averray/Production/External/pimlico-bundler-url/credential
++ PIMLICO_BUNDLER_URL=op://Averray/Production/BackendExternal/pimlico-bundler-url/credential
 ```
 
 ### 2d. Render at deploy time (with hardening)
@@ -282,6 +342,18 @@ After deploy, the rendered `backend.env` is on tmpfs, never written
 to disk. A reboot clears it. A `docker compose up` re-renders it
 from 1Password.
 
+**What Phase 2 does NOT remove** (honest framing, revised in v3 per
+security review): once Docker Compose reads `backend.env` via
+`env_file`, the values live in the container's process environment
+and are visible to anyone with root on the host through
+`docker inspect <container>` and `cat /proc/$(pgrep -f backend)/environ`.
+That is **expected** — not a Phase 2 failure. The signer key
+specifically is removed from this surface in **Phase 3** (KMS); the
+other runtime secrets (DB URL, API keys, etc.) remain in container
+env throughout the platform's life unless the application is
+refactored to fetch them dynamically. The Phase 2 verification
+checklist below is calibrated against this reality.
+
 ### 2e. Convert GitHub Actions secrets (with environment protection)
 
 **Revised in v2.** Wrap the deploy in a GitHub **Environment** with
@@ -310,7 +382,7 @@ jobs:
           # environment-gated job sees it.
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PROD_CI }}
           VPS_SSH_KEY:                  op://Averray/Production/CI/vps-ssh-key/credential
-          ADMIN_JWT:                    op://Averray/Production/CI/admin-jwt/credential
+          ADMIN_JWT:                    op://Averray/Production/Smoke/admin-jwt/credential
           APP_BASIC_AUTH_PASSWORD_HASH: op://Averray/Production/CI/app-basic-auth-password-hash/credential
           RESEND_API_KEY:               op://Averray/Production/CI/resend-api-key/credential
 ```
@@ -354,6 +426,18 @@ gains access to the action's repo.
 - [ ] Old plain-text secrets are removed from GitHub Actions / VPS
 - [ ] Test rotation: change one secret in 1Password → redeploy → new
   value reaches runtime
+- [ ] **Tmpfs check**: `findmnt /run/agent-stack` reports `tmpfs`;
+  rendered env files are mode `0400`, owner `root:agent-stack-service`
+- [ ] **Backup check**: `/run/agent-stack/*` and any
+  `/srv/agent-stack/*.env*` are excluded from every backup /
+  snapshot / image-export job (grep the backup config to confirm)
+- [ ] **Deploy-log check**: a fresh deploy log contains no rendered
+  values (grep the deploy log + `journalctl -u agent-stack` for
+  the first 8 chars of one known secret → zero hits)
+- [ ] **Acknowledged residual** (not pass/fail): runtime secrets
+  remain visible inside the container via `docker inspect` and
+  `/proc/$pid/environ`. This is expected; eliminating that surface
+  for the signer key is Phase 3's job.
 
 ### Rollback
 
@@ -385,16 +469,33 @@ automatically.
    - Use root only for billing + initial IAM setup; never daily
    - Print recovery info offline
 2. Create the IAM **role** `averray-signer-prod-role` (not user!) with
-   only these permissions on the KMS key:
+   only these permissions on the KMS key. **The Sign statement and
+   the GetPublicKey statement must be separate** — `kms:SigningAlgorithm`
+   and `kms:MessageType` are condition keys for `Sign`/`Verify` only,
+   not `GetPublicKey`. Combining them in one statement implicitly
+   denies `GetPublicKey` because the condition keys are absent from
+   its request context (revised in v3 per security review):
    ```json
    {
      "Version": "2012-10-17",
      "Statement": [
        {
-         "Sid": "AllowSignWithCanonicalConditions",
+         "Sid": "AllowGetPublicKey",
          "Effect": "Allow",
-         "Action": ["kms:Sign", "kms:GetPublicKey"],
-         "Resource": "arn:aws:kms:<region>:<account>:key/<key-id>",
+         "Action": "kms:GetPublicKey",
+         "Resource": [
+           "arn:aws:kms:<primary-region>:<account>:key/<key-id>",
+           "arn:aws:kms:<replica-region>:<account>:key/<key-id>"
+         ]
+       },
+       {
+         "Sid": "AllowSignDigestOnly",
+         "Effect": "Allow",
+         "Action": "kms:Sign",
+         "Resource": [
+           "arn:aws:kms:<primary-region>:<account>:key/<key-id>",
+           "arn:aws:kms:<replica-region>:<account>:key/<key-id>"
+         ],
          "Condition": {
            "StringEquals": {
              "kms:SigningAlgorithm": "ECDSA_SHA_256",
@@ -403,7 +504,7 @@ automatically.
          }
        },
        {
-         "Sid": "ExplicitDenyDangerousOps",
+         "Sid": "ExplicitDenyDangerousOpsForSignerRole",
          "Effect": "Deny",
          "Action": [
            "kms:ScheduleKeyDeletion",
@@ -413,37 +514,99 @@ automatically.
            "kms:ReplicateKey",
            "kms:UpdatePrimaryRegion"
          ],
-         "Resource": "arn:aws:kms:<region>:<account>:key/<key-id>"
+         "Resource": [
+           "arn:aws:kms:<primary-region>:<account>:key/<key-id>",
+           "arn:aws:kms:<replica-region>:<account>:key/<key-id>"
+         ]
        }
      ]
    }
    ```
+
+   **Scope of the explicit deny**: it applies to the signer role
+   only. It does NOT constrain AWS root or admin principals on this
+   account. Admin-path protection requires key-policy constraints
+   (on the KMS key itself), SCPs at the organization level,
+   permission boundaries, an approval process for IAM admin
+   actions, and CloudTrail monitoring — covered in the
+   `ExplicitDenyDangerousOps` discussion under "CloudWatch alarms"
+   below.
+
    The condition keys (`kms:SigningAlgorithm`, `kms:MessageType`)
-   bind the role to one signing algorithm + digest mode. Even with
+   bind the Sign action to one signing algorithm + digest mode.
+   Even with
    the credentials, an attacker cannot ask for a different algorithm
    or sign a raw message instead of a digest.
 
 3. **VPS access**: configure IAM Roles Anywhere
-   - Provision a private CA (AWS ACM-PCA for ~$400/month, OR
-     self-managed CA with the private key stored in an HSM)
+   - Provision a private CA. AWS Private CA offers two modes:
+     - **General-purpose mode**: ~$400/month (cert lifetimes up to
+       any duration the CA supports). Easiest to operate.
+     - **Short-lived certificate mode**: ~$50/month (cert validity
+       ≤7 days). Requires automated cert renewal but cuts cost ~8x.
+     - Or self-managed CA with the private key in an HSM
+       (CloudHSM, YubiHSM, hardware-backed TPM). Lower vendor cost,
+       more ops burden.
    - Create a Trust Anchor in IAM referencing the CA
    - Create a Profile referencing `averray-signer-prod-role`
-   - Issue an X.509 client cert to the VPS
-   - Store the client cert + private key on the VPS at
-     `/etc/agent-stack/roles-anywhere/`, mode 0400
-   - The backend uses the cert to call STS and obtain temporary
-     credentials (≤1h lifetime); rotates automatically
+   - **Issue the client cert + key directly on the VPS** (revised in
+     v3): generate the cert keypair on the host, submit the CSR to
+     the CA, install the issued cert. Do NOT generate the private
+     key on a workstation and copy it to the VPS.
+   - Store client cert + private key at
+     `/etc/agent-stack/roles-anywhere/{cert.pem,key.pem}`,
+     mode 0400, owner root.
+   - **Do NOT store the client private key in any 1Password vault
+     that a service account can read.** That would defeat the
+     architecture: `prod-vps-backend` token + Roles Anywhere key =
+     AWS temp creds = `kms:Sign` capability. Optional emergency
+     escrow only in `Averray/Production/Critical` (human-only,
+     never service-readable), documented as explicit residual
+     risk.
+   - **Roles Anywhere session duration must be enforced** at three
+     places, not just policy: (a) the Profile's `durationSeconds`,
+     (b) the `CreateSession` request's `durationSeconds`, (c) the
+     target IAM role's `MaxSessionDuration`. Set all three to ≤1h.
+     For production signer access, prefer 15–30 minutes unless
+     operationally painful — sessions cap at 12h by default if
+     unconfigured.
+   - **Add certificate identity constraints to the trust policy**.
+     AWS Roles Anywhere exposes X.509 subject / issuer / SAN
+     attributes as source identity and principal tags. Use
+     `aws:PrincipalTag/...` or `aws:SourceIdentity` conditions on
+     the trust policy so only the expected VPS cert can assume
+     this role, not any cert issued by the trust anchor.
 
 4. **GitHub Actions access** (if any workflow needs to call AWS):
-   configure GitHub as an OIDC provider in IAM
+   configure GitHub as an OIDC provider in IAM, and **use a
+   separate role from the production signer role**. (Revised in v3
+   per security review — the previous wording reused
+   `averray-signer-prod-role` for OIDC, which would have given any
+   workflow that can assume it the same `kms:Sign` capability as
+   the backend. That's an unacceptable blast radius for CI.)
    - In IAM: add `token.actions.githubusercontent.com` as an
      identity provider
-   - Trust policy on `averray-signer-prod-role` allows
-     `sts:AssumeRoleWithWebIdentity` from workflows in
-     `repo:<your-org>/<your-repo>:environment:production`
+   - Create `averray-ci-deploy-role` (separate from
+     `averray-signer-prod-role`). Default attached permissions
+     should NOT include `kms:Sign`. Grant only what the CI job
+     actually needs (e.g. read-only ECR, read-only S3 for build
+     artifacts). If a workflow legitimately needs the signer's
+     public key (e.g. to verify deployment metadata), grant
+     **`kms:GetPublicKey`** on the specific key ARN only — not
+     `kms:Sign`.
+   - Trust policy on `averray-ci-deploy-role` allows
+     `sts:AssumeRoleWithWebIdentity` only from
+     `repo:<your-org>/<your-repo>:environment:production` (use the
+     `environment:` claim, not just `ref:` — a fork PR can't set
+     the environment claim).
+   - The production signer role
+     (`averray-signer-prod-role`) trusts ONLY the Roles Anywhere
+     trust anchor + the production VPS cert identity — no GitHub
+     OIDC trust on that role.
    - Workflow uses `aws-actions/configure-aws-credentials` with
-     `role-to-assume:` and `aws-region:`; gets ≤1h credentials per
-     job; no AWS keys ever stored in GitHub
+     `role-to-assume: arn:aws:iam::<acct>:role/averray-ci-deploy-role`
+     and `aws-region:`; gets ≤1h credentials per job; no AWS keys
+     ever stored in GitHub.
 
 5. **Do NOT store static IAM access keys for the signer principal
    anywhere.** If you must start with static keys during early
@@ -516,10 +679,36 @@ PagerDuty):
 - Sign requests from unusual source IPs / ASNs
 - Any activity by root or admin IAM principals on this key
 
-**Test each alarm with a synthetic event** before going to mainnet
-(e.g., temporarily call `DisableKey` from an admin session and
-confirm the alarm notifies). Untested alarms have a habit of being
-silently broken.
+**Test each alarm with a synthetic event** before going to mainnet.
+Untested alarms have a habit of being silently broken.
+
+**How to test safely** (revised in v3 per security review — do
+**not** call `DisableKey` / `ScheduleKeyDeletion` / `PutKeyPolicy`
+against a live production key just to verify alarms; the cure
+becomes worse than the disease):
+
+1. **Preferred**: create a **dedicated non-production test KMS key**
+   in the same account/region with the same tag, policy, and
+   CloudWatch alarm wiring. Trigger the destructive APIs against
+   that key. The alarm rules can be written against either a tag
+   selector that covers both, or a duplicate alarm scoped to the
+   test key — choose the form that exercises the same notification
+   path you rely on in prod.
+2. **EventBridge `PutEvents` test events**: most of these alarms
+   are CloudTrail-driven EventBridge rules. Use
+   `aws events put-events` to inject a synthetic event matching
+   the rule pattern (e.g., a `DisableKey` event for the prod key
+   ARN). This validates routing → SNS → PagerDuty without ever
+   calling the destructive API.
+3. **Unusual-`kms:Sign`-volume / source-IP alarms**: drive these
+   from synthetic CloudWatch metric data points
+   (`aws cloudwatch put-metric-data`) or by running a controlled
+   load test against the test key.
+4. **Never** call `DisableKey`, `ScheduleKeyDeletion`,
+   `PutKeyPolicy`, or `CreateGrant` against the production signer
+   key as a test. The blast radius (signing pauses → user
+   payouts stall) is the exact failure mode the alarm is supposed
+   to warn you about — don't trigger it on purpose.
 
 ### 3c. Derive the EVM address
 
@@ -528,17 +717,45 @@ The EVM address is the keccak256 of the public key, last 20 bytes:
 ```js
 import { KMSClient, GetPublicKeyCommand } from "@aws-sdk/client-kms";
 import { keccak256 } from "ethers";
-import { secp256k1 } from "@noble/curves/secp256k1";
+import { AsnParser } from "@peculiar/asn1-schema";
+import { SubjectPublicKeyInfo } from "@peculiar/asn1-x509";
 
 const kms = new KMSClient({ region: "eu-central-1" });
 const { PublicKey } = await kms.send(new GetPublicKeyCommand({ KeyId: "<uuid>" }));
-// PublicKey is DER-encoded; extract the 64-byte uncompressed point
-const point = PublicKey.subarray(PublicKey.length - 64);
+
+// PublicKey is a DER-encoded SubjectPublicKeyInfo (SPKI).
+// Parse the structure properly — DO NOT slice the last 64 bytes;
+// SPKI length varies with the algorithm OID + parameter encoding,
+// and a fixed-offset slice will silently produce wrong addresses
+// for some keys. Parse SPKI, read the BIT STRING contents, then
+// strip the leading 0x04 uncompressed-point marker to get the
+// 64-byte (x || y) coordinate pair.
+const spki = AsnParser.parse(PublicKey, SubjectPublicKeyInfo);
+const bitString = new Uint8Array(spki.subjectPublicKey);
+if (bitString[0] !== 0x04) {
+  throw new Error(
+    `Expected uncompressed EC point (0x04 prefix), got 0x${bitString[0].toString(16)}`,
+  );
+}
+const point = bitString.subarray(1); // 64 bytes: x (32) || y (32)
+if (point.length !== 64) {
+  throw new Error(`Expected 64-byte EC point, got ${point.length}`);
+}
 const address = "0x" + keccak256(point).slice(-40);
 console.log("EVM address:", address);
 ```
 
-This becomes the new on-chain verifier address.
+This becomes the new on-chain verifier address. **Revised in v3 per
+security review**: the earlier code used `PublicKey.subarray(length - 64)`
+which works on the common-case AWS KMS output but is fragile —
+if AWS ever changes the SPKI encoding (e.g., different OID
+parameters), the slice would silently produce a wrong address.
+Use a real DER/ASN.1 parser, not byte-offset arithmetic.
+
+**Pin the parser dependency** to an exact version with a lockfile
+entry and (where available) npm provenance attestation enabled —
+a malicious DER parser update is a credible supply-chain risk
+specifically against this code path.
 
 ### 3d. Wire the backend
 
@@ -595,7 +812,25 @@ that prove:
 
 Don't write your own KMS adapter; pick a vetted one
 (`@rumblefishdev/eth-signer-kms` or `ethers-aws-kms-signer`) and
-pin to a specific commit SHA.
+**pin to an exact npm version** with:
+
+- a `package-lock.json` (or pnpm/yarn equivalent) committed to the
+  repo so the integrity hash is part of the supply-chain audit
+- the package version pinned as `"X.Y.Z"` (no `^` / `~` ranges)
+- npm provenance attestations enabled for any first-party package
+  that wraps this adapter (`npm publish --provenance`)
+- a Renovate/Dependabot rule that **requires manual review** for
+  upgrades to any package in the signing path — auto-merging
+  patch updates is not acceptable for code that handles signer
+  capability
+
+Earlier guidance to "pin to a specific commit SHA" referred to
+GitHub Actions workflow steps (where SHA pinning IS the
+recommended practice). For npm dependencies, version-pin +
+lockfile + provenance is the correct mechanism. SHA-pinning npm
+packages via git refs in `package.json` works but bypasses the
+registry-level integrity hash and provenance checks, so it's
+weaker, not stronger, supply-chain-wise.
 
 ### 3d-2. Domain separation for backend-signed messages
 
@@ -622,16 +857,29 @@ in `mcp-server/src/blockchain/`.
    the verifier (multisig signs the `setVerifier` call)
 3. Run the full hosted product-proof smoke loop end-to-end with the
    KMS path
-4. Confirm:
-   - `journalctl -u agent-stack`, `docker inspect agent-stack`,
-     `cat /proc/$(pgrep -f backend)/environ | tr '\0' '\n'` — no
-     plaintext private key (search for `0x[a-f0-9]{60,}` patterns
-     AND for env vars named `*PRIVATE*` / `*SECRET*` referencing
-     the signer key)
-   - CloudTrail shows the `kms:Sign` calls and no `Decrypt` /
-     `Export` ever
+4. Confirm (Phase 3 = the **signer key specifically** is gone from
+   every surface; other runtime secrets remain in env_file by
+   design):
+   - `SIGNER_PRIVATE_KEY` is absent from:
+     - every env-file template in the repo (`grep -R SIGNER_PRIVATE_KEY
+       . --include='*.env*' --include='*.template'` → zero hits)
+     - the rendered `/run/agent-stack/backend.env`
+     - `docker inspect agent-stack` (container env)
+     - `cat /proc/$(pgrep -f backend)/environ | tr '\0' '\n'`
+     - process command-line args (`ps -ef | grep backend`)
+     - container image layers (`docker history` for any baked-in
+       env)
+     - `journalctl -u agent-stack` from the last 7 days
+     - every 1Password vault (search by item name AND by value
+       pattern `0x[a-f0-9]{63,64}`)
+     - every operator's password manager / shell history
+     - every backup or snapshot
+   - CloudTrail shows the `kms:Sign` calls and **no** `Decrypt` /
+     `GetParametersForImport` / cross-account export events
    - Revoking the Roles Anywhere profile temporarily breaks signing
      — proves the backend really uses temp creds, not a stashed key
+   - The legacy `SIGNER_PRIVATE_KEY` value (testnet) has been
+     **rotated and discarded** so it can't be reactivated later
 
 ### 3f. Cutover and key rotation
 
@@ -910,12 +1158,17 @@ The day before:
   of expiry
 - [ ] Hosted product-proof smoke passes end-to-end 3 consecutive
   runs on mainnet
-- [ ] No secret in any log file, process listing, or env file dump
-  on the mainnet VPS (test: search for `0x[a-f0-9]{60,}` AND env
-  vars named `*PRIVATE*` / `*SECRET*` / `*KEY*` referencing the
-  signer key)
-- [ ] **No raw `SIGNER_PRIVATE_KEY` value exists anywhere** in any
-  mainnet vault, env file, backup, or operator's machine
+- [ ] **No raw `SIGNER_PRIVATE_KEY` value exists anywhere** for
+  mainnet — env file, container env, `docker inspect` output,
+  `/proc/$pid/environ`, process args, logs, backups, 1Password
+  vault, or operator machine. (Other runtime secrets — DB URL,
+  vendor API keys — remain in `env_file` by design; this check
+  is signer-key-specific.)
+- [ ] Deploy logs (CI + VPS `journalctl`) contain no rendered
+  values from the mainnet vault (grep first 8 chars of one known
+  secret → zero hits)
+- [ ] Rendered env files on the mainnet VPS are on tmpfs, mode
+  0400, excluded from backups
 - [ ] On-call rotation is live and first responder has been paged
   with a synthetic test alert successfully
 - [ ] All Phase 4 hardening verified active on mainnet (push
@@ -930,19 +1183,39 @@ The day before:
 | 1Password Business (1 user) | $7.99 |
 | 1Password Business (3 users, post second-operator) | $23.97 |
 | AWS KMS testnet key (single region) | ~$1.05 (1 key + ~$0.15 per 10k sigs) |
-| AWS KMS mainnet key (multi-region, 2 replicas) | ~$2.05 (2 replica keys + signing fees) |
+| AWS KMS mainnet key (multi-region: 1 primary + 1 replica = 2 keys total) | ~$2.05 (2 keys × ~$1/mo + signing fees) |
 | AWS Roles Anywhere | $0 (no per-request fee) |
-| AWS ACM-PCA (if used for Roles Anywhere CA) | ~$400 — **consider self-managed CA + HSM** for lower cost |
+| AWS ACM-PCA — **general-purpose mode** (long-lived certs) | ~$400/mo while the CA is active |
+| AWS ACM-PCA — **short-lived certificate mode** (≤7 day certs) | **~$50/mo** while the CA is active — recommended if Roles Anywhere is the only use case |
+| AWS ACM-PCA — **self-managed CA alternative** (CA private key in HSM) | $0 AWS recurring + operator time + HSM cost |
 | AWS CloudTrail (for KMS audit) | $0 (first management trail free) |
 | AWS CloudWatch (for KMS alarms) | < $5 |
-| **Total at 1 user, testnet** | **~$9/mo** (or ~$409/mo if ACM-PCA used) |
-| **Total at 3 users, mainnet** | **~$26/mo** (or ~$426/mo if ACM-PCA used) |
+| **Total at 1 user, testnet, ACM-PCA short-lived mode** | **~$59/mo** |
+| **Total at 3 users, mainnet, ACM-PCA short-lived mode** | **~$76/mo** |
+| **Total at 1 user, testnet, ACM-PCA general-purpose mode** | **~$409/mo** |
+| **Total at 3 users, mainnet, ACM-PCA general-purpose mode** | **~$426/mo** |
 | **YubiKey hardware keys** (one-time) | ~$50 × number of operators |
 
-The recurring cost is rounding error vs. the security improvement.
-The **ACM-PCA decision is the one to think about** — $400/mo is
-real money at our scale; self-managed CA with the private key in
-an HSM is the cheaper alternative if the operator can run one.
+The recurring cost is rounding error vs. the security improvement
+**unless** you pick general-purpose ACM-PCA. The **ACM-PCA mode
+decision is the one to think about**:
+
+- **Short-lived certificate mode** ($50/mo) issues certs with a
+  maximum 7-day validity. That fits Roles Anywhere perfectly — we
+  refresh the VPS client cert weekly via an automated job, so we
+  never need long-lived certs anyway. **This is the recommended
+  default.**
+- **General-purpose mode** ($400/mo) is needed only if you'd
+  issue certs valid longer than 7 days. We don't.
+- **Self-managed CA + HSM** is the cheapest steady-state option
+  but adds operator complexity (HSM lifecycle, CA-key rotation,
+  CRL hosting). Only worth it if the operator team can own that
+  weight.
+
+KMS mainnet pricing — to be explicit: a multi-region KMS key with
+one replica in a second region is **two billable KMS keys**, not
+"two replicas of one key." Each replica is independently priced at
+the standard KMS rate (~$1/key/mo for asymmetric secp256k1).
 
 Engineering time for the migration: ~5–7 working days spread over a
 few weeks.


### PR DESCRIPTION
## Summary
- Incorporates a second external security review on top of v2 (#226).
- 10 must-fix items + several smaller cleanups; full delta in `SECRETS_INTEGRATION_PLAN.md` revision history.
- Calendar still parses cleanly (12 entries: 1 ok / 10 warn (TBD) / 1 skipped).

## Highest-impact changes
- **IAM**: signer-role policy split into 3 statements (`GetPublicKey` + `Sign-with-conditions` + explicit deny). The previous single-statement form would have implicitly denied `kms:GetPublicKey`.
- **Roles Anywhere private key off backend-runtime-readable vaults** — generated on the VPS, never written to any vault a service account can read. Only the public cert metadata sits in `Critical` (human-only).
- **Vault split per runtime**: `BackendExternal`, `CIExternal`, dedicated `Smoke`, dedicated `Critical` (human-only). No runtime service account can read `Critical` → firebreak against bootstrapped privilege escalation.
- **Phase 2 verification softened** to match reality — `docker inspect` / `/proc/$pid/environ` WILL show env_file values; that's by design. `SIGNER_PRIVATE_KEY` absence is Phase 3's exit criterion.
- **OIDC role split**: `averray-ci-deploy-role` (GitHub OIDC, NO `kms:Sign`) vs `averray-signer-prod-role` (Roles Anywhere only). CI compromise can't pivot to signing.
- **Alarm testing**: EventBridge `PutEvents` or dedicated non-prod KMS key — never `DisableKey` on the live signer.
- **Mainnet KMS wording**: no "generate fresh `SIGNER_PRIVATE_KEY`"; `Origin=AWS_KMS` means key material is created inside the HSM and never exists as raw bytes.

## Smaller cleanups
- ADMIN_JWT runbook: `--profile production`, `op item edit` back into `Smoke` vault (not `gh secret set`), correct op:// casing, flagged transitional until Phase 4b.
- KMS public-key derivation now uses a real DER/ASN.1 SPKI parser (not `subarray(length - 64)`).
- npm pinning clarified: exact version + lockfile + provenance (not git-SHA pins).
- GitHub issue-ingestion PAT → fine-grained PAT scoped to one repo, or GitHub App installation token.
- Mainnet pauser must be a separate multisig (or hardware-protected separate EOA) — not the verifier key.
- Mainnet verifier and arbitrator must be split into two distinct KMS keys.
- `APP_BASIC_AUTH_PASSWORD` raw value moves to `Critical` (human-only); CI sees only the bcrypt hash.
- Named 1Password users; the `secrets@averray.com` mailbox is the account-owner address, not a daily sign-in identity.
- Cost summary: multi-region KMS is "primary + 1 replica = 2 keys" (not "2 replicas"); ACM-PCA short-lived mode at ~$50/mo recommended over $400/mo general-purpose.

## Test plan
- [x] `node scripts/ops/check-secrets-calendar.mjs` parses (12 entries, 1 ok / 10 warn / 1 skipped)
- [x] No stale `External/`, `Personal/op-token`, or `Production/CI/admin-jwt` references remain
- [ ] Operator reviews the v3 revision-history block and signs off

🤖 Generated with [Claude Code](https://claude.com/claude-code)