### PR TITLE
[codex] Persist event log for job timelines

### DIFF
--- a/app/lib/api/hooks.ts
+++ b/app/lib/api/hooks.ts
@@ -98,13 +98,47 @@ export const useAdminJobs = () =>
  * /runs/detail. Skips the fetch when no jobId is selected so the
  * panel doesn't 400 on first paint.
  */
-export const useJobTimeline = (jobId: string | null) =>
+export type JobTimelineFilters = {
+  topics?: string[];
+  sources?: string[];
+  phases?: string[];
+  severities?: string[];
+  correlationId?: string | null;
+  wallet?: string | null;
+};
+
+export const useJobTimeline = (jobId: string | null, filters: JobTimelineFilters = {}) =>
   useApi(
     jobId
-      ? `/admin/jobs/timeline?jobId=${encodeURIComponent(jobId)}&limit=100`
+      ? `/admin/jobs/timeline?${jobTimelineParams(jobId, filters)}`
       : null,
     { refreshInterval: 15_000 }
   );
+
+function jobTimelineParams(jobId: string, filters: JobTimelineFilters): string {
+  const params = new URLSearchParams({
+    jobId,
+    limit: "100",
+  });
+  appendCsvParam(params, "topics", filters.topics);
+  appendCsvParam(params, "sources", filters.sources);
+  appendCsvParam(params, "phases", filters.phases);
+  appendCsvParam(params, "severities", filters.severities);
+  if (filters.correlationId) {
+    params.set("correlationId", filters.correlationId);
+  }
+  if (filters.wallet) {
+    params.set("eventWallet", filters.wallet);
+  }
+  return params.toString();
+}
+
+function appendCsvParam(params: URLSearchParams, key: string, values: string[] | undefined) {
+  const clean = (values ?? []).map((value) => value.trim()).filter(Boolean);
+  if (clean.length > 0) {
+    params.set(key, clean.join(","));
+  }
+}
 export const useOnboarding = () => useApi("/onboarding");
 export const useVerifierHandlers = () => useApi("/verifier/handlers");
 export const useSessionStateMachine = () => useApi("/session/state-machine");

--- a/app/lib/api/job-timeline.ts
+++ b/app/lib/api/job-timeline.ts
@@ -80,6 +80,14 @@ export interface TimelineSummary {
   derivativeJobCount: number;
   eventCount: number;
   eventBusGap: boolean;
+  eventFilters: {
+    topics: string[];
+    sources: string[];
+    phases: string[];
+    severities: string[];
+    correlationId: string | null;
+    wallet: string | null;
+  };
   latestSessionStatus: string | null;
 }
 
@@ -115,6 +123,14 @@ export const EMPTY_JOB_TIMELINE: JobTimeline = {
     derivativeJobCount: 0,
     eventCount: 0,
     eventBusGap: false,
+    eventFilters: {
+      topics: [],
+      sources: [],
+      phases: [],
+      severities: [],
+      correlationId: null,
+      wallet: null,
+    },
     latestSessionStatus: null,
   },
   timeline: [],
@@ -149,11 +165,24 @@ export function buildJobTimeline(payload: unknown): JobTimeline {
       derivativeJobCount: nonNegInt(summary.derivativeJobCount),
       eventCount: nonNegInt(summary.eventCount),
       eventBusGap: Boolean(summary.eventBusGap),
+      eventFilters: buildEventFilters(summary.eventFilters),
       latestSessionStatus: text(summary.latestSessionStatus) || null,
     },
     timeline: timelineRaw
       .map(buildTimelineEntry)
       .filter((entry): entry is TimelineEntry => entry !== null),
+  };
+}
+
+function buildEventFilters(value: unknown): TimelineSummary["eventFilters"] {
+  const record = asRecord(value) ?? {};
+  return {
+    topics: stringArray(record.topics),
+    sources: stringArray(record.sources),
+    phases: stringArray(record.phases),
+    severities: stringArray(record.severities),
+    correlationId: text(record.correlationId) || null,
+    wallet: text(record.wallet) || null,
   };
 }
 

--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -281,16 +281,21 @@ emit into it with the same topic taxonomy.
 - timeline entries use one canonical envelope with `id`, `type`, `at`,
   `timestamp`, `correlationId`, `phase`, `source`, `topic`, `severity`,
   direct `jobId` / `sessionId` / `wallet` fields, and compact `data`
+- event-bus entries are persisted through the state store in both memory and
+  Redis modes, so `/events` replay and `/admin/jobs/timeline` can recover
+  recent event traces after a process restart
+- `/events` and `/admin/jobs/timeline` accept source, topic, phase, severity,
+  and correlation-id filters; the frontend client hook can pass the same filter
+  shape through to the backend
 - recurring template fire history is reconstructed through derivative jobs,
   and sub-job lineage is reconstructed through `parentSessionId`
 
 ### Remaining gaps
 
 - not every producer emits a canonical topic and payload shape yet
-- event-bus replay is still in-memory, so long-term history is reconstructed
-  mostly from state snapshots
 - funding and settlement state are not fully folded into the same timeline
-- operator UI still needs richer timeline filtering and source labels
+- operator UI still needs visible timeline filter controls for source, topic,
+  wallet, and correlation id
 
 ### Improve to
 
@@ -302,10 +307,9 @@ emit into it with the same topic taxonomy.
 ### Concrete next changes
 
 - standardize the remaining platform event topics and payload shapes
-- persist the event log or extend state snapshots where replay windows are too
-  short for audits
 - merge funding, settlement, and dispute state into the same job/session trace
-- expose UI/SDK filters for source, topic, wallet, and correlation id
+- expose visible operator controls for source, topic, wallet, and correlation-id
+  filters
 
 ### What this unlocks
 

--- a/mcp-server/src/core/event-bus.js
+++ b/mcp-server/src/core/event-bus.js
@@ -1,10 +1,13 @@
 const DEFAULT_EVENT_BUFFER_SIZE = 500;
 
 export class EventBus {
-  constructor({ bufferSize = DEFAULT_EVENT_BUFFER_SIZE } = {}) {
+  constructor({ bufferSize = DEFAULT_EVENT_BUFFER_SIZE, eventStore = undefined, logger = console } = {}) {
     this.bufferSize = bufferSize;
+    this.eventStore = eventStore;
+    this.logger = logger;
     this.buffer = [];
     this.subscribers = new Set();
+    this.persistQueue = Promise.resolve();
   }
 
   subscribe(filter, handler) {
@@ -24,6 +27,7 @@ export class EventBus {
     if (this.buffer.length > this.bufferSize) {
       this.buffer.shift();
     }
+    this.queuePersist(normalized);
 
     for (const subscription of this.subscribers) {
       if (matchesFilter(normalized, subscription.filter)) {
@@ -32,6 +36,26 @@ export class EventBus {
     }
 
     return normalized;
+  }
+
+  queuePersist(event) {
+    if (!this.eventStore?.appendEventLog) {
+      return;
+    }
+
+    this.persistQueue = this.persistQueue
+      .catch(() => undefined)
+      .then(() => this.eventStore.appendEventLog(event))
+      .catch((error) => {
+        this.logger?.warn?.(
+          { eventId: event.id, topic: event.topic, error: error?.message ?? String(error) },
+          "event_bus.persist_failed"
+        );
+      });
+  }
+
+  async flush() {
+    await this.persistQueue;
   }
 
   replay(filter = {}, lastEventId = undefined) {
@@ -56,6 +80,32 @@ export class EventBus {
       gap: false
     };
   }
+
+  async replayDurable(filter = {}, lastEventId = undefined, { limit = this.bufferSize } = {}) {
+    const normalizedFilter = normalizeFilter(filter);
+    if (!this.eventStore?.listEventLog) {
+      return this.replay(normalizedFilter, lastEventId);
+    }
+
+    const stored = await this.eventStore.listEventLog({
+      ...normalizedFilter,
+      lastEventId,
+      limit
+    });
+    const live = this.replay(normalizedFilter, lastEventId);
+    const byId = new Map();
+    for (const event of [...(stored.events ?? []), ...live.events]) {
+      byId.set(event.id, event);
+    }
+    const events = [...byId.values()]
+      .sort((left, right) => String(left.timestamp ?? "").localeCompare(String(right.timestamp ?? "")))
+      .slice(-Math.max(limit, 0));
+
+    return {
+      events,
+      gap: Boolean(stored.gap)
+    };
+  }
 }
 
 function normalizeFilter(filter = {}) {
@@ -63,7 +113,11 @@ function normalizeFilter(filter = {}) {
     wallet: filter.wallet?.trim() || undefined,
     jobId: filter.jobId?.trim() || undefined,
     sessionId: filter.sessionId?.trim() || undefined,
-    topics: normalizeTopics(filter.topics)
+    correlationId: filter.correlationId?.trim() || undefined,
+    topics: normalizeTopics(filter.topics ?? filter.topic),
+    sources: normalizeTopics(filter.sources ?? filter.source),
+    phases: normalizeTopics(filter.phases ?? filter.phase),
+    severities: normalizeTopics(filter.severities ?? filter.severity)
   };
 }
 
@@ -77,9 +131,10 @@ function normalizeEvent(event) {
   );
   const jobId = normalizeText(event.jobId);
   const sessionId = normalizeText(event.sessionId);
+  const timestamp = normalizeText(event.timestamp) || new Date().toISOString();
 
   return {
-    id: normalizeText(event.id) || undefined,
+    id: normalizeText(event.id) || `event-${Date.parse(timestamp) || Date.now()}-${nextEventSequence()}`,
     topic,
     type: normalizeText(event.type) || "event_bus",
     source: normalizeText(event.source) || taxonomy.source,
@@ -92,7 +147,7 @@ function normalizeEvent(event) {
     sessionId: sessionId || undefined,
     blockNumber: event.blockNumber ?? null,
     txHash: event.txHash ?? null,
-    timestamp: event.timestamp ?? new Date().toISOString(),
+    timestamp,
     data: event.data ?? {}
   };
 }
@@ -249,11 +304,30 @@ export function matchesFilter(event, filter = {}) {
     return false;
   }
 
+  const sources = normalizeTopics(filter.sources);
+  if (sources.length && !sources.includes(event.source)) {
+    return false;
+  }
+
+  const phases = normalizeTopics(filter.phases);
+  if (phases.length && !phases.includes(event.phase)) {
+    return false;
+  }
+
+  const severities = normalizeTopics(filter.severities);
+  if (severities.length && !severities.includes(event.severity)) {
+    return false;
+  }
+
   if (filter.jobId && event.jobId !== filter.jobId) {
     return false;
   }
 
   if (filter.sessionId && event.sessionId !== filter.sessionId) {
+    return false;
+  }
+
+  if (filter.correlationId && event.correlationId !== filter.correlationId) {
     return false;
   }
 
@@ -265,4 +339,11 @@ export function matchesFilter(event, filter = {}) {
   }
 
   return true;
+}
+
+let eventSequence = 0;
+
+function nextEventSequence() {
+  eventSequence = (eventSequence + 1) % Number.MAX_SAFE_INTEGER;
+  return eventSequence;
 }

--- a/mcp-server/src/core/event-bus.test.js
+++ b/mcp-server/src/core/event-bus.test.js
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { EventBus } from "./event-bus.js";
+import { MemoryStateStore } from "./state-store.js";
 
 test("EventBus replays filtered events after a cursor", () => {
   const bus = new EventBus({ bufferSize: 3 });
@@ -80,4 +81,45 @@ test("EventBus preserves canonical timeline fields and classifies chain topics",
   assert.equal(rejected.phase, "settlement");
   assert.equal(rejected.severity, "error");
   assert.equal(rejected.correlationId, "session-3");
+});
+
+test("EventBus persists events and replays durable filters beyond the ring buffer", async () => {
+  const store = new MemoryStateStore();
+  const bus = new EventBus({ bufferSize: 1, eventStore: store });
+  bus.publish({
+    id: "funded-1",
+    topic: "escrow.job_funded",
+    wallet: "0xabc",
+    jobId: "job-1",
+    timestamp: "2026-01-01T00:00:00.000Z"
+  });
+  bus.publish({
+    id: "submitted-1",
+    topic: "session.submitted",
+    wallet: "0xabc",
+    jobId: "job-1",
+    sessionId: "session-1",
+    correlationId: "session-1",
+    timestamp: "2026-01-01T00:00:01.000Z"
+  });
+  bus.publish({
+    id: "settled-1",
+    topic: "xcm.settlement_succeeded",
+    wallet: "0xabc",
+    jobId: "job-1",
+    correlationId: "settlement-1",
+    timestamp: "2026-01-01T00:00:02.000Z"
+  });
+  await bus.flush();
+
+  const chainReplay = await bus.replayDurable({ jobId: "job-1", sources: ["chain"] }, undefined, { limit: 10 });
+  assert.equal(chainReplay.gap, false);
+  assert.deepEqual(chainReplay.events.map((event) => event.id), ["funded-1"]);
+
+  const correlationReplay = await bus.replayDurable(
+    { wallet: "0xabc", correlationId: "settlement-1" },
+    undefined,
+    { limit: 10 }
+  );
+  assert.deepEqual(correlationReplay.events.map((event) => event.id), ["settled-1"]);
 });

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -660,7 +660,17 @@ export class PlatformService {
     };
   }
 
-  async getJobTimeline(jobId, { wallet = undefined, now = new Date(), limit = 100 } = {}) {
+  async getJobTimeline(jobId, {
+    wallet = undefined,
+    now = new Date(),
+    limit = 100,
+    topics = undefined,
+    sources = undefined,
+    phases = undefined,
+    severities = undefined,
+    correlationId = undefined,
+    eventWallet = undefined
+  } = {}) {
     const baseJob = this.jobCatalogService.getJobDefinition(jobId);
     const [job, sessions] = await Promise.all([
       this.attachClaimState(baseJob, { wallet, now }),
@@ -690,7 +700,10 @@ export class PlatformService {
     const parentSession = job.parentSessionId
       ? await this.stateStore.getSession?.(job.parentSessionId)
       : undefined;
-    const eventBusReplay = this.eventBus?.replay?.({ jobId }, undefined) ?? { events: [], gap: false };
+    const eventFilter = { jobId, wallet: eventWallet, topics, sources, phases, severities, correlationId };
+    const eventBusReplay = this.eventBus?.replayDurable
+      ? await this.eventBus.replayDurable(eventFilter, undefined, { limit })
+      : (this.eventBus?.replay?.(eventFilter, undefined) ?? { events: [], gap: false });
 
     const sessionEvents = sessions.flatMap((session) => buildSessionTimelineEntries(session));
     const verificationEvents = sessions
@@ -747,6 +760,14 @@ export class PlatformService {
         derivativeJobCount: derivativeJobs.length,
         eventCount: timeline.length,
         eventBusGap: Boolean(eventBusReplay.gap),
+        eventFilters: {
+          topics: topics ?? [],
+          sources: sources ?? [],
+          phases: phases ?? [],
+          severities: severities ?? [],
+          correlationId: correlationId ?? null,
+          wallet: eventWallet ?? null
+        },
         latestSessionStatus: sessions[0]?.status ?? null
       },
       timeline

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import { PlatformService } from "./platform-service.js";
 import { EventBus } from "./event-bus.js";
+import { MemoryStateStore } from "./state-store.js";
 
 const WALLET = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const CANONICAL_USDC_ASSET = {
@@ -14,7 +15,7 @@ const CANONICAL_USDC_ASSET = {
   minBalanceRaw: "70000"
 };
 
-function makePlatformService(blockchainGateway = undefined, eventBus = undefined) {
+function makePlatformService(blockchainGateway = undefined, eventBus = undefined, stateStore = undefined) {
   const jobs = [
     {
       id: "parent-job-001",
@@ -62,7 +63,7 @@ function makePlatformService(blockchainGateway = undefined, eventBus = undefined
   const reputations = new Map([
     [WALLET, { skill: 50, reliability: 50, economic: 50, tier: "starter" }]
   ]);
-  return new PlatformService(jobs, profiles, accounts, reputations, blockchainGateway, undefined, eventBus);
+  return new PlatformService(jobs, profiles, accounts, reputations, blockchainGateway, stateStore, eventBus);
 }
 
 test("createSubJob links the child job to the active parent session", async () => {
@@ -537,6 +538,64 @@ test("getJobTimeline stitches sessions, verification, events, and child lineage"
   assert.equal(fundedEvent.severity, "info");
   assert.equal(fundedEvent.correlationId, "parent-job-001");
   assert.equal(fundedEvent.data.txHash, "0xabc");
+});
+
+test("getJobTimeline reads durable event log and applies event filters", async () => {
+  const stateStore = new MemoryStateStore();
+  const writerBus = new EventBus({ bufferSize: 1, eventStore: stateStore });
+  writerBus.publish({
+    id: "durable-chain-funded",
+    topic: "escrow.job_funded",
+    jobId: "parent-job-001",
+    wallet: WALLET,
+    timestamp: "2026-01-01T00:00:00.000Z"
+  });
+  writerBus.publish({
+    id: "durable-settlement",
+    topic: "xcm.settlement_succeeded",
+    jobId: "parent-job-001",
+    wallet: WALLET,
+    correlationId: "settlement-correlation-1",
+    timestamp: "2026-01-01T00:00:01.000Z"
+  });
+  writerBus.publish({
+    id: "durable-other-wallet",
+    topic: "escrow.job_funded",
+    jobId: "parent-job-001",
+    wallet: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    timestamp: "2026-01-01T00:00:02.000Z"
+  });
+  await writerBus.flush();
+
+  const readerBus = new EventBus({ bufferSize: 1, eventStore: stateStore });
+  const service = makePlatformService(undefined, readerBus, stateStore);
+
+  const chainTimeline = await service.getJobTimeline("parent-job-001", {
+    wallet: WALLET,
+    sources: ["chain"],
+    limit: 10
+  });
+  assert.ok(chainTimeline.timeline.some((entry) => entry.id === "durable-chain-funded"));
+  assert.ok(!chainTimeline.timeline.some((entry) => entry.id === "durable-settlement"));
+  assert.deepEqual(chainTimeline.summary.eventFilters.sources, ["chain"]);
+
+  const correlationTimeline = await service.getJobTimeline("parent-job-001", {
+    wallet: WALLET,
+    correlationId: "settlement-correlation-1",
+    limit: 10
+  });
+  assert.ok(correlationTimeline.timeline.some((entry) => entry.id === "durable-settlement"));
+  assert.ok(!correlationTimeline.timeline.some((entry) => entry.id === "durable-chain-funded"));
+  assert.equal(correlationTimeline.summary.eventFilters.correlationId, "settlement-correlation-1");
+
+  const walletTimeline = await service.getJobTimeline("parent-job-001", {
+    wallet: WALLET,
+    eventWallet: WALLET,
+    limit: 10
+  });
+  assert.ok(walletTimeline.timeline.some((entry) => entry.id === "durable-chain-funded"));
+  assert.ok(!walletTimeline.timeline.some((entry) => entry.id === "durable-other-wallet"));
+  assert.equal(walletTimeline.summary.eventFilters.wallet, WALLET);
 });
 
 test("getAdminStatus surfaces recurring scheduler anomalies", async () => {

--- a/mcp-server/src/core/state-store.js
+++ b/mcp-server/src/core/state-store.js
@@ -1,5 +1,8 @@
 import { createClient } from "redis";
 import { ExternalServiceError } from "./errors.js";
+import { matchesFilter } from "./event-bus.js";
+
+const DEFAULT_EVENT_LOG_RETENTION = 5_000;
 
 const RELEASE_CLAIM_LOCK_SCRIPT = `
 if redis.call("get", KEYS[1]) == ARGV[1] then
@@ -47,6 +50,7 @@ export class MemoryStateStore {
     this.content = new Map();
     this.fundedJobs = new Map();
     this.capabilityGrants = new Map();
+    this.eventLog = [];
   }
 
   async getSession(sessionId) {
@@ -254,6 +258,22 @@ export class MemoryStateStore {
       .filter((entry) => !entry.processed)
       .sort((left, right) => String(left.observedAt ?? "").localeCompare(String(right.observedAt ?? "")))
       .slice(0, Math.max(limit, 0));
+  }
+
+  async appendEventLog(event) {
+    const existingIndex = this.eventLog.findIndex((entry) => entry.id === event.id);
+    if (existingIndex >= 0) {
+      this.eventLog.splice(existingIndex, 1);
+    }
+    this.eventLog.push(event);
+    if (this.eventLog.length > DEFAULT_EVENT_LOG_RETENTION) {
+      this.eventLog.splice(0, this.eventLog.length - DEFAULT_EVENT_LOG_RETENTION);
+    }
+    return event;
+  }
+
+  async listEventLog(filter = {}) {
+    return listEventLogFromRecords(this.eventLog, filter);
   }
 
   async markXcmObservationProcessed(requestId, result = undefined) {
@@ -608,6 +628,33 @@ export class RedisStateStore {
     return entries.filter((entry) => entry && !entry.processed);
   }
 
+  async appendEventLog(event) {
+    await this.connect();
+    const id = String(event?.id ?? "");
+    if (!id) return event;
+    const score = Date.parse(event?.timestamp ?? "") || Date.now();
+    const recordKey = this.key("event-log", id);
+    const indexKey = this.key("event-log", "all");
+    await this.client.set(recordKey, JSON.stringify(event));
+    await this.client.zAdd(indexKey, { score, value: id });
+    const staleIds = await this.client.zRange(indexKey, 0, -(DEFAULT_EVENT_LOG_RETENTION + 1));
+    if (staleIds.length > 0) {
+      await this.client.zRem(indexKey, staleIds);
+      await this.client.del(staleIds.map((staleId) => this.key("event-log", staleId)));
+    }
+    return event;
+  }
+
+  async listEventLog(filter = {}) {
+    await this.connect();
+    const ids = await this.client.zRange(this.key("event-log", "all"), 0, -1);
+    const records = await Promise.all(ids.map(async (id) => {
+      const raw = await this.client.get(this.key("event-log", id));
+      return raw ? JSON.parse(raw) : undefined;
+    }));
+    return listEventLogFromRecords(records.filter(Boolean), filter);
+  }
+
   async markXcmObservationProcessed(requestId, result = undefined) {
     await this.connect();
     const current = await this.getXcmObservation(requestId);
@@ -748,6 +795,28 @@ export class RedisStateStore {
   key(kind, id) {
     return `${this.namespace}:${kind}:${id}`;
   }
+}
+
+function listEventLogFromRecords(records, filter = {}) {
+  const limit = normalizeListLimit(filter.limit, 100, 500);
+  const lastEventId = String(filter.lastEventId ?? "").trim();
+  const cursorIndex = lastEventId
+    ? records.findIndex((event) => event.id === lastEventId)
+    : -1;
+  const scoped = cursorIndex >= 0
+    ? records.slice(cursorIndex + 1)
+    : records;
+  const filtered = scoped.filter((event) => matchesFilter(event, filter));
+  return {
+    events: lastEventId ? filtered.slice(0, limit) : filtered.slice(-limit),
+    gap: Boolean(lastEventId && cursorIndex === -1 && records.length > 0)
+  };
+}
+
+function normalizeListLimit(value, fallback, max) {
+  const parsed = Number(value ?? fallback);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.min(Math.trunc(parsed), max);
 }
 
 export function createStateStore(env = process.env, { logger = console } = {}) {

--- a/mcp-server/src/core/state-store.test.js
+++ b/mcp-server/src/core/state-store.test.js
@@ -122,6 +122,50 @@ test("MemoryStateStore xcm observations round-trip and clear from pending when p
   assert.equal(after.length, 0);
 });
 
+test("MemoryStateStore event log survives buffer-sized reads and filters by source/correlation", async () => {
+  const store = new MemoryStateStore();
+  await store.appendEventLog({
+    id: "event-1",
+    topic: "escrow.job_funded",
+    source: "chain",
+    phase: "funding",
+    severity: "info",
+    wallet: "0xaaa",
+    wallets: ["0xaaa"],
+    jobId: "job-1",
+    correlationId: "job-1",
+    timestamp: "2026-01-01T00:00:00.000Z",
+    data: {}
+  });
+  await store.appendEventLog({
+    id: "event-2",
+    topic: "xcm.settlement_failed",
+    source: "settlement",
+    phase: "settlement",
+    severity: "error",
+    wallet: "0xaaa",
+    wallets: ["0xaaa"],
+    jobId: "job-1",
+    correlationId: "settlement-1",
+    timestamp: "2026-01-01T00:00:01.000Z",
+    data: {}
+  });
+
+  const sourceFiltered = await store.listEventLog({ jobId: "job-1", sources: ["chain"], limit: 10 });
+  assert.deepEqual(sourceFiltered.events.map((event) => event.id), ["event-1"]);
+  assert.equal(sourceFiltered.gap, false);
+
+  const correlationFiltered = await store.listEventLog({
+    wallet: "0xaaa",
+    correlationId: "settlement-1",
+    limit: 10
+  });
+  assert.deepEqual(correlationFiltered.events.map((event) => event.id), ["event-2"]);
+
+  const afterCursor = await store.listEventLog({ jobId: "job-1", lastEventId: "event-1", limit: 10 });
+  assert.deepEqual(afterCursor.events.map((event) => event.id), ["event-2"]);
+});
+
 test("MemoryStateStore service state round-trips and merges", async () => {
   const store = new MemoryStateStore();
   await store.upsertServiceState("xcm-observer", {

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -152,11 +152,29 @@ function writeSseEvent(response, { id, topic, data }) {
 }
 
 function parseTopics(url) {
+  return parseCsvParam(url, "topics");
+}
+
+function parseCsvParam(url, name) {
   return url.searchParams
-    .get("topics")
+    .get(name)
     ?.split(",")
     .map((topic) => topic.trim())
     .filter(Boolean) ?? [];
+}
+
+function parseEventFilters(url, { includeWallet = false } = {}) {
+  const filters = {
+    topics: parseTopics(url),
+    sources: parseCsvParam(url, "sources").concat(parseCsvParam(url, "source")),
+    phases: parseCsvParam(url, "phases").concat(parseCsvParam(url, "phase")),
+    severities: parseCsvParam(url, "severities").concat(parseCsvParam(url, "severity")),
+    correlationId: url.searchParams.get("correlationId")?.trim() || undefined
+  };
+  if (includeWallet) {
+    filters.eventWallet = url.searchParams.get("eventWallet")?.trim() || url.searchParams.get("wallet")?.trim() || undefined;
+  }
+  return filters;
 }
 
 function generateNonce() {
@@ -1678,7 +1696,8 @@ const server = createServer(async (request, response) => {
         200,
         await service.getJobTimeline(jobId.trim(), {
           wallet: auth.wallet,
-          limit: parseLimit(url, 100, 250)
+          limit: parseLimit(url, 100, 250),
+          ...parseEventFilters(url, { includeWallet: true })
         })
       );
     }
@@ -2336,10 +2355,12 @@ const server = createServer(async (request, response) => {
         wallet: auth.wallet,
         jobId: url.searchParams.get("jobId") ?? undefined,
         sessionId: url.searchParams.get("sessionId") ?? undefined,
-        topics: parseTopics(url)
+        ...parseEventFilters(url)
       };
       const lastEventId = request.headers["last-event-id"] ?? url.searchParams.get("lastEventId") ?? undefined;
-      const replay = eventBus?.replay?.(filter, lastEventId);
+      const replay = eventBus?.replayDurable
+        ? await eventBus.replayDurable(filter, lastEventId, { limit: parseLimit(url, 100, 500) })
+        : eventBus?.replay?.(filter, lastEventId);
 
       if (replay?.gap) {
         writeSseEvent(response, {

--- a/mcp-server/src/services/bootstrap.js
+++ b/mcp-server/src/services/bootstrap.js
@@ -137,7 +137,7 @@ const reputations = new Map([
 export function createPlatformService() {
   const gateway = new BlockchainGateway();
   const stateStore = createStateStore();
-  const eventBus = new EventBus();
+  const eventBus = new EventBus({ eventStore: stateStore });
   return new PlatformService(jobs, profiles, accounts, reputations, gateway, stateStore, eventBus);
 }
 
@@ -159,7 +159,7 @@ export async function createPlatformRuntime() {
   const contentRecoveryLog = initStep("init-content-recovery-log", logger, () =>
     createContentRecoveryLog(process.env, { logger })
   );
-  const eventBus = initStep("init-event-bus", logger, () => new EventBus());
+  const eventBus = initStep("init-event-bus", logger, () => new EventBus({ eventStore: stateStore, logger }));
   const platformService = initStep(
     "init-platform-service",
     logger,


### PR DESCRIPTION
## Summary
- add a durable event-log path to Memory/Redis state stores and wire EventBus append/replay through it
- make `/events` and `/admin/jobs/timeline` replay durable events and support topic/source/phase/severity/correlation/wallet filters
- expose the timeline filter shape in the operator app API hook/types and update the framework roadmap

## Impact
- Backend: yes
- Operator frontend source/types: yes
- Docs: yes
- Indexer/Caddy/contracts/public site/env: no

## Validation
- `node --test mcp-server/src/core/event-bus.test.js mcp-server/src/core/state-store.test.js mcp-server/src/core/platform-service.test.js`
- `npm --workspace mcp-server test`
- `npm run typecheck:app`
- `npm run build:frontend`
- `git diff --check`

## Notes
- Checked against the Polkadot docs MCP: emitted events are part of the diagnostic surface for XCM execution debugging, so preserving and replaying our timeline events lines up with the platform debugging model.