### PR TITLE
PR 2.8a hotfix: admin-jwt OP field is 'password', not 'credential'

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -367,7 +367,7 @@ jobs:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE }}
-          ADMIN_JWT_OP: op://prod-smoke/admin-jwt/credential
+          ADMIN_JWT_OP: op://prod-smoke/admin-jwt/password
 
       # Same compare-via-tempfiles pattern as the SSH key check above:
       # value never printed; mtime-077 mktemp; cmp -s; warn on
@@ -385,7 +385,7 @@ jobs:
           fail_warn=false
 
           if [ -z "${ADMIN_JWT_OP:-}" ]; then
-            echo "::warning::OP-loaded ADMIN_JWT_OP is empty — check op://prod-smoke/admin-jwt/credential exists"
+            echo "::warning::OP-loaded ADMIN_JWT_OP is empty — check op://prod-smoke/admin-jwt/password exists"
             fail_warn=true
           fi
           if [ -z "${LEGACY_JWT:-}" ]; then

--- a/deploy/secrets-inventory.md
+++ b/deploy/secrets-inventory.md
@@ -78,7 +78,7 @@ CI vaults (the firebreak).
 
 | Env var       | `op://` path                                | Used in PR | Notes                                                                                                                                            |
 | ------------- | ------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ADMIN_JWT`   | `op://prod-smoke/admin-jwt/credential`      | 2.8        | Long-lived (30d) admin JWT for hosted product-proof smoke. TRANSITIONAL — replaced by short-lived OIDC→KMS-signed JWTs in Phase 4b. PR 2.8a adds parity-check load (non-blocking); PR 2.8b flips active source and deletes legacy `${{ secrets.ADMIN_JWT }}`. |
+| `ADMIN_JWT`   | `op://prod-smoke/admin-jwt/password`      | 2.8        | Long-lived (30d) admin JWT for hosted product-proof smoke. TRANSITIONAL — replaced by short-lived OIDC→KMS-signed JWTs in Phase 4b. PR 2.8a adds parity-check load (non-blocking); PR 2.8b flips active source and deletes legacy `${{ secrets.ADMIN_JWT }}`. |
 
 ## Items in 1Password NOT loaded into any runtime template
 

--- a/docs/SECRETS_MIGRATION.md
+++ b/docs/SECRETS_MIGRATION.md
@@ -1047,7 +1047,7 @@ that worked for the VPS SSH key migration:
 - Add a new `Load smoke-vault secret from 1Password (parity check, non-blocking)`
   step in `deploy-production.yml`, using the
   `OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE` environment secret. Loads
-  `ADMIN_JWT_OP` from `op://prod-smoke/admin-jwt/credential`.
+  `ADMIN_JWT_OP` from `op://prod-smoke/admin-jwt/password`.
 - `continue-on-error: true` so a missing/invalid token doesn't break
   the deploy — the legacy `${{ secrets.ADMIN_JWT }}` is still the
   active source.


### PR DESCRIPTION
## Summary

After PR 2.8a merged and the operator wired `OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE` into the production env, the first verification deploy (run 25787954698) successfully authenticated to 1Password but failed at the read step with:

> `could not read secret 'op://prod-smoke/admin-jwt/credential': item 'prod-smoke/admin-jwt' does not have a field 'credential'`

The item exists in the right vault and the deploy proceeded fine on the legacy `${{ secrets.ADMIN_JWT }}` fallback, but the parity check never ran because our reference was guessing the wrong field name. Verified via `op item get`:

```
password   (id=password, type=CONCEALED, purpose=PASSWORD)
notesPlain (id=notesPlain, type=STRING, purpose=NOTES)
```

The JWT lives in the default `password` field — same convention as the existing `op://prod-backend-external/resend-api-key/password`. PR 2.8a's guess of `/credential` would have been right for an "API Credential" item type, but the actual item was created as a "Password" item.

## Changes (single rename across 3 files)

- `.github/workflows/deploy-production.yml`: load step's `ADMIN_JWT_OP` + warning text
- `deploy/secrets-inventory.md`: ADMIN_JWT row's op:// path
- `docs/SECRETS_MIGRATION.md`: PR 2.8 section's path reference

## Test plan

- [x] Both Phase 2 CI guards still pass locally (env-template-structure, template-matches-manifest)
- [ ] After merge + auto-deploy, expect:
  - `Load smoke-vault secret ... outcome: success`
  - `Compare OP-loaded ADMIN_JWT ... runs and logs:` **`ADMIN_JWT_OP matches legacy secret: yes`**
- [ ] Green parity unblocks PR 2.8b (actual source flip + delete legacy GH secret)

🤖 Generated with [Claude Code](https://claude.com/claude-code)