### PR TITLE
ci: bump GitHub Actions to Node-24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     name: Solidity — forge test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Foundry
         # Phase 2 PR 2.9 follow-up: pinned to commit SHA (not moving @v1
@@ -41,10 +41,10 @@ jobs:
     name: Backend — node --test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: npm
@@ -76,12 +76,12 @@ jobs:
     name: Operator app — static export
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 2
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: npm
@@ -99,12 +99,12 @@ jobs:
     name: Public site — static export
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 2
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: npm
@@ -119,10 +119,10 @@ jobs:
     name: Indexer — typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: npm
@@ -144,10 +144,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: npm

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -231,11 +231,16 @@ jobs:
       #      includes prod-ci (1Password Web → Integrations).
       - name: Load prod-ci secrets from 1Password (fail-closed)
         id: load_op_ci
-        # Pinned to 1password/load-secrets-action v2.0.0 commit SHA
-        # (verified via the v2.0.0 annotated tag's commit object).
-        # Refresh by re-running:
-        #   curl -s https://api.github.com/repos/1Password/load-secrets-action/git/tags/<tag-sha> | jq .object.sha
-        uses: 1password/load-secrets-action@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0
+        # Pinned to 1password/load-secrets-action v4.0.0 commit SHA
+        # (verified via the v4.0.0 annotated tag's commit object).
+        # v4.0.0 is the first release that runs on Node 24, required by
+        # GitHub Actions runners after 2026-06-02 (auto-flip date) and
+        # mandatory after 2026-09-16:
+        #   https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+        # Refresh by re-running (annotated tag → commit):
+        #   tag_sha=$(gh api repos/1Password/load-secrets-action/git/refs/tags/<tag> --jq .object.sha)
+        #   gh api repos/1Password/load-secrets-action/git/tags/$tag_sha --jq .object.sha
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
         with:
           export-env: true
         env:
@@ -326,7 +331,7 @@ jobs:
       #      includes prod-smoke (1Password Web → Integrations).
       - name: Load ADMIN_JWT from 1Password (fail-closed)
         id: load_op_smoke
-        uses: 1password/load-secrets-action@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
         with:
           export-env: true
         env:

--- a/.github/workflows/publish-discovery-manifest.yml
+++ b/.github/workflows/publish-discovery-manifest.yml
@@ -31,10 +31,10 @@ jobs:
       RPC_URL: ${{ secrets.RPC_URL }}
       DISCOVERY_PUBLISHER_PRIVATE_KEY: ${{ secrets.DISCOVERY_PUBLISHER_PRIVATE_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: npm


### PR DESCRIPTION
## Summary

GitHub Actions runners auto-flip Node-20-based JS actions to Node 24 on **2026-06-02** (~3 weeks out) and remove Node 20 entirely on **2026-09-16** ([blog post](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Upgrading the three pinned actions now surfaces any breakage on our schedule rather than the runner's auto-flip date.

- `actions/checkout@v4` → `@v5` (6 occurrences in ci.yml + 1 in publish-discovery-manifest.yml)
- `actions/setup-node@v4` → `@v5` (5 occurrences in ci.yml + 1 in publish-discovery-manifest.yml)
- `1password/load-secrets-action` SHA-pin refreshed from `581a835f…` (v2.0.0, Node 20) → `92467eb2…` (v4.0.0, Node 24) — 2 occurrences in deploy-production.yml

## Why these specific versions

- **actions/checkout v5.0.0** is the explicit Node 24 upgrade. v6.0.0 also exists and runs Node 24, but adds an unrelated "persist creds to a separate file" change. Staying on v5 keeps this PR's scope tight.
- **actions/setup-node v5.0.0** is the explicit Node 24 upgrade. v6 also runs Node 24 but tweaks auto-cache defaults. v5 is the minimal bump.
- **1password/load-secrets-action v4.0.0** is the explicit Node 24 release (changelog cites the deprecation notice directly). v4 is also the first version after the v3.0.0 breaking change that flipped `export-env` default to `false` — both our call sites already set `export-env: true` explicitly, so behavior is unchanged.

## Convention

Per Phase 2 PR 2.9 follow-up: third-party actions are SHA-pinned (so a compromised future release can't silently retarget our CI); first-party `actions/*` may use the moving major tag. This PR follows that split.

## Test plan
- [ ] CI green on this PR (covers checkout@v5 + setup-node@v5 across all 6 jobs).
- [ ] No deprecation warnings in the CI logs for any of the upgraded actions.
- [ ] `deploy-production.yml` cannot be exercised in this PR; the 1Password step's correctness depends on the production environment's service-account tokens. Verify on next deploy to main that "Load prod-ci secrets from 1Password (fail-closed)" and "Load ADMIN_JWT from 1Password (fail-closed)" both succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)