### PR TITLE
Flip Roles Anywhere CA default to self-managed ($0 vs $50/mo)

### DIFF
--- a/docs/SECRETS_CALENDAR.yml
+++ b/docs/SECRETS_CALENDAR.yml
@@ -200,29 +200,40 @@ entries:
     # threat model (backend service token + cert+key = AWS temp
     # creds = kms:Sign capability).
     vault_path: op://Averray/Production/Critical/aws-roles-anywhere-cert-metadata
-    expires_at: "TBD"   # 1y general-purpose ACM-PCA; ≤7d short-lived mode
-    warn_days: 30
+    expires_at: "TBD"   # 7-day rotation cadence for the self-managed CA path
+    warn_days: 3        # 7-day cert => warn 3 days before expiry
     notes: |
-      Reissue procedure (revised in v3 per security review):
-        1. Generate a new keypair ON THE VPS (do not generate
-           remotely and copy).
-        2. Submit the CSR to the IAM Roles Anywhere Trust Anchor's
-           CA (ACM-PCA or your self-managed CA).
+      Reissue procedure (revised in v3 per security review,
+      updated to self-managed CA as the default — see
+      SECRETS_MIGRATION.md §3a cost summary for the rationale):
+        1. Generate a new client keypair ON THE VPS (do not
+           generate remotely and copy).
+        2. Submit the CSR to our self-managed CA (CA private key
+           lives in Averray/Production/Critical; human-only).
+           Sign for a 7-day validity.
         3. Install the new cert at /etc/agent-stack/roles-anywhere/
            on the VPS (mode 0400, owner root).
         4. Update this calendar entry with the new expires_at.
+
+      Automate steps 1–4 as a weekly cron on the VPS that triggers
+      an SSH-out to the operator workstation for CA signing. The
+      operator workstation prompts for the 1Password unlock and
+      runs `openssl x509 -req` against the CA private key from
+      Critical.
 
       What lives where:
         - Public certificate (PEM, metadata): Critical vault for
           audit + expiry tracking. Human-only access; service
           accounts cannot read Critical.
-        - Client private key: VPS only. Generated on VPS. Never
-          written to any vault readable by a service account.
+        - Client private key (per-VPS): VPS only. Generated on VPS.
+          Never written to any vault readable by a service account.
           Optional emergency escrow in Averray/Production/Critical
           (human-only) is documented as residual risk in
           SECRETS_INTEGRATION_PLAN.md.
-        - CA private key: AWS ACM-PCA, OR a hardware-backed HSM.
-          Never on disk.
+        - CA private key: Averray/Production/Critical, human-only
+          (current default). Optional upgrade: YubiKey ($25 one-
+          time) or AWS Private CA short-lived mode ($50/mo) — see
+          SECRETS_MIGRATION.md §3a for when to upgrade.
 
   # The KMS SIGNER KEY itself is NOT calendar-tracked. Rotation of
   # the asymmetric KMS key is an on-chain signer migration event

--- a/docs/SECRETS_INTEGRATION_PLAN.md
+++ b/docs/SECRETS_INTEGRATION_PLAN.md
@@ -482,11 +482,14 @@ approval process, and CloudTrail monitoring. See `SECRETS_MIGRATION.md`
 §3a for the full JSON policy.
 
 **Temporary credentials, not long-lived IAM keys** (corrected from v1):
-- **VPS**: IAM Roles Anywhere. Provision a private CA (AWS ACM-PCA or
-  self-managed), create a Trust Anchor in IAM with that CA, create a
-  Profile referencing the signer role, issue an X.509 client cert to
-  the VPS. Backend uses the cert to call STS and obtain temporary
-  credentials (≤1h lifetime). Rotates automatically.
+- **VPS**: IAM Roles Anywhere. Provision a private CA (default:
+  self-managed CA with the CA private key in
+  `Averray/Production/Critical`; see `SECRETS_MIGRATION.md` §3a for
+  alternatives and the cost-vs-operator-burden trade-off). Create a
+  Trust Anchor in IAM with that CA, create a Profile referencing
+  the signer role, issue an X.509 client cert to the VPS. Backend
+  uses the cert to call STS and obtain temporary credentials (≤1h
+  lifetime). Rotates weekly.
 - **GitHub Actions** (if any workflow needs AWS access): configure
   GitHub as an OIDC provider in IAM; AssumeRoleWithWebIdentity from
   the workflow; ≤1h credentials per job.
@@ -501,8 +504,14 @@ setup), make that an explicit residual risk with a removal date.
    (YubiKey) on root; recovery info printed offline.
 2. **Roles Anywhere trust anchor compromise** → if the CA private key
    leaks, attacker can mint client certs and impersonate the VPS.
-   Store CA private key in AWS ACM-PCA (best) or, if self-managed,
-   in an HSM. Never on disk.
+   **Self-managed CA (default at our scale)**: CA private key in
+   `Averray/Production/Critical` (human-only, no service account
+   readable). Residual risk: a Critical-vault compromise = full CA
+   compromise — same blast radius as a 1Password recovery-kit
+   leak, accepted. **Upgrade options** when scale or audit
+   pressure warrants: CA key on a YubiKey ($25 one-time), or AWS
+   Private CA short-lived mode ($50/mo). See
+   `SECRETS_MIGRATION.md` §3a cost summary.
 3. **CloudTrail KMS event exclusion** → CloudTrail can be configured
    to exclude KMS events from a trail. Verify your trail explicitly
    includes them. Verify in CloudTrail Insights as well.
@@ -762,18 +771,39 @@ By moving away from long-lived IAM access keys, we introduce a new
 single point of compromise: the trust anchor's CA private key. If
 that leaks, attacker can mint client certs and impersonate the VPS.
 
-**Why I think it's net positive**: Static IAM keys leak via OS-level
-compromise, environment dumps, backups, etc. CA private keys, if
-stored in AWS ACM-PCA, never leave AWS HSMs. If self-managing the
-CA, the private key MUST live in an HSM (CloudHSM, YubiHSM, or a
-hardware-backed TPM) — never on disk.
+**Why it's net positive even at our pre-launch scale**: Static IAM
+access keys are bearer credentials — anyone who sees the string can
+use it indefinitely. A Roles Anywhere CA private key is one step
+removed: an attacker who steals the CA key still has to (a) mint a
+client cert from it, (b) present that cert to AWS STS to get temp
+creds, (c) use the temp creds within their 1h lifetime. Each step
+leaves CloudTrail evidence on a separate timeline.
+
+**v3-revised default (this PR)**: self-managed CA with the CA
+private key in `Averray/Production/Critical` (1Password, human-only).
+$0 AWS recurring fees. Documented residual risk: a Critical-vault
+compromise = full CA compromise, which is the same risk we already
+accept for the 1Password recovery kit and AWS root credentials. The
+CA does one thing — sign a fresh weekly client cert — so the
+operator burden is a 30-second scripted operation per week.
+
+**Upgrade options when scale or audit pressure warrants**:
+- CA private key on a YubiKey ($25 one-time per operator). CA key
+  never touches disk; signing requires the physical key + PIN.
+- AWS Private CA short-lived certificate mode ($50/mo). AWS-managed
+  CA with CloudTrail evidence of every issuance. Right call once
+  there are 2+ operators or audit pressure.
+- AWS Private CA general-purpose mode ($400/mo). Skip — we never
+  need certs valid longer than 7 days.
 
 **What to verify**:
-- Decide whether AWS ACM-PCA or self-managed CA. ACM-PCA is more
-  expensive (~$400/month) but easier to operate. For our scale,
-  worth checking the actual cost calculator.
-- If self-managed: explicitly document where the CA private key lives
-  and who has access
+- The CA private key in `Critical` is accessible only via a human
+  1Password unlock (no service account has read on Critical)
+- The weekly client-cert reissuance script runs successfully
+  (calendar entry `aws-roles-anywhere-client-cert` warns 3 days
+  before the 7-day cert expires)
+- Plan to revisit the choice at: (a) second operator onboarded,
+  (b) revenue justifies external audit, or (c) mainnet maturity
 
 ### 6c. Multi-region KMS doubles ops complexity
 
@@ -834,8 +864,13 @@ Areas where I'd defer to a human security expert before mainnet:
 1. **Exact cipher choices for the JWT refresh-token flow**. Concept
    is clear; implementation needs review by someone who's done it
    before.
-2. **IAM Roles Anywhere CA model choice** (ACM-PCA vs self-managed
-   with HSM). Strong opinions exist; I don't have one.
+2. **IAM Roles Anywhere CA model choice**. v3 (revised, this PR)
+   lands on **self-managed CA with the CA key in
+   `Averray/Production/Critical`** as the pre-launch default;
+   AWS Private CA short-lived mode ($50/mo) and YubiKey-backed CA
+   key ($25 one-time) are documented upgrade paths. Worth a fresh
+   review when (a) a second operator joins, (b) revenue justifies
+   audit pressure, or (c) at mainnet maturity.
 3. **Domain separation for backend-signed messages** — what exactly
    to include (chain ID, contract, environment, purpose, job ID,
    nonce, expiry). Get a contract auditor's input.
@@ -896,8 +931,12 @@ These need explicit decisions before phase execution:
 1. **Multi-region KMS for mainnet**: yes (recommended) or no?
    Decision must be made before mainnet key creation — cannot
    convert later.
-2. **Roles Anywhere CA**: AWS ACM-PCA (~$400/mo) or self-managed
-   with HSM?
+2. **Roles Anywhere CA**: v3-revised default is self-managed CA
+   with the CA key in `Averray/Production/Critical` ($0 recurring,
+   ~30 sec/week of operator time). Confirm this is acceptable for
+   our current risk posture, OR pick an upgrade: YubiKey ($25
+   one-time) or AWS Private CA short-lived mode ($50/mo). See
+   `SECRETS_MIGRATION.md` §3a cost summary.
 3. **Asymmetric JWT migration**: full migration in Phase 4 or
    accept HMAC + hardening as residual risk?
 4. **Second operator**: who, when?
@@ -945,12 +984,20 @@ true. Each is a checkbox the security reviewer signs:
 | 1Password Business (1 user) | $7.99 |
 | 1Password Business (3 users, post-second-operator) | $23.97 |
 | AWS KMS testnet key (single region) | $1 + ~$0.15 per 10k sigs (~$1.05/mo) |
-| AWS KMS mainnet key (multi-region, 2 replicas) | $2 + ~$0.15 per 10k sigs (~$2.05/mo) |
-| AWS ACM-PCA (if used for Roles Anywhere) | ~$400 (consider self-managed CA + HSM for lower cost) |
+| AWS KMS mainnet key (multi-region: primary + 1 replica = 2 keys) | $2 + ~$0.15 per 10k sigs (~$2.05/mo) |
+| Roles Anywhere CA — **self-managed, CA key in `Critical` 1Password vault** (recommended default) | **$0 recurring** |
 | AWS Roles Anywhere itself | $0 |
-| **Total at 1 user, testnet** | ~$9/mo (or $409/mo if ACM-PCA used) |
-| **Total at 3 users, mainnet** | ~$26/mo (or $426/mo if ACM-PCA used) |
-| **YubiKey hardware keys** | ~$50 × number of operators (one-time) |
+| **Total at 1 user, testnet (recommended config)** | **~$9/mo** |
+| **Total at 3 users, mainnet (recommended config)** | **~$26/mo** |
+| Upgrade option: CA key on YubiKey ($25 one-time per operator) | $0 recurring |
+| Upgrade option: AWS Private CA short-lived mode | ~$50/mo |
+| **YubiKey hardware keys for operator MFA** (separate from CA-key YubiKey) | ~$50 × number of operators (one-time) |
+
+**Revised in v3 (this PR)**: the default Roles Anywhere CA model is
+now self-managed with the CA private key in
+`Averray/Production/Critical` ($0 recurring), not AWS Private CA
+($50–$400/mo). AWS Private CA stays in the table as an upgrade
+path when scale or audit pressure justifies it.
 
 The real cost is engineering time for the migration (~5–7 working
 days spread over a few weeks).
@@ -1021,6 +1068,17 @@ Substantive changes from v2 (all driven by external review):
     replica = 2 keys total" (not "2 replicas of one key").
     Added ACM-PCA short-lived certificate mode at ~$50/mo as the
     recommended Roles Anywhere CA option.
+11. **Roles Anywhere CA default flipped to self-managed** (post-
+    review operator decision, this PR). The CA private key lives
+    in `Averray/Production/Critical` (1Password, human-only).
+    $0 AWS recurring fees instead of $50/mo for AWS Private CA
+    short-lived mode. AWS Private CA short-lived mode and
+    YubiKey-backed CA key remain documented as upgrade paths for
+    when a second operator joins, when revenue justifies audit
+    pressure, or at mainnet maturity. Documented residual risk: a
+    `Critical`-vault compromise = full CA compromise, same
+    blast-radius assumption we already accept for the 1Password
+    recovery kit and AWS root credentials.
 
 Smaller v3 edits:
 - KMS public-key derivation uses a real DER/ASN.1 SPKI parser

--- a/docs/SECRETS_MIGRATION.md
+++ b/docs/SECRETS_MIGRATION.md
@@ -539,14 +539,27 @@ automatically.
    or sign a raw message instead of a digest.
 
 3. **VPS access**: configure IAM Roles Anywhere
-   - Provision a private CA. AWS Private CA offers two modes:
-     - **General-purpose mode**: ~$400/month (cert lifetimes up to
-       any duration the CA supports). Easiest to operate.
-     - **Short-lived certificate mode**: ~$50/month (cert validity
-       ≤7 days). Requires automated cert renewal but cuts cost ~8x.
-     - Or self-managed CA with the private key in an HSM
-       (CloudHSM, YubiHSM, hardware-backed TPM). Lower vendor cost,
-       more ops burden.
+   - Provision a private CA. **Recommended default for our scale: a
+     self-managed CA with the CA private key stored in
+     `Averray/Production/Critical` (1Password, human-only).** $0
+     AWS recurring fees; the operator burden is one weekly cert-
+     issuance script. Documented residual risk: a Critical-vault
+     compromise = full CA compromise. Acceptable while there is one
+     operator and pre-mainnet stakes; revisit at mainnet maturity
+     or when adding a second operator.
+   - **Cheap upgrade ($25 one-time, $0 recurring)**: hold the CA
+     private key on a YubiKey instead of in 1Password. CA key never
+     touches disk; cert issuance requires the YubiKey + PIN. Single
+     operator availability constraint (only the YubiKey holder can
+     issue certs) is fine pre-mainnet.
+   - **Managed upgrade ($50/mo)**: AWS Private CA in **short-lived
+     certificate mode** (cert validity ≤7 days). Trade $600/year
+     for "any on-call operator can issue certs at 3am via the AWS
+     console with CloudTrail evidence." Right call once we have 2+
+     operators or audit pressure.
+   - **General-purpose AWS Private CA (~$400/mo)**: don't bother.
+     We never need certs valid longer than 7 days for this use
+     case, so paying for that capability is pure overhead.
    - Create a Trust Anchor in IAM referencing the CA
    - Create a Profile referencing `averray-signer-prod-role`
    - **Issue the client cert + key directly on the VPS** (revised in
@@ -1185,32 +1198,46 @@ The day before:
 | AWS KMS testnet key (single region) | ~$1.05 (1 key + ~$0.15 per 10k sigs) |
 | AWS KMS mainnet key (multi-region: 1 primary + 1 replica = 2 keys total) | ~$2.05 (2 keys × ~$1/mo + signing fees) |
 | AWS Roles Anywhere | $0 (no per-request fee) |
-| AWS ACM-PCA — **general-purpose mode** (long-lived certs) | ~$400/mo while the CA is active |
-| AWS ACM-PCA — **short-lived certificate mode** (≤7 day certs) | **~$50/mo** while the CA is active — recommended if Roles Anywhere is the only use case |
-| AWS ACM-PCA — **self-managed CA alternative** (CA private key in HSM) | $0 AWS recurring + operator time + HSM cost |
+| Roles Anywhere CA — **self-managed, key in `Critical` 1Password vault** (recommended) | **$0 recurring** |
+| Roles Anywhere CA — **self-managed, key on YubiKey** ($25 one-time per operator) | $0 recurring + one-time $25/op |
+| Roles Anywhere CA — AWS Private CA, short-lived certificate mode (≤7d certs) | ~$50/mo — upgrade option once we have 2+ operators or audit pressure |
+| Roles Anywhere CA — AWS Private CA, general-purpose mode | ~$400/mo — not needed for our use case |
 | AWS CloudTrail (for KMS audit) | $0 (first management trail free) |
 | AWS CloudWatch (for KMS alarms) | < $5 |
-| **Total at 1 user, testnet, ACM-PCA short-lived mode** | **~$59/mo** |
-| **Total at 3 users, mainnet, ACM-PCA short-lived mode** | **~$76/mo** |
-| **Total at 1 user, testnet, ACM-PCA general-purpose mode** | **~$409/mo** |
-| **Total at 3 users, mainnet, ACM-PCA general-purpose mode** | **~$426/mo** |
-| **YubiKey hardware keys** (one-time) | ~$50 × number of operators |
+| **Total at 1 user, testnet, self-managed CA** | **~$9/mo** |
+| **Total at 3 users, mainnet, self-managed CA** | **~$26/mo** |
+| **Total at 1 user, testnet, AWS Private CA short-lived mode** | ~$59/mo |
+| **Total at 3 users, mainnet, AWS Private CA short-lived mode** | ~$76/mo |
+| **YubiKey hardware keys** (one-time, for operator MFA — separate from CA-key YubiKey) | ~$50 × number of operators |
 
-The recurring cost is rounding error vs. the security improvement
-**unless** you pick general-purpose ACM-PCA. The **ACM-PCA mode
-decision is the one to think about**:
+The **Roles Anywhere CA decision is the one to think about**, but
+v3 (revised) lands on a different default than v2:
 
-- **Short-lived certificate mode** ($50/mo) issues certs with a
-  maximum 7-day validity. That fits Roles Anywhere perfectly — we
-  refresh the VPS client cert weekly via an automated job, so we
-  never need long-lived certs anyway. **This is the recommended
-  default.**
-- **General-purpose mode** ($400/mo) is needed only if you'd
-  issue certs valid longer than 7 days. We don't.
-- **Self-managed CA + HSM** is the cheapest steady-state option
-  but adds operator complexity (HSM lifecycle, CA-key rotation,
-  CRL hosting). Only worth it if the operator team can own that
-  weight.
+- **Self-managed CA, key in `Averray/Production/Critical`** ($0).
+  **This is the recommended default at our current scale.** The
+  CA's only job is signing a fresh client cert for the VPS once a
+  week — a 30-second scripted operation. The CA key sits in
+  1Password Critical (human-only, no service account can read it).
+  Documented residual risk: a Critical-vault compromise = full CA
+  compromise. That's the same trust-chain assumption we already
+  make for the 1Password recovery kit and AWS root credentials.
+- **Self-managed CA, key on YubiKey** ($25 one-time). One step
+  better. The CA key never touches disk; cert issuance requires the
+  physical YubiKey + PIN. Only the YubiKey holder can issue certs
+  (fine pre-mainnet with one operator).
+- **AWS Private CA, short-lived mode** ($50/mo). Worth the $600/year
+  when we have 2+ operators who need to issue certs without
+  coordinating, or when an external audit wants AWS-managed
+  CloudTrail evidence of every CA operation. Not worth it today.
+- **AWS Private CA, general-purpose mode** ($400/mo). Skip. We
+  never need certs valid longer than 7 days.
+
+**Revised in v3 (this PR)**: the previous wording recommended AWS
+Private CA short-lived mode as the default. For a pre-launch
+product with one operator, $600/year buys "AWS handles the CA"
+convenience that we don't yet need. Self-managed is the honest
+default; AWS Private CA short-lived mode stays in the menu as the
+upgrade path when scale or audit requirements justify it.
 
 KMS mainnet pricing — to be explicit: a multi-region KMS key with
 one replica in a second region is **two billable KMS keys**, not


### PR DESCRIPTION
## Summary
- Post-v3 operator decision (#227): flip the Roles Anywhere CA default from AWS Private CA short-lived mode (~\$50/mo) to self-managed CA with the CA key in `Averray/Production/Critical` (\$0 recurring).
- Recommended-config totals drop from ~\$59-76/mo to ~\$9-26/mo.
- AWS Private CA short-lived mode (\$50/mo) and YubiKey-backed CA key (\$25 one-time) stay documented as upgrade paths.

## Rationale
The CA's only job is signing a fresh client cert for the VPS once a week — a 30-second scripted operation. \$600/year for AWS to manage that is overhead we don't need yet at our pre-launch scale.

Residual risk explicitly accepted: a `Critical`-vault compromise = full CA compromise. Same blast-radius assumption we already make for the 1Password recovery kit and AWS root credentials.

## When to revisit (upgrade triggers)
- A second operator joins (needs 24/7 cert issuance without coordinating)
- Revenue justifies external audit pressure
- Mainnet maturity

## Files touched
- `SECRETS_MIGRATION.md` §3a: new CA selection block with all 4 options ranked
- `SECRETS_MIGRATION.md` cost summary: new totals (~\$9-26/mo)
- `SECRETS_INTEGRATION_PLAN.md` §6b: residual-risk paragraph rewritten
- `SECRETS_INTEGRATION_PLAN.md` §7, §10, §12: open-question + cost-table updated
- `SECRETS_INTEGRATION_PLAN.md` revision history: new item 11
- `SECRETS_CALENDAR.yml`: cert entry now references self-managed CA, 7-day cadence, warn_days: 3, with automation-flow note

## Test plan
- [x] `node scripts/ops/check-secrets-calendar.mjs` parses (12 entries, 1 ok / 10 warn / 1 skipped)
- [x] No remaining "ACM-PCA … recommended default" wording
- [ ] Operator signs off on the residual-risk framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)