### PR TITLE
Add schema-native prevalidation helpers

### DIFF
--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -146,13 +146,15 @@ discipline for custom/off-platform schemas.
   verifier execution
 - `/jobs/definition.submissionContract` and `/jobs/validate-submission` remain
   the no-mutation source of truth for exact submit shape
+- the SDK exposes fail-closed helpers that validate drafts before claim/submit
+  mutations (`claimJobAfterValidation` and `submitValidatedWork`)
 
 ### Gaps today
 
 - custom/off-platform schema refs are still allowed without signed schema
   registration
-- helper workflows outside the platform still need to call
-  `/jobs/validate-submission` before consuming a claim/submit attempt
+- external agents still need to adopt the SDK pre-validation helpers in their
+  own hosted workflows
 - richer verifier replay fixtures should land before introducing v2 handlers
 
 ### Improve to
@@ -163,8 +165,7 @@ discipline for custom/off-platform schemas.
 
 ### Concrete next changes
 
-- validate structured output before claim/submit helper flows consume a claim
-  attempt
+- migrate hosted/reference-agent workflows to the SDK pre-validation helpers
 - continue tightening custom/off-platform schema refs once a signed schema
   registration flow exists
 

--- a/docs/EXTERNAL_AGENT_WALLET_ONBOARDING.md
+++ b/docs/EXTERNAL_AGENT_WALLET_ONBOARDING.md
@@ -147,6 +147,11 @@ curl -s https://api.averray.com/jobs/validate-submission \
   -d '{"jobId":"<job-id>","submission":{"summary":"Complete","output":"complete verified output","status":"complete"}}'
 ```
 
+Proceed only when the response contains `"valid": true` and
+`"submitSafe": true`. SDK users can enforce the same guard with
+`claimJobAfterValidation(jobId, draft, idempotencyKey)` before claim and
+`submitValidatedWork(jobId, sessionId, draft)` before submit.
+
 For schema-native jobs, `/jobs/definition.submissionContract` shows the exact
 `payload.submission` shape. Do not wrap the schema object under
 `submission.output`.

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -10,6 +10,7 @@ import { VerificationIngestionService } from "../services/verification-ingestion
 import { ConflictError, InsufficientLiquidityError, ValidationError } from "./errors.js";
 import { normalizeSubmission } from "./submission.js";
 import { buildPlatformCapabilities } from "./discovery-manifest.js";
+import { getBuiltinJobSchema } from "./job-schema-registry.js";
 import {
   buildSessionLifecycle,
   describeSessionStatus,
@@ -504,25 +505,30 @@ export class PlatformService {
 
   validateJobSubmission(jobId, submissionInput) {
     const job = this.getJobDefinition(jobId);
+    const contract = buildSubmissionValidationContract(job.outputSchemaRef);
     try {
       const normalized = normalizeSubmission(normalizeSubmitPayloadShape(job.outputSchemaRef, submissionInput));
       validateSubmissionContract(job.outputSchemaRef, normalized);
       return {
         jobId,
         valid: true,
+        submitSafe: true,
+        ...contract,
         schemaRef: job.outputSchemaRef,
-        schemaValidates: "payload.submission",
         submissionKind: normalized.kind,
         normalizedSubmission: normalized.kind === "structured" ? normalized.structured : normalized.rawText
       };
     } catch (error) {
+      const path = validationPathFromError(error);
       return {
         jobId,
         valid: false,
+        submitSafe: false,
+        ...contract,
         schemaRef: job.outputSchemaRef,
-        schemaValidates: "payload.submission",
         code: error?.code ?? "invalid_submission",
         message: error?.message ?? "Invalid submission.",
+        ...(path ? { path, errorPaths: [path] } : {}),
         details: error?.details
       };
     }
@@ -1719,4 +1725,54 @@ function toNonNegativeInteger(value) {
 
 function stringOrUndefined(value) {
   return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function buildSubmissionValidationContract(schemaRef) {
+  const schema = getBuiltinJobSchema(schemaRef);
+  const requiredTopLevelKeys = Array.isArray(schema?.required) ? schema.required : [];
+  return {
+    validationEndpoint: "POST /jobs/validate-submission",
+    submitEndpoint: "POST /jobs/submit",
+    submissionShape: "direct_schema_object",
+    schemaValidates: "payload.submission",
+    doNotWrapInOutput: true,
+    ...(requiredTopLevelKeys.length ? { requiredTopLevelKeys } : {})
+  };
+}
+
+function validationPathFromError(error) {
+  const details = error?.details && typeof error.details === "object" ? error.details : {};
+  const directPath = [
+    details.path,
+    details.expectedPath,
+    details.expected,
+    details.received
+  ].find((entry) => typeof entry === "string" && entry.trim());
+  if (directPath) {
+    return normalizeValidationPath(directPath);
+  }
+  return normalizeValidationPath(parseValidationPathFromMessage(error?.message));
+}
+
+function parseValidationPathFromMessage(message) {
+  if (typeof message !== "string") {
+    return undefined;
+  }
+  const payloadMatch = message.match(/\bpayload\.submission(?:\.[A-Za-z0-9_-]+|\[[0-9]+\])*/u);
+  if (payloadMatch) {
+    return payloadMatch[0];
+  }
+  const submissionMatch = message.match(/\bsubmission(?:\.[A-Za-z0-9_-]+|\[[0-9]+\])*/u);
+  if (submissionMatch) {
+    return submissionMatch[0];
+  }
+  return undefined;
+}
+
+function normalizeValidationPath(path) {
+  if (typeof path !== "string" || !path.trim()) {
+    return undefined;
+  }
+  const trimmed = path.trim();
+  return trimmed.startsWith("payload.") ? trimmed : `payload.${trimmed}`;
 }

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -383,14 +383,20 @@ test("validateJobSubmission gives a non-mutating schema-native verdict", () => {
     status: "complete"
   });
   assert.equal(valid.valid, true);
+  assert.equal(valid.submitSafe, true);
   assert.equal(valid.schemaRef, "schema://jobs/coding-output");
   assert.equal(valid.schemaValidates, "payload.submission");
+  assert.equal(valid.validationEndpoint, "POST /jobs/validate-submission");
+  assert.deepEqual(valid.requiredTopLevelKeys, ["summary", "output", "status"]);
   assert.equal(valid.submissionKind, "structured");
 
   const invalid = service.validateJobSubmission("parent-job-001", "complete");
   assert.equal(invalid.valid, false);
+  assert.equal(invalid.submitSafe, false);
   assert.equal(invalid.schemaRef, "schema://jobs/coding-output");
   assert.match(invalid.message, /Schema-native jobs require/u);
+  assert.equal(invalid.path, "payload.submission.summary");
+  assert.deepEqual(invalid.errorPaths, ["payload.submission.summary"]);
   assert.equal(invalid.details.schemaValidates, "payload.submission");
 });
 

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -4116,9 +4116,11 @@ const server = createServer(async (request, response) => {
       }
       const submission = payload && typeof payload === "object" && "submission" in payload
         ? payload.submission
-        : (typeof payload?.evidence === "string"
-            ? payload.evidence
-            : undefined);
+        : (payload && typeof payload === "object" && "output" in payload
+            ? payload.output
+            : (typeof payload?.evidence === "string"
+                ? payload.evidence
+                : undefined));
       if (submission === undefined) {
         throw new ValidationError("submission is required.");
       }

--- a/mcp-server/src/protocols/http/server.smoke.test.js
+++ b/mcp-server/src/protocols/http/server.smoke.test.js
@@ -208,7 +208,10 @@ test("http smoke: /jobs/validate-submission validates draft output before claim"
       })
     });
     assert.equal(valid.status, 200);
-    assert.equal((await valid.json()).valid, true);
+    const validPayload = await valid.json();
+    assert.equal(validPayload.valid, true);
+    assert.equal(validPayload.submitSafe, true);
+    assert.equal(validPayload.validationEndpoint, "POST /jobs/validate-submission");
 
     const invalid = await fetch(`${base}/jobs/validate-submission`, {
       method: "POST",
@@ -218,7 +221,9 @@ test("http smoke: /jobs/validate-submission validates draft output before claim"
     assert.equal(invalid.status, 200);
     const payload = await invalid.json();
     assert.equal(payload.valid, false);
+    assert.equal(payload.submitSafe, false);
     assert.equal(payload.schemaValidates, "payload.submission");
+    assert.equal(payload.path, "payload.submission.summary");
   });
 });
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -22,13 +22,18 @@ const preflight = await client.preflightJob(definition.id);
 For external agents, keep the mutation sequence explicit:
 
 1. Read `/onboarding`, `/jobs/definition`, and `/jobs/preflight`.
-2. Validate structured output with `validateJobSubmission`.
-3. Claim with a caller-provided idempotency key.
-4. Submit once for the returned `sessionId`.
+2. Validate structured output with `validateJobSubmission` or `assertValidJobSubmission`.
+3. Claim with a caller-provided idempotency key only after validation passes.
+4. Submit once for the returned `sessionId`, preferably through `submitValidatedWork`.
 5. Read `getSessionTimeline` for state and lineage.
 
 The SDK does not hide these steps because mutation safety depends on callers
-seeing where claim and submit happen.
+seeing where claim and submit happen. For helper workflows that need a hard
+guard, `claimJobAfterValidation(jobId, draft, key)` validates the exact draft
+before consuming a claim attempt, and `submitValidatedWork(jobId, sessionId,
+draft)` validates again before the submit mutation. Both throw
+`AgentPlatformValidationError` and make no mutation when the draft is not
+`submitSafe`.
 
 ## Idempotency Keys
 

--- a/sdk/agent-platform-client.d.ts
+++ b/sdk/agent-platform-client.d.ts
@@ -700,14 +700,22 @@ export interface PreflightResponse extends ApiEnvelope {
 
 export interface ValidationResponse<TSubmission = unknown> extends ApiEnvelope {
   valid: boolean;
+  submitSafe?: boolean;
   errors?: ApiEnvelope[];
   submission?: TSubmission;
   schemaRef?: BuiltinJobSchemaRef | string;
   schemaValidates?: "payload.submission" | string;
+  validationEndpoint?: "POST /jobs/validate-submission" | string;
+  submitEndpoint?: "POST /jobs/submit" | string;
+  submissionShape?: "direct_schema_object" | string;
+  doNotWrapInOutput?: boolean;
+  requiredTopLevelKeys?: string[];
   submissionKind?: "structured" | string;
   message?: string;
+  code?: string;
   details?: ApiEnvelope;
   path?: string;
+  errorPaths?: string[];
   expected?: string;
   expectedPath?: string;
 }
@@ -1021,6 +1029,16 @@ export class AgentPlatformApiError extends Error {
   details?: unknown;
 }
 
+export class AgentPlatformValidationError<TValidation = ValidationResponse> extends Error {
+  constructor(options: {
+    message: string;
+    validation?: TValidation;
+  });
+  validation?: TValidation;
+  code?: string;
+  details?: unknown;
+}
+
 export class AgentPlatformClient {
   constructor(options?: AgentPlatformClientOptions);
 
@@ -1072,10 +1090,24 @@ export class AgentPlatformClient {
     jobId: JobId,
     submission: TSubmission
   ): Promise<ValidationResponse<TSubmission>>;
+  assertValidJobSubmission<TSubmission extends StructuredSubmission = StructuredSubmission>(
+    jobId: JobId,
+    submission: TSubmission
+  ): Promise<ValidationResponse<TSubmission>>;
+  claimJobAfterValidation<TSubmission extends StructuredSubmission = StructuredSubmission>(
+    jobId: JobId,
+    submission: TSubmission,
+    idempotencyKey?: IdempotencyKey
+  ): Promise<ClaimResponse>;
   claimJob(jobId: JobId, idempotencyKey?: IdempotencyKey): Promise<ClaimResponse>;
   submitWork<TSubmission extends StructuredSubmission = StructuredSubmission>(
     sessionId: SessionId,
     submission: string | TSubmission
+  ): Promise<SubmitResponse>;
+  submitValidatedWork<TSubmission extends StructuredSubmission = StructuredSubmission>(
+    jobId: JobId,
+    sessionId: SessionId,
+    submission: TSubmission
   ): Promise<SubmitResponse>;
   getSession(sessionId: SessionId): Promise<SessionRecord>;
   getSessionTimeline(sessionId: SessionId): Promise<SessionTimelineResponse>;

--- a/sdk/agent-platform-client.js
+++ b/sdk/agent-platform-client.js
@@ -268,6 +268,23 @@ export class AgentPlatformClient {
     });
   }
 
+  async assertValidJobSubmission(jobId, submission) {
+    const validation = await this.validateJobSubmission(jobId, submission);
+    if (!isSubmitSafeValidation(validation)) {
+      throw new AgentPlatformValidationError({
+        message: validation?.message ?? "Submission validation failed; refusing to mutate.",
+        validation
+      });
+    }
+    return validation;
+  }
+
+  /** Validate the exact draft first; only then consume a claim attempt. */
+  async claimJobAfterValidation(jobId, submission, idempotencyKey = undefined) {
+    await this.assertValidJobSubmission(jobId, submission);
+    return this.claimJob(jobId, idempotencyKey);
+  }
+
   /** Omit `idempotencyKey` to inherit the server default of `<wallet>:<jobId>`; pass one to scope per run. See docs/IDEMPOTENCY.md. */
   async claimJob(jobId, idempotencyKey = undefined) {
     return this.request("/jobs/claim", {
@@ -287,6 +304,12 @@ export class AgentPlatformClient {
         ...(typeof submission === "string" ? { evidence: submission } : { submission })
       }
     });
+  }
+
+  /** Validate the exact draft first; only then send the submit mutation. */
+  async submitValidatedWork(jobId, sessionId, submission) {
+    await this.assertValidJobSubmission(jobId, submission);
+    return this.submitWork(sessionId, submission);
   }
 
   async getSession(sessionId) {
@@ -509,6 +532,20 @@ export class AgentPlatformApiError extends Error {
     this.code = payload?.code ?? payload?.error ?? undefined;
     this.details = payload?.details ?? undefined;
   }
+}
+
+export class AgentPlatformValidationError extends Error {
+  constructor({ message, validation }) {
+    super(message);
+    this.name = "AgentPlatformValidationError";
+    this.code = validation?.code ?? "submission_validation_failed";
+    this.validation = validation;
+    this.details = validation?.details ?? undefined;
+  }
+}
+
+function isSubmitSafeValidation(validation) {
+  return validation?.valid === true && validation?.submitSafe !== false;
 }
 
 function safeJsonParse(text) {

--- a/sdk/agent-platform-client.test.mjs
+++ b/sdk/agent-platform-client.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   AgentPlatformApiError,
   AgentPlatformClient,
+  AgentPlatformValidationError,
   createIdempotencyKey
 } from "./agent-platform-client.js";
 
@@ -173,6 +174,62 @@ test("job helpers build compact filters, mutation bodies, and admin timeline URL
     rewardAmount: 2
   });
   assert.equal(calls[8].url, "https://api.example.test/jobs/sub?parentSessionId=parent%20session");
+});
+
+test("validated job helpers fail closed before claim or submit mutations", async () => {
+  const calls = [];
+  const client = new AgentPlatformClient({
+    baseUrl: "https://api.example.test",
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options });
+      if (url.endsWith("/jobs/validate-submission")) {
+        const payload = JSON.parse(options.body);
+        return jsonResponse(
+          payload.submission?.status === "complete"
+            ? { valid: true, submitSafe: true, schemaRef: "schema://jobs/coding-output" }
+            : {
+                valid: false,
+                submitSafe: false,
+                code: "invalid_request",
+                message: "submission.status is required",
+                path: "payload.submission.status"
+              }
+        );
+      }
+      if (url.endsWith("/jobs/claim")) {
+        return jsonResponse({ sessionId: "claimed-session", jobId: "job-1", wallet: "0xabc" });
+      }
+      return jsonResponse({ sessionId: "claimed-session", status: "submitted" });
+    }
+  });
+
+  await client.claimJobAfterValidation("job-1", { status: "complete" }, "claim-key-1");
+  await client.submitValidatedWork("job-1", "claimed-session", { status: "complete" });
+
+  assert.equal(calls[0].url, "https://api.example.test/jobs/validate-submission");
+  assert.equal(calls[1].url, "https://api.example.test/jobs/claim");
+  assert.equal(calls[2].url, "https://api.example.test/jobs/validate-submission");
+  assert.equal(calls[3].url, "https://api.example.test/jobs/submit");
+
+  calls.length = 0;
+  await assert.rejects(
+    () => client.claimJobAfterValidation("job-1", { summary: "missing status" }, "claim-key-2"),
+    (error) => {
+      assert.ok(error instanceof AgentPlatformValidationError);
+      assert.equal(error.validation.path, "payload.submission.status");
+      return true;
+    }
+  );
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://api.example.test/jobs/validate-submission");
+
+  calls.length = 0;
+  await assert.rejects(
+    () => client.submitValidatedWork("job-1", "claimed-session", { summary: "missing status" }),
+    AgentPlatformValidationError
+  );
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://api.example.test/jobs/validate-submission");
 });
 
 test("operator surface helpers call policy, audit, and alert endpoints", async () => {

--- a/sdk/agent-platform-client.types.test.ts
+++ b/sdk/agent-platform-client.types.test.ts
@@ -1,6 +1,7 @@
 import {
   AgentPlatformApiError,
   AgentPlatformClient,
+  AgentPlatformValidationError,
   createIdempotencyKey,
   type AccountSummary,
   type BuiltinJobSchemaValue,
@@ -45,6 +46,8 @@ if (firstJobId) {
   } satisfies BuiltinJobSchemaValue<"schema://jobs/wikipedia-citation-repair-output">;
 
   await client.validateJobSubmission(definition.id, wikipediaSubmission);
+  await client.claimJobAfterValidation(definition.id, wikipediaSubmission, "example-run-id-validated");
+  await client.submitValidatedWork(definition.id, claim.sessionId, wikipediaSubmission);
   await client.submitWork(claim.sessionId, wikipediaSubmission);
   await client.createSubJob({
     parentSessionId: claim.sessionId,
@@ -63,6 +66,7 @@ const account: AccountSummary = await client.borrowFunds({ amount: "1", idempote
 await client.repayFunds({ amount: "1" });
 void account.wallet;
 void createIdempotencyKey();
+void AgentPlatformValidationError;
 
 const serviceTokens: ServiceTokenListResponse = await client.listServiceTokens({
   status: "active",

--- a/sdk/api-surface-model.mjs
+++ b/sdk/api-surface-model.mjs
@@ -361,14 +361,22 @@ export interface PreflightResponse extends ApiEnvelope {
 
 export interface ValidationResponse<TSubmission = unknown> extends ApiEnvelope {
   valid: boolean;
+  submitSafe?: boolean;
   errors?: ApiEnvelope[];
   submission?: TSubmission;
   schemaRef?: BuiltinJobSchemaRef | string;
   schemaValidates?: "payload.submission" | string;
+  validationEndpoint?: "POST /jobs/validate-submission" | string;
+  submitEndpoint?: "POST /jobs/submit" | string;
+  submissionShape?: "direct_schema_object" | string;
+  doNotWrapInOutput?: boolean;
+  requiredTopLevelKeys?: string[];
   submissionKind?: "structured" | string;
   message?: string;
+  code?: string;
   details?: ApiEnvelope;
   path?: string;
+  errorPaths?: string[];
   expected?: string;
   expectedPath?: string;
 }
@@ -682,6 +690,16 @@ export class AgentPlatformApiError extends Error {
   details?: unknown;
 }
 
+export class AgentPlatformValidationError<TValidation = ValidationResponse> extends Error {
+  constructor(options: {
+    message: string;
+    validation?: TValidation;
+  });
+  validation?: TValidation;
+  code?: string;
+  details?: unknown;
+}
+
 export class AgentPlatformClient {
   constructor(options?: AgentPlatformClientOptions);
 
@@ -733,10 +751,24 @@ export class AgentPlatformClient {
     jobId: JobId,
     submission: TSubmission
   ): Promise<ValidationResponse<TSubmission>>;
+  assertValidJobSubmission<TSubmission extends StructuredSubmission = StructuredSubmission>(
+    jobId: JobId,
+    submission: TSubmission
+  ): Promise<ValidationResponse<TSubmission>>;
+  claimJobAfterValidation<TSubmission extends StructuredSubmission = StructuredSubmission>(
+    jobId: JobId,
+    submission: TSubmission,
+    idempotencyKey?: IdempotencyKey
+  ): Promise<ClaimResponse>;
   claimJob(jobId: JobId, idempotencyKey?: IdempotencyKey): Promise<ClaimResponse>;
   submitWork<TSubmission extends StructuredSubmission = StructuredSubmission>(
     sessionId: SessionId,
     submission: string | TSubmission
+  ): Promise<SubmitResponse>;
+  submitValidatedWork<TSubmission extends StructuredSubmission = StructuredSubmission>(
+    jobId: JobId,
+    sessionId: SessionId,
+    submission: TSubmission
   ): Promise<SubmitResponse>;
   getSession(sessionId: SessionId): Promise<SessionRecord>;
   getSessionTimeline(sessionId: SessionId): Promise<SessionTimelineResponse>;


### PR DESCRIPTION
## What changed
- Enrich /jobs/validate-submission responses with submitSafe, endpoint/shape metadata, required top-level keys, and validation path hints.
- Add SDK fail-closed helpers: assertValidJobSubmission, claimJobAfterValidation, and submitValidatedWork.
- Update generated SDK types, SDK docs, onboarding docs, and the spec audit/roadmap status.

## Checks run
- npm run test:sdk
- npm --workspace mcp-server test
- RUN_HTTP_SMOKE=1 node --test mcp-server/src/protocols/http/server.smoke.test.js (needed escalated localhost bind because sandbox blocked server.listen)
- git diff --check

## Impact
- Backend: validation response shape and validate-submission compatibility alias for top-level output.
- SDK/docs: new safe helpers and typed validation response fields.
- Frontend/indexer/contracts/Caddy/public site: no runtime changes.

## Env/VPS changes
- None.