### PR TITLE
Phase 2 PR 2.7a: flip VPS_SSH_KEY + APP_BASIC_AUTH_* to 1Password (fail-closed)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -130,15 +130,18 @@ jobs:
       VPS_HOST: ${{ secrets.VPS_HOST }}
       VPS_PORT: ${{ secrets.VPS_PORT }}
       VPS_USER: ${{ secrets.VPS_USER }}
-      VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
-      APP_BASIC_AUTH_USER: ${{ secrets.APP_BASIC_AUTH_USER }}
-      APP_BASIC_AUTH_PASSWORD_HASH: ${{ secrets.APP_BASIC_AUTH_PASSWORD_HASH }}
-      # APP_BASIC_AUTH_PASSWORD (raw) was here pre-PR-2.2. Removed: the
-      # render-caddyfile.sh script no longer accepts raw passwords —
-      # it would have put them in `ps` output during the call. The raw
-      # password lives only in op://prod-critical/app-basic-auth, used by
-      # human operators when typing into the browser basic-auth dialog.
-      # Caddy verifies via the bcrypt HASH below.
+      # Phase 2 PR 2.7a removed three legacy GH-secret job-env bindings:
+      #   VPS_SSH_KEY                  → now $VPS_SSH_KEY_OP from op://prod-ci/vps-ssh-key/private key
+      #   APP_BASIC_AUTH_USER          → now $APP_BASIC_AUTH_USER_OP from op://prod-ci/app-basic-auth-hash/username
+      #   APP_BASIC_AUTH_PASSWORD_HASH → now $APP_BASIC_AUTH_PASSWORD_HASH_OP from op://prod-ci/app-basic-auth-hash/credential
+      # All three were parity-checked successfully across many deploys in
+      # PRs 2.1 and 2.2 before the flip. APP_BASIC_AUTH_PASSWORD (raw)
+      # has been absent since PR 2.2 — the bcrypt HASH is sufficient for
+      # Caddy auth; the raw plaintext lives only in op://prod-critical
+      # for human operators typing into the browser dialog.
+      #
+      # Operator action after this PR merges + one green deploy:
+      #   gh secret delete VPS_SSH_KEY APP_BASIC_AUTH_USER APP_BASIC_AUTH_PASSWORD_HASH -R averray-agent/agent
       APP_ALLOW_PROTECTED_SHELL: ${{ secrets.APP_ALLOW_PROTECTED_SHELL }}
       # ADMIN_JWT (legacy GH secret) removed in PR 2.8b — the deploy
       # now reads $ADMIN_JWT_OP from 1Password
@@ -170,34 +173,52 @@ jobs:
         run: |
           test -n "$VPS_HOST"
           test -n "$VPS_USER"
-          test -n "$VPS_SSH_KEY"
-          if [ -n "$APP_BASIC_AUTH_USER" ]; then
-            # Phase 2 PR 2.2: raw APP_BASIC_AUTH_PASSWORD no longer flows
-            # through CI. Caddy auth is verified via the bcrypt HASH only.
-            test -n "$APP_BASIC_AUTH_PASSWORD_HASH"
-          fi
-          # Phase 2 PR 2.8b: ADMIN_JWT validation moved below the
-          # smoke-vault load step (it's $ADMIN_JWT_OP now, not available
-          # until after `load-secrets-action` runs). The load step is
-          # fail-closed, so an empty/missing OP value will abort the
-          # deploy before any container restart.
+          # Phase 2 PR 2.7a: VPS_SSH_KEY + APP_BASIC_AUTH_* checks moved
+          # below the prod-ci load step (they're $VPS_SSH_KEY_OP /
+          # $APP_BASIC_AUTH_USER_OP / $APP_BASIC_AUTH_PASSWORD_HASH_OP
+          # now, populated by `load-secrets-action`). That step is
+          # fail-closed; an empty/missing OP value aborts the deploy
+          # before any container restart.
+          # Phase 2 PR 2.8b: ADMIN_JWT validation lives below the
+          # smoke-vault load step for the same reason.
 
-      # ─── Phase 2 PR 2.1: parity check between OP-loaded and legacy SSH key ──
+      # ─── Phase 2 PR 2.7a: prod-ci secrets from 1Password (FAIL-CLOSED, active source) ──
       #
-      # Load VPS_SSH_KEY_OP from 1Password via the prod-ci-deploy
-      # service-account token. The OP token is set ONLY on this step
-      # (step-level `env:`, NOT job-level) so subsequent steps in this
-      # job cannot read it — per 1Password's docs, putting the token at
-      # job level would expose it to every step that follows.
+      # PRs 2.1 and 2.2 wired this up as a non-blocking parity check;
+      # PR 2.7a flips the active source: $VPS_SSH_KEY_OP /
+      # $APP_BASIC_AUTH_USER_OP / $APP_BASIC_AUTH_PASSWORD_HASH_OP are
+      # now what the Configure SSH step and the Deploy heredoc consume.
+      # The three legacy GH-secret env bindings have been removed from
+      # the job-level env block above.
       #
-      # continue-on-error: a 1Password outage MUST NOT break the deploy
-      # during the validation window. The downstream "Configure SSH"
-      # step still uses the legacy ${{ secrets.VPS_SSH_KEY }} value.
-      # PR 2.4 will flip the SSH write to use $VPS_SSH_KEY_OP and delete
-      # the legacy secret 24h after the OP path has been proven stable.
-      - name: Load CI-side secrets from 1Password (parity check, non-blocking)
-        id: load_op_ssh
-        continue-on-error: true
+      # Per-secret verification history:
+      #   • VPS_SSH_KEY: byte-for-byte cmp -s against legacy was green
+      #     for the entire PR 2.1 → 2.4 window. SSH key was rotated
+      #     during PR 2.1 acceptance (lost-legacy-key incident) and
+      #     re-aligned in OP + GH; subsequent deploys verified parity.
+      #   • APP_BASIC_AUTH_USER: byte-for-byte against legacy. Green.
+      #   • APP_BASIC_AUTH_PASSWORD_HASH: bcrypt salts make byte-
+      #     compare impossible (same plaintext + different salt =
+      #     different hash). The hash was verified semantically by
+      #     hashing the OP plaintext during PR 2.2 setup, and the
+      #     end-to-end 401/200 smoke check (still runs at end of
+      #     deploy) is the load-bearing verification that the hash
+      #     authenticates the correct password.
+      #
+      # A 1Password outage / wrong token / missing item / wrong vault
+      # scope now fails the deploy at this step, before any container
+      # restart — fail-closed.
+      #
+      # If you see this step fail post-PR-2.7a:
+      #   1. Confirm OP_SERVICE_ACCOUNT_TOKEN_PROD_CI is set in the
+      #      production GitHub environment.
+      #   2. Confirm the three op:// paths resolve:
+      #      op item get vps-ssh-key --vault=prod-ci
+      #      op item get app-basic-auth-hash --vault=prod-ci
+      #   3. Confirm the service-account token's vault scope still
+      #      includes prod-ci (1Password Web → Integrations).
+      - name: Load prod-ci secrets from 1Password (fail-closed)
+        id: load_op_ci
         # Pinned to 1password/load-secrets-action v2.0.0 commit SHA
         # (verified via the v2.0.0 annotated tag's commit object).
         # Refresh by re-running:
@@ -208,132 +229,69 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PROD_CI }}
           VPS_SSH_KEY_OP: op://prod-ci/vps-ssh-key/private key
-          # PR 2.2 additions — Caddy basic-auth bundle, parity-loaded here,
-          # used by render-caddyfile.sh once PR 2.4 swaps the heredoc.
           APP_BASIC_AUTH_USER_OP: op://prod-ci/app-basic-auth-hash/username
           APP_BASIC_AUTH_PASSWORD_HASH_OP: op://prod-ci/app-basic-auth-hash/credential
 
-      # Compare without ever printing key material. Writes both to
-      # umask-077 mktemp files, runs `cmp -s`, and logs only the
-      # yes/no result plus byte lengths on mismatch. The byte length
-      # is intentionally NOT a fingerprint — it only helps diagnose
-      # newline-handling regressions.
-      - name: Compare OP-loaded VPS SSH key against legacy GH secret
-        if: steps.load_op_ssh.outcome == 'success'
-        env:
-          LEGACY_KEY: ${{ secrets.VPS_SSH_KEY }}
+      # Shape + non-empty check on the three loaded values. Without
+      # legacy secrets to byte-compare against (they've been removed
+      # from the job env in PR 2.7a), this is structural validation
+      # only: fail fast here rather than at SSH-write or at the
+      # 401/200 smoke check downstream.
+      - name: Verify prod-ci OP values loaded and shape-valid
         run: |
           set -euo pipefail
           set +x
-          umask 077
 
-          legacy_file=$(mktemp)
-          op_file=$(mktemp)
-          trap 'rm -f "$legacy_file" "$op_file"' EXIT
+          fail=false
 
-          printf '%s' "$LEGACY_KEY" > "$legacy_file"
-          printf '%s' "$VPS_SSH_KEY_OP" > "$op_file"
-          chmod 0400 "$legacy_file" "$op_file"
-
-          if cmp -s "$legacy_file" "$op_file"; then
-            echo "VPS_SSH_KEY_OP matches legacy secret: yes"
+          # VPS_SSH_KEY_OP: OpenSSH private-key shape sanity.
+          # We don't print the value; we just confirm the leading
+          # "-----BEGIN OPENSSH PRIVATE KEY-----" marker is there.
+          if [ -z "${VPS_SSH_KEY_OP:-}" ]; then
+            echo "::error::VPS_SSH_KEY_OP is empty after load step — check op://prod-ci/vps-ssh-key/private key"
+            fail=true
           else
-            legacy_len=$(wc -c < "$legacy_file" | tr -d ' ')
-            op_len=$(wc -c < "$op_file" | tr -d ' ')
-            echo "VPS_SSH_KEY_OP matches legacy secret: no"
-            echo "    legacy length: $legacy_len bytes"
-            echo "    OP length:     $op_len bytes"
-            echo "::warning::OP-loaded VPS SSH key does NOT match legacy GH Actions secret. Investigate before PR 2.4 swaps to the OP value."
+            case "$VPS_SSH_KEY_OP" in
+              -----BEGIN*PRIVATE\ KEY-----*)
+                echo "VPS_SSH_KEY_OP: SSH private-key shape valid"
+                ;;
+              *)
+                echo "::error::VPS_SSH_KEY_OP does not look like an OpenSSH/PEM private key"
+                fail=true
+                ;;
+            esac
           fi
 
-      - name: Note when 1Password load step failed (deploy proceeds with legacy key)
-        if: steps.load_op_ssh.outcome == 'failure'
-        run: |
-          echo "::warning::1Password load-secrets-action failed; falling back to legacy VPS_SSH_KEY from GH Actions. Investigate before assuming Phase 2 is healthy."
-
-      # ─── Phase 2 PR 2.2: Caddy basic-auth parity / presence check ──
-      #
-      # The bcrypt hash in op://prod-ci/app-basic-auth-hash/credential is
-      # SEMANTICALLY equivalent to ${{ secrets.APP_BASIC_AUTH_PASSWORD_HASH }}
-      # but bcrypt salts make the two byte-strings non-identical. We
-      # therefore can't `cmp -s` them — we only check:
-      #   (a) the OP-loaded values are non-empty (load worked end-to-end)
-      #   (b) the OP-loaded hash starts with $2a$ / $2b$ / $2y$
-      #   (c) the legacy GH-secret hash also starts with $2a$ / $2b$ / $2y$
-      #   (d) the OP-loaded user matches the legacy user byte-for-byte
-      # Mismatches surface as workflow ::warning:: annotations so they're
-      # visible in the PR check summary; the deploy still uses the legacy
-      # values until PR 2.4 swaps the heredoc. The 401/200 smoke check at
-      # the end of the deploy is the load-bearing verification.
-      - name: Verify OP-loaded Caddy basic-auth values (parity, non-blocking)
-        if: steps.load_op_ssh.outcome == 'success'
-        env:
-          LEGACY_USER: ${{ secrets.APP_BASIC_AUTH_USER }}
-          LEGACY_HASH: ${{ secrets.APP_BASIC_AUTH_PASSWORD_HASH }}
-        run: |
-          set -euo pipefail
-          set +x
-
-          fail_warn=false
-
-          # (a) non-empty checks
+          # APP_BASIC_AUTH_USER_OP: non-empty string. Usernames have
+          # no fixed shape; non-empty is the only meaningful check.
           if [ -z "${APP_BASIC_AUTH_USER_OP:-}" ]; then
-            echo "::warning::OP-loaded APP_BASIC_AUTH_USER_OP is empty — check op://prod-ci/app-basic-auth-hash/username exists"
-            fail_warn=true
-          fi
-          if [ -z "${APP_BASIC_AUTH_PASSWORD_HASH_OP:-}" ]; then
-            echo "::warning::OP-loaded APP_BASIC_AUTH_PASSWORD_HASH_OP is empty — check op://prod-ci/app-basic-auth-hash/credential exists"
-            fail_warn=true
+            echo "::error::APP_BASIC_AUTH_USER_OP is empty — check op://prod-ci/app-basic-auth-hash/username"
+            fail=true
+          else
+            echo "APP_BASIC_AUTH_USER_OP: non-empty"
           fi
 
-          # (b) OP-loaded hash shape
-          if [ -n "${APP_BASIC_AUTH_PASSWORD_HASH_OP:-}" ]; then
+          # APP_BASIC_AUTH_PASSWORD_HASH_OP: bcrypt shape check ($2a$/$2b$/$2y$).
+          # Semantic correctness (the hash authenticates the right
+          # password) is verified end-to-end by the 401/200 smoke
+          # check on app.averray.com later in this deploy.
+          if [ -z "${APP_BASIC_AUTH_PASSWORD_HASH_OP:-}" ]; then
+            echo "::error::APP_BASIC_AUTH_PASSWORD_HASH_OP is empty — check op://prod-ci/app-basic-auth-hash/credential"
+            fail=true
+          else
             case "$APP_BASIC_AUTH_PASSWORD_HASH_OP" in
               \$2a\$*|\$2b\$*|\$2y\$*)
                 echo "APP_BASIC_AUTH_PASSWORD_HASH_OP: bcrypt shape valid"
                 ;;
               *)
-                echo "::warning::OP-loaded APP_BASIC_AUTH_PASSWORD_HASH_OP does not look like a bcrypt hash"
-                fail_warn=true
+                echo "::error::APP_BASIC_AUTH_PASSWORD_HASH_OP does not look like a bcrypt hash"
+                fail=true
                 ;;
             esac
           fi
 
-          # (c) legacy GH-secret hash shape (sanity check on the value
-          # we're actually still deploying with).
-          if [ -n "${LEGACY_HASH:-}" ]; then
-            case "$LEGACY_HASH" in
-              \$2a\$*|\$2b\$*|\$2y\$*)
-                echo "legacy APP_BASIC_AUTH_PASSWORD_HASH: bcrypt shape valid"
-                ;;
-              *)
-                echo "::warning::legacy APP_BASIC_AUTH_PASSWORD_HASH (GH secret) does not look like a bcrypt hash — deploy will likely fail at render-caddyfile.sh"
-                fail_warn=true
-                ;;
-            esac
-          fi
-
-          # (d) byte-for-byte compare of usernames (not secrets, but
-          # mismatch means OP and GH drifted; same printf '%s' / cmp -s
-          # pattern as the SSH key check).
-          if [ -n "${APP_BASIC_AUTH_USER_OP:-}" ] && [ -n "${LEGACY_USER:-}" ]; then
-            umask 077
-            legacy_file=$(mktemp)
-            op_file=$(mktemp)
-            trap 'rm -f "$legacy_file" "$op_file"' EXIT
-            printf '%s' "$LEGACY_USER" > "$legacy_file"
-            printf '%s' "$APP_BASIC_AUTH_USER_OP" > "$op_file"
-            if cmp -s "$legacy_file" "$op_file"; then
-              echo "APP_BASIC_AUTH_USER_OP matches legacy secret: yes"
-            else
-              echo "APP_BASIC_AUTH_USER_OP matches legacy secret: no"
-              echo "::warning::OP-loaded basic-auth username drifted from legacy GH secret. Investigate before PR 2.4 swaps."
-              fail_warn=true
-            fi
-          fi
-
-          if [ "$fail_warn" = "true" ]; then
-            echo "::warning::Caddy basic-auth parity check raised warnings (deploy proceeds with legacy values)"
+          if [ "$fail" = "true" ]; then
+            exit 1
           fi
 
       # ─── Phase 2 PR 2.8b: ADMIN_JWT from 1Password (FAIL-CLOSED, active source) ──
@@ -393,7 +351,11 @@ jobs:
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
-          printf '%s\n' "$VPS_SSH_KEY" > ~/.ssh/id_ed25519
+          # Phase 2 PR 2.7a: $VPS_SSH_KEY_OP was loaded from
+          # op://prod-ci/vps-ssh-key/private key by the fail-closed
+          # prod-ci load step above; the legacy ${{ secrets.VPS_SSH_KEY }}
+          # GH-secret env binding is gone.
+          printf '%s\n' "$VPS_SSH_KEY_OP" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan -p "${VPS_PORT:-22}" -H "$VPS_HOST" >> ~/.ssh/known_hosts
 
@@ -401,21 +363,31 @@ jobs:
         run: |
           # APP_BASIC_AUTH_PASSWORD (raw) is intentionally NOT in this
           # heredoc anymore — render-caddyfile.sh on the VPS now requires
-          # the HASH and rejects the raw value. PR 2.4 will further
-          # eliminate the SSH-heredoc transport for APP_BASIC_AUTH_USER
-          # + APP_BASIC_AUTH_PASSWORD_HASH once op inject runs on the VPS.
+          # the HASH and rejects the raw value (PR 2.2). The plaintext
+          # lives only in op://prod-critical/app-basic-auth for human
+          # operators typing into the browser dialog.
           #
-          # Phase 2 PR 2.8b: ADMIN_JWT below now reads $ADMIN_JWT_OP
+          # Phase 2 PR 2.7a: APP_BASIC_AUTH_USER and APP_BASIC_AUTH_PASSWORD_HASH
+          # below now read $APP_BASIC_AUTH_USER_OP and
+          # $APP_BASIC_AUTH_PASSWORD_HASH_OP, loaded from
+          # op://prod-ci/app-basic-auth-hash by the fail-closed prod-ci
+          # load step. The legacy GH-secret env bindings have been
+          # removed; the secrets can be deleted with
+          #   gh secret delete APP_BASIC_AUTH_USER APP_BASIC_AUTH_PASSWORD_HASH -R averray-agent/agent
+          # after one green deploy.
+          #
+          # Phase 2 PR 2.8b: ADMIN_JWT below reads $ADMIN_JWT_OP
           # (loaded from op://prod-smoke/admin-jwt/password by the
           # fail-closed smoke-load step above), not the legacy
-          # ${{ secrets.ADMIN_JWT }} GH secret. The legacy job-env
-          # binding has been removed; the GH secret can be deleted with
-          # `gh secret delete ADMIN_JWT -R averray-agent/agent` after
-          # one green deploy on this PR.
+          # ${{ secrets.ADMIN_JWT }} GH secret.
+          #
+          # PR 2.7b will move the SSH-heredoc transport for the
+          # remaining values (RESEND_API_KEY, BOOTSTRAP_SELF_REPORT_*)
+          # to 1Password as well.
           remote_env=$(
             printf 'APP_BASIC_AUTH_USER=%q APP_BASIC_AUTH_PASSWORD_HASH=%q APP_ALLOW_PROTECTED_SHELL=%q ADMIN_JWT=%q RESEND_API_KEY=%q BOOTSTRAP_SELF_REPORT_TO=%q BOOTSTRAP_SELF_REPORT_FROM=%q BOOTSTRAP_SELF_REPORT_SEND_ON_START=%q RUN_INDEXER=%q WAIT_FOR_READY=%q HEALTH_STABILITY_SEC=%q INDEXER_LOG_TAIL=%q SMOKE_CHECK_INDEXER=%q SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION=%q SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT=%q SMOKE_CHECK_PRODUCT_PROOF_GATE=%q PRODUCT_PROOF_REQUIRE_WORKER_LOOP=%q PRODUCT_PROOF_REWARD_ASSET=%q INDEXER_DATABASE_SCHEMA=%q INDEXER_FRESH_SCHEMA=%q ' \
-              "$APP_BASIC_AUTH_USER" \
-              "$APP_BASIC_AUTH_PASSWORD_HASH" \
+              "$APP_BASIC_AUTH_USER_OP" \
+              "$APP_BASIC_AUTH_PASSWORD_HASH_OP" \
               "$APP_ALLOW_PROTECTED_SHELL" \
               "$ADMIN_JWT_OP" \
               "$RESEND_API_KEY" \

--- a/docs/SECRETS_MIGRATION.md
+++ b/docs/SECRETS_MIGRATION.md
@@ -990,21 +990,61 @@ manifest with its own parity guard.
 
 ### PR 2.7 — Cleanup of legacy artifacts AND rotation
 
-**Touches**: `.github/workflows/deploy-production.yml`, VPS env files,
-`SECRETS_CALENDAR.yml`.
+Split into four sub-PRs to keep blast-radius small and let operator
+coordination interleave with code changes:
 
-Cleanup (the easy part):
+| Sub-PR | Scope | Risk |
+|---|---|---|
+| **2.7a** | Flip `VPS_SSH_KEY` + `APP_BASIC_AUTH_USER` + `APP_BASIC_AUTH_PASSWORD_HASH` to 1Password, fail-closed | Low — parity green since PR 2.1 / 2.2 |
+| 2.7b | Move `RESEND_API_KEY` + `BOOTSTRAP_SELF_REPORT_*` through OP (new parity → flip) | Medium |
+| 2.7c | SSH to VPS: delete `/srv/agent-stack/{backend,indexer}.env` + `.pre-pr2.5` rollback backup | Trivial |
+| 2.7d | Rotate `VPS_SSH_KEY`, `APP_BASIC_AUTH_PASSWORD`, `RESEND_API_KEY`, `AUTH_JWT_SECRETS` (each its own coordinated window) | High |
 
-- Delete legacy GitHub Actions secrets: `VPS_SSH_KEY`,
-  `APP_BASIC_AUTH_USER`, `APP_BASIC_AUTH_PASSWORD`,
-  `APP_BASIC_AUTH_PASSWORD_HASH`, `RESEND_API_KEY`,
-  `BOOTSTRAP_SELF_REPORT_*`.
-- Delete `/srv/agent-stack/backend.env` and `/srv/agent-stack/indexer.env`
-  from the VPS.
-- Reboot test: confirm `/run/agent-stack` is recreated by
-  `systemd-tmpfiles` and the next deploy renders fresh env files.
+#### PR 2.7a — flip prod-ci secrets to 1Password (this PR)
 
-Rotation (the part that actually closes the exposure window):
+**Touches**: `.github/workflows/deploy-production.yml`.
+
+Mirrors PR 2.8b for the three prod-ci-vault secrets:
+
+- **Source swaps** in the workflow:
+  - `Configure SSH` step: `"$VPS_SSH_KEY"` → `"$VPS_SSH_KEY_OP"` (the ed25519 key written to `~/.ssh/id_ed25519`).
+  - `Deploy production` heredoc: `"$APP_BASIC_AUTH_USER"` → `"$APP_BASIC_AUTH_USER_OP"`, `"$APP_BASIC_AUTH_PASSWORD_HASH"` → `"$APP_BASIC_AUTH_PASSWORD_HASH_OP"`.
+- **Legacy job-env bindings removed**: the three `${{ secrets.* }}` lines for these are gone.
+- **Load step now fail-closed**: the prod-ci load step's `continue-on-error: true` is removed. A 1Password outage / wrong token / missing item now fails the deploy at this step rather than silently falling through to a legacy that no longer exists.
+- **Compare + Note steps replaced with a single Verify step**: non-empty + shape checks on all three values (SSH private-key PEM marker, basic-auth user non-empty, bcrypt-hash shape). Failures emit `::error::` and `exit 1`. The 401/200 smoke check on `app.averray.com` later in the deploy remains the load-bearing semantic verification for basic-auth.
+- **Validate-required-secrets**: legacy `test -n` lines dropped (those values aren't in env at that point anymore; the load+verify pair below catches missing/empty OP values).
+
+**Operator action after this PR merges + one green deploy:**
+
+```sh
+gh secret delete VPS_SSH_KEY APP_BASIC_AUTH_USER APP_BASIC_AUTH_PASSWORD_HASH -R averray-agent/agent
+```
+
+(Also still pending from PR 2.8b: `gh secret delete ADMIN_JWT`.)
+
+#### PR 2.7b — move smoke-channel secrets through 1Password (TODO)
+
+`RESEND_API_KEY` and `BOOTSTRAP_SELF_REPORT_*` still flow through the
+job env block as legacy GH secrets. They're parity-loadable from
+`op://prod-backend-external/resend-api-key/password` and (for the
+report addresses) the inventory but not yet wired into a load step.
+Follow the PR 2.8a → 2.8b → 2.7a pattern: add a parity-check load,
+let it run a few deploys, then flip + remove legacy.
+
+#### PR 2.7c — delete legacy `/srv` files from the VPS
+
+After at least 24h of stable deploys on PR 2.5 + PR 2.6 + PR 2.7a
+(the cutover stack):
+
+```sh
+ssh ubuntu@141.94.121.188 'sudo rm /srv/agent-stack/backend.env /srv/agent-stack/indexer.env /srv/agent-stack/docker-compose.yml.pre-pr2.5'
+```
+
+Then **reboot test**: confirm `/run/agent-stack` is recreated by
+`systemd-tmpfiles` and the next deploy renders fresh env files
+successfully end-to-end.
+
+#### PR 2.7d — rotation (the part that actually closes the exposure window)
 
 Deletion alone is not enough. The values that lived in GitHub Actions
 secrets, SSH heredoc command strings, hand-managed VPS env files, shell
@@ -1020,19 +1060,20 @@ to those surfaces and rotated.
 | `AUTH_JWT_SECRETS`             | **Rotate** in a controlled key-ring window (prepend new, redeploy, wait 24–48h for in-flight tokens, remove old, redeploy) | Lived in the hand-managed VPS env file; HMAC compromise = ability to mint any admin JWT                                                                                                                                   |
 | `SIGNER_PRIVATE_KEY`           | **NOT rotated here.** Honest framing: the key remains exposed by historical VPS env files until Phase 3. Phase 2 reduces distribution drift but does NOT solve backend signer private-key exposure. | Phase 3's job. Calling it out so the security claim stays honest.                                                                                                                                                          |
 
-**Acceptance criteria**:
+**Acceptance criteria across PR 2.7a/b/c/d**:
 
-- [ ] Legacy GitHub Actions secrets deleted (verified with
-      `gh secret list -R averray-agent/agent`)
-- [ ] Legacy `/srv/agent-stack/*.env` files deleted (verified with
-      `ssh ... ls /srv/agent-stack/*.env`)
-- [ ] Rotation completed (or rotation tickets filed with explicit
+- [ ] (2.7a) Legacy `VPS_SSH_KEY` + `APP_BASIC_AUTH_USER` + `APP_BASIC_AUTH_PASSWORD_HASH`
+      GitHub Actions secrets deleted (`gh secret list -R averray-agent/agent`)
+- [ ] (2.7b) `RESEND_API_KEY` + `BOOTSTRAP_SELF_REPORT_*` moved through 1Password
+- [ ] (2.7c) Legacy `/srv/agent-stack/*.env` + `.pre-pr2.5` backup deleted
+      (`ssh ... ls /srv/agent-stack/`)
+- [ ] (2.7c) Reboot test green: `/run/agent-stack` recreated; deploy renders
+      fresh env files successfully
+- [ ] (2.7d) Rotation completed (or rotation tickets filed with explicit
       deadlines) for every secret in the table above except
       `SIGNER_PRIVATE_KEY`
-- [ ] `SECRETS_CALENDAR.yml` updated with the new `expires_at` values
+- [ ] (2.7d) `SECRETS_CALENDAR.yml` updated with the new `expires_at` values
       for any rotated calendar-tracked entry
-- [ ] Reboot test green: `/run/agent-stack` recreated; deploy renders
-      fresh env files successfully
 
 ### PR 2.8 — Smoke auth secret to 1Password
 


### PR DESCRIPTION
## Summary

Mirrors PR 2.8b's pattern for the three prod-ci-vault secrets whose parity check has been green since PRs 2.1 and 2.2 wired up `load-secrets-action`:

| Legacy GH secret | OP path |
|---|---|
| `VPS_SSH_KEY` | `op://prod-ci/vps-ssh-key/private key` |
| `APP_BASIC_AUTH_USER` | `op://prod-ci/app-basic-auth-hash/username` |
| `APP_BASIC_AUTH_PASSWORD_HASH` | `op://prod-ci/app-basic-auth-hash/credential` |

After this PR + one green deploy, the operator deletes all three legacy GH secrets and another major surface of Phase 2 is retired.

## Workflow surgery (single file)

`.github/workflows/deploy-production.yml`:

1. **Three legacy job-env bindings removed** from the job-level `env:` block.
2. **Load step is now fail-closed**: dropped `continue-on-error: true` from the prod-ci `load-secrets-action` step.
3. **Compare + Note steps collapsed into one Verify step** (`Verify prod-ci OP values loaded and shape-valid`):
   - `VPS_SSH_KEY_OP`: non-empty + OpenSSH PEM marker (`-----BEGIN ... PRIVATE KEY-----`)
   - `APP_BASIC_AUTH_USER_OP`: non-empty
   - `APP_BASIC_AUTH_PASSWORD_HASH_OP`: non-empty + bcrypt shape (`$2a$/$2b$/$2y$`)
   All failures emit `::error::` and `exit 1`.
4. **Source swaps**:
   - Configure SSH: `"$VPS_SSH_KEY"` → `"$VPS_SSH_KEY_OP"`
   - Deploy heredoc: `"$APP_BASIC_AUTH_USER"` → `"$APP_BASIC_AUTH_USER_OP"`, `"$APP_BASIC_AUTH_PASSWORD_HASH"` → `"$APP_BASIC_AUTH_PASSWORD_HASH_OP"`
5. **Validate-required-secrets**: dropped the legacy `test -n` lines (the values aren't in env at that point in the job).

Workflow now has 9 named steps (down from 11 — two parity-check steps collapsed into one Verify step).

## Verification history (justifying the flip)

- **`VPS_SSH_KEY`**: byte-for-byte `cmp -s` against legacy was green across the entire PR 2.1 → 2.4 window. The key was rotated during PR 2.1 acceptance and re-aligned in OP + GH; subsequent deploys re-verified parity.
- **`APP_BASIC_AUTH_USER`**: byte-for-byte against legacy. Green since PR 2.2.
- **`APP_BASIC_AUTH_PASSWORD_HASH`**: bcrypt salts prevent byte-compare (same plaintext + different salt = different hash). The hash was verified semantically by hashing the OP plaintext during PR 2.2 setup, and the **401/200 smoke check on `app.averray.com`** remains as the load-bearing end-to-end test.

## Operator action after merge + one green deploy

```bash
gh secret delete VPS_SSH_KEY APP_BASIC_AUTH_USER APP_BASIC_AUTH_PASSWORD_HASH -R averray-agent/agent
```

(Plus the still-pending PR 2.8b cleanup: `gh secret delete ADMIN_JWT`.)

## Docs

`docs/SECRETS_MIGRATION.md`: rewrite the PR 2.7 section as a four-way sub-PR split — **2.7a** (this PR, code flip), 2.7b (smoke-channel secrets), 2.7c (VPS file cleanup), 2.7d (rotation).

## Test plan

- [x] YAML structurally valid (9 named steps)
- [x] Both Phase 2 CI guards (env template structural lint, manifest parity) pass locally
- [ ] After merge + auto-deploy:
  - Load + Verify steps succeed; log shows the three "shape valid"/"non-empty" messages
  - `Configure SSH` writes the OP-loaded key; SSH into VPS succeeds (proves the OP key is the right private key)
  - 401/200 smoke check on `app.averray.com` passes (proves OP user + hash authenticate the right password end-to-end)

## Revert plan

If anything fails: re-add the three job-env bindings, swap the three printf args back, restore `continue-on-error: true` on the load step. Mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)