### PR TITLE
PR 2.3 hotfix: don't chmod 0400 tmp file before op inject writes to it

### DIFF
--- a/scripts/ops/render-vps-env.sh
+++ b/scripts/ops/render-vps-env.sh
@@ -113,8 +113,13 @@ fi
 
 # mktemp alongside the target, so the atomic mv is on the same filesystem.
 # `XXXXXX` is the tmpname suffix; trap cleans up on any exit path.
+#
+# NB: do NOT chmod 0400 the file here — op inject needs to write to it.
+# The umask 077 at the top of the script ensures mktemp's default mode
+# is 0600 (read+write only by the owning user) during the brief window
+# between create and op inject's write. Final chmod 0400 happens AFTER
+# op inject succeeds, just before the atomic mv into place.
 tmp=$(mktemp "$runtime_dir/$(basename "$target").XXXXXX")
-chmod 0400 "$tmp"
 trap 'rm -f "$tmp"' EXIT
 
 # Load the OP service-account token into this script's env. `set -a`


### PR DESCRIPTION
## Summary
Caught during PR #237's operator runbook step 6 (manual render on VPS). \`render-vps-env.sh\` chmod'd the mktemp tmp file to 0400 right after creation, then called \`op inject\` which can't write to a read-only file → falls back to confirmation prompt → fails in non-interactive shell:

\`\`\`
[ERROR] cannot prompt for confirmation. Use the '-f' or '--force' flag to skip confirmation.
\`\`\`

## Fix
Remove the early \`chmod 0400\`. The script's \`umask 077\` already makes \`mktemp\` default to mode 0600, so the file is never world-readable. The final \`chmod 0400 + chown root:root\` still happens after \`op inject\` succeeds, right before the atomic \`mv\`.

## Test plan
After merge, retry operator step 6 — \`sudo bash render-vps-env.sh <template> <target> <token>\` on the VPS should now produce \`/run/agent-stack/*.env\` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)