### PR TITLE
PR 2.2 hotfix: Validate-required-secrets references the HASH not the raw

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -166,7 +166,9 @@ jobs:
           test -n "$VPS_USER"
           test -n "$VPS_SSH_KEY"
           if [ -n "$APP_BASIC_AUTH_USER" ]; then
-            test -n "$APP_BASIC_AUTH_PASSWORD"
+            # Phase 2 PR 2.2: raw APP_BASIC_AUTH_PASSWORD no longer flows
+            # through CI. Caddy auth is verified via the bcrypt HASH only.
+            test -n "$APP_BASIC_AUTH_PASSWORD_HASH"
           fi
 
       # ─── Phase 2 PR 2.1: parity check between OP-loaded and legacy SSH key ──


### PR DESCRIPTION
## Summary
Hotfix to PR #233. The workflow's first step asserts \`APP_BASIC_AUTH_PASSWORD\` when \`APP_BASIC_AUTH_USER\` is set — but PR #233 removed the raw from the env block, so the assertion fails every deploy. Caught immediately by the acceptance deploy on PR #233.

## Fix
Flip the assertion to require \`APP_BASIC_AUTH_PASSWORD_HASH\` instead. The raw no longer flows through CI by design.

## Verification
After merge, re-run \`gh workflow run deploy-production.yml -R averray-agent/agent\`. The "Validate required secrets" step should pass and the deploy should proceed through the parity check + caddy validate + reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)