### PR TITLE
Phase 2 PR 2.3: VPS bootstrap + atomic render-vps-env.sh (foundation, no cutover)

### DIFF
--- a/deploy/agent-stack.tmpfiles.conf
+++ b/deploy/agent-stack.tmpfiles.conf
@@ -1,0 +1,27 @@
+# systemd-tmpfiles config for agent-stack runtime env files.
+#
+# Install location on VPS: /etc/tmpfiles.d/agent-stack.conf
+# Apply with:              sudo systemd-tmpfiles --create
+#
+# Phase 2 PR 2.3 of the secrets migration.
+#
+# Why systemd-tmpfiles instead of a one-shot `mkdir`:
+#   - Creates /run/agent-stack/ atomically with strict mode at boot.
+#   - /run is tmpfs on every Debian/Ubuntu system, so contents are
+#     wiped on reboot — exactly what we want for rendered env files
+#     containing secrets.
+#   - tmpfiles.d entries are declarative; idempotent; auditable.
+#
+# Why 0700 root:root:
+#   - The Docker daemon runs as root and starts the agent-stack
+#     containers as root. Containers read /run/agent-stack/*.env via
+#     compose's env_file directive at startup.
+#   - Mode 0700 means no other user on the VPS (including the
+#     `ubuntu` deploy user) can read the rendered env files.
+#   - render-vps-env.sh writes individual files at 0400 root:root
+#     inside this directory.
+#
+# Format: type path mode user group age argument
+# Reference: man tmpfiles.d
+
+d /run/agent-stack 0700 root root - -

--- a/docs/SECRETS_MIGRATION.md
+++ b/docs/SECRETS_MIGRATION.md
@@ -504,106 +504,220 @@ future PRs don't repeat them:
 The `ssh -o BatchMode=yes ...` pre-flight should be added to PR 2.4's
 runbook before any "swap legacy GH secret to OP-loaded value" step.
 
-### PR 2.3 — VPS: atomic, fail-closed render flow (the cutover)
+### PR 2.3 — VPS bootstrap + atomic render script (foundation, no cutover)
 
-**Touches**: new `scripts/ops/render-vps-env.sh`,
-`/etc/tmpfiles.d/agent-stack.conf` (delivered via repo + an apt-managed
-install step), `scripts/ops/deploy-production.sh`, `docker-compose.yml`
-on the VPS.
+**Honest scope adjustment from the original plan**: the original PR 2.3
+section bundled "install op + tokens + tmpfiles + render script +
+templates + compose env_file swap" into a single PR. After PR 2.1 and
+PR 2.2 each surfaced 1-3 unexpected acceptance bugs ("we removed X
+from CI; some other path silently relied on X"), we're splitting the
+work:
 
-VPS bootstrap (one-time, documented in §2c of this file):
+- **PR 2.3 (this PR)** — lands the bootstrap toolchain + render
+  script + helper to fill templates, **WITHOUT changing the deploy
+  workflow or docker-compose**. Operator runs the bootstrap on the
+  VPS and verifies render parity manually. Zero production risk.
+- **PR 2.4 (next)** — wires `render-vps-env.sh` into
+  `deploy-production.sh`, flips the compose `env_file:` paths to
+  `/run/agent-stack/*.env`, and removes the heredoc transport for
+  the secrets `op://prod-ci/*` now covers. This is the actual
+  cutover.
 
-- Install `op` CLI via 1Password's apt repo with a SHA-pinned signing
-  key.
-- Drop **two separate token files**, each containing ONLY
-  `OP_SERVICE_ACCOUNT_TOKEN=ops_...`:
-  - `/etc/agent-stack/op-backend.env` (token: `op-token-prod-vps-backend`,
-    reads `prod-backend` + `prod-backend-external`)
-  - `/etc/agent-stack/op-indexer.env` (token: `op-token-prod-vps-indexer`,
-    reads `prod-indexer`)
-  - Mode `0400`, owner `root`. **No** `OP_CONNECT_HOST` or
-    `OP_CONNECT_TOKEN` — 1Password's docs note those env vars take
-    precedence over `OP_SERVICE_ACCOUNT_TOKEN` and would create confusing
-    behaviour if present.
-- `/etc/tmpfiles.d/agent-stack.conf`:
-  `d /run/agent-stack 0700 root root -` (or `RuntimeDirectory=agent-stack`
-  on the systemd unit). Apply with `systemd-tmpfiles --create`. This
-  gives a predictable, strict, automatically-cleaned-at-boot directory
-  — more robust than ad-hoc tmpfs mounts.
+**Touches** (this PR):
 
-Render script (`scripts/ops/render-vps-env.sh`):
+- new `scripts/ops/render-vps-env.sh` — atomic, fail-closed renderer
+  (see §2c below for the design)
+- new `scripts/ops/install-op-vps.sh` — idempotent 1Password CLI
+  installer for Debian/Ubuntu via the official apt repo + debsig policy
+- new `scripts/ops/fill-env-template.mjs` — operator helper that
+  takes a SCP'd snapshot of `/srv/agent-stack/*.env` and uses it to
+  populate the `# TODO(operator)` lines in
+  `deploy/backend.env.template` / `deploy/indexer.env.template`,
+  refusing to write any value that looks like a secret (hex private
+  key, JWT, API-key prefix, long base64-ish)
+- new `deploy/agent-stack.tmpfiles.conf` — `systemd-tmpfiles.d`
+  snippet that declares `/run/agent-stack` as `drwx------ root root`
+- updates to this doc reflecting the split
 
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-set +x
-umask 077
+**No changes to** `deploy-production.yml`, `deploy-production.sh`,
+docker-compose, or any GH Actions secret. Production runtime is
+unchanged after this PR merges.
 
-runtime_dir="/run/agent-stack"
-template="$1"   # /srv/agent-stack/app/deploy/backend.env.template
-target="$2"     # /run/agent-stack/backend.env
-token_file="$3" # /etc/agent-stack/op-backend.env
+**Operator runbook** (steps in order, on your laptop unless noted):
 
-# Load OP token from root-only file. `set -a` exports without echoing.
-set -a
-. "$token_file"
-set +a
+1. **Install `op` CLI on the VPS** (one-time):
+   ```bash
+   scp scripts/ops/install-op-vps.sh ubuntu@141.94.121.188:/tmp/
+   ssh ubuntu@141.94.121.188 "sudo bash /tmp/install-op-vps.sh && rm /tmp/install-op-vps.sh"
+   ```
+   Expected: `op --version` prints, no errors.
 
-tmp="$(mktemp "$runtime_dir/$(basename "$target").XXXXXX")"
-trap 'rm -f "$tmp"' EXIT
+2. **Drop per-runtime service-account tokens** at
+   `/etc/agent-stack/op-{backend,indexer}.env`:
+   ```bash
+   eval $(op signin)
+   BACKEND_TOKEN=$(op read 'op://prod-critical/op-token-prod-vps-backend/credential')
+   INDEXER_TOKEN=$(op read 'op://prod-critical/op-token-prod-vps-indexer/credential')
 
-op inject --in-file "$template" --out-file "$tmp" --cache=false
+   ssh ubuntu@141.94.121.188 "sudo install -d -m 0755 /etc/agent-stack"
+   ssh ubuntu@141.94.121.188 "sudo tee /etc/agent-stack/op-backend.env >/dev/null" <<< "OP_SERVICE_ACCOUNT_TOKEN=$BACKEND_TOKEN"
+   ssh ubuntu@141.94.121.188 "sudo tee /etc/agent-stack/op-indexer.env >/dev/null" <<< "OP_SERVICE_ACCOUNT_TOKEN=$INDEXER_TOKEN"
+   ssh ubuntu@141.94.121.188 "sudo chmod 0400 /etc/agent-stack/op-*.env && sudo chown root:root /etc/agent-stack/op-*.env"
+   unset BACKEND_TOKEN INDEXER_TOKEN
+   ```
 
-# Fail-closed: any unresolved op:// reference aborts the deploy.
-if grep -q 'op://' "$tmp"; then
-  echo "render-vps-env.sh: unresolved 1Password references remain" >&2
-  exit 1
-fi
+3. **Install the systemd-tmpfiles snippet**:
+   ```bash
+   ssh ubuntu@141.94.121.188 "sudo cp /srv/agent-stack/app/deploy/agent-stack.tmpfiles.conf /etc/tmpfiles.d/agent-stack.conf && sudo systemd-tmpfiles --create"
+   ssh ubuntu@141.94.121.188 "ls -ld /run/agent-stack"   # expect: drwx------ root root
+   ```
+   (`/srv/agent-stack/app` is the repo checkout on the VPS; adjust if
+   different.)
 
-chmod 0400 "$tmp"
-chown root:root "$tmp"   # adjust if compose runs as non-root agent-stack user
-mv "$tmp" "$target"
-trap - EXIT
-```
+4. **Verify both tokens can read their scoped vaults** (and ONLY those):
+   ```bash
+   ssh ubuntu@141.94.121.188 "sudo -E env OP_SERVICE_ACCOUNT_TOKEN=\$(sudo grep -h '^OP_SERVICE_ACCOUNT_TOKEN=' /etc/agent-stack/op-backend.env | cut -d= -f2) op vault list"
+   # expect: prod-backend, prod-backend-external (NOT prod-critical, NOT prod-indexer)
 
-Docker Compose changes:
+   ssh ubuntu@141.94.121.188 "sudo -E env OP_SERVICE_ACCOUNT_TOKEN=\$(sudo grep -h '^OP_SERVICE_ACCOUNT_TOKEN=' /etc/agent-stack/op-indexer.env | cut -d= -f2) op vault list"
+   # expect: prod-indexer ONLY
+   ```
 
-- Switch `env_file:` from `/srv/agent-stack/*.env` to `/run/agent-stack/*.env`.
-- **Audit `docker-compose.yml` for any `environment:` keys that duplicate
-  `env_file:` variables.** Compose's `environment:` block wins over
-  `env_file:`, and a duplicate there would silently defeat the migration
-  on that variable. The acceptance criterion below catches this.
+5. **Fill the `TODO(operator)` lines in the env templates** (on your
+   laptop, in this PR's worktree):
+   ```bash
+   # Pull a copy of each live env file to a local tmpdir
+   mkdir -p ~/secrets-tmp && chmod 0700 ~/secrets-tmp
+   scp ubuntu@141.94.121.188:/srv/agent-stack/backend.env ~/secrets-tmp/backend.env
+   scp ubuntu@141.94.121.188:/srv/agent-stack/indexer.env ~/secrets-tmp/indexer.env
 
-Failure semantics (documented explicitly to prevent a class of bugs where
-"we think production is using 1Password but it quietly fell back"):
+   # Use the helper to fill TODO(operator) lines without touching
+   # secret-shaped values:
+   node scripts/ops/fill-env-template.mjs \
+     --snapshot ~/secrets-tmp/backend.env \
+     --template deploy/backend.env.template \
+     --out      deploy/backend.env.template.filled
 
-> The fallback to `/srv/agent-stack/*.env` is **manual only**. If render
-> fails, deployment fails; it does **not** silently start with stale env.
-> The old env files remain on disk for 24h as a rollback option, but
-> switching back requires an operator to edit `docker-compose.yml`'s
-> `env_file:` directive — making the regression visible.
+   diff deploy/backend.env.template deploy/backend.env.template.filled
+   # If the diff looks right (config values filled, secrets untouched):
+   mv deploy/backend.env.template.filled deploy/backend.env.template
 
-**Acceptance criteria**:
+   # Repeat for indexer:
+   node scripts/ops/fill-env-template.mjs \
+     --snapshot ~/secrets-tmp/indexer.env \
+     --template deploy/indexer.env.template \
+     --out      deploy/indexer.env.template.filled
+   diff deploy/indexer.env.template deploy/indexer.env.template.filled
+   mv deploy/indexer.env.template.filled deploy/indexer.env.template
 
-- [ ] `/run/agent-stack/*.env` exists with mode `0400`, owner appropriate
-      to the compose run-as user
-- [ ] `systemd-tmpfiles --create` creates `/run/agent-stack` with mode
-      `0700` at boot (verified with `ls -ld /run/agent-stack` after a
-      reboot)
-- [ ] `docker compose config` (audited manually, **not piped to CI
-      logs** to avoid interpolating secrets) shows no `environment:` keys
-      that shadow `env_file:` variables
-- [ ] Render script fails closed when any required variable is unresolved
-      (test by removing one entry from `prod-backend` temporarily,
-      redeploy, confirm exit 1)
-- [ ] Backend and indexer containers restart and read from
-      `/run/agent-stack/*.env`
-- [ ] No rendered secret values appear in `journalctl -u agent-stack` or
-      CI deploy logs (grep first 8 chars of one known secret → zero hits)
-- [ ] No production secret transits an SSH heredoc body anywhere in
-      `deploy-production.sh` or the workflow
-- [ ] Token files at `/etc/agent-stack/op-*.env` contain only
-      `OP_SERVICE_ACCOUNT_TOKEN=...`, mode `0400` root, no `OP_CONNECT_*`
+   # Validate STRICT (no TODO markers, all op:// refs resolve):
+   bash scripts/ops/validate-env-render.sh backend
+   bash scripts/ops/validate-env-render.sh indexer
+   STRICT=1 bash scripts/ops/validate-env-render.sh backend
+   STRICT=1 bash scripts/ops/validate-env-render.sh indexer
+
+   # Shred the local snapshot copies:
+   for f in ~/secrets-tmp/*.env; do dd if=/dev/urandom of="$f" bs=4096 count=1 conv=notrunc 2>/dev/null || true; rm -f "$f"; done
+   rmdir ~/secrets-tmp
+
+   # Commit the filled templates as part of this PR.
+   ```
+
+6. **Run `render-vps-env.sh` manually on the VPS** and verify parity
+   against the existing `/srv/agent-stack/*.env`:
+   ```bash
+   ssh ubuntu@141.94.121.188 "
+     cd /srv/agent-stack/app
+     sudo bash scripts/ops/render-vps-env.sh \
+       deploy/backend.env.template \
+       /run/agent-stack/backend.env \
+       /etc/agent-stack/op-backend.env
+
+     sudo bash scripts/ops/render-vps-env.sh \
+       deploy/indexer.env.template \
+       /run/agent-stack/indexer.env \
+       /etc/agent-stack/op-indexer.env
+
+     # Parity diff — should be empty (or only sort-order differences):
+     echo '── backend diff ──'
+     sudo diff <(sort /run/agent-stack/backend.env) <(sort /srv/agent-stack/backend.env) | head -30
+     echo '── indexer diff ──'
+     sudo diff <(sort /run/agent-stack/indexer.env) <(sort /srv/agent-stack/indexer.env) | head -30
+   "
+   ```
+   Any non-empty diff means the template doesn't match what's live —
+   investigate before PR 2.4 flips the cutover.
+
+#### §2c — Render script design
+
+`scripts/ops/render-vps-env.sh` is **atomic** and **fail-closed**:
+
+1. Refuses to write outside `/run/agent-stack` (defense against
+   misuse).
+2. Verifies the token file is mode `0400`; rejects wider perms.
+3. Verifies `op` CLI is installed.
+4. Renders to a `mktemp` file in the same directory as the target
+   (so the final `mv` is atomic via `rename(2)` on the same fs).
+5. `op inject --cache=false` — always hit 1Password, never a stale
+   local cache.
+6. Greps the rendered file for any unresolved `op://` substring;
+   any hit aborts the deploy without touching the live target.
+7. Asserts ≥1 `KEY=value` line in the rendered file (sanity check
+   against empty templates).
+8. `chmod 0400 + chown root:root`, then `mv` into place.
+9. Unsets `OP_SERVICE_ACCOUNT_TOKEN` immediately after `op inject`
+   to minimize lifetime in the script's process env.
+10. Refuses to run if `OP_CONNECT_HOST` or `OP_CONNECT_TOKEN` is
+    set — those override `OP_SERVICE_ACCOUNT_TOKEN` per 1Password's
+    docs and would create confusing behaviour.
+
+**Failure semantics**:
+
+> The fallback to `/srv/agent-stack/*.env` is **manual only**. If
+> render fails, the script exits non-zero and the previous runtime
+> env file (if any) is untouched. PR 2.4 will make `deploy-production.sh`
+> abort the deploy when render fails — there is NO silent fallback
+> to stale env.
+
+**Acceptance criteria for PR 2.3**:
+
+- [ ] `scripts/ops/install-op-vps.sh` runs cleanly on the VPS and
+      `op --version` succeeds afterwards
+- [ ] `/etc/agent-stack/op-{backend,indexer}.env` exist with mode
+      `0400`, owner `root`, content `OP_SERVICE_ACCOUNT_TOKEN=ops_…`
+      and nothing else (verified with
+      `sudo stat -c '%a %U:%G' /etc/agent-stack/op-*.env` and
+      `sudo wc -l /etc/agent-stack/op-*.env`)
+- [ ] `/run/agent-stack` exists with mode `0700`, owner root, after
+      `systemd-tmpfiles --create`
+- [ ] Backend token reads ONLY `prod-backend` + `prod-backend-external`
+      (verified with `op vault list`)
+- [ ] Indexer token reads ONLY `prod-indexer`
+- [ ] Neither token can read `prod-critical` (firebreak verified —
+      try `op vault get prod-critical --token <…>`; expect permission
+      denied)
+- [ ] `STRICT=1 bash scripts/ops/validate-env-render.sh backend`
+      passes (templates have no `TODO(operator)` markers remaining)
+- [ ] `STRICT=1 bash scripts/ops/validate-env-render.sh indexer`
+      passes
+- [ ] Manual `render-vps-env.sh` invocation on the VPS produces
+      `/run/agent-stack/*.env` that matches `/srv/agent-stack/*.env`
+      via sorted diff (zero differences)
+- [ ] No production runtime change — backend and indexer still read
+      from `/srv/agent-stack/*.env` (compose unchanged)
+
+**Deferred to PR 2.4** (the actual cutover):
+
+- Wire `render-vps-env.sh` into `deploy-production.sh` so each
+  deploy renders fresh `/run/agent-stack/*.env` files
+- Audit `docker-compose.yml` for `environment:` keys that shadow
+  `env_file:` variables
+- Flip compose `env_file:` from `/srv/agent-stack/*.env` to
+  `/run/agent-stack/*.env`
+- Remove the SSH heredoc transport for the secrets that
+  `render-vps-env.sh` now provides via `op inject`
+- Delete the legacy `/srv/agent-stack/*.env` files after 24h of
+  green deploys
 
 ### PR 2.4 — Cleanup AND rotation
 

--- a/scripts/ops/fill-env-template.mjs
+++ b/scripts/ops/fill-env-template.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+//
+// fill-env-template.mjs — operator helper for PR 2.3.
+//
+// Reads a SCP'd snapshot of the VPS's hand-managed env file and uses
+// it to fill the `# TODO(operator)` placeholder lines in the matching
+// `deploy/*.env.template`. Produces a filled template the operator
+// reviews + commits.
+//
+// SECRET LINES (op:// references) are NEVER touched — they're already
+// correct in the template. Only commented `# TODO(operator)` lines
+// are uncommented and populated with the literal value from the env
+// snapshot.
+//
+// Lines in the env snapshot that AREN'T in the template are reported
+// as orphans for operator review.
+// Lines in the template that have no match in the env snapshot stay
+// as `# TODO(operator)` so the operator can decide (leave commented,
+// fill manually, or remove).
+//
+// Usage:
+//   node scripts/ops/fill-env-template.mjs \
+//     --snapshot /tmp/backend.env \
+//     --template deploy/backend.env.template \
+//     --out      deploy/backend.env.template.filled
+//
+// Then review the diff before overwriting the template:
+//   diff deploy/backend.env.template deploy/backend.env.template.filled
+//   mv  deploy/backend.env.template.filled deploy/backend.env.template
+//
+// Security:
+//   - Reads the snapshot from a local file path. The snapshot may
+//     contain secret values (it's a copy of the live env file).
+//   - The OUTPUT (filled template) will also contain those values
+//     for the keys the template explicitly lists. To avoid leaking
+//     real secrets into the template (and into git), this script
+//     REFUSES to write any value to a line that has an op:// ref —
+//     those stay as op:// references. If a TODO(operator) line in
+//     the template matches a key whose snapshot value LOOKS like a
+//     secret (long hex, JWT shape, API-key prefix), the script
+//     flags it as a likely-secret and leaves the line commented
+//     with a `# TODO(secret? value omitted)` marker.
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+
+const args = process.argv.slice(2);
+
+function getArg(flag) {
+  const i = args.indexOf(flag);
+  if (i === -1 || i === args.length - 1) return null;
+  return args[i + 1];
+}
+
+const snapshotPath = getArg('--snapshot');
+const templatePath = getArg('--template');
+const outPath = getArg('--out');
+
+if (!snapshotPath || !templatePath || !outPath) {
+  console.error(`Usage: node fill-env-template.mjs --snapshot <env-file> --template <template> --out <filled-template>
+
+Reads --snapshot (a SCP'd copy of the VPS env file), substitutes its
+KEY=value pairs into the corresponding # TODO(operator) lines in
+--template, and writes the result to --out.
+
+Then review with:
+  diff --template --out
+  # if happy:
+  mv --out --template
+`);
+  process.exit(2);
+}
+
+if (!existsSync(snapshotPath)) {
+  console.error(`fill-env-template: snapshot not found: ${snapshotPath}`);
+  process.exit(1);
+}
+if (!existsSync(templatePath)) {
+  console.error(`fill-env-template: template not found: ${templatePath}`);
+  process.exit(1);
+}
+
+// ── Parse snapshot ─────────────────────────────────────────────────────────
+
+const snapshot = readFileSync(snapshotPath, 'utf8');
+const snapshotMap = new Map();
+
+for (const raw of snapshot.split('\n')) {
+  const line = raw.trimEnd();
+  if (!line || line.startsWith('#')) continue;
+  const m = line.match(/^([A-Z][A-Z0-9_]*)\s*=\s*(.*)$/);
+  if (!m) continue;
+  let [, key, value] = m;
+  // Strip surrounding quotes (sh-style env files).
+  if ((value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))) {
+    value = value.slice(1, -1);
+  }
+  snapshotMap.set(key, value);
+}
+
+// ── Likely-secret heuristics ───────────────────────────────────────────────
+
+const SECRET_PATTERNS = [
+  /^0x[a-fA-F0-9]{60,}$/,                    // hex private key
+  /^ey[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/, // JWT
+  /^(sk_live_|sk_test_|re_|pk_live_|ghp_|github_pat_|ops_)[A-Za-z0-9_-]{8,}/, // API-key prefixes
+  /^[A-Za-z0-9+/=]{80,}$/,                   // long base64-ish
+];
+
+function looksLikeSecret(value) {
+  if (!value) return false;
+  for (const re of SECRET_PATTERNS) if (re.test(value)) return true;
+  return false;
+}
+
+// ── Process template ───────────────────────────────────────────────────────
+
+const template = readFileSync(templatePath, 'utf8');
+const outLines = [];
+
+// Stats
+let filledCount = 0;
+let skippedSecretCount = 0;
+let leftTodoCount = 0;
+let opRefLines = 0;
+const templateKeys = new Set();
+const filledKeys = [];
+const orphanKeys = [];
+
+for (const raw of template.split('\n')) {
+  // Active KEY=op://... — never touch.
+  let m = raw.match(/^([A-Z][A-Z0-9_]*)\s*=\s*op:\/\//);
+  if (m) {
+    outLines.push(raw);
+    templateKeys.add(m[1]);
+    opRefLines += 1;
+    continue;
+  }
+
+  // Active KEY=value (already filled) — keep as is, mark as known.
+  m = raw.match(/^([A-Z][A-Z0-9_]*)\s*=/);
+  if (m) {
+    outLines.push(raw);
+    templateKeys.add(m[1]);
+    continue;
+  }
+
+  // Commented TODO(operator) line: # KEY= ... # TODO(operator) ...
+  m = raw.match(/^#\s*([A-Z][A-Z0-9_]*)\s*=.*TODO\(operator\)/);
+  if (m) {
+    const key = m[1];
+    templateKeys.add(key);
+    if (snapshotMap.has(key)) {
+      const value = snapshotMap.get(key);
+      if (looksLikeSecret(value)) {
+        // Don't write a likely-secret literal to the template.
+        outLines.push(`# ${key}=  # TODO(secret? value in snapshot looks sensitive — confirm and store in 1Password instead)`);
+        skippedSecretCount += 1;
+      } else {
+        // Substitute the literal value, uncomment the line.
+        outLines.push(`${key}=${value}`);
+        filledKeys.push(key);
+        filledCount += 1;
+      }
+    } else {
+      // Snapshot doesn't have this key; leave the TODO as-is.
+      outLines.push(raw);
+      leftTodoCount += 1;
+    }
+    continue;
+  }
+
+  // Anything else (blank lines, prose comments) — passthrough.
+  outLines.push(raw);
+}
+
+// Snapshot keys NOT in template → orphans (operator should decide:
+// add to template, or remove from snapshot).
+for (const key of snapshotMap.keys()) {
+  if (!templateKeys.has(key)) {
+    orphanKeys.push(key);
+  }
+}
+
+// ── Write + report ─────────────────────────────────────────────────────────
+
+writeFileSync(outPath, outLines.join('\n'));
+
+console.log(`fill-env-template: wrote ${outPath}`);
+console.log(`    template keys total:          ${templateKeys.size}`);
+console.log(`    op:// reference lines:        ${opRefLines}`);
+console.log(`    filled from snapshot:         ${filledCount}`);
+console.log(`    left as TODO(operator):       ${leftTodoCount}`);
+console.log(`    likely-secret values skipped: ${skippedSecretCount}`);
+
+if (filledKeys.length > 0) {
+  console.log(`\n  Filled keys:`);
+  for (const k of filledKeys.sort()) console.log(`    + ${k}`);
+}
+
+if (orphanKeys.length > 0) {
+  console.log(`\n  Snapshot keys NOT in template (orphans — operator review):`);
+  for (const k of orphanKeys.sort()) console.log(`    ? ${k}`);
+}
+
+console.log(`\nNext: review the diff before overwriting the template:`);
+console.log(`  diff ${templatePath} ${outPath}`);
+console.log(`  # if happy:`);
+console.log(`  mv  ${outPath} ${templatePath}`);
+console.log(`  bash scripts/ops/validate-env-render.sh ${templatePath.match(/(\w+)\.env\.template/)?.[1] ?? 'backend'}`);

--- a/scripts/ops/install-op-vps.sh
+++ b/scripts/ops/install-op-vps.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+#
+# install-op-vps.sh — idempotent 1Password CLI installer for the
+# production VPS (Debian/Ubuntu).
+#
+# Phase 2 PR 2.3 of the secrets migration. Wire-frame for the runtime
+# (`op` CLI) that PR 2.3's render-vps-env.sh depends on. Subsequent
+# steps (drop service-account tokens, install tmpfiles.d snippet,
+# verify `op vault list`) are documented in SECRETS_MIGRATION.md.
+#
+# What this script does:
+#   1. Verifies it's running as root on an apt-based system.
+#   2. Adds 1Password's signing key to /usr/share/keyrings/.
+#   3. Adds the 1Password apt source with `signed-by=` referencing
+#      the keyring file (NOT the trusted.gpg.d global keyring — per
+#      Debian's apt-secure docs, scoped keyrings are the correct
+#      practice).
+#   4. apt-get update + install 1password-cli.
+#   5. Logs the installed version and the key fingerprint for audit.
+#
+# Idempotency: re-running is safe. The keyring + source files are
+# overwritten with the same content; apt is told there are no changes
+# to publish; install is a no-op if the package is already current.
+#
+# Trust chain: the signing key comes from
+# https://downloads.1password.com/linux/keys/1password.asc over TLS.
+# The integrity guarantee is the HTTPS certificate chain on
+# downloads.1password.com — same trust model 1Password's own install
+# docs use. If you want stricter, fetch the key once on a trusted
+# machine, verify its fingerprint out-of-band, and pin its SHA-256
+# in this script.
+#
+# Usage (on VPS, as root):
+#   sudo bash install-op-vps.sh
+
+set -euo pipefail
+set +x
+
+fail() { echo "install-op-vps.sh: $*" >&2; exit 1; }
+info() { echo "install-op-vps.sh: $*"; }
+
+# ── Pre-flight ─────────────────────────────────────────────────────────────
+
+[ "$(id -u)" -eq 0 ] || fail "must run as root (try: sudo bash install-op-vps.sh)"
+
+if ! command -v apt-get >/dev/null 2>&1; then
+  fail "apt-get not found; this script targets Debian/Ubuntu only"
+fi
+
+# Identify the distro for the log only — actual apt source is the
+# same for Debian and Ubuntu per 1Password's published packages.
+. /etc/os-release 2>/dev/null || true
+info "host: ${PRETTY_NAME:-unknown} ($(uname -m))"
+
+# ── Signing key ────────────────────────────────────────────────────────────
+
+KEYRING=/usr/share/keyrings/1password-archive-keyring.gpg
+SOURCE_LIST=/etc/apt/sources.list.d/1password.list
+
+info "downloading 1Password signing key..."
+tmpkey=$(mktemp)
+trap 'rm -f "$tmpkey"' EXIT
+curl -fsSL --proto '=https' --tlsv1.2 \
+  https://downloads.1password.com/linux/keys/1password.asc \
+  -o "$tmpkey"
+
+# Dearmor to binary form and install in scoped keyring location.
+gpg --dearmor < "$tmpkey" > "$KEYRING"
+chmod 0644 "$KEYRING"
+chown root:root "$KEYRING"
+
+# Log the key fingerprint for audit. Operators can compare to the
+# fingerprint published at 1Password's docs.
+info "installed signing key:"
+gpg --no-default-keyring --keyring "$KEYRING" --list-keys 2>&1 | sed 's/^/    /'
+
+# ── apt source ─────────────────────────────────────────────────────────────
+
+info "writing apt source to $SOURCE_LIST..."
+cat > "$SOURCE_LIST" <<'EOF'
+deb [arch=amd64 signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/amd64 stable main
+EOF
+chmod 0644 "$SOURCE_LIST"
+chown root:root "$SOURCE_LIST"
+
+# ── Debsig policy (1Password's recommended extra layer) ────────────────────
+#
+# 1Password also publishes a debsig policy that validates installed
+# packages against the same signing key. This is belt-and-suspenders
+# beyond the apt-secure check. We install it because the cost is zero
+# and the audit trail is cleaner.
+
+mkdir -p /etc/debsig/policies/AC2D62742012EA22
+mkdir -p /usr/share/debsig/keyrings/AC2D62742012EA22
+
+if [ ! -f /etc/debsig/policies/AC2D62742012EA22/1password.pol ]; then
+  curl -fsSL --proto '=https' --tlsv1.2 \
+    https://downloads.1password.com/linux/debian/debsig/1password.pol \
+    -o /etc/debsig/policies/AC2D62742012EA22/1password.pol
+fi
+
+cp -f "$KEYRING" /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg
+
+# ── Install ────────────────────────────────────────────────────────────────
+
+info "running apt-get update..."
+apt-get update -qq
+
+info "installing 1password-cli..."
+DEBIAN_FRONTEND=noninteractive apt-get install -y -qq 1password-cli
+
+# ── Verify ─────────────────────────────────────────────────────────────────
+
+if ! command -v op >/dev/null 2>&1; then
+  fail "op installed but not in PATH; check /usr/bin/op"
+fi
+
+info "installed version: $(op --version)"
+info "binary location:   $(command -v op)"
+
+# Cleanup
+rm -f "$tmpkey"
+trap - EXIT
+
+cat <<'NEXT'
+
+install-op-vps.sh: complete.
+
+Next operator steps (do these manually, see SECRETS_MIGRATION.md Phase 2 PR 2.3):
+
+  1. Create /etc/agent-stack/ directory:
+       sudo install -d -m 0755 /etc/agent-stack
+
+  2. Drop the per-runtime service-account tokens. From your laptop with
+     an active op signin, scp the values to the VPS:
+
+       # On laptop (one terminal):
+       BACKEND_TOKEN=$(op read 'op://prod-critical/op-token-prod-vps-backend/credential')
+       INDEXER_TOKEN=$(op read 'op://prod-critical/op-token-prod-vps-indexer/credential')
+
+       # Then scp via a heredoc that writes the file with strict perms:
+       ssh ubuntu@<VPS> "sudo tee /etc/agent-stack/op-backend.env > /dev/null" <<< "OP_SERVICE_ACCOUNT_TOKEN=$BACKEND_TOKEN"
+       ssh ubuntu@<VPS> "sudo tee /etc/agent-stack/op-indexer.env > /dev/null" <<< "OP_SERVICE_ACCOUNT_TOKEN=$INDEXER_TOKEN"
+       ssh ubuntu@<VPS> "sudo chmod 0400 /etc/agent-stack/op-backend.env /etc/agent-stack/op-indexer.env && sudo chown root:root /etc/agent-stack/op-*.env"
+
+       unset BACKEND_TOKEN INDEXER_TOKEN
+
+  3. Install systemd-tmpfiles snippet for /run/agent-stack:
+       sudo cp /srv/agent-stack/app/deploy/agent-stack.tmpfiles.conf /etc/tmpfiles.d/agent-stack.conf
+       sudo systemd-tmpfiles --create
+       ls -ld /run/agent-stack   # expect: drwx------ root root
+
+  4. Verify both tokens work:
+       sudo -E env OP_SERVICE_ACCOUNT_TOKEN="$(sudo cat /etc/agent-stack/op-backend.env | cut -d= -f2)" op vault list
+       sudo -E env OP_SERVICE_ACCOUNT_TOKEN="$(sudo cat /etc/agent-stack/op-indexer.env | cut -d= -f2)" op vault list
+
+     Backend token should list prod-backend + prod-backend-external.
+     Indexer token should list prod-indexer.
+
+  5. Run render-vps-env.sh manually to verify it produces a healthy
+     /run/agent-stack/backend.env that matches the live env file:
+
+       sudo /srv/agent-stack/app/scripts/ops/render-vps-env.sh \
+         /srv/agent-stack/app/deploy/backend.env.template \
+         /run/agent-stack/backend.env \
+         /etc/agent-stack/op-backend.env
+
+       sudo diff <(sort /run/agent-stack/backend.env) <(sort /srv/agent-stack/backend.env) | head -50
+
+     Expect: zero diff (or only ordering differences) when the
+     template's TODO(operator) lines have been filled in correctly.
+NEXT

--- a/scripts/ops/render-vps-env.sh
+++ b/scripts/ops/render-vps-env.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+#
+# render-vps-env.sh — atomic, fail-closed render of a deploy/*.env.template
+# to a runtime env file on the VPS.
+#
+# Phase 2 PR 2.3 of the secrets migration:
+# https://github.com/averray-agent/agent/blob/main/docs/SECRETS_MIGRATION.md
+#
+# This script runs ON THE VPS during deploy (wired in PR 2.4). It uses
+# the per-runtime 1Password service-account token to resolve every
+# `op://` reference in the template, writes the rendered output to a
+# mktemp file, validates that no unresolved references remain, sets
+# strict file permissions, and atomically moves the file into place.
+#
+# Failure semantics are STRICT and FAIL-CLOSED:
+#   • op inject error → script exits non-zero, target file untouched
+#   • Any unresolved op:// in the rendered output → exit non-zero
+#   • mktemp / mv failure → exit non-zero
+#   • The live runtime env file is NEVER replaced with a partial,
+#     unvalidated, or empty file.
+#
+# The rendered content is NEVER printed to stdout, stderr, or any log.
+# Diagnostic output is counts and byte lengths only.
+#
+# Usage:
+#   render-vps-env.sh <template> <target> <token-file>
+#
+# Example (on VPS):
+#   /srv/agent-stack/app/scripts/ops/render-vps-env.sh \
+#     /srv/agent-stack/app/deploy/backend.env.template \
+#     /run/agent-stack/backend.env \
+#     /etc/agent-stack/op-backend.env
+#
+# Arguments:
+#   template     Path to a deploy/*.env.template file. Must exist and
+#                contain `op://` references resolvable by the token.
+#   target       Final path of the rendered env file. Must be inside
+#                /run/agent-stack/ (the tmpfs from systemd-tmpfiles).
+#   token-file   Path to a file containing exactly:
+#                  OP_SERVICE_ACCOUNT_TOKEN=ops_…
+#                Must be mode 0400, owner root. Sourced with `set -a`
+#                so the token enters this script's env briefly, then
+#                is unset before exit.
+#
+# Exit codes:
+#   0   render succeeded; target file in place with correct perms
+#   1   render failed (template, op inject, validation, or mv error)
+#   2   usage error (wrong args, missing files, target outside /run)
+
+set -euo pipefail
+set +x
+umask 077
+
+fail() {
+  echo "render-vps-env.sh: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: render-vps-env.sh <template> <target> <token-file>
+
+  template     deploy/*.env.template path
+  target       /run/agent-stack/*.env path (must be inside /run/agent-stack)
+  token-file   /etc/agent-stack/op-*.env path (mode 0400, root)
+
+See SECRETS_MIGRATION.md Phase 2 PR 2.3 for the full design.
+USAGE
+  exit 2
+}
+
+[ "$#" -eq 3 ] || usage
+template="$1"
+target="$2"
+token_file="$3"
+
+# ── Pre-flight checks ──────────────────────────────────────────────────────
+
+[ -f "$template" ] || fail "template not found: $template"
+[ -f "$token_file" ] || fail "token file not found: $token_file"
+
+# Verify token file permissions. We tolerate mode 0400 (root readable
+# only) but reject anything wider. 1Password's docs note service tokens
+# are vault-decryption capabilities — wider perms are a real risk.
+token_mode=$(stat -c '%a' "$token_file" 2>/dev/null || stat -f '%A' "$token_file" 2>/dev/null || echo "?")
+case "$token_mode" in
+  400|0400) : ;;
+  *) fail "token file $token_file has mode $token_mode; require 0400" ;;
+esac
+
+# Target MUST be inside /run/agent-stack to enforce the tmpfs invariant.
+# This is a defense against an attacker who can call this script with a
+# different target — they cannot redirect output to a persistent disk
+# location like /tmp or /srv.
+case "$target" in
+  /run/agent-stack/*) : ;;
+  *) fail "target $target is not inside /run/agent-stack; refusing to render" ;;
+esac
+
+# The runtime dir must exist (set up by systemd-tmpfiles at boot, or
+# by `systemd-tmpfiles --create` after a config change).
+runtime_dir=$(dirname "$target")
+if [ ! -d "$runtime_dir" ]; then
+  fail "$runtime_dir does not exist (did systemd-tmpfiles --create run?)"
+fi
+
+# Verify op CLI is installed.
+if ! command -v op >/dev/null 2>&1; then
+  fail "1Password CLI (op) not in PATH; run install-op-vps.sh"
+fi
+
+# ── Render ─────────────────────────────────────────────────────────────────
+
+# mktemp alongside the target, so the atomic mv is on the same filesystem.
+# `XXXXXX` is the tmpname suffix; trap cleans up on any exit path.
+tmp=$(mktemp "$runtime_dir/$(basename "$target").XXXXXX")
+chmod 0400 "$tmp"
+trap 'rm -f "$tmp"' EXIT
+
+# Load the OP service-account token into this script's env. `set -a`
+# exports without echoing the value. The token-file is sourced (NOT
+# eval'd) so it must be strict KEY=VALUE lines only.
+set -a
+# shellcheck source=/dev/null
+. "$token_file"
+set +a
+
+if [ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
+  fail "OP_SERVICE_ACCOUNT_TOKEN not set after sourcing $token_file"
+fi
+
+# Refuse OP Connect config that would override the service-account
+# token (1Password's docs note OP_CONNECT_* takes precedence).
+if [ -n "${OP_CONNECT_HOST:-}" ] || [ -n "${OP_CONNECT_TOKEN:-}" ]; then
+  unset OP_SERVICE_ACCOUNT_TOKEN
+  fail "OP_CONNECT_HOST or OP_CONNECT_TOKEN is set; these take precedence over OP_SERVICE_ACCOUNT_TOKEN and create confusing behavior. Clear them in $token_file."
+fi
+
+# `--cache=false` ensures we always hit 1Password, never a stale local
+# cache. Critical for deploy paths.
+#
+# Both stdout and stderr are captured to tmpfiles so they never leak
+# rendered content or path information to the deploy log.
+op_stdout=$(mktemp)
+op_stderr=$(mktemp)
+trap 'rm -f "$tmp" "$op_stdout" "$op_stderr"; unset OP_SERVICE_ACCOUNT_TOKEN' EXIT
+
+if ! op inject --in-file "$template" --out-file "$tmp" --cache=false \
+    >"$op_stdout" 2>"$op_stderr"; then
+  echo "render-vps-env.sh: op inject failed:" >&2
+  sed 's/^/    /' < "$op_stderr" >&2
+  unset OP_SERVICE_ACCOUNT_TOKEN
+  exit 1
+fi
+
+# Unset the token immediately after op inject — minimize its lifetime
+# in this script's process env.
+unset OP_SERVICE_ACCOUNT_TOKEN
+
+# ── Validation ─────────────────────────────────────────────────────────────
+
+# Fail-closed: any unresolved op:// substring is a hard error. op inject
+# can return 0 even when a reference fails to resolve under some syntax
+# conditions — re-check ourselves.
+if grep -q 'op://' "$tmp"; then
+  echo "render-vps-env.sh: rendered output still contains unresolved op:// references" >&2
+  echo "                  (rendered file path withheld; inspect with KEEP_TMPFILE=1)" >&2
+  exit 1
+fi
+
+# Sanity: rendered file must have at least one KEY=value line.
+key_value_lines=$(grep -cE '^[A-Z][A-Z0-9_]*=' "$tmp" 2>/dev/null || echo 0)
+if [ "$key_value_lines" -lt 1 ]; then
+  fail "rendered file has zero KEY=value lines; aborting (template likely malformed)"
+fi
+
+# ── Install ────────────────────────────────────────────────────────────────
+
+# Final permissions match the v3 plan: 0400, root-owned. The compose
+# service that consumes this file MUST be readable by root at startup
+# (Docker daemon runs as root). If compose runs as non-root, the chown
+# needs adjustment — make that an explicit operator decision rather
+# than a silent permission drift.
+chmod 0400 "$tmp"
+chown root:root "$tmp" 2>/dev/null || {
+  # Non-root invocation: skip chown, log a note, continue. The file is
+  # still 0400; only the owning user can read it.
+  echo "render-vps-env.sh: warning: chown root:root failed (not running as root?); leaving file owned by $(id -un)" >&2
+}
+
+# Atomic mv on the same filesystem (tmp is in $runtime_dir, target is
+# in $runtime_dir). The previous target, if it existed, is replaced
+# atomically by the rename(2) syscall.
+mv "$tmp" "$target"
+
+# Clear EXIT trap — successful path, no cleanup needed.
+trap - EXIT
+rm -f "$op_stdout" "$op_stderr"
+
+# ── Report ─────────────────────────────────────────────────────────────────
+#
+# Counts only, never values.
+total_lines=$(wc -l < "$target" | tr -d ' ')
+echo "render-vps-env.sh: rendered $target"
+echo "    template:        $template"
+echo "    total lines:     $total_lines"
+echo "    KEY=value lines: $key_value_lines"
+echo "    mode:            0400"


### PR DESCRIPTION
## Summary

Foundation for the env-file cutover that PR 2.4 will land. **Zero production risk in this PR** — additive only, no changes to the deploy workflow, no changes to docker-compose, runtime unchanged.

After PR 2.1 and PR 2.2 each surfaced 1-3 unexpected acceptance bugs ("we removed X from CI; some other path silently relied on X"), the original PR 2.3 scope is split:

- **PR 2.3 (this)** — bootstrap toolchain + render script + helpers
- **PR 2.4 (next)** — wire `render-vps-env.sh` into deploy, flip compose `env_file:`, retire SSH heredoc, rotate exposed secrets, delete legacy GH secrets

## New files

| File | Purpose |
|---|---|
| `scripts/ops/render-vps-env.sh` | Atomic, fail-closed renderer. Refuses to write outside `/run/agent-stack/`, verifies token file mode `0400`, `op inject --cache=false`, greps for unresolved `op://` post-render → abort, `chmod 0400 + chown root:root`, atomic `mv`. Unsets OP token immediately after `op inject`. Refuses to run if `OP_CONNECT_HOST/TOKEN` is set. Never prints rendered content. |
| `scripts/ops/install-op-vps.sh` | Idempotent 1Password CLI installer for Debian/Ubuntu via the official apt repo (scoped `signed-by` keyring at `/usr/share/keyrings/`, debsig policy as second layer). Verifies with `op --version`. |
| `deploy/agent-stack.tmpfiles.conf` | `d /run/agent-stack 0700 root root - -` — systemd-tmpfiles declaration. |
| `scripts/ops/fill-env-template.mjs` | Operator helper to populate `# TODO(operator)` lines in `deploy/*.env.template` from a SCP'd snapshot of `/srv/agent-stack/*.env`. **Refuses to write secret-shaped values** (hex private keys, JWTs, API-key prefixes) into the template; flags them for review instead. |

## Updates

`docs/SECRETS_MIGRATION.md` PR 2.3 section rewritten end-to-end with the conservative scope plus a 6-step operator runbook.

## Operator runbook (full text in SECRETS_MIGRATION.md)

1. SSH + run `sudo bash install-op-vps.sh` on the VPS.
2. Drop service-account tokens at `/etc/agent-stack/op-{backend,indexer}.env` (mode 0400 root).
3. Install `/etc/tmpfiles.d/agent-stack.conf`, run `systemd-tmpfiles --create`.
4. Verify backend token reads ONLY `prod-backend` + `prod-backend-external`; indexer token reads ONLY `prod-indexer`. Neither can read `prod-critical` (firebreak).
5. SCP `/srv/agent-stack/*.env` locally, run `fill-env-template.mjs`, review diff, commit filled templates as part of this PR. `STRICT=1` validate.
6. Run `render-vps-env.sh` manually on the VPS. Diff `/run/agent-stack/*.env` against `/srv/agent-stack/*.env` — expect zero drift.

## Test plan / acceptance

- [ ] `install-op-vps.sh` runs cleanly; `op --version` works on VPS
- [ ] `/etc/agent-stack/op-{backend,indexer}.env` exist with mode 0400, content is exactly `OP_SERVICE_ACCOUNT_TOKEN=ops_…` and nothing else
- [ ] `/run/agent-stack` exists with mode 0700 after `systemd-tmpfiles --create`
- [ ] Backend token reads ONLY backend vaults; indexer token reads ONLY indexer vault (verified with `op vault list`)
- [ ] Neither token reads `prod-critical` (firebreak)
- [ ] `STRICT=1 bash scripts/ops/validate-env-render.sh backend` passes
- [ ] `STRICT=1 bash scripts/ops/validate-env-render.sh indexer` passes
- [ ] Manual `render-vps-env.sh` on VPS produces `/run/agent-stack/*.env` matching `/srv/agent-stack/*.env` byte-for-byte (sorted diff is empty)
- [ ] Backend + indexer containers unchanged — still reading from `/srv/agent-stack/*.env` (compose unchanged in this PR)

## Deferred to PR 2.4

- Wire `render-vps-env.sh` into `deploy-production.sh`
- Audit `docker-compose.yml` for `environment:` keys shadowing `env_file:`
- Flip compose `env_file:` paths
- Retire SSH heredoc transport for secrets `op://prod-ci/*` now provides
- Rotate secrets that lived through the heredoc / hand-managed paths
- Delete legacy GH Actions secrets + `/srv/agent-stack/*.env` after 24h stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)