### PR TITLE
Phase 2 PR 2.7a catch-up: load VPS_SSH_KEY from 1Password in Hermes workflow

### DIFF
--- a/.github/workflows/hermes-pr-handoff.yml
+++ b/.github/workflows/hermes-pr-handoff.yml
@@ -25,7 +25,15 @@ jobs:
       VPS_HOST: ${{ secrets.VPS_HOST }}
       VPS_PORT: ${{ secrets.VPS_PORT }}
       VPS_USER: ${{ secrets.VPS_USER }}
-      VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+      # Phase 2 PR 2.7a removed the legacy `VPS_SSH_KEY` GH-secret
+      # job-env binding when the canonical source flipped to
+      # 1Password at op://prod-ci/vps-ssh-key/private key. The deploy
+      # workflow was updated; this workflow was missed and started
+      # failing the "Validate required secrets" check below with an
+      # empty $VPS_SSH_KEY (caught in production on 2026-05-14 as
+      # ~2/3 Hermes runs failing). We now load it from OP via the
+      # same SHA-pinned load-secrets-action used in deploy-production
+      # (step below) before the validate step runs.
       HERMES_HANDOFF_TIMEOUT: 12m
     steps:
       - name: Extract PR context
@@ -48,19 +56,53 @@ jobs:
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
           echo "correlation_id=github-pr-${pr_number}-${head_sha}-${run_id}" >> "$GITHUB_OUTPUT"
 
+      # Phase 2 PR 2.7a (catch-up for this workflow): load VPS_SSH_KEY
+      # from 1Password instead of the legacy GH-secret. Mirrors the
+      # pattern in deploy-production.yml — same SHA-pinned action,
+      # same OP path, same fail-closed shape check below.
+      - name: Load prod-ci secrets from 1Password (fail-closed)
+        if: steps.pr.outputs.skip != 'true'
+        # Pinned to 1password/load-secrets-action v4.0.0 commit SHA.
+        # v4.0.0 is the first Node-24-compatible release; refresh with
+        # the same procedure documented in deploy-production.yml.
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PROD_CI }}
+          VPS_SSH_KEY_OP: op://prod-ci/vps-ssh-key/private key
+
       - name: Validate required secrets
         if: steps.pr.outputs.skip != 'true'
         run: |
+          set -euo pipefail
           test -n "$VPS_HOST"
           test -n "$VPS_USER"
-          test -n "$VPS_SSH_KEY"
+          # VPS_SSH_KEY_OP must be a non-empty PEM/OpenSSH private key.
+          # Identical shape check to deploy-production.yml's
+          # "Verify prod-ci OP values loaded and shape-valid" step,
+          # collapsed to one block here because Hermes only needs the
+          # SSH key from prod-ci, not the basic-auth pair.
+          if [ -z "${VPS_SSH_KEY_OP:-}" ]; then
+            echo "::error::VPS_SSH_KEY_OP is empty after load step — check op://prod-ci/vps-ssh-key/private key and OP_SERVICE_ACCOUNT_TOKEN_PROD_CI"
+            exit 1
+          fi
+          case "$VPS_SSH_KEY_OP" in
+            -----BEGIN*PRIVATE\ KEY-----*)
+              echo "VPS_SSH_KEY_OP: SSH private-key shape valid"
+              ;;
+            *)
+              echo "::error::VPS_SSH_KEY_OP does not look like an OpenSSH/PEM private key"
+              exit 1
+              ;;
+          esac
 
       - name: Configure SSH
         if: steps.pr.outputs.skip != 'true'
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
-          printf '%s\n' "$VPS_SSH_KEY" > ~/.ssh/id_ed25519
+          printf '%s\n' "$VPS_SSH_KEY_OP" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan -p "${VPS_PORT:-22}" -H "$VPS_HOST" >> ~/.ssh/known_hosts
 


### PR DESCRIPTION
## What this fixes

Hermes PR Handoff has been failing today (~2/3 of runs) with:

\`\`\`
VPS_HOST: ***
VPS_USER: ***
VPS_SSH_KEY:
Process completed with exit code 1
\`\`\`

Root cause: Phase 2 PR 2.7a (#254) migrated \`VPS_SSH_KEY\` from a GitHub Actions secret to 1Password (\`op://prod-ci/vps-ssh-key/private key\`) and updated \`deploy-production.yml\` accordingly, then deleted the legacy GH secret. **We missed \`hermes-pr-handoff.yml\`**. It kept referencing \`${{ secrets.VPS_SSH_KEY }}\` which has been empty since the cleanup.

## Why not just restore the GH secret

Restoring \`VPS_SSH_KEY\` to GH Actions would undo Phase 2 PR 2.7a's whole point — the migration was specifically to remove a plaintext private key from GitHub's secrets store, where every workflow on the repo can read it. We migrate the source of truth, not run two parallel sources.

## What this PR does

Mirrors the deploy-production.yml pattern exactly:

1. Removes \`VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}\` from the job-env block
2. Adds \`Load prod-ci secrets from 1Password (fail-closed)\` step using the SHA-pinned \`1password/load-secrets-action@v4.0.0\` (same SHA as deploy-production.yml since PR #270)
3. Validate step now does a real PEM/OpenSSH shape check on \`$VPS_SSH_KEY_OP\`, not just \`test -n\`
4. Configure SSH step writes \`$VPS_SSH_KEY_OP\` instead of \`$VPS_SSH_KEY\`

## Test plan

- [x] Static review — every \`VPS_SSH_KEY\` reference is now \`VPS_SSH_KEY_OP\`
- [ ] After merge: next Hermes run picks up the new workflow and succeeds (will fire automatically on the next CI completion)

## Outstanding (separate)

- Branch protection audit (auto-merge bypassed a failing required check on PR #285 earlier today)
- A small comment-cleanup in \`check-secrets-calendar.mjs\` ("hoisted via transitive" claim is now misleading)

🤖 Generated with [Claude Code](https://claude.com/claude-code)