### PR TITLE
Phase 4d hotfix: add js-yaml as root devDependency to unbreak CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,16 @@ jobs:
           node-version: "22"
           cache: npm
 
+      # Phase 4d (PR #287 hotfix): the calendar check below needs
+      # `js-yaml` from node_modules, so we now have to install deps
+      # here. Earlier sibling checks (structural lint, manifest parity,
+      # install-script allowlist) use only Node stdlib and didn't
+      # require an install — that's why this job historically had no
+      # `npm ci`. Cost: ~30s install vs. ~12s before; calendar coverage
+      # is worth it.
+      - name: Install workspace dependencies
+        run: npm ci
+
       - name: Structural lint
         run: node scripts/ops/check-env-template-structure.mjs
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@paraspell/sdk-core": "^13.4.0",
         "@polkadot/util": "^14.0.3",
         "@polkadot/util-crypto": "^14.0.3",
+        "js-yaml": "^4.1.0",
         "polkadot-api": "^2.1.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@paraspell/sdk-core": "^13.4.0",
     "@polkadot/util": "^14.0.3",
     "@polkadot/util-crypto": "^14.0.3",
+    "js-yaml": "^4.1.0",
     "polkadot-api": "^2.1.1"
   }
 }


### PR DESCRIPTION
## Hotfix — main is currently red

PR #285 landed at 15:45Z despite its CI failing on the new \`Secrets calendar expiry check\` step:

\`\`\`
check-secrets-calendar requires js-yaml. Run \`npm install\` at the repo root and try again.
(underlying error: Cannot find module 'js-yaml')
\`\`\`

The check-secrets-calendar.mjs comment claimed js-yaml was hoisted via a transitive dep, but that only worked on the operator's machine (which finds it in the parent monorepo's node_modules). On a fresh \`npm ci\` runner, the transitive js-yaml doesn't dedupe to the workspace root. False positive in my local "it works" verify.

The local verification mistake aside, the bigger issue is that PR #285 was allowed to merge with a failing required-looking check. That's worth a separate investigation — \`Phase 2 — env template structural lint\` apparently isn't an enforced status check on \`main\` even though it's been there since PR 2.1. Not addressed in this PR.

## Fix

One-line: add \`js-yaml@^4.1.0\` to root \`devDependencies\` so it's installed at the workspace root and resolvable from \`scripts/ops/check-secrets-calendar.mjs\`.

## Verify

- [x] \`node scripts/ops/check-secrets-calendar.mjs\` runs locally with the new install
- [x] \`node scripts/ops/check-npm-install-scripts.mjs\` — 6/6 allowlisted, exit 0 (js-yaml has no install scripts)
- [ ] CI on this PR confirms the env-template-structure job goes green
- [ ] After merge: confirm main's next CI run is green and a deploy fires

## Follow-up

After this lands, separately:
- Audit branch protection on \`main\` to confirm which status checks are actually required (the failing check should have blocked #285)
- Update the comment in \`check-secrets-calendar.mjs\` that still claims "js-yaml is hoisted via a transitive dep"

🤖 Generated with [Claude Code](https://claude.com/claude-code)