### PR TITLE
Expose agent sub-job lineage

### DIFF
--- a/app/components/agents/AgentDirectoryTable.tsx
+++ b/app/components/agents/AgentDirectoryTable.tsx
@@ -183,6 +183,7 @@ export function AgentDirectoryTable({
                       {a.activeSession ? (
                         <ActiveSessionLine session={a.activeSession} />
                       ) : null}
+                      <LineageLine agent={a} />
                     </Td>
                     <Td>
                       <span
@@ -255,6 +256,36 @@ function ActiveSessionLine({ session }: { session: AgentActiveSession }) {
           <span className="opacity-40">·</span>
           <span>{deadlineLabel}</span>
         </>
+      ) : null}
+    </div>
+  );
+}
+
+function LineageLine({ agent }: { agent: AgentRecord }) {
+  const stats = agent.lineageStats ?? {
+    delegated: agent.lineage?.delegated.length ?? 0,
+    subcontracted: agent.lineage?.subcontracted.length ?? 0,
+  };
+  if (stats.delegated + stats.subcontracted === 0) return null;
+  return (
+    <div
+      className="mt-1 inline-flex flex-wrap items-center gap-1 rounded-[6px] border border-[color:rgba(30,102,66,0.18)] bg-[color:rgba(30,102,66,0.04)] px-1.5 py-0.5 font-[family-name:var(--font-mono)] text-[10.5px] text-[var(--avy-muted)]"
+      style={{ letterSpacing: 0 }}
+      title="Sub-contracting history"
+    >
+      <span className="h-1.5 w-1.5 rounded-full bg-[var(--avy-accent)] opacity-70" />
+      {stats.delegated > 0 ? (
+        <span>
+          delegated <span className="text-[var(--avy-accent)]">{stats.delegated}</span>
+        </span>
+      ) : null}
+      {stats.delegated > 0 && stats.subcontracted > 0 ? (
+        <span className="opacity-40">·</span>
+      ) : null}
+      {stats.subcontracted > 0 ? (
+        <span>
+          sub-job <span className="text-[var(--avy-accent)]">{stats.subcontracted}</span>
+        </span>
       ) : null}
     </div>
   );

--- a/app/components/agents/AgentDrawerBody.tsx
+++ b/app/components/agents/AgentDrawerBody.tsx
@@ -10,7 +10,9 @@ import {
   tierFor,
   nextThreshold,
   type AgentActiveSession,
+  type AgentDelegatedLineage,
   type AgentRecord,
+  type AgentSubcontractedLineage,
   type AgentTier,
 } from "./types";
 
@@ -166,6 +168,10 @@ export function AgentDrawerBody({ agent }: { agent: AgentRecord }) {
 
       <Section title="Recent runs · last 8">
         <RecentRunsBlock agent={agent} />
+      </Section>
+
+      <Section title="Sub-contracting">
+        <SubcontractingBlock agent={agent} />
       </Section>
 
       <Section title="Stake">
@@ -473,6 +479,192 @@ function RecentRunsBlock({ agent }: { agent: AgentRecord }) {
   );
 }
 
+function SubcontractingBlock({ agent }: { agent: AgentRecord }) {
+  const lineage = agent.lineage ?? { delegated: [], subcontracted: [] };
+  const stats = agent.lineageStats ?? {
+    delegated: lineage.delegated.length,
+    subcontracted: lineage.subcontracted.length,
+  };
+  const hasLineage =
+    stats.delegated > 0 ||
+    stats.subcontracted > 0 ||
+    lineage.delegated.length > 0 ||
+    lineage.subcontracted.length > 0;
+
+  if (!hasLineage) {
+    return (
+      <div
+        className="rounded-[8px] border border-dashed border-[var(--avy-line)] bg-[rgba(255,253,247,0.5)] px-3.5 py-2.5 font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-muted)]"
+        style={{ letterSpacing: 0 }}
+      >
+        No sub-contracting history yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-3">
+      <div className="grid grid-cols-2 gap-2">
+        <LineageStat label="Delegated out" value={stats.delegated} />
+        <LineageStat label="Worked as sub-job" value={stats.subcontracted} />
+      </div>
+
+      {lineage.delegated.length > 0 ? (
+        <div className="grid gap-1.5">
+          <LineageGroupLabel label="Delegated sessions" />
+          {lineage.delegated.slice(0, 3).map((entry) => (
+            <DelegatedLineageCard key={entry.sessionId} entry={entry} />
+          ))}
+          {lineage.delegated.length > 3 ? (
+            <LineageMore count={lineage.delegated.length - 3} label="delegated session" />
+          ) : null}
+        </div>
+      ) : null}
+
+      {lineage.subcontracted.length > 0 ? (
+        <div className="grid gap-1.5">
+          <LineageGroupLabel label="Sub-job work" />
+          {lineage.subcontracted.slice(0, 3).map((entry) => (
+            <SubcontractedLineageCard key={entry.sessionId} entry={entry} />
+          ))}
+          {lineage.subcontracted.length > 3 ? (
+            <LineageMore count={lineage.subcontracted.length - 3} label="sub-job session" />
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function LineageStat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-[8px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-3 py-2">
+      <span
+        className="block font-[family-name:var(--font-display)] text-[9.5px] font-extrabold uppercase text-[var(--avy-muted)]"
+        style={{ letterSpacing: "0.1em" }}
+      >
+        {label}
+      </span>
+      <span
+        className="mt-1 block font-[family-name:var(--font-mono)] text-[18px] font-semibold tabular-nums text-[var(--avy-ink)]"
+        style={{ letterSpacing: 0 }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function LineageGroupLabel({ label }: { label: string }) {
+  return (
+    <span
+      className="font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-muted)]"
+      style={{ letterSpacing: "0.1em" }}
+    >
+      {label}
+    </span>
+  );
+}
+
+function DelegatedLineageCard({ entry }: { entry: AgentDelegatedLineage }) {
+  const childJobs = entry.children.jobIds.slice(0, 2);
+  return (
+    <div className="rounded-[8px] border border-[var(--avy-line-soft)] bg-[var(--avy-paper-solid)] px-3 py-2.5">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="m-0 text-[13px] font-semibold leading-tight text-[var(--avy-ink)]">
+            {entry.jobTitle || titleFromJobId(entry.jobId)}
+          </p>
+          <p
+            className="m-0 mt-0.5 font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
+            style={{ letterSpacing: 0 }}
+          >
+            {middleTruncate(entry.sessionId, 18)} · {relativeOrFallback(entry.updatedAt)}
+          </p>
+        </div>
+        <LineageStatus label={entry.status} />
+      </div>
+      <div
+        className="mt-2 flex flex-wrap items-center gap-1.5 font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
+        style={{ letterSpacing: 0 }}
+      >
+        <span>{entry.children.count} child job{entry.children.count === 1 ? "" : "s"}</span>
+        {childJobs.map((jobId) => (
+          <span
+            key={jobId}
+            className="rounded-[5px] bg-[color:rgba(30,102,66,0.08)] px-1.5 py-0.5 text-[var(--avy-accent)]"
+            title={jobId}
+          >
+            {middleTruncate(jobId, 18)}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SubcontractedLineageCard({ entry }: { entry: AgentSubcontractedLineage }) {
+  return (
+    <div className="rounded-[8px] border border-[var(--avy-line-soft)] bg-[var(--avy-paper-solid)] px-3 py-2.5">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="m-0 text-[13px] font-semibold leading-tight text-[var(--avy-ink)]">
+            {entry.jobTitle || titleFromJobId(entry.jobId)}
+          </p>
+          <p
+            className="m-0 mt-0.5 font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
+            style={{ letterSpacing: 0 }}
+          >
+            {middleTruncate(entry.sessionId, 18)} · {relativeOrFallback(entry.updatedAt)}
+          </p>
+        </div>
+        <LineageStatus label={entry.status} />
+      </div>
+      <div
+        className="mt-2 flex flex-wrap items-center gap-1.5 font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
+        style={{ letterSpacing: 0 }}
+      >
+        {entry.parent.wallet ? (
+          <span>parent wallet {middleTruncate(entry.parent.wallet, 18)}</span>
+        ) : (
+          <span>parent session {middleTruncate(entry.parent.sessionId ?? "unknown", 18)}</span>
+        )}
+        {entry.parent.jobId ? (
+          <span
+            className="rounded-[5px] bg-[color:rgba(30,102,66,0.08)] px-1.5 py-0.5 text-[var(--avy-accent)]"
+            title={entry.parent.jobId}
+          >
+            {middleTruncate(entry.parent.jobId, 18)}
+          </span>
+        ) : null}
+        {entry.parent.isSelf ? <span>self-delegated</span> : null}
+      </div>
+    </div>
+  );
+}
+
+function LineageStatus({ label }: { label: string }) {
+  return (
+    <span
+      className="shrink-0 rounded-full bg-[var(--avy-accent-soft)] px-2 py-0.5 font-[family-name:var(--font-display)] text-[9.5px] font-extrabold uppercase text-[var(--avy-accent)]"
+      style={{ letterSpacing: "0.08em" }}
+    >
+      {label || "unknown"}
+    </span>
+  );
+}
+
+function LineageMore({ count, label }: { count: number; label: string }) {
+  return (
+    <div
+      className="rounded-[8px] border border-dashed border-[var(--avy-line)] bg-[rgba(255,253,247,0.5)] px-3 py-2 font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-muted)]"
+      style={{ letterSpacing: 0 }}
+    >
+      +{count} more {label}{count === 1 ? "" : "s"}
+    </div>
+  );
+}
+
 function Section({
   title,
   children,
@@ -544,6 +736,10 @@ function formatRelative(iso: string): string {
   return `${Math.round(deltaHr / 24)}d ago`;
 }
 
+function relativeOrFallback(iso: string): string {
+  return iso ? formatRelative(iso) : "time unknown";
+}
+
 function formatDeadline(iso: string): string {
   const t = Date.parse(iso);
   if (!Number.isFinite(t)) return iso;
@@ -555,4 +751,13 @@ function formatDeadline(iso: string): string {
   const deltaHr = Math.round(deltaMin / 60);
   if (deltaHr < 24) return `in ${deltaHr}h`;
   return `in ${Math.round(deltaHr / 24)}d`;
+}
+
+function titleFromJobId(jobId: string): string {
+  return jobId
+    .split("-")
+    .filter(Boolean)
+    .slice(0, 5)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ") || jobId;
 }

--- a/app/components/agents/types.ts
+++ b/app/components/agents/types.ts
@@ -72,6 +72,48 @@ export interface AgentSlash {
   ref: string;
 }
 
+export interface AgentLineageChildSummary {
+  count: number;
+  jobIds: string[];
+  sessionIds: string[];
+  wallets: string[];
+}
+
+export interface AgentDelegatedLineage {
+  role: "parent";
+  sessionId: string;
+  jobId: string;
+  jobTitle?: string;
+  status: string;
+  updatedAt: string;
+  children: AgentLineageChildSummary;
+}
+
+export interface AgentSubcontractedLineage {
+  role: "child";
+  sessionId: string;
+  jobId: string;
+  jobTitle?: string;
+  status: string;
+  updatedAt: string;
+  parent: {
+    sessionId?: string;
+    jobId?: string;
+    wallet?: string;
+    isSelf?: boolean;
+  };
+}
+
+export interface AgentLineage {
+  delegated: AgentDelegatedLineage[];
+  subcontracted: AgentSubcontractedLineage[];
+}
+
+export interface AgentLineageStats {
+  delegated: number;
+  subcontracted: number;
+}
+
 export interface AgentStake {
   deposited: number;
   locked: number;
@@ -115,6 +157,13 @@ export interface AgentRecord {
   hasVerifiedBadges?: boolean;
   recentRuns: AgentRecentRun[];
   slashes: AgentSlash[];
+  /**
+   * Sub-contracting history from the public agent profile. `delegated`
+   * means this wallet spawned child jobs from one of its sessions;
+   * `subcontracted` means this wallet completed work as a child run.
+   */
+  lineage: AgentLineage;
+  lineageStats: AgentLineageStats;
 }
 
 export const BADGES: Record<string, BadgeDef> = {

--- a/app/lib/api/agent-adapters.ts
+++ b/app/lib/api/agent-adapters.ts
@@ -39,6 +39,8 @@ export function extractAgent(data: unknown): AgentRecord | null {
 
   const activeSession = activeSessionFor(record);
   const verifiedBadgeCount = badgesRaw.length;
+  const lineage = lineageFor(record);
+  const lineageStats = lineageStatsFor(record, lineage);
   return {
     handle: text(record.handle, handleForWallet(walletFull)),
     wallet: shortAddress(walletFull),
@@ -56,6 +58,8 @@ export function extractAgent(data: unknown): AgentRecord | null {
     hasVerifiedBadges: verifiedBadgeCount > 0,
     recentRuns: recentRunsFor(badgesRaw),
     slashes: slashEvents(record.slashEvents),
+    lineage,
+    lineageStats,
   };
 }
 
@@ -268,6 +272,78 @@ function slashEvents(value: unknown): AgentRecord["slashes"] {
   });
 }
 
+function lineageFor(record: RawRecord): AgentRecord["lineage"] {
+  const lineage = objectField(record, "lineage");
+  return {
+    delegated: arrayField(lineage, "delegated")
+      ?.map(delegatedLineageEntry)
+      .filter((entry): entry is AgentRecord["lineage"]["delegated"][number] => Boolean(entry))
+      ?? [],
+    subcontracted: arrayField(lineage, "subcontracted")
+      ?.map(subcontractedLineageEntry)
+      .filter((entry): entry is AgentRecord["lineage"]["subcontracted"][number] => Boolean(entry))
+      ?? [],
+  };
+}
+
+function lineageStatsFor(
+  record: RawRecord,
+  lineage: AgentRecord["lineage"]
+): AgentRecord["lineageStats"] {
+  const stats = objectField(record, "stats");
+  const raw = objectField(stats, "lineage");
+  return {
+    delegated: number(raw?.delegated, lineage.delegated.length),
+    subcontracted: number(raw?.subcontracted, lineage.subcontracted.length),
+  };
+}
+
+function delegatedLineageEntry(value: unknown): AgentRecord["lineage"]["delegated"][number] | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as RawRecord;
+  const sessionId = text(record.sessionId, "");
+  const jobId = text(record.jobId, "");
+  if (!sessionId || !jobId) return null;
+  const children = objectField(record, "children");
+  return {
+    role: "parent",
+    sessionId,
+    jobId,
+    ...(text(record.jobTitle, "") ? { jobTitle: text(record.jobTitle) } : {}),
+    status: text(record.status, "unknown"),
+    updatedAt: text(record.updatedAt, ""),
+    children: {
+      count: number(children?.count, arrayField(children, "jobIds")?.length ?? 0),
+      jobIds: stringArray(children, "jobIds"),
+      sessionIds: stringArray(children, "sessionIds"),
+      wallets: stringArray(children, "wallets"),
+    },
+  };
+}
+
+function subcontractedLineageEntry(value: unknown): AgentRecord["lineage"]["subcontracted"][number] | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as RawRecord;
+  const sessionId = text(record.sessionId, "");
+  const jobId = text(record.jobId, "");
+  if (!sessionId || !jobId) return null;
+  const parent = objectField(record, "parent");
+  return {
+    role: "child",
+    sessionId,
+    jobId,
+    ...(text(record.jobTitle, "") ? { jobTitle: text(record.jobTitle) } : {}),
+    status: text(record.status, "unknown"),
+    updatedAt: text(record.updatedAt, ""),
+    parent: {
+      ...(text(parent?.sessionId, "") ? { sessionId: text(parent?.sessionId) } : {}),
+      ...(text(parent?.jobId, "") ? { jobId: text(parent?.jobId) } : {}),
+      ...(text(parent?.wallet, "") ? { wallet: text(parent?.wallet).toLowerCase() } : {}),
+      ...(typeof parent?.isSelf === "boolean" ? { isSelf: parent.isSelf } : {}),
+    },
+  };
+}
+
 function sparkline(score: number): number[] {
   const base = Math.max(0, score - 32);
   return Array.from({ length: 14 }, (_, index) => Math.max(0, base + Math.round(index * 2.4)));
@@ -326,4 +402,10 @@ function arrayField(value: unknown, key: string): unknown[] | null {
   if (!value || typeof value !== "object") return null;
   const field = (value as RawRecord)[key];
   return Array.isArray(field) ? field : null;
+}
+
+function stringArray(value: unknown, key: string): string[] {
+  return (arrayField(value, key) ?? [])
+    .map((entry) => text(entry, ""))
+    .filter(Boolean);
 }


### PR DESCRIPTION
## Summary
- parse agent profile lineage and lineage stats into the operator AgentRecord model
- show sub-contracting history in the agent drawer with delegated/sub-job counts and recent entries
- add a compact lineage indicator to agent directory rows

## Checks
- npm run typecheck:app
- npm run build:frontend
- git diff --check
- local /agents dev smoke via curl against http://127.0.0.1:3001/agents

## Impact
- Frontend/operator app only
- No backend, indexer, contracts, Caddy, or public site changes
- No environment or VPS secret changes

## Polkadot MCP
- Checked Polkadot Developer Docs MCP project metadata; this is an off-chain UI/API lineage display and does not depend on chain-specific behavior.