### PR TITLE
Schema-native first-wave jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Discovery manifest sync check
         run: npm run check:discovery-manifest
 
+      - name: Job schema docs sync check
+        run: npm run check:job-schemas
+
   frontend:
     name: Operator app — static export
     runs-on: ubuntu-latest

--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -132,36 +132,37 @@ is still too loose for high-trust operation.
 ### Why this matters
 
 The platform already points at schema-first jobs through
-`inputSchemaRef` and `outputSchemaRef`, but those fields are still
-mostly metadata. Real quality control still depends heavily on
-verifier terms and operator discipline.
+`inputSchemaRef` and `outputSchemaRef`, and the first built-in schema-native
+paths now validate against the runtime registry before submit and verifier
+execution. Real quality control still depends on verifier terms and operator
+discipline for custom/off-platform schemas.
+
+### Current state
+
+- `docs/schemas/jobs/` is generated from the runtime registry and checked in CI
+- first-party schemas exist for PR review findings, release readiness, issue
+  triage, and docs drift audit
+- built-in schema-native outputs are validated at submit time and again before
+  verifier execution
+- `/jobs/definition.submissionContract` and `/jobs/validate-submission` remain
+  the no-mutation source of truth for exact submit shape
 
 ### Gaps today
 
-- schema refs are not strongly validated at job creation time
-- submit flows do not validate structured output against a concrete schema
-- the first-wave jobs are structured by convention, not enforced runtime
-- schema libraries are still sparse outside the public profile and badge docs
+- custom/off-platform schema refs are still allowed without signed schema
+  registration
+- helper workflows outside the platform still need to call
+  `/jobs/validate-submission` before consuming a claim/submit attempt
+- richer verifier replay fixtures should land before introducing v2 handlers
 
 ### Improve to
 
-- a small reusable schema registry
 - job creation that verifies referenced schemas exist
-- submit-time validation before verifier execution
 - richer operator errors for invalid structured submissions
+- signed schema registration for custom/off-platform work
 
 ### Concrete next changes
 
-- keep job schema docs under `docs/schemas/jobs/` aligned with the runtime
-  registry
-- define first-party schemas for:
-  - PR review findings
-  - release readiness
-  - issue triage
-  - docs drift audit
-- keep `/jobs/definition.submissionContract` and
-  `/jobs/validate-submission` as the no-mutation source of truth for exact
-  submit shape
 - validate structured output before claim/submit helper flows consume a claim
   attempt
 - continue tightening custom/off-platform schema refs once a signed schema

--- a/docs/SPEC_AUDIT_2026-05-13.md
+++ b/docs/SPEC_AUDIT_2026-05-13.md
@@ -158,11 +158,11 @@ SSH/basic-auth/admin-JWT cutovers, and the basic hosted smoke is green.
 
 ### Schema-Native Jobs
 
-- Align `docs/schemas/jobs/` with the runtime registry.
-- Define first-party schemas for PR review findings, release readiness, issue
-  triage, and docs drift audit.
-- Enforce structured output validation before verifier execution and before
-  helper workflows consume a claim/submit attempt.
+- Status: first-wave runtime schemas, public docs sync, submit-time validation,
+  and pre-verifier validation are implemented.
+- Remaining: make external/helper workflows call `/jobs/validate-submission`
+  before consuming a claim/submit attempt, and add signed registration before
+  tightening custom/off-platform schema refs.
 
 ### Verifier Replay Hardening
 

--- a/docs/schemas/jobs/coding-input.json
+++ b/docs/schemas/jobs/coding-input.json
@@ -1,20 +1,37 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "schema://jobs/coding-input",
   "title": "Coding Input",
+  "description": "Generic coding job input.",
   "type": "object",
-  "required": ["task", "acceptanceCriteria"],
   "properties": {
-    "task": { "type": "string", "minLength": 1 },
+    "task": {
+      "type": "string",
+      "minLength": 1
+    },
     "acceptanceCriteria": {
       "type": "array",
-      "minItems": 1,
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
     },
-    "repo": { "type": "string", "minLength": 1 },
+    "repo": {
+      "type": "string",
+      "minLength": 1
+    },
     "files": {
       "type": "array",
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
     }
   },
+  "required": [
+    "task",
+    "acceptanceCriteria"
+  ],
   "additionalProperties": false
 }

--- a/docs/schemas/jobs/coding-output.json
+++ b/docs/schemas/jobs/coding-output.json
@@ -1,16 +1,38 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "schema://jobs/coding-output",
   "title": "Coding Output",
+  "description": "Generic coding job output.",
   "type": "object",
-  "required": ["summary", "output", "status"],
   "properties": {
-    "summary": { "type": "string", "minLength": 1 },
-    "output": { "type": "string", "minLength": 1 },
-    "status": { "type": "string", "enum": ["complete", "partial", "blocked"] },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "output": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "complete",
+        "partial",
+        "blocked"
+      ]
+    },
     "filesChanged": {
       "type": "array",
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
     }
   },
+  "required": [
+    "summary",
+    "output",
+    "status"
+  ],
   "additionalProperties": false
 }

--- a/docs/schemas/jobs/dependency-remediation-input.json
+++ b/docs/schemas/jobs/dependency-remediation-input.json
@@ -1,20 +1,15 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "schema://jobs/dependency-remediation-input",
-  "type": "object",
+  "title": "Dependency Remediation Input",
   "description": "Dependency vulnerability remediation input from public advisory sources such as OSV/NVD.",
-  "required": [
-    "ecosystem",
-    "packageName",
-    "vulnerableVersion",
-    "fixedVersion",
-    "advisoryIds",
-    "instructions"
-  ],
+  "type": "object",
   "properties": {
     "ecosystem": {
       "type": "string",
-      "enum": ["npm"]
+      "enum": [
+        "npm"
+      ]
     },
     "packageName": {
       "type": "string",
@@ -36,24 +31,35 @@
     },
     "advisoryIds": {
       "type": "array",
-      "minItems": 1,
       "items": {
-        "type": "string"
-      }
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
     },
     "advisoryUrls": {
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       }
     },
     "instructions": {
       "type": "array",
-      "minItems": 1,
       "items": {
-        "type": "string"
-      }
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
     }
   },
-  "additionalProperties": true
+  "required": [
+    "ecosystem",
+    "packageName",
+    "vulnerableVersion",
+    "fixedVersion",
+    "advisoryIds",
+    "instructions"
+  ],
+  "additionalProperties": false
 }

--- a/docs/schemas/jobs/dependency-remediation-output.json
+++ b/docs/schemas/jobs/dependency-remediation-output.json
@@ -1,17 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "schema://jobs/dependency-remediation-output",
-  "type": "object",
+  "title": "Dependency Remediation Output",
   "description": "Structured pull request evidence for a dependency vulnerability remediation.",
-  "required": [
-    "prUrl",
-    "packageName",
-    "vulnerableVersion",
-    "fixedVersion",
-    "advisoryIds",
-    "summary",
-    "tests"
-  ],
+  "type": "object",
   "properties": {
     "prUrl": {
       "type": "string",
@@ -31,10 +23,11 @@
     },
     "advisoryIds": {
       "type": "array",
-      "minItems": 1,
       "items": {
-        "type": "string"
-      }
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
     },
     "summary": {
       "type": "string",
@@ -53,18 +46,25 @@
     "lockfilesUpdated": {
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       }
     },
     "filesChanged": {
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       }
     },
     "ciStatus": {
       "type": "string",
-      "enum": ["unknown", "pending", "passing", "failing"]
+      "enum": [
+        "unknown",
+        "pending",
+        "passing",
+        "failing"
+      ]
     },
     "checksPassing": {
       "type": "boolean"
@@ -73,5 +73,14 @@
       "type": "string"
     }
   },
-  "additionalProperties": true
+  "required": [
+    "prUrl",
+    "packageName",
+    "vulnerableVersion",
+    "fixedVersion",
+    "advisoryIds",
+    "summary",
+    "tests"
+  ],
+  "additionalProperties": false
 }

--- a/docs/schemas/jobs/docs-drift-audit-output.json
+++ b/docs/schemas/jobs/docs-drift-audit-output.json
@@ -1,29 +1,66 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "schema://jobs/docs-drift-audit-output",
   "title": "Docs Drift Audit Output",
+  "description": "Structured docs drift output.",
   "type": "object",
-  "required": ["source_surface", "drift_findings", "missing_updates", "severity", "fix_recommendation"],
   "properties": {
-    "source_surface": { "type": "string", "minLength": 1 },
+    "source_surface": {
+      "type": "string",
+      "minLength": 1
+    },
     "drift_findings": {
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["surface_a", "surface_b", "mismatch"],
         "properties": {
-          "surface_a": { "type": "string", "minLength": 1 },
-          "surface_b": { "type": "string", "minLength": 1 },
-          "mismatch": { "type": "string", "minLength": 1 }
+          "surface_a": {
+            "type": "string",
+            "minLength": 1
+          },
+          "surface_b": {
+            "type": "string",
+            "minLength": 1
+          },
+          "mismatch": {
+            "type": "string",
+            "minLength": 1
+          }
         },
+        "required": [
+          "surface_a",
+          "surface_b",
+          "mismatch"
+        ],
         "additionalProperties": false
       }
     },
     "missing_updates": {
       "type": "array",
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
     },
-    "severity": { "type": "string", "enum": ["low", "medium", "high"] },
-    "fix_recommendation": { "type": "string", "minLength": 1 }
+    "severity": {
+      "type": "string",
+      "enum": [
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    "fix_recommendation": {
+      "type": "string",
+      "minLength": 1
+    }
   },
+  "required": [
+    "source_surface",
+    "drift_findings",
+    "missing_updates",
+    "severity",
+    "fix_recommendation"
+  ],
   "additionalProperties": false
 }

--- a/docs/schemas/jobs/docs-input.json
+++ b/docs/schemas/jobs/docs-input.json
@@ -1,19 +1,33 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "schema://jobs/docs-input",
   "title": "Docs Input",
+  "description": "Documentation audit input.",
   "type": "object",
-  "required": ["surfaces", "goal"],
   "properties": {
     "surfaces": {
       "type": "array",
-      "minItems": 1,
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
     },
-    "goal": { "type": "string", "minLength": 1 },
+    "goal": {
+      "type": "string",
+      "minLength": 1
+    },
     "context": {
       "type": "array",
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
     }
   },
+  "required": [
+    "surfaces",
+    "goal"
+  ],
   "additionalProperties": false
 }

--- a/docs/schemas/jobs/github-pr-evidence-output.json
+++ b/docs/schemas/jobs/github-pr-evidence-output.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "schema://jobs/github-pr-evidence-output",
+  "title": "GitHub PR Evidence Output",
+  "description": "GitHub pull request evidence for open-source issue jobs.",
+  "type": "object",
+  "properties": {
+    "prUrl": {
+      "type": "string",
+      "minLength": 1
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tests": {
+      "type": "string",
+      "minLength": 1
+    },
+    "notes": {
+      "type": "string"
+    },
+    "prBody": {
+      "type": "string"
+    },
+    "issueNumber": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "issueUrl": {
+      "type": "string"
+    },
+    "commitUrl": {
+      "type": "string"
+    },
+    "branchUrl": {
+      "type": "string"
+    },
+    "filesChanged": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "referencesIssue": {
+      "type": "boolean"
+    },
+    "checksPassing": {
+      "type": "boolean"
+    },
+    "ciStatus": {
+      "type": "string",
+      "enum": [
+        "unknown",
+        "pending",
+        "passing",
+        "failing"
+      ]
+    },
+    "reviewApproved": {
+      "type": "boolean"
+    },
+    "merged": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "prUrl",
+    "summary",
+    "tests"
+  ],
+  "additionalProperties": false
+}

--- a/docs/schemas/jobs/governance-input.json
+++ b/docs/schemas/jobs/governance-input.json
@@ -1,15 +1,29 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "schema://jobs/governance-input",
   "title": "Governance Input",
+  "description": "Generic governance job input.",
   "type": "object",
-  "required": ["proposal", "requestedOutcome"],
   "properties": {
-    "proposal": { "type": "string", "minLength": 1 },
-    "requestedOutcome": { "type": "string", "minLength": 1 },
+    "proposal": {
+      "type": "string",
+      "minLength": 1
+    },
+    "requestedOutcome": {
+      "type": "string",
+      "minLength": 1
+    },
     "constraints": {
       "type": "array",
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
     }
   },
+  "required": [
+    "proposal",
+    "requestedOutcome"
+  ],
   "additionalProperties": false
 }

--- a/docs/schemas/jobs/governance-output.json
+++ b/docs/schemas/jobs/governance-output.json
@@ -1,15 +1,33 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "schema://jobs/governance-output",
   "title": "Governance Output",
+  "description": "Generic governance job output.",
   "type": "object",
-  "required": ["summary", "decisionSignal"],
   "properties": {
-    "summary": { "type": "string", "minLength": 1 },
-    "decisionSignal": { "type": "string", "enum": ["approve", "reject", "revise"] },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "decisionSignal": {
+      "type": "string",
+      "enum": [
+        "approve",
+        "reject",
+        "revise"
+      ]
+    },
     "recommendations": {
       "type": "array",
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
     }
   },
+  "required": [
+    "summary",
+    "decisionSignal"
+  ],
   "additionalProperties": false
 }

--- a/docs/schemas/jobs/issue-defect-triage-output.json
+++ b/docs/schemas/jobs/issue-defect-triage-output.json
@@ -1,15 +1,73 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "schema://jobs/issue-defect-triage-output",
   "title": "Issue Defect Triage Output",
+  "description": "Structured issue triage output.",
   "type": "object",
-  "required": ["category", "severity", "component", "repro_clarity", "next_owner", "duplication_risk"],
   "properties": {
-    "category": { "type": "string", "enum": ["bug", "ops", "docs", "governance", "integration"] },
-    "severity": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
-    "component": { "type": "string", "enum": ["api", "indexer", "frontend", "contracts", "ops"] },
-    "repro_clarity": { "type": "string", "enum": ["clear", "partial", "unclear"] },
-    "next_owner": { "type": "string", "enum": ["backend", "frontend", "ops", "contracts", "docs"] },
-    "duplication_risk": { "type": "string", "enum": ["low", "medium", "high"] }
+    "category": {
+      "type": "string",
+      "enum": [
+        "bug",
+        "ops",
+        "docs",
+        "governance",
+        "integration"
+      ]
+    },
+    "severity": {
+      "type": "string",
+      "enum": [
+        "low",
+        "medium",
+        "high",
+        "critical"
+      ]
+    },
+    "component": {
+      "type": "string",
+      "enum": [
+        "api",
+        "indexer",
+        "frontend",
+        "contracts",
+        "ops"
+      ]
+    },
+    "repro_clarity": {
+      "type": "string",
+      "enum": [
+        "clear",
+        "partial",
+        "unclear"
+      ]
+    },
+    "next_owner": {
+      "type": "string",
+      "enum": [
+        "backend",
+        "frontend",
+        "ops",
+        "contracts",
+        "docs"
+      ]
+    },
+    "duplication_risk": {
+      "type": "string",
+      "enum": [
+        "low",
+        "medium",
+        "high"
+      ]
+    }
   },
+  "required": [
+    "category",
+    "severity",
+    "component",
+    "repro_clarity",
+    "next_owner",
+    "duplication_risk"
+  ],
   "additionalProperties": false
 }

--- a/docs/schemas/jobs/open-data-quality-audit-input.json
+++ b/docs/schemas/jobs/open-data-quality-audit-input.json
@@ -1,13 +1,15 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "schema://jobs/open-data-quality-audit-input",
-  "type": "object",
+  "title": "Open Data Quality Audit Input",
   "description": "Public open-data dataset/resource quality audit input.",
-  "required": ["portal", "datasetTitle", "datasetUrl", "resourceUrl", "instructions"],
+  "type": "object",
   "properties": {
     "portal": {
       "type": "string",
-      "enum": ["data.gov"]
+      "enum": [
+        "data.gov"
+      ]
     },
     "datasetId": {
       "type": "string"
@@ -47,11 +49,19 @@
     },
     "instructions": {
       "type": "array",
-      "minItems": 1,
       "items": {
-        "type": "string"
-      }
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
     }
   },
-  "additionalProperties": true
+  "required": [
+    "portal",
+    "datasetTitle",
+    "datasetUrl",
+    "resourceUrl",
+    "instructions"
+  ],
+  "additionalProperties": false
 }

--- a/docs/schemas/jobs/open-data-quality-audit-output.json
+++ b/docs/schemas/jobs/open-data-quality-audit-output.json
@@ -1,18 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "schema://jobs/open-data-quality-audit-output",
-  "type": "object",
+  "title": "Open Data Quality Audit Output",
   "description": "Structured evidence for a public open-data dataset/resource quality audit.",
-  "required": [
-    "dataset_title",
-    "dataset_url",
-    "resource_url",
-    "checks",
-    "findings",
-    "no_issue_found",
-    "summary",
-    "recommended_actions"
-  ],
+  "type": "object",
   "properties": {
     "dataset_title": {
       "type": "string",
@@ -34,7 +25,6 @@
       "minItems": 1,
       "items": {
         "type": "object",
-        "required": ["name", "status", "evidence"],
         "properties": {
           "name": {
             "type": "string",
@@ -42,25 +32,38 @@
           },
           "status": {
             "type": "string",
-            "enum": ["pass", "warn", "fail", "unknown"]
+            "enum": [
+              "pass",
+              "warn",
+              "fail",
+              "unknown"
+            ]
           },
           "evidence": {
             "type": "string",
             "minLength": 1
           }
         },
-        "additionalProperties": true
+        "required": [
+          "name",
+          "status",
+          "evidence"
+        ],
+        "additionalProperties": false
       }
     },
     "findings": {
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["severity", "issue", "evidence", "recommendation"],
         "properties": {
           "severity": {
             "type": "string",
-            "enum": ["low", "medium", "high"]
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "issue": {
             "type": "string",
@@ -75,7 +78,13 @@
             "minLength": 1
           }
         },
-        "additionalProperties": true
+        "required": [
+          "severity",
+          "issue",
+          "evidence",
+          "recommendation"
+        ],
+        "additionalProperties": false
       }
     },
     "no_issue_found": {
@@ -87,14 +96,25 @@
     },
     "recommended_actions": {
       "type": "array",
-      "minItems": 1,
       "items": {
-        "type": "string"
-      }
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
     },
     "notes": {
       "type": "string"
     }
   },
-  "additionalProperties": true
+  "required": [
+    "dataset_title",
+    "dataset_url",
+    "resource_url",
+    "checks",
+    "findings",
+    "no_issue_found",
+    "summary",
+    "recommended_actions"
+  ],
+  "additionalProperties": false
 }

--- a/docs/schemas/jobs/openapi-quality-audit-input.json
+++ b/docs/schemas/jobs/openapi-quality-audit-input.json
@@ -1,22 +1,52 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "schema://jobs/openapi-quality-audit-input",
   "title": "OpenAPI Quality Audit Input",
+  "description": "Public OpenAPI quality audit input.",
   "type": "object",
-  "required": ["apiTitle", "specUrl", "instructions"],
   "properties": {
-    "apiTitle": { "type": "string", "minLength": 1 },
-    "specUrl": { "type": "string", "minLength": 1 },
-    "localSurface": { "type": "string" },
-    "repo": { "type": "string" },
-    "openapiVersion": { "type": "string" },
-    "pathCount": { "type": "integer", "minimum": 0 },
-    "operationCount": { "type": "integer", "minimum": 0 },
-    "schemaCount": { "type": "integer", "minimum": 0 },
+    "apiTitle": {
+      "type": "string",
+      "minLength": 1
+    },
+    "specUrl": {
+      "type": "string",
+      "minLength": 1
+    },
+    "localSurface": {
+      "type": "string"
+    },
+    "repo": {
+      "type": "string"
+    },
+    "openapiVersion": {
+      "type": "string"
+    },
+    "pathCount": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "operationCount": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "schemaCount": {
+      "type": "integer",
+      "minimum": 0
+    },
     "instructions": {
       "type": "array",
-      "minItems": 1,
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
     }
   },
+  "required": [
+    "apiTitle",
+    "specUrl",
+    "instructions"
+  ],
   "additionalProperties": false
 }

--- a/docs/schemas/jobs/openapi-quality-audit-output.json
+++ b/docs/schemas/jobs/openapi-quality-audit-output.json
@@ -1,24 +1,53 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "schema://jobs/openapi-quality-audit-output",
   "title": "OpenAPI Quality Audit Output",
+  "description": "Structured evidence for an OpenAPI spec quality audit.",
   "type": "object",
-  "required": ["api_title", "spec_url", "checks", "findings", "no_issue_found", "summary", "recommended_actions"],
   "properties": {
-    "api_title": { "type": "string", "minLength": 1 },
-    "spec_url": { "type": "string", "minLength": 1 },
-    "local_surface": { "type": "string" },
-    "openapi_version": { "type": "string" },
+    "api_title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "spec_url": {
+      "type": "string",
+      "minLength": 1
+    },
+    "local_surface": {
+      "type": "string"
+    },
+    "openapi_version": {
+      "type": "string"
+    },
     "checks": {
       "type": "array",
       "minItems": 1,
       "items": {
         "type": "object",
-        "required": ["name", "status", "evidence"],
         "properties": {
-          "name": { "type": "string", "minLength": 1 },
-          "status": { "type": "string", "enum": ["pass", "warn", "fail", "unknown"] },
-          "evidence": { "type": "string", "minLength": 1 }
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pass",
+              "warn",
+              "fail",
+              "unknown"
+            ]
+          },
+          "evidence": {
+            "type": "string",
+            "minLength": 1
+          }
         },
+        "required": [
+          "name",
+          "status",
+          "evidence"
+        ],
         "additionalProperties": false
       }
     },
@@ -26,25 +55,69 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["severity", "location", "issue", "evidence", "recommendation"],
         "properties": {
-          "severity": { "type": "string", "enum": ["low", "medium", "high"] },
-          "location": { "type": "string", "minLength": 1 },
-          "issue": { "type": "string", "minLength": 1 },
-          "evidence": { "type": "string", "minLength": 1 },
-          "recommendation": { "type": "string", "minLength": 1 }
+          "severity": {
+            "type": "string",
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ]
+          },
+          "location": {
+            "type": "string",
+            "minLength": 1
+          },
+          "issue": {
+            "type": "string",
+            "minLength": 1
+          },
+          "evidence": {
+            "type": "string",
+            "minLength": 1
+          },
+          "recommendation": {
+            "type": "string",
+            "minLength": 1
+          }
         },
+        "required": [
+          "severity",
+          "location",
+          "issue",
+          "evidence",
+          "recommendation"
+        ],
         "additionalProperties": false
       }
     },
-    "no_issue_found": { "type": "boolean" },
-    "summary": { "type": "string", "minLength": 1 },
+    "no_issue_found": {
+      "type": "boolean"
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
     "recommended_actions": {
       "type": "array",
-      "minItems": 1,
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
     },
-    "notes": { "type": "string" }
+    "notes": {
+      "type": "string"
+    }
   },
+  "required": [
+    "api_title",
+    "spec_url",
+    "checks",
+    "findings",
+    "no_issue_found",
+    "summary",
+    "recommended_actions"
+  ],
   "additionalProperties": false
 }

--- a/docs/schemas/jobs/pr-review-findings-output.json
+++ b/docs/schemas/jobs/pr-review-findings-output.json
@@ -1,35 +1,82 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "schema://jobs/pr-review-findings-output",
   "title": "PR Review Findings Output",
+  "description": "Structured PR review findings.",
   "type": "object",
-  "required": ["summary", "findings", "risk_level", "files_touched", "recommended_next_step"],
   "properties": {
-    "summary": { "type": "string", "minLength": 1 },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
     "findings": {
       "type": "array",
       "minItems": 1,
       "items": {
         "type": "object",
-        "required": ["severity", "file", "issue", "recommendation"],
         "properties": {
-          "severity": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
-          "file": { "type": "string", "minLength": 1 },
-          "issue": { "type": "string", "minLength": 1 },
-          "recommendation": { "type": "string", "minLength": 1 }
+          "severity": {
+            "type": "string",
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "critical"
+            ]
+          },
+          "file": {
+            "type": "string",
+            "minLength": 1
+          },
+          "issue": {
+            "type": "string",
+            "minLength": 1
+          },
+          "recommendation": {
+            "type": "string",
+            "minLength": 1
+          }
         },
+        "required": [
+          "severity",
+          "file",
+          "issue",
+          "recommendation"
+        ],
         "additionalProperties": false
       }
     },
-    "risk_level": { "type": "string", "enum": ["low", "medium", "high"] },
+    "risk_level": {
+      "type": "string",
+      "enum": [
+        "low",
+        "medium",
+        "high"
+      ]
+    },
     "files_touched": {
       "type": "array",
-      "minItems": 1,
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
     },
     "recommended_next_step": {
       "type": "string",
-      "enum": ["merge", "fix_and_retest", "request_changes"]
+      "enum": [
+        "merge",
+        "fix_and_retest",
+        "request_changes"
+      ]
     }
   },
+  "required": [
+    "summary",
+    "findings",
+    "risk_level",
+    "files_touched",
+    "recommended_next_step"
+  ],
   "additionalProperties": false
 }

--- a/docs/schemas/jobs/release-input.json
+++ b/docs/schemas/jobs/release-input.json
@@ -1,19 +1,33 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "schema://jobs/release-input",
   "title": "Release Input",
+  "description": "Release readiness review input.",
   "type": "object",
-  "required": ["release_id", "checklist"],
   "properties": {
-    "release_id": { "type": "string", "minLength": 1 },
+    "release_id": {
+      "type": "string",
+      "minLength": 1
+    },
     "checklist": {
       "type": "array",
-      "minItems": 1,
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
     },
     "context": {
       "type": "array",
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
     }
   },
+  "required": [
+    "release_id",
+    "checklist"
+  ],
   "additionalProperties": false
 }

--- a/docs/schemas/jobs/release-readiness-output.json
+++ b/docs/schemas/jobs/release-readiness-output.json
@@ -1,23 +1,49 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "schema://jobs/release-readiness-output",
   "title": "Release Readiness Output",
+  "description": "Structured release go/no-go output.",
   "type": "object",
-  "required": ["release_id", "checks_passed", "checks_failed", "blockers", "go_no_go"],
   "properties": {
-    "release_id": { "type": "string", "minLength": 1 },
+    "release_id": {
+      "type": "string",
+      "minLength": 1
+    },
     "checks_passed": {
       "type": "array",
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
     },
     "checks_failed": {
       "type": "array",
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
     },
     "blockers": {
       "type": "array",
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
     },
-    "go_no_go": { "type": "string", "enum": ["go", "no_go"] }
+    "go_no_go": {
+      "type": "string",
+      "enum": [
+        "go",
+        "no_go"
+      ]
+    }
   },
+  "required": [
+    "release_id",
+    "checks_passed",
+    "checks_failed",
+    "blockers",
+    "go_no_go"
+  ],
   "additionalProperties": false
 }

--- a/docs/schemas/jobs/review-input.json
+++ b/docs/schemas/jobs/review-input.json
@@ -1,20 +1,38 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "schema://jobs/review-input",
   "title": "Review Input",
+  "description": "PR or document review input.",
   "type": "object",
-  "required": ["subject", "reviewScope", "rubric"],
   "properties": {
-    "subject": { "type": "string", "minLength": 1 },
-    "reviewScope": { "type": "string", "minLength": 1 },
+    "subject": {
+      "type": "string",
+      "minLength": 1
+    },
+    "reviewScope": {
+      "type": "string",
+      "minLength": 1
+    },
     "rubric": {
       "type": "array",
-      "minItems": 1,
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
     },
     "files": {
       "type": "array",
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
     }
   },
+  "required": [
+    "subject",
+    "reviewScope",
+    "rubric"
+  ],
   "additionalProperties": false
 }

--- a/docs/schemas/jobs/triage-input.json
+++ b/docs/schemas/jobs/triage-input.json
@@ -1,19 +1,33 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "schema://jobs/triage-input",
   "title": "Triage Input",
+  "description": "Issue triage input.",
   "type": "object",
-  "required": ["report", "routingOptions"],
   "properties": {
-    "report": { "type": "string", "minLength": 1 },
+    "report": {
+      "type": "string",
+      "minLength": 1
+    },
     "routingOptions": {
       "type": "array",
-      "minItems": 1,
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
     },
     "componentHints": {
       "type": "array",
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
     }
   },
+  "required": [
+    "report",
+    "routingOptions"
+  ],
   "additionalProperties": false
 }

--- a/docs/schemas/jobs/wikipedia-citation-repair-output.json
+++ b/docs/schemas/jobs/wikipedia-citation-repair-output.json
@@ -1,26 +1,53 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "schema://jobs/wikipedia-citation-repair-output",
   "title": "Wikipedia Citation Repair Output",
+  "description": "Reviewable citation repair proposal for Wikipedia articles.",
   "type": "object",
-  "required": ["page_title", "revision_id", "citation_findings", "proposed_changes", "review_notes"],
   "properties": {
-    "page_title": { "type": "string", "minLength": 1 },
-    "revision_id": { "type": "string", "minLength": 1 },
+    "page_title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "revision_id": {
+      "type": "string",
+      "minLength": 1
+    },
     "citation_findings": {
       "type": "array",
       "minItems": 1,
       "items": {
         "type": "object",
-        "required": ["section", "problem", "current_claim", "evidence_url"],
         "properties": {
-          "section": { "type": "string", "minLength": 1 },
+          "section": {
+            "type": "string",
+            "minLength": 1
+          },
           "problem": {
             "type": "string",
-            "enum": ["dead_link", "missing_citation", "weak_source", "outdated_source", "claim_mismatch"]
+            "enum": [
+              "dead_link",
+              "missing_citation",
+              "weak_source",
+              "outdated_source",
+              "claim_mismatch"
+            ]
           },
-          "current_claim": { "type": "string", "minLength": 1 },
-          "evidence_url": { "type": "string", "minLength": 1 }
+          "current_claim": {
+            "type": "string",
+            "minLength": 1
+          },
+          "evidence_url": {
+            "type": "string",
+            "minLength": 1
+          }
         },
+        "required": [
+          "section",
+          "problem",
+          "current_claim",
+          "evidence_url"
+        ],
         "additionalProperties": false
       }
     },
@@ -29,20 +56,48 @@
       "minItems": 1,
       "items": {
         "type": "object",
-        "required": ["change_type", "target_text", "replacement_text", "source_url"],
         "properties": {
           "change_type": {
             "type": "string",
-            "enum": ["replace_citation", "add_citation", "flag_for_editor_review"]
+            "enum": [
+              "replace_citation",
+              "add_citation",
+              "flag_for_editor_review"
+            ]
           },
-          "target_text": { "type": "string", "minLength": 1 },
-          "replacement_text": { "type": "string", "minLength": 1 },
-          "source_url": { "type": "string", "minLength": 1 }
+          "target_text": {
+            "type": "string",
+            "minLength": 1
+          },
+          "replacement_text": {
+            "type": "string",
+            "minLength": 1
+          },
+          "source_url": {
+            "type": "string",
+            "minLength": 1
+          }
         },
+        "required": [
+          "change_type",
+          "target_text",
+          "replacement_text",
+          "source_url"
+        ],
         "additionalProperties": false
       }
     },
-    "review_notes": { "type": "string", "minLength": 1 }
+    "review_notes": {
+      "type": "string",
+      "minLength": 1
+    }
   },
+  "required": [
+    "page_title",
+    "revision_id",
+    "citation_findings",
+    "proposed_changes",
+    "review_notes"
+  ],
   "additionalProperties": false
 }

--- a/docs/schemas/jobs/wikipedia-freshness-check-output.json
+++ b/docs/schemas/jobs/wikipedia-freshness-check-output.json
@@ -1,35 +1,78 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "schema://jobs/wikipedia-freshness-check-output",
   "title": "Wikipedia Freshness Check Output",
+  "description": "Freshness and factual drift check for a public Wikipedia article.",
   "type": "object",
-  "required": ["page_title", "revision_id", "freshness_findings", "recommended_editor_actions", "risk_level"],
   "properties": {
-    "page_title": { "type": "string", "minLength": 1 },
-    "revision_id": { "type": "string", "minLength": 1 },
+    "page_title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "revision_id": {
+      "type": "string",
+      "minLength": 1
+    },
     "freshness_findings": {
       "type": "array",
       "minItems": 1,
       "items": {
         "type": "object",
-        "required": ["claim", "status", "evidence_url", "note"],
         "properties": {
-          "claim": { "type": "string", "minLength": 1 },
+          "claim": {
+            "type": "string",
+            "minLength": 1
+          },
           "status": {
             "type": "string",
-            "enum": ["current", "outdated", "unclear", "needs_editor_review"]
+            "enum": [
+              "current",
+              "outdated",
+              "unclear",
+              "needs_editor_review"
+            ]
           },
-          "evidence_url": { "type": "string", "minLength": 1 },
-          "note": { "type": "string", "minLength": 1 }
+          "evidence_url": {
+            "type": "string",
+            "minLength": 1
+          },
+          "note": {
+            "type": "string",
+            "minLength": 1
+          }
         },
+        "required": [
+          "claim",
+          "status",
+          "evidence_url",
+          "note"
+        ],
         "additionalProperties": false
       }
     },
     "recommended_editor_actions": {
       "type": "array",
-      "minItems": 1,
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
     },
-    "risk_level": { "type": "string", "enum": ["low", "medium", "high"] }
+    "risk_level": {
+      "type": "string",
+      "enum": [
+        "low",
+        "medium",
+        "high"
+      ]
+    }
   },
+  "required": [
+    "page_title",
+    "revision_id",
+    "freshness_findings",
+    "recommended_editor_actions",
+    "risk_level"
+  ],
   "additionalProperties": false
 }

--- a/docs/schemas/jobs/wikipedia-infobox-consistency-output.json
+++ b/docs/schemas/jobs/wikipedia-infobox-consistency-output.json
@@ -1,27 +1,57 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "schema://jobs/wikipedia-infobox-consistency-output",
   "title": "Wikipedia Infobox Consistency Output",
+  "description": "Reviewable proposal for reconciling a Wikipedia infobox with cited article evidence.",
   "type": "object",
-  "required": ["page_title", "revision_id", "checked_fields", "proposed_changes", "review_notes"],
   "properties": {
-    "page_title": { "type": "string", "minLength": 1 },
-    "revision_id": { "type": "string", "minLength": 1 },
+    "page_title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "revision_id": {
+      "type": "string",
+      "minLength": 1
+    },
     "checked_fields": {
       "type": "array",
       "minItems": 1,
       "items": {
         "type": "object",
-        "required": ["field", "current_value", "evidence_url", "status", "note"],
         "properties": {
-          "field": { "type": "string", "minLength": 1 },
-          "current_value": { "type": "string", "minLength": 1 },
-          "evidence_url": { "type": "string", "minLength": 1 },
+          "field": {
+            "type": "string",
+            "minLength": 1
+          },
+          "current_value": {
+            "type": "string",
+            "minLength": 1
+          },
+          "evidence_url": {
+            "type": "string",
+            "minLength": 1
+          },
           "status": {
             "type": "string",
-            "enum": ["consistent", "inconsistent", "missing_source", "needs_editor_review"]
+            "enum": [
+              "consistent",
+              "inconsistent",
+              "missing_source",
+              "needs_editor_review"
+            ]
           },
-          "note": { "type": "string", "minLength": 1 }
+          "note": {
+            "type": "string",
+            "minLength": 1
+          }
         },
+        "required": [
+          "field",
+          "current_value",
+          "evidence_url",
+          "status",
+          "note"
+        ],
         "additionalProperties": false
       }
     },
@@ -30,17 +60,44 @@
       "minItems": 1,
       "items": {
         "type": "object",
-        "required": ["field", "target_text", "replacement_text", "source_url"],
         "properties": {
-          "field": { "type": "string", "minLength": 1 },
-          "target_text": { "type": "string", "minLength": 1 },
-          "replacement_text": { "type": "string", "minLength": 1 },
-          "source_url": { "type": "string", "minLength": 1 }
+          "field": {
+            "type": "string",
+            "minLength": 1
+          },
+          "target_text": {
+            "type": "string",
+            "minLength": 1
+          },
+          "replacement_text": {
+            "type": "string",
+            "minLength": 1
+          },
+          "source_url": {
+            "type": "string",
+            "minLength": 1
+          }
         },
+        "required": [
+          "field",
+          "target_text",
+          "replacement_text",
+          "source_url"
+        ],
         "additionalProperties": false
       }
     },
-    "review_notes": { "type": "string", "minLength": 1 }
+    "review_notes": {
+      "type": "string",
+      "minLength": 1
+    }
   },
+  "required": [
+    "page_title",
+    "revision_id",
+    "checked_fields",
+    "proposed_changes",
+    "review_notes"
+  ],
   "additionalProperties": false
 }

--- a/docs/schemas/jobs/wikipedia-maintenance-input.json
+++ b/docs/schemas/jobs/wikipedia-maintenance-input.json
@@ -1,17 +1,42 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "schema://jobs/wikipedia-maintenance-input",
   "title": "Wikipedia Maintenance Input",
+  "description": "Wikipedia public article maintenance job input.",
   "type": "object",
-  "required": ["project", "pageTitle", "pageUrl", "revisionId", "taskType", "instructions"],
   "properties": {
     "project": {
       "type": "string",
-      "enum": ["wikipedia"]
+      "enum": [
+        "wikipedia"
+      ]
     },
-    "language": { "type": "string" },
-    "pageTitle": { "type": "string", "minLength": 1 },
-    "pageUrl": { "type": "string", "minLength": 1 },
-    "revisionId": { "type": "string", "minLength": 1 },
+    "language": {
+      "type": "string"
+    },
+    "lang": {
+      "type": "string"
+    },
+    "pageTitle": {
+      "type": "string",
+      "minLength": 1
+    },
+    "pageUrl": {
+      "type": "string",
+      "minLength": 1
+    },
+    "articleUrl": {
+      "type": "string",
+      "minLength": 1
+    },
+    "revisionId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "pinnedRevisionUrl": {
+      "type": "string",
+      "minLength": 1
+    },
     "taskType": {
       "type": "string",
       "enum": [
@@ -20,15 +45,40 @@
         "infobox_consistency"
       ]
     },
+    "proposalOnly": {
+      "type": "boolean"
+    },
+    "attributionPolicy": {
+      "type": "string",
+      "minLength": 1
+    },
+    "outputSchemaUrl": {
+      "type": "string",
+      "minLength": 1
+    },
     "sourceUrls": {
       "type": "array",
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
     },
     "instructions": {
       "type": "array",
-      "minItems": 1,
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
     }
   },
+  "required": [
+    "project",
+    "pageTitle",
+    "pageUrl",
+    "revisionId",
+    "taskType",
+    "instructions"
+  ],
   "additionalProperties": false
 }

--- a/mcp-server/src/core/job-schema-registry.js
+++ b/mcp-server/src/core/job-schema-registry.js
@@ -519,9 +519,13 @@ function cloneSchema(schema) {
 }
 
 function toPublicSchemaDocument(schema) {
+  const { $id, description, ...rest } = cloneSchema(schema);
   return {
     $schema: "http://json-schema.org/draft-07/schema#",
-    ...cloneSchema(schema)
+    $id,
+    title: titleFromSchemaRef($id),
+    ...(description ? { description } : {}),
+    ...rest
   };
 }
 
@@ -531,6 +535,26 @@ export function schemaRefToJobSchemaPath(schemaRef) {
     return undefined;
   }
   return `/schemas/jobs/${normalized.slice("schema://jobs/".length)}.json`;
+}
+
+function titleFromSchemaRef(schemaRef) {
+  const normalized = normalizeBuiltinJobSchemaRef(schemaRef) ?? "";
+  const name = normalized.slice("schema://jobs/".length);
+  return name
+    .split("-")
+    .filter(Boolean)
+    .map((part) => {
+      const lower = part.toLowerCase();
+      const acronym = {
+        api: "API",
+        docs: "Docs",
+        github: "GitHub",
+        openapi: "OpenAPI",
+        pr: "PR"
+      }[lower];
+      return acronym ?? `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`;
+    })
+    .join(" ");
 }
 
 export function jobSchemaPathToRef(pathname) {

--- a/mcp-server/src/core/job-schema-registry.test.js
+++ b/mcp-server/src/core/job-schema-registry.test.js
@@ -11,9 +11,29 @@ import {
   validateStructuredSubmission
 } from "./job-schema-registry.js";
 
+const FIRST_WAVE_SCHEMA_REFS = [
+  "schema://jobs/review-input",
+  "schema://jobs/pr-review-findings-output",
+  "schema://jobs/release-input",
+  "schema://jobs/release-readiness-output",
+  "schema://jobs/triage-input",
+  "schema://jobs/issue-defect-triage-output",
+  "schema://jobs/docs-input",
+  "schema://jobs/docs-drift-audit-output"
+];
+
 test("getBuiltinJobSchema resolves built-in first-wave schemas", () => {
   const schema = getBuiltinJobSchema("schema://jobs/pr-review-findings-output");
   assert.equal(schema?.$id, "schema://jobs/pr-review-findings-output");
+});
+
+test("first-wave schema-native job refs are public built-ins", () => {
+  for (const ref of FIRST_WAVE_SCHEMA_REFS) {
+    const schema = getBuiltinJobSchema(ref);
+    assert.equal(schema?.$id, ref);
+    assert.equal(schemaRefToJobSchemaPath(ref), `/schemas/jobs/${ref.slice("schema://jobs/".length)}.json`);
+    assert.equal(getPublicBuiltinJobSchemaByName(ref.slice("schema://jobs/".length))?.$id, ref);
+  }
 });
 
 test("validateStructuredSubmission accepts a schema-compliant PR review payload", () => {
@@ -34,6 +54,55 @@ test("validateStructuredSubmission accepts a schema-compliant PR review payload"
 
   assert.doesNotThrow(() => {
     validateStructuredSubmission("schema://jobs/pr-review-findings-output", payload);
+  });
+});
+
+test("validateStructuredSubmission accepts first-wave release readiness payloads", () => {
+  const payload = {
+    release_id: "release-2026-05-13",
+    checks_passed: ["api-health", "frontend-build"],
+    checks_failed: [],
+    blockers: [],
+    go_no_go: "go"
+  };
+
+  assert.doesNotThrow(() => {
+    validateStructuredSubmission("schema://jobs/release-readiness-output", payload);
+  });
+});
+
+test("validateStructuredSubmission accepts first-wave defect triage payloads", () => {
+  const payload = {
+    category: "bug",
+    severity: "high",
+    component: "api",
+    repro_clarity: "clear",
+    next_owner: "backend",
+    duplication_risk: "low"
+  };
+
+  assert.doesNotThrow(() => {
+    validateStructuredSubmission("schema://jobs/issue-defect-triage-output", payload);
+  });
+});
+
+test("validateStructuredSubmission accepts first-wave docs drift payloads", () => {
+  const payload = {
+    source_surface: "docs/CORE_FRAMEWORK_ROADMAP.md",
+    drift_findings: [
+      {
+        surface_a: "docs/CORE_FRAMEWORK_ROADMAP.md",
+        surface_b: "docs/SPEC_AUDIT_2026-05-13.md",
+        mismatch: "Roadmap still described convention-only schemas after runtime validation landed."
+      }
+    ],
+    missing_updates: ["docs/SPEC_AUDIT_2026-05-13.md"],
+    severity: "medium",
+    fix_recommendation: "Update the audit once the schema sync gate lands."
+  };
+
+  assert.doesNotThrow(() => {
+    validateStructuredSubmission("schema://jobs/docs-drift-audit-output", payload);
   });
 });
 

--- a/mcp-server/src/services/verifier-service.js
+++ b/mcp-server/src/services/verifier-service.js
@@ -5,6 +5,9 @@ import {
   jobWithVerifierConfigSnapshot
 } from "../core/verifier-contract.js";
 import { assertSessionCanReceiveVerification } from "../core/session-state-machine.js";
+import { normalizeSubmission } from "../core/submission.js";
+import { getBuiltinJobSchema } from "../core/job-schema-registry.js";
+import { normalizeSubmitPayloadShape, validateSubmissionContract } from "../core/job-execution-service.js";
 
 export class VerifierService {
   constructor(platformService, stateStore, blockchainGateway = undefined, registry = new VerifierRegistry()) {
@@ -20,7 +23,8 @@ export class VerifierService {
     const job = this.platformService.getJobDefinition(session.jobId);
     const chainJobId = session.chainJobId ?? session.jobId;
     const verificationInput = this.resolveVerificationInput(session, evidence);
-    const verdict = await this.registry.evaluate(job, verificationInput);
+    const validatedVerificationInput = this.validateVerificationInput(job, verificationInput);
+    const verdict = await this.registry.evaluate(job, validatedVerificationInput);
     const reasoningHash = hashCanonicalContent({
       handler: verdict.handler,
       handlerVersion: verdict.handlerVersion,
@@ -44,7 +48,7 @@ export class VerifierService {
       ...verdict,
       sessionId,
       metadataURI,
-      ...buildVerificationAuditFields(job, { verdict, verificationInput }),
+      ...buildVerificationAuditFields(job, { verdict, verificationInput: validatedVerificationInput }),
       session: updatedSession ?? session
     };
 
@@ -57,13 +61,14 @@ export class VerifierService {
     const existing = await this.stateStore.getVerificationResult(sessionId);
     const verificationInput = existing?.verificationInput ?? this.resolveVerificationInput(session);
     const replayJob = jobWithVerifierConfigSnapshot(job, existing?.verifierConfigSnapshot);
-    const verdict = await this.registry.evaluate(replayJob, verificationInput);
+    const validatedVerificationInput = this.validateVerificationInput(replayJob, verificationInput);
+    const verdict = await this.registry.evaluate(replayJob, validatedVerificationInput);
     return {
       ...verdict,
       sessionId,
       replay: true,
       originalOutcome: existing?.outcome,
-      ...buildVerificationAuditFields(replayJob, { verdict, verificationInput })
+      ...buildVerificationAuditFields(replayJob, { verdict, verificationInput: validatedVerificationInput })
     };
   }
 
@@ -86,4 +91,26 @@ export class VerifierService {
     }
     return "";
   }
+
+  validateVerificationInput(job, verificationInput) {
+    if (!getBuiltinJobSchema(job?.outputSchemaRef)) {
+      return verificationInput;
+    }
+
+    const normalized = isNormalizedSubmission(verificationInput)
+      ? verificationInput
+      : normalizeSubmission(normalizeSubmitPayloadShape(job.outputSchemaRef, verificationInput));
+    validateSubmissionContract(job.outputSchemaRef, normalized, { path: "verificationInput" });
+    return normalized;
+  }
+}
+
+function isNormalizedSubmission(input) {
+  if (!input || typeof input !== "object") {
+    return false;
+  }
+  if (input.kind === "structured" && "structured" in input) {
+    return true;
+  }
+  return input.kind === "text" && typeof input.evidenceText === "string";
 }

--- a/mcp-server/src/services/verifier-service.test.js
+++ b/mcp-server/src/services/verifier-service.test.js
@@ -30,6 +30,7 @@ test("verifySubmission persists verification input and supports replay", async (
 
   const job = {
     id: "release-readiness-check-001",
+    outputSchemaRef: "schema://jobs/release-readiness-output",
     verifierMode: "deterministic",
     verifierConfig: {
       version: 1,
@@ -122,6 +123,64 @@ test("verifySubmission rejects non-verifiable sessions before handler or chain s
       assert.equal(error.code, "invalid_session_transition");
       assert.equal(error.details.currentStatus, "claimed");
       assert.equal(error.details.nextStatus, "resolved|rejected|disputed");
+      return true;
+    }
+  );
+  assert.equal(evaluated, false);
+  assert.equal(resolvedOnChain, false);
+});
+
+test("verifySubmission validates built-in schema-native input before handler or chain side effects", async () => {
+  const stateStore = new MemoryStateStore();
+  const session = transitionSession({
+    sessionId: SESSION_ID,
+    wallet: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    jobId: "release-readiness-check-001",
+    submission: normalizeSubmission("complete")
+  }, "claimed", { reason: "job_claimed" });
+  await stateStore.upsertSession(transitionSession(session, "submitted", { reason: "work_submitted" }));
+
+  let evaluated = false;
+  let resolvedOnChain = false;
+  const service = new VerifierService(
+    {
+      resumeSession: (sessionId) => stateStore.getSession(sessionId),
+      getJobDefinition: () => ({
+        id: "release-readiness-check-001",
+        outputSchemaRef: "schema://jobs/release-readiness-output",
+        verifierConfig: {
+          version: 1,
+          handler: "deterministic",
+          expectedOutputs: ["release_id"],
+          matchMode: "contains_all"
+        }
+      }),
+      ingestVerification: () => {
+        throw new Error("verification should not ingest before schema validation passes");
+      }
+    },
+    stateStore,
+    {
+      isEnabled: () => true,
+      resolveSinglePayout: async () => {
+        resolvedOnChain = true;
+      }
+    },
+    {
+      evaluate: async () => {
+        evaluated = true;
+        return { outcome: "approved" };
+      },
+      listHandlers: () => []
+    }
+  );
+
+  await assert.rejects(
+    () => service.verifySubmission({ sessionId: SESSION_ID }),
+    (error) => {
+      assert.equal(error.code, "invalid_request");
+      assert.match(error.message, /Schema-native jobs require/u);
+      assert.equal(error.details.schemaValidates, "payload.submission");
       return true;
     }
   );

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "publish:discovery-manifest": "node scripts/ops/publish-discovery-manifest.mjs",
     "sync:discovery-manifest": "node scripts/ops/sync-discovery-manifest.mjs",
     "check:discovery-manifest": "node scripts/ops/sync-discovery-manifest.mjs --check",
+    "sync:job-schemas": "node scripts/ops/sync-job-schemas.mjs",
+    "check:job-schemas": "node scripts/ops/sync-job-schemas.mjs --check",
     "check:product-proof": "node scripts/ops/check-product-proof-gate.mjs",
     "product-proof:worker-loop": "node scripts/ops/run-hosted-worker-loop.mjs",
     "dev:app": "npm --workspace averray-app run dev",

--- a/scripts/ops/sync-job-schemas.mjs
+++ b/scripts/ops/sync-job-schemas.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  getPublicBuiltinJobSchemaByName,
+  listBuiltinJobSchemas,
+  schemaRefToJobSchemaPath
+} from "../../mcp-server/src/core/job-schema-registry.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "../..");
+const docsDir = path.join(repoRoot, "docs/schemas/jobs");
+const checkOnly = process.argv.includes("--check");
+
+await mkdir(docsDir, { recursive: true });
+
+const expected = new Map(
+  listBuiltinJobSchemas().map((entry) => {
+    const schemaPath = schemaRefToJobSchemaPath(entry.$id);
+    const fileName = path.basename(schemaPath);
+    const schema = getPublicBuiltinJobSchemaByName(fileName);
+    return [fileName, `${JSON.stringify(schema, null, 2)}\n`];
+  })
+);
+
+let drifted = false;
+
+for (const [fileName, content] of expected) {
+  const file = path.join(docsDir, fileName);
+  const current = await readFile(file, "utf8").catch(() => "");
+  if (current === content) {
+    continue;
+  }
+
+  drifted = true;
+  const relative = path.relative(repoRoot, file);
+  if (checkOnly) {
+    console.error(`${relative} is not in sync with the runtime job schema registry.`);
+    continue;
+  }
+
+  await writeFile(file, content);
+  console.log(`Synced ${relative}`);
+}
+
+const existing = await readdir(docsDir).catch(() => []);
+for (const fileName of existing.filter((name) => name.endsWith(".json")).sort()) {
+  if (expected.has(fileName)) {
+    continue;
+  }
+  drifted = true;
+  console.error(`docs/schemas/jobs/${fileName} is not backed by the runtime job schema registry.`);
+}
+
+if (checkOnly && drifted) {
+  process.exitCode = 1;
+} else if (checkOnly) {
+  console.log("Job schemas are in sync.");
+} else if (drifted) {
+  console.log("Job schema docs synced.");
+}


### PR DESCRIPTION
## Summary
- generate docs/schemas/jobs from the runtime schema registry and add a CI drift check
- add missing public GitHub PR evidence schema docs and first-wave schema coverage tests
- validate built-in schema-native submissions again before verifier handlers or chain side effects run
- update the spec audit/roadmap status for schema-native jobs

## Checks
- npm run check:job-schemas
- node --test mcp-server/src/core/job-schema-registry.test.js mcp-server/src/services/verifier-service.test.js
- npm --workspace mcp-server test
- npm run check:sdk-types
- npm run check:discovery-manifest
- npm run test:ops
- git diff --check

## Impact
- Backend: yes, verifier preflight validation for built-in schema-native jobs
- Public docs/site source: yes, canonical job schema JSON files
- CI: yes, adds job schema docs sync check
- Frontend/indexer/contracts/Caddy: no
- Env/VPS secrets: none