### PR TITLE
[codex] Harden product-proof worker-loop evidence

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -98,7 +98,7 @@ on:
           - "0"
           - "1"
       product_proof_reward_asset:
-        description: Reward asset symbol for the hosted product-proof worker loop. Leave blank to keep the deploy-script default (DOT). Set to "USDC" to exercise the v1 USDC settlement path against the on-chain TreasuryPolicy approved-asset list.
+        description: Reward asset symbol for the hosted product-proof worker loop. Leave blank for the canonical v1 USDC settlement path; non-USDC values fail closed before mutation.
         required: false
         default: ""
         type: string

--- a/docs/PRODUCT_PROOF_GATE.md
+++ b/docs/PRODUCT_PROOF_GATE.md
@@ -42,9 +42,11 @@ The deploy workflow can generate this evidence itself when run manually with:
 - `product_proof_require_worker_loop=1`
 
 That path uses the production `ADMIN_JWT` secret, creates a tiny benchmark job,
-claims it as the token wallet, submits matching evidence, runs the verifier, and
-writes the evidence file before running the required gate. It does not print the
-token.
+preflights it as the token wallet, claims it, submits matching evidence, runs
+the verifier, and writes the evidence file before running the required gate. It
+does not print the token. The worker loop fails closed before mutation unless
+the hosted stack reports canonical v1 USDC settlement readiness and the worker
+wallet has enough AgentAccountCore USDC liquidity for the reward.
 
 For a local/manual run, first complete one hosted loop and write evidence:
 
@@ -54,15 +56,52 @@ ADMIN_JWT="$ADMIN_TOKEN" \
 npm run product-proof:worker-loop
 ```
 
-After a real hosted worker loop completes, write a local evidence file:
+The worker-loop command writes a local evidence file like:
 
 ```json
 {
-  "sessionId": "sess_...",
-  "jobId": "starter-coding-001",
+  "apiBaseUrl": "https://api.averray.com",
   "wallet": "0x...",
-  "badgeUrl": "https://api.averray.com/badges/sess_...",
-  "profileUrl": "https://api.averray.com/agents/0x..."
+  "jobId": "product-proof-worker-loop-...",
+  "sessionId": "sess_...",
+  "verificationOutcome": "approved",
+  "settlementReadiness": {
+    "settlementReady": true,
+    "asset": {
+      "symbol": "USDC",
+      "address": "0x0000053900000000000000000000000001200000",
+      "assetClass": "trust_backed",
+      "assetId": 1337,
+      "decimals": 6,
+      "minBalanceRaw": "70000",
+      "approved": true
+    }
+  },
+  "rewardReadiness": {
+    "asset": "USDC",
+    "rewardRaw": "100000",
+    "minBalanceRaw": "70000"
+  },
+  "liquidityReadiness": {
+    "wallet": "0x...",
+    "asset": "USDC",
+    "requiredRaw": "100000",
+    "availableRaw": "100000"
+  },
+  "preflightReadiness": {
+    "jobId": "product-proof-worker-loop-...",
+    "wallet": "0x...",
+    "eligible": true,
+    "claimable": true,
+    "requiredOutputSchema": "schema://jobs/product-proof-worker-loop"
+  },
+  "claimReadiness": {
+    "status": "claimed",
+    "sessionId": "sess_..."
+  },
+  "submitStatus": "submitted",
+  "sessionStatus": "resolved",
+  "completedAt": "2026-05-13T11:11:31.000Z"
 }
 ```
 
@@ -76,6 +115,12 @@ npm run check:product-proof
 
 The script fetches the badge and profile documents and verifies that:
 
+- the evidence host matches the checked API host
+- the evidence proves canonical v1 USDC settlement readiness
+- the reward clears the USDC minBalance and the worker has enough USDC liquidity
+- the job preflight was eligible and claimable before claim
+- the submit, verification, and session statuses reached submitted, approved,
+  and resolved
 - the badge uses `averray.schemaVersion = "v1"`
 - the badge session, job, and worker match the evidence file
 - the profile uses `schemaVersion = "v1"`

--- a/scripts/ops/check-product-proof-gate.mjs
+++ b/scripts/ops/check-product-proof-gate.mjs
@@ -2,9 +2,19 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
+import { DEFAULT_ESCROW_ASSET } from "../../mcp-server/src/core/assets.js";
+
 const DEFAULT_PUBLIC_SITE_URL = "https://averray.com";
 const DEFAULT_API_BASE_URL = "https://api.averray.com";
 const DEFAULT_SAMPLE_SCHEMA = "wikipedia-citation-repair-output";
+const REQUIRED_ESCROW_ASSET = {
+  symbol: DEFAULT_ESCROW_ASSET.symbol,
+  address: DEFAULT_ESCROW_ASSET.address.toLowerCase(),
+  assetClass: DEFAULT_ESCROW_ASSET.assetClass,
+  assetId: DEFAULT_ESCROW_ASSET.assetId,
+  decimals: DEFAULT_ESCROW_ASSET.decimals,
+  minBalanceRaw: String(DEFAULT_ESCROW_ASSET.minBalanceRaw)
+};
 
 export async function checkProductProofGate({
   env = process.env,
@@ -118,6 +128,7 @@ async function checkWorkerLoopEvidence(fetchImpl, evidence, { apiBaseUrl }) {
   assert.ok(evidence.sessionId, "worker-loop evidence requires sessionId");
   assert.ok(evidence.jobId, "worker-loop evidence requires jobId");
   assert.ok(evidence.wallet, "worker-loop evidence requires wallet");
+  assertWorkerLoopCompletionEvidence(evidence, { apiBaseUrl });
 
   const badgeUrl = evidence.badgeUrl || `${apiBaseUrl}/badges/${encodeURIComponent(evidence.sessionId)}`;
   const profileUrl = evidence.profileUrl || `${apiBaseUrl}/agents/${encodeURIComponent(evidence.wallet)}`;
@@ -137,6 +148,67 @@ async function checkWorkerLoopEvidence(fetchImpl, evidence, { apiBaseUrl }) {
     )),
     "profile badges must include the verified worker-loop session"
   );
+}
+
+function assertWorkerLoopCompletionEvidence(evidence, { apiBaseUrl }) {
+  if (evidence.apiBaseUrl) {
+    assert.equal(stripTrailingSlash(evidence.apiBaseUrl), apiBaseUrl, "worker-loop evidence apiBaseUrl must match the checked API host");
+  }
+  assert.equal(evidence.verificationOutcome, "approved", "worker-loop evidence requires approved verificationOutcome");
+  assert.equal(evidence.submitStatus, "submitted", "worker-loop evidence requires submitted submitStatus");
+  assert.equal(evidence.sessionStatus, "resolved", "worker-loop evidence requires resolved sessionStatus");
+  assert.ok(Date.parse(evidence.completedAt) > 0, "worker-loop evidence requires completedAt timestamp");
+
+  const settlement = evidence.settlementReadiness;
+  assert.ok(settlement?.settlementReady === true, "worker-loop evidence requires settlementReadiness.settlementReady=true");
+  const asset = settlement.asset;
+  assert.equal(asset?.symbol, REQUIRED_ESCROW_ASSET.symbol, "worker-loop evidence settlement asset must be USDC");
+  assert.equal(String(asset?.address ?? "").toLowerCase(), REQUIRED_ESCROW_ASSET.address, "worker-loop evidence settlement asset address must match canonical USDC precompile");
+  assert.equal(asset?.assetClass, REQUIRED_ESCROW_ASSET.assetClass, "worker-loop evidence settlement asset class must match canonical USDC");
+  assert.equal(Number(asset?.assetId), REQUIRED_ESCROW_ASSET.assetId, "worker-loop evidence settlement asset id must match canonical USDC");
+  assert.equal(Number(asset?.decimals), REQUIRED_ESCROW_ASSET.decimals, "worker-loop evidence settlement asset decimals must match canonical USDC");
+  assert.equal(String(asset?.minBalanceRaw ?? ""), REQUIRED_ESCROW_ASSET.minBalanceRaw, "worker-loop evidence settlement asset minBalanceRaw must match canonical USDC");
+  assert.equal(asset?.approved, true, "worker-loop evidence settlement asset must be approved");
+  assert.equal(settlement.roles?.signerIsVerifier, true, "worker-loop evidence requires signer verifier role");
+  assert.equal(settlement.roles?.escrowIsServiceOperator, true, "worker-loop evidence requires EscrowCore service-operator role");
+  assert.equal(settlement.roles?.agentAccountIsServiceOperator, true, "worker-loop evidence requires AgentAccountCore service-operator role");
+
+  assert.equal(evidence.rewardReadiness?.asset, REQUIRED_ESCROW_ASSET.symbol, "worker-loop evidence reward readiness must be USDC");
+  assertRawAtLeast(
+    evidence.rewardReadiness?.rewardRaw,
+    REQUIRED_ESCROW_ASSET.minBalanceRaw,
+    "worker-loop evidence reward must clear the USDC minBalance"
+  );
+  assert.equal(evidence.rewardReadiness?.minBalanceRaw, REQUIRED_ESCROW_ASSET.minBalanceRaw, "worker-loop evidence reward minBalance must match canonical USDC");
+
+  assert.equal(evidence.liquidityReadiness?.wallet?.toLowerCase(), evidence.wallet.toLowerCase(), "worker-loop evidence liquidity wallet must match worker wallet");
+  assert.equal(evidence.liquidityReadiness?.asset, REQUIRED_ESCROW_ASSET.symbol, "worker-loop evidence liquidity readiness must be USDC");
+  assertRawAtLeast(
+    evidence.liquidityReadiness?.availableRaw,
+    evidence.liquidityReadiness?.requiredRaw,
+    "worker-loop evidence liquidity must cover required reward"
+  );
+
+  assert.equal(evidence.preflightReadiness?.jobId, evidence.jobId, "worker-loop evidence preflight jobId must match evidence jobId");
+  assert.equal(String(evidence.preflightReadiness?.wallet ?? "").toLowerCase(), evidence.wallet.toLowerCase(), "worker-loop evidence preflight wallet must match worker wallet");
+  assert.equal(evidence.preflightReadiness?.eligible, true, "worker-loop evidence requires eligible preflight");
+  assert.equal(evidence.preflightReadiness?.claimable, true, "worker-loop evidence requires claimable preflight");
+  assert.notEqual(evidence.preflightReadiness?.currentWalletCanClaim, false, "worker-loop evidence requires currentWalletCanClaim not false");
+  assert.equal(evidence.preflightReadiness?.requiredOutputSchema, "schema://jobs/product-proof-worker-loop", "worker-loop evidence must use the product-proof output schema");
+
+  assert.equal(evidence.claimReadiness?.sessionId, evidence.sessionId, "worker-loop evidence claim sessionId must match evidence sessionId");
+  assert.ok(evidence.claimReadiness?.status, "worker-loop evidence requires claim status");
+}
+
+function assertRawAtLeast(value, minimum, message) {
+  const actual = parseRawAmount(value, message);
+  const expected = parseRawAmount(minimum, message);
+  assert.ok(actual >= expected, `${message}: ${actual} < ${expected}`);
+}
+
+function parseRawAmount(value, label) {
+  assert.ok(typeof value === "string" && /^\d+$/u.test(value), `${label}: expected raw integer string`);
+  return BigInt(value);
 }
 
 async function fetchPageWithMarkers(fetchImpl, url, markers) {

--- a/scripts/ops/check-product-proof-gate.test.mjs
+++ b/scripts/ops/check-product-proof-gate.test.mjs
@@ -1,5 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 import { buildDiscoveryManifest } from "../../mcp-server/src/core/discovery-manifest.js";
 import { checkProductProofGate } from "./check-product-proof-gate.mjs";
@@ -110,6 +113,64 @@ test("checkProductProofGate requires an evidence file when the worker loop is ma
   );
 });
 
+test("checkProductProofGate validates required hosted worker-loop evidence", async () => {
+  const manifest = buildDiscoveryManifest();
+  const wallet = "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519";
+  const sessionId = "session-product-proof";
+  const jobId = "product-proof-worker-loop-1700000000000";
+  const evidence = workerLoopEvidence({ wallet, sessionId, jobId });
+  const tmp = await mkdtemp(join(tmpdir(), "product-proof-gate-"));
+  const evidenceFile = join(tmp, "evidence.json");
+  await writeFile(evidenceFile, `${JSON.stringify(evidence, null, 2)}\n`);
+
+  const responses = productProofResponses(manifest);
+  responses.set(`https://api.averray.com/badges/${sessionId}`, {
+    averray: {
+      schemaVersion: "v1",
+      sessionId,
+      jobId,
+      worker: wallet
+    }
+  });
+  responses.set(`https://api.averray.com/agents/${wallet}`, {
+    schemaVersion: "v1",
+    wallet,
+    badges: [{ sessionId, jobId }]
+  });
+
+  await checkProductProofGate({
+    env: {
+      PRODUCT_PROOF_REQUIRE_WORKER_LOOP: "1",
+      PRODUCT_PROOF_EVIDENCE_FILE: evidenceFile
+    },
+    fetchImpl: fakeFetch(responses),
+    log: () => {}
+  });
+});
+
+test("checkProductProofGate rejects minimal evidence when worker-loop proof is required", async () => {
+  const manifest = buildDiscoveryManifest();
+  const tmp = await mkdtemp(join(tmpdir(), "product-proof-gate-"));
+  const evidenceFile = join(tmp, "evidence.json");
+  await writeFile(evidenceFile, JSON.stringify({
+    sessionId: "session-product-proof",
+    jobId: "product-proof-worker-loop-1700000000000",
+    wallet: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519"
+  }));
+
+  await assert.rejects(
+    () => checkProductProofGate({
+      env: {
+        PRODUCT_PROOF_REQUIRE_WORKER_LOOP: "1",
+        PRODUCT_PROOF_EVIDENCE_FILE: evidenceFile
+      },
+      fetchImpl: fakeFetch(productProofResponses(manifest)),
+      log: () => {}
+    }),
+    /worker-loop evidence requires approved verificationOutcome/u
+  );
+});
+
 function fakeFetch(responses) {
   return async (url) => {
     const value = responses.get(String(url));
@@ -125,5 +186,93 @@ function fakeFetch(responses) {
       status: 200,
       text: async () => typeof value === "string" ? value : JSON.stringify(value)
     };
+  };
+}
+
+function productProofResponses(manifest) {
+  return new Map([
+    ["https://averray.com/.well-known/agent-tools.json", manifest],
+    ["https://api.averray.com/agent-tools.json", manifest],
+    ["https://api.averray.com/onboarding", {
+      name: manifest.name,
+      discoveryUrl: manifest.discoveryUrl,
+      discoveryMode: manifest.discoveryMode,
+      protocols: manifest.protocols,
+      onboarding: { starterFlow: manifest.onboarding.starterFlow },
+      auth: { schemeId: manifest.auth.schemeId },
+      tools: manifest.tools.map((tool) => tool.name)
+    }],
+    ["https://averray.com/trust/", "Averray — Trust Open discovery manifest https://api.averray.com/onboarding"],
+    ["https://averray.com/schemas/", "Averray — Schemas agent-badge-v1.json agent-profile-v1.json"],
+    ["https://averray.com/agents/", "Averray — For agents Read /.well-known/agent-tools.json https://api.averray.com/onboarding"],
+    ["https://averray.com/builders/", "Averray — Builders https://api.averray.com/schemas/jobs"],
+    ["https://averray.com/llms.txt", "Discovery manifest: https://averray.com/.well-known/agent-tools.json\nOnboarding: https://api.averray.com/onboarding"],
+    ["https://averray.com/schemas/agent-badge-v1.json", {
+      $id: "https://averray.com/schemas/agent-badge-v1.json"
+    }],
+    ["https://averray.com/schemas/agent-profile-v1.json", {
+      $id: "https://averray.com/schemas/agent-profile-v1.json"
+    }],
+    ["https://api.averray.com/schemas/jobs", {
+      count: 1,
+      schemas: [{ $id: "schema://jobs/wikipedia-citation-repair-output" }]
+    }],
+    ["https://api.averray.com/schemas/jobs/wikipedia-citation-repair-output.json", {
+      $id: "schema://jobs/wikipedia-citation-repair-output"
+    }]
+  ]);
+}
+
+function workerLoopEvidence({ wallet, sessionId, jobId }) {
+  return {
+    apiBaseUrl: "https://api.averray.com",
+    wallet,
+    jobId,
+    sessionId,
+    verificationOutcome: "approved",
+    verificationReasonCode: "BENCHMARK_THRESHOLD_MET",
+    settlementReadiness: {
+      settlementReady: true,
+      asset: {
+        symbol: "USDC",
+        address: "0x0000053900000000000000000000000001200000",
+        assetClass: "trust_backed",
+        assetId: 1337,
+        decimals: 6,
+        minBalanceRaw: "70000",
+        approved: true
+      },
+      roles: {
+        signerIsVerifier: true,
+        escrowIsServiceOperator: true,
+        agentAccountIsServiceOperator: true
+      }
+    },
+    rewardReadiness: {
+      asset: "USDC",
+      rewardRaw: "100000",
+      minBalanceRaw: "70000"
+    },
+    liquidityReadiness: {
+      wallet,
+      asset: "USDC",
+      requiredRaw: "100000",
+      availableRaw: "100000"
+    },
+    preflightReadiness: {
+      wallet,
+      jobId,
+      eligible: true,
+      claimable: true,
+      currentWalletCanClaim: true,
+      requiredOutputSchema: "schema://jobs/product-proof-worker-loop"
+    },
+    claimReadiness: {
+      status: "claimed",
+      sessionId
+    },
+    submitStatus: "submitted",
+    sessionStatus: "resolved",
+    completedAt: "2026-05-13T11:11:31.000Z"
   };
 }

--- a/scripts/ops/deploy-production.sh
+++ b/scripts/ops/deploy-production.sh
@@ -32,10 +32,9 @@ SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION=${SMOKE_CHECK_BOOTSTRAP_INSTRUMENTATION:-0
 SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT=${SMOKE_CHECK_BOOTSTRAP_SELF_REPORT_SENT:-0}
 SMOKE_CHECK_PRODUCT_PROOF_GATE=${SMOKE_CHECK_PRODUCT_PROOF_GATE:-0}
 PRODUCT_PROOF_REQUIRE_WORKER_LOOP=${PRODUCT_PROOF_REQUIRE_WORKER_LOOP:-0}
-# Optional override for the hosted worker-loop's reward asset symbol.
-# Empty string keeps the run-hosted-worker-loop.mjs default (DOT today).
-# Set to "USDC" via the workflow_dispatch input to exercise the v1 USDC
-# settlement path against the on-chain TreasuryPolicy approved-asset list.
+# Optional override for the hosted worker-loop's reward asset symbol. Empty
+# string keeps run-hosted-worker-loop.mjs on the canonical v1 USDC settlement
+# path; non-USDC values fail closed before mutation.
 PRODUCT_PROOF_REWARD_ASSET=${PRODUCT_PROOF_REWARD_ASSET:-}
 PRODUCT_PROOF_EVIDENCE_FILE=${PRODUCT_PROOF_EVIDENCE_FILE:-"$STACK_ROOT/product-proof-worker-loop-evidence.json"}
 PRODUCT_PROOF_NODE_IMAGE=${PRODUCT_PROOF_NODE_IMAGE:-node:22-bookworm-slim}

--- a/scripts/ops/run-hosted-worker-loop.mjs
+++ b/scripts/ops/run-hosted-worker-loop.mjs
@@ -84,6 +84,10 @@ export async function runHostedWorkerLoop({
     throw new Error(`created job id mismatch: expected ${jobId}, got ${created?.id ?? "missing"}`);
   }
 
+  log(`Preflighting hosted product-proof job ${jobId}`);
+  const preflight = await platform.preflightJob(jobId);
+  const preflightReadiness = assertClaimPreflightReady({ preflight, jobId, wallet });
+
   log(`Claiming hosted product-proof job ${jobId}`);
   const claim = await platform.claimJob(jobId, idempotencyKey);
   const sessionId = claim?.sessionId;
@@ -134,6 +138,13 @@ export async function runHostedWorkerLoop({
     settlementReadiness,
     rewardReadiness,
     liquidityReadiness,
+    preflightReadiness,
+    claimReadiness: {
+      status: claim.status ?? null,
+      sessionId,
+      claimExpiresAt: claim.claimExpiresAt ?? claim.deadline ?? null
+    },
+    submitStatus: submit.status,
     sessionStatus: session.status,
     completedAt: new Date(timestamp).toISOString()
   };
@@ -206,6 +217,39 @@ function assertRewardClearsAssetMinBalance({ rewardAsset, rewardAmount, asset })
     reward: formatBaseUnits(rewardRaw, decimals),
     minBalanceRaw: minBalanceRaw.toString(),
     minBalance: formatBaseUnits(minBalanceRaw, decimals)
+  };
+}
+
+function assertClaimPreflightReady({ preflight, jobId, wallet }) {
+  if (!preflight || typeof preflight !== "object") {
+    throw new Error("Hosted product-proof worker loop requires /jobs/preflight before claim.");
+  }
+  if (preflight.jobId !== jobId) {
+    throw new Error(`preflight job id mismatch: expected ${jobId}, got ${preflight.jobId ?? "missing"}`);
+  }
+  if (preflight.wallet && !sameWallet(preflight.wallet, wallet)) {
+    throw new Error(
+      `Hosted product-proof worker loop preflight wallet mismatch: authWallet=${wallet}; preflightWallet=${preflight.wallet}.`
+    );
+  }
+  if (preflight.eligible !== true || preflight.claimable !== true || preflight.currentWalletCanClaim === false) {
+    throw new Error(
+      `Hosted product-proof worker loop preflight failed: ` +
+      `eligible=${String(preflight.eligible)}; claimable=${String(preflight.claimable)}; ` +
+      `currentWalletCanClaim=${String(preflight.currentWalletCanClaim)}; reason=${preflight.reason ?? "missing"}.`
+    );
+  }
+  return {
+    jobId,
+    wallet: preflight.wallet ?? wallet,
+    eligible: true,
+    claimable: true,
+    currentWalletCanClaim: preflight.currentWalletCanClaim,
+    reason: preflight.reason ?? null,
+    requiredOutputSchema: preflight.requiredOutputSchema ?? null,
+    verifierMode: preflight.verifierMode ?? null,
+    totalClaimLock: preflight.totalClaimLock ?? null,
+    claimEconomicsWaived: preflight.claimEconomicsWaived ?? null
   };
 }
 

--- a/scripts/ops/run-hosted-worker-loop.test.mjs
+++ b/scripts/ops/run-hosted-worker-loop.test.mjs
@@ -30,9 +30,13 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
       calls.push(["createJob", payload]);
       return { id: payload.id };
     },
+    async preflightJob(id) {
+      calls.push(["preflightJob", id]);
+      return preflightReady({ jobId: id, wallet });
+    },
     async claimJob(id, idempotencyKey) {
       calls.push(["claimJob", id, idempotencyKey]);
-      return { status: "claimed", sessionId };
+      return { status: "claimed", sessionId, claimExpiresAt: "2026-01-01T01:00:00.000Z" };
     },
     async submitWork(id, evidence) {
       calls.push(["submitWork", id, evidence]);
@@ -77,6 +81,7 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
     "getAdminStatus",
     "getAccountSummary",
     "createJob",
+    "preflightJob",
     "claimJob",
     "submitWork",
     "runVerifier",
@@ -87,7 +92,7 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
   assert.equal(calls[3][1].verifierMode, "benchmark");
   assert.equal(calls[3][1].rewardAsset, "USDC");
   assert.equal(calls[3][1].rewardAmount, 0.1);
-  assert.equal(calls[4][2], `product-proof:${jobId}`);
+  assert.equal(calls[5][2], `product-proof:${jobId}`);
 
   const written = JSON.parse(await readFile(evidenceFile, "utf8"));
   assert.equal(written.jobId, jobId);
@@ -98,6 +103,11 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
   assert.equal(written.rewardReadiness.rewardRaw, "100000");
   assert.equal(written.liquidityReadiness.requiredRaw, "100000");
   assert.equal(written.liquidityReadiness.availableRaw, "100000");
+  assert.equal(written.preflightReadiness.eligible, true);
+  assert.equal(written.preflightReadiness.requiredOutputSchema, "schema://jobs/product-proof-worker-loop");
+  assert.equal(written.claimReadiness.status, "claimed");
+  assert.equal(written.claimReadiness.claimExpiresAt, "2026-01-01T01:00:00.000Z");
+  assert.equal(written.submitStatus, "submitted");
 });
 
 test("runHostedWorkerLoop fails closed without a token", async () => {
@@ -122,6 +132,10 @@ test("runHostedWorkerLoop accepts an explicit positive reward amount", async () 
     async createJob(payload) {
       calls.push(["createJob", payload]);
       return { id: payload.id };
+    },
+    async preflightJob(id) {
+      calls.push(["preflightJob", id]);
+      return preflightReady({ jobId: id });
     },
     async claimJob(id) {
       return { status: "claimed", sessionId: `${id}:wallet` };
@@ -222,6 +236,60 @@ test("runHostedWorkerLoop fails closed before mutation when account summary wall
   );
 
   assert.deepEqual(calls.map(([name]) => name), ["getAuthSession", "getAdminStatus", "getAccountSummary"]);
+});
+
+test("runHostedWorkerLoop fails closed after job creation when preflight blocks claim", async () => {
+  const calls = [];
+  const jobId = "product-proof-worker-loop-1700000000000";
+  await assert.rejects(
+    runHostedWorkerLoop({
+      client: {
+        async getAuthSession() {
+          calls.push(["getAuthSession"]);
+          return { wallet: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519" };
+        },
+        async getAdminStatus() {
+          calls.push(["getAdminStatus"]);
+          return settlementReadyStatus();
+        },
+        async getAccountSummary() {
+          calls.push(["getAccountSummary"]);
+          return accountSummary({ liquidUsdcRaw: 100_000 });
+        },
+        async createJob(payload) {
+          calls.push(["createJob", payload]);
+          return { id: payload.id };
+        },
+        async preflightJob(id) {
+          calls.push(["preflightJob", id]);
+          return {
+            ...preflightReady({ jobId: id }),
+            eligible: false,
+            claimable: false,
+            currentWalletCanClaim: false,
+            reason: "tier_gate"
+          };
+        },
+        async claimJob() {
+          calls.push(["claimJob"]);
+          throw new Error("should not claim when preflight blocks claim");
+        }
+      },
+      now: () => 1700000000000,
+      log: () => {},
+      env: { ADMIN_JWT: "token" }
+    }),
+    /preflight failed: eligible=false; claimable=false; currentWalletCanClaim=false; reason=tier_gate/u
+  );
+
+  assert.deepEqual(calls.map(([name]) => name), [
+    "getAuthSession",
+    "getAdminStatus",
+    "getAccountSummary",
+    "createJob",
+    "preflightJob"
+  ]);
+  assert.equal(calls[4][1], jobId);
 });
 
 test("runHostedWorkerLoop fails closed before mutation when settlement is not ready", async () => {
@@ -460,6 +528,24 @@ function accountSummary({
     collateralLocked: {},
     jobStakeLocked: {},
     debtOutstanding: {}
+  };
+}
+
+function preflightReady({
+  jobId,
+  wallet = "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519"
+}) {
+  return {
+    jobId,
+    wallet,
+    eligible: true,
+    claimable: true,
+    currentWalletCanClaim: true,
+    reason: "claimable",
+    requiredOutputSchema: "schema://jobs/product-proof-worker-loop",
+    verifierMode: "benchmark",
+    totalClaimLock: 0,
+    claimEconomicsWaived: true
   };
 }
 


### PR DESCRIPTION
## Summary
- require hosted worker-loop evidence to prove the full claim path: USDC settlement readiness, minBalance, AgentAccountCore liquidity, preflight, claim, submit, approved verification, resolved session, badge, and profile
- make the worker-loop command call /jobs/preflight before /jobs/claim and persist the preflight/claim/submit evidence
- correct deploy workflow/docs language so blank product_proof_reward_asset means canonical v1 USDC, not DOT

## Validation
- git diff --check
- node --test scripts/ops/check-product-proof-gate.test.mjs scripts/ops/run-hosted-worker-loop.test.mjs
- npm run test:ops
- npm run check:product-proof
- Polkadot docs MCP check: Hub assets such as USDC are accessed through ERC20 precompiles, so the proof gate remains USDC/precompile-centered

## Impact
- Deployment/smoke script behavior only when product_proof_require_worker_loop=1 is explicitly enabled
- No frontend, indexer, Caddy, contracts, or runtime backend changes

## Required env or VPS changes
None. After merge, run the manual production workflow with smoke_check_product_proof_gate=1 and product_proof_require_worker_loop=1 to produce the live evidence file.