### PR TITLE
[codex] Guard XCM deposit settlement shares

### DIFF
--- a/contracts/strategies/XcmVdotAdapter.sol
+++ b/contracts/strategies/XcmVdotAdapter.sol
@@ -192,8 +192,8 @@ contract XcmVdotAdapter is IXcmStrategyAdapter, ReentrancyGuard {
         if (request.kind == IXcmWrapper.RequestKind.Deposit) {
             pendingDepositAssets -= request.requestedAssets;
             if (status == IXcmWrapper.RequestStatus.Succeeded) {
-                uint256 assetsToBook = settledAssets == 0 ? request.requestedAssets : settledAssets;
-                totalAssets += assetsToBook;
+                if (settledAssets == 0 || settledShares == 0) revert InvalidStatus();
+                totalAssets += settledAssets;
                 totalShares += settledShares;
             } else {
                 SafeTransfer.safeTransfer(asset, request.requester, request.requestedAssets);

--- a/test/AgentAccountAsyncStrategy.t.sol
+++ b/test/AgentAccountAsyncStrategy.t.sol
@@ -89,6 +89,30 @@ contract AgentAccountAsyncStrategyTest is Test {
         assertEq(adapter.totalShares(), 20 ether);
     }
 
+    function testSettleStrategyDepositRejectsZeroShareSuccessAndKeepsPending() public {
+        bytes32 requestId = _requestDeposit(20 ether, 1);
+
+        (bool ok, bytes memory data) = address(accounts)
+            .call(
+                abi.encodeCall(
+                    accounts.settleStrategyRequest,
+                    (requestId, IXcmWrapper.RequestStatus.Succeeded, 20 ether, 0, bytes32("REMOTE"), bytes32(0))
+                )
+            );
+        _assertCustomError(ok, data, XcmVdotAdapter.InvalidStatus.selector);
+
+        (uint256 liquid,, uint256 strategyAllocated,,,) = accounts.positions(worker, address(dot));
+        assertEq(liquid, WORKER_DEPOSIT - 20 ether);
+        assertEq(strategyAllocated, 0);
+        assertEq(accounts.pendingStrategyAssets(worker, address(dot)), 20 ether);
+        assertEq(accounts.strategyShares(worker, STRATEGY_ID), 0);
+        assertEq(adapter.pendingDepositAssets(), 20 ether);
+        assertEq(adapter.totalAssets(), 0);
+        assertEq(adapter.totalShares(), 0);
+        assertEq(dot.balanceOf(address(accounts)), WORKER_DEPOSIT - 20 ether);
+        assertEq(dot.balanceOf(address(adapter)), 20 ether);
+    }
+
     function testStrategyDepositFailureRefundsLiquidBalance() public {
         bytes32 requestId = _requestDeposit(20 ether, 2);
 
@@ -240,5 +264,17 @@ contract AgentAccountAsyncStrategyTest is Test {
 
     function _withdrawMessage(bytes32 requestId) internal pure returns (bytes memory) {
         return abi.encodePacked(hex"050800010203040506070809", bytes1(0x2c), requestId);
+    }
+
+    function _assertCustomError(bool ok, bytes memory data, bytes4 selector) internal pure {
+        require(!ok, "expected revert");
+        require(data.length >= 4, "missing selector");
+
+        bytes4 actual;
+        assembly {
+            actual := mload(add(data, 32))
+        }
+
+        require(actual == selector, "unexpected selector");
     }
 }

--- a/test/XcmVdotAdapter.t.sol
+++ b/test/XcmVdotAdapter.t.sol
@@ -105,6 +105,68 @@ contract XcmVdotAdapterTest is Test {
         assertEq(wrapperRequest.settledShares, 23 ether);
     }
 
+    function testSettleDepositRejectsSuccessWithZeroAssets() public {
+        bytes32 requestId = _requestDeposit(worker, 25 ether, 1);
+
+        vm.prank(operator);
+        (bool ok, bytes memory data) = address(adapter)
+            .call(
+                abi.encodeCall(
+                    adapter.settleRequest,
+                    (
+                        requestId,
+                        IXcmWrapper.RequestStatus.Succeeded,
+                        0,
+                        23 ether,
+                        keccak256("remote-deposit"),
+                        bytes32(0)
+                    )
+                )
+            );
+        _assertCustomError(ok, data, XcmVdotAdapter.InvalidStatus.selector);
+
+        IXcmStrategyAdapter.AdapterRequest memory request = adapter.getAdapterRequest(requestId);
+        IXcmWrapper.RequestRecord memory wrapperRequest = wrapper.getRequest(requestId);
+
+        assertEq(adapter.pendingDepositAssets(), 25 ether);
+        assertEq(adapter.totalAssets(), 0);
+        assertEq(adapter.totalShares(), 0);
+        assertEq(asset.balanceOf(address(adapter)), 25 ether);
+        assertEq(uint256(request.status), uint256(IXcmWrapper.RequestStatus.Pending));
+        assertEq(uint256(wrapperRequest.status), uint256(IXcmWrapper.RequestStatus.Pending));
+    }
+
+    function testSettleDepositRejectsSuccessWithZeroShares() public {
+        bytes32 requestId = _requestDeposit(worker, 25 ether, 1);
+
+        vm.prank(operator);
+        (bool ok, bytes memory data) = address(adapter)
+            .call(
+                abi.encodeCall(
+                    adapter.settleRequest,
+                    (
+                        requestId,
+                        IXcmWrapper.RequestStatus.Succeeded,
+                        25 ether,
+                        0,
+                        keccak256("remote-deposit"),
+                        bytes32(0)
+                    )
+                )
+            );
+        _assertCustomError(ok, data, XcmVdotAdapter.InvalidStatus.selector);
+
+        IXcmStrategyAdapter.AdapterRequest memory request = adapter.getAdapterRequest(requestId);
+        IXcmWrapper.RequestRecord memory wrapperRequest = wrapper.getRequest(requestId);
+
+        assertEq(adapter.pendingDepositAssets(), 25 ether);
+        assertEq(adapter.totalAssets(), 0);
+        assertEq(adapter.totalShares(), 0);
+        assertEq(asset.balanceOf(address(adapter)), 25 ether);
+        assertEq(uint256(request.status), uint256(IXcmWrapper.RequestStatus.Pending));
+        assertEq(uint256(wrapperRequest.status), uint256(IXcmWrapper.RequestStatus.Pending));
+    }
+
     function testRequestWithdrawQueuesAndReservesShares() public {
         bytes32 depositRequestId = _seedSettledDeposit();
         bytes32 previewId = _previewWithdrawRequestId(worker, 10 ether, recipient, 2);
@@ -169,17 +231,27 @@ contract XcmVdotAdapterTest is Test {
     }
 
     function _seedSettledDeposit() internal returns (bytes32 requestId) {
-        bytes32 previewId = _previewDepositRequestId(worker, 25 ether, 1);
-
-        vm.prank(operator);
-        requestId = adapter.requestDeposit(
-            worker, 25 ether, hex"0102", _depositMessage(previewId), IXcmWrapper.Weight({refTime: 11, proofSize: 22}), 1
-        );
+        requestId = _requestDeposit(worker, 25 ether, 1);
 
         vm.prank(operator);
         adapter.settleRequest(
             requestId, IXcmWrapper.RequestStatus.Succeeded, 25 ether, 23 ether, keccak256("remote-deposit"), bytes32(0)
         );
+    }
+
+    function _requestDeposit(address account, uint256 assets, uint64 nonce) internal returns (bytes32 requestId) {
+        bytes32 previewId = _previewDepositRequestId(account, assets, nonce);
+
+        vm.prank(operator);
+        requestId = adapter.requestDeposit(
+            account,
+            assets,
+            hex"0102",
+            _depositMessage(previewId),
+            IXcmWrapper.Weight({refTime: 11, proofSize: 22}),
+            nonce
+        );
+        require(requestId == previewId, "WRONG_REQUEST_ID");
     }
 
     function _previewDepositRequestId(address account, uint256 assets, uint64 nonce) internal view returns (bytes32) {
@@ -226,5 +298,17 @@ contract XcmVdotAdapterTest is Test {
 
     function _withdrawMessage(bytes32 requestId) internal pure returns (bytes memory) {
         return abi.encodePacked(hex"050800010203040506070809", bytes1(0x2c), requestId);
+    }
+
+    function _assertCustomError(bool ok, bytes memory data, bytes4 selector) internal pure {
+        require(!ok, "expected revert");
+        require(data.length >= 4, "missing selector");
+
+        bytes4 actual;
+        assembly {
+            actual := mload(add(data, 32))
+        }
+
+        require(actual == selector, "unexpected selector");
     }
 }


### PR DESCRIPTION
## What changed
- Reject successful XCM/vDOT deposit settlements unless both settled assets and settled shares are nonzero.
- Remove the implicit settledAssets=0 fallback that booked the requested amount as success.
- Add adapter-level and AgentAccountCore-path regression tests that prove failed zero-share/zero-asset successes leave pending escrowed state intact.

## Checks run
- forge test --match-contract XcmVdotAdapterTest
- forge test --match-contract AgentAccountAsyncStrategyTest
- forge build --sizes
- forge test

## Affected components
- Contracts: XcmVdotAdapter async strategy settlement logic.
- Tests: XcmVdotAdapter and AgentAccountAsyncStrategy coverage.
- No backend, frontend, indexer, Caddy, public site, generated static output, or VPS env changes.

## Notes
- This is the next blockchain-audit slice after the native borrow accounting PR. It closes the zero-share successful deposit settlement hole before any production vDOT/XCM lane can be enabled.