### PR TITLE
Harden capability grant mutations

### DIFF
--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -1414,6 +1414,25 @@ async function storeIdempotentMutationReceipt({ bucket, key, requestHash, respon
   return response;
 }
 
+function assertIssuerCanGrantCapabilities(grant, auth) {
+  const issuerCapabilities = new Set(Array.isArray(auth?.capabilities) ? auth.capabilities : []);
+  const missingCapabilities = (Array.isArray(grant?.capabilities) ? grant.capabilities : [])
+    .filter((capability) => !issuerCapabilities.has(capability))
+    .sort();
+
+  if (missingCapabilities.length) {
+    throw new AuthorizationError(
+      "Cannot grant capabilities the issuer token does not have.",
+      "grant_capability_not_owned",
+      {
+        grantId: grant?.id,
+        issuerWallet: auth?.wallet,
+        missingCapabilities
+      }
+    );
+  }
+}
+
 function buildLaneAttention({ shares, isMock, debtTotal, borrowCapacity, deploymentShareBps }) {
   if (!(shares > 0)) {
     return undefined;
@@ -3309,26 +3328,36 @@ const server = createServer(async (request, response) => {
       const auth = await authMiddleware(request, url, { requireRole: "admin" });
       await enforceLimit("admin_jobs", auth.wallet, rateLimitConfig.adminJobs);
       const payload = await readJsonBody(request);
-      const idempotencyKey = typeof payload?.idempotencyKey === "string" && payload.idempotencyKey.trim()
-        ? payload.idempotencyKey.trim()
-        : undefined;
+      const idempotencyKey = parseIdempotencyKey(payload);
       const mutationKey = idempotencyKey ? `${auth.wallet}:${idempotencyKey}` : undefined;
-      const existing = mutationKey
-        ? await stateStore.getMutationReceipt?.("capability_grant", mutationKey)
-        : undefined;
-      if (existing) {
-        return respond(response, 200, existing);
+      const requestHash = buildMutationRequestHash({
+        route: "/admin/capability-grants",
+        wallet: auth.wallet,
+        payload
+      });
+      const replay = await getIdempotentMutationReplay({
+        bucket: "capability_grant",
+        key: mutationKey,
+        requestHash
+      });
+      if (replay) {
+        return respond(response, replay.statusCode, replay.body);
       }
       const knownCapabilities = listAllKnownCapabilities();
       const grant = buildCapabilityGrant(payload ?? {}, {
         knownCapabilities,
         issuerWallet: auth.wallet
       });
+      assertIssuerCanGrantCapabilities(grant, auth);
       await stateStore.upsertCapabilityGrant?.(grant);
       const projection = projectGrant(grant);
-      if (mutationKey) {
-        await stateStore.upsertMutationReceipt?.("capability_grant", mutationKey, projection);
-      }
+      await storeIdempotentMutationReceipt({
+        bucket: "capability_grant",
+        key: mutationKey,
+        requestHash,
+        response: projection,
+        statusCode: 201
+      });
       eventBus?.publish({
         id: `capability-grant-${grant.id}-${Date.now()}`,
         topic: "capability.grant",
@@ -3353,15 +3382,20 @@ const server = createServer(async (request, response) => {
         throw new ValidationError("grantId is required.");
       }
       const payload = (await readJsonBody(request).catch(() => undefined)) ?? {};
-      const idempotencyKey = typeof payload?.idempotencyKey === "string" && payload.idempotencyKey.trim()
-        ? payload.idempotencyKey.trim()
-        : undefined;
+      const idempotencyKey = parseIdempotencyKey(payload);
       const mutationKey = idempotencyKey ? `${auth.wallet}:${grantId}:${idempotencyKey}` : undefined;
-      const existing = mutationKey
-        ? await stateStore.getMutationReceipt?.("capability_revoke", mutationKey)
-        : undefined;
-      if (existing) {
-        return respond(response, 200, existing);
+      const requestHash = buildMutationRequestHash({
+        route: "/admin/capability-grants/:id/revoke",
+        wallet: auth.wallet,
+        payload: { grantId, ...payload }
+      });
+      const replay = await getIdempotentMutationReplay({
+        bucket: "capability_revoke",
+        key: mutationKey,
+        requestHash
+      });
+      if (replay) {
+        return respond(response, replay.statusCode, replay.body);
       }
       const current = await stateStore.getCapabilityGrant?.(grantId);
       if (!current) {
@@ -3375,9 +3409,13 @@ const server = createServer(async (request, response) => {
         await stateStore.upsertCapabilityGrant?.(record);
       }
       const projection = projectGrant(record);
-      if (mutationKey) {
-        await stateStore.upsertMutationReceipt?.("capability_revoke", mutationKey, projection);
-      }
+      await storeIdempotentMutationReceipt({
+        bucket: "capability_revoke",
+        key: mutationKey,
+        requestHash,
+        response: projection,
+        statusCode: 200
+      });
       if (!alreadyRevoked) {
         eventBus?.publish({
           id: `capability-revoke-${record.id}-${Date.now()}`,

--- a/mcp-server/src/protocols/http/server.smoke.test.js
+++ b/mcp-server/src/protocols/http/server.smoke.test.js
@@ -1136,6 +1136,128 @@ test("http smoke: admin job creation idempotency replays and rejects payload dri
   });
 });
 
+test("http smoke: capability grants reject capabilities the issuer token lacks", { skip: !RUN }, async () => {
+  await runWithServer(async (base) => {
+    const adminToken = issueToken(ADMIN_WALLET, { roles: ["admin"] });
+    const response = await fetch(`${base}/admin/capability-grants`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${adminToken}` },
+      body: JSON.stringify({
+        subject: STRANGER_WALLET,
+        capabilities: ["verifier:run"],
+        issuedAt: "2026-05-01T00:00:00.000Z",
+        nonce: "issuer-subset-smoke",
+        idempotencyKey: "issuer-subset-smoke"
+      })
+    });
+    assert.equal(response.status, 403);
+    const body = await response.json();
+    assert.equal(body.error, "grant_capability_not_owned");
+    assert.deepEqual(body.details.missingCapabilities, ["verifier:run"]);
+  });
+});
+
+test("http smoke: capability grant idempotency replays and rejects payload drift", { skip: !RUN }, async () => {
+  await runWithServer(async (base) => {
+    const adminToken = issueToken(ADMIN_WALLET, { roles: ["admin"] });
+    const headers = { "content-type": "application/json", authorization: `Bearer ${adminToken}` };
+    const payload = {
+      subject: STRANGER_WALLET,
+      capabilities: ["jobs:lifecycle"],
+      scope: "worker-loop-smoke",
+      issuedAt: "2026-05-01T00:00:00.000Z",
+      nonce: "grant-idempotency-smoke",
+      idempotencyKey: "capability-grant-same-key"
+    };
+
+    const create = await fetch(`${base}/admin/capability-grants`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload)
+    });
+    assert.equal(create.status, 201);
+    const grant = await create.json();
+    assert.equal(grant.subject, STRANGER_WALLET.toLowerCase());
+    assert.deepEqual(grant.capabilities, ["jobs:lifecycle"]);
+
+    const replay = await fetch(`${base}/admin/capability-grants`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ capabilities: ["jobs:lifecycle"], ...payload })
+    });
+    assert.equal(replay.status, 200);
+    assert.deepEqual(await replay.json(), grant);
+
+    const drift = await fetch(`${base}/admin/capability-grants`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        ...payload,
+        capabilities: ["policies:propose"]
+      })
+    });
+    assert.equal(drift.status, 409);
+    const body = await drift.json();
+    assert.equal(body.error, "idempotency_key_payload_mismatch");
+    assert.equal(body.details.bucket, "capability_grant");
+  });
+});
+
+test("http smoke: capability revoke idempotency replays and rejects payload drift", { skip: !RUN }, async () => {
+  await runWithServer(async (base) => {
+    const adminToken = issueToken(ADMIN_WALLET, { roles: ["admin"] });
+    const headers = { "content-type": "application/json", authorization: `Bearer ${adminToken}` };
+    const create = await fetch(`${base}/admin/capability-grants`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        subject: STRANGER_WALLET,
+        capabilities: ["jobs:lifecycle"],
+        scope: "revoke-smoke",
+        issuedAt: "2026-05-01T00:00:00.000Z",
+        nonce: "revoke-idempotency-smoke"
+      })
+    });
+    assert.equal(create.status, 201);
+    const grant = await create.json();
+
+    const revokePayload = {
+      note: "rotated service token",
+      idempotencyKey: "capability-revoke-same-key"
+    };
+    const revoke = await fetch(`${base}/admin/capability-grants/${grant.id}/revoke`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(revokePayload)
+    });
+    assert.equal(revoke.status, 200);
+    const revoked = await revoke.json();
+    assert.equal(revoked.status, "revoked");
+    assert.equal(revoked.revokeNote, "rotated service token");
+
+    const replay = await fetch(`${base}/admin/capability-grants/${grant.id}/revoke`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(revokePayload)
+    });
+    assert.equal(replay.status, 200);
+    assert.deepEqual(await replay.json(), revoked);
+
+    const drift = await fetch(`${base}/admin/capability-grants/${grant.id}/revoke`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        ...revokePayload,
+        note: "different operator note"
+      })
+    });
+    assert.equal(drift.status, 409);
+    const body = await drift.json();
+    assert.equal(body.error, "idempotency_key_payload_mismatch");
+    assert.equal(body.details.bucket, "capability_revoke");
+  });
+});
+
 test("http smoke: admin recurring fire idempotency replays and rejects firedAt drift", { skip: !RUN }, async () => {
   await runWithServer(async (base) => {
     const adminToken = issueToken(ADMIN_WALLET, { roles: ["admin"] });


### PR DESCRIPTION
## Summary
- enforce capability grants as a strict subset of the issuer token's resolved capabilities
- wrap capability grant/revoke idempotency receipts with request hashes so payload drift returns 409
- add HTTP smoke coverage for over-grant rejection and grant/revoke replay vs drift

## Checks
- node --test mcp-server/src/core/capability-grants.test.js mcp-server/src/auth/capabilities.test.js
- RUN_HTTP_SMOKE=1 node --test --test-name-pattern "capability" mcp-server/src/protocols/http/server.smoke.test.js
- npm --workspace mcp-server test

## Impact
- Backend only: capability grant/revoke admin API behavior
- No frontend, indexer, Caddy, contracts, public site, env, or VPS secret changes