### PR TITLE
[codex] Harden XCM status reporting

### DIFF
--- a/docs/POLKADOT_EXECUTION_PLAN.md
+++ b/docs/POLKADOT_EXECUTION_PLAN.md
@@ -396,6 +396,10 @@ Current status:
   - it auto-finalizes pending requests through
     `PlatformService.finalizeXcmRequest`
   - admin status can now surface watcher runtime + pending queue status
+  - watcher status reads now fail soft: if the durable state store is
+    temporarily unavailable, `/admin/status` keeps returning a degraded
+    watcher block plus an anomaly instead of failing the whole operator
+    status response
 - the hosted stack now also ships the first external observation
   connector:
   - `XcmObservationRelayService` polls an operator-configured observer
@@ -405,6 +409,9 @@ Current status:
     observation unless the payload actually changed
   - admin status now surfaces relay runtime, cursor, last sync time, and
     last relay error
+  - relay status reads now fail soft as well, preserving configured feed
+    URL / runtime flags and surfacing an anomaly when cursor state cannot
+    be read
 - the remaining gap is the network-specific relayer feed itself:
   the repo now includes the connector the API needs, but operators still
   need a real observer feed that watches Bifrost / XCM results and serves

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -57,10 +57,32 @@ const DEFAULT_TREASURY_POLICY_STATUS = {
   roles: {
     signerAddress: undefined,
     signerIsVerifier: false,
-    escrowIsServiceOperator: false
+    escrowIsServiceOperator: false,
+    agentAccountIsServiceOperator: false
   },
   readErrors: [],
   risk: {}
+};
+
+const DEFAULT_XCM_SETTLEMENT_WATCHER_STATUS = {
+  enabled: false,
+  running: false,
+  pendingCount: 0,
+  pending: []
+};
+
+const DEFAULT_XCM_OBSERVATION_RELAY_STATUS = {
+  enabled: false,
+  running: false,
+  syncing: false,
+  feedUrl: undefined,
+  batchSize: 0,
+  pollIntervalMs: 0,
+  cursor: undefined,
+  lastObservedCount: 0,
+  lastSyncedAt: undefined,
+  lastError: undefined,
+  updatedAt: undefined
 };
 
 export class PlatformService {
@@ -350,6 +372,10 @@ export class PlatformService {
       this.jobExecutionService.listRecentSessions(14),
       Promise.resolve().then(() => collectHostDiagnostics())
     ]);
+    const [xcmSettlementWatcher, xcmObservationRelay] = await Promise.all([
+      getXcmSettlementWatcherStatusSafely(this.xcmSettlementWatcher),
+      getXcmObservationRelayStatusSafely(this.xcmObservationRelay)
+    ]);
     const recentEvents = this.eventBus?.replay?.({}, undefined)?.events ?? [];
     const activeStatuses = new Set(["claimed", "submitted", "disputed", "rejected"]);
     const activeSessions = recentSessions.filter((session) => activeStatuses.has(session.status));
@@ -393,6 +419,22 @@ export class PlatformService {
         code: "policy_status_unavailable",
         message: "Treasury policy status is unavailable.",
         details: policy.error
+      });
+    }
+    if (xcmSettlementWatcher?.error) {
+      anomalies.push({
+        severity: "medium",
+        code: "xcm_settlement_watcher_status_unavailable",
+        message: "XCM settlement watcher status is unavailable.",
+        details: xcmSettlementWatcher.error
+      });
+    }
+    if (xcmObservationRelay?.error) {
+      anomalies.push({
+        severity: "medium",
+        code: "xcm_observation_relay_status_unavailable",
+        message: "XCM observation relay status is unavailable.",
+        details: xcmObservationRelay.error
       });
     }
     for (const template of scheduler.templates ?? []) {
@@ -468,25 +510,8 @@ export class PlatformService {
       openApiIngestion: openApiIngestion,
       upstreamStatus,
       bootstrapSelfReport,
-      xcmSettlementWatcher: await this.xcmSettlementWatcher?.getStatus?.() ?? {
-        enabled: false,
-        running: false,
-        pendingCount: 0,
-        pending: []
-      },
-      xcmObservationRelay: await this.xcmObservationRelay?.getStatus?.() ?? {
-        enabled: false,
-        running: false,
-        syncing: false,
-        feedUrl: undefined,
-        batchSize: 0,
-        pollIntervalMs: 0,
-        cursor: undefined,
-        lastObservedCount: 0,
-        lastSyncedAt: undefined,
-        lastError: undefined,
-        updatedAt: undefined
-      }
+      xcmSettlementWatcher,
+      xcmObservationRelay
     };
   }
 
@@ -1603,6 +1628,52 @@ async function getTreasuryPolicyStatusSafely(blockchainGateway) {
       }
     };
   }
+}
+
+async function getXcmSettlementWatcherStatusSafely(xcmSettlementWatcher) {
+  if (!xcmSettlementWatcher?.getStatus) {
+    return { ...DEFAULT_XCM_SETTLEMENT_WATCHER_STATUS };
+  }
+
+  try {
+    return await xcmSettlementWatcher.getStatus();
+  } catch (error) {
+    return {
+      ...DEFAULT_XCM_SETTLEMENT_WATCHER_STATUS,
+      enabled: Boolean(xcmSettlementWatcher.enabled),
+      running: Boolean(xcmSettlementWatcher.running),
+      error: normalizeStatusReadError(error, "xcm_settlement_watcher_status_error")
+    };
+  }
+}
+
+async function getXcmObservationRelayStatusSafely(xcmObservationRelay) {
+  if (!xcmObservationRelay?.getStatus) {
+    return { ...DEFAULT_XCM_OBSERVATION_RELAY_STATUS };
+  }
+
+  try {
+    return await xcmObservationRelay.getStatus();
+  } catch (error) {
+    return {
+      ...DEFAULT_XCM_OBSERVATION_RELAY_STATUS,
+      enabled: Boolean(xcmObservationRelay.enabled),
+      running: Boolean(xcmObservationRelay.running),
+      syncing: Boolean(xcmObservationRelay.syncing),
+      feedUrl: xcmObservationRelay.feedUrl,
+      batchSize: xcmObservationRelay.batchSize ?? 0,
+      pollIntervalMs: xcmObservationRelay.pollIntervalMs ?? 0,
+      error: normalizeStatusReadError(error, "xcm_observation_relay_status_error")
+    };
+  }
+}
+
+function normalizeStatusReadError(error, code) {
+  return {
+    code: error?.code ?? code,
+    message: error?.message ?? "Status read failed.",
+    details: error?.details
+  };
 }
 
 function buildProviderOperations(statuses) {

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -674,6 +674,7 @@ test("getAdminStatus reports treasury policy failures without failing the status
 
   assert.equal(status.maintenance.policy.enabled, true);
   assert.equal(status.maintenance.policy.policyAddress, "0x1111111111111111111111111111111111111111");
+  assert.equal(status.maintenance.policy.roles.agentAccountIsServiceOperator, false);
   assert.equal(status.maintenance.policy.error.code, "blockchain_revert");
   assert.equal(status.maintenance.policy.error.details.rawReason, "require(false)");
   assert.ok(status.anomalies.some((entry) => entry.code === "policy_status_unavailable"));
@@ -1011,6 +1012,44 @@ test("getAdminStatus surfaces XCM observation relay status", async () => {
   const status = await service.getAdminStatus();
   assert.equal(status.xcmObservationRelay.enabled, true);
   assert.equal(status.xcmObservationRelay.cursor, "cursor-1");
+});
+
+test("getAdminStatus reports XCM status read failures without failing the response", async () => {
+  const service = makePlatformService();
+  service.xcmSettlementWatcher = {
+    enabled: true,
+    running: true,
+    async getStatus() {
+      const error = new Error("redis unavailable");
+      error.code = "state_store_unavailable";
+      throw error;
+    }
+  };
+  service.xcmObservationRelay = {
+    enabled: true,
+    running: true,
+    syncing: true,
+    feedUrl: "https://observer.example/outcomes",
+    batchSize: 25,
+    pollIntervalMs: 30_000,
+    async getStatus() {
+      throw new Error("observer cursor read failed");
+    }
+  };
+
+  const status = await service.getAdminStatus();
+
+  assert.equal(status.xcmSettlementWatcher.enabled, true);
+  assert.equal(status.xcmSettlementWatcher.running, true);
+  assert.equal(status.xcmSettlementWatcher.pendingCount, 0);
+  assert.equal(status.xcmSettlementWatcher.error.code, "state_store_unavailable");
+  assert.equal(status.xcmObservationRelay.enabled, true);
+  assert.equal(status.xcmObservationRelay.running, true);
+  assert.equal(status.xcmObservationRelay.syncing, true);
+  assert.equal(status.xcmObservationRelay.feedUrl, "https://observer.example/outcomes");
+  assert.equal(status.xcmObservationRelay.error.code, "xcm_observation_relay_status_error");
+  assert.ok(status.anomalies.some((entry) => entry.code === "xcm_settlement_watcher_status_unavailable"));
+  assert.ok(status.anomalies.some((entry) => entry.code === "xcm_observation_relay_status_unavailable"));
 });
 
 test("getGithubOperatorStatus exposes the read-only GitHub helper", async () => {


### PR DESCRIPTION
## What changed
- Make /admin/status fail soft when XCM settlement watcher status reads fail.
- Make XCM observation relay status reads degrade in place while preserving configured runtime/feed fields.
- Surface explicit admin anomalies for XCM watcher/relay status read failures.
- Keep the default treasury policy role shape complete with agentAccountIsServiceOperator.
- Update the Polkadot execution plan with the fail-soft status invariant.

## Audit note
Polkadot docs MCP check: the XCM precompile is barebones and expects callers to build the surrounding abstractions for XCM details/status handling. This reinforces keeping observer/relay diagnostics isolated from the availability of the operator status endpoint.

## Checks
- node --test mcp-server/src/core/platform-service.test.js
- npm --workspace mcp-server test

## Impact
- Backend: yes, /admin/status payload resilience only.
- Frontend: no required change; existing status UI can read the same xcmSettlementWatcher/xcmObservationRelay blocks plus optional error/anomaly fields.
- Indexer/Caddy/contracts/public site: no.
- Env/VPS secrets: none.