### PR TITLE
Add typed SDK surface + docs for scoped service tokens

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -52,6 +52,95 @@ The generated declaration exports endpoint-oriented types such as:
 Objects include index signatures where the platform intentionally returns
 extensible metadata, so integrations can keep compiling as new fields land.
 
+## Service Tokens (Scoped Bearer Tokens for Automation)
+
+External agents authenticate to the platform with a **service token** — a bearer
+JWT signed against a *capability grant* the operator issued from an admin
+wallet. The token is a strict subset of the operator's own capabilities;
+adding `account:fund` to a grant only works if the issuing admin already has
+`account:fund` themselves.
+
+Treat service-token bytes like any other secret: the response includes the
+token plaintext exactly once. Idempotent replay (same `idempotencyKey` on the
+same request) returns the grant metadata but redacts the token.
+
+### Issue a least-privilege token
+
+A worker agent that only claims and submits jobs needs nothing more than
+`jobs:claim` + `jobs:submit`:
+
+```js
+import { AgentPlatformClient } from "./agent-platform-client.js";
+
+const admin = new AgentPlatformClient({
+  baseUrl: "https://api.averray.com",
+  token: process.env.AVERRAY_ADMIN_TOKEN
+});
+
+const issued = await admin.issueServiceToken({
+  subject: "0xagent-wallet-address",
+  capabilities: ["jobs:claim", "jobs:submit"],
+  scope: "wikipedia-citation-bot",
+  tokenTtlSeconds: 3600,
+  idempotencyKey: "issue-wikipedia-bot-2026-05"
+});
+
+// `issued.token` is returned exactly once — store it in your secret manager.
+const worker = new AgentPlatformClient({
+  baseUrl: "https://api.averray.com",
+  token: issued.token
+});
+```
+
+Useful capability bundles for common worker shapes:
+
+| Worker shape | Capabilities |
+|---|---|
+| Job claimer + submitter | `jobs:claim`, `jobs:submit` |
+| Recommendation reader | `jobs:list`, `jobs:recommend`, `jobs:preflight` |
+| Session inspector | `session:read`, `session:timeline`, `events:read` |
+| Idle-balance allocator | `account:read`, `account:allocate`, `account:deallocate` |
+
+Do not grant capabilities the worker does not exercise — every extra
+capability widens the blast radius if the token leaks.
+
+### Rotate before the secret ages out
+
+`rotateServiceToken` atomically revokes the old grant and issues a new one
+with the same subject. Pass overrides (`capabilities`, `scope`, `expiresAt`,
+`tokenTtlSeconds`) to tighten or extend in the same call:
+
+```js
+const rotated = await admin.rotateServiceToken(issued.grant.id, {
+  tokenTtlSeconds: 1800,
+  revokeNote: "30-day rotation"
+});
+// rotated.rotatedFrom.id === issued.grant.id, rotated.grant.id is new.
+```
+
+### Revoke on incident or end-of-life
+
+```js
+await admin.revokeServiceToken(issued.grant.id, {
+  note: "agent decommissioned"
+});
+```
+
+Revocation is idempotent — replaying the same call returns
+`alreadyRevoked: true` rather than erroring.
+
+### Listing
+
+```js
+const active = await admin.listServiceTokens({ status: "active", limit: 50 });
+for (const entry of active.items) {
+  console.log(entry.grant.subject, entry.grant.capabilities);
+}
+```
+
+The `token` field is never returned by `listServiceTokens` — it only exists
+in the issue/rotate response and is unrecoverable afterwards.
+
 ## Errors
 
 Failed responses throw `AgentPlatformApiError`.

--- a/sdk/agent-platform-client.d.ts
+++ b/sdk/agent-platform-client.d.ts
@@ -915,6 +915,88 @@ export interface AdminStatusResponse extends ApiEnvelope {
   };
 }
 
+export type CapabilityGrantStatus = "active" | "revoked";
+
+export interface CapabilityGrantProjection {
+  id: string;
+  subject: WalletAddress;
+  capabilities: string[];
+  scope?: string;
+  note?: string;
+  issuedBy: WalletAddress;
+  issuedAt: ISODateTime;
+  expiresAt?: ISODateTime;
+  status: CapabilityGrantStatus;
+  revokedAt?: ISODateTime;
+  revokedBy?: WalletAddress;
+  revokeNote?: string;
+}
+
+export interface ServiceTokenListOptions {
+  subject?: WalletAddress;
+  status?: CapabilityGrantStatus;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ServiceTokenListItem {
+  tokenKind: "service";
+  tokenAvailable: false;
+  grant: CapabilityGrantProjection;
+}
+
+export interface ServiceTokenListResponse extends ApiEnvelope {
+  items: ServiceTokenListItem[];
+  limit: number;
+  offset: number;
+}
+
+export interface ServiceTokenIssueInput {
+  subject: WalletAddress;
+  capabilities: string[];
+  scope?: string;
+  note?: string;
+  expiresAt?: ISODateTime;
+  tokenTtlSeconds?: number;
+  idempotencyKey?: IdempotencyKey;
+}
+
+export interface ServiceTokenRotateInput {
+  capabilities?: string[];
+  scope?: string;
+  note?: string;
+  expiresAt?: ISODateTime;
+  tokenTtlSeconds?: number;
+  revokeNote?: string;
+  idempotencyKey?: IdempotencyKey;
+}
+
+export interface ServiceTokenRevokeInput {
+  note?: string;
+  idempotencyKey?: IdempotencyKey;
+}
+
+export interface ServiceTokenIssueResponse extends ApiEnvelope {
+  token: string;
+  tokenType: "Bearer";
+  tokenKind: "service";
+  tokenAvailable: true;
+  wallet: WalletAddress;
+  capabilities: string[];
+  expiresAt: ISODateTime;
+  grant: CapabilityGrantProjection;
+  rotatedFrom?: CapabilityGrantProjection;
+  usage: { header: string };
+}
+
+export interface ServiceTokenRevokeResponse extends ApiEnvelope {
+  tokenKind: "service";
+  tokenAvailable: false;
+  status: "revoked";
+  alreadyRevoked: boolean;
+  grant: CapabilityGrantProjection;
+}
+
 export class AgentPlatformApiError extends Error {
   constructor(options: {
     message: string;
@@ -1015,6 +1097,17 @@ export class AgentPlatformClient {
   pauseRecurringJob(templateId: JobId, options?: { idempotencyKey?: IdempotencyKey }): Promise<ApiEnvelope>;
   resumeRecurringJob(templateId: JobId, options?: { idempotencyKey?: IdempotencyKey }): Promise<ApiEnvelope>;
   getAdminStatus(): Promise<AdminStatusResponse>;
+
+  listServiceTokens(options?: ServiceTokenListOptions): Promise<ServiceTokenListResponse>;
+  issueServiceToken(input: ServiceTokenIssueInput): Promise<ServiceTokenIssueResponse>;
+  rotateServiceToken(
+    grantId: string,
+    input?: ServiceTokenRotateInput
+  ): Promise<ServiceTokenIssueResponse>;
+  revokeServiceToken(
+    grantId: string,
+    input?: ServiceTokenRevokeInput
+  ): Promise<ServiceTokenRevokeResponse>;
 
   request<T = unknown>(path: string, options?: RequestOptions): Promise<T>;
 }

--- a/sdk/agent-platform-client.js
+++ b/sdk/agent-platform-client.js
@@ -374,21 +374,49 @@ export class AgentPlatformClient {
     return this.request(`/admin/service-tokens${params.size ? `?${params.toString()}` : ""}`);
   }
 
-  async issueServiceToken(payload) {
+  async issueServiceToken({
+    subject,
+    capabilities,
+    scope = undefined,
+    note = undefined,
+    expiresAt = undefined,
+    tokenTtlSeconds = undefined,
+    idempotencyKey = undefined
+  } = {}) {
+    if (typeof subject !== "string" || !subject) {
+      throw new TypeError("issueServiceToken requires a non-empty `subject` wallet.");
+    }
+    if (!Array.isArray(capabilities) || capabilities.length === 0) {
+      throw new TypeError("issueServiceToken requires a non-empty `capabilities` array.");
+    }
     return this.request("/admin/service-tokens", {
       method: "POST",
-      body: payload
+      body: compact({ subject, capabilities, scope, note, expiresAt, tokenTtlSeconds, idempotencyKey })
     });
   }
 
-  async rotateServiceToken(grantId, payload = {}) {
+  async rotateServiceToken(grantId, {
+    capabilities = undefined,
+    scope = undefined,
+    note = undefined,
+    expiresAt = undefined,
+    tokenTtlSeconds = undefined,
+    revokeNote = undefined,
+    idempotencyKey = undefined
+  } = {}) {
+    if (typeof grantId !== "string" || !grantId) {
+      throw new TypeError("rotateServiceToken requires a non-empty `grantId`.");
+    }
     return this.request(`/admin/service-tokens/${encodeURIComponent(grantId)}/rotate`, {
       method: "POST",
-      body: payload
+      body: compact({ capabilities, scope, note, expiresAt, tokenTtlSeconds, revokeNote, idempotencyKey })
     });
   }
 
   async revokeServiceToken(grantId, { note = undefined, idempotencyKey = undefined } = {}) {
+    if (typeof grantId !== "string" || !grantId) {
+      throw new TypeError("revokeServiceToken requires a non-empty `grantId`.");
+    }
     return this.request(`/admin/service-tokens/${encodeURIComponent(grantId)}/revoke`, {
       method: "POST",
       body: compact({ note, idempotencyKey })

--- a/sdk/agent-platform-client.test.mjs
+++ b/sdk/agent-platform-client.test.mjs
@@ -233,6 +233,164 @@ test("request throws server-provided error messages with structured metadata", a
   );
 });
 
+test("listServiceTokens builds optional admin query string", async () => {
+  const calls = [];
+  const client = new AgentPlatformClient({
+    baseUrl: "https://api.example.test",
+    token: "admin-token",
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options });
+      return jsonResponse({ items: [], limit: 50, offset: 0 });
+    }
+  });
+
+  await client.listServiceTokens();
+  await client.listServiceTokens({
+    subject: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+    status: "active",
+    limit: 25,
+    offset: 50
+  });
+
+  assert.equal(calls[0].url, "https://api.example.test/admin/service-tokens");
+  assert.equal(calls[0].options.method ?? "GET", "GET");
+  assert.equal(calls[0].options.headers.get("authorization"), "Bearer admin-token");
+  assert.equal(
+    calls[1].url,
+    "https://api.example.test/admin/service-tokens?subject=0xabcdefabcdefabcdefabcdefabcdefabcdefabcd&status=active&limit=25&offset=50"
+  );
+});
+
+test("issueServiceToken posts a least-privilege payload and strips undefined fields", async () => {
+  const calls = [];
+  const client = new AgentPlatformClient({
+    baseUrl: "https://api.example.test",
+    token: "admin-token",
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options });
+      return jsonResponse({
+        token: "svc-token-secret",
+        tokenType: "Bearer",
+        tokenKind: "service",
+        tokenAvailable: true,
+        wallet: "0xagent",
+        capabilities: ["jobs:claim", "jobs:submit"],
+        expiresAt: "2026-06-01T00:00:00.000Z",
+        grant: { id: "grant-1", status: "active" },
+        usage: { header: "Authorization: Bearer <token>" }
+      }, { status: 201 });
+    }
+  });
+
+  const response = await client.issueServiceToken({
+    subject: "0xagent",
+    capabilities: ["jobs:claim", "jobs:submit"],
+    scope: "wikipedia-bot",
+    idempotencyKey: "issue-1"
+  });
+
+  assert.equal(calls[0].url, "https://api.example.test/admin/service-tokens");
+  assert.equal(calls[0].options.method, "POST");
+  assert.equal(calls[0].options.headers.get("authorization"), "Bearer admin-token");
+  assert.equal(calls[0].options.headers.get("content-type"), "application/json");
+  assert.deepEqual(JSON.parse(calls[0].options.body), {
+    subject: "0xagent",
+    capabilities: ["jobs:claim", "jobs:submit"],
+    scope: "wikipedia-bot",
+    idempotencyKey: "issue-1"
+  });
+  assert.equal(response.token, "svc-token-secret");
+  assert.equal(response.tokenAvailable, true);
+});
+
+test("issueServiceToken rejects missing subject or empty capabilities before any HTTP call", async () => {
+  const client = new AgentPlatformClient({
+    baseUrl: "https://api.example.test",
+    fetchImpl: async () => {
+      throw new Error("fetch must not be called when input is invalid");
+    }
+  });
+
+  await assert.rejects(() => client.issueServiceToken({}), TypeError);
+  await assert.rejects(
+    () => client.issueServiceToken({ subject: "0xagent", capabilities: [] }),
+    TypeError
+  );
+});
+
+test("rotateServiceToken URL-encodes the grant id and forwards optional overrides", async () => {
+  const calls = [];
+  const client = new AgentPlatformClient({
+    baseUrl: "https://api.example.test",
+    token: "admin-token",
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options });
+      return jsonResponse({
+        token: "rotated-token-secret",
+        tokenAvailable: true,
+        grant: { id: "grant-2" }
+      }, { status: 201 });
+    }
+  });
+
+  await client.rotateServiceToken("grant id/with slash", {
+    capabilities: ["jobs:claim"],
+    tokenTtlSeconds: 1800,
+    revokeNote: "tightened scope"
+  });
+
+  assert.equal(
+    calls[0].url,
+    "https://api.example.test/admin/service-tokens/grant%20id%2Fwith%20slash/rotate"
+  );
+  assert.equal(calls[0].options.method, "POST");
+  assert.deepEqual(JSON.parse(calls[0].options.body), {
+    capabilities: ["jobs:claim"],
+    tokenTtlSeconds: 1800,
+    revokeNote: "tightened scope"
+  });
+});
+
+test("revokeServiceToken posts a compact body and survives an empty input", async () => {
+  const calls = [];
+  const client = new AgentPlatformClient({
+    baseUrl: "https://api.example.test",
+    token: "admin-token",
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options });
+      return jsonResponse({
+        tokenKind: "service",
+        tokenAvailable: false,
+        status: "revoked",
+        alreadyRevoked: false,
+        grant: { id: "grant-3", status: "revoked" }
+      });
+    }
+  });
+
+  await client.revokeServiceToken("grant-3");
+  await client.revokeServiceToken("grant-3", { note: "key rotated out-of-band", idempotencyKey: "revoke-1" });
+
+  assert.equal(calls[0].url, "https://api.example.test/admin/service-tokens/grant-3/revoke");
+  assert.deepEqual(JSON.parse(calls[0].options.body), {});
+  assert.deepEqual(JSON.parse(calls[1].options.body), {
+    note: "key rotated out-of-band",
+    idempotencyKey: "revoke-1"
+  });
+});
+
+test("rotate/revoke require a non-empty grant id", async () => {
+  const client = new AgentPlatformClient({
+    baseUrl: "https://api.example.test",
+    fetchImpl: async () => {
+      throw new Error("fetch must not be called when input is invalid");
+    }
+  });
+
+  await assert.rejects(() => client.rotateServiceToken(""), TypeError);
+  await assert.rejects(() => client.revokeServiceToken(undefined), TypeError);
+});
+
 function jsonResponse(payload, { status = 200 } = {}) {
   return new Response(JSON.stringify(payload), {
     status,

--- a/sdk/agent-platform-client.types.test.ts
+++ b/sdk/agent-platform-client.types.test.ts
@@ -6,6 +6,9 @@ import {
   type ClaimResponse,
   type JobDefinition,
   type JobsListResponse,
+  type ServiceTokenIssueResponse,
+  type ServiceTokenListResponse,
+  type ServiceTokenRevokeResponse,
   type SessionTimelineResponse
 } from "./agent-platform-client.js";
 
@@ -56,6 +59,32 @@ if (firstJobId) {
 const account: AccountSummary = await client.borrowFunds({ amount: "1", idempotencyKey: "borrow-1" });
 await client.repayFunds({ amount: "1" });
 void account.wallet;
+
+const serviceTokens: ServiceTokenListResponse = await client.listServiceTokens({
+  status: "active",
+  limit: 25
+});
+void serviceTokens.items.length;
+
+const issued: ServiceTokenIssueResponse = await client.issueServiceToken({
+  subject: "0xagent-wallet-0xagent-wallet-0xagent-wal",
+  capabilities: ["jobs:claim", "jobs:submit"],
+  scope: "wikipedia-bot",
+  tokenTtlSeconds: 3600,
+  idempotencyKey: "issue-1"
+});
+const bearerToken: string = issued.token;
+void bearerToken;
+
+const rotated: ServiceTokenIssueResponse = await client.rotateServiceToken(issued.grant.id, {
+  capabilities: ["jobs:claim"]
+});
+void rotated.grant.id;
+
+const revoked: ServiceTokenRevokeResponse = await client.revokeServiceToken(issued.grant.id, {
+  note: "key rotated"
+});
+void revoked.alreadyRevoked;
 
 try {
   await client.getHealth();

--- a/sdk/api-surface-model.mjs
+++ b/sdk/api-surface-model.mjs
@@ -576,6 +576,88 @@ export interface AdminStatusResponse extends ApiEnvelope {
   };
 }
 
+export type CapabilityGrantStatus = "active" | "revoked";
+
+export interface CapabilityGrantProjection {
+  id: string;
+  subject: WalletAddress;
+  capabilities: string[];
+  scope?: string;
+  note?: string;
+  issuedBy: WalletAddress;
+  issuedAt: ISODateTime;
+  expiresAt?: ISODateTime;
+  status: CapabilityGrantStatus;
+  revokedAt?: ISODateTime;
+  revokedBy?: WalletAddress;
+  revokeNote?: string;
+}
+
+export interface ServiceTokenListOptions {
+  subject?: WalletAddress;
+  status?: CapabilityGrantStatus;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ServiceTokenListItem {
+  tokenKind: "service";
+  tokenAvailable: false;
+  grant: CapabilityGrantProjection;
+}
+
+export interface ServiceTokenListResponse extends ApiEnvelope {
+  items: ServiceTokenListItem[];
+  limit: number;
+  offset: number;
+}
+
+export interface ServiceTokenIssueInput {
+  subject: WalletAddress;
+  capabilities: string[];
+  scope?: string;
+  note?: string;
+  expiresAt?: ISODateTime;
+  tokenTtlSeconds?: number;
+  idempotencyKey?: IdempotencyKey;
+}
+
+export interface ServiceTokenRotateInput {
+  capabilities?: string[];
+  scope?: string;
+  note?: string;
+  expiresAt?: ISODateTime;
+  tokenTtlSeconds?: number;
+  revokeNote?: string;
+  idempotencyKey?: IdempotencyKey;
+}
+
+export interface ServiceTokenRevokeInput {
+  note?: string;
+  idempotencyKey?: IdempotencyKey;
+}
+
+export interface ServiceTokenIssueResponse extends ApiEnvelope {
+  token: string;
+  tokenType: "Bearer";
+  tokenKind: "service";
+  tokenAvailable: true;
+  wallet: WalletAddress;
+  capabilities: string[];
+  expiresAt: ISODateTime;
+  grant: CapabilityGrantProjection;
+  rotatedFrom?: CapabilityGrantProjection;
+  usage: { header: string };
+}
+
+export interface ServiceTokenRevokeResponse extends ApiEnvelope {
+  tokenKind: "service";
+  tokenAvailable: false;
+  status: "revoked";
+  alreadyRevoked: boolean;
+  grant: CapabilityGrantProjection;
+}
+
 export class AgentPlatformApiError extends Error {
   constructor(options: {
     message: string;
@@ -676,6 +758,17 @@ export class AgentPlatformClient {
   pauseRecurringJob(templateId: JobId, options?: { idempotencyKey?: IdempotencyKey }): Promise<ApiEnvelope>;
   resumeRecurringJob(templateId: JobId, options?: { idempotencyKey?: IdempotencyKey }): Promise<ApiEnvelope>;
   getAdminStatus(): Promise<AdminStatusResponse>;
+
+  listServiceTokens(options?: ServiceTokenListOptions): Promise<ServiceTokenListResponse>;
+  issueServiceToken(input: ServiceTokenIssueInput): Promise<ServiceTokenIssueResponse>;
+  rotateServiceToken(
+    grantId: string,
+    input?: ServiceTokenRotateInput
+  ): Promise<ServiceTokenIssueResponse>;
+  revokeServiceToken(
+    grantId: string,
+    input?: ServiceTokenRevokeInput
+  ): Promise<ServiceTokenRevokeResponse>;
 
   request<T = unknown>(path: string, options?: RequestOptions): Promise<T>;
 }


### PR DESCRIPTION
## Summary

The four `/admin/service-tokens` endpoints (list / issue / rotate / revoke) shipped with [averray-agent/agent#271](https://github.com/averray-agent/agent/pull/271) but the SDK exposed them only as untyped pass-throughs with no docs and no tests. External agents had to hand-roll URLs and guess the payload shape. This PR fixes the ergonomic + safety gap.

- `api-surface-model.mjs` gains `CapabilityGrantProjection`, `ServiceTokenIssueInput` / `RotateInput` / `RevokeInput`, `ServiceTokenListResponse`, `ServiceTokenIssueResponse`, `ServiceTokenRevokeResponse`; `AgentPlatformClient` lists the four methods. `agent-platform-client.d.ts` regenerated from the model.
- `issueServiceToken` and `rotateServiceToken` accept a named-param shape consistent with the rest of the SDK and reject missing `subject` / empty `capabilities` / empty `grantId` **before** any HTTP call, so misuse fails locally rather than after a 400.
- `agent-platform-client.types.test.ts` exercises the new types so consumers get autocompletion + compile-time checks.
- Six new unit tests cover URL shape, query-string encoding, body compaction, auth header, idempotency-key passthrough, and the pre-flight argument validation.
- `sdk/README.md` gains a Service Tokens section: least-privilege issuance example with `jobs:claim` + `jobs:submit`, common capability-bundle table, rotate-before-expiry pattern, and idempotent revoke.

Backend behavior is unchanged — this is SDK ergonomics + types + docs.

## Test plan

- [x] `npm run test:sdk` — all 12 SDK tests pass (6 new), generated `.d.ts` check passes, `typecheck:sdk` clean
- [x] `npm --workspace mcp-server test` — all 475 backend tests pass (paraspell module-not-found surface from prior local runs gone after a clean `npm install`)
- [ ] Manual: copy the README example into a scratch script, issue a token against staging, claim + submit a job using the bearer

## Acceptance check (per task brief)

- [x] External agent can call SDK methods without hand-building URLs
- [x] Docs clearly show least-privilege token creation and rotation
- [x] Relevant SDK + backend tests run cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)