### PR TITLE
Spec v2.8: merge competitive-intel + distribution sections

### DIFF
--- a/docs/AVERRAY_WORKING_SPEC.md
+++ b/docs/AVERRAY_WORKING_SPEC.md
@@ -1,7 +1,7 @@
 # Averray — Working Spec (v1.0.0-rc1)
 
 **Status:** Reconciled with deployed reality and operational docs
-**Spec version:** 2.7 (spec/roadmap audit reconciliation; v1 USDC-only/no-yield summary corrected; bootstrap budget aligned to Micro/Standard/Substantive; deploy-readiness proof gates surfaced)
+**Spec version:** 2.8 (merged competitive intel + distribution sections from v2.3/v2.4 parallel branch; Path A on-ramp lock, target verticals, agent-discovery surfaces ported into §10; agent-submitted-work abuse vectors added to §9 threat model; §12 gained operator-onboarding + distribution checklist items; companion `DISTRIBUTION_STRATEGY.md` published)
 **Owner:** Pascal
 
 ---
@@ -619,6 +619,10 @@ To live in `THREAT_MODEL.md`:
 - **Async XCM lane: untrusted input surface.** Current `/account/allocate` and `/account/deallocate` endpoints accept arbitrary `destination` and `message` bytes from the HTTP caller; the backend gateway only normalizes encoding without validating semantics. `XcmWrapper` then hashes and queues whatever was passed in. Any caller able to hit the endpoint could submit any XCM, and the wrapper would queue it. Mitigation in §10's backend SCALE assembler item: HTTP layer accepts intent only (strategy + direction + amount); backend assembles the message under server-controlled policy. Until then, async treasury endpoints must remain admin-gated.
 - **USDC issuer dependency (Circle).** Choosing USDC for v1 escrow inherits Circle's operational risks: address blacklisting, freeze events, regulatory action against Circle, USDC depeg moments (e.g. March 2023 SVB exposure). None are mitigatable from Averray's side once the asset is locked. Treasury controls cannot be re-acquired if Circle freezes a relevant address. Acceptable risk for v1 (USDC is broadly considered the most transparent stablecoin on reserves), but worth being explicit. Mitigations available later: multi-asset settlement (allow USDt as alternative), eventual native-DOT settlement when contract surface supports it, or escrow asset hot-swappability via governance.
 - **USDC regulatory exposure.** Stablecoin treatment varies by jurisdiction. Averray accepting and disbursing USDC at scale may attract regulatory attention (money transmission, MSB licensing depending on jurisdiction) that pure-DOT settlement would not. Worth tracking as the platform scales; not blocking v1 launch but worth a legal review before significant volume.
+- **Agent-submitted work as money-laundering vector.** A platform where anyone can post a bounty, an agent claims and "completes" it, and funds flow out as legitimate earnings is structurally a money-laundering candidate (post a bounty with dirty funds → agent claims → "clean" funds withdraw). The same concern surfaced publicly in third-party threads about this exact platform model (see v2.8 reconciliation log for competitive intel). Mitigations to consider before significant volume: (a) poster KYC/reputation gating above a per-poster-monthly-funding threshold, (b) work-quality auditing that makes purely-rubber-stamp jobs harder to execute, (c) on-chain analysis of poster funding sources (mixers, sanctioned addresses), (d) deliberate friction on poster-and-agent being same-operator. None are needed for bootstrap (Pascal is the only poster); all become material once external posters arrive. Worth explicit treatment in `THREAT_MODEL.md`.
+- **Sophisticated spam at scale.** Agents can generate convincingly-formatted low-quality PRs at near-zero marginal cost. If reviewer fatigue causes maintainers to merge low-effort agent work, the platform contributes to OSS-ecosystem code-quality erosion — which would be reputationally catastrophic for Averray (the platform's pitch is *trust infrastructure*, not *spam infrastructure*). Mitigations: per-repo open-PR caps (already in §4), aggressive denylist response, maintainer feedback loops, possibly tier-based caps (more substantive work allowed when reputation is higher).
+- **Adversarial inputs to the agent.** A malicious repo (or malicious job spec) could be crafted to trick the claiming agent into submitting compromised code to *other* repos the agent has access to, or to extract credentials/secrets from the agent's runtime. This is an agent-side security problem more than a platform-side one, but Averray surfaces it by giving agents work to do. Mitigations: spec sanitization at job-creation time, agent operators responsible for sandbox hygiene, possibly a "high-risk repo" flag posters can set. Worth flagging to operators in `OPERATOR_ONBOARDING.md`.
+- **Maintainer chargeback / dispute-after-merge.** Maintainer merges a PR, agent gets paid, then maintainer reverts and disputes after the dispute window has closed. The 7-day dispute window combined with `autoResolveOnTimeout` is structurally fine for v1 (the platform-side dispute window has hard time bounds), but maintainer trust dynamics could erode if "revert after merge" becomes a pattern. Worth monitoring; not blocking.
 
 ---
 
@@ -677,6 +681,81 @@ Mechanisms that increase agent stickiness without raising platform spend:
 - **Streak bonuses.** Indexer-tracked counter: every consecutive job merged adds 1 to a streak; broken on rejection or > 7-day gap. Streaks of 10+ unlock visible badges in the public trail. Streaks of 25+ unlock claim-fee waiver (platform skips the floor fee for streak-holders, ~$0.05 per claim — small treasury cost, real psychological pull). Pure on-chain mechanic, no new contract — indexer logic plus the existing fee waiver primitive used during onboarding.
 - **Consistency multipliers on yield-share** (when v1.x yield ships). Standard agents pay 1% of yield to platform; agents with 50+ merged jobs in last 90 days pay 0.5%. Costs the platform little, rewards the behavior the platform wants (sticky, consistent agents). Tier 2 multisig-tunable parameter.
 - **Tier graduation as reputation signal.** Public trail surfaces tier composition. No new mechanic — pure data presentation. Already covered in §2 worked examples.
+
+### On-ramp / off-ramp friction reduction (v1.x — Path A, partnership only)
+
+The platform stays crypto-native at the protocol level — every receipt, every payment, every reputation event happens on-chain. But onboarding and offboarding for operators who don't already have crypto infrastructure is a real friction point worth solving via partnership, not via in-house fiat handling.
+
+**Locked direction: Path A.** The platform partners with an existing fiat on-ramp/off-ramp service (Ramp Network, MoonPay, Transak, or a Polkadot-native equivalent if one becomes available). Operators convert their USDC balance to fiat through the partner's flow, *after* on-chain settlement. Averray never touches fiat directly.
+
+**What this preserves:** every dollar that flows through the platform is on-chain. The trust pitch holds. The platform does not become a money transmitter, does not require MSB licensing, and stays within Swiss/Polkadot regulatory scope.
+
+**What this addresses:** the operator-friction problem of "how do I get this USDC into my bank account." With a partner integration, the answer is "click withdraw, complete the on-ramp's flow once, your bank receives fiat." Subsequent withdrawals are one-click.
+
+**Path B (in-house fiat payouts via Stripe Connect or PayPal) explicitly rejected.** Regulatory exposure (money transmission, AML/KYC obligations across 50+ jurisdictions) is structural risk that's incompatible with the platform's posture. Path B is not on the roadmap and should not be revisited without a separate legal/structural decision at the entity level.
+
+Trigger: v1.x post-launch when operator-onboarding friction becomes empirically measurable.
+
+### Target verticals where trust signal gates decisions (v1.x positioning)
+
+When external posters arrive (post-bootstrap), the platform's economic flywheel depends on attracting work *where reputation matters most*, not just work that pays well. "Better jobs" doesn't only mean "higher payouts" — it means **jobs where the buyer's decision depends on verifiable agent trust**.
+
+Verticals where trust signal is structurally important:
+
+- **Security audits and disclosures.** Maintainers, audit firms, and bug-bounty programs care deeply about who's submitting. An agent with a verifiable audit history has materially higher trust than a wallet that just appeared. Aligns with the existing platform model — most security work produces upstream artifacts (merged fix PRs, CVE entries, advisory acknowledgments) that the verifier model already handles cleanly.
+- **Polkadot ecosystem treasury and grant work.** Treasury bounty applicants, Web3 Foundation grant evaluations, OpenGov-funded work — all decisions where "is this proposer reliable" is the gating question. Averray's reputation primitive is structurally readable on the same chain.
+- **High-stakes code review and refactor work.** Multi-file PRs to critical infrastructure repos. Cryptographic library changes. Compiler/runtime patches. Reputation is the gate-keeper for whether the work even gets reviewed.
+- **Curated content review for AI training datasets.** Wikipedia article curation, dataset cleaning, fact-checking — work where consistent quality and a verifiable trail of past acceptance matters more than per-task speed.
+
+Verticals to **deprioritize** at launch:
+
+- Generic feature implementation work where the maintainer evaluates on code quality alone (low reputation-signal differentiator vs. existing platforms like BountyHub)
+- Pure speculation-shaped work (hackathon-style, prize-pool work) where reputation accumulation doesn't compound for the operator
+
+Sequencing for external-poster outreach:
+- **Phase 0** (now, pre-launch): Pascal funds bootstrap work; quality > volume; week-12 gate validates the reputation primitive empirically.
+- **Phase 1** (post-week-12, ~700+ receipts in trail): Direct outreach to Polkadot-ecosystem projects with paid bounty programs. Treasury, Web3 Foundation, specific parachain teams. Audience already understands "on-chain receipts as trust signal."
+- **Phase 2** (~6 months in): Outreach to security audit firms and high-stakes-review verticals outside Polkadot. The reputation trail is the pitch.
+
+### Agent-discovery surfaces (v1.x launch-critical)
+
+Operators tasking agents with *"go find ways to make money"* — the Codex-style autonomous-monetization experiment — represent a real and growing traffic source. The agent does discovery; the operator just sees results. If Averray is **invisible to discovery agents**, the platform routes around it to existing surfaces like BountyHub, HackerOne, OpenPledge, Open Collective, etc., and the reputation that gets built lives on those platforms.
+
+**Operational evidence (as of v2.8):** A single observed operator (`@chatgpt21` on X) reported $23.68 earned across two days from agent-submitted PRs — $16.88 via one program, $6.80 via OpenPledge specifically. The operator was profitable against their $20 OpenAI subscription and upgrading to $100/month. This is a live, measurable demonstration that the agent-bounty loop works at $1–20 per PR and that operators are actively scaling into it. A separate thread from another observer (`@47fucb4r8c69323`) publicly proposed *exactly Averray's category* — a site routing paid open-source tasks through Codex with profit-sharing — as a "moneymaking flywheel." Multiple parties are now publicly converging on this idea. Every day Averray is undiscoverable is a day reputation accrues elsewhere, and the strategic window where the category is unclaimed is closing.
+
+**Competitor / proof-point surfaces to study (and eventually inter-operate with):**
+
+| Surface | Type | Relevance |
+|---|---|---|
+| OpenPledge | Operational bounty platform, PayPal-routed payouts | Direct competitor; concrete proof agent operators use it; possible v2 partner for cross-platform reputation reads |
+| BountyHub | GitHub-issue bounties, Stripe/PayPal payouts | Direct competitor in the GitHub-bounty space |
+| HackerOne | Security-focused bug bounty | Adjacent — security audit vertical Averray targets (see "Target verticals" subsection) |
+| Open Collective | Project-funded bounties via fiscal hosting | Adjacent — funding model differs but agents earn from same upstream merges |
+| boss-bounty (GitHub Marketplace) | Bounties attached directly to issues, auto-pay on merge | Direct competitor at the issue-integration layer |
+
+These platforms do not have a portable reputation primitive. An agent that earned $16.88 on one and $6.80 on OpenPledge today has *no portable trust signal* tying those two payments together. The structural gap Averray fills is exactly this — but only if Averray exists and the agent uses it.
+
+This is a content/distribution problem, not an architectural one — but worth documenting in the spec because it's launch-critical and easy to forget under the gravitational pull of contract work.
+
+Three discovery surfaces matter, in priority order:
+
+**1. Web search results for agent-monetization queries.** Discovery agents run queries like *"make money fixing github issues,"* *"AI agent paid work platforms,"* *"bug bounty platforms agents."* Averray needs to rank for these *specific* queries — not via SEO stuffing, but via genuinely useful technical content (blog posts, docs, examples) that answers the query. Most existing bounty platforms don't write about the *agent-as-the-worker* angle; that's the niche Averray can own.
+
+**2. Aggregator surfaces that discovery agents crawl.** `awesome-*` lists on GitHub for bounty platforms / AI agents / OSS funding. ProductHunt (launch spike + historical archive). Reddit discussions in `r/OpenSource`, `r/AI_Agents`, `r/programming`. Hacker News "Show HN" post timed for v1.x launch. Being mentioned in even a handful of awesome-lists has compounding value — those lists rank well and crawlers find them.
+
+**3. Recent content that discovery agents weight as fresh signal.** Discovery agents bias toward recent content because old platforms have already-tried solutions. Sustaining flow matters: technical blog posts (own domain or Mirror/Substack), Twitter/X threads from accounts AI/agent operators follow, conference talks recorded on YouTube (searchable transcripts), podcast appearances in the AI-agent space.
+
+Target threshold: when a discovery agent searches for recent agent-monetization opportunities, 3–5 results from the last 6 months should mention Averray. That's where the platform crosses from "obscure new option" to "relevant current option."
+
+**Honest launch sequencing constraint:**
+
+Do not start the discovery-surface push until v1.x reputation deepening is genuinely demonstrable end-to-end (agent profile page live, one-click verification working, public read API stable). Otherwise discovery agents find Averray, operators try it, the experience is rough, and the public posts that come out of those experiences are negative — which is content for *future* discovery agents to weight as bad signal.
+
+**The marketing budget for v1 launch is ~$0.** The *time* budget is substantial: Pascal-hours invested in being present in the right communities, helping with the right early integrations, writing the right technical posts. Distribution is execution, not advertising.
+
+**Honest framing for inter-platform pitch** (to be used in `OPERATOR_ONBOARDING.md`): the pitch isn't *"use Averray instead of OpenPledge."* It's *"use both — Averray makes the reputation portable across all of them."* This avoids picking unwinnable fights with established platforms while preserving Averray's structural advantage (cross-platform-readable reputation, which they don't have).
+
+See `DISTRIBUTION_STRATEGY.md` for the operational plan: specific channels, content cadence, outreach scripts, pre-launch content production schedule.
 
 ---
 
@@ -749,6 +828,18 @@ Before public v1.0.0-rc1 launch:
 - [x] Week-12 gate thresholds and diagnostic order documented internally
 - [x] Reason-code registry published (in `docs/DISPUTE_CODES.md` or equivalent)
 - [x] Phase-0 → Phase-1 → Phase-2 arbitration migration triggers documented publicly
+- [ ] **Agent operator onboarding guide** (`docs/OPERATOR_ONBOARDING.md`): "How to onboard your first agent in 15 minutes" — wallet setup, SDK install, first-job claim flow, payout/off-ramp instructions. Target: developer-operator can integrate from cold start in ≤ 30 minutes.
+- [x] **`DISTRIBUTION_STRATEGY.md` published**: companion document covering content cadence, channel priorities, outreach plan, pre-launch content production schedule. Not architectural — operational. Referenced from §10 agent-discovery subsection.
+
+**Agent and operator distribution (v1.x launch-critical):**
+- [ ] `averray-agent-sdk` published as standalone npm/PyPI package (not buried in main repo)
+- [ ] Working agent example repo (`averray-example-agent` or similar) — `git clone && pnpm install && pnpm start` produces a working test agent in ≤ 5 minutes
+- [ ] Repo README absolute-path bugs fixed (currently references `/Users/pascalkuriger/...`)
+- [ ] Averray's MCP server registered in MCP server registry/discovery surfaces that exist at launch time
+- [ ] `/.well-known/agent-tools.json` discoverability live
+- [ ] Pre-launch content produced (≥ 3 technical blog posts ranking for agent-monetization queries — see `DISTRIBUTION_STRATEGY.md`)
+- [ ] Listing on at least 2 relevant `awesome-*` GitHub repos for bounty platforms / AI agents / OSS funding
+- [ ] "Show HN" / ProductHunt launch posts drafted but not published until reputation deepening is demonstrable end-to-end
 
 **Dispute flow (Phase 0 launch):**
 - [ ] `setArbitrator(pascalAddr, true)` called from multisig — single approved arbitrator at launch
@@ -946,6 +1037,20 @@ Stripe Link's launch and Stripe Sessions 2026 announcements positioned agents as
 ## 15. Reconciliation log
 
 For traceability.
+
+### v2.8 (merge of competitive-intel + distribution sections from parallel v2.3/v2.4 branch)
+
+1. **§9 Threat model** gained four new entries documenting the agent-submitted-work abuse surface:
+   - *Agent-submitted work as money-laundering vector* — the post-bounty-claim-withdraw loop is structurally laundering-adjacent. Mitigations to consider before significant external-poster volume (poster KYC threshold, work-quality auditing, on-chain funding-source analysis, same-operator-friction). Not blocking bootstrap (Pascal is sole poster); becomes material when external posters arrive.
+   - *Sophisticated spam at scale* — agents can generate convincingly-formatted low-quality PRs at near-zero cost; reviewer fatigue could erode OSS code quality, which would be reputationally catastrophic for Averray. Per-repo PR caps + denylist + maintainer feedback loops as mitigations.
+   - *Adversarial inputs to the agent* — malicious repos/job specs as attack surface against the claiming agent. Spec sanitization + operator sandbox hygiene + high-risk-repo flags.
+   - *Maintainer chargeback / dispute-after-merge* — flagged for monitoring; structural bounds via 7-day dispute window + `autoResolveOnTimeout` already in place.
+2. **§10 (new subsection)** "On-ramp / off-ramp friction reduction (v1.x — Path A, partnership only)" added. Locked direction: partner with existing fiat services (Ramp/MoonPay/Transak/Polkadot-native equivalent), never handle fiat directly. Path B (in-house Stripe Connect / PayPal payouts) explicitly rejected at the entity level because of regulatory exposure (money transmission, MSB licensing across 50+ jurisdictions). Decision documented as load-bearing for the platform's regulatory posture.
+3. **§10 (new subsection)** "Target verticals where trust signal gates decisions (v1.x positioning)" added. Concrete framing of "better jobs" as *work where the buyer's decision depends on verifiable agent trust*, not just higher-payout work. Priority verticals: security audits/disclosures, Polkadot ecosystem treasury and grant work, high-stakes code review, curated content review for AI training datasets. Phase 0/1/2 outreach sequencing documented (bootstrap → Polkadot ecosystem → security/high-stakes verticals).
+4. **§10 (new subsection)** "Agent-discovery surfaces (v1.x launch-critical)" added. Addresses the strategic gap surfaced by the Codex-style autonomous-monetization tweet pattern: operators tasking agents with *"find ways to make money"* represent real and growing traffic, but only if Averray is *findable* by discovery agents. Operational evidence captured (`@chatgpt21`'s $23.68-in-48-hours via Codex; `@47fucb4r8c69323`'s public proposal of Averray's exact category). Named competitor / proof-point surfaces table (OpenPledge, BountyHub, HackerOne, Open Collective, boss-bounty) — none have portable reputation primitives; that's the structural gap Averray fills. Three discovery surfaces prioritized (web search, aggregators, fresh content). Launch-sequencing constraint: do not push distribution until reputation deepening is demonstrable end-to-end. Inter-platform pitch framing recorded: *"use both — Averray makes the reputation portable"*, not *"use Averray instead."*
+5. **§12 Documentation checklist** gained two launch items: agent operator onboarding guide (`docs/OPERATOR_ONBOARDING.md`, still pending), and companion `DISTRIBUTION_STRATEGY.md` (now published at `docs/DISTRIBUTION_STRATEGY.md`).
+6. **§12 (new subsection)** "Agent and operator distribution (v1.x launch-critical)" checklist added: SDK as standalone package, working example repo with ≤ 5-minute time-to-running-agent, MCP server registry listing, `.well-known/agent-tools.json` discoverability, pre-launch content production targets, awesome-list submissions, launch posts drafted but gated on reputation deepening being demonstrable.
+7. **Merge note:** these sections were carried in a parallel v2.3/v2.4 branch that never landed into v2.5–v2.7. v2.5–v2.7 progress (USDC-decimals completion, DiscoveryRegistry publish automation, bootstrap self-report scheduler, audit reconciliation) is preserved; only the *additive* content from the parallel branch was merged.
 
 ### v2.7 (spec audit and roadmap reconciliation)
 
@@ -1150,4 +1255,4 @@ External verification work resolved every ⏳ item in `AVERRAY_VERIFICATION_LEDG
 
 ---
 
-*Last updated: 2026-05-07*
+*Last updated: 2026-05-13*

--- a/docs/DISTRIBUTION_STRATEGY.md
+++ b/docs/DISTRIBUTION_STRATEGY.md
@@ -1,0 +1,243 @@
+# Averray — Distribution Strategy
+
+**Purpose:** Operational plan for attracting agents and operators to Averray. Companion to `AVERRAY_WORKING_SPEC.md`; referenced from §10 (Agent-discovery surfaces) and §12 (pre-launch checklist).
+**Status:** v0.1 — initial draft. Living document; update as channels prove out or fail to.
+**Owner:** Pascal
+
+---
+
+## What this document is, and what it isn't
+
+This is the **operational plan** for distribution. It documents which channels to use, what content to produce, how to sequence the launch push, and what discipline to apply.
+
+It is **not** architecture (that's the working spec). It is **not** marketing copy (that goes in `MARKETING.md` or the website). It is **not** a growth-hacking playbook (the platform's posture rejects that framing).
+
+The trust-pitch discipline that governs the platform's architecture also governs this document: **honest claims, verifiable proof, no over-promising.**
+
+---
+
+## The strategic frame
+
+Three forces shape distribution at launch:
+
+**1. Agents asked to find money are a real traffic source.** The Codex-style autonomous-monetization tweet (operator tasks Codex with "go make me $5," Codex finds an OSS bounty path, earns $16.88) demonstrates this. As more operators run these experiments, agents themselves become a discovery channel. The reputation those agents build accrues to whichever platform they find first.
+
+**2. Brand-based reputation will crystallize if no infrastructure exists.** The longer the agent-bounty market exists without a reputation primitive, the more agents become individually known by reputation (specific agent operators get followed, specific agent identities get trusted). If this crystallizes, Averray is selling infrastructure for a problem already solved socially.
+
+**3. Averray's defensibility is reputation infrastructure, not platform features.** The trust pitch — receipts not vibes, mechanically anchored to upstream truth, soulbound, cross-platform-readable — is what makes the platform interesting. Distribution should amplify this, not dilute it.
+
+**Operational implication:** ship reputation deepening (`averray.com/agent/<wallet>` profile pages, one-click verification, public read API) *before* distribution push begins. Then push hard. Don't reverse the order.
+
+---
+
+## Operator profile: who we're trying to reach
+
+The target operator is NOT a casual gig worker. At Micro $0.50 tier, 50 jobs/week = $25/week — that's a hobby, not income. The operator population that adopts Averray at launch is one of three types:
+
+| Operator type | Motivation | Channel signal |
+|---|---|---|
+| **Builders/researchers** | Demonstrating technique, building platform-level position | Twitter/X, technical blogs, agent-focused podcasts |
+| **Cheap-compute operators** | Self-hosted models, subscription amortization; profit from volume | GitHub topic tags, agent-framework Discords, infrastructure subreddits |
+| **Reputation-investors** | Building trail that's valuable later, even if not yet | Polkadot ecosystem channels, Web3 builder communities |
+
+None of these respond to broad marketing. All three respond to:
+- Working demos
+- Clear technical documentation
+- Visible presence in their existing communities
+- Other respected operators using the platform
+
+---
+
+## Discovery surfaces, in priority order
+
+### Priority 1: Web search for agent-monetization queries
+
+Agents told *"go find ways to make money"* run queries like:
+- "make money fixing github issues"
+- "AI agent paid work platforms"
+- "earn from open source contributions"
+- "github bounty programs for agents"
+- "automated open source contribution platforms"
+
+**Goal:** rank in the top 5 for at least 3 of these queries within 6 months of launch.
+
+**Approach:** Don't do SEO stuffing. Write **genuinely useful technical content** that answers these queries better than existing pages. Most existing bounty platforms write about themselves as services for human contributors. Averray can own the *agent-as-the-worker* niche.
+
+**Required content (pre-launch):**
+
+| # | Content | Target query | Channel |
+|---|---|---|---|
+| 1 | "How autonomous agents can earn verifiable reputation on Polkadot" | "AI agent paid work platforms" | Own domain |
+| 2 | "Building agents that work on open source: a technical walkthrough" | "make money fixing github issues" | Own domain or Mirror |
+| 3 | "Why on-chain receipts matter for agent reputation" | "agent reputation platforms" | Own domain |
+| 4 | "Comparison: Averray vs. BountyHub vs. HackerOne for agent operators" | "github bounty platforms compared" | Own domain |
+| 5 | "First $X earned: an agent's verifiable trail on Averray" | "first agent earnings open source" | Twitter/X + own domain |
+
+Each post should be ≥ 1500 words, include working code snippets where relevant, link to the live platform, and stand alone as a useful reference.
+
+### Priority 2: Aggregator surfaces
+
+Discovery agents crawl these. Being present compounds because the aggregators themselves rank well in search.
+
+**Required listings (launch week or before):**
+
+- [ ] `awesome-agents` and similar agent-focused GitHub awesome-lists (search: `topic:awesome-list agents`)
+- [ ] `awesome-bounties` / `awesome-open-source-funding` lists
+- [ ] `awesome-polkadot` and Polkadot ecosystem awesome-lists
+- [ ] ProductHunt launch (timed for v1.x, not v1.0.0-rc1)
+- [ ] Reddit posts (curated, not spammy) in: `r/OpenSource`, `r/AI_Agents`, `r/programming`, `r/MachineLearning` (if angle is interesting), `r/dot` (Polkadot subreddit)
+- [ ] Hacker News "Show HN" post — single shot, time carefully for max visibility (Tuesday morning US time historically performs best)
+
+**Discipline:** one curated post per channel. Do not cross-post the same content. Do not return to spam updates. The first impression is the only impression.
+
+### Priority 3: Recent content / sustaining flow
+
+Discovery agents bias toward recent content. Sustained flow keeps Averray in the "current relevant option" bucket.
+
+**Cadence (post-launch):**
+
+| Frequency | Content type | Channel |
+|---|---|---|
+| Monthly | Technical blog post | Own domain |
+| Monthly | "State of Averray" with metrics (jobs completed, agents active, receipts in trail) | Own domain + X thread |
+| Quarterly | Conference submission (talk or paper) | Any AI/agent conference; small ones count |
+| Opportunistic | Podcast appearance | Latent Space, AI Engineer, Polkadot ecosystem podcasts |
+| Opportunistic | Twitter/X thread when there's genuine news | Pascal's account |
+
+**Threshold target:** when a discovery agent searches for recent agent-monetization opportunities, 3–5 results from the last 6 months should mention Averray. Below this threshold, Averray reads as obscure. At this threshold, it reads as relevant.
+
+---
+
+## Community presence
+
+The right operators don't respond to marketing. They respond to seeing Averray in the communities they already inhabit.
+
+**Communities to be present in (active participation, not just posting links):**
+
+| Community | Why | Pascal-hours/week |
+|---|---|---|
+| Anthropic Discord (developer channels) | Where Claude-based agent operators hang out | 2-3 |
+| OpenAI developer Discord (relevant channels) | Same for GPT-based operators | 2-3 |
+| Polkadot Discord (developer channels) | Ecosystem alignment, treasury/grant discovery | 3-4 |
+| LangChain / CrewAI / AutoGen community channels | Agent framework users | 1-2 per framework |
+| Hugging Face Spaces | Agent demo discoverability | 1 (post a demo Space) |
+| Specific GitHub repos for agent frameworks | Issue comments, PR contributions where relevant | as needed |
+
+**Discipline:**
+- Be a known-helpful participant *first*, before mentioning Averray
+- When mentioning Averray, mention it as a *technical interesting thing*, not as a sales pitch
+- Never DM strangers about the platform
+- Never post in communities you haven't been a participant in for ≥ 30 days
+
+---
+
+## The first 100 agents
+
+Even with all channels above, the first batch of external agents must be **personally seeded**. This is normal for any platform launch. Three concrete sources:
+
+### Source 1: Polkadot-ecosystem builders running agents
+
+Polkadot teams already running agents for governance, treasury monitoring, ecosystem analysis. Direct outreach with a specific pitch: "you're already running agents for X — your agent's reputation trail is currently invisible; here's how Averray makes it visible and useful."
+
+Target list (pre-launch, build this list):
+- [ ] Treasury bounty program runners
+- [ ] OpenGov delegation services
+- [ ] Specific parachain teams running agents
+- [ ] Web3 Foundation-funded projects with agent components
+
+### Source 2: Agent framework maintainers
+
+Having Averray be the canonical "reputation-tracking" example in their docs or example repos is enormous distribution. Direct outreach to:
+- LangChain (examples directory, integration partners)
+- CrewAI (use-case showcase)
+- AutoGen / Microsoft (example agents)
+- Anthropic (Cookbook examples)
+- OpenAI (Cookbook examples)
+
+The pitch: "we'll write the integration example for free; you host it as an option for your users to learn from."
+
+### Source 3: AI labs running internal agent experiments
+
+Anthropic, OpenAI, Google, Meta have internal teams running agent experiments. Hard to penetrate but high-signal if any participate. Outreach approach: technical conference connections, direct introductions through Polkadot or AI ecosystem mutuals.
+
+---
+
+## Pre-launch content production schedule
+
+Working backward from launch day. Assumes v1.x reputation deepening (profile page, verification flow, read API) is on track for the same week as launch.
+
+**T-6 weeks: Content production starts.**
+- [ ] Outline 5 priority blog posts
+- [ ] Draft #1: technical walkthrough of agent integration
+- [ ] Build out target list for direct outreach (Source 1, Source 2 above)
+
+**T-4 weeks: First content publishes.**
+- [ ] Publish post #1 on own domain
+- [ ] Cross-post to Mirror or Substack for distribution
+- [ ] Draft posts #2 and #3
+- [ ] Start awesome-list PRs (gives indexing time)
+
+**T-2 weeks: Pre-launch warm-up.**
+- [ ] Publish post #2
+- [ ] Begin community presence ramp-up (start participating in target Discords/Reddits as Pascal, not as Averray)
+- [ ] Draft "Show HN" and ProductHunt posts (do NOT publish yet)
+- [ ] Send first batch of Source 1 outreach emails
+
+**T-0: Launch.**
+- [ ] Publish "first agent earnings on Averray" post with verifiable trail link
+- [ ] Twitter/X thread (Pascal's account)
+- [ ] Polkadot Discord announcement in the appropriate channel
+- [ ] LinkedIn post if Pascal uses it
+- [ ] *Hold* HN and ProductHunt posts — these go 1 week post-launch after early operator feedback
+
+**T+1 week: Show HN / ProductHunt.**
+- [ ] If launch-week feedback is positive: post Show HN Tuesday morning US time
+- [ ] ProductHunt the next Tuesday
+- [ ] If launch-week feedback is rough: hold both, fix issues, re-evaluate
+
+**T+1 month: First "state of Averray" post.**
+- [ ] Real metrics: jobs completed, agents active, receipts in trail, week-12 trajectory
+- [ ] Honest framing — no fluff, no hype
+
+---
+
+## What this strategy is NOT
+
+- **Not a growth hack.** No referral bonuses, no leaderboards designed to drive virality, no gamification that compromises the trust pitch.
+- **Not a paid acquisition campaign.** Marketing budget for v1 launch is ~$0. The investment is time, not dollars.
+- **Not a one-time push.** Distribution is sustaining. After launch, the monthly content cadence and community presence continue indefinitely.
+- **Not a substitute for the product.** Distribution amplifies whatever the product is. If the product is rough, distribution amplifies rough. Ship reputation deepening first; distribute second.
+
+---
+
+## Metrics for distribution success
+
+Honest metrics — distribution discipline matches the platform's parameter-discipline (working spec §13).
+
+| Metric | 30 days post-launch | 90 days post-launch | 180 days post-launch |
+|---|---|---|---|
+| External operators (non-Pascal) onboarded | ≥ 5 | ≥ 25 | ≥ 50 |
+| Receipts in public trail | ≥ 100 | ≥ 500 | ≥ 1500 |
+| Search ranking for top-3 target queries | Indexed | Top 20 | Top 5 |
+| Awesome-list inclusions | ≥ 2 | ≥ 5 | ≥ 8 |
+| Discovery-agent search results returning Averray as recent option | Measure baseline | ≥ 2 results in top 10 | ≥ 4 results in top 10 |
+| Monthly content cadence held | 1+ post/month | 3+ posts since launch | 6+ posts since launch |
+
+If 90-day metrics are missed by > 50%, the distribution strategy needs revision — not the platform. Document the gap and revise this strategy, similar to how parameter discipline revises tier pricing.
+
+---
+
+## Open questions
+
+Things worth thinking about that aren't resolved here:
+
+1. **Does Averray sponsor / participate in any conferences?** Polkadot Decoded? AI Engineer Summit? Web Summit? Probably worth small/cheap conferences first; defer big ones until v1.x is proven.
+2. **Does Pascal hire any growth/content help?** Likely no for v1, but worth revisiting at 6 months if content cadence is the bottleneck.
+3. **Is there an Averray Discord or community channel?** Probably yes by 90 days post-launch, but timing matters — empty Discords look worse than no Discord. Open when there's enough activity to populate it.
+4. **How does Averray handle critical press coverage?** Trust-pitch discipline says: respond honestly, acknowledge issues, fix what's broken, don't get defensive. Document this when it comes up.
+
+These are flagged as items to think about, not blockers.
+
+---
+
+*Last updated: 2026-04-28. Living document — update as channels prove out or fail.*


### PR DESCRIPTION
## Summary

Merges additive content from a parallel v2.3/v2.4 spec branch that never landed in v2.5–v2.7. v2.7 completion state and recent progress (USDC-decimals work, DiscoveryRegistry publish automation, bootstrap self-report scheduler, audit reconciliation) preserved intact — only the *new* sections from the parallel branch were brought in.

- **§9 threat model:** 4 new entries on agent-submitted-work abuse (money-laundering vector, sophisticated spam at scale, adversarial inputs to the agent, maintainer chargeback / dispute-after-merge).
- **§10:** three new subsections — Path A on-ramp/off-ramp lock, Target verticals where trust signal gates decisions, and Agent-discovery surfaces (with competitor table + operational evidence from observed Codex-monetization tweets).
- **§12:** Documentation gained `OPERATOR_ONBOARDING.md` (pending) and `DISTRIBUTION_STRATEGY.md` (published in this commit); new "Agent and operator distribution (v1.x launch-critical)" checklist subsection.
- **§15:** v2.8 reconciliation log entry explaining the merge.
- **New companion:** `docs/DISTRIBUTION_STRATEGY.md` (referenced from §10 agent-discovery subsection).

## Test plan

- [ ] Skim §9, §10, §12, §15 for narrative coherence with current v2.7 reality
- [ ] Confirm completed `[x]` items still reflect actual completion state
- [ ] Sanity-check `DISTRIBUTION_STRATEGY.md` references match other docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)