### PR TITLE
Persist hosted product-proof evidence from Docker

### DIFF
--- a/scripts/ops/deploy-production.sh
+++ b/scripts/ops/deploy-production.sh
@@ -37,6 +37,9 @@ PRODUCT_PROOF_REQUIRE_WORKER_LOOP=${PRODUCT_PROOF_REQUIRE_WORKER_LOOP:-0}
 # path; non-USDC values fail closed before mutation.
 PRODUCT_PROOF_REWARD_ASSET=${PRODUCT_PROOF_REWARD_ASSET:-}
 PRODUCT_PROOF_EVIDENCE_FILE=${PRODUCT_PROOF_EVIDENCE_FILE:-"$STACK_ROOT/product-proof-worker-loop-evidence.json"}
+if [[ "$PRODUCT_PROOF_EVIDENCE_FILE" != /* ]]; then
+  PRODUCT_PROOF_EVIDENCE_FILE="$APP_ROOT/$PRODUCT_PROOF_EVIDENCE_FILE"
+fi
 PRODUCT_PROOF_NODE_IMAGE=${PRODUCT_PROOF_NODE_IMAGE:-node:22-bookworm-slim}
 INDEXER_DATABASE_SCHEMA=${INDEXER_DATABASE_SCHEMA:-}
 INDEXER_FRESH_SCHEMA=${INDEXER_FRESH_SCHEMA:-0}
@@ -260,8 +263,12 @@ run_node_script() {
   fi
 
   local relative_script="${script#$APP_ROOT/}"
+  local product_proof_evidence_dir
+  product_proof_evidence_dir="$(dirname "$PRODUCT_PROOF_EVIDENCE_FILE")"
+  mkdir -p "$product_proof_evidence_dir"
   docker run --rm \
     -v "$APP_ROOT:/workspace" \
+    -v "$product_proof_evidence_dir:$product_proof_evidence_dir" \
     -w /workspace \
     -e API_BASE_URL="${API_BASE_URL:-https://api.averray.com}" \
     -e ADMIN_JWT="${ADMIN_JWT:-}" \

--- a/scripts/ops/deploy-production.test.mjs
+++ b/scripts/ops/deploy-production.test.mjs
@@ -122,6 +122,31 @@ test("deploy wrapper retries frontend after an earlier failed indexer deploy", a
   assert.equal((await readFile(join(stateDir, "frontend.last-good"), "utf8")).trim(), indexerFixSha);
 });
 
+test("docker node fallback persists product-proof evidence on the host", async () => {
+  const script = await readFile(DEPLOY_SCRIPT, "utf8");
+
+  assert.match(
+    script,
+    /PRODUCT_PROOF_EVIDENCE_FILE="\$APP_ROOT\/\$PRODUCT_PROOF_EVIDENCE_FILE"/u,
+    "relative evidence paths should be normalized before docker env propagation"
+  );
+  assert.match(
+    script,
+    /product_proof_evidence_dir="\$\(dirname "\$PRODUCT_PROOF_EVIDENCE_FILE"\)"/u,
+    "docker fallback should derive the host evidence directory"
+  );
+  assert.match(
+    script,
+    /mkdir -p "\$product_proof_evidence_dir"/u,
+    "docker fallback should create the host evidence directory"
+  );
+  assert.match(
+    script,
+    /-v "\$product_proof_evidence_dir:\$product_proof_evidence_dir"/u,
+    "docker fallback should mount the evidence directory at the same path"
+  );
+});
+
 async function writeExecutable(path, content) {
   await writeFile(path, `${content}\n`);
   await chmod(path, 0o755);


### PR DESCRIPTION
## Summary
- mount the product-proof evidence directory into the deploy Docker node fallback
- normalize relative evidence paths before propagating them to worker-loop and smoke scripts
- add focused coverage for the evidence mount contract

## Validation
- node --test scripts/ops/deploy-production.test.mjs
- bash -n scripts/ops/deploy-production.sh
- git diff --check

## Impact
- Ops/deploy only. Fixes the hosted product-proof worker-loop evidence gate after the real loop writes evidence from a Docker fallback runtime.