### PR TITLE
Harden async XCM idempotency receipts

### DIFF
--- a/docs/ASYNC_XCM_STAGING.md
+++ b/docs/ASYNC_XCM_STAGING.md
@@ -156,6 +156,8 @@ What the helper script does:
 
 - reads `/xcm/request` before mutation
 - posts to `/admin/xcm/observe` or `/admin/xcm/finalize`
+- uses an idempotency key; exact same request bodies replay the stored receipt,
+  while same-key payload drift returns `idempotency_key_payload_mismatch`
 - polls `/xcm/request` until terminal when using `observe`
 - optionally writes a JSON report to disk
 

--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -237,23 +237,20 @@ load and automation grow.
 
 - claim idempotency is enforced through session lookup and claim locks
 - `POST /admin/jobs`, `POST /admin/jobs/fire`, recurring pause/resume, and
-  async XCM admin actions can persist mutation receipts in the state store
-- admin job creation, manual recurring fires, and recurring pause/resume store
-  canonical request hashes with their idempotency receipts, so same-key replays
-  return the original result while same-key payload drift fails with a clear
-  conflict
+  async XCM actions persist mutation receipts in the state store
+- admin job creation, manual recurring fires, recurring pause/resume, and
+  async XCM allocate/deallocate plus observe/finalize store canonical request
+  hashes with their idempotency receipts, so same-key replays return the
+  original result while same-key payload drift fails with a clear conflict
 
 ### Remaining gaps
 
 - provider ingestion endpoints still rely mostly on deterministic job ids and
   duplicate-skip behavior rather than explicit idempotency receipts
-- async XCM actions replay receipts but still need the same canonical
-  payload-drift guard as create/fire/pause/resume
 - future dispute and settlement routes should adopt the same receipt wrapper
 
 ### Concrete next changes
 
-- extend canonical request-hash receipts to async XCM admin routes
 - add optional idempotency keys to provider ingestion routes where callers need
   whole-run replay semantics
 - reuse the same receipt wrapper for future dispute and settlement routes

--- a/docs/SPEC_AUDIT_2026-05-13.md
+++ b/docs/SPEC_AUDIT_2026-05-13.md
@@ -184,7 +184,6 @@ SSH/basic-auth/admin-JWT cutovers, and the basic hosted smoke is green.
 
 ### Idempotency And Mutation Hardening
 
-- Extend canonical request-hash receipts to async XCM admin routes.
 - Add optional ingestion-run idempotency where callers need whole-run replay
   semantics.
 - Reuse the receipt wrapper for future dispute and settlement routes.

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -2577,9 +2577,25 @@ const server = createServer(async (request, response) => {
         const mutationKey = options.idempotencyKey
           ? `${auth.wallet}:${strategyId}:${options.idempotencyKey}`
           : undefined;
-        const existing = mutationKey ? await stateStore.getMutationReceipt?.("account_allocate_async", mutationKey) : undefined;
-        if (existing) {
-          return respond(response, 200, existing);
+        const requestHash = buildMutationRequestHash({
+          route: "/account/allocate",
+          wallet: auth.wallet,
+          payload: {
+            ...payload,
+            asset,
+            amount,
+            strategyId,
+            strategyAsset,
+            asyncXcm: stripIdempotencyKey(options)
+          }
+        });
+        const replay = await getIdempotentMutationReplay({
+          bucket: "account_allocate_async",
+          key: mutationKey,
+          requestHash
+        });
+        if (replay) {
+          return respond(response, replay.statusCode, replay.body);
         }
         const nonce = options.nonce ?? (mutationKey ? deriveAsyncNonce(mutationKey) : Date.now());
         const result = await service.allocateIdleFunds(
@@ -2590,9 +2606,13 @@ const server = createServer(async (request, response) => {
           strategy,
           { ...options, nonce }
         );
-        if (mutationKey) {
-          await stateStore.upsertMutationReceipt?.("account_allocate_async", mutationKey, result);
-        }
+        await storeIdempotentMutationReceipt({
+          bucket: "account_allocate_async",
+          key: mutationKey,
+          requestHash,
+          response: result,
+          statusCode: 200
+        });
         return respond(response, 200, result);
       }
       return respond(response, 200, await service.allocateIdleFunds(auth.wallet, asset, amount, strategyId, strategy));
@@ -2618,9 +2638,25 @@ const server = createServer(async (request, response) => {
         const mutationKey = options.idempotencyKey
           ? `${auth.wallet}:${strategyId}:${options.idempotencyKey}`
           : undefined;
-        const existing = mutationKey ? await stateStore.getMutationReceipt?.("account_deallocate_async", mutationKey) : undefined;
-        if (existing) {
-          return respond(response, 200, existing);
+        const requestHash = buildMutationRequestHash({
+          route: "/account/deallocate",
+          wallet: auth.wallet,
+          payload: {
+            ...payload,
+            asset,
+            amount,
+            strategyId,
+            strategyAsset,
+            asyncXcm: stripIdempotencyKey(options)
+          }
+        });
+        const replay = await getIdempotentMutationReplay({
+          bucket: "account_deallocate_async",
+          key: mutationKey,
+          requestHash
+        });
+        if (replay) {
+          return respond(response, replay.statusCode, replay.body);
         }
         const nonce = options.nonce ?? (mutationKey ? deriveAsyncNonce(mutationKey) : Date.now());
         const result = await service.deallocateIdleFunds(
@@ -2631,9 +2667,13 @@ const server = createServer(async (request, response) => {
           strategy,
           { ...options, nonce }
         );
-        if (mutationKey) {
-          await stateStore.upsertMutationReceipt?.("account_deallocate_async", mutationKey, result);
-        }
+        await storeIdempotentMutationReceipt({
+          bucket: "account_deallocate_async",
+          key: mutationKey,
+          requestHash,
+          response: result,
+          statusCode: 200
+        });
         return respond(response, 200, result);
       }
       return respond(response, 200, await service.deallocateIdleFunds(auth.wallet, asset, amount, strategyId, strategy));
@@ -3753,9 +3793,21 @@ const server = createServer(async (request, response) => {
         ? payload.idempotencyKey.trim()
         : undefined;
       const mutationKey = idempotencyKey ? `${auth.wallet}:${requestId}:${idempotencyKey}` : undefined;
-      const existing = mutationKey ? await stateStore.getMutationReceipt?.("admin_xcm_observe", mutationKey) : undefined;
-      if (existing) {
-        return respond(response, 200, existing);
+      const requestHash = buildMutationRequestHash({
+        route: "/admin/xcm/observe",
+        wallet: auth.wallet,
+        payload: {
+          ...payload,
+          requestId
+        }
+      });
+      const replay = await getIdempotentMutationReplay({
+        bucket: "admin_xcm_observe",
+        key: mutationKey,
+        requestHash
+      });
+      if (replay) {
+        return respond(response, replay.statusCode, replay.body);
       }
       const observed = await service.observeXcmOutcome(requestId, {
         status: payload?.status,
@@ -3766,9 +3818,13 @@ const server = createServer(async (request, response) => {
         source: payload?.source ?? "admin_observer",
         observedAt: payload?.observedAt
       });
-      if (mutationKey) {
-        await stateStore.upsertMutationReceipt?.("admin_xcm_observe", mutationKey, observed);
-      }
+      await storeIdempotentMutationReceipt({
+        bucket: "admin_xcm_observe",
+        key: mutationKey,
+        requestHash,
+        response: observed,
+        statusCode: 200
+      });
       return respond(response, 200, observed);
     }
 
@@ -3786,9 +3842,21 @@ const server = createServer(async (request, response) => {
         ? payload.idempotencyKey.trim()
         : undefined;
       const mutationKey = idempotencyKey ? `${auth.wallet}:${requestId}:${idempotencyKey}` : undefined;
-      const existing = mutationKey ? await stateStore.getMutationReceipt?.("admin_xcm_finalize", mutationKey) : undefined;
-      if (existing) {
-        return respond(response, 200, existing);
+      const requestHash = buildMutationRequestHash({
+        route: "/admin/xcm/finalize",
+        wallet: auth.wallet,
+        payload: {
+          ...payload,
+          requestId
+        }
+      });
+      const replay = await getIdempotentMutationReplay({
+        bucket: "admin_xcm_finalize",
+        key: mutationKey,
+        requestHash
+      });
+      if (replay) {
+        return respond(response, replay.statusCode, replay.body);
       }
       const finalized = await service.finalizeXcmRequest(requestId, {
         status: payload?.status,
@@ -3797,9 +3865,13 @@ const server = createServer(async (request, response) => {
         remoteRef: payload?.remoteRef,
         failureCode: payload?.failureCode
       });
-      if (mutationKey) {
-        await stateStore.upsertMutationReceipt?.("admin_xcm_finalize", mutationKey, finalized);
-      }
+      await storeIdempotentMutationReceipt({
+        bucket: "admin_xcm_finalize",
+        key: mutationKey,
+        requestHash,
+        response: finalized,
+        statusCode: 200
+      });
       return respond(response, 200, finalized);
     }
 

--- a/mcp-server/src/protocols/http/server.smoke.test.js
+++ b/mcp-server/src/protocols/http/server.smoke.test.js
@@ -488,6 +488,63 @@ test("http smoke: async XCM routes reject caller-supplied raw message bytes", { 
   );
 });
 
+test("http smoke: admin XCM observation idempotency guards payload drift", { skip: !RUN }, async () => {
+  await runWithServer(async (base) => {
+    const token = issueToken(ADMIN_WALLET, { roles: ["admin"] });
+    const headers = { "content-type": "application/json", authorization: `Bearer ${token}` };
+    const requestId = `0x${"ab".repeat(32)}`;
+    const payload = {
+      requestId,
+      status: "succeeded",
+      settledAssets: 5,
+      settledShares: 5,
+      remoteRef: `0x${"12".repeat(32)}`,
+      observedAt: "2026-05-14T12:00:00.000Z",
+      idempotencyKey: "observe-same-key"
+    };
+
+    const observe = await fetch(`${base}/admin/xcm/observe`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload)
+    });
+    assert.equal(observe.status, 200);
+    const observed = await observe.json();
+    assert.equal(observed.requestId, requestId);
+
+    const replay = await fetch(`${base}/admin/xcm/observe`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        status: "succeeded",
+        settledAssets: 5,
+        settledShares: 5,
+        remoteRef: `0x${"12".repeat(32)}`,
+        observedAt: "2026-05-14T12:00:00.000Z",
+        requestId,
+        idempotencyKey: "observe-same-key"
+      })
+    });
+    assert.equal(replay.status, 200);
+    assert.deepEqual(await replay.json(), observed);
+
+    const drift = await fetch(`${base}/admin/xcm/observe`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        ...payload,
+        settledAssets: 6
+      })
+    });
+    assert.equal(drift.status, 409);
+    const body = await drift.json();
+    assert.equal(body.error, "idempotency_key_payload_mismatch");
+    assert.equal(body.details.bucket, "admin_xcm_observe");
+    assert.ok(body.details.originalRequestHash);
+    assert.ok(body.details.requestHash);
+  });
+});
+
 test("http smoke: /auth/nonce returns 429 once the window limit is crossed", { skip: !RUN }, async () => {
   await runWithServer(async (base) => {
     const body = JSON.stringify({ wallet: Wallet.createRandom().address });


### PR DESCRIPTION
## Summary
- wrap async XCM allocate/deallocate and admin observe/finalize receipts with canonical request hashes
- reject same idempotency key payload drift with idempotency_key_payload_mismatch while replaying exact matches
- update roadmap/staging docs and add an HTTP smoke for admin XCM observation replay/drift

## Checks
- npm --workspace mcp-server test
- RUN_HTTP_SMOKE=1 node --test --test-name-pattern "admin XCM observation idempotency" mcp-server/src/protocols/http/server.smoke.test.js

## Impact
- Backend/API only
- No contract, frontend, indexer, Caddy, or public site changes
- No environment or VPS secret changes