### PR TITLE
Phase 2 PR 2.8a: load ADMIN_JWT from 1Password (parity check, non-blocking)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -170,6 +170,12 @@ jobs:
             # through CI. Caddy auth is verified via the bcrypt HASH only.
             test -n "$APP_BASIC_AUTH_PASSWORD_HASH"
           fi
+          # Phase 2 PR 2.8a: fail fast if the legacy ADMIN_JWT is empty.
+          # The hosted product-proof smoke check on the VPS needs this to
+          # authenticate; without it, it would silently 401 late in the
+          # deploy. PR 2.8b sources this from 1Password and removes the
+          # legacy GH-secret dependency once parity has been green.
+          test -n "$ADMIN_JWT"
 
       # ─── Phase 2 PR 2.1: parity check between OP-loaded and legacy SSH key ──
       #
@@ -324,6 +330,111 @@ jobs:
           if [ "$fail_warn" = "true" ]; then
             echo "::warning::Caddy basic-auth parity check raised warnings (deploy proceeds with legacy values)"
           fi
+
+      # ─── Phase 2 PR 2.8a: ADMIN_JWT from 1Password (parity check, non-blocking) ──
+      #
+      # Mirrors the PR 2.1 / PR 2.2 staging pattern: load the OP value
+      # in a separate step that uses the prod-smoke service-account
+      # token, compare byte-for-byte against the legacy
+      # ${{ secrets.ADMIN_JWT }} GH secret, surface drift as a workflow
+      # warning, but DON'T switch the active source yet. PR 2.8b flips
+      # to $ADMIN_JWT_OP once we've seen a few green parity checks.
+      #
+      # Why a separate load step (not just adding ADMIN_JWT_OP to the
+      # existing prod-ci load step): 1Password service-account tokens
+      # are vault-scoped at creation and immutable. The prod-ci token
+      # cannot read from prod-smoke; we need a second token specifically
+      # for the smoke vault. Operator action required BEFORE this
+      # path produces a value:
+      #
+      #   1. In 1Password, create a service account with read access
+      #      to the prod-smoke vault (only that vault).
+      #   2. Save the token (859 chars, `ops_…` prefix) to the
+      #      production GH environment as
+      #      OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE.
+      #
+      # Until that's done, the load step below fails (continue-on-error)
+      # and the deploy proceeds with the legacy GH secret. Look for
+      # "Note when 1Password smoke load step failed" in the workflow
+      # output to confirm whether the token is wired.
+      - name: Load smoke-vault secret from 1Password (parity check, non-blocking)
+        id: load_op_smoke
+        continue-on-error: true
+        # Pinned to the same load-secrets-action SHA as the prod-ci step
+        # above; refresh the two in lockstep.
+        uses: 1password/load-secrets-action@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE }}
+          ADMIN_JWT_OP: op://prod-smoke/admin-jwt/credential
+
+      # Same compare-via-tempfiles pattern as the SSH key check above:
+      # value never printed; mtime-077 mktemp; cmp -s; warn on
+      # mismatch. JWTs have a 3-part dot-separated shape we sanity
+      # check separately so a malformed value surfaces a clear error.
+      - name: Compare OP-loaded ADMIN_JWT against legacy GH secret
+        if: steps.load_op_smoke.outcome == 'success'
+        env:
+          LEGACY_JWT: ${{ secrets.ADMIN_JWT }}
+        run: |
+          set -euo pipefail
+          set +x
+          umask 077
+
+          fail_warn=false
+
+          if [ -z "${ADMIN_JWT_OP:-}" ]; then
+            echo "::warning::OP-loaded ADMIN_JWT_OP is empty — check op://prod-smoke/admin-jwt/credential exists"
+            fail_warn=true
+          fi
+          if [ -z "${LEGACY_JWT:-}" ]; then
+            echo "::warning::legacy ADMIN_JWT GH secret is empty — smoke check that uses it will fail downstream"
+            fail_warn=true
+          fi
+
+          # JWT shape sanity: <base64url>.<base64url>.<base64url>
+          if [ -n "${ADMIN_JWT_OP:-}" ]; then
+            case "$ADMIN_JWT_OP" in
+              ey*.*.*)
+                echo "ADMIN_JWT_OP: JWT shape valid"
+                ;;
+              *)
+                echo "::warning::OP-loaded ADMIN_JWT_OP does not look like a JWT (expected ey<...>.<...>.<...>)"
+                fail_warn=true
+                ;;
+            esac
+          fi
+
+          if [ -n "${ADMIN_JWT_OP:-}" ] && [ -n "${LEGACY_JWT:-}" ]; then
+            legacy_file=$(mktemp)
+            op_file=$(mktemp)
+            trap 'rm -f "$legacy_file" "$op_file"' EXIT
+            printf '%s' "$LEGACY_JWT" > "$legacy_file"
+            printf '%s' "$ADMIN_JWT_OP" > "$op_file"
+            chmod 0400 "$legacy_file" "$op_file"
+
+            if cmp -s "$legacy_file" "$op_file"; then
+              echo "ADMIN_JWT_OP matches legacy secret: yes"
+            else
+              legacy_len=$(wc -c < "$legacy_file" | tr -d ' ')
+              op_len=$(wc -c < "$op_file" | tr -d ' ')
+              echo "ADMIN_JWT_OP matches legacy secret: no"
+              echo "    legacy length: $legacy_len bytes"
+              echo "    OP length:     $op_len bytes"
+              echo "::warning::OP-loaded ADMIN_JWT does NOT match legacy GH Actions secret. Investigate before PR 2.8b swaps to the OP value."
+              fail_warn=true
+            fi
+          fi
+
+          if [ "$fail_warn" = "true" ]; then
+            echo "::warning::ADMIN_JWT parity check raised warnings (deploy proceeds with legacy value)"
+          fi
+
+      - name: Note when 1Password smoke load step failed (deploy proceeds with legacy ADMIN_JWT)
+        if: steps.load_op_smoke.outcome == 'failure'
+        run: |
+          echo "::warning::1Password smoke-vault load failed; falling back to legacy ADMIN_JWT from GH Actions. If you haven't yet, add OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE to the production environment to activate the OP path."
 
       - name: Configure SSH
         run: |

--- a/deploy/secrets-inventory.md
+++ b/deploy/secrets-inventory.md
@@ -78,7 +78,7 @@ CI vaults (the firebreak).
 
 | Env var       | `op://` path                                | Used in PR | Notes                                                                                                                                            |
 | ------------- | ------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ADMIN_JWT`   | `op://prod-smoke/admin-jwt/credential`      | 2.5        | Long-lived (30d) admin JWT for hosted product-proof smoke. TRANSITIONAL — replaced by short-lived OIDC→KMS-signed JWTs in Phase 4b.              |
+| `ADMIN_JWT`   | `op://prod-smoke/admin-jwt/credential`      | 2.8        | Long-lived (30d) admin JWT for hosted product-proof smoke. TRANSITIONAL — replaced by short-lived OIDC→KMS-signed JWTs in Phase 4b. PR 2.8a adds parity-check load (non-blocking); PR 2.8b flips active source and deletes legacy `${{ secrets.ADMIN_JWT }}`. |
 
 ## Items in 1Password NOT loaded into any runtime template
 

--- a/docs/SECRETS_MIGRATION.md
+++ b/docs/SECRETS_MIGRATION.md
@@ -1036,33 +1036,81 @@ to those surfaces and rotated.
 
 ### PR 2.8 — Smoke auth secret to 1Password
 
-**Touches**: `scripts/ops/check-hosted-stack.sh`,
-`.github/workflows/deploy-production.yml`, `SECRETS_CALENDAR.yml`.
+Split into two sub-PRs, mirroring the PR 2.1 → PR 2.4 staging pattern
+that worked for the VPS SSH key migration:
 
-- Mint a fresh `ADMIN_JWT` using `mint-admin-jwt.mjs` with
-  `--profile testnet` (current production chain — switch to `mainnet`
-  once Phase 5 cutover provisions `deployments/mainnet.json`). Store at
-  `op://prod-smoke/admin-jwt/credential`.
-- Add `OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE` as a **separate** GitHub
-  Environment secret (uses the `prod-smoke-tests` service-account token).
-- Smoke step in the workflow loads `ADMIN_JWT` from 1Password via
-  `load-secrets-action` scoped to the smoke step only.
-- After a clean smoke run: delete `ADMIN_JWT` from GitHub Actions secrets.
+#### PR 2.8a — parity-check load (non-blocking)
 
-**Token-scope verification** (firebreak proof): from a CI step using
+**Touches**: `.github/workflows/deploy-production.yml`,
+`deploy/secrets-inventory.md`.
+
+- Add a new `Load smoke-vault secret from 1Password (parity check, non-blocking)`
+  step in `deploy-production.yml`, using the
+  `OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE` environment secret. Loads
+  `ADMIN_JWT_OP` from `op://prod-smoke/admin-jwt/credential`.
+- `continue-on-error: true` so a missing/invalid token doesn't break
+  the deploy — the legacy `${{ secrets.ADMIN_JWT }}` is still the
+  active source.
+- Add a parity-check step: byte-for-byte `cmp -s` against the legacy
+  GH secret, JWT-shape sanity check, length-only diagnostics on
+  mismatch (the value itself never enters the log).
+- Add `test -n "$ADMIN_JWT"` to the existing Validate-required-secrets
+  step so an empty legacy secret fails the deploy fast instead of
+  401'ing later in the smoke check.
+
+**Operator action required to actually populate the OP path:**
+
+  1. In 1Password, create a service account with read access to the
+     `prod-smoke` vault (and ONLY that vault). The token-scope
+     firebreak claim is that this token can't read `prod-backend`,
+     `prod-indexer`, `prod-ci`, or any other vault.
+  2. Save the token to the **production GitHub environment** (not the
+     repository secrets) as `OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE`.
+
+Until step 2 is done, the new load step's `outcome` is `failure` and
+the workflow's "Note when 1Password smoke load step failed" annotation
+fires. Deploy still succeeds via legacy.
+
+**Acceptance criteria for PR 2.8a:**
+
+- [ ] PR merged; CI green
+- [ ] One deploy with the token absent → "Note when…" warning visible
+      in workflow output; deploy still succeeds
+- [ ] Operator mints token + adds to prod env
+- [ ] Next deploy: `load_op_smoke.outcome == success` and parity check
+      logs `ADMIN_JWT_OP matches legacy secret: yes`
+
+#### PR 2.8b — flip the active source
+
+**Touches**: `.github/workflows/deploy-production.yml`,
+`SECRETS_CALENDAR.yml`.
+
+- Once 2.8a's parity check has been green for a few deploys, swap
+  the `printf 'ADMIN_JWT=%q ...' "$ADMIN_JWT"` to `"$ADMIN_JWT_OP"`
+  (the variable exported by the smoke-load step).
+- Remove `ADMIN_JWT: ${{ secrets.ADMIN_JWT }}` from the job env block.
+- Delete the `ADMIN_JWT` repository secret via `gh secret delete`.
+- Update `SECRETS_CALENDAR.yml`'s `expires_at` for `ADMIN_JWT` to
+  reflect the new mint's 30-day expiry (since we're now reading
+  from 1Password, the calendar entry tracks the OP item).
+
+**Token-scope verification** (firebreak proof, do once after operator
+adds the token): from a one-shot workflow_dispatch step that uses
 `OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE`, attempt
-`op item get auth-jwt-secrets --vault=prod-backend` and assert it FAILS
-with permission denied. The smoke token must not be able to read backend
-or CI vaults.
+`op item get auth-jwt-secrets --vault=prod-backend` and assert it
+fails with permission denied. The smoke token must not be able to
+read backend, indexer, or CI vaults.
 
-**Acceptance criteria**:
+**Acceptance criteria for PR 2.8b:**
 
-- [ ] Smoke run passes with `ADMIN_JWT` loaded from 1Password
+- [ ] Smoke run passes with `ADMIN_JWT_OP` (loaded from 1Password) as
+      the source
 - [ ] `OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE` is a distinct token, not
       reused from any other purpose
 - [ ] Negative test: smoke token receives permission denied when
       attempting to read `prod-backend` or `prod-ci`
-- [ ] `ADMIN_JWT` GitHub Actions secret deleted
+- [ ] `ADMIN_JWT` repository secret deleted (verified with
+      `gh secret list -R averray-agent/agent`)
 - [ ] Calendar entry's `expires_at` updated to the new mint's 30-day
       expiry
 


### PR DESCRIPTION
## Summary

Adds a new \`load-secrets-action\` step that loads \`ADMIN_JWT_OP\` from \`op://prod-smoke/admin-jwt/credential\` via a **separate** prod-smoke-scoped service-account token, plus a parity-check step that byte-compares against the legacy \`\${{ secrets.ADMIN_JWT }}\` GH secret. \`continue-on-error: true\` — the deploy itself still uses the legacy value. This is PR 2.8a (parity stage); PR 2.8b flips the active source once parity has been green for a few deploys.

Mirrors the proven PR 2.1 / PR 2.2 staging pattern used for the VPS SSH key and Caddy basic-auth bundle.

## Operator action required (before the OP path produces a value)

1. In 1Password, create a service account with read access to ONLY the \`prod-smoke\` vault (firebreak: this token must NOT be able to read \`prod-backend\`, \`prod-indexer\`, or \`prod-ci\`).
2. Save the 859-char \`ops_…\` token to the **production GitHub environment** (not repo secrets) as \`OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE\`.

The PR can merge before step 2 is done — the new load step's \`outcome\` is \`failure\` while the token is absent and the workflow's \`Note when 1Password smoke load step failed\` annotation fires. Deploy still succeeds via the legacy secret. Once the token is wired, the parity check runs each deploy.

## Changes

1. **\`.github/workflows/deploy-production.yml\`**:
   - New step \`Load smoke-vault secret from 1Password (parity check, non-blocking)\`, pinned to the same load-secrets-action commit SHA as the prod-ci step.
   - New step \`Compare OP-loaded ADMIN_JWT against legacy GH secret\`: non-empty + JWT-shape + \`cmp -s\` via umask-077 mktemp files. Length-only diagnostics on mismatch — the JWT itself never enters the log.
   - New step \`Note when 1Password smoke load step failed (deploy proceeds with legacy ADMIN_JWT)\` for the pre-token-mint window.
   - Add \`test -n \"\$ADMIN_JWT\"\` to \`Validate required secrets\` so an empty legacy secret fails the deploy fast instead of 401'ing later.

2. **\`deploy/secrets-inventory.md\`**: ADMIN_JWT row's PR column 2.5 → 2.8; documents the 2.8a/2.8b split.

3. **\`docs/SECRETS_MIGRATION.md\`**: split PR 2.8 section into 2.8a (parity) and 2.8b (flip + delete legacy secret) with explicit operator actions and acceptance criteria.

## Test plan

- [x] Workflow YAML structurally valid (12 named steps; 3 new ones inserted between Caddy basic-auth check and Configure SSH)
- [x] \`check-env-template-structure.mjs\` and \`check-template-matches-manifest.mjs\` still pass
- [ ] After merge — without token: one deploy logs the \"Note when…\" warning; deploy succeeds via legacy
- [ ] After operator adds token: next deploy logs \`ADMIN_JWT_OP matches legacy secret: yes\`
- [ ] Once parity green for ≥2 deploys: ship PR 2.8b (flip source, delete legacy GH secret)

🤖 Generated with [Claude Code](https://claude.com/claude-code)