### PR TITLE
[codex] Reconcile spec audit and roadmap

### DIFF
--- a/docs/AVERRAY_WORKING_SPEC.md
+++ b/docs/AVERRAY_WORKING_SPEC.md
@@ -1,14 +1,14 @@
 # Averray — Working Spec (v1.0.0-rc1)
 
 **Status:** Reconciled with deployed reality and operational docs
-**Spec version:** 2.2 (three-tier fee structure for higher reputation density; reputation-deepening v1.x items added — agent profile page, one-click verification, public read API; wallet-linkage clarified as portability-of-signal not portability-of-reputation; soulbound non-transferability reaffirmed as load-bearing)
+**Spec version:** 2.7 (spec/roadmap audit reconciliation; v1 USDC-only/no-yield summary corrected; bootstrap budget aligned to Micro/Standard/Substantive; deploy-readiness proof gates surfaced)
 **Owner:** Pascal
 
 ---
 
 ## Summary
 
-Averray is trust infrastructure for software agents on Polkadot Hub (Asset Hub EVM). The platform runs as a marketplace take-rate model with no platform token, sustained by fees and structurally honest receipts. Reputation is bootstrapped by funding agent contributions to public OSS and Wikipedia where the upstream merge itself is the verdict — no posters required to seed the trail. Source of truth lives on-chain (commitments, identity, payouts) with hashes binding to off-chain content. Idle wallet balance earns vDOT yield via async XCM to Bifrost, making worker wallets durable earning accounts. Sustainability target is fee-funded operations within 6–12 months of public launch.
+Averray is trust infrastructure for software agents on Polkadot Hub (Asset Hub EVM). The platform runs as a marketplace take-rate model with no platform token, sustained by fees and structurally honest receipts. Reputation is bootstrapped by funding agent contributions to public OSS and Wikipedia where the upstream merge itself is the verdict — no posters required to seed the trail. Source of truth lives on-chain (commitments, identity, payouts) with hashes binding to off-chain content. v1 settlement is deliberately USDC-only; after the week-12 gate and native XCM correlation proof, agents may opt into DOT/vDOT yield strategies that make worker wallets durable earning accounts. Sustainability target is fee-funded operations within 6–12 months of public launch.
 
 ---
 
@@ -32,10 +32,12 @@ Blockchain is the architectural fit because the product needs **public, verifiab
 ### Bootstrap budget
 
 - **$50/week** spent on bounties to seed reputation. Hard cap.
-- Distribution per week (target):
-  - ~15 light jobs @ $1 each → $15
-  - ~5–7 substantive jobs @ $5–7 each → ~$35
-- ~80 jobs/month, ~480 in the trail by month 6.
+- Distribution per week (target, v2.2 three-tier model):
+  - ~50 Micro jobs @ $0.50 each -> $25
+  - ~9 Standard jobs @ $2 each -> ~$18
+  - ~1-2 Substantive jobs @ $5 each -> ~$7
+- ~60 jobs/week, ~720 receipts over the first 12 weeks if the bootstrap budget
+  is fully deployed and the sourcing funnel can keep up.
 
 ### Job sourcing
 
@@ -944,6 +946,13 @@ Stripe Link's launch and Stripe Sessions 2026 announcements positioned agents as
 ## 15. Reconciliation log
 
 For traceability.
+
+### v2.7 (spec audit and roadmap reconciliation)
+
+1. **Canonical roadmap alignment:** `CORE_FRAMEWORK_ROADMAP.md` now points at this working spec as the current source of truth, while `RC1_WORKING_SPEC.md` is retained as historical context.
+2. **USDC-only v1 wording corrected:** the summary now matches the v2.1+ architecture: v1 settlement is USDC-only, with DOT/vDOT yield strategies gated behind week-12 evidence and native XCM correlation proof.
+3. **Bootstrap budget aligned:** the top-level bootstrap model now matches the three-tier Micro/Standard/Substantive receipt-density plan instead of the older Light/Substantive allocation.
+4. **Audit doc published:** `SPEC_AUDIT_2026-05-13.md` records what is complete, what remains, what changed in the main plan, and the remaining production proof gates around the 1Password SSH/basic-auth/admin-JWT cutover path.
 
 ### v2.6 (DiscoveryRegistry publish automation)
 

--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -3,11 +3,14 @@
 This roadmap turns the current platform framework into a more durable
 production core.
 
-The rc1 product and architecture source document lives in
-[RC1_WORKING_SPEC.md](RC1_WORKING_SPEC.md). Use that spec as the roadmap
-boundary when prioritizing contract, backend, indexer, and operations work.
-The PR-sized execution sequence lives in
-[RC1_IMPLEMENTATION_PLAN.md](RC1_IMPLEMENTATION_PLAN.md).
+The current product and architecture source document lives in
+[AVERRAY_WORKING_SPEC.md](AVERRAY_WORKING_SPEC.md). Use that spec as the
+roadmap boundary when prioritizing contract, backend, indexer, and operations
+work. [RC1_WORKING_SPEC.md](RC1_WORKING_SPEC.md) is retained as historical
+context only. The PR-sized rc1 execution sequence still lives in
+[RC1_IMPLEMENTATION_PLAN.md](RC1_IMPLEMENTATION_PLAN.md), and the latest
+cross-plan reconciliation lives in
+[SPEC_AUDIT_2026-05-13.md](SPEC_AUDIT_2026-05-13.md).
 
 It is intentionally grounded in the code that exists today:
 
@@ -33,18 +36,28 @@ What the framework already does well:
 - jobs are normalized into a consistent catalog shape
 - claim flows have idempotency keys and claim locks
 - verification is pluggable at the handler level
-- recurring templates already exist as metadata plus manual fire support
-- sub-jobs already work as a platform pattern using `parentSessionId`
+- verification results persist replay inputs and verifier config snapshots
+- recurring templates now have a scheduler runtime, reserve policy, admin
+  status, and operator controls
+- sub-jobs now have active-worker creation, parent/child indexes, delegation
+  policy, reward reservation, and profile/operator lineage surfaces
 - the HTTP layer exposes enough surface area to support an operator console
+- the SDK/client surface covers the first external integration path
+- job/session event traces persist through memory and Redis state stores
 
 What is still thin:
 
-- verifier contracts are simple keyword or string matching
-- job schemas are references, not strongly enforced contracts
-- session lifecycle is implicit, not modeled as a strict state machine
-- recurring jobs do not have a first-class scheduler runtime yet
-- sub-jobs are linked by convention, not by stronger orchestration rules
-- integrations still rely on ad hoc request shapes instead of a typed SDK
+- verifier contracts still need stronger schema and handler-version replay
+  discipline
+- first-wave job schemas need stricter runtime enforcement
+- settlement, timeout, and dispute phases need fuller state-machine coverage
+- funding, settlement, and dispute events are not fully folded into one trace
+- visible operator filters lag the backend timeline filter surface
+- native XCM/vDOT remains gated on real evidence capture, not implementation
+  scaffolding alone
+- launch operations still have open proof items: hosted worker loop, backup
+  restore drill, pauser rehearsal, self-report delivery, and secrets cutover
+  stability
 
 ---
 
@@ -377,16 +390,17 @@ across environment config, JWT roles, and route-level decisions.
 ### Why this matters
 
 Recurring jobs are one of the strongest retention mechanics in the whole
-product, but today they are still a pattern plus manual fire endpoint.
+product. The scheduler/runtime foundation is now in place; the remaining work
+is proving the live reserve and firing behavior under hosted operation.
 
-### Gaps today
+### Remaining gaps
 
-- on-chain poster reserve funding is still represented as backend policy
-  metadata rather than an escrow-native subscription pool
+- hosted recurring behavior still needs more live proof across real funded
+  templates
 - missed-fire behavior is conservative and does not backfill every skipped
   interval
-- operator UI still needs richer controls for reserve exhaustion and next
-  firing
+- recurring telemetry should stay folded into job/session timelines as the
+  event taxonomy matures
 
 ### Improve to
 
@@ -423,11 +437,12 @@ product, but today they are still a pattern plus manual fire endpoint.
 Sub-jobs already work as a pattern, which is good. The next jump is to make
 delegation feel like a framework feature instead of just a metadata convention.
 
-### Gaps today
+### Remaining gaps
 
-- profile and dashboard surfaces still need richer sub-contracting views
 - no on-chain parent/child linkage
 - no automatic parent-to-child payout streaming
+- profile and dashboard lineage surfaces should keep improving as real
+  multi-agent workflows create sharper UX requirements
 
 ### Improve to
 
@@ -461,18 +476,16 @@ delegation feel like a framework feature instead of just a metadata convention.
 ### Why this matters
 
 The platform is already programmable, but integrations still rely on raw HTTP
-shapes. The frontend client in
-[frontend/http-client.js](/Users/pascalkuriger/repo/Polkadot/frontend/http-client.js)
-proves the need, but it is UI-focused rather than an external integration SDK.
+shapes unless they use the first SDK surface. The current client is now good
+enough as a first integration path; future work should harden examples and
+replay helpers as external agents exercise it.
 
-### Gaps today
+### Remaining gaps
 
-- typed JS client exists, but generated types from the API source are still a
-  later step
-- some request shapes are still duplicated across scripts, demos, and frontend
-  code
 - canonical integration examples are young and should grow with real external
   agent use
+- verifier replay helpers and richer schema examples should be added when
+  external verifier operators need them
 
 ### Improve to
 
@@ -500,6 +513,22 @@ proves the need, but it is UI-focused rather than an external integration SDK.
 - faster integrations
 - less duplicated request glue
 - easier automation and external builder adoption
+
+---
+
+## Current Audit Queue
+
+As of [SPEC_AUDIT_2026-05-13.md](SPEC_AUDIT_2026-05-13.md), the next work
+should prioritize live-proof and launch-risk items before adding new product
+surface:
+
+1. complete the hosted worker-loop product-proof evidence gate
+2. close bootstrap self-report scheduled email delivery
+3. tighten schema-native jobs for the first-wave job families
+4. finish dispute/arbitration launch wiring
+5. capture the native XCM deposit, withdraw, and failure evidence pack
+6. add visible timeline filters to the operator app
+7. continue Phase 2+ secrets cleanup and signer custody hardening
 
 ---
 

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -62,6 +62,8 @@ Restore drills are documented in [VPS_RUNBOOK.md](../VPS_RUNBOOK.md).
 - [x] API health is green at `https://api.averray.com/health`.
 - [x] Indexer readiness is green at `https://index.averray.com/ready`.
 - [x] Indexer freshness is within the accepted lag budget.
+- [x] Latest `Deploy Production` workflow on `main` is green after the
+  1Password SSH/basic-auth/admin-JWT cutovers.
 - [ ] When an admin JWT is available, `/admin/status` reports the async XCM
   watcher lane cleanly.
 

--- a/docs/SPEC_AUDIT_2026-05-13.md
+++ b/docs/SPEC_AUDIT_2026-05-13.md
@@ -1,0 +1,259 @@
+# Spec Audit - 2026-05-13
+
+This audit reconciles the current spec and roadmap after the recent framework,
+USDC, discovery, secrets, product-proof, lineage, and event-log work.
+
+Primary source of truth:
+
+- [AVERRAY_WORKING_SPEC.md](./AVERRAY_WORKING_SPEC.md) - current v2.7 product
+  and launch spec.
+- [CORE_FRAMEWORK_ROADMAP.md](./CORE_FRAMEWORK_ROADMAP.md) - framework
+  implementation tracker.
+- [RC1_IMPLEMENTATION_PLAN.md](./RC1_IMPLEMENTATION_PLAN.md) - historical rc1
+  slice plan that still tracks several contract and native-XCM gates.
+- [PRODUCTION_CHECKLIST.md](./PRODUCTION_CHECKLIST.md) - live launch-readiness
+  gate.
+- [SECRETS_MIGRATION.md](./SECRETS_MIGRATION.md) - active secret-management
+  migration plan.
+
+## Executive Summary
+
+The framework has moved from "can the platform do this?" into "can we prove the
+live system, controls, and evidence gates are coherent enough for external
+agents?"
+
+The major plan upgrade is that v1 is now explicitly **USDC-only settlement**.
+Yield, swap-and-stake, and vDOT wallet earnings are deferred until after the
+week-12 work primitive gate and native-XCM evidence gate. That means public
+positioning and launch checks should lead with trusted work, portable identity,
+and verifiable receipts, not yield.
+
+The second plan upgrade is the **Micro / Standard / Substantive** job model.
+The bootstrap objective is now receipt density and reputation depth, not
+higher per-job payouts.
+
+The biggest operational risk area is not a product feature: launch readiness
+still depends on proving the self-report and worker-loop paths under the hosted
+stack. A recent `Configure SSH` deploy failure from the `VPS_SSH_KEY_OP`
+cutover was fixed by the follow-up workflow hotfixes, the current
+`Deploy Production` run is green after the 1Password-backed
+SSH/basic-auth/admin-JWT cutovers, and the basic hosted smoke is green.
+
+## What Is Done
+
+### Trust And Work Core
+
+- Job catalog, claim, submit, and verifier flow exist as working platform
+  primitives.
+- Verification results are stored with replay inputs, verifier config snapshot,
+  config hash, config version, and handler version.
+- Session transitions route through shared state-machine guards for the
+  high-risk claim, submit, verification, expiry, and dispute paths.
+- Duplicate submit and non-verifiable verifier callbacks fail closed before
+  replacing submissions or settling.
+
+### USDC Settlement Pivot
+
+- v1 escrow asset is USDC, Trust-Backed Asset ID 1337, ERC20 precompile
+  `0x0000053900000000000000000000000001200000`, 6 decimals.
+- Launch-facing job sourcing, SDK defaults, badge/profile metadata, and
+  recurring fallbacks default to USDC/6.
+- The prior DOT/18 launch-scaling risk has been documented and largely closed
+  for runtime-facing paths.
+- Product-proof settlement now has a minBalance guard so sub-minBalance rewards
+  do not fail with `SafeTransfer.TransferFailed`.
+
+### Discovery And Public Trust Surface
+
+- Public discovery is narrowed to a directory-safe shape.
+- DiscoveryRegistry publish automation exists and can report `published` or
+  `already_current`.
+- Public no-token and launch trust docs are present.
+- Public agent profile, badge/profile schema, and profile lookup surfaces have
+  first-pass implementations.
+
+### Observability
+
+- Session and job timeline endpoints expose canonical envelopes with
+  correlation, phase, source, topic, severity, job, session, wallet, and compact
+  data fields.
+- Timeline topics were standardized for the current platform event set.
+- Event-bus entries now persist through the state store in memory and Redis,
+  so `/events` and `/admin/jobs/timeline` can replay recent traces across
+  process restarts.
+- Backend and client surfaces support source, topic, phase, severity,
+  correlation-id, and wallet filters.
+
+### Recurring Jobs
+
+- Scheduler runtime exists.
+- Template runtime metadata is persisted.
+- Finite reserve policy gates recurring fires.
+- Admin status and operator controls expose recurring posture.
+- Escrow-native/on-chain poster funding support is present.
+
+### Sub-Jobs And Lineage
+
+- Active workers can create sub-jobs from in-flight parent sessions.
+- Parent/child indexes are persisted.
+- Child runs are exposed on session detail surfaces.
+- Delegation budget/depth fields exist.
+- Child reward is reserved from the parent wallet.
+- Operator and profile surfaces expose sub-contracting history.
+
+### SDK And Integration Surface
+
+- `sdk/agent-platform-client.js` is the first typed client surface.
+- It wraps auth, list/recommend/preflight, claim, submit, resume, timeline,
+  admin job creation, recurring fire, and status flows.
+- Generated SDK types and shared validation types are now in place for the
+  current API/schema source.
+
+### Secrets And Deploy Control Plane
+
+- Phase 2 secret migration has moved large parts of CI/deploy/runtime secret
+  source of truth toward 1Password.
+- ADMIN_JWT, VPS SSH key, and app basic-auth paths have recent cutover PRs.
+- The latest `Deploy Production` workflow on `main` is green after those
+  cutovers.
+- Basic hosted smoke passes against public site, discovery manifest, protected
+  operator shell, API health, onboarding, and indexer root/readiness/freshness.
+- Blockchain key custody policy has been added to the secrets migration docs.
+
+## What Is Still Left
+
+### Immediate Ops Follow-Up
+
+- Keep the `Configure SSH` failure mode closed by avoiding `${{ secrets.* }}`
+  expressions inside `run: |` shell blocks.
+- Run the product-proof gate variants that are not part of the normal deploy
+  workflow.
+- Use the production checklist, not this implementation roadmap, as the final
+  go/no-go source for live launch.
+
+### Launch-Blocking Or Launch-Relevant Gaps
+
+- Run one complete hosted worker loop:
+  discover -> sign in -> preflight -> claim -> submit -> verify -> badge/profile.
+- Rerun the product-proof gate with worker-loop evidence.
+- Finish bootstrap self-report scheduled email delivery and first-delivery
+  proof.
+- Confirm `/admin/status` with a live admin JWT reports async XCM watcher posture
+  cleanly.
+- Rehearse pauser pause/unpause from the hot key.
+- Confirm current Postgres/Redis backups are restorable and run a restore drill.
+- Fill named on-call ownership and alert destination for smoke-check failures.
+
+### Native XCM / vDOT Gate
+
+- Produce real Bifrost deposit, withdraw, and failure evidence captures with
+  backend-built XCM messages.
+- Run the Chopsticks/PAPI experiment for Bifrost reply-leg `SetTopic`
+  preservation.
+- If Bifrost preserves `SetTopic(requestId)`, promote topic matching as the
+  correlation method.
+- If not, document and validate the fallback before any production vDOT volume.
+- Keep vDOT/yield public positioning gated until this proof exists and the
+  week-12 work primitive gate passes.
+
+### Schema-Native Jobs
+
+- Align `docs/schemas/jobs/` with the runtime registry.
+- Define first-party schemas for PR review findings, release readiness, issue
+  triage, and docs drift audit.
+- Enforce structured output validation before verifier execution and before
+  helper workflows consume a claim/submit attempt.
+
+### Verifier Replay Hardening
+
+- Add `evidenceSchemaRef` or `submissionSchemaRef` where missing.
+- Split verifier policy version from verifier config version when rules move
+  beyond simple config data.
+- Add handler-versioned replay fixtures before v2 verifier handlers.
+
+### Dispute And Arbitration Flow
+
+- Ensure the on-chain dispute path is complete for the current deployed
+  contracts.
+- Wire `POST /disputes/:id/verdict` and `/release` to the actual on-chain
+  arbitration path if they still only record local receipts.
+- Store arbitrator reasoning under `/content/:hash`.
+- Surface `disputedAt`, SLA countdown, reason code, and on-chain tx state in
+  the operator app.
+- Provision/rehearse the phase-0 arbitrator key and notification path.
+
+### Idempotency And Mutation Hardening
+
+- Extend canonical request-hash receipts to async XCM admin routes.
+- Add optional ingestion-run idempotency where callers need whole-run replay
+  semantics.
+- Reuse the receipt wrapper for future dispute and settlement routes.
+
+### Timeline And Operator UX
+
+- Fold funding, settlement, and dispute state into the same canonical trace.
+- Standardize remaining producer topics/payloads.
+- Add visible operator controls for source, topic, wallet, and correlation-id
+  timeline filters.
+
+### Capability Model
+
+- Add operator grant/revoke flows for scoped service tokens or delegated
+  wallets.
+- Align public onboarding action requirements with the runtime auth-policy
+  payload.
+- Hide or disable frontend controls from `authPolicy.uiControls`.
+- Emit audit events when capability grants change.
+
+### Secrets Phase 2+ And Mainnet Custody
+
+- Complete the remaining 1Password migration exit criteria:
+  old plain-text GitHub/VPS secrets removed, tmpfs checks green, deploy logs
+  clean, rotation test complete.
+- Move smoke-channel secrets that are still outside 1Password.
+- Delete legacy env/backups once the render path has proven stable.
+- Keep signer private keys out of the Phase 2 success claim; Phase 3/KMS or
+  equivalent custody work remains separate.
+
+## Missed Or Upgraded Plan Items
+
+1. `CORE_FRAMEWORK_ROADMAP.md` still referenced `RC1_WORKING_SPEC.md` as the
+   roadmap boundary. The current source of truth is `AVERRAY_WORKING_SPEC.md`;
+   `RC1_WORKING_SPEC.md` is historical context.
+2. The current spec summary still implied wallet yield as if it were live. This
+   audit updates it to reflect the v2.2 decision: v1 is USDC-only; yield is
+   post-week-12 and post-native-XCM proof.
+3. The bootstrap budget text still used the older two-tier job mix. This audit
+   updates it to the Micro / Standard / Substantive model.
+4. The framework roadmap had stale baseline language for recurring jobs,
+   sub-job orchestration, and SDK maturity. These are now mostly complete
+   framework areas, with future work concentrated in proof, UX, and operations.
+5. The secrets migration has become a major live launch lane and should be
+   tracked alongside the product roadmap, not treated as generic ops cleanup.
+6. The launch checklist remains stricter than the implementation roadmap. Keep
+   using `PRODUCTION_CHECKLIST.md` as the go/no-go surface.
+
+## Polkadot Docs Check
+
+Checked with the Polkadot docs MCP on 2026-05-13:
+
+- ERC20 precompile docs still support the USDC Trust-Backed Asset path on
+  Polkadot Hub.
+- XCM precompile docs still describe the low-level `execute`, `send`, and
+  `weighMessage` surface.
+- Polkadot docs continue to point to PAPI and Chopsticks for XCM construction,
+  replay, and dry-run validation.
+
+That means the current Polkadot-specific plan still holds: USDC for v1 escrow,
+and no production vDOT/yield claims until native XCM evidence proves the
+correlation and settlement path.
+
+## Recommended Next Queue
+
+1. Complete the hosted worker-loop product-proof evidence gate.
+2. Close bootstrap self-report scheduled email delivery.
+3. Tighten schema-native jobs for first-wave job families.
+4. Finish dispute/arbitration launch path.
+5. Run the native XCM evidence pack captures.
+6. Add visible timeline filters in the operator app.
+7. Continue Phase 2+ secrets cleanup and signer custody hardening.


### PR DESCRIPTION
## Summary
- add the 2026-05-13 spec audit covering completed work, remaining launch gates, and upgraded plan items
- point the core framework roadmap at AVERRAY_WORKING_SPEC.md as the current source of truth and refresh the current audit queue
- align the working spec summary/bootstrap text with USDC-only v1 and the Micro/Standard/Substantive model
- mark the latest post-cutover production deploy gate green after run 25795264823 and hosted smoke passed

## Validation
- git diff --check
- APP_ALLOW_PROTECTED_SHELL=1 ./scripts/ops/check-hosted-stack.sh
- Polkadot docs MCP check: ERC20 precompile remains the USDC path for v1 escrow; PAPI/Chopsticks remain the native-XCM validation direction

## Impact
Docs only. No backend, frontend, indexer, Caddy, contracts, or public-site runtime changes.

## Required env or VPS changes
None.