### PR TITLE
Guard product-proof rewards against asset minBalance

### DIFF
--- a/mcp-server/src/blockchain/config.js
+++ b/mcp-server/src/blockchain/config.js
@@ -1,4 +1,5 @@
 import { ConfigError } from "../core/errors.js";
+import { knownAssetMinBalanceRaw } from "../core/assets.js";
 import { derivePolkadotHubAssetAddress } from "../services/strategy-asset-config.js";
 
 function parseLegacyAssets(rawAssets) {
@@ -50,6 +51,10 @@ function normalizeAssetEntry(entry, idx) {
     entry.foreignAssetIndex,
     `SUPPORTED_ASSETS_JSON[${idx}].foreignAssetIndex`
   );
+  const configuredMinBalanceRaw = normalizeOptionalRawAmount(
+    entry.minBalanceRaw,
+    `SUPPORTED_ASSETS_JSON[${idx}].minBalanceRaw`
+  );
   const address = entry.address === undefined
     ? undefined
     : normalizeAddress(entry.address, `SUPPORTED_ASSETS_JSON[${idx}].address`);
@@ -87,6 +92,8 @@ function normalizeAssetEntry(entry, idx) {
   if (assetId !== undefined) normalized.assetId = assetId;
   if (foreignAssetIndex !== undefined) normalized.foreignAssetIndex = foreignAssetIndex;
   if (xcmLocation !== undefined) normalized.xcmLocation = xcmLocation;
+  const minBalanceRaw = configuredMinBalanceRaw ?? knownAssetMinBalanceRaw(normalized);
+  if (minBalanceRaw !== undefined) normalized.minBalanceRaw = minBalanceRaw;
   return normalized;
 }
 
@@ -138,6 +145,17 @@ function normalizeAddress(raw, label) {
     throw new ConfigError(`${label} must be a 0x + 20-byte EVM address.`);
   }
   return raw.toLowerCase();
+}
+
+function normalizeOptionalRawAmount(raw, label) {
+  if (raw === undefined || raw === null || raw === "") {
+    return undefined;
+  }
+  const value = typeof raw === "bigint" ? raw.toString() : String(raw).trim();
+  if (!/^\d+$/u.test(value)) {
+    throw new ConfigError(`${label} must be a non-negative integer string in base units.`);
+  }
+  return value;
 }
 
 function normalizeOptionalXcmLocation(raw, idx) {

--- a/mcp-server/src/blockchain/config.test.js
+++ b/mcp-server/src/blockchain/config.test.js
@@ -55,7 +55,8 @@ test("loadBlockchainConfig accepts explicit SUPPORTED_ASSETS_JSON metadata", () 
         symbol: "USDt",
         assetClass: "trust_backed",
         assetId: 1984,
-        decimals: 6
+        decimals: 6,
+        minBalanceRaw: "123"
       },
       {
         symbol: "vDOT",
@@ -74,6 +75,7 @@ test("loadBlockchainConfig accepts explicit SUPPORTED_ASSETS_JSON metadata", () 
       assetClass: "trust_backed",
       assetId: 1984,
       decimals: 6,
+      minBalanceRaw: "123",
       address: "0x000007c000000000000000000000000001200000"
     },
     {
@@ -108,9 +110,31 @@ test("loadBlockchainConfig prefers SUPPORTED_ASSETS_JSON when both config format
       assetClass: "trust_backed",
       assetId: 1337,
       decimals: 6,
+      minBalanceRaw: "70000",
       address: "0x0000053900000000000000000000000001200000"
     }
   ]);
+});
+
+test("loadBlockchainConfig rejects invalid minBalanceRaw metadata", () => {
+  assert.throws(
+    () =>
+      loadBlockchainConfig({
+        ...baseEnv,
+        RPC_URL: "https://legacy.example",
+        SUPPORTED_ASSETS: "",
+        SUPPORTED_ASSETS_JSON: JSON.stringify([
+          {
+            symbol: "USDC",
+            assetClass: "trust_backed",
+            assetId: 1337,
+            decimals: 6,
+            minBalanceRaw: "0.07"
+          }
+        ])
+      }),
+    /SUPPORTED_ASSETS_JSON\[0\]\.minBalanceRaw must be a non-negative integer string in base units/u
+  );
 });
 
 test("loadBlockchainConfig rejects mismatched derived addresses in SUPPORTED_ASSETS_JSON", () => {

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -44,7 +44,7 @@ function summarizeSupportedAssets(assets = []) {
 }
 
 function summarizeSupportedAsset(asset) {
-  return {
+  const summary = {
     symbol: asset.symbol,
     address: asset.address,
     assetClass: asset.assetClass ?? "custom",
@@ -52,6 +52,10 @@ function summarizeSupportedAsset(asset) {
     foreignAssetIndex: asset.foreignAssetIndex,
     decimals: asset.decimals
   };
+  if (asset.minBalanceRaw !== undefined) {
+    summary.minBalanceRaw = asset.minBalanceRaw;
+  }
+  return summary;
 }
 
 function canAutoMintAsset(asset) {

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -15,7 +15,8 @@ const USDC_TRUST_ASSET = {
   address: "0x0000053900000000000000000000000001200000",
   assetClass: "trust_backed",
   assetId: 1337,
-  decimals: 6
+  decimals: 6,
+  minBalanceRaw: "70000"
 };
 
 function gatewayWithDot() {

--- a/mcp-server/src/core/assets.js
+++ b/mcp-server/src/core/assets.js
@@ -3,7 +3,8 @@ export const DEFAULT_ESCROW_ASSET = {
   assetClass: "trust_backed",
   assetId: 1337,
   address: "0x0000053900000000000000000000000001200000",
-  decimals: 6
+  decimals: 6,
+  minBalanceRaw: "70000"
 };
 
 export const DEFAULT_ESCROW_ASSET_SYMBOL = DEFAULT_ESCROW_ASSET.symbol;
@@ -27,4 +28,15 @@ export function decimalsForAssetSymbol(symbol, fallback = DEFAULT_ESCROW_ASSET_D
   const normalized = normalizeAssetSymbol(symbol);
   const decimals = ASSET_DECIMALS_BY_SYMBOL[normalized];
   return Number.isInteger(decimals) ? decimals : fallback;
+}
+
+export function knownAssetMinBalanceRaw(asset = {}) {
+  if (
+    asset.assetClass === DEFAULT_ESCROW_ASSET.assetClass
+    && Number(asset.assetId) === DEFAULT_ESCROW_ASSET.assetId
+    && normalizeAssetSymbol(asset.symbol) === DEFAULT_ESCROW_ASSET.symbol
+  ) {
+    return DEFAULT_ESCROW_ASSET.minBalanceRaw;
+  }
+  return undefined;
 }

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -18,7 +18,7 @@ import {
 import { computeClaimEconomics, countClaimedSessions } from "./claim-economics.js";
 import { claimStatusFields, isTerminalSession, summarizeJobClaimState } from "./claim-state.js";
 import { capabilityMatrix } from "../auth/capabilities.js";
-import { normalizeAssetSymbol } from "./assets.js";
+import { knownAssetMinBalanceRaw, normalizeAssetSymbol } from "./assets.js";
 import { collectGithubOperatorStatus } from "./github-operator-helper.js";
 import { collectHostDiagnostics } from "./host-diagnostics.js";
 
@@ -161,11 +161,18 @@ export class PlatformService {
   }
 
   createJob(input) {
-    return this.jobCatalogService.createJob(input);
+    const created = this.jobCatalogService.createJob(input);
+    try {
+      this.validateJobRewardMinBalance(created);
+      return created;
+    } catch (error) {
+      this.jobCatalogService.removeJob(created.id);
+      throw error;
+    }
   }
 
   async createAdminJob(input, { posterWallet = undefined } = {}) {
-    const created = this.jobCatalogService.createJob(input);
+    const created = this.createJob(input);
     try {
       await this.reserveRecurringTemplateFunding(created, posterWallet);
       return created;
@@ -826,7 +833,7 @@ export class PlatformService {
     }
 
     const createdAt = new Date().toISOString();
-    const child = this.jobCatalogService.createJob({
+    const child = this.createJob({
       ...input,
       rewardAsset,
       parentSessionId,
@@ -1042,6 +1049,38 @@ export class PlatformService {
       funding: job.recurringPolicy.funding
     });
     return receipt;
+  }
+
+  validateJobRewardMinBalance(job) {
+    const asset = this.resolveSupportedSettlementAsset(job?.rewardAsset);
+    const minBalanceRaw = minBalanceRawForAsset(asset);
+    if (minBalanceRaw === undefined) {
+      return;
+    }
+    const decimals = Number(asset.decimals);
+    const rewardRaw = decimalToBaseUnits(job.rewardAmount, decimals, "rewardAmount");
+    if (rewardRaw >= minBalanceRaw) {
+      return;
+    }
+    throw new ValidationError(
+      `Job reward below asset minBalance: asset=${asset.symbol} minBalance=${minBalanceRaw} base units ` +
+      `(${formatBaseUnits(minBalanceRaw, decimals)} ${asset.symbol}); reward=${job.rewardAmount} ${asset.symbol} ` +
+      `= ${rewardRaw} base units.`,
+      {
+        asset: asset.symbol,
+        assetClass: asset.assetClass,
+        assetId: asset.assetId,
+        rewardAmount: job.rewardAmount,
+        rewardRaw: rewardRaw.toString(),
+        minBalanceRaw: minBalanceRaw.toString()
+      }
+    );
+  }
+
+  resolveSupportedSettlementAsset(rewardAsset) {
+    const symbol = normalizeAssetSymbol(rewardAsset);
+    const assets = this.blockchainGateway?.config?.supportedAssets ?? [];
+    return assets.find((asset) => normalizeAssetSymbol(asset.symbol) === symbol);
   }
 
   async sendToAgent(from, recipient, asset, amount) {
@@ -1400,6 +1439,53 @@ function timelineTime(value) {
 
 function firstDefined(...values) {
   return values.find((value) => value !== undefined && value !== null) ?? null;
+}
+
+function minBalanceRawForAsset(asset) {
+  if (!asset) {
+    return undefined;
+  }
+  const raw = asset.minBalanceRaw ?? knownAssetMinBalanceRaw(asset);
+  if (raw === undefined || raw === null || raw === "") {
+    return undefined;
+  }
+  if (typeof raw === "bigint") {
+    return raw >= 0n ? raw : undefined;
+  }
+  const value = String(raw).trim();
+  return /^\d+$/u.test(value) ? BigInt(value) : undefined;
+}
+
+function decimalToBaseUnits(amount, decimals, label) {
+  if (!Number.isInteger(decimals) || decimals < 0 || decimals > 30) {
+    throw new ValidationError(`${label} asset decimals must be an integer in [0, 30].`);
+  }
+  const normalized = normalizeDecimalString(amount, label);
+  const [whole, fractional = ""] = normalized.split(".");
+  if (fractional.length > decimals) {
+    throw new ValidationError(`${label} must fit ${decimals} decimal places.`);
+  }
+  return BigInt(whole) * (10n ** BigInt(decimals))
+    + BigInt(fractional.padEnd(decimals, "0") || "0");
+}
+
+function normalizeDecimalString(value, label) {
+  const raw = typeof value === "number"
+    ? value.toLocaleString("en-US", { useGrouping: false, maximumFractionDigits: 30 })
+    : String(value ?? "").trim();
+  if (!/^(?:0|[1-9]\d*)(?:\.\d+)?$/u.test(raw)) {
+    throw new ValidationError(`${label} must be a positive decimal amount.`);
+  }
+  return raw;
+}
+
+function formatBaseUnits(raw, decimals) {
+  const scale = 10n ** BigInt(decimals);
+  const whole = raw / scale;
+  const fractional = raw % scale;
+  if (fractional === 0n || decimals === 0) return whole.toString();
+  const padded = fractional.toString().padStart(decimals, "0").replace(/0+$/u, "");
+  return `${whole}.${padded}`;
 }
 
 function compactTimelineData(value) {

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -5,6 +5,14 @@ import { PlatformService } from "./platform-service.js";
 import { EventBus } from "./event-bus.js";
 
 const WALLET = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const CANONICAL_USDC_ASSET = {
+  symbol: "USDC",
+  assetClass: "trust_backed",
+  assetId: 1337,
+  decimals: 6,
+  address: "0x0000053900000000000000000000000001200000",
+  minBalanceRaw: "70000"
+};
 
 function makePlatformService(blockchainGateway = undefined, eventBus = undefined) {
   const jobs = [
@@ -119,6 +127,75 @@ test("createAdminJob reserves finite recurring template funding from the poster 
   assert.equal(derivative.funding.source, "recurring_template_reserve");
   assert.equal(derivative.funding.wallet, WALLET);
   assert.equal(derivative.funding.amount, 5);
+});
+
+test("createJob allows USDC rewards at or above asset minBalance", () => {
+  const service = makePlatformService({
+    config: { supportedAssets: [CANONICAL_USDC_ASSET] }
+  });
+
+  const exact = service.createJob({
+    id: "usdc-minbalance-exact",
+    category: "product_proof",
+    tier: "starter",
+    rewardAmount: 0.07,
+    rewardAsset: "USDC",
+    verifierMode: "benchmark",
+    verifierTerms: ["complete"],
+    verifierMinimumMatches: 1,
+    inputSchemaRef: "schema://jobs/coding-input",
+    outputSchemaRef: "schema://jobs/coding-output",
+    claimTtlSeconds: 1800,
+    retryLimit: 1
+  });
+  const double = service.createJob({
+    id: "usdc-minbalance-double",
+    category: "product_proof",
+    tier: "starter",
+    rewardAmount: 0.14,
+    rewardAsset: "USDC",
+    verifierMode: "benchmark",
+    verifierTerms: ["complete"],
+    verifierMinimumMatches: 1,
+    inputSchemaRef: "schema://jobs/coding-input",
+    outputSchemaRef: "schema://jobs/coding-output",
+    claimTtlSeconds: 1800,
+    retryLimit: 1
+  });
+
+  assert.equal(exact.rewardAmount, 0.07);
+  assert.equal(double.rewardAmount, 0.14);
+});
+
+test("createJob rejects USDC rewards below asset minBalance and rolls back catalog insertion", () => {
+  const service = makePlatformService({
+    config: { supportedAssets: [CANONICAL_USDC_ASSET] }
+  });
+
+  assert.throws(
+    () => service.createJob({
+      id: "usdc-minbalance-low",
+      category: "product_proof",
+      tier: "starter",
+      rewardAmount: 0.069999,
+      rewardAsset: "USDC",
+      verifierMode: "benchmark",
+      verifierTerms: ["complete"],
+      verifierMinimumMatches: 1,
+      inputSchemaRef: "schema://jobs/coding-input",
+      outputSchemaRef: "schema://jobs/coding-output",
+      claimTtlSeconds: 1800,
+      retryLimit: 1
+    }),
+    (error) => {
+      assert.equal(error.code, "invalid_request");
+      assert.match(error.message, /Job reward below asset minBalance/u);
+      assert.equal(error.details.rewardRaw, "69999");
+      assert.equal(error.details.minBalanceRaw, "70000");
+      return true;
+    }
+  );
+  assert.equal(service.listJobs().some((job) => job.id === "usdc-minbalance-low"), false);
 });
 
 test("createSubJob enforces parent delegation budget and count policy", async () => {

--- a/scripts/ops/deploy-production.test.mjs
+++ b/scripts/ops/deploy-production.test.mjs
@@ -274,7 +274,7 @@ test("deploy wrapper refreshes settlement backend env from testnet deployment ma
   assert.match(contents, /^DISCOVERY_REGISTRY_ADDRESS="0x0a1b78F8A2A3C28dB47f35Cb3E6b3b83412dad57"$/m);
   assert.match(contents, /^XCM_WRAPPER_ADDRESS=""$/m);
   assert.match(contents, /^SUPPORTED_ASSETS=""$/m);
-  assert.match(contents, /^SUPPORTED_ASSETS_JSON="\[{\\"symbol\\":\\"USDC\\",\\"assetClass\\":\\"trust_backed\\",\\"assetId\\":1337,\\"address\\":\\"0x0000053900000000000000000000000001200000\\",\\"decimals\\":6}\]"$/m);
+  assert.match(contents, /^SUPPORTED_ASSETS_JSON="\[{\\"symbol\\":\\"USDC\\",\\"assetClass\\":\\"trust_backed\\",\\"assetId\\":1337,\\"address\\":\\"0x0000053900000000000000000000000001200000\\",\\"decimals\\":6,\\"minBalanceRaw\\":\\"70000\\"}\]"$/m);
   assert.match(await readFile(deployLog, "utf8"), /^backend$/m);
 });
 

--- a/scripts/ops/derive-settlement-env.mjs
+++ b/scripts/ops/derive-settlement-env.mjs
@@ -46,7 +46,8 @@ const supportedAssets = JSON.stringify([{
   assetClass: "trust_backed",
   assetId: 1337,
   address: usdc,
-  decimals: 6
+  decimals: 6,
+  minBalanceRaw: "70000"
 }]);
 
 const entries = {

--- a/scripts/ops/run-hosted-worker-loop.mjs
+++ b/scripts/ops/run-hosted-worker-loop.mjs
@@ -6,23 +6,17 @@ import { AgentPlatformClient } from "../../sdk/agent-platform-client.js";
 import { DEFAULT_ESCROW_ASSET } from "../../mcp-server/src/core/assets.js";
 
 const DEFAULT_API_BASE_URL = "https://api.averray.com";
-// Reward must yield at least the asset's `minBalance` (existential
-// deposit on the Polkadot Hub Assets pallet) once converted to base
-// units, otherwise EscrowCore.resolveSinglePayout will revert with
-// SafeTransfer.TransferFailed when settling to a worker whose asset
-// account has been destroyed (balance dropped to 0). Trust-Backed
-// assets on Asset Hub Paseo carry non-trivial minBalance values — for
-// USDC asset id 1337 the value is 70_000 base units (0.07 USDC). Pick
-// a default well above any common minBalance: 0.1 USDC = 100_000 base
-// units. Operators running with cheaper assets (DOT-decimals) can set
-// PRODUCT_PROOF_REWARD_AMOUNT explicitly to a smaller number.
+// Above USDC's current Asset Hub minBalance of 70_000 base units. The
+// explicit minBalance preflight below remains the launch gate; this is
+// just a humane default for manual workflow dispatches.
 const DEFAULT_REWARD_AMOUNT = 0.1;
 const REQUIRED_ESCROW_ASSET = {
   symbol: DEFAULT_ESCROW_ASSET.symbol,
   address: DEFAULT_ESCROW_ASSET.address.toLowerCase(),
   assetClass: DEFAULT_ESCROW_ASSET.assetClass,
   assetId: DEFAULT_ESCROW_ASSET.assetId,
-  decimals: DEFAULT_ESCROW_ASSET.decimals
+  decimals: DEFAULT_ESCROW_ASSET.decimals,
+  minBalanceRaw: DEFAULT_ESCROW_ASSET.minBalanceRaw
 };
 
 export async function runHostedWorkerLoop({
@@ -58,6 +52,11 @@ export async function runHostedWorkerLoop({
   }
 
   const settlementReadiness = await assertSettlementReadiness(platform, rewardAsset);
+  const rewardReadiness = assertRewardClearsAssetMinBalance({
+    rewardAsset,
+    rewardAmount: rewardAmountInput,
+    asset: settlementReadiness.asset
+  });
   const liquidityReadiness = await assertProductProofLiquidity({
     platform,
     wallet,
@@ -133,6 +132,7 @@ export async function runHostedWorkerLoop({
     verificationOutcome: verification.outcome,
     verificationReasonCode: verification.reasonCode ?? null,
     settlementReadiness,
+    rewardReadiness,
     liquidityReadiness,
     sessionStatus: session.status,
     completedAt: new Date(timestamp).toISOString()
@@ -179,6 +179,33 @@ async function assertProductProofLiquidity({ platform, wallet, rewardAsset, rewa
     availableRaw: availableRaw.toString(),
     required: formatBaseUnits(requiredRaw, decimals),
     available: formatBaseUnits(availableRaw, decimals)
+  };
+}
+
+function assertRewardClearsAssetMinBalance({ rewardAsset, rewardAmount, asset }) {
+  const decimals = Number(asset?.decimals);
+  const rewardRaw = toBaseUnits(rewardAmount, decimals);
+  const minBalanceRaw = minBalanceRawForAsset(asset);
+  if (minBalanceRaw === undefined) {
+    throw new Error(
+      `Hosted product-proof worker loop requires ${rewardAsset} minBalance metadata before mutation. ` +
+      `Expose minBalanceRaw for the settlement asset in /admin/status.`
+    );
+  }
+  if (rewardRaw < minBalanceRaw) {
+    throw new Error(
+      `Hosted product-proof worker loop reward below asset minBalance: asset=${rewardAsset} ` +
+      `(id=${asset.assetId ?? "unknown"}) minBalance=${minBalanceRaw} base units ` +
+      `(${formatBaseUnits(minBalanceRaw, decimals)} ${rewardAsset}); reward=${rewardAmount} ${rewardAsset} ` +
+      `= ${rewardRaw} base units. Increase PRODUCT_PROOF_REWARD_AMOUNT, or pre-fund the worker's asset account so it stays alive.`
+    );
+  }
+  return {
+    asset: rewardAsset,
+    rewardRaw: rewardRaw.toString(),
+    reward: formatBaseUnits(rewardRaw, decimals),
+    minBalanceRaw: minBalanceRaw.toString(),
+    minBalance: formatBaseUnits(minBalanceRaw, decimals)
   };
 }
 
@@ -244,6 +271,23 @@ function toBigIntAmount(value, label) {
     return BigInt(value.trim());
   }
   throw new Error(`${label} must be present as a raw integer amount.`);
+}
+
+function minBalanceRawForAsset(asset) {
+  if (!asset) {
+    return undefined;
+  }
+  const raw = asset?.minBalanceRaw ?? (
+    describeRequiredAssetMismatch(asset) ? undefined : REQUIRED_ESCROW_ASSET.minBalanceRaw
+  );
+  if (raw === undefined || raw === null || raw === "") {
+    return undefined;
+  }
+  if (typeof raw === "bigint") {
+    return raw >= 0n ? raw : undefined;
+  }
+  const value = String(raw).trim();
+  return /^\d+$/u.test(value) ? BigInt(value) : undefined;
 }
 
 function formatBaseUnits(raw, decimals) {

--- a/scripts/ops/run-hosted-worker-loop.test.mjs
+++ b/scripts/ops/run-hosted-worker-loop.test.mjs
@@ -24,7 +24,7 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
     },
     async getAccountSummary() {
       calls.push(["getAccountSummary"]);
-      return accountSummary({ liquidUsdcRaw: 1 });
+      return accountSummary({ liquidUsdcRaw: 100_000 });
     },
     async createJob(payload) {
       calls.push(["createJob", payload]);
@@ -63,13 +63,7 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
     env: {
       API_BASE_URL: "https://api.example.test/",
       ADMIN_JWT: "token",
-      PRODUCT_PROOF_EVIDENCE_FILE: evidenceFile,
-      // Pin the reward to the original test value so this test's assertions
-      // (rewardAmount === 0.000001, requiredRaw === "1") remain independent
-      // of DEFAULT_REWARD_AMOUNT. The default was bumped to clear USDC's
-      // existential deposit; this test still exercises the small-reward
-      // configuration path explicitly.
-      PRODUCT_PROOF_REWARD_AMOUNT: "0.000001"
+      PRODUCT_PROOF_EVIDENCE_FILE: evidenceFile
     }
   });
 
@@ -92,7 +86,7 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
   ]);
   assert.equal(calls[3][1].verifierMode, "benchmark");
   assert.equal(calls[3][1].rewardAsset, "USDC");
-  assert.equal(calls[3][1].rewardAmount, 0.000001);
+  assert.equal(calls[3][1].rewardAmount, 0.1);
   assert.equal(calls[4][2], `product-proof:${jobId}`);
 
   const written = JSON.parse(await readFile(evidenceFile, "utf8"));
@@ -100,8 +94,10 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
   assert.equal(written.sessionId, sessionId);
   assert.equal(written.verificationOutcome, "approved");
   assert.equal(written.settlementReadiness.settlementReady, true);
-  assert.equal(written.liquidityReadiness.requiredRaw, "1");
-  assert.equal(written.liquidityReadiness.availableRaw, "1");
+  assert.equal(written.rewardReadiness.minBalanceRaw, "70000");
+  assert.equal(written.rewardReadiness.rewardRaw, "100000");
+  assert.equal(written.liquidityReadiness.requiredRaw, "100000");
+  assert.equal(written.liquidityReadiness.availableRaw, "100000");
 });
 
 test("runHostedWorkerLoop fails closed without a token", async () => {
@@ -121,7 +117,7 @@ test("runHostedWorkerLoop accepts an explicit positive reward amount", async () 
       return settlementReadyStatus();
     },
     async getAccountSummary() {
-      return accountSummary({ liquidUsdcRaw: 10_000 });
+      return accountSummary({ liquidUsdcRaw: 70_000 });
     },
     async createJob(payload) {
       calls.push(["createJob", payload]);
@@ -153,11 +149,11 @@ test("runHostedWorkerLoop accepts an explicit positive reward amount", async () 
     log: () => {},
     env: {
       ADMIN_JWT: "token",
-      PRODUCT_PROOF_REWARD_AMOUNT: "0.01"
+      PRODUCT_PROOF_REWARD_AMOUNT: "0.07"
     }
   });
 
-  assert.equal(calls[0][1].rewardAmount, 0.01);
+  assert.equal(calls[0][1].rewardAmount, 0.07);
 });
 
 test("runHostedWorkerLoop fails closed before mutation when AgentAccountCore USDC liquidity is missing", async () => {
@@ -185,11 +181,9 @@ test("runHostedWorkerLoop fails closed before mutation when AgentAccountCore USD
       },
       now: () => 1700000000000,
       log: () => {},
-      // Pinning the reward keeps the assertion regex stable across changes
-      // to DEFAULT_REWARD_AMOUNT.
-      env: { ADMIN_JWT: "token", PRODUCT_PROOF_REWARD_AMOUNT: "0.000001" }
+      env: { ADMIN_JWT: "token" }
     }),
-    /requires funded USDC liquidity before mutation; wallet=0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519; account=0x3333333333333333333333333333333333333333; required=0\.000001 USDC \(raw 1\); available=0 USDC \(raw 0\)/u
+    /requires funded USDC liquidity before mutation; wallet=0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519; account=0x3333333333333333333333333333333333333333; required=0\.1 USDC \(raw 100000\); available=0 USDC \(raw 0\)/u
   );
 
   assert.deepEqual(calls.map(([name]) => name), ["getAuthSession", "getAdminStatus", "getAccountSummary"]);
@@ -387,6 +381,7 @@ test("runHostedWorkerLoop rejects unapproved canonical USDC settlement asset", a
                 assetClass: "trust_backed",
                 assetId: 1337,
                 decimals: 6,
+                minBalanceRaw: "70000",
                 approved: false
               }]
             }
@@ -420,6 +415,37 @@ test("runHostedWorkerLoop rejects invalid reward amounts", async () => {
     }),
     /PRODUCT_PROOF_REWARD_AMOUNT must be greater than zero/u
   );
+});
+
+test("runHostedWorkerLoop rejects rewards below the USDC minBalance before mutation", async () => {
+  const calls = [];
+  await assert.rejects(
+    runHostedWorkerLoop({
+      client: {
+        async getAuthSession() {
+          calls.push(["getAuthSession"]);
+          return { wallet: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519" };
+        },
+        async getAdminStatus() {
+          calls.push(["getAdminStatus"]);
+          return settlementReadyStatus();
+        },
+        async getAccountSummary() {
+          calls.push(["getAccountSummary"]);
+          throw new Error("should not read liquidity after minBalance preflight fails");
+        },
+        async createJob() {
+          calls.push(["createJob"]);
+          throw new Error("should not mutate below asset minBalance");
+        }
+      },
+      env: { ADMIN_JWT: "token", PRODUCT_PROOF_REWARD_AMOUNT: "0.069999" },
+      log: () => {}
+    }),
+    /reward below asset minBalance: asset=USDC \(id=1337\) minBalance=70000 base units \(0\.07 USDC\); reward=0\.069999 USDC = 69999 base units/u
+  );
+
+  assert.deepEqual(calls.map(([name]) => name), ["getAuthSession", "getAdminStatus"]);
 });
 
 function accountSummary({
@@ -461,6 +487,7 @@ function settlementReadyStatus(overrides = {}) {
             assetClass: "trust_backed",
             assetId: 1337,
             decimals: 6,
+            minBalanceRaw: "70000",
             approved: true
           }]
         }


### PR DESCRIPTION
## What changed
- Add canonical Polkadot Hub USDC minBalance metadata and preserve configured minBalanceRaw in SUPPORTED_ASSETS_JSON.
- Surface minBalanceRaw through admin settlement status supported assets.
- Fail closed before mutation when hosted product-proof reward is below the asset minBalance.
- Apply the same minBalance guard to platform job creation and sub-job creation so tiny USDC rewards cannot create settlement-time failures.
- Include minBalanceRaw in derived production settlement env.

## Polkadot MCP check
- Checked Polkadot docs for the ERC20 precompile: USDC asset id 1337 has 6 decimals at 0x0000053900000000000000000000000001200000, and ERC20 metadata functions are not exposed; metadata/minBalance must come from Assets-pallet-backed config/status rather than ERC20 calls.

## Checks run
- npm install
- node --test scripts/ops/run-hosted-worker-loop.test.mjs scripts/ops/deploy-production.test.mjs
- node --test mcp-server/src/core/platform-service.test.js --test-name-pattern="createJob .*USDC"
- node --test mcp-server/src/blockchain/config.test.js mcp-server/src/blockchain/gateway.test.js --test-name-pattern="loadBlockchainConfig|ensureJob rejects real settlement asset shortfalls|TreasuryPolicyStatus"
- npm --workspace mcp-server test -- --test-name-pattern="loadBlockchainConfig|createJob allows USDC|createJob rejects USDC|ensureJob rejects real settlement|TreasuryPolicyStatus"
- git diff --check

Fixes #222