### PR TITLE
Phase 2 PR 2.2: Caddy basic-auth hash-only + raw password leaves CI

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -132,8 +132,13 @@ jobs:
       VPS_USER: ${{ secrets.VPS_USER }}
       VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
       APP_BASIC_AUTH_USER: ${{ secrets.APP_BASIC_AUTH_USER }}
-      APP_BASIC_AUTH_PASSWORD: ${{ secrets.APP_BASIC_AUTH_PASSWORD }}
       APP_BASIC_AUTH_PASSWORD_HASH: ${{ secrets.APP_BASIC_AUTH_PASSWORD_HASH }}
+      # APP_BASIC_AUTH_PASSWORD (raw) was here pre-PR-2.2. Removed: the
+      # render-caddyfile.sh script no longer accepts raw passwords —
+      # it would have put them in `ps` output during the call. The raw
+      # password lives only in op://prod-critical/app-basic-auth, used by
+      # human operators when typing into the browser basic-auth dialog.
+      # Caddy verifies via the bcrypt HASH below.
       APP_ALLOW_PROTECTED_SHELL: ${{ secrets.APP_ALLOW_PROTECTED_SHELL }}
       ADMIN_JWT: ${{ secrets.ADMIN_JWT }}
       RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
@@ -177,7 +182,7 @@ jobs:
       # step still uses the legacy ${{ secrets.VPS_SSH_KEY }} value.
       # PR 2.4 will flip the SSH write to use $VPS_SSH_KEY_OP and delete
       # the legacy secret 24h after the OP path has been proven stable.
-      - name: Load VPS SSH key from 1Password (parity check, non-blocking)
+      - name: Load CI-side secrets from 1Password (parity check, non-blocking)
         id: load_op_ssh
         continue-on-error: true
         # Pinned to 1password/load-secrets-action v2.0.0 commit SHA
@@ -190,6 +195,10 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PROD_CI }}
           VPS_SSH_KEY_OP: op://prod-ci/vps-ssh-key/private key
+          # PR 2.2 additions — Caddy basic-auth bundle, parity-loaded here,
+          # used by render-caddyfile.sh once PR 2.4 swaps the heredoc.
+          APP_BASIC_AUTH_USER_OP: op://prod-ci/app-basic-auth-hash/username
+          APP_BASIC_AUTH_PASSWORD_HASH_OP: op://prod-ci/app-basic-auth-hash/credential
 
       # Compare without ever printing key material. Writes both to
       # umask-077 mktemp files, runs `cmp -s`, and logs only the
@@ -229,6 +238,91 @@ jobs:
         run: |
           echo "::warning::1Password load-secrets-action failed; falling back to legacy VPS_SSH_KEY from GH Actions. Investigate before assuming Phase 2 is healthy."
 
+      # ─── Phase 2 PR 2.2: Caddy basic-auth parity / presence check ──
+      #
+      # The bcrypt hash in op://prod-ci/app-basic-auth-hash/credential is
+      # SEMANTICALLY equivalent to ${{ secrets.APP_BASIC_AUTH_PASSWORD_HASH }}
+      # but bcrypt salts make the two byte-strings non-identical. We
+      # therefore can't `cmp -s` them — we only check:
+      #   (a) the OP-loaded values are non-empty (load worked end-to-end)
+      #   (b) the OP-loaded hash starts with $2a$ / $2b$ / $2y$
+      #   (c) the legacy GH-secret hash also starts with $2a$ / $2b$ / $2y$
+      #   (d) the OP-loaded user matches the legacy user byte-for-byte
+      # Mismatches surface as workflow ::warning:: annotations so they're
+      # visible in the PR check summary; the deploy still uses the legacy
+      # values until PR 2.4 swaps the heredoc. The 401/200 smoke check at
+      # the end of the deploy is the load-bearing verification.
+      - name: Verify OP-loaded Caddy basic-auth values (parity, non-blocking)
+        if: steps.load_op_ssh.outcome == 'success'
+        env:
+          LEGACY_USER: ${{ secrets.APP_BASIC_AUTH_USER }}
+          LEGACY_HASH: ${{ secrets.APP_BASIC_AUTH_PASSWORD_HASH }}
+        run: |
+          set -euo pipefail
+          set +x
+
+          fail_warn=false
+
+          # (a) non-empty checks
+          if [ -z "${APP_BASIC_AUTH_USER_OP:-}" ]; then
+            echo "::warning::OP-loaded APP_BASIC_AUTH_USER_OP is empty — check op://prod-ci/app-basic-auth-hash/username exists"
+            fail_warn=true
+          fi
+          if [ -z "${APP_BASIC_AUTH_PASSWORD_HASH_OP:-}" ]; then
+            echo "::warning::OP-loaded APP_BASIC_AUTH_PASSWORD_HASH_OP is empty — check op://prod-ci/app-basic-auth-hash/credential exists"
+            fail_warn=true
+          fi
+
+          # (b) OP-loaded hash shape
+          if [ -n "${APP_BASIC_AUTH_PASSWORD_HASH_OP:-}" ]; then
+            case "$APP_BASIC_AUTH_PASSWORD_HASH_OP" in
+              \$2a\$*|\$2b\$*|\$2y\$*)
+                echo "APP_BASIC_AUTH_PASSWORD_HASH_OP: bcrypt shape valid"
+                ;;
+              *)
+                echo "::warning::OP-loaded APP_BASIC_AUTH_PASSWORD_HASH_OP does not look like a bcrypt hash"
+                fail_warn=true
+                ;;
+            esac
+          fi
+
+          # (c) legacy GH-secret hash shape (sanity check on the value
+          # we're actually still deploying with).
+          if [ -n "${LEGACY_HASH:-}" ]; then
+            case "$LEGACY_HASH" in
+              \$2a\$*|\$2b\$*|\$2y\$*)
+                echo "legacy APP_BASIC_AUTH_PASSWORD_HASH: bcrypt shape valid"
+                ;;
+              *)
+                echo "::warning::legacy APP_BASIC_AUTH_PASSWORD_HASH (GH secret) does not look like a bcrypt hash — deploy will likely fail at render-caddyfile.sh"
+                fail_warn=true
+                ;;
+            esac
+          fi
+
+          # (d) byte-for-byte compare of usernames (not secrets, but
+          # mismatch means OP and GH drifted; same printf '%s' / cmp -s
+          # pattern as the SSH key check).
+          if [ -n "${APP_BASIC_AUTH_USER_OP:-}" ] && [ -n "${LEGACY_USER:-}" ]; then
+            umask 077
+            legacy_file=$(mktemp)
+            op_file=$(mktemp)
+            trap 'rm -f "$legacy_file" "$op_file"' EXIT
+            printf '%s' "$LEGACY_USER" > "$legacy_file"
+            printf '%s' "$APP_BASIC_AUTH_USER_OP" > "$op_file"
+            if cmp -s "$legacy_file" "$op_file"; then
+              echo "APP_BASIC_AUTH_USER_OP matches legacy secret: yes"
+            else
+              echo "APP_BASIC_AUTH_USER_OP matches legacy secret: no"
+              echo "::warning::OP-loaded basic-auth username drifted from legacy GH secret. Investigate before PR 2.4 swaps."
+              fail_warn=true
+            fi
+          fi
+
+          if [ "$fail_warn" = "true" ]; then
+            echo "::warning::Caddy basic-auth parity check raised warnings (deploy proceeds with legacy values)"
+          fi
+
       - name: Configure SSH
         run: |
           mkdir -p ~/.ssh
@@ -239,10 +333,14 @@ jobs:
 
       - name: Deploy production
         run: |
+          # APP_BASIC_AUTH_PASSWORD (raw) is intentionally NOT in this
+          # heredoc anymore — render-caddyfile.sh on the VPS now requires
+          # the HASH and rejects the raw value. PR 2.4 will further
+          # eliminate the SSH-heredoc transport for APP_BASIC_AUTH_USER
+          # + APP_BASIC_AUTH_PASSWORD_HASH once op inject runs on the VPS.
           remote_env=$(
-            printf 'APP_BASIC_AUTH_USER=%q APP_BASIC_AUTH_PASSWORD=%q APP_BASIC_AUTH_PASSWORD_HASH=%q APP_ALLOW_PROTECTED_SHELL=%q ADMIN_JWT=%q RESEND_API_KEY=%q BOOTSTRAP_SELF_REPORT_TO=%q BOOTSTRAP_SELF_REPORT_FROM=%q BOOTSTRAP_SELF_REPORT_SEND_ON_START=%q RUN_INDEXER=%q WAIT_FOR_READY=%q HEALTH_STABILITY_SEC=%q INDEXER_LOG_TAIL=%q SMOKE_CHECK_INDEXER=%q SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION=%q SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT=%q SMOKE_CHECK_PRODUCT_PROOF_GATE=%q PRODUCT_PROOF_REQUIRE_WORKER_LOOP=%q PRODUCT_PROOF_REWARD_ASSET=%q INDEXER_DATABASE_SCHEMA=%q INDEXER_FRESH_SCHEMA=%q ' \
+            printf 'APP_BASIC_AUTH_USER=%q APP_BASIC_AUTH_PASSWORD_HASH=%q APP_ALLOW_PROTECTED_SHELL=%q ADMIN_JWT=%q RESEND_API_KEY=%q BOOTSTRAP_SELF_REPORT_TO=%q BOOTSTRAP_SELF_REPORT_FROM=%q BOOTSTRAP_SELF_REPORT_SEND_ON_START=%q RUN_INDEXER=%q WAIT_FOR_READY=%q HEALTH_STABILITY_SEC=%q INDEXER_LOG_TAIL=%q SMOKE_CHECK_INDEXER=%q SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION=%q SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT=%q SMOKE_CHECK_PRODUCT_PROOF_GATE=%q PRODUCT_PROOF_REQUIRE_WORKER_LOOP=%q PRODUCT_PROOF_REWARD_ASSET=%q INDEXER_DATABASE_SCHEMA=%q INDEXER_FRESH_SCHEMA=%q ' \
               "$APP_BASIC_AUTH_USER" \
-              "$APP_BASIC_AUTH_PASSWORD" \
               "$APP_BASIC_AUTH_PASSWORD_HASH" \
               "$APP_ALLOW_PROTECTED_SHELL" \
               "$ADMIN_JWT" \

--- a/deploy/secrets-inventory.md
+++ b/deploy/secrets-inventory.md
@@ -66,8 +66,9 @@ needed inside GitHub Actions runners.
 
 | Env var                          | `op://` path                                                              | Used in PR | Notes                                                                                                                                  |
 | -------------------------------- | ------------------------------------------------------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `VPS_SSH_KEY`                    | `op://prod-ci/vps-ssh-key/private key`                                    | 2.1        | ED25519 private key. The op item also stores host/user/port as fields.                                                                 |
-| `APP_BASIC_AUTH_PASSWORD_HASH`   | `op://prod-ci/app-basic-auth-password-hash/credential`                    | 2.2        | bcrypt hash injected into Caddyfile. Item created in PR 2.2; raw password lives separately in prod-critical (human-only).              |
+| `VPS_SSH_KEY`                    | `op://prod-ci/vps-ssh-key/private key`                                    | 2.1        | ED25519 private key. The op item also stores host/user/port as fields. **Rotated 2026-05-12 during PR 2.1 acceptance** (legacy GH-secret value was lost when an intermediate step overwrote it; recovered by minting a fresh key and installing via password SSH). |
+| `APP_BASIC_AUTH_USER`            | `op://prod-ci/app-basic-auth-hash/username`                               | 2.2        | Basic-auth username for Caddy on app.averray.com. Not strictly a secret but lives with the hash for atomic rotation.                  |
+| `APP_BASIC_AUTH_PASSWORD_HASH`   | `op://prod-ci/app-basic-auth-hash/credential`                             | 2.2        | bcrypt hash injected into Caddyfile. **Raw password lives only in `op://prod-critical/app-basic-auth/password`** (human-only). Different bcrypt salt each generation, so this hash will NOT byte-match any other hash of the same password. Item created during PR 2.2 operator setup. |
 
 ## Smoke-test secrets
 

--- a/docs/SECRETS_MIGRATION.md
+++ b/docs/SECRETS_MIGRATION.md
@@ -348,40 +348,161 @@ for 24h after each, and is reversible.
 - [ ] `1password/load-secrets-action` is pinned to commit SHA
       `581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0`, not a tag
 
-### PR 2.2 — Caddy basic-auth: hash-only, validated, no plaintext in transit
+### PR 2.2 — Caddy basic-auth: hash-only, validated, no plaintext in CI
 
-**Touches**: `scripts/ops/render-caddyfile.sh`, `deploy/Caddyfile.averray`,
+**Touches**: `scripts/ops/render-caddyfile.sh`,
+`scripts/ops/deploy-production.sh`,
 `.github/workflows/deploy-production.yml`.
 
-- Generate the bcrypt hash with `caddy hash-password` reading the password
-  from **stdin** (no `--plaintext` flag — that places the raw password in
-  shell history and `ps` output). Run in a shell with `set +o history` or
-  in an explicit subshell that doesn't write history.
-- Store the hash at `op://prod-ci/app-basic-auth-password-hash/credential`.
-- **Render the Caddyfile on the VPS via `op inject`** (templated
-  Caddyfile committed to repo; secrets resolved at deploy time). The
-  hash never traverses an SSH heredoc body.
-- Modify `render-caddyfile.sh` to require `APP_BASIC_AUTH_PASSWORD_HASH`
-  and fail loudly if `APP_BASIC_AUTH_PASSWORD` is present — catches
-  accidental fallback to the old plaintext flow.
-- Add `caddy validate --config /etc/caddy/Caddyfile` as a deploy gate
-  before reload.
-- Add smoke verification: `curl -I https://app.averray.com` expects 401;
-  `curl -u user:pass https://app.averray.com/<known-path>` expects 200.
-- Treat the bcrypt hash as a credential verifier (leaked hash enables
-  offline guessing). The underlying raw password MUST be high-entropy
-  random, not human-memorable. If today's password is memorable, **rotate
-  it to a random value during this PR.**
+**Honest scope adjustment from the original plan**: the plan said "render
+Caddyfile on the VPS via `op inject` — hash never traverses an SSH
+heredoc." That requires `op` CLI on the VPS, which is PR 2.3's bootstrap
+work. PR 2.2 lands the things that don't depend on the VPS bootstrap:
+hardening, hash-only flow in CI, deploy-time validation, removal of raw
+password from CI. PR 2.4 will move the render to op-inject-on-VPS after
+PR 2.3 provisions the toolchain.
+
+**Operator setup BEFORE merge** (one-time, on your laptop with
+`op signin` active):
+
+1. Install `caddy` locally so we can generate the bcrypt hash without
+   spinning up a docker container:
+   ```bash
+   brew install caddy
+   ```
+2. Generate the bcrypt hash from the raw password in `prod-critical`
+   and store the new hash + username together as a single
+   `prod-ci/app-basic-auth-hash` item. The raw password never appears
+   on a command line or in shell history.
+   ```bash
+   eval $(op signin)
+
+   set +o history
+   RAW=$(op read 'op://prod-critical/app-basic-auth/password')
+   USER=$(op read 'op://prod-critical/app-basic-auth/username')
+
+   # caddy hash-password reads stdin when --plaintext is omitted.
+   HASH=$(printf '%s' "$RAW" | caddy hash-password --algorithm bcrypt)
+
+   # Sanity-check the hash shape before storing.
+   case "$HASH" in
+     \$2a\$*|\$2b\$*|\$2y\$*) echo "✓ hash shape ok ($(printf '%s' "$HASH" | wc -c | tr -d ' ') chars)" ;;
+     *) echo "✗ hash does not look like bcrypt; abort"; unset RAW USER HASH; return 1 2>/dev/null || exit 1 ;;
+   esac
+
+   op item create --vault=prod-ci --category=password --title=app-basic-auth-hash \
+     "username=$USER" \
+     "credential[concealed]=$HASH" \
+     "notes=Bcrypt hash of raw password from prod-critical/app-basic-auth. Used by Caddy basic-auth on app.averray.com. Different bcrypt salt → different hash each generation; do NOT expect this to byte-match any other hash. Regenerate when raw rotates."
+
+   unset RAW USER HASH
+   set -o history
+   ```
+3. **Verify the new hash actually authenticates against the live Caddy**
+   before merging. This catches drift between `prod-critical/app-basic-auth`
+   and whatever password the legacy GH-secret hash was generated from.
+   ```bash
+   RAW=$(op read 'op://prod-critical/app-basic-auth/password')
+   USER=$(op read 'op://prod-critical/app-basic-auth/username')
+   status=$(curl -sS -o /dev/null -w '%{http_code}' -u "$USER:$RAW" https://app.averray.com/)
+   echo "auth status: $status (expect 200/3xx, NOT 401)"
+   unset RAW USER
+   ```
+   If this returns 401, the password in `prod-critical/app-basic-auth`
+   doesn't match what Caddy currently expects. **DO NOT MERGE** — resolve
+   the drift first (likely by updating `prod-critical/app-basic-auth` to
+   the password your browser autofill remembers).
+
+**Changes in this PR**:
+
+- `scripts/ops/render-caddyfile.sh`: drops the in-script `render_hash()`
+  helper that called `caddy hash-password --plaintext` (the unsafe form
+  that put the raw password in `ps` output). Now **requires** the
+  precomputed bcrypt hash and **rejects** the deploy outright if
+  `APP_BASIC_AUTH_PASSWORD` (raw) is set in the env. Adds a bcrypt
+  shape check (`^\$2[aby]\$`) so a typoed hash is caught before render.
+- `scripts/ops/deploy-production.sh` `apply_caddy()`: renders to a
+  `mktemp` file alongside the target, runs `caddy validate` inside the
+  running caddy container against the rendered file (mounted read-only
+  via `-v`), and only `mv`s into place after validation passes. A
+  failed validate aborts the deploy before touching the live config.
+- `.github/workflows/deploy-production.yml`:
+  - Removes `APP_BASIC_AUTH_PASSWORD` (raw) from the job-level `env:`
+    block and from the SSH heredoc env string. Raw password no longer
+    flows through CI at all.
+  - Extends the PR 2.1 `load-secrets-action` step to also load
+    `APP_BASIC_AUTH_USER_OP` and `APP_BASIC_AUTH_PASSWORD_HASH_OP` from
+    `op://prod-ci/app-basic-auth-hash/...` (parity-style, non-blocking).
+  - Adds a "Verify OP-loaded Caddy basic-auth values" step that asserts:
+    - both OP-loaded values are non-empty
+    - the OP-loaded hash starts with `$2a$` / `$2b$` / `$2y$`
+    - the legacy GH-secret hash also starts with one of those
+    - the OP-loaded username matches the legacy username byte-for-byte
+    Mismatches surface as `::warning::` annotations; the deploy still
+    uses the legacy GH secret values until PR 2.4 swaps the heredoc.
 
 **Acceptance criteria**:
 
-- [ ] Caddyfile contains the bcrypt hash, never a raw password
-- [ ] `caddy validate` passes before reload
-- [ ] Unauthenticated request → 401
-- [ ] Authenticated request → expected 200/redirect
-- [ ] Raw `APP_BASIC_AUTH_PASSWORD` GH Actions secret deleted
-- [ ] No raw or hashed value transits an SSH heredoc body
-- [ ] Underlying raw password is high-entropy random (rotated if it wasn't)
+- [ ] Operator setup complete: `op://prod-ci/app-basic-auth-hash` item
+      exists with `username` and `credential` fields
+- [ ] Manual auth-check curl with `prod-critical/app-basic-auth` raw
+      returns 200/3xx against the live Caddy (proves no drift)
+- [ ] After merge, a manual `workflow_dispatch` deploy succeeds end-to-end
+- [ ] The parity-check step logs `APP_BASIC_AUTH_USER_OP matches legacy
+      secret: yes` (or surfaces a warning if not)
+- [ ] `caddy validate` step in `apply_caddy()` passes before reload
+- [ ] Unauthenticated request to `https://app.averray.com/` returns 401
+      (smoke check at end of deploy)
+- [ ] No raw or hashed value appears in deploy logs
+- [ ] `APP_BASIC_AUTH_PASSWORD` is no longer referenced anywhere in the
+      workflow YAML (verified with `grep`)
+- [ ] (Deferred to PR 2.4 / 2.5) authenticated request → 200 — needs a
+      smoke-side OP token that can read `prod-critical/app-basic-auth`
+      OR a separate `prod-smoke/app-basic-auth` mirror; out of scope for
+      this PR.
+- [ ] (Deferred to PR 2.4) legacy `APP_BASIC_AUTH_PASSWORD` GH Actions
+      secret deleted (24h after this PR ships green deploys)
+- [ ] (Deferred to PR 2.4) `op inject` render of Caddyfile on the VPS,
+      eliminating the SSH-heredoc transport of the hash entirely
+
+### Lessons from PR 2.1 (folded into future PR procedures)
+
+The PR 2.1 acceptance walked into three pitfalls. Documented here so
+future PRs don't repeat them:
+
+1. **`scp` / `ssh` falling back to password auth is a SILENT signal that
+   the key isn't authorized.** When loading SSH keys into 1Password,
+   always verify with
+   `ssh -o BatchMode=yes -o PreferredAuthentications=publickey ...`
+   BEFORE treating the local file as canonical. The PR 2.1 loader
+   trusted `~/.ssh/averray_deploy` based on filename and pushed an
+   unauthorized key into the vault.
+
+2. **`op read | gh secret set` pipes silently overwrite with empty
+   stdin if `op read` errors.** `op` writes the error to stderr, exits
+   non-zero, and produces no stdout. `gh secret set` then dutifully
+   stores an empty value. Always capture into a shell variable first,
+   verify non-empty + minimum length, then `printf '%s' "$VAR" | gh
+   secret set`. Pattern:
+   ```bash
+   KEY=$(op read 'op://...')
+   key_len=$(printf '%s' "$KEY" | wc -c | tr -d ' ')
+   if [ -n "$KEY" ] && [ "$key_len" -gt 100 ]; then
+     printf '%s' "$KEY" | gh secret set NAME -R repo
+   else
+     echo "✗ OP value short/empty — do NOT overwrite GH"
+   fi
+   unset KEY key_len
+   ```
+
+3. **GitHub Actions secrets are write-only.** Once overwritten there's
+   no way to read the previous value. Treat them as fire-and-forget
+   sinks; the canonical value must live in 1Password. PR 2.1 lost the
+   legacy VPS_SSH_KEY because we overwrote it without backup, then
+   discovered the local-file source wasn't authorized.
+
+The `ssh -o BatchMode=yes ...` pre-flight should be added to PR 2.4's
+runbook before any "swap legacy GH secret to OP-loaded value" step.
 
 ### PR 2.3 — VPS: atomic, fail-closed render flow (the cutover)
 

--- a/scripts/ops/deploy-production.sh
+++ b/scripts/ops/deploy-production.sh
@@ -426,16 +426,50 @@ run_product_proof_worker_loop() {
 apply_caddy() {
   if [[ -z "${APP_BASIC_AUTH_USER:-}" ]]; then
     echo "Skipping Caddy render: APP_BASIC_AUTH_USER is not set." >&2
-    echo "Set APP_BASIC_AUTH_USER plus APP_BASIC_AUTH_PASSWORD or APP_BASIC_AUTH_PASSWORD_HASH to deploy Caddy changes." >&2
+    echo "Set APP_BASIC_AUTH_USER plus APP_BASIC_AUTH_PASSWORD_HASH to deploy Caddy changes." >&2
     return 0
   fi
 
-  if [[ -z "${APP_BASIC_AUTH_PASSWORD:-}" && -z "${APP_BASIC_AUTH_PASSWORD_HASH:-}" ]]; then
-    echo "Skipping Caddy render: no app basic-auth password/hash set." >&2
+  if [[ -z "${APP_BASIC_AUTH_PASSWORD_HASH:-}" ]]; then
+    echo "Skipping Caddy render: APP_BASIC_AUTH_PASSWORD_HASH is not set." >&2
+    echo "PR 2.2 removed the raw-password code path; pass the bcrypt hash only." >&2
     return 0
   fi
 
-  "$APP_ROOT/scripts/ops/render-caddyfile.sh" "$STACK_ROOT/Caddyfile"
+  # Render the new Caddyfile atomically: write to a tmp file alongside
+  # the target, validate via `caddy validate` inside the running caddy
+  # container, then move into place. If validate fails, the live
+  # Caddyfile is untouched and the deploy aborts.
+  local rendered_tmp
+  rendered_tmp=$(mktemp "$STACK_ROOT/Caddyfile.XXXXXX")
+  trap 'rm -f "$rendered_tmp"' RETURN
+
+  "$APP_ROOT/scripts/ops/render-caddyfile.sh" "$rendered_tmp"
+
+  # caddy validate inside the running caddy container. The container's
+  # Caddyfile path is /etc/caddy/Caddyfile; we mount the rendered tmp
+  # over that path with `-v` for the validate call only. If the
+  # validate fails, caddy returns non-zero and `set -e` aborts the
+  # deploy before we touch the live config.
+  echo "Validating rendered Caddyfile via caddy validate (PR 2.2)..."
+  if ! docker compose \
+        --project-directory "$STACK_ROOT" \
+        -f "$COMPOSE_FILE" \
+        run --rm \
+          -v "$rendered_tmp:/etc/caddy/Caddyfile:ro" \
+          --no-deps \
+          --entrypoint caddy \
+          caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile; then
+    echo "ERROR: caddy validate rejected the rendered Caddyfile; aborting before reload." >&2
+    rm -f "$rendered_tmp"
+    return 1
+  fi
+
+  # Atomic install of the validated Caddyfile.
+  chmod 0644 "$rendered_tmp"
+  mv "$rendered_tmp" "$STACK_ROOT/Caddyfile"
+  trap - RETURN
+
   docker compose \
     --project-directory "$STACK_ROOT" \
     -f "$COMPOSE_FILE" \

--- a/scripts/ops/render-caddyfile.sh
+++ b/scripts/ops/render-caddyfile.sh
@@ -1,6 +1,24 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+set +x
+
+# render-caddyfile.sh — render deploy/Caddyfile.averray with basic-auth block.
+#
+# Phase 2 PR 2.2 hardening:
+#   • REQUIRES the precomputed bcrypt hash. No in-script hashing.
+#   • REFUSES to run if APP_BASIC_AUTH_PASSWORD (raw) is set in the env —
+#     catches accidental fallback paths that would put the raw password
+#     into shell args / ps output / journald.
+#   • Raw passwords belong in `op://prod-critical/app-basic-auth` (human-only).
+#     CI and the VPS only ever see the bcrypt HASH, which Caddy uses to
+#     verify the password presented at HTTP basic-auth time.
+#
+# Backwards-incompat note: pre-PR-2.2 callers of this script could pass
+# APP_BASIC_AUTH_PASSWORD as plaintext and have it hashed in-process by
+# `caddy hash-password --plaintext`. That path is removed in this PR
+# because it puts the raw password on the script's command line, visible
+# in `ps -ef` for the duration of the call.
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
@@ -9,17 +27,27 @@ TEMPLATE_PATH="${TEMPLATE_PATH:-$REPO_ROOT/deploy/Caddyfile.averray}"
 usage() {
   cat <<'EOF'
 Usage:
-  APP_BASIC_AUTH_USER=operator APP_BASIC_AUTH_PASSWORD='secret' \
+  APP_BASIC_AUTH_USER=operator \
+  APP_BASIC_AUTH_PASSWORD_HASH='$2a$14$...' \
     ./scripts/ops/render-caddyfile.sh /path/to/output/Caddyfile
 
-Optional env:
-  TEMPLATE_PATH                 Override the source template
+Required env (when basic-auth is enabled — set both, or neither):
   APP_BASIC_AUTH_USER           Basic-auth username for app.averray.com
-  APP_BASIC_AUTH_PASSWORD       Plaintext password; rendered as bcrypt hash
-  APP_BASIC_AUTH_PASSWORD_HASH  Precomputed bcrypt hash; use instead of plaintext
+  APP_BASIC_AUTH_PASSWORD_HASH  bcrypt hash of the raw password.
+                                Generate with:
+                                  printf '%s' "$RAW" | caddy hash-password --algorithm bcrypt
 
-If no APP_BASIC_AUTH_* values are provided, the rendered file keeps
-app.averray.com public.
+Rejected env (the script fails if this is set):
+  APP_BASIC_AUTH_PASSWORD       Raw password. Removed in Phase 2 PR 2.2 —
+                                raw passwords no longer flow through CI.
+                                The raw lives only in op://prod-critical/app-basic-auth
+                                (human-only) for operator browser-login.
+
+Optional env:
+  TEMPLATE_PATH                 Override the source template.
+
+If neither APP_BASIC_AUTH_USER nor APP_BASIC_AUTH_PASSWORD_HASH is set,
+the rendered file keeps app.averray.com public.
 EOF
 }
 
@@ -34,21 +62,6 @@ require_command() {
   fi
 }
 
-render_hash() {
-  local plaintext="$1"
-  if command -v caddy >/dev/null 2>&1; then
-    caddy hash-password --plaintext "$plaintext"
-    return
-  fi
-
-  if command -v docker >/dev/null 2>&1; then
-    docker run --rm caddy:2 caddy hash-password --plaintext "$plaintext"
-    return
-  fi
-
-  fail "Need either 'caddy' or 'docker' installed to hash a basic-auth password"
-}
-
 [[ $# -eq 1 ]] || {
   usage >&2
   exit 1
@@ -56,26 +69,29 @@ render_hash() {
 
 OUTPUT_PATH="$1"
 APP_BASIC_AUTH_USER="${APP_BASIC_AUTH_USER:-}"
-APP_BASIC_AUTH_PASSWORD="${APP_BASIC_AUTH_PASSWORD:-}"
 APP_BASIC_AUTH_PASSWORD_HASH="${APP_BASIC_AUTH_PASSWORD_HASH:-}"
+
+# Hard reject — raw passwords MUST NOT enter this script.
+if [[ -n "${APP_BASIC_AUTH_PASSWORD:-}" ]]; then
+  fail "APP_BASIC_AUTH_PASSWORD (raw) is set, but Phase 2 PR 2.2 removed that code path. The raw password should live only in op://prod-critical/app-basic-auth. Pass APP_BASIC_AUTH_PASSWORD_HASH (bcrypt) instead — see usage."
+fi
 
 [[ -f "$TEMPLATE_PATH" ]] || fail "Template not found: $TEMPLATE_PATH"
 require_command awk
 
-if [[ -n "$APP_BASIC_AUTH_PASSWORD" && -n "$APP_BASIC_AUTH_PASSWORD_HASH" ]]; then
-  fail "Set either APP_BASIC_AUTH_PASSWORD or APP_BASIC_AUTH_PASSWORD_HASH, not both"
+# Basic-auth enabled requires BOTH user and hash. Half-set is an error.
+if [[ -n "$APP_BASIC_AUTH_USER" || -n "$APP_BASIC_AUTH_PASSWORD_HASH" ]]; then
+  [[ -n "$APP_BASIC_AUTH_USER" ]] || fail "APP_BASIC_AUTH_USER is required when APP_BASIC_AUTH_PASSWORD_HASH is set"
+  [[ -n "$APP_BASIC_AUTH_PASSWORD_HASH" ]] || fail "APP_BASIC_AUTH_PASSWORD_HASH is required when APP_BASIC_AUTH_USER is set"
+
+  # Sanity check: bcrypt hashes start with $2a$, $2b$, or $2y$.
+  if ! [[ "$APP_BASIC_AUTH_PASSWORD_HASH" =~ ^\$2[aby]\$ ]]; then
+    fail "APP_BASIC_AUTH_PASSWORD_HASH does not look like a bcrypt hash (expected leading \$2a\$, \$2b\$, or \$2y\$)"
+  fi
 fi
 
 auth_block_file=""
-if [[ -n "$APP_BASIC_AUTH_USER" || -n "$APP_BASIC_AUTH_PASSWORD" || -n "$APP_BASIC_AUTH_PASSWORD_HASH" ]]; then
-  [[ -n "$APP_BASIC_AUTH_USER" ]] || fail "APP_BASIC_AUTH_USER is required when enabling basic auth"
-
-  if [[ -n "$APP_BASIC_AUTH_PASSWORD" ]]; then
-    APP_BASIC_AUTH_PASSWORD_HASH="$(render_hash "$APP_BASIC_AUTH_PASSWORD")"
-  fi
-
-  [[ -n "$APP_BASIC_AUTH_PASSWORD_HASH" ]] || fail "APP_BASIC_AUTH_PASSWORD or APP_BASIC_AUTH_PASSWORD_HASH is required when enabling basic auth"
-
+if [[ -n "$APP_BASIC_AUTH_USER" && -n "$APP_BASIC_AUTH_PASSWORD_HASH" ]]; then
   auth_block_file=$(mktemp)
   cat >"$auth_block_file" <<EOF
   @protectedOperatorShell {


### PR DESCRIPTION
## Summary

Raw basic-auth password no longer flows through CI. The deploy workflow loads only the bcrypt hash; the raw lives in `op://prod-critical/app-basic-auth` for human browser-login. `render-caddyfile.sh` fails-closed on any path that would have leaked the raw, and `apply_caddy()` validates the rendered Caddyfile before reload.

## Operator setup BEFORE merge

Run this on your laptop with `op signin` active:

```bash
brew install caddy  # if not already installed

eval $(op signin)
set +o history

RAW=$(op read 'op://prod-critical/app-basic-auth/password')
USER=$(op read 'op://prod-critical/app-basic-auth/username')
HASH=$(printf '%s' "$RAW" | caddy hash-password --algorithm bcrypt)

case "$HASH" in
  \$2a\$*|\$2b\$*|\$2y\$*) echo "✓ hash shape ok" ;;
  *) echo "✗ abort"; unset RAW USER HASH; return 1 ;;
esac

op item create --vault=prod-ci --category=password --title=app-basic-auth-hash \
  "username=$USER" "credential[concealed]=$HASH" \
  "notes=Bcrypt hash. Raw lives in prod-critical/app-basic-auth."

unset RAW USER HASH
set -o history
```

Then **verify the new hash actually authenticates** against live Caddy:

```bash
RAW=$(op read 'op://prod-critical/app-basic-auth/password')
USER=$(op read 'op://prod-critical/app-basic-auth/username')
curl -sS -o /dev/null -w '%{http_code}\n' -u "$USER:$RAW" https://app.averray.com/
unset RAW USER
```

Expect `200` or `3xx`. If `401`, the password in `prod-critical/app-basic-auth` doesn't match what Caddy currently expects — **don't merge** until that drift is resolved.

## What's in the workflow change

- Drops `APP_BASIC_AUTH_PASSWORD` (raw) from job env block AND SSH heredoc.
- Extends the PR 2.1 `load-secrets-action` step to also pull `APP_BASIC_AUTH_USER_OP` and `APP_BASIC_AUTH_PASSWORD_HASH_OP` from `op://prod-ci/app-basic-auth-hash/`. Same step-scoped OP token.
- New parity step: can't byte-compare hashes (bcrypt salt makes each hash unique), but verifies non-empty, bcrypt shape on both OP and legacy, and byte-match on the username. Mismatches → `::warning::` annotations.

## What's in render-caddyfile.sh / deploy-production.sh

- `render-caddyfile.sh` drops the `render_hash()` helper that called `caddy hash-password --plaintext` (raw-in-`ps`). Now requires the hash and rejects deploys outright if `APP_BASIC_AUTH_PASSWORD` is set. Bcrypt shape check on the hash.
- `apply_caddy()` writes the rendered Caddyfile to a `mktemp` alongside the live one, runs `caddy validate` inside the running caddy container with the tmp mounted read-only, and only `mv`s into place if validate exits 0.

## Honest scope note

The original plan said "render Caddyfile on the VPS via `op inject`, hash never traverses an SSH heredoc." That requires `op` CLI on the VPS, which is PR 2.3's bootstrap. PR 2.2 lands the things that don't depend on it. **The hash still transits the SSH heredoc** in this PR; PR 2.4 will eliminate that once 2.3 provisions `op` on the VPS.

## Lessons-learned section added to SECRETS_MIGRATION.md

Three pitfalls we hit during PR 2.1 acceptance, documented to prevent recurrence:
1. `scp` / `ssh` password fallback is a silent signal the key isn't authorized — always `BatchMode=yes` first.
2. `op read | gh secret set` silently writes empty on op auth failure — always capture + length-check before piping.
3. GH Actions secrets are write-only; treat the canonical store as 1Password.

## Acceptance gate

- [ ] Operator setup completed (`op://prod-ci/app-basic-auth-hash` exists)
- [ ] Manual auth-check curl returns 200/3xx (no drift)
- [ ] After merge, `gh workflow run deploy-production.yml -R averray-agent/agent` succeeds
- [ ] Parity step logs `APP_BASIC_AUTH_USER_OP matches legacy secret: yes`
- [ ] `caddy validate` passes before reload
- [ ] Unauthenticated `curl -I https://app.averray.com/` returns 401

## Deferred

- **Auth-200 smoke** — needs a smoke-side OP token that can read raw from `prod-critical`. Lands in PR 2.5.
- **Heredoc removal for the hash** — lands in PR 2.4 once `op inject` runs on the VPS (PR 2.3 provisions).
- **Legacy `APP_BASIC_AUTH_PASSWORD` GH secret deletion** — 24h after this PR ships green deploys, in PR 2.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)