### PR TITLE
Mount product-proof evidence in hosted checker

### DIFF
--- a/scripts/ops/check-hosted-stack.sh
+++ b/scripts/ops/check-hosted-stack.sh
@@ -243,6 +243,13 @@ if enabled "$CHECK_PRODUCT_PROOF_GATE"; then
   echo "Checking product-proof gate"
   script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
   repo_root="$(cd "$script_dir/../.." && pwd)"
+  if [[ -n "$PRODUCT_PROOF_EVIDENCE_FILE" ]]; then
+    if [[ "$PRODUCT_PROOF_EVIDENCE_FILE" != /* ]]; then
+      PRODUCT_PROOF_EVIDENCE_FILE="$repo_root/$PRODUCT_PROOF_EVIDENCE_FILE"
+    fi
+    product_proof_evidence_dir="$(dirname "$PRODUCT_PROOF_EVIDENCE_FILE")"
+    mkdir -p "$product_proof_evidence_dir"
+  fi
   if command -v node >/dev/null 2>&1; then
     PUBLIC_SITE_URL="$PUBLIC_SITE_URL" \
       PUBLIC_DISCOVERY_URL="$DISCOVERY_URL" \
@@ -251,8 +258,12 @@ if enabled "$CHECK_PRODUCT_PROOF_GATE"; then
       PRODUCT_PROOF_REQUIRE_WORKER_LOOP="$PRODUCT_PROOF_REQUIRE_WORKER_LOOP" \
       node "$script_dir/check-product-proof-gate.mjs"
   else
+    product_proof_docker_volume_args=(-v "$repo_root:/workspace")
+    if [[ -n "${product_proof_evidence_dir:-}" ]]; then
+      product_proof_docker_volume_args+=(-v "$product_proof_evidence_dir:$product_proof_evidence_dir")
+    fi
     docker run --rm \
-      -v "$repo_root:/workspace" \
+      "${product_proof_docker_volume_args[@]}" \
       -w /workspace \
       -e PUBLIC_SITE_URL="$PUBLIC_SITE_URL" \
       -e PUBLIC_DISCOVERY_URL="$DISCOVERY_URL" \

--- a/scripts/ops/check-hosted-stack.test.mjs
+++ b/scripts/ops/check-hosted-stack.test.mjs
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const CHECK_SCRIPT = join(REPO_ROOT, "scripts/ops/check-hosted-stack.sh");
+
+test("docker product-proof gate can read hosted worker-loop evidence", async () => {
+  const script = await readFile(CHECK_SCRIPT, "utf8");
+
+  assert.match(
+    script,
+    /PRODUCT_PROOF_EVIDENCE_FILE="\$repo_root\/\$PRODUCT_PROOF_EVIDENCE_FILE"/u,
+    "relative evidence paths should be normalized before node or docker checks"
+  );
+  assert.match(
+    script,
+    /product_proof_evidence_dir="\$\(dirname "\$PRODUCT_PROOF_EVIDENCE_FILE"\)"/u,
+    "docker fallback should derive the host evidence directory"
+  );
+  assert.match(
+    script,
+    /mkdir -p "\$product_proof_evidence_dir"/u,
+    "docker fallback should create the host evidence directory"
+  );
+  assert.match(
+    script,
+    /product_proof_docker_volume_args=\(-v "\$repo_root:\/workspace"\)/u,
+    "docker fallback should keep mounting the repository"
+  );
+  assert.match(
+    script,
+    /product_proof_docker_volume_args\+=\(-v "\$product_proof_evidence_dir:\$product_proof_evidence_dir"\)/u,
+    "docker fallback should mount the evidence directory at the same absolute path"
+  );
+  assert.match(
+    script,
+    /"\$\{product_proof_docker_volume_args\[@\]\}"/u,
+    "docker fallback should pass the dynamic volume list to docker run"
+  );
+});


### PR DESCRIPTION
## What changed
- Normalize product-proof evidence paths in the hosted stack smoke script before either host-node or Docker checks run.
- Mount the evidence directory into the Docker fallback so /srv/agent-stack/product-proof-worker-loop-evidence.json is readable after the hosted worker loop writes it.
- Add a regression test for the shell-script Docker volume contract.

## Checks run
- node --test scripts/ops/check-hosted-stack.test.mjs scripts/ops/check-product-proof-gate.test.mjs
- bash -n scripts/ops/check-hosted-stack.sh
- git diff --check

## Impact
- Deployment/smoke tooling only.
- No backend, frontend, indexer, contracts, Caddy, or public-site runtime changes.
- No new secrets required.