### PR TITLE
Fix Hermes handoff production secret access

### DIFF
--- a/.github/workflows/hermes-pr-handoff.yml
+++ b/.github/workflows/hermes-pr-handoff.yml
@@ -20,6 +20,10 @@ jobs:
     name: Ask Hermes to review PR and run testbed checks
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # OP_SERVICE_ACCOUNT_TOKEN_PROD_CI is stored as a production
+    # environment secret, matching deploy-production.yml. Without this,
+    # workflow_run PR handoffs see an empty OP token and fail before SSH.
+    environment: production
     if: github.event.workflow_run.conclusion == 'success'
     env:
       VPS_HOST: ${{ secrets.VPS_HOST }}


### PR DESCRIPTION
## Summary
- run Hermes PR handoff in the production environment so it can read the production-scoped OP_SERVICE_ACCOUNT_TOKEN_PROD_CI secret
- document why this is needed for the 1Password VPS key load step

## Checks
- git diff --check

## Notes
This does not restore the legacy VPS_SSH_KEY GitHub secret. The SSH key remains loaded from 1Password via op://prod-ci/vps-ssh-key/private key.