### PR TITLE
[codex] Preflight product-proof token capabilities

### DIFF
--- a/docs/PRODUCT_PROOF_GATE.md
+++ b/docs/PRODUCT_PROOF_GATE.md
@@ -45,8 +45,15 @@ That path uses the production `ADMIN_JWT` secret, creates a tiny benchmark job,
 preflights it as the token wallet, claims it, submits matching evidence, runs
 the verifier, and writes the evidence file before running the required gate. It
 does not print the token. The worker loop fails closed before mutation unless
-the hosted stack reports canonical v1 USDC settlement readiness and the worker
-wallet has enough AgentAccountCore USDC liquidity for the reward.
+the token exposes the full loop capability set, the hosted stack reports
+canonical v1 USDC settlement readiness, and the worker wallet has enough
+AgentAccountCore USDC liquidity for the reward.
+
+The hosted smoke token must resolve from `/auth/session` with capabilities for:
+`account:read`, `admin:status`, `jobs:create`, `jobs:preflight`, `jobs:claim`,
+`jobs:submit`, `verifier:run`, and `session:read`. In practice this means the
+1Password `prod-smoke/admin-jwt` item should be minted with both `admin` and
+`verifier` roles before the manual production workflow is run.
 
 For a local/manual run, first complete one hosted loop and write evidence:
 
@@ -65,6 +72,19 @@ The worker-loop command writes a local evidence file like:
   "jobId": "product-proof-worker-loop-...",
   "sessionId": "sess_...",
   "verificationOutcome": "approved",
+  "authReadiness": {
+    "roles": ["admin", "verifier"],
+    "capabilitiesPresent": [
+      "account:read",
+      "admin:status",
+      "jobs:create",
+      "jobs:preflight",
+      "jobs:claim",
+      "jobs:submit",
+      "verifier:run",
+      "session:read"
+    ]
+  },
   "settlementReadiness": {
     "settlementReady": true,
     "asset": {

--- a/scripts/ops/run-hosted-worker-loop.mjs
+++ b/scripts/ops/run-hosted-worker-loop.mjs
@@ -50,6 +50,7 @@ export async function runHostedWorkerLoop({
   if (!wallet) {
     throw new Error("/auth/session did not return a wallet for the worker token.");
   }
+  const authReadiness = assertWorkerTokenReadiness(authSession);
 
   const settlementReadiness = await assertSettlementReadiness(platform, rewardAsset);
   const rewardReadiness = assertRewardClearsAssetMinBalance({
@@ -135,6 +136,7 @@ export async function runHostedWorkerLoop({
     profileUrl,
     verificationOutcome: verification.outcome,
     verificationReasonCode: verification.reasonCode ?? null,
+    authReadiness,
     settlementReadiness,
     rewardReadiness,
     liquidityReadiness,
@@ -217,6 +219,33 @@ function assertRewardClearsAssetMinBalance({ rewardAsset, rewardAmount, asset })
     reward: formatBaseUnits(rewardRaw, decimals),
     minBalanceRaw: minBalanceRaw.toString(),
     minBalance: formatBaseUnits(minBalanceRaw, decimals)
+  };
+}
+
+function assertWorkerTokenReadiness(authSession) {
+  const requiredCapabilities = [
+    "account:read",
+    "admin:status",
+    "jobs:create",
+    "jobs:preflight",
+    "jobs:claim",
+    "jobs:submit",
+    "verifier:run",
+    "session:read"
+  ];
+  const capabilities = Array.isArray(authSession?.capabilities) ? authSession.capabilities : [];
+  const roles = Array.isArray(authSession?.roles) ? authSession.roles : [];
+  const missing = requiredCapabilities.filter((capability) => !capabilities.includes(capability));
+  if (missing.length > 0) {
+    throw new Error(
+      "Hosted product-proof worker loop requires a token with all mutation-loop capabilities before mutation; " +
+      `missing=${missing.join(",")}; roles=${roles.join(",") || "none"}.`
+    );
+  }
+  return {
+    roles: [...roles],
+    requiredCapabilities,
+    capabilitiesPresent: requiredCapabilities
   };
 }
 

--- a/scripts/ops/run-hosted-worker-loop.test.mjs
+++ b/scripts/ops/run-hosted-worker-loop.test.mjs
@@ -16,7 +16,7 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
   const client = {
     async getAuthSession() {
       calls.push(["getAuthSession"]);
-      return { wallet };
+      return authSession({ wallet });
     },
     async getAdminStatus() {
       calls.push(["getAdminStatus"]);
@@ -103,6 +103,8 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
   assert.equal(written.rewardReadiness.rewardRaw, "100000");
   assert.equal(written.liquidityReadiness.requiredRaw, "100000");
   assert.equal(written.liquidityReadiness.availableRaw, "100000");
+  assert.deepEqual(written.authReadiness.roles, ["admin", "verifier"]);
+  assert.ok(written.authReadiness.capabilitiesPresent.includes("verifier:run"));
   assert.equal(written.preflightReadiness.eligible, true);
   assert.equal(written.preflightReadiness.requiredOutputSchema, "schema://jobs/product-proof-worker-loop");
   assert.equal(written.claimReadiness.status, "claimed");
@@ -117,11 +119,50 @@ test("runHostedWorkerLoop fails closed without a token", async () => {
   );
 });
 
+test("runHostedWorkerLoop fails closed before mutation when token lacks verifier capability", async () => {
+  const calls = [];
+  await assert.rejects(
+    runHostedWorkerLoop({
+      client: {
+        async getAuthSession() {
+          calls.push(["getAuthSession"]);
+          return authSession({
+            roles: ["admin"],
+            capabilities: [
+              "account:read",
+              "admin:status",
+              "jobs:create",
+              "jobs:preflight",
+              "jobs:claim",
+              "jobs:submit",
+              "session:read"
+            ]
+          });
+        },
+        async getAdminStatus() {
+          calls.push(["getAdminStatus"]);
+          throw new Error("should not inspect settlement after token capability preflight fails");
+        },
+        async createJob() {
+          calls.push(["createJob"]);
+          throw new Error("should not mutate without verifier capability");
+        }
+      },
+      now: () => 1700000000000,
+      log: () => {},
+      env: { ADMIN_JWT: "token" }
+    }),
+    /requires a token with all mutation-loop capabilities before mutation; missing=verifier:run; roles=admin/u
+  );
+
+  assert.deepEqual(calls.map(([name]) => name), ["getAuthSession"]);
+});
+
 test("runHostedWorkerLoop accepts an explicit positive reward amount", async () => {
   const calls = [];
   const client = {
     async getAuthSession() {
-      return { wallet: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519" };
+      return authSession();
     },
     async getAdminStatus() {
       return settlementReadyStatus();
@@ -178,7 +219,7 @@ test("runHostedWorkerLoop fails closed before mutation when AgentAccountCore USD
       client: {
         async getAuthSession() {
           calls.push(["getAuthSession"]);
-          return { wallet };
+          return authSession({ wallet });
         },
         async getAdminStatus() {
           calls.push(["getAdminStatus"]);
@@ -210,7 +251,7 @@ test("runHostedWorkerLoop fails closed before mutation when account summary wall
       client: {
         async getAuthSession() {
           calls.push(["getAuthSession"]);
-          return { wallet: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519" };
+          return authSession();
         },
         async getAdminStatus() {
           calls.push(["getAdminStatus"]);
@@ -246,7 +287,7 @@ test("runHostedWorkerLoop fails closed after job creation when preflight blocks 
       client: {
         async getAuthSession() {
           calls.push(["getAuthSession"]);
-          return { wallet: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519" };
+          return authSession();
         },
         async getAdminStatus() {
           calls.push(["getAdminStatus"]);
@@ -299,7 +340,7 @@ test("runHostedWorkerLoop fails closed before mutation when settlement is not re
       client: {
         async getAuthSession() {
           calls.push(["getAuthSession"]);
-          return { wallet: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519" };
+          return authSession();
         },
         async getAdminStatus() {
           calls.push(["getAdminStatus"]);
@@ -336,7 +377,7 @@ test("runHostedWorkerLoop rejects non-USDC product-proof reward assets before mu
       client: {
         async getAuthSession() {
           calls.push(["getAuthSession"]);
-          return { wallet: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519" };
+          return authSession();
         },
         async createJob() {
           calls.push(["createJob"]);
@@ -360,7 +401,7 @@ test("runHostedWorkerLoop rejects USDC symbol with non-canonical asset metadata"
       client: {
         async getAuthSession() {
           calls.push(["getAuthSession"]);
-          return { wallet: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519" };
+          return authSession();
         },
         async getAdminStatus() {
           calls.push(["getAdminStatus"]);
@@ -399,7 +440,7 @@ test("runHostedWorkerLoop rejects missing matching USDC settlement asset", async
       client: {
         async getAuthSession() {
           calls.push(["getAuthSession"]);
-          return { wallet: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519" };
+          return authSession();
         },
         async getAdminStatus() {
           calls.push(["getAdminStatus"]);
@@ -437,7 +478,7 @@ test("runHostedWorkerLoop rejects unapproved canonical USDC settlement asset", a
       client: {
         async getAuthSession() {
           calls.push(["getAuthSession"]);
-          return { wallet: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519" };
+          return authSession();
         },
         async getAdminStatus() {
           calls.push(["getAdminStatus"]);
@@ -492,7 +533,7 @@ test("runHostedWorkerLoop rejects rewards below the USDC minBalance before mutat
       client: {
         async getAuthSession() {
           calls.push(["getAuthSession"]);
-          return { wallet: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519" };
+          return authSession();
         },
         async getAdminStatus() {
           calls.push(["getAdminStatus"]);
@@ -600,4 +641,21 @@ function settlementReadyStatus(overrides = {}) {
       }
     }
   };
+}
+
+function authSession({
+  wallet = "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+  roles = ["admin", "verifier"],
+  capabilities = [
+    "account:read",
+    "admin:status",
+    "jobs:create",
+    "jobs:preflight",
+    "jobs:claim",
+    "jobs:submit",
+    "verifier:run",
+    "session:read"
+  ]
+} = {}) {
+  return { wallet, roles, capabilities };
 }


### PR DESCRIPTION
## What changed
- Fail the hosted product-proof worker loop immediately after /auth/session if the token lacks any required loop capability, especially verifier:run.
- Include auth readiness in the generated product-proof evidence file.
- Document the admin+verifier token requirement for the manual production smoke.

## Checks
- node --test scripts/ops/run-hosted-worker-loop.test.mjs scripts/ops/check-product-proof-gate.test.mjs
- npm run test:ops
- git diff --check

## Impact
Ops/product-proof smoke scripts and docs only. No backend, frontend, indexer, contract, Caddy, or public site runtime changes. The production 1Password prod-smoke/admin-jwt secret still needs to be rotated to a token with admin and verifier roles before rerunning the manual worker-loop gate.