### PR TITLE
Add dispute-verdict hosted proof harness with dry-run default

### DIFF
--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -206,7 +206,45 @@ RUN_SUBSCAN_XCM_VALIDATION=1 ./scripts/ops/check-release-readiness.sh testnet
   `node --test app/lib/api/guarded-submit.test.mjs`.
 - [ ] The phase-0 dispute verdict path has been exercised on the hosted stack
   with the configured arbitrator/gateway and a recorded on-chain tx state from
-  `POST /disputes/:id/verdict`.
+  `POST /disputes/:id/verdict`. Flip this box only after running the dry-run
+  *and* the live-mode proof harness against a specific open dispute on the
+  hosted stack, and only when both runs print the documented evidence
+  fields:
+
+  ```bash
+  # 1. Dry-run first to confirm the payload the script will submit.
+  ADMIN_JWT=$op_admin_jwt \
+  DISPUTE_PROOF_ID=dispute-xxxxxxxxxx \
+  DISPUTE_PROOF_VERDICT=dismissed \
+  DISPUTE_PROOF_RATIONALE="upstream PR merged after the verifier's rejection" \
+  API_BASE_URL=https://api.averray.com \
+    node scripts/ops/run-dispute-verdict-proof.mjs
+  # Expect: { "mode": "dry_run", "payload": { ... } } and *no* network mutation.
+
+  # 2. Live run - only with Pascal-approved dispute id + LIVE=1.
+  ADMIN_JWT=$op_admin_jwt \
+  DISPUTE_PROOF_ID=dispute-xxxxxxxxxx \
+  DISPUTE_PROOF_VERDICT=dismissed \
+  DISPUTE_PROOF_RATIONALE="upstream PR merged after the verifier's rejection" \
+  DISPUTE_PROOF_LIVE=1 \
+  API_BASE_URL=https://api.averray.com \
+    node scripts/ops/run-dispute-verdict-proof.mjs
+  ```
+
+  Required live-mode evidence in the JSON output:
+  - `mode = "live"`,
+  - `response.verdict`, `response.reasonCode`, `response.reasoningHash`,
+    and `response.metadataURI` all populated,
+  - `response.chainStatus` is one of `confirmed | submitted | local_only`
+    (`confirmed`/`submitted` means the on-chain `EscrowCore.resolveDispute`
+    actually dispatched; `local_only` means blockchain env was not wired),
+  - `persisted.status = "resolved"` and `persisted.reasoningHash` matches
+    `response.reasoningHash` (proves the receipt persisted, not just echoed).
+
+  The script refuses to act without a specific `DISPUTE_PROOF_ID` and a
+  pre-existing open dispute. It never creates disputes and never iterates
+  the queue. Regression covered by
+  `node --test scripts/ops/run-dispute-verdict-proof.test.mjs`.
 - [ ] Public discovery, schema, and trust pages reflect the current deployed behavior.
 - [ ] Canonical public discovery manifest matches the API mirror.
 

--- a/scripts/ops/run-dispute-verdict-proof.mjs
+++ b/scripts/ops/run-dispute-verdict-proof.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+//
+// Hosted dispute-verdict proof harness.
+//
+// Defaults to **dry-run**. The script only mutates state when
+// `DISPUTE_PROOF_LIVE=1` is set explicitly *and* a specific dispute id
+// is named via `DISPUTE_PROOF_ID`. The dry-run path prints the exact
+// payload it would submit so a reviewer can sanity-check before
+// flipping the live flag.
+//
+// Live-mode safety rails (fail-closed):
+//   - The dispute is fetched first; the script refuses to submit if
+//     the dispute is not in `open` status or already carries a verdict.
+//   - The verdict is submitted with an explicit `idempotencyKey` so
+//     accidental retries replay rather than re-resolve.
+//   - The response is verified to contain the documented evidence
+//     fields (`verdict`, `reasonCode`, `reasoningHash`, `metadataURI`,
+//     `chainStatus`, `timeline[].verdict_submitted`).
+//   - A follow-up `getDispute(id)` confirms the verdict persisted on
+//     the server — not just echoed back in the response body.
+//
+// This script never creates disputes and never iterates the queue
+// looking for "something to resolve". The caller chooses the dispute.
+
+import { AgentPlatformClient } from "../../sdk/agent-platform-client.js";
+
+const DEFAULT_API_BASE_URL = "https://api.averray.com";
+const ALLOWED_VERDICTS = new Set(["upheld", "dismissed", "split", "timeout"]);
+const REQUIRED_VERDICT_RESPONSE_FIELDS = [
+  "verdict",
+  "reasonCode",
+  "reasoningHash",
+  "metadataURI",
+  "chainStatus"
+];
+
+export async function runDisputeVerdictProof({
+  env = process.env,
+  client = undefined,
+  log = console.log
+} = {}) {
+  const config = parseConfig(env);
+  const platform = client ?? new AgentPlatformClient({
+    baseUrl: config.apiBaseUrl,
+    token: config.token
+  });
+
+  log(`Fetching dispute ${config.disputeId} from ${config.apiBaseUrl}`);
+  const dispute = await platform.getDispute(config.disputeId);
+  assertDisputable(dispute, config.disputeId);
+
+  const payload = buildVerdictPayload(config);
+
+  if (!config.live) {
+    log("Dry-run: not submitting. Set DISPUTE_PROOF_LIVE=1 to mutate.");
+    return {
+      mode: "dry_run",
+      disputeId: config.disputeId,
+      dispute: projectDisputeSummary(dispute),
+      payload
+    };
+  }
+
+  log(`Submitting verdict for ${config.disputeId} (idempotencyKey=${payload.idempotencyKey})`);
+  const response = await platform.submitDisputeVerdict(config.disputeId, payload);
+  assertVerdictEvidence(response, config.disputeId);
+
+  log(`Re-fetching dispute ${config.disputeId} to confirm persistence`);
+  const persisted = await platform.getDispute(config.disputeId);
+  assertPersisted(persisted, response, config.disputeId);
+
+  return {
+    mode: "live",
+    disputeId: config.disputeId,
+    dispute: projectDisputeSummary(dispute),
+    payload,
+    response: projectVerdictResponse(response),
+    persisted: projectPersistedDispute(persisted)
+  };
+}
+
+function parseConfig(env) {
+  const token = pick(env.ADMIN_JWT) || pick(env.AVERRAY_TOKEN);
+  if (!token) {
+    throw new Error("ADMIN_JWT (or AVERRAY_TOKEN) is required.");
+  }
+  const disputeId = pick(env.DISPUTE_PROOF_ID);
+  if (!disputeId) {
+    throw new Error(
+      "DISPUTE_PROOF_ID is required. The script never resolves an arbitrary dispute — the caller must name the dispute id explicitly."
+    );
+  }
+  const rawVerdict = pick(env.DISPUTE_PROOF_VERDICT)?.toLowerCase();
+  if (!rawVerdict || !ALLOWED_VERDICTS.has(rawVerdict)) {
+    throw new Error(
+      `DISPUTE_PROOF_VERDICT must be one of ${[...ALLOWED_VERDICTS].join(" | ")}. Got: ${rawVerdict ?? "(empty)"}`
+    );
+  }
+  const rationale = pick(env.DISPUTE_PROOF_RATIONALE);
+  if (!rationale) {
+    throw new Error("DISPUTE_PROOF_RATIONALE is required (arbitrator reasoning text).");
+  }
+  let workerPayout;
+  if (rawVerdict === "split") {
+    const raw = pick(env.DISPUTE_PROOF_WORKER_PAYOUT);
+    if (!raw) {
+      throw new Error("DISPUTE_PROOF_WORKER_PAYOUT is required for split verdicts.");
+    }
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      throw new Error(`DISPUTE_PROOF_WORKER_PAYOUT must be a positive number. Got: ${raw}`);
+    }
+    workerPayout = parsed;
+  }
+  const idempotencyKey = pick(env.DISPUTE_PROOF_IDEMPOTENCY_KEY) || `dispute-proof-${disputeId}`;
+  const apiBaseUrl = stripTrailingSlash(pick(env.API_BASE_URL) || DEFAULT_API_BASE_URL);
+  // Live mode requires *both* an explicit flag AND a non-empty dispute
+  // id; the second is already enforced above but kept here as the
+  // single point of truth for "we are about to mutate".
+  const live = pick(env.DISPUTE_PROOF_LIVE) === "1";
+  return { token, disputeId, verdict: rawVerdict, rationale, workerPayout, idempotencyKey, apiBaseUrl, live };
+}
+
+function assertDisputable(dispute, disputeId) {
+  if (!dispute || typeof dispute !== "object") {
+    throw new Error(`Dispute ${disputeId} not found.`);
+  }
+  if (dispute.id !== disputeId) {
+    throw new Error(`Dispute fetch returned a different id (${dispute.id}); refusing to proceed.`);
+  }
+  if (dispute.status !== "open") {
+    throw new Error(
+      `Dispute ${disputeId} is not in 'open' status (got status=${dispute.status}). Refusing to re-resolve a closed dispute.`
+    );
+  }
+  if (dispute.verdict) {
+    throw new Error(
+      `Dispute ${disputeId} already carries a verdict (${dispute.verdict}). Refusing to overwrite.`
+    );
+  }
+}
+
+function buildVerdictPayload(config) {
+  const payload = {
+    verdict: config.verdict,
+    rationale: config.rationale,
+    idempotencyKey: config.idempotencyKey
+  };
+  if (config.workerPayout !== undefined) {
+    payload.workerPayout = config.workerPayout;
+  }
+  return payload;
+}
+
+function assertVerdictEvidence(response, disputeId) {
+  if (!response || typeof response !== "object") {
+    throw new Error(`Verdict response was not a JSON object (disputeId=${disputeId}).`);
+  }
+  const missing = REQUIRED_VERDICT_RESPONSE_FIELDS.filter((field) => !response[field]);
+  if (missing.length) {
+    throw new Error(
+      `Verdict response missing required evidence fields: ${missing.join(", ")}.`
+    );
+  }
+  if (!/^0x[a-f0-9]{64}$/u.test(String(response.reasoningHash))) {
+    throw new Error(
+      `Verdict response reasoningHash is not a 32-byte hex value: ${response.reasoningHash}`
+    );
+  }
+  if (!Array.isArray(response.timeline)) {
+    throw new Error("Verdict response is missing a timeline array.");
+  }
+  const verdictEvent = response.timeline.find((entry) => entry?.action === "verdict_submitted");
+  if (!verdictEvent) {
+    throw new Error("Verdict response timeline does not include a verdict_submitted entry.");
+  }
+  // chainStatus must be one of the documented values; a typo would
+  // mask a wiring drift, so be strict.
+  const allowedChainStatus = new Set(["confirmed", "submitted", "local_only"]);
+  if (!allowedChainStatus.has(String(response.chainStatus))) {
+    throw new Error(
+      `Unknown chainStatus '${response.chainStatus}'. Expected one of ${[...allowedChainStatus].join(" | ")}.`
+    );
+  }
+}
+
+function assertPersisted(persisted, response, disputeId) {
+  if (!persisted || persisted.id !== disputeId) {
+    throw new Error(`Re-fetch of dispute ${disputeId} did not return the same record.`);
+  }
+  if (persisted.status !== "resolved") {
+    throw new Error(
+      `After verdict submission, dispute ${disputeId} is still status=${persisted.status} on re-fetch. Receipt did not persist.`
+    );
+  }
+  if (persisted.reasoningHash !== response.reasoningHash) {
+    throw new Error(
+      "Persisted dispute reasoningHash does not match the verdict response — server may have stored a different record."
+    );
+  }
+}
+
+function projectDisputeSummary(dispute) {
+  return {
+    id: dispute.id,
+    status: dispute.status,
+    sessionId: dispute.sessionId,
+    chainJobId: dispute.chainJobId,
+    claimant: dispute.claimant,
+    openedAt: dispute.openedAt,
+    windowEndsAt: dispute.windowEndsAt,
+    slaSeconds: dispute.slaSeconds,
+    stakedAmount: dispute.stakedAmount
+  };
+}
+
+function projectVerdictResponse(response) {
+  return {
+    status: response.status,
+    verdict: response.verdict,
+    reasonCode: response.reasonCode,
+    reasoningHash: response.reasoningHash,
+    metadataURI: response.metadataURI,
+    workerPayout: response.workerPayout,
+    remainingPayout: response.remainingPayout,
+    txHash: response.txHash,
+    blockNumber: response.blockNumber,
+    chainStatus: response.chainStatus
+  };
+}
+
+function projectPersistedDispute(persisted) {
+  return {
+    id: persisted.id,
+    status: persisted.status,
+    verdict: persisted.verdict,
+    reasonCode: persisted.reasonCode,
+    reasoningHash: persisted.reasoningHash,
+    metadataURI: persisted.metadataURI,
+    txHash: persisted.txHash,
+    chainStatus: persisted.chainStatus
+  };
+}
+
+function pick(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function stripTrailingSlash(value) {
+  return typeof value === "string" ? value.replace(/\/+$/u, "") : value;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runDisputeVerdictProof()
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2));
+    })
+    .catch((error) => {
+      console.error(error?.message ?? String(error));
+      process.exitCode = 1;
+    });
+}

--- a/scripts/ops/run-dispute-verdict-proof.test.mjs
+++ b/scripts/ops/run-dispute-verdict-proof.test.mjs
@@ -1,0 +1,320 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runDisputeVerdictProof } from "./run-dispute-verdict-proof.mjs";
+
+const DISPUTE_ID = "dispute-abc123def4";
+const SESSION_ID = "session-product-proof";
+const REASONING_HASH = "0x" + "a".repeat(64);
+
+function openDispute(overrides = {}) {
+  return {
+    id: DISPUTE_ID,
+    status: "open",
+    sessionId: SESSION_ID,
+    chainJobId: "job-1",
+    claimant: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    openedAt: "2026-05-10T00:00:00.000Z",
+    windowEndsAt: "2026-05-24T00:00:00.000Z",
+    slaSeconds: 14 * 24 * 60 * 60,
+    stakedAmount: 0.5,
+    verdict: null,
+    timeline: [],
+    ...overrides
+  };
+}
+
+function verdictResponse(overrides = {}) {
+  return {
+    id: DISPUTE_ID,
+    status: "resolved",
+    verdict: "dismissed",
+    reasonCode: "DISPUTE_OVERTURNED",
+    reasoningHash: REASONING_HASH,
+    metadataURI: `urn:averray:content:${REASONING_HASH}`,
+    workerPayout: 0.5,
+    remainingPayout: 0.5,
+    txHash: undefined,
+    blockNumber: undefined,
+    chainStatus: "local_only",
+    timeline: [
+      {
+        id: `${DISPUTE_ID}:verdict`,
+        at: "2026-05-15T12:00:00.000Z",
+        actor: "0x9999999999999999999999999999999999999999",
+        action: "verdict_submitted",
+        data: { reasoningHash: REASONING_HASH, chainStatus: "local_only" }
+      }
+    ],
+    ...overrides
+  };
+}
+
+function persistedDispute(overrides = {}) {
+  return {
+    ...openDispute(),
+    status: "resolved",
+    verdict: "dismissed",
+    reasonCode: "DISPUTE_OVERTURNED",
+    reasoningHash: REASONING_HASH,
+    metadataURI: `urn:averray:content:${REASONING_HASH}`,
+    chainStatus: "local_only",
+    ...overrides
+  };
+}
+
+function baseEnv(overrides = {}) {
+  return {
+    ADMIN_JWT: "test-token",
+    DISPUTE_PROOF_ID: DISPUTE_ID,
+    DISPUTE_PROOF_VERDICT: "dismissed",
+    DISPUTE_PROOF_RATIONALE: "Upstream PR merged after the verifier's initial rejection.",
+    API_BASE_URL: "https://api.example.test",
+    ...overrides
+  };
+}
+
+function recordingClient({ disputeBeforeVerdict, disputeAfterVerdict, response }) {
+  const calls = [];
+  return {
+    calls,
+    async getDispute(id) {
+      calls.push(["getDispute", id]);
+      // First call returns the pre-verdict dispute; second call (after
+      // submission) returns the persisted record.
+      return calls.filter(([name]) => name === "getDispute").length === 1
+        ? disputeBeforeVerdict
+        : disputeAfterVerdict;
+    },
+    async submitDisputeVerdict(id, payload) {
+      calls.push(["submitDisputeVerdict", id, payload]);
+      return response;
+    }
+  };
+}
+
+test("dry-run default never submits and prints the exact payload it would send", async () => {
+  const client = recordingClient({
+    disputeBeforeVerdict: openDispute(),
+    disputeAfterVerdict: persistedDispute(),
+    response: verdictResponse()
+  });
+
+  const result = await runDisputeVerdictProof({ env: baseEnv(), client, log: () => {} });
+
+  assert.equal(result.mode, "dry_run");
+  assert.deepEqual(client.calls.map(([name]) => name), ["getDispute"]);
+  assert.deepEqual(result.payload, {
+    verdict: "dismissed",
+    rationale: "Upstream PR merged after the verifier's initial rejection.",
+    idempotencyKey: `dispute-proof-${DISPUTE_ID}`
+  });
+  assert.equal(result.dispute.status, "open");
+  assert.equal(result.disputeId, DISPUTE_ID);
+});
+
+test("dry-run for a split verdict includes the worker payout in the proposed payload", async () => {
+  const client = recordingClient({
+    disputeBeforeVerdict: openDispute(),
+    disputeAfterVerdict: persistedDispute(),
+    response: verdictResponse()
+  });
+
+  const result = await runDisputeVerdictProof({
+    env: baseEnv({
+      DISPUTE_PROOF_VERDICT: "split",
+      DISPUTE_PROOF_WORKER_PAYOUT: "0.25"
+    }),
+    client,
+    log: () => {}
+  });
+
+  assert.equal(result.mode, "dry_run");
+  assert.equal(result.payload.workerPayout, 0.25);
+});
+
+test("live mode submits and verifies the response carries verdict + reasoning + chain status evidence", async () => {
+  const client = recordingClient({
+    disputeBeforeVerdict: openDispute(),
+    disputeAfterVerdict: persistedDispute(),
+    response: verdictResponse()
+  });
+
+  const result = await runDisputeVerdictProof({
+    env: baseEnv({ DISPUTE_PROOF_LIVE: "1" }),
+    client,
+    log: () => {}
+  });
+
+  assert.equal(result.mode, "live");
+  assert.deepEqual(client.calls.map(([name]) => name), [
+    "getDispute",
+    "submitDisputeVerdict",
+    "getDispute"
+  ]);
+  const submitCall = client.calls.find(([name]) => name === "submitDisputeVerdict");
+  assert.equal(submitCall[1], DISPUTE_ID);
+  assert.equal(submitCall[2].verdict, "dismissed");
+  assert.equal(submitCall[2].idempotencyKey, `dispute-proof-${DISPUTE_ID}`);
+  assert.equal(result.response.reasoningHash, REASONING_HASH);
+  assert.equal(result.response.chainStatus, "local_only");
+  assert.equal(result.persisted.status, "resolved");
+});
+
+test("live mode refuses to mutate a dispute that is not in open status", async () => {
+  const client = recordingClient({
+    disputeBeforeVerdict: openDispute({ status: "resolved", verdict: "upheld" }),
+    disputeAfterVerdict: openDispute({ status: "resolved" }),
+    response: verdictResponse()
+  });
+
+  await assert.rejects(
+    () => runDisputeVerdictProof({
+      env: baseEnv({ DISPUTE_PROOF_LIVE: "1" }),
+      client,
+      log: () => {}
+    }),
+    /not in 'open' status/u
+  );
+
+  assert.deepEqual(client.calls.map(([name]) => name), ["getDispute"]);
+});
+
+test("live mode refuses if the dispute already carries a verdict, even when status is somehow 'open'", async () => {
+  const client = recordingClient({
+    disputeBeforeVerdict: openDispute({ verdict: "dismissed" }),
+    disputeAfterVerdict: persistedDispute(),
+    response: verdictResponse()
+  });
+
+  await assert.rejects(
+    () => runDisputeVerdictProof({
+      env: baseEnv({ DISPUTE_PROOF_LIVE: "1" }),
+      client,
+      log: () => {}
+    }),
+    /already carries a verdict/u
+  );
+
+  assert.deepEqual(client.calls.map(([name]) => name), ["getDispute"]);
+});
+
+test("live mode rejects a verdict response missing required evidence fields", async () => {
+  const client = recordingClient({
+    disputeBeforeVerdict: openDispute(),
+    disputeAfterVerdict: persistedDispute(),
+    response: verdictResponse({ reasoningHash: undefined })
+  });
+
+  await assert.rejects(
+    () => runDisputeVerdictProof({
+      env: baseEnv({ DISPUTE_PROOF_LIVE: "1" }),
+      client,
+      log: () => {}
+    }),
+    /missing required evidence fields.*reasoningHash/u
+  );
+});
+
+test("live mode rejects an unknown chainStatus value to catch wiring drift", async () => {
+  const client = recordingClient({
+    disputeBeforeVerdict: openDispute(),
+    disputeAfterVerdict: persistedDispute(),
+    response: verdictResponse({ chainStatus: "fictional_state" })
+  });
+
+  await assert.rejects(
+    () => runDisputeVerdictProof({
+      env: baseEnv({ DISPUTE_PROOF_LIVE: "1" }),
+      client,
+      log: () => {}
+    }),
+    /Unknown chainStatus 'fictional_state'/u
+  );
+});
+
+test("live mode fails closed when the persisted dispute re-fetch disagrees with the response", async () => {
+  const client = recordingClient({
+    disputeBeforeVerdict: openDispute(),
+    // Server returned a verdict response but the persisted record still
+    // shows the dispute as open — receipt did not actually land.
+    disputeAfterVerdict: openDispute({ status: "open" }),
+    response: verdictResponse()
+  });
+
+  await assert.rejects(
+    () => runDisputeVerdictProof({
+      env: baseEnv({ DISPUTE_PROOF_LIVE: "1" }),
+      client,
+      log: () => {}
+    }),
+    /Receipt did not persist/u
+  );
+});
+
+test("missing DISPUTE_PROOF_ID is rejected before any HTTP call", async () => {
+  let calls = 0;
+  const client = {
+    async getDispute() {
+      calls += 1;
+      throw new Error("must not be reached");
+    }
+  };
+
+  await assert.rejects(
+    () => runDisputeVerdictProof({
+      env: baseEnv({ DISPUTE_PROOF_ID: "" }),
+      client,
+      log: () => {}
+    }),
+    /DISPUTE_PROOF_ID is required/u
+  );
+  assert.equal(calls, 0);
+});
+
+test("missing ADMIN_JWT and AVERRAY_TOKEN is rejected before any HTTP call", async () => {
+  await assert.rejects(
+    () => runDisputeVerdictProof({
+      env: { DISPUTE_PROOF_ID: DISPUTE_ID, DISPUTE_PROOF_VERDICT: "dismissed", DISPUTE_PROOF_RATIONALE: "x" },
+      log: () => {}
+    }),
+    /ADMIN_JWT \(or AVERRAY_TOKEN\) is required/u
+  );
+});
+
+test("invalid verdict value is rejected before any HTTP call", async () => {
+  await assert.rejects(
+    () => runDisputeVerdictProof({
+      env: baseEnv({ DISPUTE_PROOF_VERDICT: "maybe" }),
+      log: () => {}
+    }),
+    /DISPUTE_PROOF_VERDICT must be one of/u
+  );
+});
+
+test("split verdict without DISPUTE_PROOF_WORKER_PAYOUT is rejected before any HTTP call", async () => {
+  await assert.rejects(
+    () => runDisputeVerdictProof({
+      env: baseEnv({ DISPUTE_PROOF_VERDICT: "split" }),
+      log: () => {}
+    }),
+    /DISPUTE_PROOF_WORKER_PAYOUT is required for split verdicts/u
+  );
+});
+
+test("a non-'1' DISPUTE_PROOF_LIVE value stays in dry-run (defense against truthy strings)", async () => {
+  const client = recordingClient({
+    disputeBeforeVerdict: openDispute(),
+    disputeAfterVerdict: persistedDispute(),
+    response: verdictResponse()
+  });
+
+  const result = await runDisputeVerdictProof({
+    env: baseEnv({ DISPUTE_PROOF_LIVE: "true" }),
+    client,
+    log: () => {}
+  });
+
+  assert.equal(result.mode, "dry_run");
+  assert.deepEqual(client.calls.map(([name]) => name), ["getDispute"]);
+});


### PR DESCRIPTION
## Summary

Makes the production-checklist line **"phase-0 dispute verdict path exercised on hosted stack"** verifiable by command, not vibes. Adds a dry-run-by-default ops script that an operator can run against a specific known-open dispute on the hosted stack, plus the regression tests, plus the exact checklist evidence required to flip the box.

## What landed

- **`scripts/ops/run-dispute-verdict-proof.mjs`** — fetches a specific dispute (`DISPUTE_PROOF_ID` is **required**; the script never creates disputes and never iterates the queue), validates the inputs, and in dry-run prints the exact payload it would submit. Live mode (`DISPUTE_PROOF_LIVE=1`) submits with an explicit `idempotencyKey`, verifies the response carries the documented evidence fields, and **re-fetches the dispute** to confirm the receipt actually persisted (catches a server that echoes the response but fails to write it).
- **Safety rails (fail-closed):**
  - Refuses if the dispute is not `status === "open"`.
  - Refuses if the dispute already carries a verdict.
  - Refuses if the fetched dispute id differs from the input.
  - `DISPUTE_PROOF_LIVE=1` is the *only* live-mode trigger — any other value (including `"true"`, `"yes"`) stays in dry-run.
  - Validates `chainStatus` against the documented enum (`confirmed | submitted | local_only`); a typo or new state surfaces as a wiring drift instead of silently passing.
  - `reasoningHash` must be 32-byte hex.
  - All input validation runs **before** any HTTP call, so a misconfigured invocation never hits the dispute API.
- **`scripts/ops/run-dispute-verdict-proof.test.mjs`** — 13 new tests covering: dry-run no-op, split-verdict payload includes worker payout, live happy path, refusal on closed/already-verdicted disputes, missing evidence rejection, unknown chainStatus rejection, persistence re-fetch disagreement, missing `DISPUTE_PROOF_ID` / token / verdict / split payout, and the truthy-string defense on the LIVE flag.
- **`docs/PRODUCTION_CHECKLIST.md`** Section 7 dispute item: bare "exercised on hosted stack" replaced with the exact two-step command (dry-run then live) and the required JSON fields in the output. A reviewer can flip the box mechanically.

## Test plan

- [x] `npm run test:ops` — 50 tests pass (13 new), no other ops tests touched
- [x] `npm --workspace mcp-server test` — 496 tests pass (no backend touched)
- [ ] **Manual hosted verification (operator):** with a Pascal-chosen open dispute id, run the dry-run first to inspect the payload, then run with `DISPUTE_PROOF_LIVE=1` and confirm:
  - `mode == "live"` in the JSON output
  - `response.verdict / reasonCode / reasoningHash / metadataURI` all populated
  - `response.chainStatus` in `confirmed | submitted | local_only`
  - `persisted.status == "resolved"` and `persisted.reasoningHash == response.reasoningHash`

## Avoided per task brief

- No edits to PR #294 bootstrap smoke files
- No edits to PR #295 schema-validation UI files
- No live hosted mutation from this PR — that's an operator action gated on Pascal choosing the dispute id and the live flag
- No new disputes created; no queue iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)