### PR TITLE
Phase 2 PR 2.7b: remove dead RESEND/BOOTSTRAP_SELF_REPORT_* heredoc args

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -55,14 +55,16 @@ on:
         options:
           - "0"
           - "1"
-      bootstrap_self_report_send_on_start:
-        description: One-shot bootstrap self-report send on backend start.
-        required: false
-        default: "0"
-        type: choice
-        options:
-          - "0"
-          - "1"
+      # bootstrap_self_report_send_on_start: removed in PR 2.7b. The
+      # one-shot "send self-report on backend start" override has been
+      # broken since PR 2.6 retired configure_bootstrap_instrumentation_env
+      # (no callers on the VPS read the heredoc-passed override anymore;
+      # the backend reads BOOTSTRAP_SELF_REPORT_SEND_ON_START from
+      # /run/agent-stack/backend.env, which is rendered from
+      # deploy/backend.env.template:98 = `false`). If the operator needs
+      # to one-shot a bootstrap self-report, edit
+      # deploy/backend.env.template line 98 to `true` for a single
+      # deploy, then revert.
       smoke_check_bootstrap_instrumentation:
         description: Require bootstrap poller + self-report status in hosted smoke.
         required: false
@@ -150,9 +152,18 @@ jobs:
       # the OP value matched the legacy byte-for-byte before the flip.
       # Operator action after this PR merges + one green deploy:
       #   gh secret delete ADMIN_JWT -R averray-agent/agent
-      RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
-      BOOTSTRAP_SELF_REPORT_TO: ${{ secrets.BOOTSTRAP_SELF_REPORT_TO }}
-      BOOTSTRAP_SELF_REPORT_FROM: ${{ secrets.BOOTSTRAP_SELF_REPORT_FROM }}
+      # RESEND_API_KEY, BOOTSTRAP_SELF_REPORT_TO, BOOTSTRAP_SELF_REPORT_FROM
+      # removed in PR 2.7b. After PR 2.6 retired
+      # configure_bootstrap_instrumentation_env, the SSH-passed copies
+      # of these became dead code — the backend container now reads
+      # them directly from /run/agent-stack/backend.env, which is
+      # rendered from deploy/backend.env.template:
+      #   line 47:    RESEND_API_KEY=op://prod-backend-external/resend-api-key/password
+      #   lines 96-101: BOOTSTRAP_SELF_REPORT_* (literal hardcoded values
+      #                 — these are config, not secrets — and the
+      #                 RESEND_API_KEY entry is OP-sourced).
+      # Operator action after this PR merges + one green deploy:
+      #   gh secret delete RESEND_API_KEY BOOTSTRAP_SELF_REPORT_TO BOOTSTRAP_SELF_REPORT_FROM -R averray-agent/agent
       DEPLOY_RUN_INDEXER: ${{ github.event_name == 'workflow_dispatch' && inputs.run_indexer || 'auto' }}
       DEPLOY_WAIT_FOR_READY: ${{ github.event_name == 'workflow_dispatch' && inputs.wait_for_ready || '1' }}
       DEPLOY_HEALTH_STABILITY_SEC: ${{ github.event_name == 'workflow_dispatch' && inputs.health_stability_sec || '0' }}
@@ -160,7 +171,8 @@ jobs:
       DEPLOY_SMOKE_CHECK_INDEXER: ${{ github.event_name == 'workflow_dispatch' && inputs.smoke_check_indexer || 'auto' }}
       DEPLOY_INDEXER_DATABASE_SCHEMA: ${{ github.event_name == 'workflow_dispatch' && inputs.indexer_database_schema || '' }}
       DEPLOY_INDEXER_FRESH_SCHEMA: ${{ github.event_name == 'workflow_dispatch' && inputs.indexer_fresh_schema || '0' }}
-      DEPLOY_BOOTSTRAP_SELF_REPORT_SEND_ON_START: ${{ github.event_name == 'workflow_dispatch' && inputs.bootstrap_self_report_send_on_start || '0' }}
+      # DEPLOY_BOOTSTRAP_SELF_REPORT_SEND_ON_START removed in PR 2.7b
+      # alongside the matching workflow_dispatch input above.
       DEPLOY_SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION: ${{ github.event_name == 'workflow_dispatch' && inputs.smoke_check_bootstrap_instrumentation || '0' }}
       DEPLOY_SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT: ${{ github.event_name == 'workflow_dispatch' && inputs.smoke_check_bootstrap_self_report_sent || '0' }}
       DEPLOY_SMOKE_CHECK_PRODUCT_PROOF_GATE: ${{ github.event_name == 'workflow_dispatch' && inputs.smoke_check_product_proof_gate || '0' }}
@@ -390,19 +402,21 @@ jobs:
           # block above: never `${X secrets.NAME X}` inside a
           # run-block comment.)
           #
-          # PR 2.7b will move the SSH-heredoc transport for the
-          # remaining values (RESEND_API_KEY, BOOTSTRAP_SELF_REPORT_*)
-          # to 1Password as well.
+          # Phase 2 PR 2.7b: RESEND_API_KEY, BOOTSTRAP_SELF_REPORT_TO,
+          # BOOTSTRAP_SELF_REPORT_FROM, and BOOTSTRAP_SELF_REPORT_SEND_ON_START
+          # were removed from this heredoc. Audit confirmed nothing on
+          # the VPS reads them after PR 2.6 retired
+          # configure_bootstrap_instrumentation_env — the backend
+          # container gets these values directly from
+          # /run/agent-stack/backend.env (RESEND_API_KEY is OP-sourced
+          # via deploy/backend.env.template:47; the BOOTSTRAP_SELF_REPORT_*
+          # values are template-hardcoded config, not secrets).
           remote_env=$(
-            printf 'APP_BASIC_AUTH_USER=%q APP_BASIC_AUTH_PASSWORD_HASH=%q APP_ALLOW_PROTECTED_SHELL=%q ADMIN_JWT=%q RESEND_API_KEY=%q BOOTSTRAP_SELF_REPORT_TO=%q BOOTSTRAP_SELF_REPORT_FROM=%q BOOTSTRAP_SELF_REPORT_SEND_ON_START=%q RUN_INDEXER=%q WAIT_FOR_READY=%q HEALTH_STABILITY_SEC=%q INDEXER_LOG_TAIL=%q SMOKE_CHECK_INDEXER=%q SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION=%q SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT=%q SMOKE_CHECK_PRODUCT_PROOF_GATE=%q PRODUCT_PROOF_REQUIRE_WORKER_LOOP=%q PRODUCT_PROOF_REWARD_ASSET=%q INDEXER_DATABASE_SCHEMA=%q INDEXER_FRESH_SCHEMA=%q ' \
+            printf 'APP_BASIC_AUTH_USER=%q APP_BASIC_AUTH_PASSWORD_HASH=%q APP_ALLOW_PROTECTED_SHELL=%q ADMIN_JWT=%q RUN_INDEXER=%q WAIT_FOR_READY=%q HEALTH_STABILITY_SEC=%q INDEXER_LOG_TAIL=%q SMOKE_CHECK_INDEXER=%q SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION=%q SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT=%q SMOKE_CHECK_PRODUCT_PROOF_GATE=%q PRODUCT_PROOF_REQUIRE_WORKER_LOOP=%q PRODUCT_PROOF_REWARD_ASSET=%q INDEXER_DATABASE_SCHEMA=%q INDEXER_FRESH_SCHEMA=%q ' \
               "$APP_BASIC_AUTH_USER_OP" \
               "$APP_BASIC_AUTH_PASSWORD_HASH_OP" \
               "$APP_ALLOW_PROTECTED_SHELL" \
               "$ADMIN_JWT_OP" \
-              "$RESEND_API_KEY" \
-              "$BOOTSTRAP_SELF_REPORT_TO" \
-              "$BOOTSTRAP_SELF_REPORT_FROM" \
-              "$DEPLOY_BOOTSTRAP_SELF_REPORT_SEND_ON_START" \
               "$DEPLOY_RUN_INDEXER" \
               "$DEPLOY_WAIT_FOR_READY" \
               "$DEPLOY_HEALTH_STABILITY_SEC" \

--- a/docs/SECRETS_MIGRATION.md
+++ b/docs/SECRETS_MIGRATION.md
@@ -1263,14 +1263,67 @@ gh secret delete VPS_SSH_KEY APP_BASIC_AUTH_USER APP_BASIC_AUTH_PASSWORD_HASH -R
 
 (Also still pending from PR 2.8b: `gh secret delete ADMIN_JWT`.)
 
-#### PR 2.7b — move smoke-channel secrets through 1Password (TODO)
+#### PR 2.7b — remove dead RESEND/BOOTSTRAP_SELF_REPORT_* heredoc args (this PR)
 
-`RESEND_API_KEY` and `BOOTSTRAP_SELF_REPORT_*` still flow through the
-job env block as legacy GH secrets. They're parity-loadable from
-`op://prod-backend-external/resend-api-key/password` and (for the
-report addresses) the inventory but not yet wired into a load step.
-Follow the PR 2.8a → 2.8b → 2.7a pattern: add a parity-check load,
-let it run a few deploys, then flip + remove legacy.
+**Touches**: `.github/workflows/deploy-production.yml`.
+
+Audit while building this PR found that `RESEND_API_KEY`,
+`BOOTSTRAP_SELF_REPORT_TO`, and `BOOTSTRAP_SELF_REPORT_FROM` aren't
+actually migration candidates — they're **dead args in the SSH
+heredoc**.
+
+After PR 2.6 retired `configure_bootstrap_instrumentation_env`, no
+script on the VPS reads these values from the heredoc anymore. The
+backend container gets them directly from
+`/run/agent-stack/backend.env`, which is rendered from
+`deploy/backend.env.template`:
+
+- `RESEND_API_KEY` (template line 47): already `op://prod-backend-external/resend-api-key/password` — runs through OP at render time, not via the SSH heredoc.
+- `BOOTSTRAP_SELF_REPORT_*` (template lines 96-101): template-hardcoded literal values — these are config (email addresses, intervals), not secrets.
+
+So the secrets being deleted from the workflow's job env block
+aren't actually moving anywhere; they were simply unused. The
+deploy will pass exactly the same env to the backend container
+before and after this PR.
+
+**Changes:**
+
+- Remove three `${{ secrets.* }}` bindings from the job-level `env:`
+  block: `RESEND_API_KEY`, `BOOTSTRAP_SELF_REPORT_TO`,
+  `BOOTSTRAP_SELF_REPORT_FROM`.
+- Remove the four matching `%q` slots from the SSH-heredoc printf
+  format and their args:
+  - `RESEND_API_KEY=%q "$RESEND_API_KEY"`
+  - `BOOTSTRAP_SELF_REPORT_TO=%q "$BOOTSTRAP_SELF_REPORT_TO"`
+  - `BOOTSTRAP_SELF_REPORT_FROM=%q "$BOOTSTRAP_SELF_REPORT_FROM"`
+  - `BOOTSTRAP_SELF_REPORT_SEND_ON_START=%q "$DEPLOY_BOOTSTRAP_SELF_REPORT_SEND_ON_START"`
+- Remove the orphaned `bootstrap_self_report_send_on_start` workflow_dispatch
+  input and `DEPLOY_BOOTSTRAP_SELF_REPORT_SEND_ON_START` env mapping.
+  The one-shot "send self-report on backend start" override has been
+  silently broken since PR 2.6; an honest "unknown input" error is
+  better than the silent no-op. If the operator needs to one-shot a
+  bootstrap self-report, the workflow comment now points to
+  `deploy/backend.env.template:98` as the place to flip
+  `BOOTSTRAP_SELF_REPORT_SEND_ON_START=false` → `true` for one deploy.
+
+**Operator action after this PR merges + one green deploy:**
+
+```sh
+gh secret delete RESEND_API_KEY BOOTSTRAP_SELF_REPORT_TO BOOTSTRAP_SELF_REPORT_FROM -R averray-agent/agent
+```
+
+Plus the unused-since-PR-2.2 raw password (also safe to delete now):
+
+```sh
+gh secret delete APP_BASIC_AUTH_PASSWORD -R averray-agent/agent
+```
+
+After PR 2.7b, the only "real secrets" remaining in GH Actions are
+`VPS_HOST`, `VPS_PORT`, `VPS_USER`, and the
+`OP_SERVICE_ACCOUNT_TOKEN_PROD_*` tokens — none of which carry
+application secret material; they're connection coordinates and
+1Password service-account tokens (whose blast radius is bounded
+by the per-vault scope).
 
 #### PR 2.7c — delete legacy `/srv` files from the VPS
 


### PR DESCRIPTION
## Summary

While planning the standard load-secrets-action migration for `RESEND_API_KEY` + `BOOTSTRAP_SELF_REPORT_*`, the audit surfaced that **these aren't migration candidates — they're dead args in the SSH heredoc**.

After PR 2.6 retired `configure_bootstrap_instrumentation_env` (the function that consumed these from the SSH heredoc and wrote them into `/srv/agent-stack/backend.env`), no script on the VPS reads them anymore. The backend container gets them directly from `/run/agent-stack/backend.env`, rendered from `deploy/backend.env.template`:

- `RESEND_API_KEY` (template:47) → `op://prod-backend-external/resend-api-key/password` — already OP-sourced via the render flow.
- `BOOTSTRAP_SELF_REPORT_*` (template:96-101) → template-hardcoded literal values (email addresses, intervals — config, not secrets).

So removing them from the workflow doesn't change what the container sees. PR 2.7b is **removal of dead code**, not an OP migration.

## Changes

`.github/workflows/deploy-production.yml`:

1. **Job-env block**: removed 3 legacy GH-secret bindings (`RESEND_API_KEY`, `BOOTSTRAP_SELF_REPORT_TO`, `BOOTSTRAP_SELF_REPORT_FROM`).
2. **Deploy heredoc**: removed 4 `%q` slots + 4 args (`RESEND_API_KEY`, `BOOTSTRAP_SELF_REPORT_TO`, `BOOTSTRAP_SELF_REPORT_FROM`, `BOOTSTRAP_SELF_REPORT_SEND_ON_START`). 16 slots ↔ 16 args verified after the cut.
3. **`bootstrap_self_report_send_on_start` workflow_dispatch input**: removed. The "one-shot send self-report on backend start" override has been silently broken since PR 2.6 (no caller). An honest "unknown input" error beats the silent no-op. The replacement comment points operators at `deploy/backend.env.template:98` for the same one-shot pattern.
4. **`DEPLOY_BOOTSTRAP_SELF_REPORT_SEND_ON_START` env-var mapping**: removed (was only feeding the deleted input).

`docs/SECRETS_MIGRATION.md`: rewrote the PR 2.7b subsection to reflect the actual scope (dead-code removal, not OP migration).

## Operator action after merge + one green deploy

```bash
gh secret delete RESEND_API_KEY BOOTSTRAP_SELF_REPORT_TO BOOTSTRAP_SELF_REPORT_FROM -R averray-agent/agent
gh secret delete APP_BASIC_AUTH_PASSWORD -R averray-agent/agent   # unused since PR 2.2
```

After this, the only "real" GH Actions secrets remaining are `VPS_HOST`, `VPS_PORT`, `VPS_USER`, and the `OP_SERVICE_ACCOUNT_TOKEN_PROD_*` tokens — connection coordinates and per-vault-scoped service-account tokens. **No application-secret material remaining outside 1Password.**

## Test plan

- [x] Workflow YAML structurally valid (printf format has 16 `%q` slots and 16 matching args)
- [x] Both Phase 2 CI guards pass locally
- [ ] After merge + auto-deploy:
  - Deploy succeeds end-to-end
  - `/health` 200
  - `app.averray.com` basic-auth check still passes
  - `docker inspect agent-backend` env still shows correct `RESEND_API_KEY` + `BOOTSTRAP_SELF_REPORT_*` (those come from `/run/backend.env` via template render, not the removed heredoc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)