### PR TITLE
Validate product-proof worker submissions before claim

### DIFF
--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -148,13 +148,17 @@ discipline for custom/off-platform schemas.
   the no-mutation source of truth for exact submit shape
 - the SDK exposes fail-closed helpers that validate drafts before claim/submit
   mutations (`claimJobAfterValidation` and `submitValidatedWork`)
+- the hosted product-proof worker loop now uses a built-in
+  `schema://jobs/product-proof-worker-loop` output contract, validates its
+  structured submission before claim, and records that validation trace in the
+  launch evidence gate
 
 ### Gaps today
 
 - custom/off-platform schema refs are still allowed without signed schema
   registration
-- external agents still need to adopt the SDK pre-validation helpers in their
-  own hosted workflows
+- third-party and non-product-proof helper workflows still need to adopt the
+  SDK pre-validation helpers / `/jobs/validate-submission` before-claim pattern
 - richer verifier replay fixtures should land before introducing v2 handlers
 
 ### Improve to
@@ -165,7 +169,9 @@ discipline for custom/off-platform schemas.
 
 ### Concrete next changes
 
-- migrate hosted/reference-agent workflows to the SDK pre-validation helpers
+- extend the product-proof validation-before-claim pattern + SDK
+  pre-validation helpers to each remaining hosted/reference-agent
+  helper workflow as it graduates to schema-native output
 - continue tightening custom/off-platform schema refs once a signed schema
   registration flow exists
 

--- a/docs/PRODUCT_PROOF_GATE.md
+++ b/docs/PRODUCT_PROOF_GATE.md
@@ -42,12 +42,14 @@ The deploy workflow can generate this evidence itself when run manually with:
 - `product_proof_require_worker_loop=1`
 
 That path uses the production `ADMIN_JWT` secret, creates a tiny benchmark job,
-preflights it as the token wallet, claims it, submits matching evidence, runs
-the verifier, and writes the evidence file before running the required gate. It
-does not print the token. The worker loop fails closed before mutation unless
-the token exposes the full loop capability set, the hosted stack reports
-canonical v1 USDC settlement readiness, and the worker wallet has enough
-AgentAccountCore USDC liquidity for the reward.
+preflights it as the token wallet, validates the structured product-proof
+submission through `/jobs/validate-submission`, claims it, submits matching
+evidence, runs the verifier, and writes the evidence file before running the
+required gate. It does not print the token. The worker loop fails closed before
+claim unless schema validation succeeds, the token exposes the full loop
+capability set, the hosted stack reports canonical v1 USDC settlement
+readiness, and the worker wallet has enough AgentAccountCore USDC liquidity for
+the reward.
 
 The hosted smoke token must resolve from `/auth/session` with capabilities for:
 `account:read`, `admin:status`, `jobs:create`, `jobs:preflight`, `jobs:claim`,
@@ -115,6 +117,14 @@ The worker-loop command writes a local evidence file like:
     "claimable": true,
     "requiredOutputSchema": "schema://jobs/product-proof-worker-loop"
   },
+  "validationReadiness": {
+    "jobId": "product-proof-worker-loop-...",
+    "valid": true,
+    "schemaRef": "schema://jobs/product-proof-worker-loop",
+    "schemaValidates": "payload.submission",
+    "submissionKind": "structured",
+    "validatedBeforeClaim": true
+  },
   "claimReadiness": {
     "status": "claimed",
     "sessionId": "sess_..."
@@ -139,6 +149,7 @@ The script fetches the badge and profile documents and verifies that:
 - the evidence proves canonical v1 USDC settlement readiness
 - the reward clears the USDC minBalance and the worker has enough USDC liquidity
 - the job preflight was eligible and claimable before claim
+- the product-proof submission passed schema validation before claim
 - the submit, verification, and session statuses reached submitted, approved,
   and resolved
 - the badge uses `averray.schemaVersion = "v1"`

--- a/docs/SPEC_AUDIT_2026-05-13.md
+++ b/docs/SPEC_AUDIT_2026-05-13.md
@@ -1,11 +1,12 @@
 # Spec Audit - 2026-05-13
 
 This audit reconciles the current spec and roadmap after the recent framework,
-USDC, discovery, secrets, product-proof, lineage, and event-log work.
+USDC, discovery, secrets, product-proof, lineage, event-log, schema-native,
+idempotency, dispute, and async-XCM foundation work.
 
 Primary source of truth:
 
-- [AVERRAY_WORKING_SPEC.md](./AVERRAY_WORKING_SPEC.md) - current v2.7 product
+- [AVERRAY_WORKING_SPEC.md](./AVERRAY_WORKING_SPEC.md) - current v2.9 product
   and launch spec.
 - [CORE_FRAMEWORK_ROADMAP.md](./CORE_FRAMEWORK_ROADMAP.md) - framework
   implementation tracker.
@@ -150,8 +151,12 @@ SSH/basic-auth/admin-JWT cutovers, and the basic hosted smoke is green.
 
 ### Native XCM / vDOT Gate
 
-- Produce real Bifrost deposit, withdraw, and failure evidence captures with
-  backend-built XCM messages.
+- Treat backend-built XCM messages as the shipped foundation for the current
+  Bifrost/vDOT strategy path: the assembler appends `SetTopic(requestId)`, the
+  gateway routes strategy allocate/deallocate through intent payloads, and the
+  wrapper validates the terminal SetTopic.
+- Produce real Bifrost deposit, withdraw, and failure evidence captures from
+  the hosted stack.
 - Run the Chopsticks/PAPI experiment for Bifrost reply-leg `SetTopic`
   preservation.
 - If Bifrost preserves `SetTopic(requestId)`, promote topic matching as the
@@ -163,30 +168,35 @@ SSH/basic-auth/admin-JWT cutovers, and the basic hosted smoke is green.
 ### Schema-Native Jobs
 
 - Status: first-wave runtime schemas, public docs sync, submit-time validation,
-  and pre-verifier validation are implemented.
-- Remaining: make external/helper workflows call `/jobs/validate-submission`
-  before consuming a claim/submit attempt, and add signed registration before
-  tightening custom/off-platform schema refs.
+  pre-verifier validation, schema-native submission metadata, the read-only
+  `/jobs/validate-submission` route, SDK validation helpers, and the exact
+  submit contract in job definitions/preflight are implemented. The operator
+  run detail UI surfaces the submission contract and validate-draft affordance,
+  and the hosted product-proof worker loop now validates its structured
+  submission before claiming.
+- Remaining: prove the hosted UI/API path end-to-end, extend the
+  validation-before-claim pattern to remaining third-party/helper workflows,
+  and add signed registration before tightening custom/off-platform schema refs.
 
 ### Verifier Replay Hardening
 
-- Add `evidenceSchemaRef` or `submissionSchemaRef` where missing.
-- Split verifier policy version from verifier config version when rules move
-  beyond simple config data.
-- Add handler-versioned replay fixtures before v2 verifier handlers.
+- Status: first-wave schema refs, versioned fixtures, and replay metadata are
+  now present for the current verifier set.
+- Remaining: split verifier policy version from verifier config version before
+  rules move beyond simple config data, and require handler-versioned replay
+  fixtures before adding v2 verifier handlers.
 
 ### Dispute And Arbitration Flow
 
-Code-side wiring is in place; remaining work is operator provisioning + frontend surfacing.
-
-- [x] On-chain dispute path: `POST /disputes/:id/verdict` calls `gateway.resolveDispute` which dispatches `EscrowCore.resolveDispute(jobId, workerPayout, reasonCode, metadataURI)` via the configured arbitrator signer and waits for the receipt. With blockchain disabled the response carries `chainStatus: "local_only"`.
-- [x] Arbitrator reasoning persisted under `/content/:hash` via `buildDisputeReasoningReceipt` (owner-only, 6-month auto-public per disclosure model). `metadataURI` surfaces on the verdict response and in the `escrow.dispute_resolved` event.
-- [x] Dispute projection (`GET /disputes`, `GET /disputes/:id`) exposes `openedAt` (disputedAt), `windowEndsAt`, `slaSeconds`, `reasonCode`, `txHash`, `chainStatus`. Same fields land on the verdict + release events so timeline consumers don't need a separate fetch.
-- [x] Dispute helpers (`buildDisputeReasoningReceipt`, payload normalizers, `publicContentUri`) extracted into `mcp-server/src/core/dispute-resolution.js` with unit-test coverage. Smoke test asserts the new dispute-body / event fields and rejects an invalid verdict with 400.
-- [ ] Operator app dispute queue UI consumes the new projection fields (`openedAt` / `windowEndsAt` / `slaSeconds` / `chainStatus`).
-- [ ] Phase-0 arbitrator key provisioned: hardware wallet (Ledger) holding a single approved address recorded in `TreasuryPolicy.arbitrators` via multisig `setArbitrator(...)`, separate from the multisig cold key.
-- [ ] Backend env wired for production: `AVERRAY_RPC_URL`, `ESCROW_CORE_ADDRESS`, arbitrator signer key (verifies via `gateway.isEnabled() === true` at boot). With these unset the verdict response carries `chainStatus: "local_only"` and no `txHash`.
-- [ ] Dispute notification path live (email or messaging channel — out-of-band, not a backend code gate).
+- Status: dispute verdict/release mutations now use scoped idempotency
+  envelopes, and `POST /disputes/:id/verdict` dispatches
+  `EscrowCore.resolveDispute` when the blockchain gateway is enabled.
+- Remaining: prove the verdict path on the hosted stack with the configured
+  arbitrator/gateway, decide whether `/release` stays a local mutual-release
+  receipt or needs an explicit on-chain release action, store arbitrator
+  reasoning under `/content/:hash`, surface `disputedAt`, SLA countdown, reason
+  code, and on-chain tx state in the operator app, and provision/rehearse the
+  phase-0 arbitrator key plus notification path.
 
 ### Idempotency And Mutation Hardening
 
@@ -198,19 +208,19 @@ Code-side wiring is in place; remaining work is operator provisioning + frontend
 
 ### Timeline And Operator UX
 
-- Fold funding, settlement, and dispute state into the same canonical trace.
-- Standardize remaining producer topics/payloads.
-- Add visible operator controls for source, topic, wallet, and correlation-id
-  timeline filters.
+- Status: backend and client timeline surfaces support source, topic, phase,
+  severity, correlation-id, wallet filters, and persisted event replay.
+- Remaining: fold funding, settlement, and dispute state into the same
+  canonical trace, standardize remaining producer topics/payloads, and finish
+  exposing the filter controls coherently across the operator app.
 
 ### Capability Model
 
-- Add operator grant/revoke flows for scoped service tokens or delegated
-  wallets.
-- Align public onboarding action requirements with the runtime auth-policy
-  payload.
-- Hide or disable frontend controls from `authPolicy.uiControls`.
-- Emit audit events when capability grants change.
+- Status: typed SDK surface and docs for scoped service tokens are present.
+- Remaining: add operator grant/revoke runtime flows for scoped service tokens
+  or delegated wallets, align public onboarding action requirements with the
+  runtime auth-policy payload, hide or disable frontend controls from
+  `authPolicy.uiControls`, and emit audit events when capability grants change.
 
 ### Secrets Phase 2+ And Mainnet Custody
 
@@ -242,12 +252,20 @@ Code-side wiring is in place; remaining work is operator provisioning + frontend
 
 ## Polkadot Docs Check
 
-Checked with the Polkadot docs MCP on 2026-05-13:
+Checked with the Polkadot docs MCP on 2026-05-14:
 
 - ERC20 precompile docs still support the USDC Trust-Backed Asset path on
-  Polkadot Hub.
-- XCM precompile docs still describe the low-level `execute`, `send`, and
-  `weighMessage` surface.
+  Polkadot Hub: Trust-Backed Asset ID `1337`, symbol `USDC`, 6 decimals,
+  precompile address `0x0000053900000000000000000000000001200000`.
+- XCM precompile docs still describe the fixed precompile address
+  `0x00000000000000000000000000000000000a0000`, the low-level `execute`,
+  `send`, and `weighMessage` surface, and the requirement that messages are
+  SCALE-encoded. The docs explicitly leave higher-level abstractions to be
+  built on top, which supports the backend assembler design.
+- Data-storage docs still describe Bulletin Chain as retention-limited,
+  authorization-gated storage with renewal by `(block, index)` and a mainnet
+  authorization model still being finalized. That keeps the spec's
+  Bulletin-vs-Crust choice deferred.
 - Polkadot docs continue to point to PAPI and Chopsticks for XCM construction,
   replay, and dry-run validation.
 
@@ -262,8 +280,9 @@ correlation and settlement path.
    production stack (the code path and `/admin/status` evidence fields are
    landed; see `PRODUCTION_CHECKLIST.md` section 5 for the `curl | jq`
    sign-off).
-3. Tighten schema-native jobs for first-wave job families.
-4. Finish dispute/arbitration launch path.
+3. Prove the hosted schema-native validation path and external helper adoption.
+4. Prove the dispute verdict path live and decide `/release` semantics.
 5. Run the native XCM evidence pack captures.
-6. Add visible timeline filters in the operator app.
+6. Continue folding funding/settlement/dispute events into the canonical
+   timeline and finish visible filter adoption where still missing.
 7. Continue Phase 2+ secrets cleanup and signer custody hardening.

--- a/docs/schemas/jobs/product-proof-worker-loop.json
+++ b/docs/schemas/jobs/product-proof-worker-loop.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "schema://jobs/product-proof-worker-loop",
+  "title": "Product Proof Worker Loop",
+  "description": "Structured evidence from the hosted product-proof worker loop.",
+  "type": "object",
+  "properties": {
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "output": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "complete"
+      ]
+    },
+    "job_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "completed_at": {
+      "type": "string",
+      "minLength": 1
+    },
+    "checks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pass",
+              "warn",
+              "fail"
+            ]
+          },
+          "evidence": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "name",
+          "status",
+          "evidence"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "summary",
+    "output",
+    "status",
+    "checks"
+  ],
+  "additionalProperties": false
+}

--- a/mcp-server/src/core/job-schema-registry.js
+++ b/mcp-server/src/core/job-schema-registry.js
@@ -446,6 +446,30 @@ const BUILTIN_JOB_SCHEMAS = new Map([
       },
       review_notes: stringSchema({ minLength: 1 })
     }
+  })],
+  ["schema://jobs/product-proof-worker-loop", objectSchema({
+    $id: "schema://jobs/product-proof-worker-loop",
+    description: "Structured evidence from the hosted product-proof worker loop.",
+    required: ["summary", "output", "status", "checks"],
+    properties: {
+      summary: stringSchema({ minLength: 1 }),
+      output: stringSchema({ minLength: 1 }),
+      status: enumString(["complete"]),
+      job_id: stringSchema({ minLength: 1 }),
+      completed_at: stringSchema({ minLength: 1 }),
+      checks: {
+        type: "array",
+        minItems: 1,
+        items: objectSchema({
+          required: ["name", "status", "evidence"],
+          properties: {
+            name: stringSchema({ minLength: 1 }),
+            status: enumString(["pass", "warn", "fail"]),
+            evidence: stringSchema({ minLength: 1 })
+          }
+        })
+      }
+    }
   })]
 ]);
 

--- a/mcp-server/src/core/job-schema-registry.test.js
+++ b/mcp-server/src/core/job-schema-registry.test.js
@@ -233,6 +233,27 @@ test("validateStructuredSubmission accepts OpenAPI audit evidence", () => {
   });
 });
 
+test("validateStructuredSubmission accepts product-proof worker-loop evidence", () => {
+  const payload = {
+    summary: "complete verified output for product-proof-worker-loop-1700000000000",
+    output: "complete verified output for product-proof-worker-loop-1700000000000",
+    status: "complete",
+    job_id: "product-proof-worker-loop-1700000000000",
+    completed_at: "2026-05-13T11:11:31.000Z",
+    checks: [
+      {
+        name: "worker_output",
+        status: "pass",
+        evidence: "Benchmark output contains the required terms."
+      }
+    ]
+  };
+
+  assert.doesNotThrow(() => {
+    validateStructuredSubmission("schema://jobs/product-proof-worker-loop", payload);
+  });
+});
+
 test("validateStructuredSubmission rejects missing required fields", () => {
   assert.throws(
     () => validateStructuredSubmission("schema://jobs/pr-review-findings-output", {

--- a/scripts/ops/check-product-proof-gate.mjs
+++ b/scripts/ops/check-product-proof-gate.mjs
@@ -196,6 +196,13 @@ function assertWorkerLoopCompletionEvidence(evidence, { apiBaseUrl }) {
   assert.notEqual(evidence.preflightReadiness?.currentWalletCanClaim, false, "worker-loop evidence requires currentWalletCanClaim not false");
   assert.equal(evidence.preflightReadiness?.requiredOutputSchema, "schema://jobs/product-proof-worker-loop", "worker-loop evidence must use the product-proof output schema");
 
+  assert.equal(evidence.validationReadiness?.jobId, evidence.jobId, "worker-loop evidence validation jobId must match evidence jobId");
+  assert.equal(evidence.validationReadiness?.valid, true, "worker-loop evidence requires valid schema validation before claim");
+  assert.equal(evidence.validationReadiness?.schemaRef, "schema://jobs/product-proof-worker-loop", "worker-loop evidence validation schema must match product-proof output schema");
+  assert.equal(evidence.validationReadiness?.schemaValidates, "payload.submission", "worker-loop evidence validation must target payload.submission");
+  assert.equal(evidence.validationReadiness?.submissionKind, "structured", "worker-loop evidence validation must use structured submission");
+  assert.equal(evidence.validationReadiness?.validatedBeforeClaim, true, "worker-loop evidence must prove validation happened before claim");
+
   assert.equal(evidence.claimReadiness?.sessionId, evidence.sessionId, "worker-loop evidence claim sessionId must match evidence sessionId");
   assert.ok(evidence.claimReadiness?.status, "worker-loop evidence requires claim status");
 }

--- a/scripts/ops/check-product-proof-gate.test.mjs
+++ b/scripts/ops/check-product-proof-gate.test.mjs
@@ -267,6 +267,14 @@ function workerLoopEvidence({ wallet, sessionId, jobId }) {
       currentWalletCanClaim: true,
       requiredOutputSchema: "schema://jobs/product-proof-worker-loop"
     },
+    validationReadiness: {
+      jobId,
+      valid: true,
+      schemaRef: "schema://jobs/product-proof-worker-loop",
+      schemaValidates: "payload.submission",
+      submissionKind: "structured",
+      validatedBeforeClaim: true
+    },
     claimReadiness: {
       status: "claimed",
       sessionId

--- a/scripts/ops/run-hosted-worker-loop.mjs
+++ b/scripts/ops/run-hosted-worker-loop.mjs
@@ -6,6 +6,7 @@ import { AgentPlatformClient } from "../../sdk/agent-platform-client.js";
 import { DEFAULT_ESCROW_ASSET } from "../../mcp-server/src/core/assets.js";
 
 const DEFAULT_API_BASE_URL = "https://api.averray.com";
+const PRODUCT_PROOF_OUTPUT_SCHEMA_REF = "schema://jobs/product-proof-worker-loop";
 // Above USDC's current Asset Hub minBalance of 70_000 base units. The
 // explicit minBalance preflight below remains the launch gate; this is
 // just a humane default for manual workflow dispatches.
@@ -36,6 +37,7 @@ export async function runHostedWorkerLoop({
   const jobId = env.PRODUCT_PROOF_JOB_ID || `product-proof-worker-loop-${timestamp}`;
   const idempotencyKey = env.PRODUCT_PROOF_IDEMPOTENCY_KEY || `product-proof:${jobId}`;
   const evidence = env.PRODUCT_PROOF_SUBMISSION || `complete verified output for ${jobId}`;
+  const submission = buildProductProofSubmission({ jobId, evidence, timestamp });
   const rewardAmountInput = parsePositiveDecimalString(env.PRODUCT_PROOF_REWARD_AMOUNT, DEFAULT_REWARD_AMOUNT);
   const rewardAmount = Number(rewardAmountInput);
   const rewardAsset = normalizeAssetSymbol(env.PRODUCT_PROOF_REWARD_ASSET || REQUIRED_ESCROW_ASSET.symbol);
@@ -79,7 +81,7 @@ export async function runHostedWorkerLoop({
     requiresSponsoredGas: true,
     claimTtlSeconds: 3600,
     retryLimit: 1,
-    outputSchemaRef: "schema://jobs/product-proof-worker-loop"
+    outputSchemaRef: PRODUCT_PROOF_OUTPUT_SCHEMA_REF
   });
   if (created?.id !== jobId) {
     throw new Error(`created job id mismatch: expected ${jobId}, got ${created?.id ?? "missing"}`);
@@ -89,6 +91,14 @@ export async function runHostedWorkerLoop({
   const preflight = await platform.preflightJob(jobId);
   const preflightReadiness = assertClaimPreflightReady({ preflight, jobId, wallet });
 
+  log(`Validating hosted product-proof submission for ${jobId}`);
+  const validationReadiness = await assertSubmissionValidationReady({
+    platform,
+    jobId,
+    preflightReadiness,
+    submission
+  });
+
   log(`Claiming hosted product-proof job ${jobId}`);
   const claim = await platform.claimJob(jobId, idempotencyKey);
   const sessionId = claim?.sessionId;
@@ -97,7 +107,7 @@ export async function runHostedWorkerLoop({
   }
 
   log(`Submitting hosted product-proof session ${sessionId}`);
-  const submit = await platform.submitWork(sessionId, evidence);
+  const submit = await platform.submitWork(sessionId, submission);
   if (submit?.status !== "submitted") {
     throw new Error(`expected submitted status, got ${submit?.status ?? "missing"}`);
   }
@@ -141,6 +151,7 @@ export async function runHostedWorkerLoop({
     rewardReadiness,
     liquidityReadiness,
     preflightReadiness,
+    validationReadiness,
     claimReadiness: {
       status: claim.status ?? null,
       sessionId,
@@ -158,6 +169,61 @@ export async function runHostedWorkerLoop({
   }
 
   return evidenceDoc;
+}
+
+function buildProductProofSubmission({ jobId, evidence, timestamp }) {
+  const completedAt = new Date(timestamp).toISOString();
+  return {
+    summary: evidence,
+    output: evidence,
+    status: "complete",
+    job_id: jobId,
+    completed_at: completedAt,
+    checks: [
+      {
+        name: "worker_output",
+        status: "pass",
+        evidence
+      },
+      {
+        name: "schema_contract",
+        status: "pass",
+        evidence: `Submission targets ${PRODUCT_PROOF_OUTPUT_SCHEMA_REF}.`
+      }
+    ]
+  };
+}
+
+async function assertSubmissionValidationReady({ platform, jobId, preflightReadiness, submission }) {
+  if (typeof platform.validateJobSubmission !== "function") {
+    throw new Error("Hosted product-proof worker loop requires /jobs/validate-submission before claim.");
+  }
+  const validation = await platform.validateJobSubmission(jobId, submission);
+  if (!validation || typeof validation !== "object") {
+    throw new Error("Hosted product-proof worker loop requires a validation response before claim.");
+  }
+  if (validation.jobId && validation.jobId !== jobId) {
+    throw new Error(`submission validation job id mismatch: expected ${jobId}, got ${validation.jobId}`);
+  }
+  if (validation.valid !== true) {
+    const code = validation.code ?? "invalid_submission";
+    const message = validation.message ?? "submission failed schema validation";
+    throw new Error(`submission validation failed before claim: code=${code}; message=${message}`);
+  }
+  const expectedSchemaRef = preflightReadiness.requiredOutputSchema ?? PRODUCT_PROOF_OUTPUT_SCHEMA_REF;
+  if (validation.schemaRef && validation.schemaRef !== expectedSchemaRef) {
+    throw new Error(
+      `submission validation schema mismatch: expected ${expectedSchemaRef}, got ${validation.schemaRef}`
+    );
+  }
+  return {
+    jobId,
+    valid: true,
+    schemaRef: validation.schemaRef ?? expectedSchemaRef,
+    schemaValidates: validation.schemaValidates ?? "payload.submission",
+    submissionKind: validation.submissionKind ?? "structured",
+    validatedBeforeClaim: true
+  };
 }
 
 async function assertProductProofLiquidity({ platform, wallet, rewardAsset, rewardAmount, settlementReadiness }) {

--- a/scripts/ops/run-hosted-worker-loop.test.mjs
+++ b/scripts/ops/run-hosted-worker-loop.test.mjs
@@ -34,12 +34,16 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
       calls.push(["preflightJob", id]);
       return preflightReady({ jobId: id, wallet });
     },
+    async validateJobSubmission(id, submission) {
+      calls.push(["validateJobSubmission", id, submission]);
+      return validationReady({ jobId: id });
+    },
     async claimJob(id, idempotencyKey) {
       calls.push(["claimJob", id, idempotencyKey]);
       return { status: "claimed", sessionId, claimExpiresAt: "2026-01-01T01:00:00.000Z" };
     },
-    async submitWork(id, evidence) {
-      calls.push(["submitWork", id, evidence]);
+    async submitWork(id, submission) {
+      calls.push(["submitWork", id, submission]);
       return { status: "submitted", sessionId: id };
     },
     async runVerifier(id, evidence) {
@@ -82,6 +86,7 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
     "getAccountSummary",
     "createJob",
     "preflightJob",
+    "validateJobSubmission",
     "claimJob",
     "submitWork",
     "runVerifier",
@@ -92,7 +97,9 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
   assert.equal(calls[3][1].verifierMode, "benchmark");
   assert.equal(calls[3][1].rewardAsset, "USDC");
   assert.equal(calls[3][1].rewardAmount, 0.1);
-  assert.equal(calls[5][2], `product-proof:${jobId}`);
+  assert.equal(calls[5][2].summary, `complete verified output for ${jobId}`);
+  assert.equal(calls[6][2], `product-proof:${jobId}`);
+  assert.equal(calls[7][2].status, "complete");
 
   const written = JSON.parse(await readFile(evidenceFile, "utf8"));
   assert.equal(written.jobId, jobId);
@@ -107,6 +114,11 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
   assert.ok(written.authReadiness.capabilitiesPresent.includes("verifier:run"));
   assert.equal(written.preflightReadiness.eligible, true);
   assert.equal(written.preflightReadiness.requiredOutputSchema, "schema://jobs/product-proof-worker-loop");
+  assert.equal(written.validationReadiness.valid, true);
+  assert.equal(written.validationReadiness.schemaRef, "schema://jobs/product-proof-worker-loop");
+  assert.equal(written.validationReadiness.schemaValidates, "payload.submission");
+  assert.equal(written.validationReadiness.submissionKind, "structured");
+  assert.equal(written.validationReadiness.validatedBeforeClaim, true);
   assert.equal(written.claimReadiness.status, "claimed");
   assert.equal(written.claimReadiness.claimExpiresAt, "2026-01-01T01:00:00.000Z");
   assert.equal(written.submitStatus, "submitted");
@@ -177,6 +189,9 @@ test("runHostedWorkerLoop accepts an explicit positive reward amount", async () 
     async preflightJob(id) {
       calls.push(["preflightJob", id]);
       return preflightReady({ jobId: id });
+    },
+    async validateJobSubmission(id) {
+      return validationReady({ jobId: id });
     },
     async claimJob(id) {
       return { status: "claimed", sessionId: `${id}:wallet` };
@@ -331,6 +346,66 @@ test("runHostedWorkerLoop fails closed after job creation when preflight blocks 
     "preflightJob"
   ]);
   assert.equal(calls[4][1], jobId);
+});
+
+test("runHostedWorkerLoop fails closed after preflight when schema validation blocks submit", async () => {
+  const calls = [];
+  const jobId = "product-proof-worker-loop-1700000000000";
+  await assert.rejects(
+    runHostedWorkerLoop({
+      client: {
+        async getAuthSession() {
+          calls.push(["getAuthSession"]);
+          return authSession();
+        },
+        async getAdminStatus() {
+          calls.push(["getAdminStatus"]);
+          return settlementReadyStatus();
+        },
+        async getAccountSummary() {
+          calls.push(["getAccountSummary"]);
+          return accountSummary({ liquidUsdcRaw: 100_000 });
+        },
+        async createJob(payload) {
+          calls.push(["createJob", payload]);
+          return { id: payload.id };
+        },
+        async preflightJob(id) {
+          calls.push(["preflightJob", id]);
+          return preflightReady({ jobId: id });
+        },
+        async validateJobSubmission(id, submission) {
+          calls.push(["validateJobSubmission", id, submission]);
+          return {
+            jobId: id,
+            valid: false,
+            schemaRef: "schema://jobs/product-proof-worker-loop",
+            code: "invalid_request",
+            message: "submission.output is required"
+          };
+        },
+        async claimJob() {
+          calls.push(["claimJob"]);
+          throw new Error("should not claim after validation fails");
+        }
+      },
+      now: () => 1700000000000,
+      log: () => {},
+      env: { ADMIN_JWT: "token" }
+    }),
+    /submission validation failed before claim: code=invalid_request; message=submission\.output is required/u
+  );
+
+  assert.deepEqual(calls.map(([name]) => name), [
+    "getAuthSession",
+    "getAdminStatus",
+    "getAccountSummary",
+    "createJob",
+    "preflightJob",
+    "validateJobSubmission"
+  ]);
+  assert.equal(calls[5][1], jobId);
+  assert.equal(calls[5][2].status, "complete");
 });
 
 test("runHostedWorkerLoop fails closed before mutation when settlement is not ready", async () => {
@@ -587,6 +662,19 @@ function preflightReady({
     verifierMode: "benchmark",
     totalClaimLock: 0,
     claimEconomicsWaived: true
+  };
+}
+
+function validationReady({
+  jobId,
+  schemaRef = "schema://jobs/product-proof-worker-loop"
+}) {
+  return {
+    jobId,
+    valid: true,
+    schemaRef,
+    schemaValidates: "payload.submission",
+    submissionKind: "structured"
   };
 }
 

--- a/sdk/agent-platform-client.d.ts
+++ b/sdk/agent-platform-client.d.ts
@@ -548,6 +548,20 @@ export interface WikipediaInfoboxConsistencyOutput {
   }>;
   review_notes: string;
 }
+
+/** Structured evidence from the hosted product-proof worker loop. */
+export interface ProductProofWorkerLoop {
+  summary: string;
+  output: string;
+  status: "complete";
+  job_id?: string;
+  completed_at?: string;
+  checks: Array<{
+    name: string;
+    status: "pass" | "warn" | "fail";
+    evidence: string;
+  }>;
+}
 export interface BuiltinJobSchemaMap {
   "schema://jobs/coding-input": CodingInput;
   "schema://jobs/coding-output": CodingOutput;
@@ -572,6 +586,7 @@ export interface BuiltinJobSchemaMap {
   "schema://jobs/wikipedia-citation-repair-output": WikipediaCitationRepairOutput;
   "schema://jobs/wikipedia-freshness-check-output": WikipediaFreshnessCheckOutput;
   "schema://jobs/wikipedia-infobox-consistency-output": WikipediaInfoboxConsistencyOutput;
+  "schema://jobs/product-proof-worker-loop": ProductProofWorkerLoop;
 }
 
 export type BuiltinJobSchemaRef = keyof BuiltinJobSchemaMap;


### PR DESCRIPTION
## Summary
- add the built-in schema://jobs/product-proof-worker-loop output contract and sync the public schema JSON + SDK types
- make the hosted product-proof worker loop validate its structured submission with /jobs/validate-submission before claim, then submit the same structured object
- require validation evidence in the product-proof gate and update the spec audit/roadmap notes

## Checks
- npm --workspace mcp-server test
- npm run test:ops
- npm run test:sdk
- npm run check:job-schemas

## Surface
Backend/schema registry, SDK declarations, ops scripts, docs. No contract or frontend runtime changes.