### PR TITLE
PR 2.7d.1 follow-up: wait for backend /health after force-recreate

### DIFF
--- a/scripts/ops/deploy-production.sh
+++ b/scripts/ops/deploy-production.sh
@@ -182,6 +182,44 @@ mark_component_deployed() {
   echo "Recorded $component deploy pointer: $NEW_SHA"
 }
 
+# Phase 2 PR 2.7d.1 follow-up: wait for backend /health to return 200
+# after a force-recreate (the PR 2.7d.1 fast-path that only re-renders
+# /run/agent-stack/backend.env without going through redeploy-backend.sh).
+#
+# Why this exists: when the trigger for backend redeploy is JUST an env
+# content change (no code path changed), deploy-production.sh skips
+# redeploy-backend.sh and does `docker compose up -d --force-recreate
+# backend` inline. That gets the container restarted quickly, but the
+# script then continues straight to `check-hosted-stack.sh`, which
+# probes https://api.averray.com/health. The 14:30Z deploy on 2026-05-13
+# was the canary: smoke check hit /health 1 second after `Container
+# agent-backend Started`, got 502 (backend was still bootstrapping),
+# and the deploy was marked failure even though the recreate succeeded.
+# redeploy-backend.sh has its own wait_for_health for the full-deploy
+# path; this helper mirrors that for the force-recreate fast-path.
+#
+# Returns 0 on health, non-zero (and emits an error) on timeout.
+wait_for_backend_health() {
+  local health_url="${HEALTH_URL:-https://api.averray.com/health}"
+  local timeout="${HEALTH_TIMEOUT_SEC:-60}"
+  local interval="${HEALTH_INTERVAL_SEC:-3}"
+  local deadline=$(( $(date +%s) + timeout ))
+  local attempts=0
+  echo "Phase 2 PR 2.7d.1: waiting for backend health at $health_url (timeout ${timeout}s)"
+  while [[ $(date +%s) -lt $deadline ]]; do
+    attempts=$(( attempts + 1 ))
+    if curl -fsS --max-time 5 "$health_url" >/dev/null 2>&1; then
+      echo "Backend health check passed after ${attempts} attempt(s)."
+      return 0
+    fi
+    sleep "$interval"
+  done
+  echo "ERROR: backend /health did not return 200 within ${timeout}s after force-recreate." >&2
+  echo "       Container recreate likely succeeded but bootstrap is failing." >&2
+  echo "       Check 'sudo docker logs agent-backend --tail 100' on the VPS." >&2
+  return 1
+}
+
 should_run() {
   local component="$1"
   local setting="$2"
@@ -730,6 +768,12 @@ deploy() {
     else
       echo "Deploying backend (reason: /run/agent-stack/backend.env content changed; image unchanged — force-recreating container only)"
       sudo docker compose --project-directory "$STACK_ROOT" -f "$COMPOSE_FILE" up -d --force-recreate backend
+      # Don't continue to downstream smoke checks until /health is 200
+      # — see wait_for_backend_health() comment for the 2026-05-13 14:30Z
+      # incident that motivated this.
+      if ! wait_for_backend_health; then
+        exit 1
+      fi
     fi
     mark_component_deployed backend
   else


### PR DESCRIPTION
## Summary

Closes the canary bug from the **2026-05-13 14:30Z deploy** (run `25805714633`). PR 2.7d.1's force-recreate path correctly recreated `agent-backend`, but `deploy-production.sh` then continued straight to `check-hosted-stack.sh` which probed `https://api.averray.com/health` **just one second after `Container agent-backend Started`**. Backend wasn't done bootstrapping → 502 → exit 1 → deploy marked failure even though the rotation propagation actually succeeded.

`redeploy-backend.sh` (the full-deploy path) has its own `wait_for_health` for this reason. The PR 2.7d.1 fast-path skipped it.

## Why this matters

**Every secret rotation that touches a template-sourced env var** (`AUTH_JWT_SECRETS`, `RESEND_API_KEY`, `GITHUB_TOKEN`, future ones) hits the PR 2.7d.1 fast-path, not the full-redeploy path. Without this fix, every clean rotation deploy risks looking like a failure due to the 1-second race.

Tomorrow's **AUTH_JWT_SECRETS Phase B** deploy will exercise this path. Landing this PR first means Phase B can't hit the 502 false-failure.

## Changes

`scripts/ops/deploy-production.sh`:

- Adds `wait_for_backend_health()` helper near the other top-level helpers. Mirrors the proven curl-with-retry shape from `redeploy-backend.sh`'s `wait_for_health()` (same `HEALTH_URL` / `HEALTH_TIMEOUT_SEC` / `HEALTH_INTERVAL_SEC` env vars so operators override consistently). Defaults: 60s timeout, 3s interval — tighter than redeploy-backend.sh's 120s/5s because the force-recreate is image-unchanged so bootstrap is faster.
- Calls `wait_for_backend_health` after the PR 2.7d.1 force-recreate. If non-zero, `exit 1` with a clear error pointing at `docker logs agent-backend`.

Indexer force-recreate path **deliberately left as-is** — indexer doesn't expose a public `/health` URL the same way; its readiness is checked via `DEPLOY_WAIT_FOR_READY` + `check-hosted-stack.sh`'s internal probes. Add a matching helper later if we ever see indexer-too-soon-after-restart in practice.

## Test plan

- [x] `bash -n scripts/ops/deploy-production.sh` → ok
- [x] All three Phase 2 CI guards still pass locally (env-template structural lint, manifest parity, npm install-script allowlist)
- [ ] After merge: post-merge deploy or tomorrow's Phase B will exercise the new wait. Expect:
  ```
  Phase 2 PR 2.7d.1: waiting for backend health at https://api.averray.com/health (timeout 60s)
  Backend health check passed after N attempt(s).
  ```
  followed by the existing smoke check finding `/health` ready and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)