### PR TITLE
[codex] Harden async withdraw settlement

### DIFF
--- a/contracts/strategies/XcmVdotAdapter.sol
+++ b/contracts/strategies/XcmVdotAdapter.sol
@@ -36,11 +36,7 @@ contract XcmVdotAdapter is IXcmStrategyAdapter, ReentrancyGuard {
 
     event DepositRequested(bytes32 indexed requestId, address indexed account, uint256 assets, uint64 nonce);
     event WithdrawRequested(
-        bytes32 indexed requestId,
-        address indexed account,
-        address indexed recipient,
-        uint256 shares,
-        uint64 nonce
+        bytes32 indexed requestId, address indexed account, address indexed recipient, uint256 shares, uint64 nonce
     );
     event RequestSettled(
         bytes32 indexed requestId,
@@ -89,14 +85,8 @@ contract XcmVdotAdapter is IXcmStrategyAdapter, ReentrancyGuard {
     ) external override nonReentrant whenNotPaused onlyOperator returns (bytes32 requestId) {
         if (assets == 0) revert ZeroAmount();
 
-        IXcmWrapper.RequestContext memory context = _buildContext(
-            IXcmWrapper.RequestKind.Deposit,
-            account,
-            account,
-            assets,
-            0,
-            nonce
-        );
+        IXcmWrapper.RequestContext memory context =
+            _buildContext(IXcmWrapper.RequestKind.Deposit, account, account, assets, 0, nonce);
 
         requestId = xcmWrapper.previewRequestId(context);
         AdapterRequest storage existing = requests[requestId];
@@ -137,14 +127,8 @@ contract XcmVdotAdapter is IXcmStrategyAdapter, ReentrancyGuard {
         if (recipient == address(0) || account == address(0)) revert InvalidRequest();
         if (totalShares < pendingWithdrawalShares + shares) revert InsufficientLiquidity();
 
-        IXcmWrapper.RequestContext memory context = _buildContext(
-            IXcmWrapper.RequestKind.Withdraw,
-            account,
-            recipient,
-            0,
-            shares,
-            nonce
-        );
+        IXcmWrapper.RequestContext memory context =
+            _buildContext(IXcmWrapper.RequestKind.Withdraw, account, recipient, 0, shares, nonce);
 
         requestId = xcmWrapper.previewRequestId(context);
         AdapterRequest storage existing = requests[requestId];
@@ -187,12 +171,18 @@ contract XcmVdotAdapter is IXcmStrategyAdapter, ReentrancyGuard {
         if (request.requester == address(0)) revert InvalidRequest();
         if (request.settled) revert AlreadySettled();
 
+        if (status == IXcmWrapper.RequestStatus.Succeeded) {
+            if (request.kind == IXcmWrapper.RequestKind.Deposit && (settledAssets == 0 || settledShares == 0)) {
+                revert InvalidStatus();
+            }
+            if (request.kind == IXcmWrapper.RequestKind.Withdraw && settledAssets == 0) revert InvalidStatus();
+        }
+
         xcmWrapper.finalizeRequest(requestId, status, settledAssets, settledShares, remoteRef, failureCode);
 
         if (request.kind == IXcmWrapper.RequestKind.Deposit) {
             pendingDepositAssets -= request.requestedAssets;
             if (status == IXcmWrapper.RequestStatus.Succeeded) {
-                if (settledAssets == 0 || settledShares == 0) revert InvalidStatus();
                 totalAssets += settledAssets;
                 totalShares += settledShares;
             } else {
@@ -201,7 +191,9 @@ contract XcmVdotAdapter is IXcmStrategyAdapter, ReentrancyGuard {
         } else if (request.kind == IXcmWrapper.RequestKind.Withdraw) {
             pendingWithdrawalShares -= request.requestedShares;
             if (status == IXcmWrapper.RequestStatus.Succeeded) {
-                if (request.requestedShares > totalShares || settledAssets > totalAssets) revert InsufficientLiquidity();
+                if (request.requestedShares > totalShares || settledAssets > totalAssets) {
+                    revert InsufficientLiquidity();
+                }
                 totalShares -= request.requestedShares;
                 totalAssets -= settledAssets;
                 SafeTransfer.safeTransfer(asset, request.recipient, settledAssets);

--- a/docs/POLKADOT_EXECUTION_PLAN.md
+++ b/docs/POLKADOT_EXECUTION_PLAN.md
@@ -367,6 +367,10 @@ Current status:
 - failed async deposits now refund escrowed local DOT back into
   `AgentAccountCore` during settlement instead of stranding funds in the
   adapter
+- successful async settlements now fail closed unless the observed
+  economic effect is non-zero: deposits require non-zero settled assets
+  and shares, while withdrawals require non-zero settled assets before
+  user strategy shares can be burned
 - the contract path is covered by
   [test/XcmVdotAdapter.t.sol](/Users/pascalkuriger/repo/Polkadot/test/XcmVdotAdapter.t.sol)
   and passes with `forge test --match-contract XcmVdotAdapterTest --offline`

--- a/docs/strategies/vdot.md
+++ b/docs/strategies/vdot.md
@@ -293,6 +293,11 @@ operator / watcher
     failure: shares remain with the agent
 ```
 
+The async settlement path fails closed on empty success claims: deposits
+must settle with non-zero assets and non-zero shares, and withdrawals
+must settle with non-zero assets before the agent's reserved strategy
+shares are burned.
+
 So the repo now has both lanes:
 - synchronous mock treasury flow through `allocateIdleFunds` /
   `deallocateIdleFunds`

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -1141,6 +1141,7 @@ export class BlockchainGateway {
           throw error;
         }
       }
+      this.validateStrategySettlementOutcome(strategyRequest, normalizedStatus, settledAssets, settledShares);
 
       const tx = strategyRequest
         ? await this.accountContract.settleStrategyRequest(
@@ -1166,6 +1167,27 @@ export class BlockchainGateway {
         settledVia: strategyRequest ? "agent_account" : "xcm_wrapper"
       };
     });
+  }
+
+  validateStrategySettlementOutcome(strategyRequest, status, settledAssets, settledShares) {
+    if (!strategyRequest || status !== 2) {
+      return;
+    }
+
+    const assets = Number(settledAssets ?? 0);
+    const shares = Number(settledShares ?? 0);
+    if (!Number.isFinite(assets) || assets < 0 || !Number.isFinite(shares) || shares < 0) {
+      throw new ValidationError("settledAssets and settledShares must be non-negative finite numbers.");
+    }
+
+    if (strategyRequest.kind === 0 && (assets === 0 || shares === 0)) {
+      throw new ValidationError(
+        "Successful async strategy deposits require non-zero settledAssets and settledShares."
+      );
+    }
+    if (strategyRequest.kind === 1 && assets === 0) {
+      throw new ValidationError("Successful async strategy withdrawals require non-zero settledAssets.");
+    }
   }
 
   requireAutoMintableAsset(asset, operation, details = {}) {

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -699,6 +699,47 @@ test("async XCM request readers return display amounts and raw base-unit fields"
   assert.equal(strategyRequest.settledSharesRaw, "100000");
 });
 
+test("finalizeXcmRequest rejects successful strategy withdrawals with zero settled assets before tx", async () => {
+  const gateway = new BlockchainGateway({ enabled: false, supportedAssets: [USDC_TRUST_ASSET] });
+  const requestId = `0x${"2".repeat(64)}`;
+  const account = "0x3333333333333333333333333333333333333333";
+  const recipient = "0x4444444444444444444444444444444444444444";
+  let settlementRelayed = false;
+
+  gateway.signer = {};
+  gateway.accountContract = {
+    async strategyRequests(id) {
+      assert.equal(id, requestId);
+      return {
+        strategyId: encodeBytes32String("USDC"),
+        adapter: "0x5555555555555555555555555555555555555555",
+        account,
+        asset: USDC_TRUST_ASSET.address,
+        recipient,
+        kind: 1,
+        status: 1,
+        requestedAssets: 0n,
+        requestedShares: 500_000n,
+        settledAssets: 0n,
+        settledShares: 0n,
+        remoteRef: `0x${"0".repeat(64)}`,
+        failureCode: `0x${"0".repeat(64)}`,
+        settled: false
+      };
+    },
+    async settleStrategyRequest() {
+      settlementRelayed = true;
+      return { async wait() {} };
+    }
+  };
+
+  await assert.rejects(
+    () => gateway.finalizeXcmRequest(requestId, { status: "succeeded", settledAssets: 0, settledShares: 0 }),
+    ValidationError
+  );
+  assert.equal(settlementRelayed, false);
+});
+
 test("resolveXcmMaxWeight uses caller weight when refTime is non-zero", async () => {
   const gateway = new BlockchainGateway({ enabled: false });
   gateway.xcmWrapperContract = {

--- a/test/AgentAccountAsyncStrategy.t.sol
+++ b/test/AgentAccountAsyncStrategy.t.sol
@@ -163,6 +163,46 @@ contract AgentAccountAsyncStrategyTest is Test {
         assertEq(dot.balanceOf(address(adapter)), 25 ether);
     }
 
+    function testSettleStrategyWithdrawRejectsZeroAssetSuccessAndKeepsPending() public {
+        _seedSettledDeposit(40 ether, 3);
+
+        IXcmWrapper.Weight memory maxWeight = IXcmWrapper.Weight({refTime: 10, proofSize: 5});
+        bytes32 previewId = _previewWithdrawRequestId(worker, 15 ether, address(accounts), 4);
+        vm.prank(worker);
+        bytes32 requestId = accounts.requestStrategyWithdraw(
+            worker,
+            AgentAccountCore.StrategyWithdrawRequestParams({
+                strategyId: STRATEGY_ID,
+                shares: 15 ether,
+                recipient: address(accounts),
+                destination: hex"0a",
+                message: _withdrawMessage(previewId),
+                maxWeight: maxWeight,
+                nonce: 4
+            })
+        );
+
+        (bool ok, bytes memory data) = address(accounts)
+            .call(
+                abi.encodeCall(
+                    accounts.settleStrategyRequest,
+                    (requestId, IXcmWrapper.RequestStatus.Succeeded, 0, 0, bytes32("WITHDRAW"), bytes32(0))
+                )
+            );
+        _assertCustomError(ok, data, XcmVdotAdapter.InvalidStatus.selector);
+
+        (uint256 liquid,, uint256 strategyAllocated,,,) = accounts.positions(worker, address(dot));
+        assertEq(liquid, WORKER_DEPOSIT - 40 ether);
+        assertEq(strategyAllocated, 40 ether);
+        assertEq(accounts.pendingStrategyWithdrawalShares(worker, STRATEGY_ID), 15 ether);
+        assertEq(accounts.strategyShares(worker, STRATEGY_ID), 40 ether);
+        assertEq(adapter.pendingWithdrawalShares(), 15 ether);
+        assertEq(adapter.totalAssets(), 40 ether);
+        assertEq(adapter.totalShares(), 40 ether);
+        assertEq(dot.balanceOf(address(accounts)), WORKER_DEPOSIT - 40 ether);
+        assertEq(dot.balanceOf(address(adapter)), 40 ether);
+    }
+
     function testStrategyWithdrawFailureKeepsSharesAndLeavesLiquidityUntouched() public {
         _seedSettledDeposit(40 ether, 5);
 

--- a/test/XcmVdotAdapter.t.sol
+++ b/test/XcmVdotAdapter.t.sol
@@ -230,6 +230,49 @@ contract XcmVdotAdapterTest is Test {
         assertEq(request.settledAssets, 11 ether);
     }
 
+    function testSettleWithdrawRejectsSuccessWithZeroAssets() public {
+        _seedSettledDeposit();
+        bytes32 previewId = _previewWithdrawRequestId(worker, 10 ether, recipient, 2);
+
+        vm.prank(operator);
+        bytes32 withdrawRequestId = adapter.requestWithdraw(
+            worker,
+            10 ether,
+            recipient,
+            hex"0304",
+            _withdrawMessage(previewId),
+            IXcmWrapper.Weight({refTime: 5, proofSize: 6}),
+            2
+        );
+
+        vm.prank(operator);
+        (bool ok, bytes memory data) = address(adapter)
+            .call(
+                abi.encodeCall(
+                    adapter.settleRequest,
+                    (
+                        withdrawRequestId,
+                        IXcmWrapper.RequestStatus.Succeeded,
+                        0,
+                        0,
+                        keccak256("remote-withdraw"),
+                        bytes32(0)
+                    )
+                )
+            );
+        _assertCustomError(ok, data, XcmVdotAdapter.InvalidStatus.selector);
+
+        IXcmStrategyAdapter.AdapterRequest memory request = adapter.getAdapterRequest(withdrawRequestId);
+        IXcmWrapper.RequestRecord memory wrapperRequest = wrapper.getRequest(withdrawRequestId);
+
+        assertEq(adapter.pendingWithdrawalShares(), 10 ether);
+        assertEq(adapter.totalShares(), 23 ether);
+        assertEq(adapter.totalAssets(), 25 ether);
+        assertEq(asset.balanceOf(recipient), 0);
+        assertEq(uint256(request.status), uint256(IXcmWrapper.RequestStatus.Pending));
+        assertEq(uint256(wrapperRequest.status), uint256(IXcmWrapper.RequestStatus.Pending));
+    }
+
     function _seedSettledDeposit() internal returns (bytes32 requestId) {
         requestId = _requestDeposit(worker, 25 ether, 1);
 


### PR DESCRIPTION
Summary
- fail closed when XcmVdotAdapter receives a successful withdraw settlement with zero settled assets
- reject the same malformed strategy-backed XCM finalize payload in the backend before relaying a tx
- document the non-zero economic-effect invariant for async vDOT settlement

Audit context
- Polkadot docs MCP checked smart-contracts/precompiles/xcm.md: the XCM precompile is barebones, messages are SCALE encoded, and weighMessage is part of the contract flow. Settlement therefore must be tied to observed economic evidence, not only terminal status.

Checks
- forge test --match-contract XcmVdotAdapterTest
- forge test --match-contract AgentAccountAsyncStrategyTest
- node --test mcp-server/src/blockchain/gateway.test.js
- forge test
- forge build --sizes
- npm --workspace mcp-server test

Affected areas
- contracts
- backend
- docs

No environment or VPS secret changes required.