### PR TITLE
PR 2.3 follow-up: fill TODO(operator) lines + fix NODE_OPTIONS/PORT placement

### DIFF
--- a/deploy/backend.env.template
+++ b/deploy/backend.env.template
@@ -64,87 +64,89 @@ GITHUB_TOKEN=op://prod-backend-external/github-pat-issue-ingestion/password
 # JWT-shaped string, anything with "key" or "token" in the name) — those go
 # in 1Password, not in this template.
 
-# REDIS_URL=                  # TODO(operator) — config; expect redis://redis:6379 (no auth, public on docker network)
-# REDIS_NAMESPACE=            # TODO(operator)
+REDIS_URL=redis://redis:6379
+REDIS_NAMESPACE=agent-platform
 
-# AUTH_ADMIN_WALLETS=         # TODO(operator) — comma-separated 0x... addresses, public
-# AUTH_VERIFIER_WALLETS=      # TODO(operator)
-# AUTH_DOMAIN=                # TODO(operator)
-# AUTH_CHAIN_ID=              # TODO(operator)
+AUTH_ADMIN_WALLETS=0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519
+AUTH_VERIFIER_WALLETS=0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519
+AUTH_DOMAIN=api.averray.com
+AUTH_CHAIN_ID=420420417
 
-# CORS_ALLOWED_ORIGINS=       # TODO(operator)
-# TRUST_PROXY=                # TODO(operator)
-# LOG_LEVEL=                  # TODO(operator)
+CORS_ALLOWED_ORIGINS=https://app.averray.com
+TRUST_PROXY=1
+LOG_LEVEL=info
 
-# DWELLER_RPC_URL=            # TODO(operator) — public Polkadot testnet RPC
-# POLKADOT_RPC_URL=           # TODO(operator)
-# RPC_URL=                    # TODO(operator)
+DWELLER_RPC_URL=https://eth-rpc-testnet.polkadot.io/
+POLKADOT_RPC_URL=https://eth-rpc-testnet.polkadot.io/
+RPC_URL=https://eth-rpc-testnet.polkadot.io/
 
-# TREASURY_POLICY_ADDRESS=    # TODO(operator) — public contract address
-# AGENT_ACCOUNT_ADDRESS=      # TODO(operator)
-# ESCROW_CORE_ADDRESS=        # TODO(operator)
-# REPUTATION_SBT_ADDRESS=     # TODO(operator)
-# DISCOVERY_REGISTRY_ADDRESS= # TODO(operator)
-# XCM_WRAPPER_ADDRESS=        # TODO(operator)
-# SUPPORTED_ASSETS_JSON=      # TODO(operator)
-# SUPPORTED_ASSETS=           # TODO(operator)
+TREASURY_POLICY_ADDRESS=0x648Cc5fdE94435992296C4e5ac642d18bB64c12B
+AGENT_ACCOUNT_ADDRESS=0x71B111d8c9DF84Be26cb9067D27dAd7A2d5E7e08
+ESCROW_CORE_ADDRESS=0x7BB8fea44bDeE9870cF27c1dB616E7017BC38b0a
+REPUTATION_SBT_ADDRESS=0x68Db90db715Be59E5800Bea08c058E4CFd88e27c
+DISCOVERY_REGISTRY_ADDRESS=0x0a1b78F8A2A3C28dB47f35Cb3E6b3b83412dad57
+XCM_WRAPPER_ADDRESS=
+SUPPORTED_ASSETS_JSON=[{\"symbol\":\"USDC\",\"assetClass\":\"trust_backed\",\"assetId\":1337,\"address\":\"0x0000053900000000000000000000000001200000\",\"decimals\":6,\"minBalanceRaw\":\"70000\"}]
+SUPPORTED_ASSETS=
 
-# UPSTREAM_STATUS_POLLER_ENABLED=     # TODO(operator)
-# UPSTREAM_STATUS_POLLER_INTERVAL_MS= # TODO(operator)
-# UPSTREAM_STATUS_POLLER_BATCH_SIZE=  # TODO(operator)
+UPSTREAM_STATUS_POLLER_ENABLED=true
+UPSTREAM_STATUS_POLLER_INTERVAL_MS=86400000
+UPSTREAM_STATUS_POLLER_BATCH_SIZE=50
 
-# BOOTSTRAP_SELF_REPORT_ENABLED=         # TODO(operator) — config flag
-# BOOTSTRAP_SELF_REPORT_INTERVAL_MS=     # TODO(operator)
-# BOOTSTRAP_SELF_REPORT_SEND_ON_START=   # TODO(operator)
-# BOOTSTRAP_SELF_REPORT_FROM=            # TODO(operator) — email address, not a secret
-# BOOTSTRAP_SELF_REPORT_TO=              # TODO(operator)
-# BOOTSTRAP_SELF_REPORT_SUBJECT_PREFIX=  # TODO(operator)
-# RESEND_API_BASE_URL=                   # TODO(operator) — public vendor base URL
+BOOTSTRAP_SELF_REPORT_ENABLED=true
+BOOTSTRAP_SELF_REPORT_INTERVAL_MS=604800000
+BOOTSTRAP_SELF_REPORT_SEND_ON_START=false
+BOOTSTRAP_SELF_REPORT_FROM=ops@averray.com
+BOOTSTRAP_SELF_REPORT_TO=pkuriger@averray.com
+BOOTSTRAP_SELF_REPORT_SUBJECT_PREFIX=Averray bootstrap self-report
+RESEND_API_BASE_URL=https://api.resend.com
 
 # Issue / OSV / OpenData / Standards / OpenAPI ingestion config — all feature
 # flags + tunables, fill in 1:1 from current backend.env:
-# GITHUB_INGEST_ENABLED=                # TODO(operator)
-# GITHUB_INGEST_DRY_RUN=                # TODO(operator)
-# GITHUB_INGEST_INTERVAL_MS=            # TODO(operator)
-# GITHUB_INGEST_MIN_SCORE=              # TODO(operator)
-# GITHUB_INGEST_MAX_JOBS_PER_RUN=       # TODO(operator)
-# GITHUB_INGEST_MAX_OPEN_JOBS=          # TODO(operator)
-# GITHUB_INGEST_QUERIES_JSON=           # TODO(operator)
-# OSV_INGEST_ENABLED=                   # TODO(operator)
-# OSV_INGEST_DRY_RUN=                   # TODO(operator)
-# OSV_INGEST_INTERVAL_MS=               # TODO(operator)
-# OSV_INGEST_MAX_JOBS_PER_RUN=          # TODO(operator)
-# OSV_INGEST_MAX_OPEN_JOBS=             # TODO(operator)
-# OSV_INGEST_MIN_SCORE=                 # TODO(operator)
-# OSV_INGEST_PACKAGES_JSON=             # TODO(operator)
-# OSV_INGEST_MANIFESTS_JSON=            # TODO(operator)
-# OSV_INGEST_MAX_PACKAGE_TARGETS=       # TODO(operator)
-# OPEN_DATA_INGEST_ENABLED=             # TODO(operator)
-# OPEN_DATA_INGEST_DRY_RUN=             # TODO(operator)
-# OPEN_DATA_INGEST_INTERVAL_MS=         # TODO(operator)
-# OPEN_DATA_INGEST_MAX_JOBS_PER_RUN=    # TODO(operator)
-# OPEN_DATA_INGEST_MAX_OPEN_JOBS=       # TODO(operator)
-# OPEN_DATA_INGEST_MIN_SCORE=           # TODO(operator)
-# OPEN_DATA_INGEST_QUERY=               # TODO(operator)
-# OPEN_DATA_INGEST_QUERIES_JSON=        # TODO(operator)
-# STANDARDS_INGEST_ENABLED=             # TODO(operator)
-# STANDARDS_INGEST_DRY_RUN=             # TODO(operator)
-# STANDARDS_INGEST_INTERVAL_MS=         # TODO(operator)
-# STANDARDS_INGEST_MAX_JOBS_PER_RUN=    # TODO(operator)
-# STANDARDS_INGEST_MAX_OPEN_JOBS=       # TODO(operator)
-# STANDARDS_INGEST_SPECS_JSON=          # TODO(operator)
-# OPENAPI_INGEST_ENABLED=               # TODO(operator)
-# OPENAPI_INGEST_DRY_RUN=               # TODO(operator)
-# OPENAPI_INGEST_INTERVAL_MS=           # TODO(operator)
-# OPENAPI_INGEST_MAX_JOBS_PER_RUN=      # TODO(operator)
-# OPENAPI_INGEST_MAX_OPEN_JOBS=         # TODO(operator)
-# OPENAPI_INGEST_SPECS_JSON=            # TODO(operator)
+GITHUB_INGEST_ENABLED=true
+GITHUB_INGEST_DRY_RUN=false
+GITHUB_INGEST_INTERVAL_MS=900000
+GITHUB_INGEST_MIN_SCORE=45
+GITHUB_INGEST_MAX_JOBS_PER_RUN=8
+GITHUB_INGEST_MAX_OPEN_JOBS=30
+GITHUB_INGEST_QUERIES_JSON=["is:issue is:open label:\"good first issue\" language:TypeScript"]
+OSV_INGEST_ENABLED=true
+OSV_INGEST_DRY_RUN=false
+OSV_INGEST_INTERVAL_MS=3600000
+OSV_INGEST_MAX_JOBS_PER_RUN=2
+OSV_INGEST_MAX_OPEN_JOBS=20
+OSV_INGEST_MIN_SCORE=55
+OSV_INGEST_PACKAGES_JSON=[]
+OSV_INGEST_MANIFESTS_JSON=[{"repo":"averray-agent/agent","manifestPath":"package-lock.json","ref":"main"}]
+OSV_INGEST_MAX_PACKAGE_TARGETS=100
+OPEN_DATA_INGEST_ENABLED=true
+OPEN_DATA_INGEST_DRY_RUN=false
+OPEN_DATA_INGEST_INTERVAL_MS=3600000
+OPEN_DATA_INGEST_MAX_JOBS_PER_RUN=2
+OPEN_DATA_INGEST_MAX_OPEN_JOBS=20
+OPEN_DATA_INGEST_MIN_SCORE=55
+OPEN_DATA_INGEST_QUERY=traffic crashes
+OPEN_DATA_INGEST_QUERIES_JSON=["traffic crashes","food safety","water quality","building permits","public safety"]
+STANDARDS_INGEST_ENABLED=true
+STANDARDS_INGEST_DRY_RUN=false
+STANDARDS_INGEST_INTERVAL_MS=3600000
+STANDARDS_INGEST_MAX_JOBS_PER_RUN=2
+STANDARDS_INGEST_MAX_OPEN_JOBS=20
+STANDARDS_INGEST_SPECS_JSON=[{"provider":"w3c","specId":"vc-data-model-2.0","specTitle":"Verifiable Credentials Data Model v2.0","specUrl":"https://www.w3.org/TR/vc-data-model-2.0/","expectedStatus":"W3C Recommendation","localSurface":"docs/RC1_WORKING_SPEC.md","repo":"averray-agent/agent"}]
+OPENAPI_INGEST_ENABLED=true
+OPENAPI_INGEST_DRY_RUN=false
+OPENAPI_INGEST_INTERVAL_MS=3600000
+OPENAPI_INGEST_MAX_JOBS_PER_RUN=2
+OPENAPI_INGEST_MAX_OPEN_JOBS=10
+OPENAPI_INGEST_SPECS_JSON=[{"provider":"averray","specId":"averray-http-api","apiTitle":"Averray HTTP API","specUrl":"https://raw.githubusercontent.com/averray-agent/agent/main/docs/api/openapi.json","localSurface":"mcp-server/src/protocols/http/server.js","repo":"averray-agent/agent"}]
 
-# JOB_STALE_SWEEPER_ENABLED=         # TODO(operator)
-# JOB_STALE_SWEEPER_DRY_RUN=         # TODO(operator)
-# JOB_STALE_SWEEPER_ACTION=          # TODO(operator)
-# JOB_STALE_SWEEPER_INTERVAL_MS=     # TODO(operator)
-# JOB_STALE_SWEEPER_MAX_JOBS_PER_RUN= # TODO(operator)
+JOB_STALE_SWEEPER_ENABLED=true
+JOB_STALE_SWEEPER_DRY_RUN=false
+JOB_STALE_SWEEPER_ACTION=archive
+JOB_STALE_SWEEPER_INTERVAL_MS=3600000
+JOB_STALE_SWEEPER_MAX_JOBS_PER_RUN=25
 
-# NODE_OPTIONS=               # TODO(operator)
-# PORT=                       # TODO(operator)
+# NODE_OPTIONS and PORT are intentionally NOT set for the backend —
+# the live /srv/agent-stack/backend.env doesn't define them; the
+# backend container uses its built-in defaults. They live only in
+# the indexer template. Removing the TODO lines here in PR 2.3.

--- a/deploy/indexer.env.template
+++ b/deploy/indexer.env.template
@@ -15,12 +15,18 @@ DATABASE_URL=op://prod-indexer/database-url/password
 
 # ── Non-secret config (fill in during PR 2.3 from /srv/agent-stack/indexer.env) ─
 
-# PONDER_RPC_URL_420420417= # TODO(operator) — public Polkadot testnet RPC
-# PONDER_TREASURY_POLICY_ADDRESS=  # TODO(operator) — public contract address
-# PONDER_ESCROW_CORE_ADDRESS=      # TODO(operator)
-# PONDER_AGENT_ACCOUNT_ADDRESS=    # TODO(operator)
-# PONDER_REPUTATION_SBT_ADDRESS=   # TODO(operator)
-# PONDER_START_BLOCK_TREASURY=     # TODO(operator)
-# PONDER_START_BLOCK_ESCROW=       # TODO(operator)
-# PONDER_START_BLOCK_REPUTATION=   # TODO(operator)
-# DATABASE_SCHEMA=                 # TODO(operator)
+PONDER_RPC_URL_420420417=https://eth-rpc-testnet.polkadot.io/
+PONDER_TREASURY_POLICY_ADDRESS=0x6A796cdb27A4D9F99360a7C5BaE1e574fDC106b7
+PONDER_ESCROW_CORE_ADDRESS=0xb5De343327D934F7Cb7bD0F6d3544F09d004930c
+PONDER_AGENT_ACCOUNT_ADDRESS=0x260566cf3B6Ba99809d07479BEF2711ce89d1fF8
+PONDER_REPUTATION_SBT_ADDRESS=0x6257D6A0A67ebA33a1E9B8b983BCfce3703F3494
+PONDER_START_BLOCK_TREASURY=7667527
+PONDER_START_BLOCK_ESCROW=7667527
+PONDER_START_BLOCK_REPUTATION=7667527
+DATABASE_SCHEMA=agent_indexer_20260501184403
+
+# Indexer process config — added to template in PR 2.3 so render matches
+# the live /srv/agent-stack/indexer.env (which has both NODE_OPTIONS and
+# PORT defined):
+NODE_OPTIONS=--max-old-space-size=2048
+PORT=42069


### PR DESCRIPTION
## Summary
Operator step 5 of PR #237's runbook: populate the \`# TODO(operator)\` lines in \`deploy/{backend,indexer}.env.template\` with literal non-secret config values from the live \`/srv/agent-stack/*.env\` on the VPS.

## Mechanics
- Used \`scripts/ops/fill-env-template.mjs\` (landed in #237) to substitute values from a local SCP'd snapshot.
- The helper refused to write any secret-shaped value (hex private key, JWT, API-key prefix, long base64-ish) into the template. **Zero values flagged as secrets** — confirms the templates only reference non-sensitive config + \`op://\` for the actual secrets.
- Snapshots shredded locally after use.

## Backend template (75 KEY=value, 4 op:// refs, 71 filled)
- Public addresses, public config, RPC URLs (all public Polkadot testnet)
- Feature flags + tunables: \`*_INGEST_*\`, \`JOB_STALE_SWEEPER_*\`, \`UPSTREAM_STATUS_POLLER_*\`

## Indexer template (12 KEY=value, 1 op:// ref, 11 filled)
- Public PONDER_* contract addresses + start blocks, \`DATABASE_SCHEMA\`
- \`NODE_OPTIONS\`, \`PORT\` (process config — moved here from the backend template where they were spuriously listed; backend doesn't set them, indexer does)

## Verification
- [x] \`STRICT=1 bash scripts/ops/validate-env-render.sh backend\` → pass
- [x] \`STRICT=1 bash scripts/ops/validate-env-render.sh indexer\` → pass  
- [x] \`node scripts/ops/check-env-template-structure.mjs\` → ok (5 op:// refs, 9 inventory rows, 4 expected warnings)

## Next
After merge, operator step 6 of PR #237 runbook: run \`render-vps-env.sh\` manually on the VPS, diff \`/run/agent-stack/*.env\` against \`/srv/agent-stack/*.env\`. Expect **zero functional drift**. After that, PR 2.4 wires the render into \`deploy-production.sh\` and flips compose \`env_file:\` paths (the actual cutover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)