### PR TITLE
PR 2.2 follow-up: check-hosted-stack accepts 401 when raw absent from CI

### DIFF
--- a/scripts/ops/check-hosted-stack.sh
+++ b/scripts/ops/check-hosted-stack.sh
@@ -115,7 +115,13 @@ check_operator_app_shell() {
     return 0
   fi
 
-  if ! enabled "$APP_ALLOW_PROTECTED_SHELL"; then
+  # Fall through to the protected-status check when EITHER:
+  #   (a) APP_ALLOW_PROTECTED_SHELL is explicitly enabled, OR
+  #   (b) APP_BASIC_AUTH_PASSWORD is not present in this environment
+  #       (Phase 2 PR 2.2 removed the raw from CI; without a password
+  #       we cannot expect a successful auth-200 response, only a 401
+  #       proving Caddy is up and serving the protected app).
+  if ! enabled "$APP_ALLOW_PROTECTED_SHELL" && [[ -n "${APP_BASIC_AUTH_PASSWORD:-}" ]]; then
     echo "Operator app did not return the expected shell" >&2
     exit 1
   fi
@@ -127,7 +133,11 @@ check_operator_app_shell() {
   local status
   status="$(curl "${curl_args[@]}" "$APP_URL")"
   if status_allowed "$status"; then
-    echo "Operator app returned protected status $status as expected."
+    if [[ -z "${APP_BASIC_AUTH_PASSWORD:-}" ]]; then
+      echo "Operator app returned protected status $status as expected (no auth in CI; auth-200 verification deferred to Phase 2 PR 2.5)."
+    else
+      echo "Operator app returned protected status $status as expected."
+    fi
     return 0
   fi
 


### PR DESCRIPTION
## Summary
Third deploy-acceptance bug uncovered by removing the raw basic-auth password from CI in PR 2.2. \`check-hosted-stack.sh\`'s \`check_operator_app_shell()\` bails with "Operator app did not return the expected shell" because:
- Auth-needed unauth curl returns 401
- The accept-401 branch is gated on \`APP_ALLOW_PROTECTED_SHELL=1\`
- That env var loads from \`\${{ secrets.APP_ALLOW_PROTECTED_SHELL }}\`, which doesn't exist as a GH Actions secret

## Fix
Same pattern as the redeploy-frontend.sh fix in #235. The accept-401 branch fires when EITHER \`APP_ALLOW_PROTECTED_SHELL\` is explicitly enabled OR \`APP_BASIC_AUTH_PASSWORD\` is absent from the env. Without a password we can't get a 200; a 401 from Caddy is the strongest evidence we can produce that the protected app is up. The end-to-end auth-200 check is properly deferred to PR 2.5.

## Test plan
- [ ] After merge, manual deploy succeeds
- [ ] Smoke step's "Checking *** app shell" logs the new "(no auth in CI; auth-200 verification deferred to Phase 2 PR 2.5)" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)