### PR TITLE
Phase 2 PR 2.4: wire render-vps-env.sh into deploy (parity check, non-blocking)

### DIFF
--- a/docs/SECRETS_MIGRATION.md
+++ b/docs/SECRETS_MIGRATION.md
@@ -754,13 +754,102 @@ runtime values the backend was already consuming. As a bonus side
 effect, the cutover eliminates the duplicate-key spaghetti — the
 rendered template has no duplicates by construction.
 
-`scripts/ops/refresh-env-template.mjs` (new in this PR) is the tool
-for future template ↔ live drift reconciliation. It updates literal
-KEY=value lines from a snapshot, preserves `op://` references, and
-refuses to overwrite an op-reference with a secret-shaped literal
-from the snapshot.
+`scripts/ops/refresh-env-template.mjs` is the tool for future template
+↔ live drift reconciliation. It updates literal KEY=value lines from
+a snapshot, preserves `op://` references, and refuses to overwrite an
+op-reference with a secret-shaped literal from the snapshot.
 
-### PR 2.4 — Cleanup AND rotation
+### PR 2.4 — Wire `render-vps-env.sh` into the deploy (parity check, non-blocking)
+
+**Touches**: `scripts/ops/deploy-production.sh`.
+
+After PR 2.3 surfaced that the live `/srv/agent-stack/*.env` had
+duplicate `KEY=value` entries (last-wins semantics quietly producing
+the template's values), the cutover is safe. This PR plumbs
+`render-vps-env.sh` into `deploy-production.sh` so the render runs at
+every deploy as a parity check, BEFORE we flip compose to actually
+consume the rendered files (PR 2.5).
+
+**New function in deploy-production.sh**: `render_runtime_envs_parity_check()`
+
+For each runtime (`backend`, `indexer`):
+
+1. Skip cleanly if `render-vps-env.sh`, the `/etc/agent-stack/op-*.env`
+   token file, or `/run/agent-stack/` is missing — the deploy continues
+   on the legacy path.
+2. Invoke `sudo bash render-vps-env.sh <template> /run/agent-stack/X.env
+   /etc/agent-stack/op-X.env`. On failure, log a `::warning::` and
+   move on (non-blocking).
+3. Compare the rendered output to a **last-wins-deduplicated** view of
+   the legacy `/srv/agent-stack/X.env`. The dedup is critical: the
+   legacy file's known duplicates would otherwise produce noise. An awk
+   one-liner stores the LAST value per key, then `diff` against the
+   rendered file (which has no duplicates by construction).
+4. On mismatch, log the differing KEY NAMES only (never values) as a
+   `::warning::` annotation visible in the deploy log.
+
+**Failure semantics**: this entire step is **non-blocking** for the
+duration of PR 2.4 / 2.5. The compose `env_file:` still points at
+`/srv/agent-stack/*.env`, so a render failure or a parity mismatch is
+informational, not breaking. PR 2.5 (compose flip) will make render
+failure fail-closed once the runtime depends on it.
+
+**Operator prerequisite**: passwordless sudo for the `ubuntu` user (the
+SSH user that runs `deploy-production.sh`). This is already the case on
+our VPS — confirmed during PR 2.3 acceptance when manual `sudo bash`
+invocations of `render-vps-env.sh` ran without prompting.
+
+**Acceptance criteria**:
+
+- [ ] Manual deploy after merge logs:
+      `Phase 2 PR 2.4: rendering runtime env files via op inject (parity check, non-blocking)`
+- [ ] For both runtimes, log line:
+      `Phase 2 PR 2.4: <runtime> parity OK — /run matches /srv (last-wins dedup)`
+- [ ] `/run/agent-stack/backend.env` and `/run/agent-stack/indexer.env`
+      exist after the deploy with mode `0400 root:root`
+- [ ] No rendered secret values appear in the deploy log (only KEY
+      names on mismatch)
+- [ ] Backend and indexer containers remain healthy (they continue
+      reading from `/srv/agent-stack/*.env` — runtime unchanged)
+
+After 2-3 green parity-check deploys, the next PR (2.5) flips compose.
+
+### PR 2.5 — Compose `env_file:` cutover (the actual switch)
+
+**Touches**: `docker-compose.yml` on the VPS (NOT in repo).
+`scripts/ops/deploy-production.sh` (make render fail-closed).
+
+The cutover. After PR 2.4's parity-check has been green for several
+deploys, this PR:
+
+1. Audits `docker-compose.yml` on the VPS for any `environment:` keys
+   that duplicate `env_file:` variables — Compose's `environment:`
+   wins, and a duplicate there would silently defeat the migration.
+2. Flips `env_file:` from `/srv/agent-stack/{backend,indexer}.env` to
+   `/run/agent-stack/{backend,indexer}.env`.
+3. Updates `render_runtime_envs_parity_check()` to make render failure
+   **fail-closed** (abort deploy) — keeps the function name and call
+   site, just changes the semantics.
+4. Backend + indexer containers restart and consume `/run/*.env` from
+   here on.
+
+The legacy `/srv/agent-stack/*.env` files stay on disk for 24h as a
+manual rollback option (operator edits `env_file:` back to `/srv/`).
+PR 2.6 (the original PR-2.4 cleanup) deletes them after that window.
+
+**Acceptance criteria**:
+
+- [ ] `docker compose config` on VPS shows no `environment:` overrides
+      of `env_file:` keys
+- [ ] After cutover deploy, `docker inspect agent-backend | grep -A20
+      Env` contains the values from `/run/agent-stack/backend.env`
+- [ ] A test deploy with an intentionally-broken template (e.g. remove
+      one entry from `prod-backend` in 1Password) causes the deploy to
+      abort BEFORE backend container restart — fail-closed confirmed
+- [ ] Operator-side runbook for the manual rollback (edit `env_file:`
+      back to `/srv/`) is documented
+
+### PR 2.6 — Cleanup AND rotation
 
 **Touches**: `.github/workflows/deploy-production.yml`, VPS env files,
 `SECRETS_CALENDAR.yml`.

--- a/scripts/ops/deploy-production.sh
+++ b/scripts/ops/deploy-production.sh
@@ -423,6 +423,99 @@ run_product_proof_worker_loop() {
     run_node_script "$APP_ROOT/scripts/ops/run-hosted-worker-loop.mjs"
 }
 
+# Phase 2 PR 2.4: render runtime env files via 1Password and check parity.
+#
+# At every deploy this function uses scripts/ops/render-vps-env.sh to write
+# /run/agent-stack/{backend,indexer}.env from the in-repo templates, then
+# compares against the legacy /srv/agent-stack/*.env. The compose env_file
+# directive is NOT yet flipped — that's PR 2.5. This step exists to:
+#
+#   1. Prove the render works end-to-end on every deploy (not just the
+#      manual smoke we did in PR 2.3 acceptance).
+#   2. Surface drift between the in-repo template and the live env file
+#      as a workflow `::warning::` annotation before the cutover, so we
+#      catch operator-side edits that diverged from the template.
+#
+# Failure semantics are NON-BLOCKING for this PR. If render fails, log a
+# warning and continue — the existing /srv path is still authoritative.
+# PR 2.5's cutover will flip this to fail-closed once compose uses /run.
+#
+# Uses sudo because:
+#   • /etc/agent-stack/op-*.env is mode 0400 root
+#   • /run/agent-stack/ is mode 0700 root
+#   • the deploy runs as the `ubuntu` user (passwordless sudo expected)
+render_runtime_envs_parity_check() {
+  local render_script="$APP_ROOT/scripts/ops/render-vps-env.sh"
+
+  if [[ ! -x "$render_script" ]]; then
+    echo "Phase 2 PR 2.4: render-vps-env.sh not present, skipping parity render"
+    return 0
+  fi
+
+  if [[ ! -f /etc/agent-stack/op-backend.env ]] || [[ ! -f /etc/agent-stack/op-indexer.env ]]; then
+    echo "Phase 2 PR 2.4: /etc/agent-stack/op-*.env not present, skipping parity render"
+    echo "  (run scripts/ops/install-op-vps.sh and drop the service-account tokens to enable)"
+    return 0
+  fi
+
+  if [[ ! -d /run/agent-stack ]]; then
+    echo "Phase 2 PR 2.4: /run/agent-stack not present, skipping parity render"
+    echo "  (install /etc/tmpfiles.d/agent-stack.conf and run systemd-tmpfiles --create)"
+    return 0
+  fi
+
+  echo "Phase 2 PR 2.4: rendering runtime env files via op inject (parity check, non-blocking)"
+
+  local runtime
+  for runtime in backend indexer; do
+    local template="$APP_ROOT/deploy/${runtime}.env.template"
+    local target="/run/agent-stack/${runtime}.env"
+    local token="/etc/agent-stack/op-${runtime}.env"
+    local legacy="$STACK_ROOT/${runtime}.env"
+
+    if [[ ! -f "$template" ]]; then
+      echo "::warning:: Phase 2 PR 2.4: $template missing, skipping $runtime render"
+      continue
+    fi
+
+    if ! sudo bash "$render_script" "$template" "$target" "$token"; then
+      echo "::warning:: Phase 2 PR 2.4: render of $runtime failed (non-blocking; compose still uses $legacy)"
+      continue
+    fi
+
+    if [[ ! -f "$legacy" ]]; then
+      echo "Phase 2 PR 2.4: $legacy missing — nothing to compare against for $runtime"
+      continue
+    fi
+
+    # Parity check: compare the rendered output to a deduplicated last-wins
+    # view of the legacy file. The legacy file has known duplicate-key
+    # entries (operators appended sections without dedup); Docker Compose
+    # uses last-wins for duplicates, so that's the semantic to compare.
+    #
+    # Run as one `sudo bash -c` so the process-substitutions and the read
+    # of the 0400 /run/*.env file all happen as root.
+    if sudo bash -c "
+      diff_output=\$(diff \
+        <(awk -F= '/^[A-Z][A-Z0-9_]*=/ { val[\$1] = \$0 } END { for (k in val) print val[k] }' '$legacy' | sort) \
+        <(grep -E '^[A-Z][A-Z0-9_]*=' '$target' | sort))
+      if [[ -z \"\$diff_output\" ]]; then
+        echo 'Phase 2 PR 2.4: $runtime parity OK — /run matches /srv (last-wins dedup)'
+        exit 0
+      else
+        line_count=\$(printf '%s\n' \"\$diff_output\" | wc -l | tr -d ' ')
+        echo \"::warning:: Phase 2 PR 2.4: $runtime parity diff — \$line_count line(s) differ between /run/agent-stack/${runtime}.env and /srv/agent-stack/${runtime}.env (last-wins dedup)\"
+        echo \"  This is informational only — compose still reads /srv. Investigate before PR 2.5 flips env_file.\"
+        # Print only KEY names, not values, so secrets never enter the log.
+        printf '%s\n' \"\$diff_output\" | awk -F= '/^[<>] [A-Z]/ { print \"    \" \$1 \"=\" }' | sort -u | head -20
+        exit 0
+      fi
+    "; then
+      :
+    fi
+  done
+}
+
 apply_caddy() {
   if [[ -z "${APP_BASIC_AUTH_USER:-}" ]]; then
     echo "Skipping Caddy render: APP_BASIC_AUTH_USER is not set." >&2
@@ -585,6 +678,11 @@ deploy() {
   apply_indexer_database_schema
   configure_settlement_env
   configure_bootstrap_instrumentation_env
+
+  # Phase 2 PR 2.4: render /run/agent-stack/*.env from 1Password, compare
+  # against the legacy /srv path (last-wins dedup). Non-blocking — compose
+  # still reads /srv. PR 2.5 will flip env_file and make this fail-closed.
+  render_runtime_envs_parity_check
 
   local run_backend=0
   local run_indexer=0


### PR DESCRIPTION
## Summary
Plumbs \`render-vps-env.sh\` into \`deploy-production.sh\`. Every production deploy now renders \`/run/agent-stack/{backend,indexer}.env\` from the in-repo templates and compares against the legacy \`/srv/agent-stack/*.env\` using last-wins-deduplicated semantics.

**Non-blocking by design** — compose still consumes \`/srv\` in this PR. Render failure or parity mismatch logs a \`::warning::\` but does NOT abort the deploy. PR 2.5 will flip compose \`env_file:\` paths and turn this fail-closed.

## Why last-wins dedup

PR 2.3 acceptance surfaced that live \`/srv/agent-stack/backend.env\` has duplicate \`KEY=value\` entries. Docker Compose uses last-wins for duplicates. The template's values match those last-wins values byte-for-byte. A naive \`sort | diff\` would flag the duplicates as drift; the awk dedup compares apples to apples.

## Skip-clean conditions

The parity step short-circuits gracefully if the bootstrap isn't complete:
- \`render-vps-env.sh\` not present (older revision deployed)
- \`/etc/agent-stack/op-*.env\` token files missing
- \`/run/agent-stack/\` tmpfiles directory missing
- \`deploy/{backend,indexer}.env.template\` not present

Deploy continues on the legacy path in all those cases.

## Privilege

\`deploy-production.sh\` runs as \`ubuntu\`; \`render-vps-env.sh\` needs root (for \`/etc/agent-stack/op-*.env\` and \`/run/agent-stack/\`). Resolved with \`sudo bash render-vps-env.sh ...\`. Passwordless sudo is already configured on this VPS (confirmed by manual PR 2.3 runs).

## Acceptance criteria (after merge, run one manual deploy)

- [ ] Deploy log: \`Phase 2 PR 2.4: rendering runtime env files via op inject (parity check, non-blocking)\`
- [ ] For each runtime: \`<runtime> parity OK — /run matches /srv (last-wins dedup)\`
- [ ] \`/run/agent-stack/{backend,indexer}.env\` exists with mode \`0400 root:root\` after the deploy
- [ ] **No rendered values appear in deploy logs** — only KEY names on mismatch
- [ ] Backend + indexer containers stay healthy (still reading from \`/srv\`)

## Docs

\`SECRETS_MIGRATION.md\`: new "PR 2.4 — Wire render-vps-env.sh into deploy" section. The original "PR 2.4 — Cleanup AND rotation" renamed to PR 2.6. New PR 2.5 (compose \`env_file:\` cutover) sits between them.

## Sequencing reminder

| PR | What | Risk |
|---|---|---|
| 2.4 (this) | Wire render into deploy as parity check | Low — non-blocking, runtime unchanged |
| 2.5 (next) | Flip compose env_file to /run; make render fail-closed | Medium — actual cutover |
| 2.6 | Delete legacy /srv files + rotate exposed secrets | Low — destructive cleanup |
| 2.7 (was 2.5) | Smoke ADMIN_JWT to 1Password | Low |
| 2.8 | npm hardening, basic-auth rotation, authorized_keys cleanup | Low |

🤖 Generated with [Claude Code](https://claude.com/claude-code)