### PR TITLE
Phase 2 PR 2.7d tidy-up: Phase B script polish + doc corrections

### DIFF
--- a/docs/SECRETS_CALENDAR.yml
+++ b/docs/SECRETS_CALENDAR.yml
@@ -261,13 +261,16 @@ entries:
     warn_days: 30
     notes: |
       Mint with `ssh-keygen -t ed25519 -f ~/.ssh/averray_deploy_<date>`.
-      Add the public key to /root/.ssh/authorized_keys on the VPS,
+      Add the public key to `/home/ubuntu/.ssh/authorized_keys` on the
+      VPS (the SSH user is `ubuntu`, NOT `root` — earlier doc drafts
+      had this wrong; corrected after the 2026-05-14 Phase B cleanup),
       update 1Password (both `private key` and `public key` fields),
       redeploy once, then remove the old public key from
-      authorized_keys after 24h.
+      `authorized_keys` after 24h.
       Last rotated 2026-05-13 (Phase 2 PR 2.7d). Two-key window means
       both keys are live during the 24h post-rotation period —
-      authorized_keys.bak holds the old pubkey for emergency rollback.
+      `authorized_keys.bak` holds the old pubkey for emergency
+      rollback (per `~ubuntu` on the VPS, not `~root`).
 
   # ── App basic-auth (operator dashboard / staging gate) ────────────
 

--- a/docs/SECRETS_MIGRATION.md
+++ b/docs/SECRETS_MIGRATION.md
@@ -1408,6 +1408,34 @@ B](#custody-class-b--backend-blockchain-signer).
 - [ ] (2.7d) `SECRETS_CALENDAR.yml` updated with the new `expires_at` values
       for any rotated calendar-tracked entry
 
+#### PR 2.7d rotation history (forensic note added 2026-05-14)
+
+Captured here so future operators can reconcile what's in the VPS
+`authorized_keys` against the rotation timeline. Discovered during the
+2026-05-14 SSH hygiene step when the soon-to-be-deleted
+`authorized_keys.bak` was inspected and found to contain **three**
+historical ed25519 pubkeys rather than the expected two.
+
+| Pubkey body prefix | `ssh-keygen -l` comment            | Origin                                                                                                                                                                                                                                |
+| ------------------ | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `IM2yPx02DbKB…`    | `github-actions-averray-deploy`    | Original deploy key from initial VPS setup. No date suffix.                                                                                                                                                                            |
+| `IN/8hnF0QH88…`    | `github-actions-averray-deploy-20260512` | Earlier rotation pass on 2026-05-12, performed in-session before this rotation runbook existed. Private key was stored only in the operator's macOS Keychain (via `ssh-add --apple-use-keychain`) — no file in `~/.ssh/`. Retired 2026-05-13 when superseded. |
+| `INp68ki9cepv+…`   | `averray-prod-ci-deploy-20260513`  | **Current** production key after the Phase 2 PR 2.7d rotation. Private key in OP at `op://prod-ci/vps-ssh-key/private key` and local file `~/.ssh/averray_deploy_20260513`. Live in `~ubuntu/.ssh/authorized_keys`.                       |
+
+The 2026-05-12 rotation was a partial dry-run that successfully reached
+the VPS but didn't update the GitHub Actions secret (PR 2.1 had not
+yet landed); CI continued using the original key until PR 2.7d's
+proper rotation on 2026-05-13. None of the retired keys are authorized
+anywhere as of 2026-05-14 — `authorized_keys.bak` was deleted in the
+hygiene step, and the 2026-05-12 private key was removed from the
+operator's ssh-agent the same day.
+
+Lesson folded into the AUTH_JWT_SECRETS / SSH rotation runbooks: every
+key rotation MUST update both the VPS `authorized_keys` AND the OP item
+AND the operator's local file in one atomic gesture, and `.bak` files
+left on the VPS should be inspected before deletion to confirm they
+contain only the keys the operator expects.
+
 ### PR 2.8 — Smoke auth secret to 1Password
 
 Split into two sub-PRs, mirroring the PR 2.1 → PR 2.4 staging pattern

--- a/scripts/ops/rotate-auth-jwt-secrets-phase-b.sh
+++ b/scripts/ops/rotate-auth-jwt-secrets-phase-b.sh
@@ -278,11 +278,25 @@ green "  deploy succeeded ✓"
 # Sanity-check: confirm PR 2.7d.1 detected the env change and force-recreated
 # backend. If we don't see that marker, /run/agent-stack/backend.env may not
 # have rendered with the new keyring — that's a silent failure mode.
-if gh run view "$RUN_ID" --repo "$GH_REPO" --log 2>/dev/null \
-    | grep -q "backend /run env content changed"; then
+#
+# `gh run watch` returns as soon as the run hits a terminal status, but
+# `gh run view --log` can still serve a partially-flushed log for several
+# seconds afterwards (observed in the 2026-05-14 Phase B run: the marker
+# WAS in the log, the grep just ran too early). Retry with backoff to
+# eliminate the false negative.
+marker_found=0
+for attempt in 1 2 3 4; do
+  if gh run view "$RUN_ID" --repo "$GH_REPO" --log 2>/dev/null \
+      | grep -q "backend /run env content changed"; then
+    marker_found=1
+    break
+  fi
+  sleep "$attempt"   # 1s, 2s, 3s, 4s — total 10s worst case
+done
+if [[ $marker_found -eq 1 ]]; then
   green "  PR 2.7d.1 force-recreate marker present ✓"
 else
-  yellow "  PR 2.7d.1 marker not found in log."
+  yellow "  PR 2.7d.1 marker not found in log after 4 retries."
   yellow "  Two possibilities:"
   yellow "    (a) The render produced an identical file (extremely unlikely"
   yellow "        — the keyring just changed). Manual inspection required."


### PR DESCRIPTION
## Summary

Three small follow-ups from yesterday's Phase B execution.

1. **`scripts/ops/rotate-auth-jwt-secrets-phase-b.sh`** — retry the log grep at step [9] (4 attempts, 1s/2s/3s/4s backoff). Today's actual Phase B run produced a false-negative "marker not found" warning because `gh run view --log` had a partially-flushed log when grep ran. The marker WAS there; the race just lost. Future false negatives now require 10s of `gh` API quiet — much less likely to be a race.

2. **`docs/SECRETS_CALENDAR.yml`** — corrects the VPS SSH path under `vps-ssh-key` notes from `/root/.ssh/authorized_keys` to `/home/ubuntu/.ssh/authorized_keys`. The CI SSH user is `ubuntu`, not `root`. `/root/.ssh/authorized_keys` exists on the VPS but is 0 bytes — confirmed during today's hygiene step.

3. **`docs/SECRETS_MIGRATION.md`** — adds a forensic note under PR 2.7d documenting an unexpected third pubkey discovered in the VPS `authorized_keys.bak` on 2026-05-14. It's a 2026-05-12 rotation pass that reached the VPS but never updated the GitHub Actions secret. Private key lived in the operator's macOS Keychain only; retired and removed today. Note folds in the lesson learned.

## Test plan

- [x] `bash -n scripts/ops/rotate-auth-jwt-secrets-phase-b.sh` — syntax ok
- [x] `node scripts/ops/check-secrets-calendar.mjs` — 5 ok / 8 warn / 0 fail (unchanged from before)
- [x] Visual review of `docs/SECRETS_MIGRATION.md` table formatting
- [ ] Will exercise the script's retry loop the next time AUTH_JWT_SECRETS rotates (~2026-08-11)

## Out of scope (future work)

- Operator to run locally: `ssh-add -d`, `rm ~/.ssh/averray_deploy_ci{,.pub}`, `rm ~/.ssh/known_hosts.old` to close out the SSH hygiene loop on the Mac side
- 8 remaining `expires_at: "TBD"` calendar entries are vendor-rotation-cadence decisions, not pure code follow-ups

🤖 Generated with [Claude Code](https://claude.com/claude-code)