### PR TITLE
Phase 2 PR 2.1: parity-check VPS SSH key from 1Password (non-blocking)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -113,11 +113,18 @@ concurrency:
   group: production
   cancel-in-progress: false
 
+# Default to least privilege. Steps that need more (e.g. id-token: write
+# for OIDC in Phase 3) must elevate explicitly.
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deploy VPS production
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      contents: read
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     env:
       VPS_HOST: ${{ secrets.VPS_HOST }}
@@ -156,6 +163,71 @@ jobs:
           if [ -n "$APP_BASIC_AUTH_USER" ]; then
             test -n "$APP_BASIC_AUTH_PASSWORD"
           fi
+
+      # ─── Phase 2 PR 2.1: parity check between OP-loaded and legacy SSH key ──
+      #
+      # Load VPS_SSH_KEY_OP from 1Password via the prod-ci-deploy
+      # service-account token. The OP token is set ONLY on this step
+      # (step-level `env:`, NOT job-level) so subsequent steps in this
+      # job cannot read it — per 1Password's docs, putting the token at
+      # job level would expose it to every step that follows.
+      #
+      # continue-on-error: a 1Password outage MUST NOT break the deploy
+      # during the validation window. The downstream "Configure SSH"
+      # step still uses the legacy ${{ secrets.VPS_SSH_KEY }} value.
+      # PR 2.4 will flip the SSH write to use $VPS_SSH_KEY_OP and delete
+      # the legacy secret 24h after the OP path has been proven stable.
+      - name: Load VPS SSH key from 1Password (parity check, non-blocking)
+        id: load_op_ssh
+        continue-on-error: true
+        # Pinned to 1password/load-secrets-action v2.0.0 commit SHA
+        # (verified via the v2.0.0 annotated tag's commit object).
+        # Refresh by re-running:
+        #   curl -s https://api.github.com/repos/1Password/load-secrets-action/git/tags/<tag-sha> | jq .object.sha
+        uses: 1password/load-secrets-action@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PROD_CI }}
+          VPS_SSH_KEY_OP: op://prod-ci/vps-ssh-key/private key
+
+      # Compare without ever printing key material. Writes both to
+      # umask-077 mktemp files, runs `cmp -s`, and logs only the
+      # yes/no result plus byte lengths on mismatch. The byte length
+      # is intentionally NOT a fingerprint — it only helps diagnose
+      # newline-handling regressions.
+      - name: Compare OP-loaded VPS SSH key against legacy GH secret
+        if: steps.load_op_ssh.outcome == 'success'
+        env:
+          LEGACY_KEY: ${{ secrets.VPS_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          set +x
+          umask 077
+
+          legacy_file=$(mktemp)
+          op_file=$(mktemp)
+          trap 'rm -f "$legacy_file" "$op_file"' EXIT
+
+          printf '%s' "$LEGACY_KEY" > "$legacy_file"
+          printf '%s' "$VPS_SSH_KEY_OP" > "$op_file"
+          chmod 0400 "$legacy_file" "$op_file"
+
+          if cmp -s "$legacy_file" "$op_file"; then
+            echo "VPS_SSH_KEY_OP matches legacy secret: yes"
+          else
+            legacy_len=$(wc -c < "$legacy_file" | tr -d ' ')
+            op_len=$(wc -c < "$op_file" | tr -d ' ')
+            echo "VPS_SSH_KEY_OP matches legacy secret: no"
+            echo "    legacy length: $legacy_len bytes"
+            echo "    OP length:     $op_len bytes"
+            echo "::warning::OP-loaded VPS SSH key does NOT match legacy GH Actions secret. Investigate before PR 2.4 swaps to the OP value."
+          fi
+
+      - name: Note when 1Password load step failed (deploy proceeds with legacy key)
+        if: steps.load_op_ssh.outcome == 'failure'
+        run: |
+          echo "::warning::1Password load-secrets-action failed; falling back to legacy VPS_SSH_KEY from GH Actions. Investigate before assuming Phase 2 is healthy."
 
       - name: Configure SSH
         run: |

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -301,22 +301,32 @@ which this entry retires.
 
 **Mint with the script** (current procedure):
 ```bash
-AUTH_JWT_SECRETS=$(op read "op://Averray/Production/Backend/auth-jwt-secrets/credential") \
-  node scripts/ops/mint-admin-jwt.mjs --profile production --expires-in-days 30 --quiet \
-  | op item edit "op://Averray/Production/Smoke/admin-jwt" credential[password]=-
+NEW_JWT=$(AUTH_JWT_SECRETS=$(op read "op://prod-backend/auth-jwt-secrets/password") \
+  node scripts/ops/mint-admin-jwt.mjs --profile testnet --expires-in-days 30 --quiet)
+
+# Store in 1Password (canonical home, used by Phase 2 PR 2.5 onward):
+op item create --vault=prod-smoke --category=password --title=admin-jwt \
+  "password=$NEW_JWT" \
+  "notes=Long-lived (30d) admin JWT. TRANSITIONAL until Phase 4b."
+# OR, during the transition window, also update the GH Actions secret:
+printf '%s' "$NEW_JWT" | gh secret set ADMIN_JWT -R averray-agent/agent
+
+unset NEW_JWT
 ```
 
 Notes:
-- `--profile production` (not `testnet`) for the production smoke target.
-  Earlier instructions referenced `testnet` — that was wrong for
-  the prod smoke loop.
-- Output goes back into **1Password** at
-  `op://Averray/Production/Smoke/admin-jwt`, not directly to a
-  GitHub Actions secret. The smoke workflow reads from that
-  op:// path via the `prod-smoke-tests` service-account token.
-- The op:// path is lowercase. 1Password is case-sensitive for
-  item/section/field names; the earlier `AUTH_JWT_SECRETS`
-  uppercase reference would have failed.
+- `--profile testnet` — the current production system runs against
+  Polkadot Hub TestNet, so the mint script reads the verifier wallet
+  from `deployments/testnet.json`. After Phase 5 cutover provisions
+  `deployments/mainnet.json`, this becomes `--profile mainnet`.
+  (Earlier v3 doc drafts said `--profile production`, which doesn't
+  match a real profile file — corrected in Phase 2 PR 2.1.)
+- The op:// paths use the **flat** vault names (`prod-backend`,
+  `prod-smoke`) committed in Phase 1, not the aspirational hierarchical
+  `op://Averray/Production/...` scheme from the original plan docs.
+- Both the GH Actions secret (`ADMIN_JWT`) and the 1Password item
+  (`prod-smoke/admin-jwt`) must agree until PR 2.5 wires the smoke
+  workflow to read from 1Password exclusively.
 
 **Rotate**: Mint a new one with the script before the old expires.
 Add a [`SECRETS_CALENDAR.yml`](SECRETS_CALENDAR.yml) entry so CI warns

--- a/docs/SECRETS_CALENDAR.yml
+++ b/docs/SECRETS_CALENDAR.yml
@@ -30,23 +30,28 @@ entries:
   - name: ADMIN_JWT
     description: Long-lived admin JWT used by hosted product-proof smoke and ops scripts. TRANSITIONAL — replaced by short-lived asymmetric JWTs in Phase 4b.
     owner: deployer
-    vault_path: op://Averray/Production/Smoke/admin-jwt
-    expires_at: "2026-06-09"   # 30 days after the mint on 2026-05-10
+    vault_path: op://prod-smoke/admin-jwt
+    expires_at: "2026-06-11"   # 30 days after the re-mint on 2026-05-12 (to unblock deploy smoke 401)
     warn_days: 7
     notes: |
-      Mint a fresh one and store it back in 1Password (NOT directly
-      into the GitHub secret — the smoke workflow now reads from
-      op://Averray/Production/Smoke/admin-jwt via the
-      smoke-tests service-account token):
+      Mint a fresh one, capture into a shell variable, store in
+      1Password AND update the GH Actions secret (until PR 2.5
+      wires the smoke workflow to read from 1Password directly):
 
-        AUTH_JWT_SECRETS=$(op read 'op://Averray/Production/Backend/auth-jwt-secrets/credential') \
-          node scripts/ops/mint-admin-jwt.mjs --profile production --expires-in-days 30 --quiet \
-          | op item edit 'op://Averray/Production/Smoke/admin-jwt' credential[password]=-
+        NEW_JWT=$(AUTH_JWT_SECRETS=$(op read "op://prod-backend/auth-jwt-secrets/password") \
+          node scripts/ops/mint-admin-jwt.mjs --profile testnet --expires-in-days 30 --quiet)
 
-      Then update this entry's `expires_at`. Profile MUST be
-      `production` for the prod smoke target; `testnet` was an
-      earlier transitional value that should no longer be used
-      against the production smoke loop.
+        op item create --vault=prod-smoke --category=password --title=admin-jwt \
+          "password=$NEW_JWT" "notes=..."
+        printf '%s' "$NEW_JWT" | gh secret set ADMIN_JWT -R averray-agent/agent
+        unset NEW_JWT
+
+      Then update this entry's `expires_at`. Use `--profile testnet`
+      while the production system targets Polkadot Hub TestNet;
+      switch to `--profile mainnet` once Phase 5 cutover provisions
+      `deployments/mainnet.json`. (Earlier v3 docs referenced
+      `--profile production` — that profile name doesn't match any
+      real `deployments/*.json` file; corrected in Phase 2 PR 2.1.)
 
       This entry is **transitional**. Phase 4b (asymmetric JWTs
       signed by KMS) makes the long-lived admin JWT obsolete —

--- a/docs/SECRETS_INTEGRATION_PLAN.md
+++ b/docs/SECRETS_INTEGRATION_PLAN.md
@@ -1039,12 +1039,18 @@ Substantive changes from v2 (all driven by external review):
    deploy-log scrubbing only. The aggressive
    `SIGNER_PRIVATE_KEY`-must-be-absent-everywhere check is Phase 3's
    exit criterion (where it correctly applies).
-5. **ADMIN_JWT runbook** updated: mint with `--profile production`
-   (not testnet); store back into 1Password via `op item edit`
-   (not `gh secret set`); reference
-   `op://Averray/Production/Smoke/admin-jwt` (correct vault, correct
-   casing); flagged as transitional until Phase 4b makes it
-   obsolete.
+5. **ADMIN_JWT runbook** updated: mint with `--profile testnet`
+   (the v3 doc draft used `--profile production`, but no
+   `deployments/production.json` file exists — production today
+   runs against `deployments/testnet.json`; switch to `mainnet`
+   only after Phase 5 cutover provisions `deployments/mainnet.json`);
+   store the new JWT in 1Password at `op://prod-smoke/admin-jwt`
+   AND update the legacy `ADMIN_JWT` GH Actions secret until Phase 2
+   PR 2.5 wires the smoke workflow to read from 1Password exclusively;
+   uses the **flat** vault naming (`prod-smoke`) committed in Phase 1,
+   not the aspirational hierarchical `op://Averray/Production/...`
+   scheme. Flagged as transitional until Phase 4b makes the long-lived
+   JWT obsolete.
 6. **Mainnet KMS wording** corrected — there is no "generate fresh
    SIGNER_PRIVATE_KEY" step on mainnet. KMS key material is created
    inside the HSM (`Origin=AWS_KMS`) and never exists as raw bytes

--- a/docs/SECRETS_MIGRATION.md
+++ b/docs/SECRETS_MIGRATION.md
@@ -297,37 +297,56 @@ for 24h after each, and is reversible.
 
 **Touches**: `.github/workflows/deploy-production.yml`
 
-- Add `OP_SERVICE_ACCOUNT_TOKEN_PROD_CI` as a GitHub **Environment** secret
-  on the existing `production` environment (already gated by required
-  reviewers).
-- Add top-level `permissions: contents: read`; elevate per-step only when
-  the step needs more (e.g. `id-token: write` for OIDC in Phase 3).
-- Add `1password/load-secrets-action@<commit-sha>` step **scoped to that
-  step only** (do NOT set the OP token via a job-level `env:` block — per
-  1Password's docs, that makes the token available to subsequent steps).
-  Load `VPS_SSH_KEY_OP` from `op://prod-ci/vps-ssh-key/private key`.
-- Keep `${{ secrets.VPS_SSH_KEY }}` as the deploy fallback for one run.
-  Validate parity by writing both to `mktemp` files (`umask 077`) and
-  comparing with `cmp -s`. **Log only `VPS_SSH_KEY_OP matches legacy
-  secret: yes/no`** — never a checksum or fingerprint of the private key.
-- Once a successful deploy proves the OP-loaded key works, swap the SSH
-  key write to use `VPS_SSH_KEY_OP` and delete the legacy GH Actions
-  secret 24h later (in PR 2.4).
-- Pin every third-party action (`actions/checkout`, `1password/load-secrets-action`,
-  `aws-actions/configure-aws-credentials` if added later) to a commit SHA.
+**Operator setup BEFORE merge** (one-time, in GitHub repo settings):
+1. **Settings → Environments → production → Add environment secret**
+2. Name: `OP_SERVICE_ACCOUNT_TOKEN_PROD_CI`
+3. Value: the `ops_…` token stored in
+   `op://prod-critical/op-token-prod-ci-deploy/password` (read it with
+   `op read 'op://prod-critical/op-token-prod-ci-deploy/password'`
+   and paste — do NOT echo to terminal first).
+4. Save. The token is now visible only to workflow jobs that reference
+   `environment: production`, behind the existing required-reviewer
+   gate.
+
+**Workflow changes in this PR**:
+
+- Add top-level `permissions: contents: read`; elevate per-step only
+  when the step needs more (e.g. `id-token: write` for OIDC in Phase 3).
+- Add `1password/load-secrets-action@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0`
+  (pinned to v2.0.0's commit SHA) step **scoped to that step only**
+  (the OP token is set via step-level `env:`, NOT job-level — per
+  1Password's docs, putting the token at job level would expose it to
+  every step that follows). Loads `VPS_SSH_KEY_OP` from
+  `op://prod-ci/vps-ssh-key/private key`. `continue-on-error: true`
+  so a 1Password outage during the validation window does not break
+  deploys.
+- New parity-check step compares `VPS_SSH_KEY_OP` against the legacy
+  `${{ secrets.VPS_SSH_KEY }}` value by writing both to `umask 077`
+  `mktemp` files and running `cmp -s`. **Logs only `matches: yes/no`**
+  plus byte lengths on mismatch — never a checksum, never a fingerprint,
+  never the value itself. On mismatch, posts a workflow `::warning::`
+  annotation so it's visible in the PR check summary.
+- The existing "Configure SSH" step keeps using `${{ secrets.VPS_SSH_KEY }}`
+  (legacy) for the actual SSH write. The OP-loaded value is only used
+  for parity comparison.
+- PR 2.4 will flip the SSH write to use `$VPS_SSH_KEY_OP` and delete
+  the legacy GH Actions secret 24h after the OP path has been proven
+  stable.
 
 **Acceptance criteria**:
 
-- [ ] OP-loaded SSH key successfully connects to the VPS
-- [ ] `cmp -s` between OP and legacy keys logs `yes` — no checksum,
-      no fingerprint of the private key in logs
-- [ ] Production environment approval still required for deploys (manual
-      verification: open a PR with the workflow change, confirm review
-      gate appears)
-- [ ] OP token is available to the load step ONLY; subsequent steps see
-      it as unset
-- [ ] `permissions: contents: read` enforced at the workflow's top level
-- [ ] Every third-party action pinned to a commit SHA
+- [ ] Operator setup step complete: `OP_SERVICE_ACCOUNT_TOKEN_PROD_CI`
+      is set as a `production` Environment secret (visible in
+      Settings → Environments → production)
+- [ ] After merge, a manual `workflow_dispatch` deploy succeeds end-to-end
+- [ ] The parity-check step logs `VPS_SSH_KEY_OP matches legacy secret: yes`
+- [ ] No checksum, fingerprint, or value of the SSH private key
+      appears in the deploy log
+- [ ] Production environment approval gate still fires for deploys
+- [ ] `permissions: contents: read` is the workflow's default; no
+      step elevates without a stated reason
+- [ ] `1password/load-secrets-action` is pinned to commit SHA
+      `581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0`, not a tag
 
 ### PR 2.2 — Caddy basic-auth: hash-only, validated, no plaintext in transit
 
@@ -517,7 +536,9 @@ to those surfaces and rotated.
 `.github/workflows/deploy-production.yml`, `SECRETS_CALENDAR.yml`.
 
 - Mint a fresh `ADMIN_JWT` using `mint-admin-jwt.mjs` with
-  `--profile production`. Store at `op://prod-smoke/admin-jwt/credential`.
+  `--profile testnet` (current production chain — switch to `mainnet`
+  once Phase 5 cutover provisions `deployments/mainnet.json`). Store at
+  `op://prod-smoke/admin-jwt/credential`.
 - Add `OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE` as a **separate** GitHub
   Environment secret (uses the `prod-smoke-tests` service-account token).
 - Smoke step in the workflow loads `ADMIN_JWT` from 1Password via


### PR DESCRIPTION
## Summary
First behavioral change in the Phase 2 migration — but a small, **non-blocking** one. Adds a 1Password `load-secrets-action` step to the production deploy workflow that loads `VPS_SSH_KEY` from `op://prod-ci/vps-ssh-key` and compares it against the legacy `${{ secrets.VPS_SSH_KEY }}`. Logs `matches: yes/no` only; the actual SSH write still uses the legacy GH secret. PR 2.4 will flip the write to the OP-loaded value once we've observed a few green parity checks.

## Operator setup BEFORE this PR runs in production

The new step needs a GitHub Environment secret. **Do this before triggering a deploy after merge:**

1. **Settings → Environments → production → Add environment secret**
2. **Name**: `OP_SERVICE_ACCOUNT_TOKEN_PROD_CI`
3. **Value**: read with `op read 'op://prod-critical/op-token-prod-ci-deploy/password'` and paste. Don't echo to terminal first.
4. **Save**. The token is visible only to workflow jobs that reference `environment: production`, behind the existing required-reviewer gate.

## What's in the workflow change

- `permissions: contents: read` at workflow top level AND job level
- `1password/load-secrets-action` pinned to commit SHA `581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0` (v2.0.0's signature-verified commit)
- OP token set via **step-level** `env:`, not job-level — subsequent steps can't read it
- `continue-on-error: true` on the load step — 1Password outage doesn't break deploys during the validation window
- Parity check writes both keys to `umask 077` mktemp files, runs `cmp -s`, logs `matches: yes/no` plus byte lengths on mismatch — **never a checksum, fingerprint, or value of the private key**
- Mismatch → GH `::warning::` annotation in the Actions UI
- Load failure → separate warning annotation
- Existing "Configure SSH" step unchanged — still uses legacy `$VPS_SSH_KEY` for the actual deploy

## Smaller fold-ins (caught during PR 2.0 follow-up)

- `--profile production` → `--profile testnet` in all ADMIN_JWT runbooks. The v3 docs shipped with `production` but no `deployments/production.json` exists. Caught when re-minting ADMIN_JWT to unblock the 401 in the deploy smoke step.
- ADMIN_JWT calendar `expires_at` advanced to 2026-06-11 (re-mint date + 30 days).
- ADMIN_JWT calendar `vault_path` updated to the flat name `op://prod-smoke/admin-jwt`.

## Test plan

- [x] `node scripts/ops/check-secrets-calendar.mjs` — calendar parses (1 ok, 10 warn, 1 skipped)
- [x] `node scripts/ops/check-env-template-structure.mjs` — structural lint passes
- [x] YAML parse: top-level + job-level `permissions: contents: read`; OP token only in load step's env
- [ ] **Operator**: set `OP_SERVICE_ACCOUNT_TOKEN_PROD_CI` Environment secret per "Operator setup" above
- [ ] **After merge**: trigger `gh workflow run deploy-production.yml -R averray-agent/agent`
- [ ] **Verify**: the "Compare OP-loaded VPS SSH key against legacy GH secret" step logs `VPS_SSH_KEY_OP matches legacy secret: yes`
- [ ] **Verify**: no checksum, fingerprint, or value of the SSH key appears in the deploy log

## Rollback

Revert this PR. Workflow returns to the pre-PR-2.1 behavior. The legacy `VPS_SSH_KEY` GH Actions secret is untouched throughout this PR, so revert is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)