### PR TITLE
[codex] Standardize job timeline event topics

### DIFF
--- a/app/components/runs/JobTimelinePanel.tsx
+++ b/app/components/runs/JobTimelinePanel.tsx
@@ -247,6 +247,10 @@ function SourceChip({ source }: { source: TimelineSource }) {
         source === "state" && "bg-[color:rgba(17,19,21,0.06)] text-[var(--avy-ink)]",
         source === "lineage" && "bg-[#2a1f3a] text-white",
         source === "schedule" && "bg-[#3a2a1f] text-white",
+        source === "chain" && "bg-[#173247] text-white",
+        source === "settlement" && "bg-[#17473b] text-white",
+        source === "ingestion" && "bg-[#46381a] text-white",
+        source === "system" && "bg-[#5b2a2a] text-white",
         // Unknown source kinds — neutral fill so the row still
         // renders and the operator can read the topic.
         ![
@@ -255,6 +259,10 @@ function SourceChip({ source }: { source: TimelineSource }) {
           "state",
           "lineage",
           "schedule",
+          "chain",
+          "settlement",
+          "ingestion",
+          "system",
         ].includes(source as string) && "bg-[color:rgba(17,19,21,0.06)] text-[var(--avy-ink)]"
       )}
       style={{ letterSpacing: "0.08em" }}

--- a/app/lib/api/job-timeline.ts
+++ b/app/lib/api/job-timeline.ts
@@ -25,6 +25,10 @@ export type TimelineSource =
   | "event_bus"
   | "lineage"
   | "schedule"
+  | "chain"
+  | "settlement"
+  | "ingestion"
+  | "system"
   // Anything else the backend adds later — we still render the row
   // with a generic chip rather than dropping the entry.
   | (string & {});

--- a/mcp-server/src/core/event-bus.js
+++ b/mcp-server/src/core/event-bus.js
@@ -68,24 +68,168 @@ function normalizeFilter(filter = {}) {
 }
 
 function normalizeEvent(event) {
+  const topic = normalizeText(event.topic);
+  const taxonomy = classifyEventTopic(topic, event.data);
   const wallets = new Set(
     [event.wallet, ...(Array.isArray(event.wallets) ? event.wallets : [])]
-      .map((value) => value?.trim())
+      .map((value) => normalizeText(value))
       .filter(Boolean)
   );
+  const jobId = normalizeText(event.jobId);
+  const sessionId = normalizeText(event.sessionId);
 
   return {
-    id: event.id,
-    topic: event.topic,
-    wallet: event.wallet?.trim() || undefined,
+    id: normalizeText(event.id) || undefined,
+    topic,
+    type: normalizeText(event.type) || "event_bus",
+    source: normalizeText(event.source) || taxonomy.source,
+    phase: normalizeText(event.phase) || taxonomy.phase,
+    severity: normalizeSeverity(event.severity) || taxonomy.severity,
+    correlationId: normalizeText(event.correlationId) || sessionId || jobId || undefined,
+    wallet: normalizeText(event.wallet) || undefined,
     wallets: [...wallets],
-    jobId: event.jobId?.trim() || undefined,
-    sessionId: event.sessionId?.trim() || undefined,
+    jobId: jobId || undefined,
+    sessionId: sessionId || undefined,
     blockNumber: event.blockNumber ?? null,
     txHash: event.txHash ?? null,
     timestamp: event.timestamp ?? new Date().toISOString(),
     data: event.data ?? {}
   };
+}
+
+function classifyEventTopic(topic, data = {}) {
+  if (topic.startsWith("escrow.")) {
+    return {
+      source: "chain",
+      phase: escrowPhase(topic),
+      severity: escrowSeverity(topic)
+    };
+  }
+  if (topic.startsWith("account.")) {
+    return {
+      source: "chain",
+      phase: accountPhase(topic),
+      severity: topic.includes("slashed") ? "warn" : "info"
+    };
+  }
+  if (topic.startsWith("reputation.")) {
+    return {
+      source: "chain",
+      phase: "reputation",
+      severity: topic.includes("slashed") ? "warn" : "info"
+    };
+  }
+  if (topic.startsWith("content.")) {
+    return {
+      source: "chain",
+      phase: "content",
+      severity: "info"
+    };
+  }
+  if (topic.startsWith("xcm.")) {
+    return {
+      source: "settlement",
+      phase: "settlement",
+      severity: xcmSeverity(topic, data)
+    };
+  }
+  if (topic.startsWith("verification.")) {
+    return {
+      source: "verification",
+      phase: "verification",
+      severity: verificationSeverity(data)
+    };
+  }
+  if (topic.startsWith("recurring.")) {
+    return {
+      source: "schedule",
+      phase: "recurring",
+      severity: topic.includes("failed") ? "error" : "info"
+    };
+  }
+  if (topic.startsWith("jobs.ingest.")) {
+    return {
+      source: "ingestion",
+      phase: "ingestion",
+      severity: "info"
+    };
+  }
+  if (topic.startsWith("system.")) {
+    return {
+      source: "system",
+      phase: "system",
+      severity: topic.includes("error") || topic.includes("failed") ? "error" : "warn"
+    };
+  }
+  if (topic.startsWith("session.")) {
+    return {
+      source: "state",
+      phase: "session",
+      severity: sessionSeverity(data)
+    };
+  }
+  return {
+    source: "event_bus",
+    phase: topic || "event",
+    severity: "info"
+  };
+}
+
+function escrowPhase(topic) {
+  if (topic === "escrow.job_funded") return "funding";
+  if (topic === "escrow.dispute_opened" || topic === "escrow.dispute_resolved") return "dispute";
+  if (
+    topic === "escrow.job_closed" ||
+    topic === "escrow.job_rejected" ||
+    topic === "escrow.auto_resolved_on_timeout"
+  ) {
+    return "settlement";
+  }
+  return "execution";
+}
+
+function escrowSeverity(topic) {
+  if (topic === "escrow.job_rejected") return "error";
+  if (topic === "escrow.dispute_opened") return "warn";
+  return "info";
+}
+
+function accountPhase(topic) {
+  if (topic === "account.job_stake_locked") return "funding";
+  if (topic === "account.job_stake_slashed" || topic === "account.claim_fee_slashed") return "dispute";
+  return "settlement";
+}
+
+function xcmSeverity(topic, data) {
+  const status = normalizeText(data?.statusLabel) || normalizeText(data?.status);
+  if (topic.includes("failed") || status.toLowerCase().includes("failed")) return "error";
+  return "info";
+}
+
+function verificationSeverity(data) {
+  const outcome = normalizeText(data?.outcome);
+  const status = normalizeText(data?.status);
+  if (outcome === "rejected" || status === "rejected") return "error";
+  if (outcome === "disputed" || status === "disputed") return "warn";
+  return "info";
+}
+
+function sessionSeverity(data) {
+  const status = normalizeText(data?.status);
+  if (["failed", "rejected", "slashed"].includes(status)) return "error";
+  if (status === "disputed") return "warn";
+  return "info";
+}
+
+function normalizeSeverity(value) {
+  const normalized = normalizeText(value);
+  return normalized === "info" || normalized === "warn" || normalized === "error"
+    ? normalized
+    : undefined;
+}
+
+function normalizeText(value) {
+  return typeof value === "string" ? value.trim() : "";
 }
 
 function normalizeTopics(topics) {

--- a/mcp-server/src/core/event-bus.test.js
+++ b/mcp-server/src/core/event-bus.test.js
@@ -36,3 +36,48 @@ test("EventBus reports gap when cursor is outside the ring buffer", () => {
     ["b", "c"]
   );
 });
+
+test("EventBus preserves canonical timeline fields and classifies chain topics", () => {
+  const bus = new EventBus();
+  const explicit = bus.publish({
+    id: "explicit-1",
+    topic: "custom.topic",
+    wallet: " 0xabc ",
+    jobId: " job-1 ",
+    sessionId: " session-1 ",
+    source: "custom_source",
+    phase: "custom_phase",
+    severity: "warn",
+    correlationId: "correlation-1",
+    timestamp: "2026-01-01T00:00:00.000Z"
+  });
+
+  assert.equal(explicit.wallet, "0xabc");
+  assert.equal(explicit.source, "custom_source");
+  assert.equal(explicit.phase, "custom_phase");
+  assert.equal(explicit.severity, "warn");
+  assert.equal(explicit.correlationId, "correlation-1");
+
+  const funded = bus.publish({
+    id: "chain-1",
+    topic: "escrow.job_funded",
+    jobId: "job-2",
+    timestamp: "2026-01-01T00:00:01.000Z"
+  });
+  assert.equal(funded.source, "chain");
+  assert.equal(funded.phase, "funding");
+  assert.equal(funded.severity, "info");
+  assert.equal(funded.correlationId, "job-2");
+
+  const rejected = bus.publish({
+    id: "chain-2",
+    topic: "escrow.job_rejected",
+    jobId: "job-3",
+    sessionId: "session-3",
+    timestamp: "2026-01-01T00:00:02.000Z"
+  });
+  assert.equal(rejected.source, "chain");
+  assert.equal(rejected.phase, "settlement");
+  assert.equal(rejected.severity, "error");
+  assert.equal(rejected.correlationId, "session-3");
+});

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -1355,12 +1355,13 @@ function sumSubJobRewards(jobs, asset) {
 function buildEventBusTimelineEntry(event, index) {
   return buildTimelineEntry({
     id: event.id ?? `event-bus:${index}`,
-    type: "event_bus",
+    type: event.type ?? "event_bus",
     at: event.timestamp,
-    correlationId: event.sessionId ?? event.jobId,
-    phase: event.topic,
-    source: "event_bus",
+    correlationId: event.correlationId ?? event.sessionId ?? event.jobId,
+    phase: event.phase ?? event.topic,
+    source: event.source ?? "event_bus",
     topic: event.topic,
+    severity: event.severity ?? "info",
     jobId: event.jobId,
     sessionId: event.sessionId,
     wallet: event.wallet,

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -490,6 +490,18 @@ test("getJobTimeline stitches sessions, verification, events, and child lineage"
     outcome: "approved",
     reasonCode: "BENCHMARK_THRESHOLD_MET"
   });
+  eventBus.publish({
+    id: "chain-funded-parent-job-001",
+    topic: "escrow.job_funded",
+    jobId: "parent-job-001",
+    blockNumber: 123,
+    txHash: "0xabc",
+    timestamp: "2026-01-01T00:00:00.000Z",
+    data: {
+      amount: "2",
+      asset: "DOT"
+    }
+  });
 
   const timeline = await service.getJobTimeline("parent-job-001", { wallet: WALLET });
   assert.equal(timeline.timelineVersion, "v2");
@@ -515,9 +527,16 @@ test("getJobTimeline stitches sessions, verification, events, and child lineage"
   assert.equal(childJob.source, "lineage");
   assert.equal(childJob.jobId, subJob.id);
   const claimedEvent = timeline.timeline.find((entry) => entry.type === "event_bus" && entry.topic === "session.claimed");
-  assert.equal(claimedEvent.source, "event_bus");
+  assert.equal(claimedEvent.source, "state");
   assert.equal(claimedEvent.jobId, "parent-job-001");
   assert.equal(claimedEvent.sessionId, submitted.sessionId);
+  const fundedEvent = timeline.timeline.find((entry) => entry.topic === "escrow.job_funded");
+  assert.equal(fundedEvent.type, "event_bus");
+  assert.equal(fundedEvent.source, "chain");
+  assert.equal(fundedEvent.phase, "funding");
+  assert.equal(fundedEvent.severity, "info");
+  assert.equal(fundedEvent.correlationId, "parent-job-001");
+  assert.equal(fundedEvent.data.txHash, "0xabc");
 });
 
 test("getAdminStatus surfaces recurring scheduler anomalies", async () => {


### PR DESCRIPTION
## Summary
- Preserve canonical event-bus timeline fields (`source`, `phase`, `severity`, `type`, `correlationId`) instead of flattening everything back to generic `event_bus` rows.
- Classify chain, settlement/XCM, ingestion, system, session, recurring, and verification topics so `/admin/jobs/timeline` can show funding, settlement, dispute, and platform traces with useful labels.
- Add operator UI source chips and typed timeline sources for the new canonical source kinds.

## Impact
- Backend: yes, event-bus normalization and job timeline projection.
- Frontend/operator app: yes, timeline source chip styling/types.
- Indexer/Caddy/contracts/public site: no.
- Env/VPS secrets: none.

## Validation
- `npm --workspace mcp-server test`
- `npm run typecheck:app`
- `npm run build:frontend`
- `git diff --check HEAD~1..HEAD`

## Notes
- Checked the Polkadot docs MCP: the XCM debug/dry-run docs frame emitted events as the right evidence trail for execution diagnostics, so this change keeps those observations in Averray timelines without changing chain behavior.
