### PR TITLE
Ask Hermes for structured PR code review

### DIFF
--- a/.github/workflows/hermes-pr-handoff.yml
+++ b/.github/workflows/hermes-pr-handoff.yml
@@ -121,18 +121,28 @@ jobs:
         run: |
           prompt=$(
             cat <<PROMPT
-          Use Averray MCP tools only. Call averray_invoke_agent_task with requester='github-actions', intent='pr_handoff', repo='${HANDOFF_REPO}', pullRequestNumber=${HANDOFF_PR_NUMBER}, testCaseIds=['TBE2E-004'], correlationId='${HANDOFF_CORRELATION_ID}', reason='post-CI PR handoff'.
+          Use Averray MCP tools only.
 
-          Before giving the merge recommendation, perform a PR code and logic review:
-          - Inspect PR metadata, changed files, diff/risk summary, CI status, and requested testbed results.
-          - Look for logic bugs, unsafe defaults, missing guards, missing tests, race/idempotency problems, timeout/retry problems, secret exposure, and deployment risk.
-          - Pay extra attention to deploy workflows, auth, secrets, payments/settlement, indexer, contracts, Caddy, database migrations, and external agent hooks.
-          - Verify that CI coverage matches the touched areas. If it does not, list the missing checks.
-          - If you cannot inspect the diff or changed files, say so clearly and mark the code review verdict as needs_human_review.
+          First call averray_invoke_agent_task with requester='github-actions', intent='pr_code_review', repo='${HANDOFF_REPO}', pullRequestNumber=${HANDOFF_PR_NUMBER}, correlationId='${HANDOFF_CORRELATION_ID}-code-review', reason='post-CI independent PR verifier'.
+
+          Then call averray_invoke_agent_task with requester='github-actions', intent='pr_handoff', repo='${HANDOFF_REPO}', pullRequestNumber=${HANDOFF_PR_NUMBER}, testCaseIds=['TBE2E-004'], correlationId='${HANDOFF_CORRELATION_ID}', reason='post-CI PR handoff'.
+
+          Treat the pr_code_review result as the independent verifier lane. Use its structured codeReview block when present:
+          - finalVerdict / mergeRecommendation
+          - riskCategory and highestRisk
+          - why
+          - checks.failed and checks.active
+          - tests.matchedTouchedAreas and tests.missingTestSignals
+          - rollout.notesRequired and rollout.notesPresent
+          - reasons / recommendations
+
+          If pr_code_review is unavailable because the deployed Averray MCP version is older, say so clearly and fall back to the codeReview block attached to pr_handoff if present. If neither structured codeReview block is available, mark codeReviewVerdict as needs_human_review.
 
           Report these sections briefly:
           - finalVerdict
           - codeReviewVerdict: approve, conditional_approve, needs_human_review, or block
+          - codeReviewWhy
+          - riskCategory
           - blockingFindings
           - nonBlockingFindings
           - missingTests


### PR DESCRIPTION
Updates the Hermes PR handoff workflow to explicitly call the new Averray MCP pr_code_review verifier intent before the existing pr_handoff/testbed run.

What changed:
- First asks Hermes to run intent=pr_code_review with a dedicated correlation suffix.
- Then runs the existing pr_handoff with TBE2E-004.
- Reports structured codeReview fields: why, risk category, highest risk, check status, test-signal match, rollout-note status, reasons, and recommendations.
- Keeps the older fallback path if the deployed reference-agent has not yet picked up pr_code_review.

Checks run:
- ruby YAML parse for .github/workflows/hermes-pr-handoff.yml
- git diff --check

Affected surfaces: GitHub Actions PR handoff workflow only. No env or VPS secret changes required.