### PR TITLE
Add scoped service token issue and rotation flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         env:
           RUN_HTTP_SMOKE: "1"
         working-directory: mcp-server
-        run: node --test --test-timeout=30000 src/protocols/http/server.smoke.test.js
+        run: node --test --test-timeout=60000 src/protocols/http/server.smoke.test.js
 
       - name: Ops script regression tests
         run: npm run test:ops

--- a/discovery/.well-known/agent-tools.json
+++ b/discovery/.well-known/agent-tools.json
@@ -99,6 +99,29 @@
           "Native Substrate sign-in is not yet accepted by protected HTTP routes.",
           "Agents should inspect walletModes before choosing an account type."
         ]
+      },
+      {
+        "id": "service-token",
+        "status": "supported_operator_issued",
+        "addressFormat": "0x-prefixed 20-byte service subject address",
+        "supportedWallets": [
+          "operator-issued JWT"
+        ],
+        "authScheme": "SERVICE_TOKEN_JWT",
+        "setup": {
+          "accountGuidance": "Ask an operator to issue a grant-backed token through /admin/service-tokens for the exact capabilities required.",
+          "secretHandling": "The raw service token is returned once. Store it in a secret manager and rotate through /admin/service-tokens/:id/rotate.",
+          "revocationGuidance": "Revoking the bound capability grant removes the token's route capabilities without changing the wallet's normal SIWE session."
+        },
+        "readinessChecks": [
+          "scoped-service-token",
+          "preflight-job"
+        ],
+        "notes": [
+          "Service tokens do not inherit wallet base capabilities.",
+          "A service token is bound to one capabilityGrantId and does not inherit other grants on the same subject wallet.",
+          "Use this mode for external agents that should not receive an admin or full wallet JWT."
+        ]
       }
     ],
     "actionRequirements": [
@@ -270,6 +293,19 @@
           "/jobs/submit",
           "/account",
           "/sessions"
+        ]
+      },
+      {
+        "id": "scoped-service-token",
+        "description": "Operators can issue /admin/service-tokens for external agents that should receive only the grant-backed capabilities they need.",
+        "authScheme": "SERVICE_TOKEN_JWT",
+        "walletModes": [
+          "service-token"
+        ],
+        "blockingFor": [
+          "/jobs/claim",
+          "/jobs/submit",
+          "/jobs/preflight"
         ]
       },
       {
@@ -445,6 +481,18 @@
     {
       "path": "/admin/jobs/ingest/wikipedia",
       "description": "Admin-gated Wikipedia maintenance ingestion preview/create endpoint."
+    },
+    {
+      "path": "/admin/service-tokens",
+      "description": "Admin-gated issue/list surface for grant-backed scoped service tokens."
+    },
+    {
+      "path": "/admin/service-tokens/:id/rotate",
+      "description": "Admin-gated rotate flow: revoke old grant and return one new service-token secret."
+    },
+    {
+      "path": "/admin/service-tokens/:id/revoke",
+      "description": "Admin-gated revoke flow for a grant-backed service token."
     },
     {
       "path": "/content/:hash",

--- a/discovery/agent-tools.json
+++ b/discovery/agent-tools.json
@@ -99,6 +99,29 @@
           "Native Substrate sign-in is not yet accepted by protected HTTP routes.",
           "Agents should inspect walletModes before choosing an account type."
         ]
+      },
+      {
+        "id": "service-token",
+        "status": "supported_operator_issued",
+        "addressFormat": "0x-prefixed 20-byte service subject address",
+        "supportedWallets": [
+          "operator-issued JWT"
+        ],
+        "authScheme": "SERVICE_TOKEN_JWT",
+        "setup": {
+          "accountGuidance": "Ask an operator to issue a grant-backed token through /admin/service-tokens for the exact capabilities required.",
+          "secretHandling": "The raw service token is returned once. Store it in a secret manager and rotate through /admin/service-tokens/:id/rotate.",
+          "revocationGuidance": "Revoking the bound capability grant removes the token's route capabilities without changing the wallet's normal SIWE session."
+        },
+        "readinessChecks": [
+          "scoped-service-token",
+          "preflight-job"
+        ],
+        "notes": [
+          "Service tokens do not inherit wallet base capabilities.",
+          "A service token is bound to one capabilityGrantId and does not inherit other grants on the same subject wallet.",
+          "Use this mode for external agents that should not receive an admin or full wallet JWT."
+        ]
       }
     ],
     "actionRequirements": [
@@ -270,6 +293,19 @@
           "/jobs/submit",
           "/account",
           "/sessions"
+        ]
+      },
+      {
+        "id": "scoped-service-token",
+        "description": "Operators can issue /admin/service-tokens for external agents that should receive only the grant-backed capabilities they need.",
+        "authScheme": "SERVICE_TOKEN_JWT",
+        "walletModes": [
+          "service-token"
+        ],
+        "blockingFor": [
+          "/jobs/claim",
+          "/jobs/submit",
+          "/jobs/preflight"
         ]
       },
       {
@@ -445,6 +481,18 @@
     {
       "path": "/admin/jobs/ingest/wikipedia",
       "description": "Admin-gated Wikipedia maintenance ingestion preview/create endpoint."
+    },
+    {
+      "path": "/admin/service-tokens",
+      "description": "Admin-gated issue/list surface for grant-backed scoped service tokens."
+    },
+    {
+      "path": "/admin/service-tokens/:id/rotate",
+      "description": "Admin-gated rotate flow: revoke old grant and return one new service-token secret."
+    },
+    {
+      "path": "/admin/service-tokens/:id/revoke",
+      "description": "Admin-gated revoke flow for a grant-backed service token."
     },
     {
       "path": "/content/:hash",

--- a/docs/SERVICE_TOKENS.md
+++ b/docs/SERVICE_TOKENS.md
@@ -1,0 +1,134 @@
+# Scoped Service Tokens
+
+Scoped service tokens are operator-issued Bearer tokens for external agents,
+automation workers, and command-center integrations. They are backed by a
+capability grant, so the token resolves only the capabilities in that grant.
+Normal wallet base capabilities are not included.
+
+## Issue
+
+Use an admin wallet token with `admin:capabilities:grant`:
+
+```http
+POST /admin/service-tokens
+Authorization: Bearer <admin-token>
+Content-Type: application/json
+
+{
+  "subject": "0x3333333333333333333333333333333333333333",
+  "capabilities": ["jobs:list", "jobs:preflight", "jobs:claim", "jobs:submit"],
+  "scope": "wikipedia-citation-worker",
+  "note": "Reference agent live workflow",
+  "expiresAt": "2026-06-01T00:00:00.000Z",
+  "tokenTtlSeconds": 86400,
+  "idempotencyKey": "issue-wikipedia-worker-2026-05"
+}
+```
+
+Response:
+
+```json
+{
+  "token": "eyJ...",
+  "tokenType": "Bearer",
+  "tokenKind": "service",
+  "tokenAvailable": true,
+  "wallet": "0x3333333333333333333333333333333333333333",
+  "capabilities": ["jobs:claim", "jobs:list", "jobs:preflight", "jobs:submit"],
+  "expiresAt": "2026-05-14T00:00:00.000Z",
+  "grant": {
+    "id": "grant-abc123def456",
+    "subject": "0x3333333333333333333333333333333333333333",
+    "status": "active"
+  },
+  "usage": {
+    "header": "Authorization: Bearer <token>"
+  }
+}
+```
+
+The raw token is returned once. Idempotency replays return the grant metadata
+but omit the token with `tokenAvailable: false`.
+
+## Use
+
+External agents send:
+
+```http
+Authorization: Bearer <service-token>
+```
+
+`GET /auth/session` shows:
+
+```json
+{
+  "tokenKind": "service",
+  "serviceToken": true,
+  "capabilityGrantId": "grant-abc123def456",
+  "capabilities": ["jobs:claim", "jobs:list", "jobs:preflight", "jobs:submit"]
+}
+```
+
+If the grant is revoked or expired, the same token still verifies as a JWT until
+its JWT expiry, but it resolves no grant-backed capabilities and protected
+routes fail with `missing_capability`.
+
+## Rotate
+
+Rotation revokes the old grant and issues a new grant plus a new token:
+
+```http
+POST /admin/service-tokens/grant-abc123def456/rotate
+Authorization: Bearer <admin-token>
+Content-Type: application/json
+
+{
+  "tokenTtlSeconds": 86400,
+  "idempotencyKey": "rotate-wikipedia-worker-2026-05"
+}
+```
+
+The new token is returned once. The response includes `rotatedFrom` with the
+revoked grant projection.
+
+## Revoke
+
+```http
+POST /admin/service-tokens/grant-new123456/revoke
+Authorization: Bearer <admin-token>
+Content-Type: application/json
+
+{
+  "note": "worker retired",
+  "idempotencyKey": "revoke-wikipedia-worker-2026-05"
+}
+```
+
+Revocation is enforced by the auth middleware through the bound grant id. The
+token does not inherit other grants on the same subject wallet.
+
+## SDK
+
+```js
+import { AgentPlatformClient } from "./sdk/agent-platform-client.js";
+
+const admin = new AgentPlatformClient({
+  baseUrl: "https://api.averray.com",
+  token: process.env.ADMIN_JWT
+});
+
+const issued = await admin.issueServiceToken({
+  subject: "0x3333333333333333333333333333333333333333",
+  capabilities: ["jobs:list", "jobs:preflight", "jobs:claim", "jobs:submit"],
+  scope: "wikipedia-citation-worker",
+  tokenTtlSeconds: 86400,
+  idempotencyKey: "issue-wikipedia-worker-2026-05"
+});
+
+const worker = new AgentPlatformClient({
+  baseUrl: "https://api.averray.com",
+  token: issued.token
+});
+
+await worker.getAuthSession();
+```

--- a/mcp-server/src/auth/auth.test.js
+++ b/mcp-server/src/auth/auth.test.js
@@ -572,3 +572,82 @@ test("requireAuth ignores revoked grants when expanding capabilities", async () 
     (error) => error instanceof AuthorizationError && error.code === "missing_capability"
   );
 });
+
+test("requireAuth binds service tokens to exactly one active grant without base capabilities", async () => {
+  const subject = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  const stateStore = new MemoryStateStore();
+  await stateStore.upsertCapabilityGrant({
+    id: "grant-service",
+    subject,
+    status: "active",
+    capabilities: ["jobs:lifecycle"],
+    issuedAt: new Date().toISOString(),
+    issuedBy: "0x1111111111111111111111111111111111111111"
+  });
+  await stateStore.upsertCapabilityGrant({
+    id: "grant-other",
+    subject,
+    status: "active",
+    capabilities: ["policies:propose"],
+    issuedAt: new Date().toISOString(),
+    issuedBy: "0x1111111111111111111111111111111111111111"
+  });
+  const authConfig = {
+    secrets: [LONG_SECRET],
+    signingSecret: LONG_SECRET,
+    permissive: false,
+    strict: true
+  };
+  const middleware = createAuthMiddleware({ authConfig, stateStore, logger: silentLogger() });
+  const { token } = signToken({
+    sub: subject,
+    roles: [],
+    tokenKind: "service",
+    serviceToken: true,
+    capabilityGrantId: "grant-service"
+  }, {
+    secret: LONG_SECRET,
+    expiresInSeconds: 60
+  });
+  const request = { method: "POST", headers: { authorization: `Bearer ${token}` } };
+
+  const lifecycle = await middleware(request, new URL("http://localhost/admin/jobs/lifecycle"));
+  assert.deepEqual(lifecycle.claims.roles, []);
+  assert.ok(lifecycle.capabilities.includes("jobs:lifecycle"));
+  assert.equal(lifecycle.capabilities.includes("account:read"), false);
+  assert.equal(lifecycle.capabilities.includes("policies:propose"), false);
+
+  await assert.rejects(
+    () => middleware({ method: "GET", headers: request.headers }, new URL("http://localhost/account")),
+    (error) => {
+      assert.ok(error instanceof AuthorizationError);
+      assert.equal(error.code, "missing_capability");
+      assert.deepEqual(error.details.missingCapabilities, ["account:read"]);
+      return true;
+    }
+  );
+
+  await assert.rejects(
+    () => middleware({ method: "POST", headers: request.headers }, new URL("http://localhost/policies")),
+    (error) => {
+      assert.ok(error instanceof AuthorizationError);
+      assert.equal(error.code, "missing_capability");
+      assert.deepEqual(error.details.missingCapabilities, ["policies:propose"]);
+      return true;
+    }
+  );
+
+  await stateStore.upsertCapabilityGrant({
+    id: "grant-service",
+    subject,
+    status: "revoked",
+    capabilities: ["jobs:lifecycle"],
+    issuedAt: new Date().toISOString(),
+    revokedAt: new Date().toISOString(),
+    issuedBy: "0x1111111111111111111111111111111111111111"
+  });
+  await assert.rejects(
+    () => middleware(request, new URL("http://localhost/admin/jobs/lifecycle")),
+    (error) => error instanceof AuthorizationError && error.code === "missing_capability"
+  );
+});

--- a/mcp-server/src/auth/capabilities.js
+++ b/mcp-server/src/auth/capabilities.js
@@ -100,6 +100,10 @@ const ROUTE_CAPABILITY_RULES = [
   { method: "GET", path: "/admin/capability-grants", capabilities: ["admin:capabilities:read"] },
   { method: "POST", path: "/admin/capability-grants", capabilities: ["admin:capabilities:grant"] },
   { method: "POST", path: "/admin/capability-grants/:id/revoke", capabilities: ["admin:capabilities:revoke"] },
+  { method: "GET", path: "/admin/service-tokens", capabilities: ["admin:capabilities:read"] },
+  { method: "POST", path: "/admin/service-tokens", capabilities: ["admin:capabilities:grant"] },
+  { method: "POST", path: "/admin/service-tokens/:id/rotate", capabilities: ["admin:capabilities:grant", "admin:capabilities:revoke"] },
+  { method: "POST", path: "/admin/service-tokens/:id/revoke", capabilities: ["admin:capabilities:revoke"] },
   { method: "POST", path: "/admin/xcm/observe", capabilities: ["xcm:observe"] },
   { method: "POST", path: "/admin/xcm/finalize", capabilities: ["xcm:finalize"] },
   { method: "POST", path: "/verifier/replay", capabilities: ["verifier:replay"] },
@@ -119,6 +123,9 @@ const UI_CONTROLS = {
   "admin.capabilities.view": ["admin:capabilities:read"],
   "admin.capabilities.grant": ["admin:capabilities:grant"],
   "admin.capabilities.revoke": ["admin:capabilities:revoke"],
+  "admin.serviceTokens.issue": ["admin:capabilities:grant"],
+  "admin.serviceTokens.rotate": ["admin:capabilities:grant", "admin:capabilities:revoke"],
+  "admin.serviceTokens.revoke": ["admin:capabilities:revoke"],
   "policies.propose": ["policies:propose"],
   "verifier.run": ["verifier:run"],
   "xcm.observe": ["xcm:observe"],
@@ -138,7 +145,10 @@ const AUTOMATION_ACTIONS = {
   "xcm.observe": ["xcm:observe"],
   "xcm.finalize": ["xcm:finalize"],
   "capability.grant": ["admin:capabilities:grant"],
-  "capability.revoke": ["admin:capabilities:revoke"]
+  "capability.revoke": ["admin:capabilities:revoke"],
+  "serviceToken.issue": ["admin:capabilities:grant"],
+  "serviceToken.rotate": ["admin:capabilities:grant", "admin:capabilities:revoke"],
+  "serviceToken.revoke": ["admin:capabilities:revoke"]
 };
 
 /**
@@ -159,17 +169,20 @@ export function listAllKnownCapabilities() {
 }
 
 export function resolveCapabilities(claims = {}) {
-  const capabilities = new Set(BASE_CAPABILITIES);
-  const roles = Array.isArray(claims.roles) ? claims.roles : [];
+  const serviceToken = claims?.serviceToken === true || claims?.tokenKind === "service";
+  const capabilities = new Set(serviceToken ? [] : BASE_CAPABILITIES);
+  const roles = serviceToken ? [] : Array.isArray(claims.roles) ? claims.roles : [];
   for (const role of roles) {
     for (const capability of ROLE_CAPABILITIES[role] ?? []) {
       capabilities.add(capability);
     }
   }
-  const explicitCapabilities = [
-    ...(Array.isArray(claims.capabilities) ? claims.capabilities : []),
-    ...(Array.isArray(claims.scopes) ? claims.scopes : [])
-  ];
+  const explicitCapabilities = serviceToken
+    ? []
+    : [
+        ...(Array.isArray(claims.capabilities) ? claims.capabilities : []),
+        ...(Array.isArray(claims.scopes) ? claims.scopes : [])
+      ];
   for (const capability of explicitCapabilities) {
     if (typeof capability === "string" && capability.trim()) {
       capabilities.add(capability.trim());

--- a/mcp-server/src/auth/capabilities.test.js
+++ b/mcp-server/src/auth/capabilities.test.js
@@ -40,6 +40,17 @@ test("resolveCapabilities includes explicit future scopes from signed claims", (
   assert.ok(capabilities.includes("ops:view"));
 });
 
+test("resolveCapabilities does not give service tokens wallet base capabilities", () => {
+  const capabilities = resolveCapabilities({
+    roles: ["admin", "verifier"],
+    tokenKind: "service",
+    serviceToken: true,
+    capabilities: ["jobs:create"],
+    scopes: ["ops:view"]
+  });
+  assert.deepEqual(capabilities, []);
+});
+
 test("capabilityMatrix exposes base and role capability groups", () => {
   const matrix = capabilityMatrix();
   assert.equal(matrix.version, AUTH_POLICY_VERSION);
@@ -85,11 +96,28 @@ test("capabilityMatrix surfaces the capability-grant routes and UI controls (roa
   assert.deepEqual(matrix.routes["/admin/capability-grants/:id/revoke"], [
     "admin:capabilities:revoke"
   ]);
+  assert.deepEqual(matrix.routes["/admin/service-tokens"], [
+    "admin:capabilities:grant",
+    "admin:capabilities:read"
+  ]);
+  assert.deepEqual(matrix.routes["/admin/service-tokens/:id/rotate"], [
+    "admin:capabilities:grant",
+    "admin:capabilities:revoke"
+  ]);
+  assert.deepEqual(matrix.routes["/admin/service-tokens/:id/revoke"], [
+    "admin:capabilities:revoke"
+  ]);
   assert.deepEqual(matrix.uiControls["admin.capabilities.view"], ["admin:capabilities:read"]);
   assert.deepEqual(matrix.uiControls["admin.capabilities.grant"], ["admin:capabilities:grant"]);
   assert.deepEqual(matrix.uiControls["admin.capabilities.revoke"], ["admin:capabilities:revoke"]);
   assert.deepEqual(matrix.automationActions["capability.grant"], ["admin:capabilities:grant"]);
   assert.deepEqual(matrix.automationActions["capability.revoke"], ["admin:capabilities:revoke"]);
+  assert.deepEqual(matrix.automationActions["serviceToken.issue"], ["admin:capabilities:grant"]);
+  assert.deepEqual(matrix.automationActions["serviceToken.rotate"], [
+    "admin:capabilities:grant",
+    "admin:capabilities:revoke"
+  ]);
+  assert.deepEqual(matrix.automationActions["serviceToken.revoke"], ["admin:capabilities:revoke"]);
 });
 
 test("getRouteCapabilityRequirements resolves capability-grant routes by method", () => {
@@ -103,6 +131,22 @@ test("getRouteCapabilityRequirements resolves capability-grant routes by method"
   );
   assert.deepEqual(
     getRouteCapabilityRequirements("POST", "/admin/capability-grants/grant-abc/revoke"),
+    ["admin:capabilities:revoke"]
+  );
+  assert.deepEqual(
+    getRouteCapabilityRequirements("GET", "/admin/service-tokens"),
+    ["admin:capabilities:read"]
+  );
+  assert.deepEqual(
+    getRouteCapabilityRequirements("POST", "/admin/service-tokens"),
+    ["admin:capabilities:grant"]
+  );
+  assert.deepEqual(
+    getRouteCapabilityRequirements("POST", "/admin/service-tokens/grant-abc/rotate"),
+    ["admin:capabilities:grant", "admin:capabilities:revoke"]
+  );
+  assert.deepEqual(
+    getRouteCapabilityRequirements("POST", "/admin/service-tokens/grant-abc/revoke"),
     ["admin:capabilities:revoke"]
   );
 });

--- a/mcp-server/src/auth/middleware.js
+++ b/mcp-server/src/auth/middleware.js
@@ -7,7 +7,7 @@ import {
   missingCapabilities,
   resolveCapabilities
 } from "./capabilities.js";
-import { mergeGrantCapabilities } from "../core/capability-grants.js";
+import { isGrantActive, mergeGrantCapabilities } from "../core/capability-grants.js";
 import { buildAuthRequirementDetails } from "../core/discovery-manifest.js";
 
 const GRANT_CACHE_TTL_MS = 15_000;
@@ -71,6 +71,25 @@ export function createAuthMiddleware({ authConfig, stateStore, logger = console,
   async function expandCapabilities(claims, baseCapabilities) {
     const subject = String(claims?.sub ?? "").trim();
     if (!subject) return baseCapabilities;
+    if (isServiceTokenClaims(claims)) {
+      const grantId = String(claims?.capabilityGrantId ?? "").trim();
+      if (!grantId || typeof stateStore?.getCapabilityGrant !== "function") {
+        return baseCapabilities;
+      }
+      try {
+        const grant = await stateStore.getCapabilityGrant(grantId);
+        if (!grant || String(grant.subject ?? "").toLowerCase() !== subject.toLowerCase()) {
+          return baseCapabilities;
+        }
+        if (!isGrantActive(grant, { now })) {
+          return baseCapabilities;
+        }
+        return mergeGrantCapabilities(baseCapabilities, [grant], { now });
+      } catch (error) {
+        logger.warn?.({ subject, grantId, error: error?.message }, "auth.service_token_grant_lookup_failed");
+        return baseCapabilities;
+      }
+    }
     const grants = await loadActiveGrantsFor(subject);
     if (!grants.length) return baseCapabilities;
     return mergeGrantCapabilities(baseCapabilities, grants, { now });
@@ -166,6 +185,10 @@ export function createAuthMiddleware({ authConfig, stateStore, logger = console,
       via: headerToken ? "header" : "query_token"
     };
   };
+}
+
+function isServiceTokenClaims(claims = {}) {
+  return claims?.serviceToken === true || claims?.tokenKind === "service";
 }
 
 function enforceRole(claims, requireRole, authDetails = undefined) {

--- a/mcp-server/src/core/discovery-manifest.js
+++ b/mcp-server/src/core/discovery-manifest.js
@@ -48,6 +48,9 @@ const DISCOVERY_AUTHENTICATED_ENDPOINTS = [
   { path: "/admin/jobs/ingest/open-data", description: "Admin-gated Data.gov open-data quality audit ingestion preview/create endpoint." },
   { path: "/admin/jobs/ingest/osv", description: "Admin-gated OSV npm advisory ingestion preview/create endpoint." },
   { path: "/admin/jobs/ingest/wikipedia", description: "Admin-gated Wikipedia maintenance ingestion preview/create endpoint." },
+  { path: "/admin/service-tokens", description: "Admin-gated issue/list surface for grant-backed scoped service tokens." },
+  { path: "/admin/service-tokens/:id/rotate", description: "Admin-gated rotate flow: revoke old grant and return one new service-token secret." },
+  { path: "/admin/service-tokens/:id/revoke", description: "Admin-gated revoke flow for a grant-backed service token." },
   { path: "/content/:hash", description: "Hash-addressed content blob with read-time disclosure visibility." },
   { path: "/content/:hash/publish", description: "Owner/admin one-way early publish for private hash-addressed content." },
   { path: "/disputes", description: "Operator dispute queue derived from sessions requiring human review." },
@@ -83,6 +86,13 @@ const WALLET_READINESS_CHECKS = [
     authScheme: "SIWE_JWT",
     walletModes: ["evm-siwe"],
     blockingFor: ["/jobs/claim", "/jobs/submit", "/account", "/sessions"]
+  },
+  {
+    id: "scoped-service-token",
+    description: "Operators can issue /admin/service-tokens for external agents that should receive only the grant-backed capabilities they need.",
+    authScheme: "SERVICE_TOKEN_JWT",
+    walletModes: ["service-token"],
+    blockingFor: ["/jobs/claim", "/jobs/submit", "/jobs/preflight"]
   },
   {
     id: "wallet-funded",
@@ -158,6 +168,27 @@ const WALLET_MODES = [
     notes: [
       "Native Substrate sign-in is not yet accepted by protected HTTP routes.",
       "Agents should inspect walletModes before choosing an account type."
+    ]
+  },
+  {
+    id: "service-token",
+    status: "supported_operator_issued",
+    addressFormat: "0x-prefixed 20-byte service subject address",
+    supportedWallets: ["operator-issued JWT"],
+    authScheme: "SERVICE_TOKEN_JWT",
+    setup: {
+      accountGuidance:
+        "Ask an operator to issue a grant-backed token through /admin/service-tokens for the exact capabilities required.",
+      secretHandling:
+        "The raw service token is returned once. Store it in a secret manager and rotate through /admin/service-tokens/:id/rotate.",
+      revocationGuidance:
+        "Revoking the bound capability grant removes the token's route capabilities without changing the wallet's normal SIWE session."
+    },
+    readinessChecks: ["scoped-service-token", "preflight-job"],
+    notes: [
+      "Service tokens do not inherit wallet base capabilities.",
+      "A service token is bound to one capabilityGrantId and does not inherit other grants on the same subject wallet.",
+      "Use this mode for external agents that should not receive an admin or full wallet JWT."
     ]
   }
 ];

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -91,6 +91,7 @@ const METRICS_BEARER_TOKEN = process.env.METRICS_BEARER_TOKEN?.trim() || undefin
 const port = Number(process.env.PORT ?? 8787);
 
 const SIWE_STATEMENT = "Sign in to the Agent Platform.";
+const SERVICE_TOKEN_MAX_TTL_SECONDS = 30 * 24 * 60 * 60;
 
 function respond(response, statusCode, payload, extraHeaders = {}) {
   const headers = {
@@ -1433,6 +1434,93 @@ function assertIssuerCanGrantCapabilities(grant, auth) {
   }
 }
 
+function normalizeServiceTokenTtlSeconds(payload, grant) {
+  const requested = payload?.tokenTtlSeconds === undefined || payload?.tokenTtlSeconds === null
+    ? authConfig.tokenTtlSeconds
+    : Number(payload.tokenTtlSeconds);
+  if (!Number.isInteger(requested) || requested <= 0) {
+    throw new ValidationError("tokenTtlSeconds must be a positive integer.");
+  }
+  let ttlSeconds = Math.min(requested, SERVICE_TOKEN_MAX_TTL_SECONDS);
+  if (grant?.expiresAt) {
+    const remaining = Math.floor((Date.parse(grant.expiresAt) - Date.now()) / 1000);
+    if (remaining <= 0) {
+      throw new ValidationError("Cannot issue a service token for an expired grant.", {
+        grantId: grant.id,
+        expiresAt: grant.expiresAt
+      });
+    }
+    ttlSeconds = Math.min(ttlSeconds, remaining);
+  }
+  return Math.max(1, ttlSeconds);
+}
+
+function signServiceToken(grant, payload = {}) {
+  if (!authConfig.signingSecret) {
+    throw new AuthenticationError(
+      "Auth not configured — set AUTH_JWT_SECRETS to issue service tokens.",
+      "auth_not_configured"
+    );
+  }
+  const ttlSeconds = normalizeServiceTokenTtlSeconds(payload, grant);
+  return signToken(
+    {
+      sub: grant.subject,
+      roles: [],
+      tokenKind: "service",
+      serviceToken: true,
+      capabilityGrantId: grant.id,
+      ...(grant.scope ? { serviceScope: grant.scope } : {})
+    },
+    { secret: authConfig.signingSecret, expiresInSeconds: ttlSeconds }
+  );
+}
+
+function serviceTokenIssueResponse({ grant, token, claims, rotatedFrom = undefined }) {
+  return {
+    token,
+    tokenType: "Bearer",
+    tokenKind: "service",
+    tokenAvailable: true,
+    wallet: grant.subject,
+    capabilities: [...grant.capabilities],
+    expiresAt: new Date(claims.exp * 1000).toISOString(),
+    grant: projectGrant(grant),
+    ...(rotatedFrom ? { rotatedFrom: projectGrant(rotatedFrom) } : {}),
+    usage: {
+      header: "Authorization: Bearer <token>"
+    }
+  };
+}
+
+function serviceTokenReplayResponse(payload) {
+  if (!payload || typeof payload !== "object") {
+    return payload;
+  }
+  const { token, ...rest } = payload;
+  void token;
+  return {
+    ...rest,
+    tokenAvailable: false,
+    tokenOmittedReason: "service_token_secret_is_returned_once"
+  };
+}
+
+async function revokeCapabilityGrantRecord({ grantId, auth, note }) {
+  const current = await stateStore.getCapabilityGrant?.(grantId);
+  if (!current) {
+    throw new ValidationError("Unknown grant id.", { grantId });
+  }
+  const { record, alreadyRevoked } = applyRevocation(current, {
+    revokedBy: auth.wallet,
+    revokeNote: note
+  });
+  if (!alreadyRevoked) {
+    await stateStore.upsertCapabilityGrant?.(record);
+  }
+  return { current, record, alreadyRevoked };
+}
+
 function buildLaneAttention({ shares, isMock, debtTotal, borrowCapacity, deploymentShareBps }) {
   if (!(shares > 0)) {
     return undefined;
@@ -2342,6 +2430,9 @@ const server = createServer(async (request, response) => {
       return respond(response, 200, {
         wallet: auth.wallet,
         roles: auth.claims?.roles ?? [],
+        tokenKind: auth.claims?.tokenKind ?? (auth.claims?.serviceToken === true ? "service" : "wallet"),
+        serviceToken: auth.claims?.serviceToken === true,
+        ...(auth.claims?.capabilityGrantId ? { capabilityGrantId: auth.claims.capabilityGrantId } : {}),
         capabilities: auth.capabilities ?? [],
         capabilityMatrix: authCapabilities.capabilityMatrix()
       });
@@ -3372,6 +3463,212 @@ const server = createServer(async (request, response) => {
         }
       });
       return respond(response, 201, projection);
+    }
+
+    if (request.method === "GET" && pathname === "/admin/service-tokens") {
+      await authMiddleware(request, url, { requireRole: "admin" });
+      const subject = (url.searchParams.get("subject") ?? "").trim().toLowerCase() || undefined;
+      const status = (url.searchParams.get("status") ?? "").trim().toLowerCase() || undefined;
+      const limit = parseLimit(url, 50, 200);
+      const offset = Math.max(0, Number(url.searchParams.get("offset") ?? 0) || 0);
+      const grants = (await stateStore.listCapabilityGrants?.({ subject, status, limit, offset })) ?? [];
+      return respond(response, 200, {
+        items: grants.map((grant) => ({
+          tokenKind: "service",
+          tokenAvailable: false,
+          grant: projectGrant(grant)
+        })).filter((entry) => entry.grant),
+        limit,
+        offset
+      });
+    }
+
+    if (request.method === "POST" && pathname === "/admin/service-tokens") {
+      const auth = await authMiddleware(request, url, { requireRole: "admin" });
+      await enforceLimit("admin_jobs", auth.wallet, rateLimitConfig.adminJobs);
+      const payload = await readJsonBody(request);
+      const idempotencyKey = parseIdempotencyKey(payload);
+      const mutationKey = idempotencyKey ? `${auth.wallet}:${idempotencyKey}` : undefined;
+      const requestHash = buildMutationRequestHash({
+        route: "/admin/service-tokens",
+        wallet: auth.wallet,
+        payload
+      });
+      const replay = await getIdempotentMutationReplay({
+        bucket: "service_token_issue",
+        key: mutationKey,
+        requestHash
+      });
+      if (replay) {
+        return respond(response, replay.statusCode, replay.body);
+      }
+      const grant = buildCapabilityGrant(payload ?? {}, {
+        knownCapabilities: listAllKnownCapabilities(),
+        issuerWallet: auth.wallet
+      });
+      assertIssuerCanGrantCapabilities(grant, auth);
+      await stateStore.upsertCapabilityGrant?.(grant);
+      const { token, claims } = signServiceToken(grant, payload);
+      const body = serviceTokenIssueResponse({ grant, token, claims });
+      await storeIdempotentMutationReceipt({
+        bucket: "service_token_issue",
+        key: mutationKey,
+        requestHash,
+        response: serviceTokenReplayResponse(body),
+        statusCode: 201
+      });
+      eventBus?.publish({
+        id: `service-token-issue-${grant.id}-${Date.now()}`,
+        topic: "service-token.issue",
+        wallet: auth.wallet,
+        wallets: [auth.wallet, grant.subject],
+        timestamp: new Date().toISOString(),
+        data: {
+          grantId: grant.id,
+          subject: grant.subject,
+          capabilities: grant.capabilities,
+          scope: grant.scope ?? null,
+          tokenExpiresAt: body.expiresAt
+        }
+      });
+      return respond(response, 201, body);
+    }
+
+    if (request.method === "POST" && pathname.startsWith("/admin/service-tokens/") && pathname.endsWith("/rotate")) {
+      const auth = await authMiddleware(request, url, { requireRole: "admin" });
+      await enforceLimit("admin_jobs", auth.wallet, rateLimitConfig.adminJobs);
+      const grantId = decodeURIComponent(pathname.slice("/admin/service-tokens/".length, -"/rotate".length));
+      if (!grantId) {
+        throw new ValidationError("grantId is required.");
+      }
+      const payload = await readJsonBody(request);
+      const idempotencyKey = parseIdempotencyKey(payload);
+      const mutationKey = idempotencyKey ? `${auth.wallet}:${grantId}:${idempotencyKey}` : undefined;
+      const requestHash = buildMutationRequestHash({
+        route: "/admin/service-tokens/:id/rotate",
+        wallet: auth.wallet,
+        payload: { grantId, ...payload }
+      });
+      const replay = await getIdempotentMutationReplay({
+        bucket: "service_token_rotate",
+        key: mutationKey,
+        requestHash
+      });
+      if (replay) {
+        return respond(response, replay.statusCode, replay.body);
+      }
+      const current = await stateStore.getCapabilityGrant?.(grantId);
+      if (!current) {
+        throw new ValidationError("Unknown grant id.", { grantId });
+      }
+      if (current.status !== GRANT_STATUS.active) {
+        throw new ConflictError("Cannot rotate a revoked service token grant.", "service_token_grant_revoked", {
+          grantId
+        });
+      }
+      const nextGrant = buildCapabilityGrant({
+        subject: current.subject,
+        capabilities: payload?.capabilities ?? current.capabilities,
+        scope: payload?.scope ?? current.scope,
+        note: payload?.note ?? current.note,
+        expiresAt: payload?.expiresAt ?? current.expiresAt,
+        issuedAt: payload?.issuedAt,
+        nonce: payload?.nonce
+      }, {
+        knownCapabilities: listAllKnownCapabilities(),
+        issuerWallet: auth.wallet
+      });
+      assertIssuerCanGrantCapabilities(nextGrant, auth);
+      const { record: revoked } = await revokeCapabilityGrantRecord({
+        grantId,
+        auth,
+        note: payload?.revokeNote ?? "rotated service token"
+      });
+      await stateStore.upsertCapabilityGrant?.(nextGrant);
+      const { token, claims } = signServiceToken(nextGrant, payload);
+      const body = serviceTokenIssueResponse({ grant: nextGrant, token, claims, rotatedFrom: revoked });
+      await storeIdempotentMutationReceipt({
+        bucket: "service_token_rotate",
+        key: mutationKey,
+        requestHash,
+        response: serviceTokenReplayResponse(body),
+        statusCode: 201
+      });
+      eventBus?.publish({
+        id: `service-token-rotate-${nextGrant.id}-${Date.now()}`,
+        topic: "service-token.rotate",
+        wallet: auth.wallet,
+        wallets: [auth.wallet, nextGrant.subject],
+        timestamp: new Date().toISOString(),
+        data: {
+          previousGrantId: grantId,
+          grantId: nextGrant.id,
+          subject: nextGrant.subject,
+          capabilities: nextGrant.capabilities,
+          scope: nextGrant.scope ?? null,
+          tokenExpiresAt: body.expiresAt
+        }
+      });
+      return respond(response, 201, body);
+    }
+
+    if (request.method === "POST" && pathname.startsWith("/admin/service-tokens/") && pathname.endsWith("/revoke")) {
+      const auth = await authMiddleware(request, url, { requireRole: "admin" });
+      await enforceLimit("admin_jobs", auth.wallet, rateLimitConfig.adminJobs);
+      const grantId = decodeURIComponent(pathname.slice("/admin/service-tokens/".length, -"/revoke".length));
+      if (!grantId) {
+        throw new ValidationError("grantId is required.");
+      }
+      const payload = (await readJsonBody(request).catch(() => undefined)) ?? {};
+      const idempotencyKey = parseIdempotencyKey(payload);
+      const mutationKey = idempotencyKey ? `${auth.wallet}:${grantId}:${idempotencyKey}` : undefined;
+      const requestHash = buildMutationRequestHash({
+        route: "/admin/service-tokens/:id/revoke",
+        wallet: auth.wallet,
+        payload: { grantId, ...payload }
+      });
+      const replay = await getIdempotentMutationReplay({
+        bucket: "service_token_revoke",
+        key: mutationKey,
+        requestHash
+      });
+      if (replay) {
+        return respond(response, replay.statusCode, replay.body);
+      }
+      const { record, alreadyRevoked } = await revokeCapabilityGrantRecord({
+        grantId,
+        auth,
+        note: payload?.note
+      });
+      const body = {
+        tokenKind: "service",
+        tokenAvailable: false,
+        status: "revoked",
+        alreadyRevoked,
+        grant: projectGrant(record)
+      };
+      await storeIdempotentMutationReceipt({
+        bucket: "service_token_revoke",
+        key: mutationKey,
+        requestHash,
+        response: body,
+        statusCode: 200
+      });
+      if (!alreadyRevoked) {
+        eventBus?.publish({
+          id: `service-token-revoke-${record.id}-${Date.now()}`,
+          topic: "service-token.revoke",
+          wallet: auth.wallet,
+          wallets: [auth.wallet, record.subject],
+          timestamp: new Date().toISOString(),
+          data: {
+            grantId: record.id,
+            subject: record.subject,
+            revokedBy: record.revokedBy ?? auth.wallet
+          }
+        });
+      }
+      return respond(response, 200, body);
     }
 
     if (request.method === "POST" && pathname.startsWith("/admin/capability-grants/") && pathname.endsWith("/revoke")) {

--- a/mcp-server/src/protocols/http/server.smoke.test.js
+++ b/mcp-server/src/protocols/http/server.smoke.test.js
@@ -1258,6 +1258,111 @@ test("http smoke: capability revoke idempotency replays and rejects payload drif
   });
 });
 
+test("http smoke: service token issue/rotate/revoke is grant-backed and one-time-secret", { skip: !RUN }, async () => {
+  await runWithServer(async (base) => {
+    const adminToken = issueToken(ADMIN_WALLET, { roles: ["admin"] });
+    const adminHeaders = { "content-type": "application/json", authorization: `Bearer ${adminToken}` };
+    const issuePayload = {
+      subject: STRANGER_WALLET,
+      capabilities: ["jobs:lifecycle"],
+      scope: "external-agent-smoke",
+      issuedAt: "2026-05-01T00:00:00.000Z",
+      nonce: "service-token-issue-smoke",
+      tokenTtlSeconds: 600,
+      idempotencyKey: "service-token-issue-key"
+    };
+
+    const issue = await fetch(`${base}/admin/service-tokens`, {
+      method: "POST",
+      headers: adminHeaders,
+      body: JSON.stringify(issuePayload)
+    });
+    assert.equal(issue.status, 201);
+    const issued = await issue.json();
+    assert.equal(typeof issued.token, "string");
+    assert.equal(issued.tokenKind, "service");
+    assert.equal(issued.wallet, STRANGER_WALLET.toLowerCase());
+    assert.deepEqual(issued.capabilities, ["jobs:lifecycle"]);
+
+    const replay = await fetch(`${base}/admin/service-tokens`, {
+      method: "POST",
+      headers: adminHeaders,
+      body: JSON.stringify(issuePayload)
+    });
+    assert.equal(replay.status, 200);
+    const replayed = await replay.json();
+    assert.equal(replayed.token, undefined);
+    assert.equal(replayed.tokenAvailable, false);
+    assert.equal(replayed.tokenOmittedReason, "service_token_secret_is_returned_once");
+    assert.equal(replayed.grant.id, issued.grant.id);
+
+    const session = await fetch(`${base}/auth/session`, {
+      headers: { authorization: `Bearer ${issued.token}` }
+    });
+    assert.equal(session.status, 200);
+    const serviceSession = await session.json();
+    assert.equal(serviceSession.tokenKind, "service");
+    assert.equal(serviceSession.serviceToken, true);
+    assert.equal(serviceSession.capabilityGrantId, issued.grant.id);
+    assert.deepEqual(serviceSession.capabilities, ["jobs:lifecycle"]);
+
+    const noBase = await fetch(`${base}/account`, {
+      headers: { authorization: `Bearer ${issued.token}` }
+    });
+    assert.equal(noBase.status, 403);
+
+    const rotate = await fetch(`${base}/admin/service-tokens/${issued.grant.id}/rotate`, {
+      method: "POST",
+      headers: adminHeaders,
+      body: JSON.stringify({
+        issuedAt: "2026-05-01T00:01:00.000Z",
+        nonce: "service-token-rotate-smoke",
+        tokenTtlSeconds: 600,
+        idempotencyKey: "service-token-rotate-key"
+      })
+    });
+    assert.equal(rotate.status, 201);
+    const rotated = await rotate.json();
+    assert.equal(typeof rotated.token, "string");
+    assert.notEqual(rotated.grant.id, issued.grant.id);
+    assert.equal(rotated.rotatedFrom.id, issued.grant.id);
+    assert.equal(rotated.rotatedFrom.status, "revoked");
+
+    const oldToken = await fetch(`${base}/admin/jobs/lifecycle`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${issued.token}` },
+      body: JSON.stringify({ jobId: "missing", action: "pause" })
+    });
+    assert.equal(oldToken.status, 403);
+
+    const newToken = await fetch(`${base}/auth/session`, {
+      headers: { authorization: `Bearer ${rotated.token}` }
+    });
+    assert.equal(newToken.status, 200);
+    assert.deepEqual((await newToken.json()).capabilities, ["jobs:lifecycle"]);
+
+    const revoke = await fetch(`${base}/admin/service-tokens/${rotated.grant.id}/revoke`, {
+      method: "POST",
+      headers: adminHeaders,
+      body: JSON.stringify({
+        note: "smoke complete",
+        idempotencyKey: "service-token-revoke-key"
+      })
+    });
+    assert.equal(revoke.status, 200);
+    const revoked = await revoke.json();
+    assert.equal(revoked.status, "revoked");
+    assert.equal(revoked.grant.status, "revoked");
+
+    const revokedToken = await fetch(`${base}/admin/jobs/lifecycle`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${rotated.token}` },
+      body: JSON.stringify({ jobId: "missing", action: "pause" })
+    });
+    assert.equal(revokedToken.status, 403);
+  });
+});
+
 test("http smoke: admin recurring fire idempotency replays and rejects firedAt drift", { skip: !RUN }, async () => {
   await runWithServer(async (base) => {
     const adminToken = issueToken(ADMIN_WALLET, { roles: ["admin"] });

--- a/sdk/agent-platform-client.js
+++ b/sdk/agent-platform-client.js
@@ -365,6 +365,36 @@ export class AgentPlatformClient {
     return this.request("/admin/status");
   }
 
+  async listServiceTokens({ subject = undefined, status = undefined, limit = undefined, offset = undefined } = {}) {
+    const params = new URLSearchParams();
+    if (subject) params.set("subject", subject);
+    if (status) params.set("status", status);
+    if (limit !== undefined) params.set("limit", String(limit));
+    if (offset !== undefined) params.set("offset", String(offset));
+    return this.request(`/admin/service-tokens${params.size ? `?${params.toString()}` : ""}`);
+  }
+
+  async issueServiceToken(payload) {
+    return this.request("/admin/service-tokens", {
+      method: "POST",
+      body: payload
+    });
+  }
+
+  async rotateServiceToken(grantId, payload = {}) {
+    return this.request(`/admin/service-tokens/${encodeURIComponent(grantId)}/rotate`, {
+      method: "POST",
+      body: payload
+    });
+  }
+
+  async revokeServiceToken(grantId, { note = undefined, idempotencyKey = undefined } = {}) {
+    return this.request(`/admin/service-tokens/${encodeURIComponent(grantId)}/revoke`, {
+      method: "POST",
+      body: compact({ note, idempotencyKey })
+    });
+  }
+
   async request(path, { method = "GET", body = undefined, headers = {} } = {}) {
     const requestHeaders = new Headers(headers);
     requestHeaders.set("accept", "application/json");

--- a/site/.well-known/agent-tools.json
+++ b/site/.well-known/agent-tools.json
@@ -99,6 +99,29 @@
           "Native Substrate sign-in is not yet accepted by protected HTTP routes.",
           "Agents should inspect walletModes before choosing an account type."
         ]
+      },
+      {
+        "id": "service-token",
+        "status": "supported_operator_issued",
+        "addressFormat": "0x-prefixed 20-byte service subject address",
+        "supportedWallets": [
+          "operator-issued JWT"
+        ],
+        "authScheme": "SERVICE_TOKEN_JWT",
+        "setup": {
+          "accountGuidance": "Ask an operator to issue a grant-backed token through /admin/service-tokens for the exact capabilities required.",
+          "secretHandling": "The raw service token is returned once. Store it in a secret manager and rotate through /admin/service-tokens/:id/rotate.",
+          "revocationGuidance": "Revoking the bound capability grant removes the token's route capabilities without changing the wallet's normal SIWE session."
+        },
+        "readinessChecks": [
+          "scoped-service-token",
+          "preflight-job"
+        ],
+        "notes": [
+          "Service tokens do not inherit wallet base capabilities.",
+          "A service token is bound to one capabilityGrantId and does not inherit other grants on the same subject wallet.",
+          "Use this mode for external agents that should not receive an admin or full wallet JWT."
+        ]
       }
     ],
     "actionRequirements": [
@@ -270,6 +293,19 @@
           "/jobs/submit",
           "/account",
           "/sessions"
+        ]
+      },
+      {
+        "id": "scoped-service-token",
+        "description": "Operators can issue /admin/service-tokens for external agents that should receive only the grant-backed capabilities they need.",
+        "authScheme": "SERVICE_TOKEN_JWT",
+        "walletModes": [
+          "service-token"
+        ],
+        "blockingFor": [
+          "/jobs/claim",
+          "/jobs/submit",
+          "/jobs/preflight"
         ]
       },
       {
@@ -445,6 +481,18 @@
     {
       "path": "/admin/jobs/ingest/wikipedia",
       "description": "Admin-gated Wikipedia maintenance ingestion preview/create endpoint."
+    },
+    {
+      "path": "/admin/service-tokens",
+      "description": "Admin-gated issue/list surface for grant-backed scoped service tokens."
+    },
+    {
+      "path": "/admin/service-tokens/:id/rotate",
+      "description": "Admin-gated rotate flow: revoke old grant and return one new service-token secret."
+    },
+    {
+      "path": "/admin/service-tokens/:id/revoke",
+      "description": "Admin-gated revoke flow for a grant-backed service token."
     },
     {
       "path": "/content/:hash",


### PR DESCRIPTION
## Summary
- add admin list/issue/rotate/revoke endpoints for scoped service tokens backed by capability grants
- bind service-token JWTs to exactly one active grant with no wallet base, role, inline scope, or sibling-grant inheritance
- add SDK helpers, discovery manifest affordances, docs, and smoke coverage for one-time secret handling
- raise the HTTP smoke file timeout to 60s because the full integration file now crosses the old 30s CI ceiling

## Checks
- node --check mcp-server/src/protocols/http/server.js
- node --test mcp-server/src/auth/capabilities.test.js mcp-server/src/auth/auth.test.js mcp-server/src/core/discovery-manifest.test.js
- RUN_HTTP_SMOKE=1 node --test --test-name-pattern "service token" mcp-server/src/protocols/http/server.smoke.test.js
- RUN_HTTP_SMOKE=1 node --test --test-timeout=60000 src/protocols/http/server.smoke.test.js (from mcp-server/)
- npm --workspace mcp-server test
- npm run check:discovery-manifest

## Impact
Backend API/auth, SDK, docs, CI HTTP-smoke timeout, and discovery manifest. No frontend app, indexer, Caddy, contracts, public site runtime, or env changes required.