### PR TITLE
[codex] Preserve policy risk raw values

### DIFF
--- a/docs/AUDIT_PACKAGE.md
+++ b/docs/AUDIT_PACKAGE.md
@@ -194,6 +194,11 @@ only. `PROFILE=mainnet` refuses to proceed unless the outflow cap, borrow cap,
 collateral ratio, claim-stake basis points, and slash penalties are all set
 explicitly at deploy time.
 
+The backend operator status surface preserves these policy parameters as exact
+raw chain strings. Numeric mirrors are only populated when the value fits
+JavaScript safe-integer precision, so sentinel values such as `uint256.max` do
+not appear as precise decimal numbers in `/admin/status`.
+
 The recommended **mainnet launch profile** lives in
 [MAINNET_PARAMETERS.md](./MAINNET_PARAMETERS.md), with the corresponding
 operator env template in

--- a/docs/POLKADOT_EXECUTION_PLAN.md
+++ b/docs/POLKADOT_EXECUTION_PLAN.md
@@ -250,6 +250,9 @@ Current status:
 - the broader blockchain config now accepts `SUPPORTED_ASSETS_JSON` with
   the same explicit asset metadata model and still preserves the old
   `SUPPORTED_ASSETS=SYMBOL:0x...` shorthand
+- `/admin/status` policy risk values now preserve exact raw chain strings
+  for `uint256` caps/penalties and only expose numeric mirrors when the
+  value fits JS safe-integer precision
 - next step is to thread the same model through deployment manifests and
   strategy registration outputs so operators do not lose metadata at the
   deploy boundary

--- a/docs/RC1_WORKING_SPEC.md
+++ b/docs/RC1_WORKING_SPEC.md
@@ -4,7 +4,7 @@
 > This file is retained as historical design context only.
 
 **Status:** Reconciled with deployed reality and operational docs
-**Spec version:** 1.11 (blockchain audit follow-up: gateway display/base-unit boundary documented and fixed, `submitWork` claim-expiry guard tracked, async XCM remaining gates clarified, relayed borrow/repay gap recorded)
+**Spec version:** 1.11 (blockchain audit follow-up: gateway display/base-unit boundary documented and fixed, policy risk caps preserve raw chain values, `submitWork` claim-expiry guard tracked, async XCM remaining gates clarified, relayed borrow/repay gap recorded)
 **Owner:** Pascal
 
 ---
@@ -628,9 +628,10 @@ For traceability.
 ### v1.11 (blockchain audit follow-up)
 
 1. Gateway display/base-unit boundary fixed and documented: contract calls now convert display inputs through asset decimals, and account/XCM reads expose display values plus explicit raw fields.
-2. `EscrowCore.submitWork` now rejects submissions after `claimExpiry`; expired claims must go through the timeout/reclaim path.
-3. Async XCM status clarified: assembler and SetTopic validation are shipped, while live XCM precompile dispatch and native observer proof remain production gates.
-4. Relayed borrow/repay gap recorded: current contract methods act on `msg.sender`, so backend relay is unsafe unless signer == wallet or explicit `borrowFor`/`repayFor` primitives are added.
+2. Treasury policy risk values now follow the same boundary: `/admin/status` preserves raw `uint256` strings for caps/penalties and only exposes numeric mirrors when they fit JS safe-integer precision.
+3. `EscrowCore.submitWork` now rejects submissions after `claimExpiry`; expired claims must go through the timeout/reclaim path.
+4. Async XCM status clarified: assembler and SetTopic validation are shipped, while live XCM precompile dispatch and native observer proof remain production gates.
+5. Relayed borrow/repay gap recorded: current contract methods act on `msg.sender`, so backend relay is unsafe unless signer == wallet or explicit `borrowFor`/`repayFor` primitives are added.
 
 ### v1.10 (repository sync after Slice 9)
 

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -38,6 +38,7 @@ const REQUEST_KIND_LABELS = ["deposit", "withdraw", "claim"];
 const REQUEST_STATUS_LABELS = ["unknown", "pending", "succeeded", "failed", "cancelled"];
 const abiCoder = AbiCoder.defaultAbiCoder();
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const MAX_SAFE_INTEGER_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
 
 function summarizeSupportedAssets(assets = []) {
   return assets.map(summarizeSupportedAsset);
@@ -424,19 +425,19 @@ export class BlockchainGateway {
           agentAccountIsServiceOperator
         },
         readErrors,
-        risk: {
-          dailyOutflowCap: Number(dailyOutflowCap),
-          perAccountBorrowCap: Number(perAccountBorrowCap),
-          minimumCollateralRatioBps: Number(minimumCollateralRatioBps),
-          defaultClaimStakeBps: Number(defaultClaimStakeBps),
-          claimFeeBps: Number(claimFeeBps),
-          claimFeeVerifierBps: Number(claimFeeVerifierBps),
-          onboardingWaiverClaimCount: Number(onboardingWaiverClaimCount),
-          rejectionSkillPenalty: Number(rejectionSkillPenalty),
-          rejectionReliabilityPenalty: Number(rejectionReliabilityPenalty),
-          disputeLossSkillPenalty: Number(disputeLossSkillPenalty),
-          disputeLossReliabilityPenalty: Number(disputeLossReliabilityPenalty)
-        }
+        risk: this.policyRiskSnapshot({
+          dailyOutflowCap,
+          perAccountBorrowCap,
+          minimumCollateralRatioBps,
+          defaultClaimStakeBps,
+          claimFeeBps,
+          claimFeeVerifierBps,
+          onboardingWaiverClaimCount,
+          rejectionSkillPenalty,
+          rejectionReliabilityPenalty,
+          disputeLossSkillPenalty,
+          disputeLossReliabilityPenalty
+        })
       };
     });
   }
@@ -1262,6 +1263,20 @@ export class BlockchainGateway {
       return "0";
     }
     return BigInt(amount).toString();
+  }
+
+  policyRiskSnapshot(values) {
+    return Object.fromEntries(
+      Object.entries(values).flatMap(([key, value]) => {
+        const raw = BigInt(value ?? 0);
+        const exactNumber = raw >= 0n && raw <= MAX_SAFE_INTEGER_BIGINT;
+        return [
+          [key, exactNumber ? Number(raw) : null],
+          [`${key}Raw`, raw.toString()],
+          [`${key}Exact`, exactNumber]
+        ];
+      })
+    );
   }
 
   normalizeDecimalAmount(amount, decimals, label) {

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -314,6 +314,89 @@ test("getTreasuryPolicyStatus surfaces settlement readiness roles", async () => 
   }]);
 });
 
+test("getTreasuryPolicyStatus preserves raw policy risk values when numbers are unsafe", async () => {
+  const gateway = new BlockchainGateway({
+    enabled: true,
+    rpcUrl: "http://127.0.0.1:8545",
+    signerPrivateKey: `0x${"11".repeat(32)}`,
+    treasuryPolicyAddress: "0x1111111111111111111111111111111111111111",
+    agentAccountAddress: "0x3333333333333333333333333333333333333333",
+    escrowCoreAddress: "0x2222222222222222222222222222222222222222",
+    reputationSbtAddress: "0x4444444444444444444444444444444444444444",
+    supportedAssets: [DOT_ASSET]
+  });
+  const unsafeDailyCap = (1n << 256n) - 1n;
+  const unsafeBorrowCap = BigInt(Number.MAX_SAFE_INTEGER) + 2n;
+  gateway.policyContract = {
+    async owner() {
+      return "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    },
+    async pauser() {
+      return "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    },
+    async paused() {
+      return false;
+    },
+    async verifiers() {
+      return true;
+    },
+    async serviceOperators() {
+      return true;
+    },
+    async approvedAssets() {
+      return true;
+    },
+    async dailyOutflowCap() {
+      return unsafeDailyCap;
+    },
+    async perAccountBorrowCap() {
+      return unsafeBorrowCap;
+    },
+    async minimumCollateralRatioBps() {
+      return 15000n;
+    },
+    async defaultClaimStakeBps() {
+      return 500n;
+    },
+    async claimFeeBps() {
+      return 200n;
+    },
+    async claimFeeVerifierBps() {
+      return 7000n;
+    },
+    async onboardingWaiverClaimCount() {
+      return 3n;
+    },
+    async rejectionSkillPenalty() {
+      return 10n;
+    },
+    async rejectionReliabilityPenalty() {
+      return 20n;
+    },
+    async disputeLossSkillPenalty() {
+      return 30n;
+    },
+    async disputeLossReliabilityPenalty() {
+      return 50n;
+    }
+  };
+
+  const status = await gateway.getTreasuryPolicyStatus();
+
+  assert.equal(status.risk.dailyOutflowCap, null);
+  assert.equal(status.risk.dailyOutflowCapRaw, unsafeDailyCap.toString());
+  assert.equal(status.risk.dailyOutflowCapExact, false);
+  assert.equal(status.risk.perAccountBorrowCap, null);
+  assert.equal(status.risk.perAccountBorrowCapRaw, unsafeBorrowCap.toString());
+  assert.equal(status.risk.perAccountBorrowCapExact, false);
+  assert.equal(status.risk.minimumCollateralRatioBps, 15000);
+  assert.equal(status.risk.minimumCollateralRatioBpsRaw, "15000");
+  assert.equal(status.risk.minimumCollateralRatioBpsExact, true);
+  assert.equal(status.risk.claimFeeVerifierBps, 7000);
+  assert.equal(status.risk.claimFeeVerifierBpsRaw, "7000");
+  assert.equal(status.risk.claimFeeVerifierBpsExact, true);
+});
+
 test("getTreasuryPolicyStatus records individual read errors without hiding roles", async () => {
   const gateway = new BlockchainGateway({
     enabled: true,


### PR DESCRIPTION
## What changed
- Preserve exact raw chain strings for treasury policy risk values exposed through getTreasuryPolicyStatus / /admin/status.
- Keep existing numeric mirrors only when the value fits JavaScript safe-integer precision; unsafe uint256 values become null instead of approximate numbers.
- Add coverage for uint256.max and >Number.MAX_SAFE_INTEGER policy caps.
- Document the API boundary in the RC1 spec, Polkadot execution plan, and audit package.

## Audit note
Polkadot docs MCP check: Asset Hub ERC20 precompiles expose token amounts as uint256, and metadata such as decimals is outside the ERC20 interface. API/status surfaces therefore need to preserve exact raw chain values instead of depending on JS Number for policy caps.

## Checks
- node --test mcp-server/src/blockchain/gateway.test.js
- npm --workspace mcp-server test

## Impact
- Backend: yes, /admin/status policy risk serialization.
- Frontend: optional follow-up. Existing numeric fields still exist for safe values; for unsafe cap values, use the new *Raw fields for exact display.
- Indexer/Caddy/contracts/public site: no.
- Env/VPS secrets: none.