### PR TITLE
Harden dispute mutation idempotency

### DIFF
--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -244,14 +244,17 @@ load and automation grow.
   observe/finalize store canonical request hashes with their idempotency
   receipts, so same-key replays return the original result while same-key
   payload drift fails with a clear conflict
+- dispute verdict and release routes keep their canonical dispute receipts while
+  also storing scoped idempotency envelopes keyed by wallet, dispute id, and
+  client key
 
 ### Remaining gaps
 
-- future dispute and settlement routes should adopt the same receipt wrapper
+- future direct settlement override routes should adopt the same receipt wrapper
 
 ### Concrete next changes
 
-- reuse the same receipt wrapper for future dispute and settlement routes
+- reuse the same receipt wrapper for future settlement routes
 - expose idempotency replay/conflict metadata in operator-facing docs and SDK
   helpers
 

--- a/docs/SPEC_AUDIT_2026-05-13.md
+++ b/docs/SPEC_AUDIT_2026-05-13.md
@@ -186,7 +186,9 @@ SSH/basic-auth/admin-JWT cutovers, and the basic hosted smoke is green.
 
 - Optional ingestion-run idempotency now covers provider ingestion routes where
   callers need whole-run replay semantics.
-- Reuse the receipt wrapper for future dispute and settlement routes.
+- Dispute verdict and release routes now use scoped idempotency envelopes while
+  preserving their canonical dispute receipts for timeline/profile reads.
+- Reuse the receipt wrapper for future direct settlement override routes.
 
 ### Timeline And Operator UX
 

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -1381,6 +1381,59 @@ function buildIdempotentMutationContext({ route, auth, payload, normalizedPayloa
   };
 }
 
+function buildScopedIdempotentMutationContext({ route, auth, scope, payload, normalizedPayload, bucket }) {
+  const idempotencyKey = parseIdempotencyKey(payload);
+  return {
+    bucket,
+    key: idempotencyKey ? `${auth.wallet}:${scope}:${idempotencyKey}` : undefined,
+    requestHash: buildMutationRequestHash({
+      route,
+      wallet: auth.wallet,
+      payload: normalizedPayload ?? payload
+    })
+  };
+}
+
+function normalizeOptionalString(value) {
+  return typeof value === "string" ? value.trim() : undefined;
+}
+
+function normalizeNumberLike(value) {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : value;
+}
+
+function normalizeDisputeVerdictForRequestHash(value) {
+  const verdict = normalizeOptionalString(value)?.toLowerCase();
+  if (verdict === "uphold") return "upheld";
+  if (verdict === "dismiss" || verdict === "rejected" || verdict === "reject") return "dismissed";
+  if (verdict === "partial" || verdict === "request-more") return "split";
+  if (verdict === "arb_timeout") return "timeout";
+  return verdict;
+}
+
+function normalizeDisputeVerdictRequestPayload(id, payload = {}) {
+  return {
+    disputeId: id,
+    verdict: normalizeDisputeVerdictForRequestHash(payload?.verdict ?? payload?.outcome),
+    workerPayout: normalizeNumberLike(payload?.workerPayout ?? payload?.payoutAmount),
+    rationale: normalizeOptionalString(payload?.rationale),
+    reasoningHash: normalizeOptionalString(payload?.reasoningHash),
+    metadataURI: normalizeOptionalString(payload?.metadataURI)
+  };
+}
+
+function normalizeDisputeReleaseRequestPayload(id, dispute, payload = {}) {
+  return {
+    disputeId: id,
+    action: normalizeOptionalString(payload?.action) || "release",
+    amount: normalizeNumberLike(payload?.amount ?? dispute?.stakedAmount ?? 0)
+  };
+}
+
 function isMutationReceiptEnvelope(receipt) {
   return Boolean(
     receipt
@@ -2202,10 +2255,22 @@ const server = createServer(async (request, response) => {
       if (!dispute) {
         return respond(response, 404, { status: "not_found", id });
       }
-      if (dispute.verdict || dispute.reasonCode) {
-        return respond(response, 200, dispute);
-      }
       const payload = await readJsonBody(request);
+      const idempotency = buildScopedIdempotentMutationContext({
+        route: "/disputes/:id/verdict",
+        auth,
+        scope: id,
+        payload,
+        normalizedPayload: normalizeDisputeVerdictRequestPayload(id, payload),
+        bucket: "dispute_verdict_idempotency"
+      });
+      const replay = await getIdempotentMutationReplay(idempotency);
+      if (replay) {
+        return respond(response, replay.statusCode, replay.body);
+      }
+      if (dispute.verdict || dispute.reasonCode) {
+        return respondWithMutationReceipt(response, idempotency, 200, dispute);
+      }
       const session = await service.resumeSession(dispute.sessionId);
       const decidedAt = new Date().toISOString();
       const remainingPayout = await resolveRemainingPayout(session);
@@ -2287,7 +2352,7 @@ const server = createServer(async (request, response) => {
           txHash: receipt.txHash
         }
       });
-      return respond(response, 200, {
+      const body = {
         ...dispute,
         status: "resolved",
         verdict: resolution.verdict,
@@ -2308,7 +2373,8 @@ const server = createServer(async (request, response) => {
             data: receipt
           }
         ]
-      });
+      };
+      return respondWithMutationReceipt(response, idempotency, 200, body);
     }
 
     if (request.method === "POST" && /^\/disputes\/[^/]+\/release$/u.test(pathname)) {
@@ -2319,6 +2385,21 @@ const server = createServer(async (request, response) => {
         return respond(response, 404, { status: "not_found", id });
       }
       const payload = await readJsonBody(request);
+      const idempotency = buildScopedIdempotentMutationContext({
+        route: "/disputes/:id/release",
+        auth,
+        scope: id,
+        payload,
+        normalizedPayload: normalizeDisputeReleaseRequestPayload(id, dispute, payload),
+        bucket: "dispute_release_idempotency"
+      });
+      const replay = await getIdempotentMutationReplay(idempotency);
+      if (replay) {
+        return respond(response, replay.statusCode, replay.body);
+      }
+      if (dispute.release) {
+        return respondWithMutationReceipt(response, idempotency, 200, dispute);
+      }
       const receipt = {
         id,
         disputeId: id,
@@ -2340,7 +2421,7 @@ const server = createServer(async (request, response) => {
         timestamp: receipt.releasedAt,
         data: { disputeId: id, amount: receipt.amount, action: receipt.action }
       });
-      return respond(response, 200, {
+      const body = {
         ...dispute,
         status: "resolved",
         release: receipt,
@@ -2354,7 +2435,8 @@ const server = createServer(async (request, response) => {
             data: receipt
           }
         ]
-      });
+      };
+      return respondWithMutationReceipt(response, idempotency, 200, body);
     }
 
     // ---------- auth routes ----------

--- a/mcp-server/src/protocols/http/server.smoke.test.js
+++ b/mcp-server/src/protocols/http/server.smoke.test.js
@@ -902,7 +902,11 @@ test("http smoke: /disputes exposes human-review sessions and records verdict/re
     const verdict = await fetch(`${base}/disputes/${encodeURIComponent(dispute.id)}/verdict`, {
       method: "POST",
       headers: { "content-type": "application/json", authorization: `Bearer ${verifierToken}` },
-      body: JSON.stringify({ verdict: "upheld", rationale: "Submission needs correction." })
+      body: JSON.stringify({
+        verdict: "upheld",
+        rationale: "Submission needs correction.",
+        idempotencyKey: "dispute-verdict-same-key"
+      })
     });
     assert.equal(verdict.status, 200);
     const verdictBody = await verdict.json();
@@ -910,6 +914,32 @@ test("http smoke: /disputes exposes human-review sessions and records verdict/re
     assert.equal(verdictBody.verdict, "upheld");
     assert.match(verdictBody.reasoningHash, /^0x[a-f0-9]{64}$/u);
     assert.equal(verdictBody.metadataURI, `urn:averray:content:${verdictBody.reasoningHash}`);
+
+    const verdictReplay = await fetch(`${base}/disputes/${encodeURIComponent(dispute.id)}/verdict`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${verifierToken}` },
+      body: JSON.stringify({
+        idempotencyKey: "dispute-verdict-same-key",
+        rationale: "Submission needs correction.",
+        verdict: "upheld"
+      })
+    });
+    assert.equal(verdictReplay.status, 200);
+    assert.deepEqual(await verdictReplay.json(), verdictBody);
+
+    const verdictDrift = await fetch(`${base}/disputes/${encodeURIComponent(dispute.id)}/verdict`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${verifierToken}` },
+      body: JSON.stringify({
+        verdict: "dismissed",
+        rationale: "Submission needs correction.",
+        idempotencyKey: "dispute-verdict-same-key"
+      })
+    });
+    assert.equal(verdictDrift.status, 409);
+    const verdictDriftBody = await verdictDrift.json();
+    assert.equal(verdictDriftBody.error, "idempotency_key_payload_mismatch");
+    assert.equal(verdictDriftBody.details.bucket, "dispute_verdict_idempotency");
 
     const privateContent = await fetch(`${base}/content/${encodeURIComponent(verdictBody.reasoningHash)}`);
     assert.equal(privateContent.status, 403);
@@ -950,12 +980,30 @@ test("http smoke: /disputes exposes human-review sessions and records verdict/re
     const release = await fetch(`${base}/disputes/${encodeURIComponent(dispute.id)}/release`, {
       method: "POST",
       headers: { "content-type": "application/json", authorization: `Bearer ${adminToken}` },
-      body: JSON.stringify({ action: "release", amount: 0.15 })
+      body: JSON.stringify({ action: "release", amount: 0.15, idempotencyKey: "dispute-release-same-key" })
     });
     assert.equal(release.status, 200);
     const releaseBody = await release.json();
     assert.equal(releaseBody.release.action, "release");
     assert.equal(releaseBody.release.amount, 0.15);
+
+    const releaseReplay = await fetch(`${base}/disputes/${encodeURIComponent(dispute.id)}/release`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${adminToken}` },
+      body: JSON.stringify({ amount: "0.15", action: "release", idempotencyKey: "dispute-release-same-key" })
+    });
+    assert.equal(releaseReplay.status, 200);
+    assert.deepEqual(await releaseReplay.json(), releaseBody);
+
+    const releaseDrift = await fetch(`${base}/disputes/${encodeURIComponent(dispute.id)}/release`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${adminToken}` },
+      body: JSON.stringify({ action: "release", amount: 0.2, idempotencyKey: "dispute-release-same-key" })
+    });
+    assert.equal(releaseDrift.status, 409);
+    const releaseDriftBody = await releaseDrift.json();
+    assert.equal(releaseDriftBody.error, "idempotency_key_payload_mismatch");
+    assert.equal(releaseDriftBody.details.bucket, "dispute_release_idempotency");
   });
 });
 


### PR DESCRIPTION
## Summary
- add scoped idempotency envelopes for dispute verdict and release mutations without replacing canonical dispute receipts
- replay exact retries and reject same-key payload drift before additional dispute/release side effects
- update the spec audit and roadmap notes for the now-covered dispute routes

## Checks
- RUN_HTTP_SMOKE=1 node --test --test-name-pattern "disputes exposes" mcp-server/src/protocols/http/server.smoke.test.js
- npm --workspace mcp-server test

## Impact
- Backend: yes
- Frontend/indexer/contracts/public site: no
- Env/VPS secrets: none