### PR TITLE
Tighten bootstrap self-report smoke gate

### DIFF
--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -529,7 +529,10 @@ should prioritize live-proof and launch-risk items before adding new product
 surface:
 
 1. complete the hosted worker-loop product-proof evidence gate
-2. close bootstrap self-report scheduled email delivery
+2. close bootstrap self-report scheduled email delivery with the hosted smoke's
+   explicit `bootstrapSelfReport` evidence gate (`lastAttemptedAt`,
+   `lastSuccessfulAt`, exact `from`/`to`, fresh sent provider id, no API-key
+   token leakage)
 3. tighten schema-native jobs for the first-wave job families
 4. finish dispute/arbitration launch wiring
 5. capture the native XCM deposit, withdraw, and failure evidence pack

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -84,12 +84,16 @@ ADMIN_JWT='<admin-jwt>' ./scripts/ops/check-hosted-stack.sh
 # self-report recipient list, and email provider configured.
 ADMIN_JWT='<admin-jwt>' \
 CHECK_BOOTSTRAP_INSTRUMENTATION=1 \
+BOOTSTRAP_SELF_REPORT_EXPECTED_FROM='<exact backend.env from>' \
+BOOTSTRAP_SELF_REPORT_EXPECTED_TO='<exact backend.env to>' \
 ./scripts/ops/check-hosted-stack.sh
 
 # First-delivery verification: require that the weekly report has actually sent.
 ADMIN_JWT='<admin-jwt>' \
 CHECK_BOOTSTRAP_INSTRUMENTATION=1 \
 CHECK_BOOTSTRAP_SELF_REPORT_SENT=1 \
+BOOTSTRAP_SELF_REPORT_EXPECTED_FROM='<exact backend.env from>' \
+BOOTSTRAP_SELF_REPORT_EXPECTED_TO='<exact backend.env to>' \
 ./scripts/ops/check-hosted-stack.sh
 
 # Component-scoped deploys can skip indexer checks when the indexer was not
@@ -154,16 +158,26 @@ RUN_SUBSCAN_XCM_VALIDATION=1 ./scripts/ops/check-release-readiness.sh testnet
 - [ ] Bootstrap self-report email has actually delivered. Flip this box only
   when ALL of the following are true against the production stack with a
   valid `ADMIN_JWT`:
-  - `curl -fsS -H "Authorization: Bearer $ADMIN_JWT" https://api.averray.com/admin/status \
-    | jq -r '.bootstrapSelfReport.lastSuccessfulAt'`
-    returns a non-null ISO timestamp within the last 8 days.
-  - `... | jq '.bootstrapSelfReport.providerConfigured'` returns `true`.
-  - `... | jq -r '.bootstrapSelfReport.lastFailureReason // "none"'` returns
-    `none` (or a stale failure whose timestamp is older than
-    `lastSuccessfulAt`).
-  - `... | jq -r '.bootstrapSelfReport.from'` and
-    `... | jq -r '.bootstrapSelfReport.to[]'` match the intended recipient
-    pair from `backend.env` (no `null`s, no test addresses).
+  - This command passes:
+    ```bash
+    ADMIN_JWT='<admin-jwt>' \
+    CHECK_BOOTSTRAP_INSTRUMENTATION=1 \
+    CHECK_BOOTSTRAP_SELF_REPORT_SENT=1 \
+    BOOTSTRAP_SELF_REPORT_EXPECTED_FROM='<exact backend.env from>' \
+    BOOTSTRAP_SELF_REPORT_EXPECTED_TO='<exact backend.env to>' \
+    ./scripts/ops/check-hosted-stack.sh
+    ```
+  - The smoke gate verifies `.bootstrapSelfReport.enabled`,
+    `.running`, `.providerConfigured`, `from`, `to`, `recipientCount`,
+    `lastAttemptedAt`, `lastSuccessfulAt`, and the latest sent provider id.
+    `lastSuccessfulAt` must be an ISO timestamp within 8 days by default
+    (`BOOTSTRAP_SELF_REPORT_MAX_AGE_SEC` can tighten or relax this window).
+  - The visible `from`/`to` pair matches production `backend.env` exactly
+    (comma-separate `BOOTSTRAP_SELF_REPORT_EXPECTED_TO` for multiple
+    recipients; no `null`s, no test addresses).
+  - `/admin/status.bootstrapSelfReport` does not contain API-key-shaped
+    tokens such as `Bearer ...` or `re_...`; only the boolean
+    `providerConfigured` may reveal that the provider is configured.
 
 ---
 

--- a/docs/SPEC_AUDIT_2026-05-13.md
+++ b/docs/SPEC_AUDIT_2026-05-13.md
@@ -139,10 +139,12 @@ SSH/basic-auth/admin-JWT cutovers, and the basic hosted smoke is green.
 - Rerun the product-proof gate with worker-loop evidence.
 - Finish bootstrap self-report scheduled email delivery and first-delivery
   proof. Code path is wired (`mcp-server/src/services/bootstrap-self-report-scheduler.js`);
-  the remaining gate is operational: `/admin/status.bootstrapSelfReport`
-  now exposes `lastAttemptedAt`, `lastSuccessfulAt`, `lastFailureReason`,
-  and the `from`/`to` pair, and `PRODUCTION_CHECKLIST.md` section 5 names
-  the exact `curl | jq` evidence required to flip the box.
+  the remaining gate is operational: `scripts/ops/check-hosted-stack.sh`
+  checks `/admin/status.bootstrapSelfReport` for `lastAttemptedAt`,
+  `lastSuccessfulAt`, the `from`/`to` pair, recipient-count consistency,
+  a fresh latest sent provider id, and absence of provider/API-key-shaped
+  tokens. `PRODUCTION_CHECKLIST.md` section 5 names the exact env-gated smoke
+  command required to flip the box.
 - Confirm `/admin/status` with a live admin JWT reports async XCM watcher posture
   cleanly.
 - Rehearse pauser pause/unpause from the hot key.
@@ -277,9 +279,10 @@ correlation and settlement path.
 
 1. Complete the hosted worker-loop product-proof evidence gate.
 2. Close bootstrap self-report scheduled email delivery against the live
-   production stack (the code path and `/admin/status` evidence fields are
-   landed; see `PRODUCTION_CHECKLIST.md` section 5 for the `curl | jq`
-   sign-off).
+   production stack by running `check-hosted-stack.sh` with
+   `CHECK_BOOTSTRAP_INSTRUMENTATION=1`,
+   `CHECK_BOOTSTRAP_SELF_REPORT_SENT=1`, and the exact expected `from`/`to`
+   envs from `backend.env`.
 3. Prove the hosted schema-native validation path and external helper adoption.
 4. Prove the dispute verdict path live and decide `/release` semantics.
 5. Run the native XCM evidence pack captures.

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -826,9 +826,14 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
         enabled: true,
         running: true,
         intervalMs: 604800000,
+        from: "Averray <ops@example.com>",
+        to: ["pascal@example.com"],
         recipientCount: 1,
         providerConfigured: true,
         nextRunAt: "2026-05-08T00:00:00.000Z",
+        lastAttemptedAt: "2026-05-08T00:00:00.000Z",
+        lastSuccessfulAt: "2026-05-08T00:00:00.000Z",
+        lastFailureReason: undefined,
         lastRun: { status: "sent", email: { providerId: "email_123" } }
       };
     }
@@ -870,6 +875,10 @@ test("getAdminStatus surfaces public source ingestion scheduler status", async (
   assert.equal(status.jobStaleSweeper.mode, "live");
   assert.equal(status.jobStaleSweeper.lastRun.updatedCount, 2);
   assert.equal(status.bootstrapSelfReport.providerConfigured, true);
+  assert.equal(status.bootstrapSelfReport.from, "Averray <ops@example.com>");
+  assert.deepEqual(status.bootstrapSelfReport.to, ["pascal@example.com"]);
+  assert.equal(status.bootstrapSelfReport.lastAttemptedAt, "2026-05-08T00:00:00.000Z");
+  assert.equal(status.bootstrapSelfReport.lastSuccessfulAt, "2026-05-08T00:00:00.000Z");
   assert.equal(status.bootstrapSelfReport.lastRun.email.providerId, "email_123");
 
   // Public sanitized counterpart preserves health / mode / counts but

--- a/scripts/ops/check-hosted-stack.sh
+++ b/scripts/ops/check-hosted-stack.sh
@@ -17,6 +17,9 @@ INDEXER_RETRY_SLEEP_SEC=${INDEXER_RETRY_SLEEP_SEC:-5}
 CHECK_INDEXER=${CHECK_INDEXER:-1}
 CHECK_BOOTSTRAP_INSTRUMENTATION=${CHECK_BOOTSTRAP_INSTRUMENTATION:-0}
 CHECK_BOOTSTRAP_SELF_REPORT_SENT=${CHECK_BOOTSTRAP_SELF_REPORT_SENT:-0}
+BOOTSTRAP_SELF_REPORT_EXPECTED_FROM=${BOOTSTRAP_SELF_REPORT_EXPECTED_FROM:-}
+BOOTSTRAP_SELF_REPORT_EXPECTED_TO=${BOOTSTRAP_SELF_REPORT_EXPECTED_TO:-}
+BOOTSTRAP_SELF_REPORT_MAX_AGE_SEC=${BOOTSTRAP_SELF_REPORT_MAX_AGE_SEC:-691200}
 CHECK_PRODUCT_PROOF_GATE=${CHECK_PRODUCT_PROOF_GATE:-0}
 PRODUCT_PROOF_NODE_IMAGE=${PRODUCT_PROOF_NODE_IMAGE:-node:22-bookworm-slim}
 PRODUCT_PROOF_EVIDENCE_FILE=${PRODUCT_PROOF_EVIDENCE_FILE:-}
@@ -224,17 +227,49 @@ if enabled "$CHECK_BOOTSTRAP_INSTRUMENTATION"; then
     .bootstrapSelfReport.enabled == true and
     .bootstrapSelfReport.running == true and
     .bootstrapSelfReport.providerConfigured == true and
+    (.bootstrapSelfReport.from | type) == "string" and
+    (.bootstrapSelfReport.from | length) > 0 and
+    (.bootstrapSelfReport.to | type) == "array" and
+    all(.bootstrapSelfReport.to[]; type == "string" and length > 0) and
     (.bootstrapSelfReport.recipientCount | type) == "number" and
     .bootstrapSelfReport.recipientCount > 0 and
+    .bootstrapSelfReport.recipientCount == (.bootstrapSelfReport.to | length) and
     (.bootstrapSelfReport.intervalMs | type) == "number" and
     .bootstrapSelfReport.intervalMs <= 604800000
   ' >/dev/null <<<"$admin_status_json"
+  jq -e '
+    (.bootstrapSelfReport | tostring | test("Bearer\\s+[^\\s,}\\]]+|re_[A-Za-z0-9_-]{12,}"; "i") | not)
+  ' >/dev/null <<<"$admin_status_json" || {
+    echo "Bootstrap self-report status appears to contain a provider/API key token." >&2
+    exit 1
+  }
+  if [[ -n "$BOOTSTRAP_SELF_REPORT_EXPECTED_FROM" ]]; then
+    jq -e --arg expectedFrom "$BOOTSTRAP_SELF_REPORT_EXPECTED_FROM" '
+      .bootstrapSelfReport.from == $expectedFrom
+    ' >/dev/null <<<"$admin_status_json"
+  fi
+  if [[ -n "$BOOTSTRAP_SELF_REPORT_EXPECTED_TO" ]]; then
+    jq -e --arg expectedTo "$BOOTSTRAP_SELF_REPORT_EXPECTED_TO" '
+      ($expectedTo | split(",") | map(gsub("^\\s+|\\s+$"; "") | select(length > 0))) as $recipients |
+      .bootstrapSelfReport.to == $recipients
+    ' >/dev/null <<<"$admin_status_json"
+  fi
 
   if enabled "$CHECK_BOOTSTRAP_SELF_REPORT_SENT"; then
     jq -e '
+      (.bootstrapSelfReport.lastAttemptedAt | type) == "string" and
+      (.bootstrapSelfReport.lastAttemptedAt | test("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z$")) and
+      (.bootstrapSelfReport.lastSuccessfulAt | type) == "string" and
+      (.bootstrapSelfReport.lastSuccessfulAt | test("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z$")) and
       .bootstrapSelfReport.lastRun.status == "sent" and
       (.bootstrapSelfReport.lastRun.email.providerId | type) == "string" and
       (.bootstrapSelfReport.lastRun.email.providerId | length) > 0
+    ' >/dev/null <<<"$admin_status_json"
+    jq -e --argjson maxAge "$BOOTSTRAP_SELF_REPORT_MAX_AGE_SEC" '
+      .bootstrapSelfReport.lastSuccessfulAt
+      | sub("\\.[0-9]+Z$"; "Z")
+      | fromdateiso8601 as $lastSuccessful
+      | (now - $lastSuccessful) >= 0 and (now - $lastSuccessful) <= $maxAge
     ' >/dev/null <<<"$admin_status_json"
   fi
 fi

--- a/scripts/ops/check-hosted-stack.test.mjs
+++ b/scripts/ops/check-hosted-stack.test.mjs
@@ -41,3 +41,52 @@ test("docker product-proof gate can read hosted worker-loop evidence", async () 
     "docker fallback should pass the dynamic volume list to docker run"
   );
 });
+
+test("bootstrap self-report gate requires delivery evidence and guards secrets", async () => {
+  const script = await readFile(CHECK_SCRIPT, "utf8");
+
+  assert.match(
+    script,
+    /BOOTSTRAP_SELF_REPORT_EXPECTED_FROM=/u,
+    "smoke should support an explicit expected sender check"
+  );
+  assert.match(
+    script,
+    /BOOTSTRAP_SELF_REPORT_EXPECTED_TO=/u,
+    "smoke should support an explicit expected recipient check"
+  );
+  assert.match(
+    script,
+    /\.bootstrapSelfReport\.from \| type\) == "string"/u,
+    "bootstrap instrumentation should require a concrete sender"
+  );
+  assert.match(
+    script,
+    /\.bootstrapSelfReport\.to \| type\) == "array"/u,
+    "bootstrap instrumentation should require a concrete recipient list"
+  );
+  assert.match(
+    script,
+    /\.bootstrapSelfReport\.recipientCount == \(\.bootstrapSelfReport\.to \| length\)/u,
+    "recipientCount should agree with the visible recipient list"
+  );
+  assert.ok(
+    script.includes('test("Bearer\\\\s+[^\\\\s,}\\\\]]+|re_[A-Za-z0-9_-]{12,}"; "i")'),
+    "bootstrap status should be scanned for API-key-shaped tokens"
+  );
+  assert.match(
+    script,
+    /\.bootstrapSelfReport\.lastAttemptedAt \| type\) == "string"/u,
+    "sent gate should require lastAttemptedAt"
+  );
+  assert.match(
+    script,
+    /\.bootstrapSelfReport\.lastSuccessfulAt \| type\) == "string"/u,
+    "sent gate should require lastSuccessfulAt"
+  );
+  assert.match(
+    script,
+    /BOOTSTRAP_SELF_REPORT_MAX_AGE_SEC/u,
+    "sent gate should bound the freshness of lastSuccessfulAt"
+  );
+});


### PR DESCRIPTION
## Summary
- require bootstrap self-report sender/recipient evidence, recipient-count consistency, and no API-key-shaped tokens in hosted smoke
- require first-delivery evidence via lastAttemptedAt, fresh lastSuccessfulAt, and latest sent provider id when CHECK_BOOTSTRAP_SELF_REPORT_SENT=1
- update production checklist/spec audit/roadmap with the exact operational sign-off command

## Checks
- bash -n scripts/ops/check-hosted-stack.sh
- npm run test:ops
- npm --workspace mcp-server test -- bootstrap-self-report-scheduler.test.js platform-service.test.js

## Impact
- Backend/ops smoke and docs only
- No frontend, contracts, indexer, Caddy, or public-site changes
- No environment changes required; optional smoke envs: BOOTSTRAP_SELF_REPORT_EXPECTED_FROM, BOOTSTRAP_SELF_REPORT_EXPECTED_TO, BOOTSTRAP_SELF_REPORT_MAX_AGE_SEC