### PR TITLE
PR 2.5 hotfix: chown env_file output to deploy user (compose CLI reads it)

### DIFF
--- a/deploy/agent-stack.tmpfiles.conf
+++ b/deploy/agent-stack.tmpfiles.conf
@@ -12,16 +12,26 @@
 #     containing secrets.
 #   - tmpfiles.d entries are declarative; idempotent; auditable.
 #
-# Why 0700 root:root:
-#   - The Docker daemon runs as root and starts the agent-stack
-#     containers as root. Containers read /run/agent-stack/*.env via
-#     compose's env_file directive at startup.
-#   - Mode 0700 means no other user on the VPS (including the
-#     `ubuntu` deploy user) can read the rendered env files.
-#   - render-vps-env.sh writes individual files at 0400 root:root
-#     inside this directory.
+# Why 0750 root:ubuntu (revised in PR 2.5 hotfix from 0700 root:root):
+#   - Docker Compose's CLI runs as the `ubuntu` deploy user (not root)
+#     on this VPS, and the CLI reads `env_file:` at client-side to
+#     construct the container env. The original 0700 root:root
+#     blocked that read entirely (deploy aborted with
+#     "open /run/agent-stack/backend.env: permission denied").
+#   - 0750 root:ubuntu lets the ubuntu group enter and list the
+#     directory; individual files inside are 0400 ubuntu:ubuntu (set
+#     by render-vps-env.sh's RENDER_OUTPUT_OWNER), readable only by
+#     the deploy user.
+#   - Ubuntu has passwordless sudo on this VPS, so "root-only readable"
+#     was never a meaningful firebreak in practice. The realistic
+#     threat model is: ubuntu compromise = full secret exposure either
+#     way (the attacker can sudo to root, or docker exec into the
+#     running container's env). Switching to 0750 root:ubuntu doesn't
+#     materially weaken that.
+#   - /run is still tmpfs — contents wiped on reboot — and the
+#     directory is still inaccessible to any other user on the box.
 #
 # Format: type path mode user group age argument
 # Reference: man tmpfiles.d
 
-d /run/agent-stack 0700 root root - -
+d /run/agent-stack 0750 root ubuntu - -

--- a/scripts/ops/render-vps-env.sh
+++ b/scripts/ops/render-vps-env.sh
@@ -188,16 +188,26 @@ fi
 
 # ── Install ────────────────────────────────────────────────────────────────
 
-# Final permissions match the v3 plan: 0400, root-owned. The compose
-# service that consumes this file MUST be readable by root at startup
-# (Docker daemon runs as root). If compose runs as non-root, the chown
-# needs adjustment — make that an explicit operator decision rather
-# than a silent permission drift.
+# Final permissions: 0400 readable by the deploy user (default: ubuntu).
+#
+# Docker Compose's CLI runs as the deploy user (not root) on this VPS,
+# and the CLI reads `env_file:` at *client* time to construct the
+# container env. So the file must be readable by the user that runs
+# `docker compose`. The original v3 plan called for 0400 root:root,
+# but that breaks compose CLI's read step (it has no sudo path); the
+# realistic threat model on this VPS is that the ubuntu user has
+# passwordless sudo anyway, so "root-only readable" was never a
+# meaningful firebreak in practice.
+#
+# Configurable via RENDER_OUTPUT_OWNER (default: ubuntu:ubuntu).
+# Containing directory /run/agent-stack needs to allow the same user
+# to enter it; tmpfiles.d config in this PR sets 0750 root:ubuntu.
+RENDER_OUTPUT_OWNER="${RENDER_OUTPUT_OWNER:-ubuntu:ubuntu}"
 chmod 0400 "$tmp"
-chown root:root "$tmp" 2>/dev/null || {
-  # Non-root invocation: skip chown, log a note, continue. The file is
-  # still 0400; only the owning user can read it.
-  echo "render-vps-env.sh: warning: chown root:root failed (not running as root?); leaving file owned by $(id -un)" >&2
+chown "$RENDER_OUTPUT_OWNER" "$tmp" 2>/dev/null || {
+  # Chown failure (likely: not running as root, or owner doesn't exist).
+  # Fail loud rather than leave permissions in an unexpected state.
+  fail "chown $RENDER_OUTPUT_OWNER failed on $tmp; refusing to install with wrong ownership"
 }
 
 # Atomic mv on the same filesystem (tmp is in $runtime_dir, target is


### PR DESCRIPTION
## Summary
PR 2.5 cutover attempt (deploy #272) failed with \`open /run/agent-stack/backend.env: permission denied\`. The cutover compose file was rolled back to \`/srv\` paths; production is healthy.

Root cause: \`render-vps-env.sh\` wrote env files as \`0400 root:root\`, but Docker Compose's CLI runs as the \`ubuntu\` deploy user. Compose reads \`env_file:\` at *client-side* to construct container env — it needs to read the file as ubuntu, not as root.

Fail-closed worked exactly as designed (deploy aborted before any container restart).

## Fix
- **\`scripts/ops/render-vps-env.sh\`**: replace hardcoded \`chown root:root\` with \`chown \${RENDER_OUTPUT_OWNER:-ubuntu:ubuntu}\`. Fail-loud on chown failure.
- **\`deploy/agent-stack.tmpfiles.conf\`**: change \`/run/agent-stack\` from \`0700 root root\` to \`0750 root ubuntu\` so ubuntu group can enter the directory.

## Threat model note
"Root-only readable" was never a meaningful firebreak on this VPS — ubuntu has passwordless sudo. Attacker with code-exec as ubuntu can already \`sudo cat\` the file or \`docker exec\` into the container and dump env. Switching to ubuntu-readable doesn't materially weaken security.

## Operator sequence after merge
1. Pull latest main on VPS, apply tmpfiles change:
   \`\`\`bash
   ssh ubuntu@VPS 'cd /srv/agent-stack/app && sudo git pull origin main'
   ssh ubuntu@VPS 'sudo cp /srv/agent-stack/app/deploy/agent-stack.tmpfiles.conf /etc/tmpfiles.d/agent-stack.conf && sudo systemd-tmpfiles --create && ls -ld /run/agent-stack'
   \`\`\`
2. Re-flip compose to /run paths (the .pre-pr2.5 backup is still around):
   \`\`\`bash
   ssh ubuntu@VPS "sudo sed -i -e 's|/srv/agent-stack/backend.env|/run/agent-stack/backend.env|' -e 's|/srv/agent-stack/indexer.env|/run/agent-stack/indexer.env|' /srv/agent-stack/docker-compose.yml"
   \`\`\`
3. Trigger deploy:
   \`\`\`bash
   gh workflow run deploy-production.yml -R averray-agent/agent
   \`\`\`

## Test plan
- [ ] After merge + tmpfiles apply, \`ls -ld /run/agent-stack\` shows \`drwxr-x--- root ubuntu\`
- [ ] After re-flip + deploy, deploy completes green
- [ ] \`sudo docker inspect agent-backend\` env values match \`/run/agent-stack/backend.env\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)