### PR TITLE
Phase 2 PR 2.8b: flip ADMIN_JWT to 1Password (fail-closed)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -140,7 +140,13 @@ jobs:
       # human operators when typing into the browser basic-auth dialog.
       # Caddy verifies via the bcrypt HASH below.
       APP_ALLOW_PROTECTED_SHELL: ${{ secrets.APP_ALLOW_PROTECTED_SHELL }}
-      ADMIN_JWT: ${{ secrets.ADMIN_JWT }}
+      # ADMIN_JWT (legacy GH secret) removed in PR 2.8b — the deploy
+      # now reads $ADMIN_JWT_OP from 1Password
+      # (op://prod-smoke/admin-jwt/password) via the fail-closed
+      # smoke-vault load step below. PR 2.8a's parity check confirmed
+      # the OP value matched the legacy byte-for-byte before the flip.
+      # Operator action after this PR merges + one green deploy:
+      #   gh secret delete ADMIN_JWT -R averray-agent/agent
       RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
       BOOTSTRAP_SELF_REPORT_TO: ${{ secrets.BOOTSTRAP_SELF_REPORT_TO }}
       BOOTSTRAP_SELF_REPORT_FROM: ${{ secrets.BOOTSTRAP_SELF_REPORT_FROM }}
@@ -170,12 +176,11 @@ jobs:
             # through CI. Caddy auth is verified via the bcrypt HASH only.
             test -n "$APP_BASIC_AUTH_PASSWORD_HASH"
           fi
-          # Phase 2 PR 2.8a: fail fast if the legacy ADMIN_JWT is empty.
-          # The hosted product-proof smoke check on the VPS needs this to
-          # authenticate; without it, it would silently 401 late in the
-          # deploy. PR 2.8b sources this from 1Password and removes the
-          # legacy GH-secret dependency once parity has been green.
-          test -n "$ADMIN_JWT"
+          # Phase 2 PR 2.8b: ADMIN_JWT validation moved below the
+          # smoke-vault load step (it's $ADMIN_JWT_OP now, not available
+          # until after `load-secrets-action` runs). The load step is
+          # fail-closed, so an empty/missing OP value will abort the
+          # deploy before any container restart.
 
       # ─── Phase 2 PR 2.1: parity check between OP-loaded and legacy SSH key ──
       #
@@ -331,37 +336,26 @@ jobs:
             echo "::warning::Caddy basic-auth parity check raised warnings (deploy proceeds with legacy values)"
           fi
 
-      # ─── Phase 2 PR 2.8a: ADMIN_JWT from 1Password (parity check, non-blocking) ──
+      # ─── Phase 2 PR 2.8b: ADMIN_JWT from 1Password (FAIL-CLOSED, active source) ──
       #
-      # Mirrors the PR 2.1 / PR 2.2 staging pattern: load the OP value
-      # in a separate step that uses the prod-smoke service-account
-      # token, compare byte-for-byte against the legacy
-      # ${{ secrets.ADMIN_JWT }} GH secret, surface drift as a workflow
-      # warning, but DON'T switch the active source yet. PR 2.8b flips
-      # to $ADMIN_JWT_OP once we've seen a few green parity checks.
+      # PR 2.8a wired this up as a non-blocking parity check; PR 2.8b
+      # flips the active source: $ADMIN_JWT_OP is now what the deploy
+      # heredoc passes to the VPS smoke check, and the legacy
+      # ${{ secrets.ADMIN_JWT }} env binding has been removed from the
+      # job-level env block above. A 1Password outage / wrong token /
+      # missing item now fails the deploy at this step, before any
+      # container restart — which is the correct fail-closed behavior
+      # for a load-bearing secret read.
       #
-      # Why a separate load step (not just adding ADMIN_JWT_OP to the
-      # existing prod-ci load step): 1Password service-account tokens
-      # are vault-scoped at creation and immutable. The prod-ci token
-      # cannot read from prod-smoke; we need a second token specifically
-      # for the smoke vault. Operator action required BEFORE this
-      # path produces a value:
-      #
-      #   1. In 1Password, create a service account with read access
-      #      to the prod-smoke vault (only that vault).
-      #   2. Save the token (859 chars, `ops_…` prefix) to the
-      #      production GH environment as
-      #      OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE.
-      #
-      # Until that's done, the load step below fails (continue-on-error)
-      # and the deploy proceeds with the legacy GH secret. Look for
-      # "Note when 1Password smoke load step failed" in the workflow
-      # output to confirm whether the token is wired.
-      - name: Load smoke-vault secret from 1Password (parity check, non-blocking)
+      # If you see this step fail post-PR-2.8b:
+      #   1. Confirm OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE is set in the
+      #      production GitHub environment (`gh secret list --env production`).
+      #   2. Confirm op://prod-smoke/admin-jwt/password resolves
+      #      (`op item get admin-jwt --vault=prod-smoke`).
+      #   3. Confirm the service-account token's vault scope still
+      #      includes prod-smoke (1Password Web → Integrations).
+      - name: Load ADMIN_JWT from 1Password (fail-closed)
         id: load_op_smoke
-        continue-on-error: true
-        # Pinned to the same load-secrets-action SHA as the prod-ci step
-        # above; refresh the two in lockstep.
         uses: 1password/load-secrets-action@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0
         with:
           export-env: true
@@ -369,72 +363,31 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE }}
           ADMIN_JWT_OP: op://prod-smoke/admin-jwt/password
 
-      # Same compare-via-tempfiles pattern as the SSH key check above:
-      # value never printed; mtime-077 mktemp; cmp -s; warn on
-      # mismatch. JWTs have a 3-part dot-separated shape we sanity
-      # check separately so a malformed value surfaces a clear error.
-      - name: Compare OP-loaded ADMIN_JWT against legacy GH secret
-        if: steps.load_op_smoke.outcome == 'success'
-        env:
-          LEGACY_JWT: ${{ secrets.ADMIN_JWT }}
+      # Shape + non-empty check on the loaded value. Without a legacy
+      # secret to byte-compare against (it's been removed from the job
+      # env in PR 2.8b), this is now structural validation only:
+      # if op inject silently returned empty or returned something
+      # that isn't a JWT, fail the deploy here rather than at the
+      # smoke check on the VPS.
+      - name: Verify ADMIN_JWT_OP loaded and shape-valid
         run: |
           set -euo pipefail
           set +x
-          umask 077
-
-          fail_warn=false
 
           if [ -z "${ADMIN_JWT_OP:-}" ]; then
-            echo "::warning::OP-loaded ADMIN_JWT_OP is empty — check op://prod-smoke/admin-jwt/password exists"
-            fail_warn=true
-          fi
-          if [ -z "${LEGACY_JWT:-}" ]; then
-            echo "::warning::legacy ADMIN_JWT GH secret is empty — smoke check that uses it will fail downstream"
-            fail_warn=true
+            echo "::error::ADMIN_JWT_OP is empty after load step — check op://prod-smoke/admin-jwt/password and the prod-smoke service-account scope."
+            exit 1
           fi
 
-          # JWT shape sanity: <base64url>.<base64url>.<base64url>
-          if [ -n "${ADMIN_JWT_OP:-}" ]; then
-            case "$ADMIN_JWT_OP" in
-              ey*.*.*)
-                echo "ADMIN_JWT_OP: JWT shape valid"
-                ;;
-              *)
-                echo "::warning::OP-loaded ADMIN_JWT_OP does not look like a JWT (expected ey<...>.<...>.<...>)"
-                fail_warn=true
-                ;;
-            esac
-          fi
-
-          if [ -n "${ADMIN_JWT_OP:-}" ] && [ -n "${LEGACY_JWT:-}" ]; then
-            legacy_file=$(mktemp)
-            op_file=$(mktemp)
-            trap 'rm -f "$legacy_file" "$op_file"' EXIT
-            printf '%s' "$LEGACY_JWT" > "$legacy_file"
-            printf '%s' "$ADMIN_JWT_OP" > "$op_file"
-            chmod 0400 "$legacy_file" "$op_file"
-
-            if cmp -s "$legacy_file" "$op_file"; then
-              echo "ADMIN_JWT_OP matches legacy secret: yes"
-            else
-              legacy_len=$(wc -c < "$legacy_file" | tr -d ' ')
-              op_len=$(wc -c < "$op_file" | tr -d ' ')
-              echo "ADMIN_JWT_OP matches legacy secret: no"
-              echo "    legacy length: $legacy_len bytes"
-              echo "    OP length:     $op_len bytes"
-              echo "::warning::OP-loaded ADMIN_JWT does NOT match legacy GH Actions secret. Investigate before PR 2.8b swaps to the OP value."
-              fail_warn=true
-            fi
-          fi
-
-          if [ "$fail_warn" = "true" ]; then
-            echo "::warning::ADMIN_JWT parity check raised warnings (deploy proceeds with legacy value)"
-          fi
-
-      - name: Note when 1Password smoke load step failed (deploy proceeds with legacy ADMIN_JWT)
-        if: steps.load_op_smoke.outcome == 'failure'
-        run: |
-          echo "::warning::1Password smoke-vault load failed; falling back to legacy ADMIN_JWT from GH Actions. If you haven't yet, add OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE to the production environment to activate the OP path."
+          case "$ADMIN_JWT_OP" in
+            ey*.*.*)
+              echo "ADMIN_JWT_OP: JWT shape valid"
+              ;;
+            *)
+              echo "::error::ADMIN_JWT_OP does not look like a JWT (expected ey<...>.<...>.<...>)"
+              exit 1
+              ;;
+          esac
 
       - name: Configure SSH
         run: |
@@ -451,12 +404,20 @@ jobs:
           # the HASH and rejects the raw value. PR 2.4 will further
           # eliminate the SSH-heredoc transport for APP_BASIC_AUTH_USER
           # + APP_BASIC_AUTH_PASSWORD_HASH once op inject runs on the VPS.
+          #
+          # Phase 2 PR 2.8b: ADMIN_JWT below now reads $ADMIN_JWT_OP
+          # (loaded from op://prod-smoke/admin-jwt/password by the
+          # fail-closed smoke-load step above), not the legacy
+          # ${{ secrets.ADMIN_JWT }} GH secret. The legacy job-env
+          # binding has been removed; the GH secret can be deleted with
+          # `gh secret delete ADMIN_JWT -R averray-agent/agent` after
+          # one green deploy on this PR.
           remote_env=$(
             printf 'APP_BASIC_AUTH_USER=%q APP_BASIC_AUTH_PASSWORD_HASH=%q APP_ALLOW_PROTECTED_SHELL=%q ADMIN_JWT=%q RESEND_API_KEY=%q BOOTSTRAP_SELF_REPORT_TO=%q BOOTSTRAP_SELF_REPORT_FROM=%q BOOTSTRAP_SELF_REPORT_SEND_ON_START=%q RUN_INDEXER=%q WAIT_FOR_READY=%q HEALTH_STABILITY_SEC=%q INDEXER_LOG_TAIL=%q SMOKE_CHECK_INDEXER=%q SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION=%q SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT=%q SMOKE_CHECK_PRODUCT_PROOF_GATE=%q PRODUCT_PROOF_REQUIRE_WORKER_LOOP=%q PRODUCT_PROOF_REWARD_ASSET=%q INDEXER_DATABASE_SCHEMA=%q INDEXER_FRESH_SCHEMA=%q ' \
               "$APP_BASIC_AUTH_USER" \
               "$APP_BASIC_AUTH_PASSWORD_HASH" \
               "$APP_ALLOW_PROTECTED_SHELL" \
-              "$ADMIN_JWT" \
+              "$ADMIN_JWT_OP" \
               "$RESEND_API_KEY" \
               "$BOOTSTRAP_SELF_REPORT_TO" \
               "$BOOTSTRAP_SELF_REPORT_FROM" \

--- a/docs/SECRETS_MIGRATION.md
+++ b/docs/SECRETS_MIGRATION.md
@@ -1080,19 +1080,46 @@ fires. Deploy still succeeds via legacy.
 - [ ] Next deploy: `load_op_smoke.outcome == success` and parity check
       logs `ADMIN_JWT_OP matches legacy secret: yes`
 
-#### PR 2.8b — flip the active source
+#### PR 2.8b — flip the active source (this PR)
 
-**Touches**: `.github/workflows/deploy-production.yml`,
-`SECRETS_CALENDAR.yml`.
+**Touches**: `.github/workflows/deploy-production.yml`.
 
-- Once 2.8a's parity check has been green for a few deploys, swap
-  the `printf 'ADMIN_JWT=%q ...' "$ADMIN_JWT"` to `"$ADMIN_JWT_OP"`
-  (the variable exported by the smoke-load step).
-- Remove `ADMIN_JWT: ${{ secrets.ADMIN_JWT }}` from the job env block.
-- Delete the `ADMIN_JWT` repository secret via `gh secret delete`.
-- Update `SECRETS_CALENDAR.yml`'s `expires_at` for `ADMIN_JWT` to
-  reflect the new mint's 30-day expiry (since we're now reading
-  from 1Password, the calendar entry tracks the OP item).
+After PR #252's hotfix landed and the next deploy logged
+`ADMIN_JWT_OP matches legacy secret: yes` (the parity check confirmed
+the OP value matches the legacy byte-for-byte), this PR makes the
+flip:
+
+- **Source swap**: `printf 'ADMIN_JWT=%q ...' "$ADMIN_JWT"` →
+  `"$ADMIN_JWT_OP"` in the Deploy production heredoc. The VPS smoke
+  check now consumes the 1Password-loaded value.
+- **Job-env binding removed**: `ADMIN_JWT: ${{ secrets.ADMIN_JWT }}`
+  deleted from the job-level `env:` block.
+- **Load step now fail-closed**: `continue-on-error: true` removed
+  from the smoke-vault load step. With the OP path as the only
+  source, a 1Password outage / wrong token / missing item now fails
+  the deploy at the load step — *before* any container restart —
+  rather than silently falling through to a legacy that no longer
+  exists.
+- **Compare step replaced with a shape check**: there's no legacy
+  to byte-compare against anymore, so the old `Compare OP-loaded
+  ADMIN_JWT against legacy GH secret` step is removed and replaced
+  with `Verify ADMIN_JWT_OP loaded and shape-valid` — non-empty +
+  `ey<...>.<...>.<...>` shape, both fatal on failure.
+- **"Note when smoke load failed" step removed**: unreachable now
+  that the load step is fail-closed.
+- **Validate-required-secrets**: dropped `test -n "$ADMIN_JWT"`
+  (legacy no longer in env at that point in the job; the load step
+  + Verify step downstream catches an empty/missing OP value).
+
+**Operator action after this PR merges + one green deploy:**
+
+```sh
+gh secret delete ADMIN_JWT -R averray-agent/agent
+```
+
+Also update `SECRETS_CALENDAR.yml`'s `expires_at` for `ADMIN_JWT`
+to track the OP item's 30-day expiry instead of the GH secret's
+last-rotation date.
 
 **Token-scope verification** (firebreak proof, do once after operator
 adds the token): from a one-shot workflow_dispatch step that uses


### PR DESCRIPTION
## Summary

PR 2.8a wired up the OP load + parity check as a non-blocking stepping-stone. PR #252 (the hotfix) corrected the field-name mismatch, and the next deploy logged:

```
ADMIN_JWT_OP: JWT shape valid
ADMIN_JWT_OP matches legacy secret: yes
```

This PR makes the actual flip — the deploy now reads `ADMIN_JWT` from `op://prod-smoke/admin-jwt/password` and the legacy `${{ secrets.ADMIN_JWT }}` GH secret is no longer consulted.

## Changes (one workflow file + docs)

**`.github/workflows/deploy-production.yml`:**

1. **Source swap**: `"$ADMIN_JWT"` → `"$ADMIN_JWT_OP"` in the Deploy heredoc.
2. **Legacy env binding removed**: `ADMIN_JWT: ${{ secrets.ADMIN_JWT }}` deleted from the job-level `env:` block.
3. **Load step is fail-closed**: dropped `continue-on-error: true`. A 1Password outage / wrong token / missing item now fails the deploy at this step, before any container restart.
4. **Compare → Verify step**: no legacy to byte-compare against; replaced with `Verify ADMIN_JWT_OP loaded and shape-valid` (non-empty + JWT shape, both fatal).
5. **"Note when smoke load failed" step removed**: unreachable now that the load is fail-closed.
6. **Validate-required-secrets**: dropped `test -n "$ADMIN_JWT"` (legacy no longer in env).

**`docs/SECRETS_MIGRATION.md`:** rewrites the PR 2.8b subsection to reflect what actually landed.

## Operator action (after merge + one green deploy)

```bash
gh secret delete ADMIN_JWT -R averray-agent/agent
```

Also update `SECRETS_CALENDAR.yml`'s `expires_at` for `ADMIN_JWT` to track the OP item's 30-day expiry.

## Test plan

- [x] Workflow YAML structurally valid (11 named steps; Verify replaces Compare/Note pair)
- [x] Both Phase 2 CI guards pass locally
- [ ] After merge + auto-deploy: log shows `ADMIN_JWT_OP: JWT shape valid` and the existing smoke check (401/200 → /health) continues to pass — proving the JWT made it into the container's env via the new path
- [ ] After one green deploy: delete the legacy GH secret

## Revert plan

If the JWT delivery breaks somehow, re-add the job-env binding and swap the printf back to `$ADMIN_JWT`. The OP value matched the legacy byte-for-byte, so semantic regressions are not expected — but the revert is mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)