### PR TITLE
Fix blockchain audit gaps

### DIFF
--- a/contracts/EscrowCore.sol
+++ b/contracts/EscrowCore.sol
@@ -359,6 +359,7 @@ contract EscrowCore is ReentrancyGuard {
         JobEscrow storage job = _jobs[jobId];
         if (job.state != JobState.Claimed) revert InvalidState();
         if (msg.sender != job.worker) revert Unauthorized();
+        if (block.timestamp > job.claimExpiry) revert InvalidState();
         latestEvidence[jobId] = evidenceHash;
         job.state = JobState.Submitted;
         emit WorkSubmitted(jobId, msg.sender, evidenceHash);

--- a/docs/AVERRAY_WORKING_SPEC.md
+++ b/docs/AVERRAY_WORKING_SPEC.md
@@ -1,7 +1,7 @@
 # Averray — Working Spec (v1.0.0-rc1)
 
 **Status:** Reconciled with deployed reality and operational docs
-**Spec version:** 2.8 (merged competitive intel + distribution sections from v2.3/v2.4 parallel branch; Path A on-ramp lock, target verticals, agent-discovery surfaces ported into §10; agent-submitted-work abuse vectors added to §9 threat model; §12 gained operator-onboarding + distribution checklist items; companion `DISTRIBUTION_STRATEGY.md` published)
+**Spec version:** 2.9 (blockchain audit follow-up: gateway display/base-unit boundary documented and fixed, `submitWork` claim-expiry guard tracked, async XCM remaining gates clarified, relayed borrow/repay gap recorded)
 **Owner:** Pascal
 
 ---
@@ -599,6 +599,7 @@ Before any v1.0.0-rc1 deploy (testnet or mainnet), the following must be address
 - [x] `SUPPORTED_ASSETS_JSON` env var set to: `[{"symbol":"USDC","assetClass":"trust_backed","assetId":1337,"address":"0x0000053900000000000000000000000001200000","decimals":6}]`
 - [x] Existing `BORROW_CAP` constant re-denominated from "25 DOT" to USDC equivalent (`25 USDC`, raw `25000000`)
 - [x] All decimals-aware helpers in repo audited for the 18→6 change; launch-facing job sourcing, SDK defaults, profile/badge metadata, and recurring-job fallbacks now default to USDC/6. Remaining DOT/18 constants are intentionally local mock/test or DOT/vDOT strategy-path specific.
+- [x] Blockchain gateway display/base-unit boundary audited: API inputs stay display-denominated, contract calls convert to raw base units, and account/XCM reads expose display values plus explicit `*Raw` fields.
 - [x] Test ERC20 (TestDOT-style) deployments removed from v1.0.0-rc1 scope — USDC precompile is real on both networks, no mock needed
 
 ---
@@ -616,7 +617,8 @@ To live in `THREAT_MODEL.md`:
 - **Disclosure window abuse.** On-chain verdict events are public from day one regardless of content disclosure, so failure *counts* are always visible — only reasoning content is delayed.
 - **Maintainer-side reputation poisoning.** Hostile maintainer mass-closing PRs to harm specific wallets. Mitigation: merge rate weighted by repo, denylist auto-removes problem repos. Single-actor harm is bounded.
 - **Native XCM observer correlation gap.** Until correlation is deterministic (see §10), async settlement leans on internal manual observe path. Subscan or paid third-party as fallback if internal observer fails.
-- **Async XCM lane: untrusted input surface.** Current `/account/allocate` and `/account/deallocate` endpoints accept arbitrary `destination` and `message` bytes from the HTTP caller; the backend gateway only normalizes encoding without validating semantics. `XcmWrapper` then hashes and queues whatever was passed in. Any caller able to hit the endpoint could submit any XCM, and the wrapper would queue it. Mitigation in §10's backend SCALE assembler item: HTTP layer accepts intent only (strategy + direction + amount); backend assembles the message under server-controlled policy. Until then, async treasury endpoints must remain admin-gated.
+- **Async XCM lane: dispatch and observer gap.** The untrusted raw-byte input surface is closed: HTTP accepts intent only and the backend assembler appends `SetTopic(requestId)` before calling `XcmWrapper`. Remaining risk is that `XcmWrapper.queueRequest` is still a durable intent ledger, not a live call to the Hub XCM precompile, and the native observer proof is not yet production truth. Until precompile dispatch and observer evidence are captured, async treasury endpoints stay admin-gated/staging-only.
+- **Relayed borrow/repay signer mismatch.** `AgentAccountCore.borrow` and `repay` mutate `msg.sender`; a backend hot signer cannot safely relay those calls on behalf of an authenticated wallet. The backend must either require the signer wallet to equal the authenticated wallet or ship explicit contract primitives such as `borrowFor` / `repayFor` with policy checks. Current branch takes the conservative route and refuses mismatched signer/wallet calls.
 - **USDC issuer dependency (Circle).** Choosing USDC for v1 escrow inherits Circle's operational risks: address blacklisting, freeze events, regulatory action against Circle, USDC depeg moments (e.g. March 2023 SVB exposure). None are mitigatable from Averray's side once the asset is locked. Treasury controls cannot be re-acquired if Circle freezes a relevant address. Acceptable risk for v1 (USDC is broadly considered the most transparent stablecoin on reserves), but worth being explicit. Mitigations available later: multi-asset settlement (allow USDt as alternative), eventual native-DOT settlement when contract surface supports it, or escrow asset hot-swappability via governance.
 - **USDC regulatory exposure.** Stablecoin treatment varies by jurisdiction. Averray accepting and disbursing USDC at scale may attract regulatory attention (money transmission, MSB licensing depending on jurisdiction) that pure-DOT settlement would not. Worth tracking as the platform scales; not blocking v1 launch but worth a legal review before significant volume.
 - **Agent-submitted work as money-laundering vector.** A platform where anyone can post a bounty, an agent claims and "completes" it, and funds flow out as legitimate earnings is structurally a money-laundering candidate (post a bounty with dirty funds → agent claims → "clean" funds withdraw). The same concern surfaced publicly in third-party threads about this exact platform model (see v2.8 reconciliation log for competitive intel). Mitigations to consider before significant volume: (a) poster KYC/reputation gating above a per-poster-monthly-funding threshold, (b) work-quality auditing that makes purely-rubber-stamp jobs harder to execute, (c) on-chain analysis of poster funding sources (mixers, sanctioned addresses), (d) deliberate friction on poster-and-agent being same-operator. None are needed for bootstrap (Pascal is the only poster); all become material once external posters arrive. Worth explicit treatment in `THREAT_MODEL.md`.
@@ -635,8 +637,9 @@ Tracked, not in v1.0.0-rc1:
 - **Verifier key rotation policy.** Concrete cadence and mechanism. Document in `THREAT_MODEL.md` as an explicit gap.
 - **Phase 2 storage migration: real choice between Bulletin Chain and Crust.** Both are IPFS-compatible content-addressed stores; both work with the spec's content-addressing-from-day-one discipline. Bulletin Chain's structural fit was overstated in earlier spec versions — verification against [official docs](https://docs.polkadot.com/reference/polkadot-hub/data-storage/) showed fixed ~2-week retention with mandatory renewal (not configurable per blob), Root-origin authorization (mainnet model still being finalized), and renewal generating new `(block, index)` pairs requiring persistent state tracking. Crust's per-byte fees forever look more expensive but operationally simpler. Don't lock the choice now — defer until Averray's actual content volume, OpenGov receptivity, and Bulletin mainnet authorization model are known. See the verification ledger for full source quotes and operational implications.
 - **Subjective job types** (translations, summaries, reports). Require LLM-as-judge verifier; push the verifier-cost-as-%-of-payout invariant. Re-price before introducing.
-- **Backend SCALE assembler with SetTopic = requestId.** Foundational. The current async XCM lane is scaffolded but not built: `XcmWrapper.queueRequest` is a passthrough (it hashes raw `destination`/`message` bytes and emits `RequestPayloadStored` with `keccak256(rawBytes)`, which is *not* the XCM-protocol `messageId`); the HTTP API accepts arbitrary bytes from the caller; there is no production SCALE message builder; no SetTopic appears anywhere in the codebase. Required work: build `mcp-server/src/blockchain/xcm-message-builder.js` (PAPI-based; ParaSpell evaluated as higher-level shortcut). Replace HTTP-input-as-bytes with intent-based routing (`{ strategyId, direction, amount }`). Backend assigns nonce → mirrors `previewRequestId(context)` formula → assembles SCALE message with `SetTopic(requestId)` as the last instruction → submits to wrapper. v1.x prerequisite for vDOT mainnet.
+- **XCM precompile dispatch.** The server-controlled assembler is shipped in `mcp-server/src/blockchain/xcm-message-builder.js`: HTTP rejects caller-supplied raw `destination`/`message`/`nonce`, backend assigns nonce, mirrors `previewRequestId(context)`, assembles XCM v5 bytes from strategy intent, appends `SetTopic(requestId)` as the last instruction, and submits assembled bytes to `XcmWrapper`. Remaining work before vDOT mainnet is to turn `XcmWrapper.queueRequest` from intent-ledger storage into real Hub XCM precompile dispatch (`weighMessage` + `execute`/`send` as applicable), with failure semantics and fee/weight proof captured in staging.
 - **Native XCM observer correlation gate.** Depends on the assembler. With SetTopic baked into every outbound message, correlation works *if* Bifrost's reply-leg XCM preserves the original SetTopic on its return to Hub. This is the empirical question the Chopsticks experiment validates. Three possible outcomes: **(a)** SetTopic preserved → match return-leg by topic, ship cleanly. **(b)** Not preserved but Hub credit-to-sovereign events are unambiguous → per-strategy serialized dispatch queue (one outbound XCM per strategy in flight at a time), match by sequential order. **(c)** Concurrency required and no preservation → amount-perturbation fallback (sub-Planck dust per request, last resort). v1.x prerequisite for production-volume async strategies.
+- **Relayed borrow/repay contract primitive.** If borrow-to-stake remains a backend-driven UX, add explicit service-operator-gated primitives that mutate the authenticated wallet rather than `msg.sender`; otherwise require wallet-side signing for borrow/repay. Do not let the backend hot signer borrow or repay against its own account while the UI believes it acted for a user.
 - **Liquidation mechanics for borrow facility.** Current `BORROW_CAP = 25 USDC` flat per account; no liquidation. Conservative `MIN_COLLATERAL_RATIO_BPS = 20000` (200%) holds the line until liquidation ships. v2 work.
 - **Reputation-weighted borrow caps.** Today flat. Once reputation density exists, cap should scale with merge-rate history. v2.
 - **Multisig-owns-EVM-contract composition validation.** *Empirical-only — gates `MULTISIG_SETUP.md` from being safely actionable.* The composition `pallet_multisig` SS58 address → `pallet_revive.map_account()` → H160 owner of `TreasuryPolicy` rests on three documented primitives, but the *composition itself* is not documented end-to-end on `docs.polkadot.com`. Running `MULTISIG_SETUP.md §5` against Polkadot Hub TestNet *is* the validation experiment. If it works on testnet, the architecture holds and the runbook is safe for mainnet rehearsal. If it doesn't, the multisig story needs a different shape (e.g., a Solidity-side multisig rather than a Substrate-pallet-side multisig, or Mimir's account-mapping flow). Resolve before tagging `v1.0.0-rc1` for any mainnet-adjacent purpose.
@@ -791,6 +794,7 @@ Before public v1.0.0-rc1 launch:
 - [x] Hash fields live on `JobCreated` / `Submitted` / `Verified`
 - [x] `Disclosed` / `AutoDisclosed` events live on session lifecycle contract
 - [x] `EscrowCore.openDispute` enforces deadline window (`block.timestamp <= rejectedAt + DISPUTE_WINDOW`)
+- [x] `EscrowCore.submitWork` rejects expired claims; workers must submit before `claimExpiry` or reopen through the timeout path
 - [x] `DISPUTE_WINDOW` bumped from 1 day to 7 days
 - [x] `EscrowCore.autoResolveOnTimeout(jobId)` shipped with `ARBITRATOR_SLA = 14 days`
 - [x] `disputedAt` timestamp present on job state and emitted in `DisputeOpened` event
@@ -851,10 +855,11 @@ Before public v1.0.0-rc1 launch:
 - [ ] Public migration commitment to Phase 1 by month 6 or first 50 disputes
 
 **Async XCM (optional for v1.0.0-rc1 minus the wrapper validation, required before vDOT mainnet):**
-- [ ] Backend SCALE assembler shipped (`mcp-server/src/blockchain/xcm-message-builder.js` or equivalent)
-- [ ] HTTP `/account/allocate` and `/account/deallocate` accept intent only, not raw `destination`/`message` bytes
-- [ ] Backend mirrors `previewRequestId(context)` formula and appends `SetTopic(requestId)` to every assembled XCM
-- [ ] `XcmWrapper.queueRequest` SetTopic-validation check live (ships in v1.0.0-rc1 redeployment)
+- [x] Backend SCALE assembler shipped (`mcp-server/src/blockchain/xcm-message-builder.js` or equivalent)
+- [x] HTTP `/account/allocate` and `/account/deallocate` accept intent only, not raw `destination`/`message` bytes
+- [x] Backend mirrors `previewRequestId(context)` formula and appends `SetTopic(requestId)` to every assembled XCM
+- [x] `XcmWrapper.queueRequest` SetTopic-validation check live (ships in v1.0.0-rc1 redeployment)
+- [ ] `XcmWrapper.queueRequest` dispatches through the Hub XCM precompile rather than only recording an intent
 - [ ] Chopsticks experiment confirms Bifrost preserves SetTopic on reply-leg, *or* fallback strategy chosen and documented
 - [ ] Async XCM staging proof captured per `ASYNC_XCM_STAGING.md`
 
@@ -1037,6 +1042,13 @@ Stripe Link's launch and Stripe Sessions 2026 announcements positioned agents as
 ## 15. Reconciliation log
 
 For traceability.
+
+### v2.9 (blockchain audit follow-up)
+
+1. **Gateway unit boundary fixed and documented:** API-facing values remain display-denominated, contract calls convert through asset decimals before `uint256` calls, and chain reads return display values with explicit raw base-unit fields. This closes the USDC 6-decimal corruption risk for account summaries, account mutations, async strategy requests, and XCM request reads.
+2. **`submitWork` deadline guard added:** `EscrowCore.submitWork` now rejects submissions after `claimExpiry`; expired claims must go through `handleClaimTimeout` and be reclaimed. This matches the off-chain lifecycle service and prevents stale workers from bypassing the timeout path on-chain.
+3. **Async XCM status clarified:** the assembler and SetTopic validation are shipped, but live XCM precompile dispatch and native observer proof remain open launch gates for any production vDOT/yield claim.
+4. **Relayed borrow/repay gap recorded:** current contract methods act on `msg.sender`, so backend relay is unsafe for user wallets unless signer == wallet or new `borrowFor`/`repayFor` primitives are added.
 
 ### v2.8 (merge of competitive-intel + distribution sections from parallel v2.3/v2.4 branch)
 

--- a/docs/RC1_WORKING_SPEC.md
+++ b/docs/RC1_WORKING_SPEC.md
@@ -4,7 +4,7 @@
 > This file is retained as historical design context only.
 
 **Status:** Reconciled with deployed reality and operational docs
-**Spec version:** 1.10 (repository sync after Slice 9; v1.9 verification corrections imported, backend SCALE assembler and SetTopic wrapper validation marked shipped, TOKEN_ADDRESS wording aligned with no-native-DOT-precompile correction)
+**Spec version:** 1.11 (blockchain audit follow-up: gateway display/base-unit boundary documented and fixed, `submitWork` claim-expiry guard tracked, async XCM remaining gates clarified, relayed borrow/repay gap recorded)
 **Owner:** Pascal
 
 ---
@@ -493,7 +493,8 @@ To live in `THREAT_MODEL.md`:
 - **Disclosure window abuse.** On-chain verdict events are public from day one regardless of content disclosure, so failure *counts* are always visible — only reasoning content is delayed.
 - **Maintainer-side reputation poisoning.** Hostile maintainer mass-closing PRs to harm specific wallets. Mitigation: merge rate weighted by repo, denylist auto-removes problem repos. Single-actor harm is bounded.
 - **Native XCM observer correlation gap.** Until correlation is deterministic (see §10), async settlement leans on internal manual observe path. Subscan or paid third-party as fallback if internal observer fails.
-- **Async XCM lane: untrusted input surface.** Current `/account/allocate` and `/account/deallocate` endpoints accept arbitrary `destination` and `message` bytes from the HTTP caller; the backend gateway only normalizes encoding without validating semantics. `XcmWrapper` then hashes and queues whatever was passed in. Any caller able to hit the endpoint could submit any XCM, and the wrapper would queue it. Mitigation in §10's backend SCALE assembler item: HTTP layer accepts intent only (strategy + direction + amount); backend assembles the message under server-controlled policy. Until then, async treasury endpoints must remain admin-gated.
+- **Async XCM lane: dispatch and observer gap.** The untrusted raw-byte input surface is closed: HTTP accepts intent only and the backend assembler appends `SetTopic(requestId)` before calling `XcmWrapper`. Remaining risk is that `XcmWrapper.queueRequest` is still a durable intent ledger, not a live call to the Hub XCM precompile, and the native observer proof is not yet production truth. Until precompile dispatch and observer evidence are captured, async treasury endpoints stay admin-gated/staging-only.
+- **Relayed borrow/repay signer mismatch.** `AgentAccountCore.borrow` and `repay` mutate `msg.sender`; a backend hot signer cannot safely relay those calls on behalf of an authenticated wallet. The backend must either require signer wallet == authenticated wallet or ship explicit contract primitives such as `borrowFor` / `repayFor` with policy checks.
 
 ---
 
@@ -506,9 +507,10 @@ Tracked, not in v1.0.0-rc1:
 - **Verifier key rotation policy.** Concrete cadence and mechanism. Document in `THREAT_MODEL.md` as an explicit gap.
 - **Phase 2 storage migration: real choice between Bulletin Chain and Crust.** Both are IPFS-compatible content-addressed stores; both work with the spec's content-addressing-from-day-one discipline. Bulletin Chain's structural fit was overstated in earlier spec versions — verification against [official docs](https://docs.polkadot.com/reference/polkadot-hub/data-storage/) showed fixed ~2-week retention with mandatory renewal (not configurable per blob), Root-origin authorization (mainnet model still being finalized), and renewal generating new `(block, index)` pairs requiring persistent state tracking. Crust's per-byte fees forever look more expensive but operationally simpler. Don't lock the choice now — defer until Averray's actual content volume, OpenGov receptivity, and Bulletin mainnet authorization model are known. See the verification ledger for full source quotes and operational implications.
 - **Subjective job types** (translations, summaries, reports). Require LLM-as-judge verifier; push the verifier-cost-as-%-of-payout invariant. Re-price before introducing.
-- **Backend SCALE assembler hardening.** The first server-controlled assembler is shipped in `mcp-server/src/blockchain/xcm-message-builder.js`: HTTP rejects caller-supplied raw `destination`/`message`/`nonce`, backend assigns nonce, mirrors `previewRequestId(context)`, assembles XCM v5 bytes from strategy intent, appends `SetTopic(requestId)` as the last instruction, and submits assembled bytes to `XcmWrapper`. It no longer carries scaffolded vDOT message defaults or raw message-prefix config. Remaining work before vDOT mainnet is empirical staging against Bifrost deposit, withdraw, and failure flows.
+- **XCM precompile dispatch.** The server-controlled assembler is shipped in `mcp-server/src/blockchain/xcm-message-builder.js`: HTTP rejects caller-supplied raw `destination`/`message`/`nonce`, backend assigns nonce, mirrors `previewRequestId(context)`, assembles XCM v5 bytes from strategy intent, appends `SetTopic(requestId)` as the last instruction, and submits assembled bytes to `XcmWrapper`. Remaining work before vDOT mainnet is to turn `XcmWrapper.queueRequest` from intent-ledger storage into real Hub XCM precompile dispatch (`weighMessage` + `execute`/`send` as applicable), with failure semantics and fee/weight proof captured in staging.
 - **Native XCM observer correlation gate.** Depends on the assembler. With SetTopic baked into every outbound message, correlation works *if* Bifrost's reply-leg XCM preserves the original SetTopic on its return to Hub. This is the empirical question the Chopsticks experiment validates. Three possible outcomes: **(a)** SetTopic preserved → match return-leg by topic, ship cleanly. **(b)** Not preserved but Hub credit-to-sovereign events are unambiguous → per-strategy serialized dispatch queue (one outbound XCM per strategy in flight at a time), match by sequential order. **(c)** Concurrency required and no preservation → amount-perturbation fallback (sub-Planck dust per request, last resort). v1.x prerequisite for production-volume async strategies.
 - **Liquidation mechanics for borrow facility.** Current `BORROW_CAP = 25 USDC` flat per account; no liquidation. Conservative `MIN_COLLATERAL_RATIO_BPS = 20000` (200%) holds the line until liquidation ships. v2 work.
+- **Relayed borrow/repay contract primitive.** If borrow-to-stake remains a backend-driven UX, add explicit service-operator-gated primitives that mutate the authenticated wallet rather than `msg.sender`; otherwise require wallet-side signing for borrow/repay.
 - **Reputation-weighted borrow caps.** Today flat. Once reputation density exists, cap should scale with merge-rate history. v2.
 - **Multisig-owns-EVM-contract composition validation.** *Empirical-only — gates `MULTISIG_SETUP.md` from being safely actionable.* The composition `pallet_multisig` SS58 address → `pallet_revive.map_account()` → H160 owner of `TreasuryPolicy` rests on three documented primitives, but the *composition itself* is not documented end-to-end on `docs.polkadot.com`. Running `MULTISIG_SETUP.md §5` against Polkadot Hub TestNet *is* the validation experiment. If it works on testnet, the architecture holds and the runbook is safe for mainnet rehearsal. If it doesn't, the multisig story needs a different shape (e.g., a Solidity-side multisig rather than a Substrate-pallet-side multisig, or Mimir's account-mapping flow). Resolve before tagging `v1.0.0-rc1` for any mainnet-adjacent purpose.
 - **Phase 1 arbitration (LLM-as-judge calibration).** Tooling that pre-analyzes disputes for human arbitrator review. Override rate is the metric. Trigger: ~50 disputes resolved.
@@ -559,6 +561,7 @@ Before public v1.0.0-rc1 launch:
 - [x] Hash fields live on `JobCreated` / `Submitted` / `Verified`
 - [x] `Disclosed` / `AutoDisclosed` events live on session lifecycle contract
 - [x] `EscrowCore.openDispute` enforces deadline window (`block.timestamp <= rejectedAt + DISPUTE_WINDOW`)
+- [x] `EscrowCore.submitWork` rejects expired claims; workers must submit before `claimExpiry` or reopen through the timeout path
 - [x] `DISPUTE_WINDOW` bumped from 1 day to 7 days
 - [x] `EscrowCore.autoResolveOnTimeout(jobId)` shipped with `ARBITRATOR_SLA = 14 days`
 - [x] `disputedAt` timestamp present on job state and emitted in `DisputeOpened` event
@@ -611,6 +614,7 @@ Before public v1.0.0-rc1 launch:
 - [x] HTTP `/account/allocate` and `/account/deallocate` accept intent only, not raw `destination`/`message` bytes
 - [x] Backend mirrors `previewRequestId(context)` formula and appends `SetTopic(requestId)` to every assembled XCM
 - [x] `XcmWrapper.queueRequest` SetTopic-validation check live (ships in v1.0.0-rc1 redeployment)
+- [ ] `XcmWrapper.queueRequest` dispatches through the Hub XCM precompile rather than only recording an intent
 - [ ] Chopsticks experiment confirms Bifrost preserves SetTopic on reply-leg, *or* fallback strategy chosen and documented
 - [ ] Async XCM staging proof captured per `ASYNC_XCM_STAGING.md`
 
@@ -619,6 +623,13 @@ Before public v1.0.0-rc1 launch:
 ## 13. Reconciliation log
 
 For traceability.
+
+### v1.11 (blockchain audit follow-up)
+
+1. Gateway display/base-unit boundary fixed and documented: contract calls now convert display inputs through asset decimals, and account/XCM reads expose display values plus explicit raw fields.
+2. `EscrowCore.submitWork` now rejects submissions after `claimExpiry`; expired claims must go through the timeout/reclaim path.
+3. Async XCM status clarified: assembler and SetTopic validation are shipped, while live XCM precompile dispatch and native observer proof remain production gates.
+4. Relayed borrow/repay gap recorded: current contract methods act on `msg.sender`, so backend relay is unsafe unless signer == wallet or explicit `borrowFor`/`repayFor` primitives are added.
 
 ### v1.10 (repository sync after Slice 9)
 

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -159,15 +159,29 @@ export class BlockchainGateway {
       const collateralLocked = {};
       const jobStakeLocked = {};
       const debtOutstanding = {};
+      const raw = {
+        liquid: {},
+        reserved: {},
+        strategyAllocated: {},
+        collateralLocked: {},
+        jobStakeLocked: {},
+        debtOutstanding: {}
+      };
 
       for (const asset of this.config.supportedAssets) {
         const position = await this.accountContract.positions(wallet, asset.address);
-        liquid[asset.symbol] = Number(position.liquid);
-        reserved[asset.symbol] = Number(position.reserved);
-        strategyAllocated[asset.symbol] = Number(position.strategyAllocated);
-        collateralLocked[asset.symbol] = Number(position.collateralLocked);
-        jobStakeLocked[asset.symbol] = Number(position.jobStakeLocked);
-        debtOutstanding[asset.symbol] = Number(position.debtOutstanding);
+        raw.liquid[asset.symbol] = this.toRawString(position.liquid);
+        raw.reserved[asset.symbol] = this.toRawString(position.reserved);
+        raw.strategyAllocated[asset.symbol] = this.toRawString(position.strategyAllocated);
+        raw.collateralLocked[asset.symbol] = this.toRawString(position.collateralLocked);
+        raw.jobStakeLocked[asset.symbol] = this.toRawString(position.jobStakeLocked);
+        raw.debtOutstanding[asset.symbol] = this.toRawString(position.debtOutstanding);
+        liquid[asset.symbol] = this.toDisplayUnits(position.liquid, asset);
+        reserved[asset.symbol] = this.toDisplayUnits(position.reserved, asset);
+        strategyAllocated[asset.symbol] = this.toDisplayUnits(position.strategyAllocated, asset);
+        collateralLocked[asset.symbol] = this.toDisplayUnits(position.collateralLocked, asset);
+        jobStakeLocked[asset.symbol] = this.toDisplayUnits(position.jobStakeLocked, asset);
+        debtOutstanding[asset.symbol] = this.toDisplayUnits(position.debtOutstanding, asset);
       }
 
       return {
@@ -177,7 +191,8 @@ export class BlockchainGateway {
         strategyAllocated,
         collateralLocked,
         jobStakeLocked,
-        debtOutstanding
+        debtOutstanding,
+        raw
       };
     });
   }
@@ -193,19 +208,23 @@ export class BlockchainGateway {
     return this.withGatewayError("getStrategyPositions", async () => {
       const entries = [];
       for (const strategy of strategies) {
+        const asset = this.assetForStrategy(strategy);
         const normalizedStrategyId = this.normalizeStrategyId(strategy.strategyId);
         const [rawShares, rawPendingWithdrawalShares, rawPendingDepositAssets] = await Promise.all([
           this.accountContract.strategyShares(wallet, normalizedStrategyId),
           this.accountContract.pendingStrategyWithdrawalShares(wallet, normalizedStrategyId),
-          strategy.asset
-            ? this.accountContract.pendingStrategyAssets(wallet, strategy.asset)
+          asset.address
+            ? this.accountContract.pendingStrategyAssets(wallet, asset.address)
             : Promise.resolve(0n)
         ]);
         entries.push({
           strategyId: strategy.strategyId,
-          shares: Number(rawShares),
-          pendingWithdrawalShares: Number(rawPendingWithdrawalShares),
-          pendingDepositAssets: Number(rawPendingDepositAssets)
+          shares: this.toDisplayUnits(rawShares, asset),
+          sharesRaw: this.toRawString(rawShares),
+          pendingWithdrawalShares: this.toDisplayUnits(rawPendingWithdrawalShares, asset),
+          pendingWithdrawalSharesRaw: this.toRawString(rawPendingWithdrawalShares),
+          pendingDepositAssets: this.toDisplayUnits(rawPendingDepositAssets, asset),
+          pendingDepositAssetsRaw: this.toRawString(rawPendingDepositAssets)
         });
       }
       return entries;
@@ -219,6 +238,7 @@ export class BlockchainGateway {
 
     return Promise.all(
       strategies.map(async (strategy) => {
+        const asset = this.assetForStrategy(strategy);
         const adapterContract = new Contract(strategy.adapter, STRATEGY_ADAPTER_ABI, this.provider);
         try {
           const [rawTotalAssets, rawTotalShares, liveRiskLabel] = await Promise.all([
@@ -226,8 +246,8 @@ export class BlockchainGateway {
             adapterContract.totalShares().catch(() => undefined),
             adapterContract.riskLabel().catch(() => strategy.riskLabel ?? "")
           ]);
-          const totalAssets = Number(rawTotalAssets ?? 0);
-          const totalShares = Number(rawTotalShares ?? 0);
+          const totalAssets = this.toDisplayUnits(rawTotalAssets ?? 0, asset);
+          const totalShares = this.toDisplayUnits(rawTotalShares ?? 0, asset);
           const sharePrice = totalShares > 0 ? totalAssets / totalShares : undefined;
           const performanceBps = Number.isFinite(sharePrice)
             ? Math.round((sharePrice - 1) * 10_000)
@@ -236,7 +256,9 @@ export class BlockchainGateway {
             strategyId: strategy.strategyId,
             adapter: strategy.adapter,
             totalAssets,
+            totalAssetsRaw: this.toRawString(rawTotalAssets ?? 0),
             totalShares,
+            totalSharesRaw: this.toRawString(rawTotalShares ?? 0),
             sharePrice,
             performanceBps,
             riskLabel: liveRiskLabel,
@@ -474,7 +496,7 @@ export class BlockchainGateway {
     return this.withGatewayError("getBorrowCapacity", async () => {
       const asset = this.requireAsset(assetSymbol);
       const value = await this.accountContract.getBorrowCapacity(wallet, asset.address);
-      return Number(value);
+      return this.toDisplayUnits(value, asset);
     });
   }
 
@@ -482,7 +504,8 @@ export class BlockchainGateway {
     return this.withGatewayError("reserveForJob", async () => {
       this.requireSigner("reserveForJob");
       const asset = this.requireAsset(assetSymbol);
-      const tx = await this.accountContract.reserveForJob(wallet, asset.address, amount);
+      const baseAmount = this.toBaseUnits(amount, asset, "job reserve amount");
+      const tx = await this.accountContract.reserveForJob(wallet, asset.address, baseAmount);
       await tx.wait();
       return this.getAccountSummary(wallet);
     });
@@ -508,10 +531,12 @@ export class BlockchainGateway {
     });
   }
 
-  async allocateIdleFunds(wallet, strategyId, amount) {
+  async allocateIdleFunds(wallet, strategyId, amount, assetSymbol = "DOT") {
     return this.withGatewayError("allocateIdleFunds", async () => {
       this.requireSigner("allocateIdleFunds");
-      const tx = await this.accountContract.allocateIdleFunds(wallet, this.normalizeStrategyId(strategyId), amount);
+      const asset = this.requireAsset(assetSymbol);
+      const baseAmount = this.toBaseUnits(amount, asset, "strategy allocation amount");
+      const tx = await this.accountContract.allocateIdleFunds(wallet, this.normalizeStrategyId(strategyId), baseAmount);
       await tx.wait();
       return this.getAccountSummary(wallet);
     });
@@ -522,7 +547,8 @@ export class BlockchainGateway {
       this.requireSigner("deallocateIdleFunds");
       const asset = this.requireAsset(assetSymbol);
       const before = await this.getAccountSummary(wallet);
-      const tx = await this.accountContract.deallocateIdleFunds(wallet, this.normalizeStrategyId(strategyId), amount);
+      const baseAmount = this.toBaseUnits(amount, asset, "strategy deallocation amount");
+      const tx = await this.accountContract.deallocateIdleFunds(wallet, this.normalizeStrategyId(strategyId), baseAmount);
       await tx.wait();
       const after = await this.getAccountSummary(wallet);
       return {
@@ -539,13 +565,15 @@ export class BlockchainGateway {
     return this.withGatewayError("requestStrategyDeposit", async () => {
       this.requireSigner("requestStrategyDeposit");
       this.requireAsyncStrategyConfig(strategy, "requestStrategyDeposit");
+      const asset = this.assetForStrategy(strategy);
+      const baseAmount = this.toBaseUnits(amount, asset, "strategy deposit amount");
       const requestId = this.previewStrategyRequestId({
         strategyId: strategy.strategyId,
         kind: 0,
         account: wallet,
-        asset: strategy.asset,
+        asset: asset.address,
         recipient: wallet,
-        assets: amount,
+        assets: baseAmount,
         shares: 0,
         nonce
       });
@@ -555,11 +583,11 @@ export class BlockchainGateway {
         requestId,
         account: wallet,
         recipient: wallet,
-        amount
+        amount: baseAmount
       });
       const tx = await this.accountContract.requestStrategyDeposit(wallet, {
         strategyId: this.normalizeStrategyId(strategy.strategyId),
-        amount,
+        amount: baseAmount,
         destination: payload.destination,
         message: payload.message,
         maxWeight: this.normalizeWeight(maxWeight ?? payload.maxWeight),
@@ -584,14 +612,16 @@ export class BlockchainGateway {
     return this.withGatewayError("requestStrategyWithdraw", async () => {
       this.requireSigner("requestStrategyWithdraw");
       this.requireAsyncStrategyConfig(strategy, "requestStrategyWithdraw");
+      const asset = this.assetForStrategy(strategy);
+      const baseAmount = this.toBaseUnits(amount, asset, "strategy withdraw amount");
       const shares = Number.isFinite(Number(requestedShares)) && Number(requestedShares) > 0
-        ? Number(requestedShares)
-        : await this.quoteStrategySharesForAssets(strategy, amount);
+        ? this.toBaseUnits(requestedShares, asset, "strategy withdraw shares")
+        : await this.quoteStrategySharesForAssets(strategy, baseAmount);
       const requestId = this.previewStrategyRequestId({
         strategyId: strategy.strategyId,
         kind: 1,
         account: wallet,
-        asset: strategy.asset,
+        asset: asset.address,
         recipient,
         assets: 0,
         shares,
@@ -603,7 +633,7 @@ export class BlockchainGateway {
         requestId,
         account: wallet,
         recipient,
-        amount,
+        amount: baseAmount,
         shares
       });
       const tx = await this.accountContract.requestStrategyWithdraw(wallet, {
@@ -619,28 +649,34 @@ export class BlockchainGateway {
       return {
         ...(await this.getAccountSummary(wallet)),
         requestId,
-        requestedShares: shares,
-        requestedAssets: amount,
+        requestedShares: this.toDisplayUnits(shares, asset),
+        requestedSharesRaw: this.toRawString(shares),
+        requestedAssets: this.toDisplayUnits(baseAmount, asset),
+        requestedAssetsRaw: this.toRawString(baseAmount),
         xcmRequest: await this.getXcmRequest(requestId),
         strategyRequest: await this.getStrategyRequest(requestId)
       };
     });
   }
 
-  async borrow(assetSymbol, amount) {
+  async borrow(wallet, assetSymbol, amount) {
     return this.withGatewayError("borrow", async () => {
       this.requireSigner("borrow");
       const asset = this.requireAsset(assetSymbol);
-      const tx = await this.accountContract.borrow(asset.address, amount);
+      await this.requireSignerWallet(wallet, "borrow");
+      const baseAmount = this.toBaseUnits(amount, asset, "borrow amount");
+      const tx = await this.accountContract.borrow(asset.address, baseAmount);
       await tx.wait();
     });
   }
 
-  async repay(assetSymbol, amount) {
+  async repay(wallet, assetSymbol, amount) {
     return this.withGatewayError("repay", async () => {
       this.requireSigner("repay");
       const asset = this.requireAsset(assetSymbol);
-      const tx = await this.accountContract.repay(asset.address, amount);
+      await this.requireSignerWallet(wallet, "repay");
+      const baseAmount = this.toBaseUnits(amount, asset, "repay amount");
+      const tx = await this.accountContract.repay(asset.address, baseAmount);
       await tx.wait();
     });
   }
@@ -656,7 +692,8 @@ export class BlockchainGateway {
     return this.withGatewayError("sendToAgent", async () => {
       this.requireSigner("sendToAgent");
       const asset = this.requireAsset(assetSymbol);
-      const tx = await this.accountContract.sendToAgentFor(from, recipient, asset.address, amount);
+      const baseAmount = this.toBaseUnits(amount, asset, "agent transfer amount");
+      const tx = await this.accountContract.sendToAgentFor(from, recipient, asset.address, baseAmount);
       await tx.wait();
     });
   }
@@ -1015,13 +1052,17 @@ export class BlockchainGateway {
         asset: record.context.asset,
         assetSymbol: this.resolveAssetSymbol(record.context.asset),
         recipient: record.context.recipient,
-        requestedAssets: Number(record.context.assets),
-        requestedShares: Number(record.context.shares),
+        requestedAssets: this.toDisplayUnits(record.context.assets, this.assetForAddress(record.context.asset)),
+        requestedAssetsRaw: this.toRawString(record.context.assets),
+        requestedShares: this.toDisplayUnits(record.context.shares, this.assetForAddress(record.context.asset)),
+        requestedSharesRaw: this.toRawString(record.context.shares),
         nonce: Number(record.context.nonce),
         status: Number(record.status),
         statusLabel: REQUEST_STATUS_LABELS[Number(record.status)] ?? "unknown",
-        settledAssets: Number(record.settledAssets),
-        settledShares: Number(record.settledShares),
+        settledAssets: this.toDisplayUnits(record.settledAssets, this.assetForAddress(record.context.asset)),
+        settledAssetsRaw: this.toRawString(record.settledAssets),
+        settledShares: this.toDisplayUnits(record.settledShares, this.assetForAddress(record.context.asset)),
+        settledSharesRaw: this.toRawString(record.settledShares),
         remoteRef: this.normalizeOptionalBytes32(record.remoteRef),
         remoteRefLabel: this.decodeBytes32Label(record.remoteRef),
         failureCode: this.normalizeOptionalBytes32(record.failureCode),
@@ -1052,10 +1093,14 @@ export class BlockchainGateway {
         kindLabel: REQUEST_KIND_LABELS[Number(record.kind)] ?? "unknown",
         status: Number(record.status),
         statusLabel: REQUEST_STATUS_LABELS[Number(record.status)] ?? "unknown",
-        requestedAssets: Number(record.requestedAssets),
-        requestedShares: Number(record.requestedShares),
-        settledAssets: Number(record.settledAssets),
-        settledShares: Number(record.settledShares),
+        requestedAssets: this.toDisplayUnits(record.requestedAssets, this.assetForAddress(record.asset)),
+        requestedAssetsRaw: this.toRawString(record.requestedAssets),
+        requestedShares: this.toDisplayUnits(record.requestedShares, this.assetForAddress(record.asset)),
+        requestedSharesRaw: this.toRawString(record.requestedShares),
+        settledAssets: this.toDisplayUnits(record.settledAssets, this.assetForAddress(record.asset)),
+        settledAssetsRaw: this.toRawString(record.settledAssets),
+        settledShares: this.toDisplayUnits(record.settledShares, this.assetForAddress(record.asset)),
+        settledSharesRaw: this.toRawString(record.settledShares),
         remoteRef: this.normalizeOptionalBytes32(record.remoteRef),
         remoteRefLabel: this.decodeBytes32Label(record.remoteRef),
         failureCode: this.normalizeOptionalBytes32(record.failureCode),
@@ -1142,6 +1187,18 @@ export class BlockchainGateway {
     return match ?? { symbol: this.resolveAssetSymbol(assetAddress), address: assetAddress, decimals: 18 };
   }
 
+  assetForStrategy(strategy = {}) {
+    const address = strategy.assetConfig?.address ?? strategy.asset;
+    const known = this.assetForAddress(address);
+    return {
+      ...known,
+      ...(strategy.assetConfig ?? {}),
+      address: address ?? known.address,
+      symbol: strategy.assetConfig?.symbol ?? known.symbol,
+      decimals: strategy.assetConfig?.decimals ?? known.decimals ?? 18
+    };
+  }
+
   assetDecimals(asset) {
     const decimals = Number(asset?.decimals ?? 18);
     if (!Number.isInteger(decimals) || decimals < 0 || decimals > 30) {
@@ -1166,6 +1223,13 @@ export class BlockchainGateway {
 
   toDisplayUnits(amount, asset) {
     return Number(formatUnits(amount ?? 0, this.assetDecimals(asset)));
+  }
+
+  toRawString(amount) {
+    if (amount === undefined || amount === null) {
+      return "0";
+    }
+    return BigInt(amount).toString();
   }
 
   normalizeDecimalAmount(amount, decimals, label) {
@@ -1205,6 +1269,16 @@ export class BlockchainGateway {
     if (!this.signer) {
       throw new ConfigError(`${operation} requires SIGNER_PRIVATE_KEY`);
     }
+  }
+
+  async requireSignerWallet(wallet, operation) {
+    const signerAddress = await this.signer.getAddress();
+    if (!wallet || signerAddress.toLowerCase() !== wallet.toLowerCase()) {
+      throw new ValidationError(
+        `${operation} requires the configured blockchain signer to match the authenticated wallet until a relayed contract primitive exists.`
+      );
+    }
+    return signerAddress;
   }
 
   toJobId(jobId) {
@@ -1353,12 +1427,13 @@ export class BlockchainGateway {
       adapterContract.totalAssets(),
       adapterContract.totalShares()
     ]);
-    const totalAssets = Number(rawTotalAssets ?? 0);
-    const totalShares = Number(rawTotalShares ?? 0);
-    if (!(totalAssets > 0) || !(totalShares > 0)) {
-      return Number(assets);
+    const totalAssets = BigInt(rawTotalAssets ?? 0);
+    const totalShares = BigInt(rawTotalShares ?? 0);
+    const requestedAssets = BigInt(assets ?? 0);
+    if (totalAssets <= 0n || totalShares <= 0n) {
+      return requestedAssets;
     }
-    return Math.ceil((Number(assets) * totalShares) / totalAssets);
+    return (requestedAssets * totalShares + totalAssets - 1n) / totalAssets;
   }
 
   async withGatewayError(operation, action) {

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -23,6 +23,18 @@ function gatewayWithDot() {
   return new BlockchainGateway({ enabled: false, supportedAssets: [DOT_ASSET] });
 }
 
+function emptyPosition(overrides = {}) {
+  return {
+    liquid: 0n,
+    reserved: 0n,
+    strategyAllocated: 0n,
+    collateralLocked: 0n,
+    jobStakeLocked: 0n,
+    debtOutstanding: 0n,
+    ...overrides
+  };
+}
+
 test("toDisputeReasonCode uses Solidity bytes32 string encoding", () => {
   const gateway = new BlockchainGateway({ enabled: false });
 
@@ -159,6 +171,30 @@ test("toBaseUnits converts display asset amounts before uint256 contract calls",
     gateway.toBaseUnits(0.05, DOT_ASSET, "minimum claim fee"),
     50_000_000_000_000_000n
   );
+});
+
+test("getAccountSummary returns display balances and preserves raw base units", async () => {
+  const gateway = new BlockchainGateway({ enabled: false, supportedAssets: [USDC_TRUST_ASSET] });
+  gateway.accountContract = {
+    async positions(wallet, asset) {
+      assert.equal(wallet, "0x3333333333333333333333333333333333333333");
+      assert.equal(asset, USDC_TRUST_ASSET.address);
+      return emptyPosition({
+        liquid: 1_234_500n,
+        reserved: 70_000n,
+        debtOutstanding: 250_000n
+      });
+    }
+  };
+
+  const summary = await gateway.getAccountSummary("0x3333333333333333333333333333333333333333");
+
+  assert.equal(summary.liquid.USDC, 1.2345);
+  assert.equal(summary.reserved.USDC, 0.07);
+  assert.equal(summary.debtOutstanding.USDC, 0.25);
+  assert.deepEqual(summary.raw.liquid, { USDC: "1234500" });
+  assert.deepEqual(summary.raw.reserved, { USDC: "70000" });
+  assert.deepEqual(summary.raw.debtOutstanding, { USDC: "250000" });
 });
 
 test("getClaimEconomicsConfig converts chain min fees back to display units", async () => {
@@ -521,6 +557,146 @@ test("reserveRecurringTemplateFunding converts display amounts and records the t
   ]]);
   assert.equal(receipt.source, "agent_account_recurring_template_reserve");
   assert.equal(receipt.amountRaw, "10000000000000000000");
+});
+
+test("account mutations convert display amounts before contract calls", async () => {
+  const gateway = new BlockchainGateway({ enabled: false, supportedAssets: [USDC_TRUST_ASSET] });
+  const wallet = "0x3333333333333333333333333333333333333333";
+  const recipient = "0x4444444444444444444444444444444444444444";
+  const calls = [];
+  gateway.signer = {
+    async getAddress() {
+      return wallet;
+    }
+  };
+  gateway.accountContract = {
+    async positions() {
+      return emptyPosition();
+    },
+    async reserveForJob(...args) {
+      calls.push(["reserveForJob", ...args]);
+      return { async wait() {} };
+    },
+    async allocateIdleFunds(...args) {
+      calls.push(["allocateIdleFunds", ...args]);
+      return { async wait() {} };
+    },
+    async deallocateIdleFunds(...args) {
+      calls.push(["deallocateIdleFunds", ...args]);
+      return { async wait() {} };
+    },
+    async borrow(...args) {
+      calls.push(["borrow", ...args]);
+      return { async wait() {} };
+    },
+    async repay(...args) {
+      calls.push(["repay", ...args]);
+      return { async wait() {} };
+    },
+    async sendToAgentFor(...args) {
+      calls.push(["sendToAgentFor", ...args]);
+      return { async wait() {} };
+    }
+  };
+
+  await gateway.reserveForJob(wallet, "USDC", 1.25);
+  await gateway.allocateIdleFunds(wallet, "usdc-yield", "2.5", "USDC");
+  await gateway.deallocateIdleFunds(wallet, "usdc-yield", 0.75, "USDC");
+  await gateway.borrow(wallet, "USDC", 3);
+  await gateway.repay(wallet, "USDC", 1.5);
+  await gateway.sendToAgent(wallet, recipient, "USDC", 0.125);
+
+  assert.deepEqual(calls, [
+    ["reserveForJob", wallet, USDC_TRUST_ASSET.address, 1_250_000n],
+    ["allocateIdleFunds", wallet, gateway.normalizeStrategyId("usdc-yield"), 2_500_000n],
+    ["deallocateIdleFunds", wallet, gateway.normalizeStrategyId("usdc-yield"), 750_000n],
+    ["borrow", USDC_TRUST_ASSET.address, 3_000_000n],
+    ["repay", USDC_TRUST_ASSET.address, 1_500_000n],
+    ["sendToAgentFor", wallet, recipient, USDC_TRUST_ASSET.address, 125_000n]
+  ]);
+});
+
+test("borrow refuses to relay for a wallet that is not the configured signer", async () => {
+  const gateway = new BlockchainGateway({ enabled: false, supportedAssets: [USDC_TRUST_ASSET] });
+  gateway.signer = {
+    async getAddress() {
+      return "0x3333333333333333333333333333333333333333";
+    }
+  };
+  gateway.accountContract = {
+    async borrow() {
+      throw new Error("borrow should not be sent");
+    }
+  };
+
+  await assert.rejects(
+    () => gateway.borrow("0x4444444444444444444444444444444444444444", "USDC", 1),
+    /configured blockchain signer/u
+  );
+});
+
+test("async XCM request readers return display amounts and raw base-unit fields", async () => {
+  const gateway = new BlockchainGateway({ enabled: false, supportedAssets: [USDC_TRUST_ASSET] });
+  const requestId = `0x${"1".repeat(64)}`;
+  const account = "0x3333333333333333333333333333333333333333";
+  const recipient = "0x4444444444444444444444444444444444444444";
+  gateway.xcmWrapperContract = {
+    async getRequest(id) {
+      assert.equal(id, requestId);
+      return {
+        context: {
+          strategyId: encodeBytes32String("USDC"),
+          kind: 0,
+          account,
+          asset: USDC_TRUST_ASSET.address,
+          recipient,
+          assets: 1_250_000n,
+          shares: 500_000n,
+          nonce: 7n
+        },
+        status: 1,
+        settledAssets: 250_000n,
+        settledShares: 100_000n,
+        remoteRef: `0x${"0".repeat(64)}`,
+        failureCode: `0x${"0".repeat(64)}`,
+        createdAt: 10n,
+        updatedAt: 12n
+      };
+    }
+  };
+  gateway.accountContract = {
+    async strategyRequests(id) {
+      assert.equal(id, requestId);
+      return {
+        strategyId: encodeBytes32String("USDC"),
+        adapter: "0x5555555555555555555555555555555555555555",
+        account,
+        asset: USDC_TRUST_ASSET.address,
+        recipient,
+        kind: 0,
+        status: 1,
+        requestedAssets: 1_250_000n,
+        requestedShares: 500_000n,
+        settledAssets: 250_000n,
+        settledShares: 100_000n,
+        remoteRef: `0x${"0".repeat(64)}`,
+        failureCode: `0x${"0".repeat(64)}`,
+        settled: false
+      };
+    }
+  };
+
+  const xcmRequest = await gateway.getXcmRequest(requestId);
+  const strategyRequest = await gateway.getStrategyRequest(requestId);
+
+  assert.equal(xcmRequest.requestedAssets, 1.25);
+  assert.equal(xcmRequest.requestedAssetsRaw, "1250000");
+  assert.equal(xcmRequest.requestedShares, 0.5);
+  assert.equal(xcmRequest.settledAssets, 0.25);
+  assert.equal(strategyRequest.requestedAssets, 1.25);
+  assert.equal(strategyRequest.requestedAssetsRaw, "1250000");
+  assert.equal(strategyRequest.settledShares, 0.1);
+  assert.equal(strategyRequest.settledSharesRaw, "100000");
 });
 
 test("createSinglePayoutJobForJob consumes recurring template reserve when funding metadata is present", async () => {

--- a/mcp-server/src/core/account-mutation-service.js
+++ b/mcp-server/src/core/account-mutation-service.js
@@ -326,7 +326,7 @@ export class AccountMutationService {
       throw new ValidationError("amount must be a positive number");
     }
     if (this.blockchainGateway?.isEnabled()) {
-      const liveAccount = await this.blockchainGateway.allocateIdleFunds(wallet, strategyId, amount);
+      const liveAccount = await this.blockchainGateway.allocateIdleFunds(wallet, strategyId, amount, asset);
       const account = this.attachStoredTreasuryMetadata(wallet, liveAccount);
       this.markStrategyActivity(account, strategyId, "allocate", amount, asset);
       this.updateStrategyAccountingOnAllocate(account, strategyId, asset, amount);
@@ -548,7 +548,7 @@ export class AccountMutationService {
     }
 
     if (this.blockchainGateway?.isEnabled()) {
-      await this.blockchainGateway.borrow(asset, amount);
+      await this.blockchainGateway.borrow(wallet, asset, amount);
       const account = this.attachStoredTreasuryMetadata(wallet, await this.getAccountSummary(wallet));
       this.recordTreasuryEvent(account, { type: "borrow", asset, amount });
       this.accounts.set(wallet, account);
@@ -612,7 +612,7 @@ export class AccountMutationService {
       throw new ValidationError("amount must be a positive number");
     }
     if (this.blockchainGateway?.isEnabled()) {
-      await this.blockchainGateway.repay(asset, amount);
+      await this.blockchainGateway.repay(wallet, asset, amount);
       const account = this.attachStoredTreasuryMetadata(wallet, await this.getAccountSummary(wallet));
       this.recordTreasuryEvent(account, { type: "repay", asset, amount });
       this.accounts.set(wallet, account);

--- a/test/AgentPlatform.t.sol
+++ b/test/AgentPlatform.t.sol
@@ -346,6 +346,26 @@ contract AgentPlatformTest is Test {
         assertEq(dot.balanceOf(poster), posterBalanceBefore + 1.25 ether);
     }
 
+    function testExpiredClaimCannotSubmitWork() public {
+        bytes32 jobId = keccak256("job/timeout/submit");
+
+        vm.prank(poster);
+        escrow.createSinglePayoutJob(
+            jobId, address(dot), 50 ether, 5 ether, 5 ether, 1 days, bytes32("AUTO"), bytes32("DATA"), SPEC_HASH
+        );
+
+        vm.prank(worker);
+        escrow.claimJob(jobId);
+
+        vm.warp(block.timestamp + 1 days + 1);
+
+        vm.prank(worker);
+        (bool ok, bytes memory data) =
+            address(escrow).call(abi.encodeCall(escrow.submitWork, (jobId, keccak256("late-work"))));
+        require(!ok, "EXPECTED_EXPIRED_SUBMISSION_REVERT");
+        require(bytes4(data) == EscrowCore.InvalidState.selector, "EXPECTED_INVALID_STATE");
+    }
+
     function testReclaimedJobGetsFreshClaimExpiry() public {
         bytes32 jobId = keccak256("job/timeout/2");
 


### PR DESCRIPTION
## Summary
- convert gateway account mutation inputs from display amounts into asset base units, and expose raw fields alongside display balances/request reads
- reject backend-relayed borrow/repay when the configured signer does not match the authenticated wallet
- enforce claim expiry in EscrowCore.submitWork and document remaining blockchain/XCM launch gates in the specs

## Checks
- npm --workspace mcp-server test
- forge test

## Impact
- Backend: yes, blockchain gateway/account mutation paths
- Contracts: yes, EscrowCore submitWork guard
- Docs: yes, working specs updated
- Frontend/indexer/Caddy/public site: no
- Env/VPS secrets: none