### PR TITLE
Surface bootstrap self-report delivery evidence on /admin/status

### DIFF
--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -151,6 +151,19 @@ RUN_SUBSCAN_XCM_VALIDATION=1 ./scripts/ops/check-release-readiness.sh testnet
 - [ ] Structured logs are visible from the current deploy target.
 - [ ] An alert destination is configured for hosted smoke-check failures.
 - [ ] [INCIDENT_RESPONSE.md](./INCIDENT_RESPONSE.md) has named on-call ownership.
+- [ ] Bootstrap self-report email has actually delivered. Flip this box only
+  when ALL of the following are true against the production stack with a
+  valid `ADMIN_JWT`:
+  - `curl -fsS -H "Authorization: Bearer $ADMIN_JWT" https://api.averray.com/admin/status \
+    | jq -r '.bootstrapSelfReport.lastSuccessfulAt'`
+    returns a non-null ISO timestamp within the last 8 days.
+  - `... | jq '.bootstrapSelfReport.providerConfigured'` returns `true`.
+  - `... | jq -r '.bootstrapSelfReport.lastFailureReason // "none"'` returns
+    `none` (or a stale failure whose timestamp is older than
+    `lastSuccessfulAt`).
+  - `... | jq -r '.bootstrapSelfReport.from'` and
+    `... | jq -r '.bootstrapSelfReport.to[]'` match the intended recipient
+    pair from `backend.env` (no `null`s, no test addresses).
 
 ---
 

--- a/docs/SPEC_AUDIT_2026-05-13.md
+++ b/docs/SPEC_AUDIT_2026-05-13.md
@@ -137,7 +137,11 @@ SSH/basic-auth/admin-JWT cutovers, and the basic hosted smoke is green.
   discover -> sign in -> preflight -> claim -> submit -> verify -> badge/profile.
 - Rerun the product-proof gate with worker-loop evidence.
 - Finish bootstrap self-report scheduled email delivery and first-delivery
-  proof.
+  proof. Code path is wired (`mcp-server/src/services/bootstrap-self-report-scheduler.js`);
+  the remaining gate is operational: `/admin/status.bootstrapSelfReport`
+  now exposes `lastAttemptedAt`, `lastSuccessfulAt`, `lastFailureReason`,
+  and the `from`/`to` pair, and `PRODUCTION_CHECKLIST.md` section 5 names
+  the exact `curl | jq` evidence required to flip the box.
 - Confirm `/admin/status` with a live admin JWT reports async XCM watcher posture
   cleanly.
 - Rehearse pauser pause/unpause from the hot key.
@@ -252,7 +256,10 @@ correlation and settlement path.
 ## Recommended Next Queue
 
 1. Complete the hosted worker-loop product-proof evidence gate.
-2. Close bootstrap self-report scheduled email delivery.
+2. Close bootstrap self-report scheduled email delivery against the live
+   production stack (the code path and `/admin/status` evidence fields are
+   landed; see `PRODUCTION_CHECKLIST.md` section 5 for the `curl | jq`
+   sign-off).
 3. Tighten schema-native jobs for first-wave job families.
 4. Finish dispute/arbitration launch path.
 5. Run the native XCM evidence pack captures.

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -312,10 +312,16 @@ export class PlatformService {
         running: false,
         intervalMs: 0,
         sendOnStart: false,
+        from: undefined,
+        to: [],
         recipientCount: 0,
         providerConfigured: false,
         nextRunAt: undefined,
-        lastRun: undefined
+        lastRun: undefined,
+        lastAttemptedAt: undefined,
+        lastSuccessfulAt: undefined,
+        lastFailureReason: undefined,
+        evidencePersistenceNote: "scheduler not initialised"
       },
       this.jobStaleSweeper?.getStatus?.() ?? {
         enabled: false,

--- a/mcp-server/src/services/bootstrap-self-report-scheduler.js
+++ b/mcp-server/src/services/bootstrap-self-report-scheduler.js
@@ -1,5 +1,21 @@
 const DEFAULT_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_RESEND_API_BASE_URL = "https://api.resend.com";
+const DEFAULT_STATE_SCOPE = "bootstrap-self-report";
+const FAILURE_MESSAGE_MAX_LENGTH = 240;
+
+// Failure-reason codes are stable strings the operator dashboard / launch
+// checklist greps against — keep them in one place so the test, the projection,
+// and the docs all agree on the spelling.
+export const BOOTSTRAP_SELF_REPORT_FAILURE_CODES = Object.freeze({
+  PROVIDER_NON_2XX: "provider_non_2xx",
+  PROVIDER_REQUEST_FAILED: "provider_request_failed",
+  MISSING_API_KEY: "missing_api_key",
+  MISSING_FROM_ADDRESS: "missing_from_address",
+  MISSING_RECIPIENTS: "missing_recipients",
+  MISSING_REPORT_GENERATOR: "missing_report_generator",
+  DISABLED: "disabled",
+  REPORT_GENERATION_FAILED: "report_generation_failed"
+});
 
 export class BootstrapSelfReportSchedulerService {
   constructor(upstreamStatusPoller, eventBus = undefined, {
@@ -13,7 +29,9 @@ export class BootstrapSelfReportSchedulerService {
     resendApiBaseUrl = DEFAULT_RESEND_API_BASE_URL,
     fetchImpl = fetch,
     emailSender = undefined,
-    logger = console
+    logger = console,
+    stateStore = undefined,
+    stateScope = DEFAULT_STATE_SCOPE
   } = {}) {
     this.upstreamStatusPoller = upstreamStatusPoller;
     this.eventBus = eventBus;
@@ -28,10 +46,20 @@ export class BootstrapSelfReportSchedulerService {
     this.fetchImpl = fetchImpl;
     this.emailSender = emailSender;
     this.logger = logger;
+    this.stateStore = stateStore;
+    this.stateScope = stateScope;
     this.running = false;
     this.timer = undefined;
     this.nextRunAt = undefined;
     this.lastRun = undefined;
+    // In-process mirror of the persisted evidence. Used when stateStore is
+    // absent so getStatus still returns the recent attempt; when stateStore
+    // is provided this is refreshed from persisted state on each read.
+    this.evidence = {
+      lastAttemptedAt: undefined,
+      lastSuccessfulAt: undefined,
+      lastFailureReason: undefined
+    };
   }
 
   start() {
@@ -50,16 +78,29 @@ export class BootstrapSelfReportSchedulerService {
   }
 
   async getStatus() {
-    return {
+    const persisted = await this.readPersistedEvidence();
+    const evidence = persisted ?? this.evidence;
+    const status = {
       enabled: this.enabled,
       running: this.running,
       intervalMs: this.intervalMs,
       sendOnStart: this.sendOnStart,
+      from: this.from || undefined,
+      to: [...this.to],
       recipientCount: this.to.length,
       providerConfigured: Boolean(this.emailSender || (this.resendApiKey && this.from && this.to.length)),
       nextRunAt: this.nextRunAt,
-      lastRun: this.lastRun
+      lastRun: this.lastRun,
+      lastAttemptedAt: evidence.lastAttemptedAt,
+      lastSuccessfulAt: evidence.lastSuccessfulAt,
+      lastFailureReason: evidence.lastFailureReason ?? undefined
     };
+    if (!this.stateStore) {
+      // Operators reading this need to know that a fresh process boot zeroes
+      // the timestamps until the next scheduler tick refreshes them.
+      status.evidencePersistenceNote = "in-process state, resets on restart";
+    }
+    return status;
   }
 
   async runOnce(now = new Date()) {
@@ -75,22 +116,44 @@ export class BootstrapSelfReportSchedulerService {
 
     if (!this.enabled) {
       summary.status = "skipped";
-      summary.skipped.push({ reason: "disabled" });
+      summary.skipped.push({ reason: BOOTSTRAP_SELF_REPORT_FAILURE_CODES.DISABLED });
       return this.finishRun(summary);
     }
     if (!this.upstreamStatusPoller?.generateWeeklyReport) {
       summary.status = "skipped";
-      summary.skipped.push({ reason: "missing_report_generator" });
+      summary.skipped.push({ reason: BOOTSTRAP_SELF_REPORT_FAILURE_CODES.MISSING_REPORT_GENERATOR });
+      await this.recordMisconfiguration(now, {
+        code: BOOTSTRAP_SELF_REPORT_FAILURE_CODES.MISSING_REPORT_GENERATOR,
+        message: "Upstream status poller is missing generateWeeklyReport()"
+      });
       return this.finishRun(summary);
     }
-    if (!this.hasEmailConfig()) {
+    const configCheck = this.describeEmailConfigGap();
+    if (configCheck) {
       summary.status = "skipped";
-      summary.skipped.push({ reason: "missing_email_config" });
+      summary.skipped.push({ reason: configCheck.code });
+      await this.recordMisconfiguration(now, configCheck);
+      return this.finishRun(summary);
+    }
+
+    let report;
+    try {
+      report = await this.upstreamStatusPoller.generateWeeklyReport({ now });
+    } catch (error) {
+      summary.status = "failed";
+      summary.errors.push({ message: truncateMessage(error?.message ?? String(error)) });
+      await this.recordAttempt(now, {
+        success: false,
+        failure: {
+          code: BOOTSTRAP_SELF_REPORT_FAILURE_CODES.REPORT_GENERATION_FAILED,
+          message: truncateMessage(error?.message ?? String(error))
+        }
+      });
+      this.logger.warn?.({ err: error }, "bootstrap_self_report.report_generation_failed");
       return this.finishRun(summary);
     }
 
     try {
-      const report = await this.upstreamStatusPoller.generateWeeklyReport({ now });
       const email = buildBootstrapSelfReportEmail(report, {
         now,
         from: this.from,
@@ -107,6 +170,7 @@ export class BootstrapSelfReportSchedulerService {
         subject: email.subject,
         providerId: sendResult?.id ?? sendResult?.data?.id
       };
+      await this.recordAttempt(now, { success: true });
       this.eventBus?.publish?.({
         id: `bootstrap-self-report-${Date.now()}`,
         topic: "bootstrap.self_report.sent",
@@ -119,7 +183,24 @@ export class BootstrapSelfReportSchedulerService {
       });
     } catch (error) {
       summary.status = "failed";
-      summary.errors.push({ message: error?.message ?? String(error) });
+      // ProviderHttpError carries the provider HTTP status code and a
+      // pre-truncated body excerpt; non-HTTP failures (DNS, TLS, abort) land
+      // here as plain Errors and we tag them as provider_request_failed.
+      const failure = error instanceof ProviderHttpError
+        ? {
+            code: BOOTSTRAP_SELF_REPORT_FAILURE_CODES.PROVIDER_NON_2XX,
+            providerStatus: error.providerStatus,
+            message: error.shortMessage
+          }
+        : {
+            code: BOOTSTRAP_SELF_REPORT_FAILURE_CODES.PROVIDER_REQUEST_FAILED,
+            message: truncateMessage(error?.message ?? String(error))
+          };
+      // Push the sanitized failure message rather than the raw error.message —
+      // ProviderHttpError.message interpolates the raw provider body, which
+      // can echo auth headers / API keys back through /admin/status.
+      summary.errors.push({ message: failure.message });
+      await this.recordAttempt(now, { success: false, failure });
       this.logger.warn?.({ err: error }, "bootstrap_self_report.send_failed");
     }
 
@@ -133,7 +214,33 @@ export class BootstrapSelfReportSchedulerService {
   }
 
   hasEmailConfig() {
-    return Boolean(this.emailSender || (this.resendApiKey && this.from && this.to.length));
+    return this.describeEmailConfigGap() === undefined;
+  }
+
+  // Returns undefined when the email path is fully configured, or a
+  // { code, message } describing the precise misconfiguration. Order matches
+  // the boot sequence an operator would debug top-down.
+  describeEmailConfigGap() {
+    if (this.emailSender) return undefined;
+    if (!this.resendApiKey) {
+      return {
+        code: BOOTSTRAP_SELF_REPORT_FAILURE_CODES.MISSING_API_KEY,
+        message: "RESEND_API_KEY (or BOOTSTRAP_SELF_REPORT_RESEND_API_KEY) is not set"
+      };
+    }
+    if (!this.from) {
+      return {
+        code: BOOTSTRAP_SELF_REPORT_FAILURE_CODES.MISSING_FROM_ADDRESS,
+        message: "BOOTSTRAP_SELF_REPORT_FROM is not set"
+      };
+    }
+    if (this.to.length === 0) {
+      return {
+        code: BOOTSTRAP_SELF_REPORT_FAILURE_CODES.MISSING_RECIPIENTS,
+        message: "BOOTSTRAP_SELF_REPORT_TO is empty"
+      };
+    }
+    return undefined;
   }
 
   async sendEmail(email, { idempotencyKey } = {}) {
@@ -163,6 +270,79 @@ export class BootstrapSelfReportSchedulerService {
     summary.finishedAt = new Date().toISOString();
     this.lastRun = summary;
     return summary;
+  }
+
+  async readPersistedEvidence() {
+    if (!this.stateStore?.getServiceState) return undefined;
+    try {
+      const stored = await this.stateStore.getServiceState(this.stateScope);
+      if (!stored) {
+        return {
+          lastAttemptedAt: undefined,
+          lastSuccessfulAt: undefined,
+          lastFailureReason: undefined
+        };
+      }
+      return {
+        lastAttemptedAt: stored.lastAttemptedAt,
+        lastSuccessfulAt: stored.lastSuccessfulAt,
+        lastFailureReason: stored.lastFailureReason
+      };
+    } catch (error) {
+      this.logger.warn?.({ err: error }, "bootstrap_self_report.state_read_failed");
+      return this.evidence;
+    }
+  }
+
+  async recordAttempt(now, { success, failure } = {}) {
+    const attemptedAt = now.toISOString();
+    await this.mergeEvidence(async (current) => {
+      const next = { ...current, lastAttemptedAt: attemptedAt };
+      if (success) {
+        next.lastSuccessfulAt = attemptedAt;
+        next.lastFailureReason = undefined;
+      } else if (failure) {
+        next.lastFailureReason = sanitizeFailureReason(failure);
+      }
+      return next;
+    });
+  }
+
+  // Misconfigurations don't count as "attempts that hit the provider", but the
+  // operator still needs to see *why* the scheduler isn't sending. We surface
+  // them in lastFailureReason and leave lastAttemptedAt / lastSuccessfulAt
+  // alone so the freshness check still reflects real network attempts.
+  async recordMisconfiguration(now, failure) {
+    await this.mergeEvidence(async (current) => ({
+      ...current,
+      lastFailureReason: sanitizeFailureReason(failure)
+    }));
+  }
+
+  async mergeEvidence(mutator) {
+    // Read-modify-write against either the persisted state or the in-process
+    // mirror, so callers like recordAttempt(failure) can update one field
+    // without zeroing out the others (e.g. a failed attempt must NOT drop
+    // a previously stored lastSuccessfulAt).
+    const persisted = await this.readPersistedEvidence();
+    const current = persisted ?? this.evidence;
+    const next = await mutator({
+      lastAttemptedAt: current.lastAttemptedAt,
+      lastSuccessfulAt: current.lastSuccessfulAt,
+      lastFailureReason: current.lastFailureReason
+    });
+    this.evidence = {
+      lastAttemptedAt: next.lastAttemptedAt,
+      lastSuccessfulAt: next.lastSuccessfulAt,
+      lastFailureReason: next.lastFailureReason
+    };
+    if (this.stateStore?.upsertServiceState) {
+      try {
+        await this.stateStore.upsertServiceState(this.stateScope, this.evidence);
+      } catch (error) {
+        this.logger.warn?.({ err: error }, "bootstrap_self_report.state_write_failed");
+      }
+    }
   }
 }
 
@@ -229,6 +409,19 @@ export function buildBootstrapSelfReportEmail(report, {
   };
 }
 
+// Carries the HTTP status and a pre-truncated body excerpt back to the
+// scheduler's catch block so the projection can surface a clean failure
+// reason without leaking the full provider response (which can echo the
+// authorization header back in error envelopes).
+class ProviderHttpError extends Error {
+  constructor({ status, message, shortMessage }) {
+    super(message);
+    this.name = "ProviderHttpError";
+    this.providerStatus = status;
+    this.shortMessage = shortMessage;
+  }
+}
+
 export async function sendResendEmail(email, {
   apiKey,
   apiBaseUrl = DEFAULT_RESEND_API_BASE_URL,
@@ -259,7 +452,12 @@ export async function sendResendEmail(email, {
     body = { raw: bodyText };
   }
   if (!response.ok) {
-    throw new Error(`Resend email send failed (${response.status}): ${bodyText}`);
+    const shortMessage = truncateMessage(extractProviderMessage(body, bodyText));
+    throw new ProviderHttpError({
+      status: response.status,
+      message: `Resend email send failed (${response.status}): ${bodyText}`,
+      shortMessage
+    });
   }
   return body;
 }
@@ -338,4 +536,33 @@ function parseBooleanEnv(raw) {
 function parsePositiveInt(raw, fallback) {
   const value = Number(raw);
   return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function truncateMessage(value) {
+  const text = typeof value === "string" ? value : String(value ?? "");
+  if (text.length <= FAILURE_MESSAGE_MAX_LENGTH) return text;
+  return `${text.slice(0, FAILURE_MESSAGE_MAX_LENGTH)}...`;
+}
+
+function extractProviderMessage(parsedBody, rawBody) {
+  if (parsedBody && typeof parsedBody === "object") {
+    if (typeof parsedBody.message === "string" && parsedBody.message) return parsedBody.message;
+    if (typeof parsedBody.error === "string" && parsedBody.error) return parsedBody.error;
+    if (parsedBody.error && typeof parsedBody.error === "object" && typeof parsedBody.error.message === "string") {
+      return parsedBody.error.message;
+    }
+  }
+  return rawBody || "provider returned non-2xx with empty body";
+}
+
+function sanitizeFailureReason(failure) {
+  if (!failure || typeof failure !== "object") return undefined;
+  const result = {
+    code: typeof failure.code === "string" ? failure.code : "unknown",
+    message: truncateMessage(failure.message ?? "")
+  };
+  if (typeof failure.providerStatus === "number") {
+    result.providerStatus = failure.providerStatus;
+  }
+  return result;
 }

--- a/mcp-server/src/services/bootstrap-self-report-scheduler.test.js
+++ b/mcp-server/src/services/bootstrap-self-report-scheduler.test.js
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  BOOTSTRAP_SELF_REPORT_FAILURE_CODES,
   BootstrapSelfReportSchedulerService,
   buildBootstrapSelfReportEmail,
   loadBootstrapSelfReportSchedulerConfig,
@@ -25,6 +26,22 @@ const report = {
   sourceTypes: { github_issue: 3, wikipedia_article: 1 },
   topCloseReasons: [{ reason: "closed_unmerged", count: 1 }]
 };
+
+function createMemoryServiceStateStore() {
+  const states = new Map();
+  return {
+    states,
+    async getServiceState(scope) {
+      return states.get(scope);
+    },
+    async upsertServiceState(scope, state) {
+      const existing = states.get(scope) ?? {};
+      const merged = { ...existing, ...state, updatedAt: new Date().toISOString() };
+      states.set(scope, merged);
+      return merged;
+    }
+  };
+}
 
 test("buildBootstrapSelfReportEmail renders operator-ready text and HTML", () => {
   const email = buildBootstrapSelfReportEmail(report, {
@@ -60,12 +77,20 @@ test("BootstrapSelfReportSchedulerService sends the generated report", async () 
     }
   });
 
-  const result = await scheduler.runOnce(new Date("2026-05-08T12:00:00.000Z"));
+  const now = new Date("2026-05-08T12:00:00.000Z");
+  const result = await scheduler.runOnce(now);
 
   assert.equal(result.status, "sent");
   assert.equal(result.report.mergeRate, 0.5);
   assert.equal(result.email.providerId, "email_123");
   assert.equal(events[0].topic, "bootstrap.self_report.sent");
+
+  const status = await scheduler.getStatus();
+  assert.equal(status.lastAttemptedAt, now.toISOString());
+  assert.equal(status.lastSuccessfulAt, now.toISOString());
+  assert.equal(status.lastFailureReason, undefined);
+  assert.equal(status.from, "Averray <ops@example.com>");
+  assert.deepEqual(status.to, ["pascal@example.com"]);
 });
 
 test("BootstrapSelfReportSchedulerService skips when email config is missing", async () => {
@@ -80,7 +105,204 @@ test("BootstrapSelfReportSchedulerService skips when email config is missing", a
   const result = await scheduler.runOnce(new Date("2026-05-08T12:00:00.000Z"));
 
   assert.equal(result.status, "skipped");
-  assert.deepEqual(result.skipped, [{ reason: "missing_email_config" }]);
+  assert.deepEqual(result.skipped, [{ reason: BOOTSTRAP_SELF_REPORT_FAILURE_CODES.MISSING_API_KEY }]);
+});
+
+test("provider non-2xx populates lastFailureReason and leaves lastSuccessfulAt", async () => {
+  const stateStore = createMemoryServiceStateStore();
+  const previousSend = new Date("2026-05-01T00:00:00.000Z");
+  // Seed a prior successful run so we can prove a later failure does NOT
+  // overwrite lastSuccessfulAt.
+  await stateStore.upsertServiceState("bootstrap-self-report", {
+    lastAttemptedAt: previousSend.toISOString(),
+    lastSuccessfulAt: previousSend.toISOString(),
+    lastFailureReason: undefined
+  });
+
+  const scheduler = new BootstrapSelfReportSchedulerService({
+    async generateWeeklyReport() {
+      return report;
+    }
+  }, undefined, {
+    enabled: true,
+    from: "Averray <ops@example.com>",
+    to: ["pascal@example.com"],
+    resendApiKey: "secret-key-do-not-leak",
+    fetchImpl: async () => ({
+      ok: false,
+      status: 429,
+      async text() {
+        return JSON.stringify({ message: "rate limit exceeded" });
+      }
+    }),
+    stateStore
+  });
+
+  const now = new Date("2026-05-08T12:00:00.000Z");
+  const result = await scheduler.runOnce(now);
+
+  assert.equal(result.status, "failed");
+  const status = await scheduler.getStatus();
+  assert.equal(status.lastAttemptedAt, now.toISOString());
+  assert.equal(status.lastSuccessfulAt, previousSend.toISOString());
+  assert.equal(status.lastFailureReason.code, BOOTSTRAP_SELF_REPORT_FAILURE_CODES.PROVIDER_NON_2XX);
+  assert.equal(status.lastFailureReason.providerStatus, 429);
+  assert.equal(status.lastFailureReason.message, "rate limit exceeded");
+});
+
+test("provider failure message is truncated to keep status payload bounded", async () => {
+  const huge = "x".repeat(2000);
+  const scheduler = new BootstrapSelfReportSchedulerService({
+    async generateWeeklyReport() {
+      return report;
+    }
+  }, undefined, {
+    enabled: true,
+    from: "Averray <ops@example.com>",
+    to: ["pascal@example.com"],
+    resendApiKey: "secret",
+    fetchImpl: async () => ({
+      ok: false,
+      status: 500,
+      async text() {
+        return JSON.stringify({ message: huge });
+      }
+    })
+  });
+
+  await scheduler.runOnce(new Date("2026-05-08T12:00:00.000Z"));
+  const status = await scheduler.getStatus();
+  assert.ok(status.lastFailureReason.message.length < huge.length);
+  assert.ok(status.lastFailureReason.message.endsWith("..."));
+});
+
+test("missing API key reports the precise misconfiguration without crashing", async () => {
+  const scheduler = new BootstrapSelfReportSchedulerService({
+    async generateWeeklyReport() {
+      return report;
+    }
+  }, undefined, {
+    enabled: true,
+    from: "Averray <ops@example.com>",
+    to: ["pascal@example.com"]
+    // resendApiKey intentionally absent
+  });
+
+  const result = await scheduler.runOnce(new Date("2026-05-08T12:00:00.000Z"));
+  assert.equal(result.status, "skipped");
+  assert.equal(result.skipped[0].reason, BOOTSTRAP_SELF_REPORT_FAILURE_CODES.MISSING_API_KEY);
+
+  const status = await scheduler.getStatus();
+  assert.equal(status.lastFailureReason.code, BOOTSTRAP_SELF_REPORT_FAILURE_CODES.MISSING_API_KEY);
+  // Misconfiguration must not mark a real attempt — operators check
+  // lastAttemptedAt to know "did we hit the provider at all?".
+  assert.equal(status.lastAttemptedAt, undefined);
+  assert.equal(status.lastSuccessfulAt, undefined);
+});
+
+test("missing from address is reported distinctly from missing recipients / key", async () => {
+  const noFrom = new BootstrapSelfReportSchedulerService({
+    async generateWeeklyReport() { return report; }
+  }, undefined, {
+    enabled: true,
+    to: ["pascal@example.com"],
+    resendApiKey: "secret"
+  });
+  const noFromResult = await noFrom.runOnce(new Date("2026-05-08T12:00:00.000Z"));
+  assert.equal(noFromResult.skipped[0].reason, BOOTSTRAP_SELF_REPORT_FAILURE_CODES.MISSING_FROM_ADDRESS);
+
+  const noTo = new BootstrapSelfReportSchedulerService({
+    async generateWeeklyReport() { return report; }
+  }, undefined, {
+    enabled: true,
+    from: "Averray <ops@example.com>",
+    resendApiKey: "secret"
+  });
+  const noToResult = await noTo.runOnce(new Date("2026-05-08T12:00:00.000Z"));
+  assert.equal(noToResult.skipped[0].reason, BOOTSTRAP_SELF_REPORT_FAILURE_CODES.MISSING_RECIPIENTS);
+});
+
+test("status projection does not leak the API key or full provider response", async () => {
+  const apiKey = "re_super_secret_should_not_leak";
+  const providerBody = JSON.stringify({
+    // A defective provider that echoes the auth header back in its error
+    // envelope — we must not relay this to /admin/status callers.
+    message: "Unauthorized",
+    debug: { authorization: `Bearer ${apiKey}` }
+  });
+  const scheduler = new BootstrapSelfReportSchedulerService({
+    async generateWeeklyReport() {
+      return report;
+    }
+  }, undefined, {
+    enabled: true,
+    from: "Averray <ops@example.com>",
+    to: ["pascal@example.com"],
+    resendApiKey: apiKey,
+    fetchImpl: async () => ({
+      ok: false,
+      status: 401,
+      async text() {
+        return providerBody;
+      }
+    })
+  });
+
+  await scheduler.runOnce(new Date("2026-05-08T12:00:00.000Z"));
+  const status = await scheduler.getStatus();
+  const serialized = JSON.stringify(status);
+  assert.equal(serialized.includes(apiKey), false, "API key must not appear in status payload");
+  assert.equal(serialized.includes("debug"), false, "raw provider body must not appear in status payload");
+  assert.equal(status.lastFailureReason.code, BOOTSTRAP_SELF_REPORT_FAILURE_CODES.PROVIDER_NON_2XX);
+  assert.equal(status.lastFailureReason.providerStatus, 401);
+  assert.equal(status.lastFailureReason.message, "Unauthorized");
+});
+
+test("evidence persists across scheduler instances when a stateStore is provided", async () => {
+  const stateStore = createMemoryServiceStateStore();
+  const first = new BootstrapSelfReportSchedulerService({
+    async generateWeeklyReport() {
+      return report;
+    }
+  }, undefined, {
+    enabled: true,
+    from: "Averray <ops@example.com>",
+    to: ["pascal@example.com"],
+    emailSender: async () => ({ id: "email_persisted" }),
+    stateStore
+  });
+  const now = new Date("2026-05-08T12:00:00.000Z");
+  await first.runOnce(now);
+
+  const second = new BootstrapSelfReportSchedulerService({
+    async generateWeeklyReport() {
+      return report;
+    }
+  }, undefined, {
+    enabled: true,
+    from: "Averray <ops@example.com>",
+    to: ["pascal@example.com"],
+    emailSender: async () => ({ id: "ignored" }),
+    stateStore
+  });
+  const status = await second.getStatus();
+  assert.equal(status.lastSuccessfulAt, now.toISOString());
+  assert.equal(status.evidencePersistenceNote, undefined);
+});
+
+test("without stateStore, getStatus advertises in-process evidence", async () => {
+  const scheduler = new BootstrapSelfReportSchedulerService({
+    async generateWeeklyReport() {
+      return report;
+    }
+  }, undefined, {
+    enabled: true,
+    from: "Averray <ops@example.com>",
+    to: ["pascal@example.com"],
+    emailSender: async () => ({ id: "email_mem" })
+  });
+  const status = await scheduler.getStatus();
+  assert.equal(status.evidencePersistenceNote, "in-process state, resets on restart");
 });
 
 test("sendResendEmail posts to the Resend emails endpoint", async () => {

--- a/mcp-server/src/services/bootstrap.js
+++ b/mcp-server/src/services/bootstrap.js
@@ -246,6 +246,7 @@ export async function createPlatformRuntime() {
   const bootstrapSelfReportScheduler = initStep("init-bootstrap-self-report-scheduler", logger, () =>
     new BootstrapSelfReportSchedulerService(upstreamStatusPoller, eventBus, {
       ...loadBootstrapSelfReportSchedulerConfig(process.env),
+      stateStore,
       logger
     })
   );


### PR DESCRIPTION
## Summary

The scheduled self-report email path was already wired, but the `/admin/status.bootstrapSelfReport` projection didn't expose enough for an operator to flip the production-checklist box mechanically. This PR closes the launch-checklist item by adding the four fields a reviewer needs, persisting them across restarts, and writing the exact evidence-check into the checklist.

**Strictly scheduler observability** — `git diff --stat origin/main..HEAD` shows zero edits under `mcp-server/src/jobs/`, `mcp-server/src/core/job-schema-registry.js`, or `sdk/` (the schema-native validation lane is untouched).

### What landed in `/admin/status.bootstrapSelfReport`

```json
{
  "enabled": true,
  "running": true,
  "intervalMs": 604800000,
  "sendOnStart": false,
  "from": "Averray <ops@example.com>",
  "to": ["pascal@example.com"],
  "recipientCount": 1,
  "providerConfigured": true,
  "nextRunAt": "2026-05-15T12:00:00.000Z",
  "lastRun": { "...": "existing" },
  "lastAttemptedAt": "2026-05-08T12:00:00.000Z",
  "lastSuccessfulAt": "2026-05-08T12:00:00.000Z",
  "lastFailureReason": {
    "code": "provider_non_2xx",
    "providerStatus": 429,
    "message": "rate limit exceeded"
  }
}
```

Existing field names preserved as-is; new fields are additive.

### Persistence

Scheduler takes an optional `stateStore` and reads/writes evidence via `getServiceState` / `upsertServiceState` (scope `"bootstrap-self-report"`) — the same seam `xcm-observation-relay` uses. `mcp-server/src/services/bootstrap.js` passes the platform state-store in by default, so production gets durable evidence across restarts. Without a state-store the scheduler advertises `evidencePersistenceNote: "in-process state, resets on restart"` so operators can tell the modes apart.

### Security-relevant fix found while writing the leakage regression test

`ProviderHttpError.message` interpolated the raw provider body (`Resend email send failed (401): ${bodyText}`). A defective provider that echoes the auth header back in its error envelope would have leaked `Authorization: Bearer <api-key>` through `lastRun.errors[].message`. Now `summary.errors.push` stores the pre-sanitized `failure.message` (provider-extracted + truncated to a bounded length), not `error.message`. A regression test (`status projection does not leak the API key or full provider response`) seeds a hostile provider body and asserts the API key never appears in the status payload.

### Production-checklist line that replaces `[ ]`

```
- [ ] Bootstrap self-report email has actually delivered. Flip this box only
  when ALL of the following are true against the production stack with a
  valid ADMIN_JWT:
  - curl ... /admin/status | jq -r '.bootstrapSelfReport.lastSuccessfulAt'
    returns a non-null ISO timestamp within the last 8 days.
  - ... | jq '.bootstrapSelfReport.providerConfigured' returns true.
  - ... | jq -r '.bootstrapSelfReport.lastFailureReason // "none"' returns
    "none" (or a stale failure whose timestamp is older than lastSuccessfulAt).
  - ... | jq -r '.bootstrapSelfReport.from' and .to[] match the intended
    recipient pair from backend.env (no nulls, no test addresses).
```

`docs/SPEC_AUDIT_2026-05-13.md` was updated to note that the code-path/projection is now in place and the gate moves from blocked-on-code to blocked-on-evidence.

## Test plan

- [x] `npm --workspace mcp-server test` — 482 tests pass (8 new/extended on the scheduler, including the API-key-leakage regression)
- [x] `git diff --stat origin/main..HEAD` confirms zero `mcp-server/src/jobs/`, `mcp-server/src/core/job-schema-registry.js`, or `sdk/` files touched
- [ ] Manual production check: run the curl/jq sequence from the checklist after the next scheduled tick fires, confirm `lastSuccessfulAt` is recent

## Out-of-scope findings (filed here so they don't get lost)

- No `bootstrap.self_report.failed` event-bus topic — only `.sent`. A Sentry-style alert on first failed delivery would be a separate small addition.
- `loadBootstrapSelfReportSchedulerConfig` parses `BOOTSTRAP_SELF_REPORT_TO` with comma-splitting that doesn't trim quotes; a value like `'"a@b","c@d"'` splits awkwardly. Not load-bearing for launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)