### PR TITLE
Align claim expiry with escrow deadline

### DIFF
--- a/docs/AVERRAY_WORKING_SPEC.md
+++ b/docs/AVERRAY_WORKING_SPEC.md
@@ -797,7 +797,7 @@ Before public v1.0.0-rc1 launch:
 - [x] Hash fields live on `JobCreated` / `Submitted` / `Verified`
 - [x] `Disclosed` / `AutoDisclosed` events live on session lifecycle contract
 - [x] `EscrowCore.openDispute` enforces deadline window (`block.timestamp <= rejectedAt + DISPUTE_WINDOW`)
-- [x] `EscrowCore.submitWork` rejects expired claims; workers must submit before `claimExpiry` or reopen through the timeout path
+- [x] `EscrowCore.submitWork` rejects claims after `claimExpiry`; workers may submit at the exact deadline, and timeout/reclaim starts once chain time is greater than `claimExpiry`
 - [x] `DISPUTE_WINDOW` bumped from 1 day to 7 days
 - [x] `EscrowCore.autoResolveOnTimeout(jobId)` shipped with `ARBITRATOR_SLA = 14 days`
 - [x] `disputedAt` timestamp present on job state and emitted in `DisputeOpened` event

--- a/mcp-server/src/core/claim-state.js
+++ b/mcp-server/src/core/claim-state.js
@@ -2,6 +2,12 @@ const TERMINAL_SESSION_STATUSES = new Set(["resolved", "rejected", "closed", "ex
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 export function claimExpiresAt(session, job) {
+  if (session?.chainClaimExpiresAt) {
+    const chainExpiresAtMs = Date.parse(session.chainClaimExpiresAt);
+    if (Number.isFinite(chainExpiresAtMs)) {
+      return new Date(chainExpiresAtMs).toISOString();
+    }
+  }
   if (!session?.claimedAt) return undefined;
   const claimedAtMs = Date.parse(session.claimedAt);
   const ttlSeconds = Number(job?.claimTtlSeconds ?? 0);
@@ -14,7 +20,9 @@ export function claimExpiresAt(session, job) {
 export function isExpiredClaim(session, job, now = new Date()) {
   if (session?.status !== "claimed") return false;
   const expiresAt = claimExpiresAt(session, job);
-  return Boolean(expiresAt && Date.parse(expiresAt) <= now.getTime());
+  // EscrowCore allows submitWork at exactly claimExpiry and only reopens via
+  // handleClaimTimeout once block.timestamp is greater than claimExpiry.
+  return Boolean(expiresAt && Date.parse(expiresAt) < now.getTime());
 }
 
 export function isTerminalSession(session) {

--- a/mcp-server/src/core/claim-state.test.js
+++ b/mcp-server/src/core/claim-state.test.js
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { claimExpiresAt, isExpiredClaim, summarizeJobClaimState } from "./claim-state.js";
+
+const CLAIMED_SESSION = {
+  sessionId: "job-001:0xabc",
+  jobId: "job-001",
+  wallet: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  status: "claimed",
+  claimedAt: "2026-05-01T10:00:00.000Z"
+};
+
+const JOB = {
+  id: "job-001",
+  lifecycle: { state: "open" },
+  claimTtlSeconds: 60,
+  retryLimit: 2
+};
+
+test("claim expiry follows the escrow timeout boundary at the exact deadline", () => {
+  assert.equal(
+    claimExpiresAt(CLAIMED_SESSION, JOB),
+    "2026-05-01T10:01:00.000Z"
+  );
+  assert.equal(isExpiredClaim(CLAIMED_SESSION, JOB, new Date("2026-05-01T10:01:00.000Z")), false);
+  assert.equal(isExpiredClaim(CLAIMED_SESSION, JOB, new Date("2026-05-01T10:01:00.001Z")), true);
+});
+
+test("claim expiry prefers the canonical on-chain claimExpiry when present", () => {
+  const session = {
+    ...CLAIMED_SESSION,
+    chainClaimExpiresAt: "2026-05-01T10:00:45.000Z"
+  };
+
+  assert.equal(claimExpiresAt(session, JOB), "2026-05-01T10:00:45.000Z");
+  assert.equal(isExpiredClaim(session, JOB, new Date("2026-05-01T10:00:45.000Z")), false);
+  assert.equal(isExpiredClaim(session, JOB, new Date("2026-05-01T10:00:45.001Z")), true);
+});
+
+test("summarizeJobClaimState uses chain expiry before local claimedAt ttl", () => {
+  const status = summarizeJobClaimState({
+    job: JOB,
+    session: {
+      ...CLAIMED_SESSION,
+      chainClaimExpiresAt: "2026-05-01T10:00:45.000Z"
+    },
+    sessions: [CLAIMED_SESSION],
+    now: new Date("2026-05-01T10:00:46.000Z")
+  });
+
+  assert.equal(status.claimState, "expired");
+  assert.equal(status.effectiveState, "claimable");
+  assert.equal(status.claimExpiresAt, "2026-05-01T10:00:45.000Z");
+});

--- a/mcp-server/src/core/job-execution-service.js
+++ b/mcp-server/src/core/job-execution-service.js
@@ -159,6 +159,7 @@ export class JobExecutionService {
       const chainJobId = this.blockchainGateway?.isEnabled()
         ? this.blockchainGateway.toJobId(jobId)
         : jobId;
+      let chainClaimTiming = {};
       const priorClaimCount = countClaimedSessions(await this.collectSessionHistory(wallet));
       const claimEconomicsConfig = await this.getClaimEconomicsConfig();
       let claimEconomics = computeClaimEconomics({
@@ -181,6 +182,9 @@ export class JobExecutionService {
         }
         await this.blockchainGateway.ensureClaimStakeLiquidity?.(job.rewardAsset, claimEconomics.totalClaimLock);
         await this.blockchainGateway.claimJob(jobId);
+        chainClaimTiming = this.buildChainClaimTiming(
+          await this.blockchainGateway.getJob(jobId).catch(() => undefined)
+        );
       } else if (claimEconomics.totalClaimLock > 0) {
         await this.accountMutationService?.lockJobStake?.(wallet, job.rewardAsset, claimEconomics.totalClaimLock, undefined);
       }
@@ -197,6 +201,7 @@ export class JobExecutionService {
         claimEconomicsWaived: claimEconomics.claimEconomicsWaived,
         claimNumber: claimEconomics.claimNumber,
         totalClaimLock: claimEconomics.totalClaimLock,
+        ...chainClaimTiming,
         idempotencyKey,
         protocolHistory: [protocol]
       };
@@ -410,6 +415,16 @@ export class JobExecutionService {
       claimedAt: session?.claimedAt,
       claimExpiresAt: claimExpiresAt(session, job) ?? session?.expiredAt,
       claimTtlSeconds: job?.claimTtlSeconds
+    };
+  }
+
+  buildChainClaimTiming(liveJob = undefined) {
+    const claimExpirySeconds = Number(liveJob?.claimExpiry ?? 0);
+    if (!Number.isFinite(claimExpirySeconds) || claimExpirySeconds <= 0) {
+      return {};
+    }
+    return {
+      chainClaimExpiresAt: new Date(claimExpirySeconds * 1000).toISOString()
     };
   }
 

--- a/mcp-server/src/core/job-execution-service.test.js
+++ b/mcp-server/src/core/job-execution-service.test.js
@@ -5,6 +5,7 @@ import { ValidationError } from "./errors.js";
 import { JobExecutionService } from "./job-execution-service.js";
 import { MemoryStateStore } from "./state-store.js";
 import { computeClaimEconomics } from "./claim-economics.js";
+import { claimExpiresAt } from "./claim-state.js";
 import { buildAverrayDisclosureFooter } from "./maintainer-surface-policy.js";
 
 const WALLET = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -263,6 +264,31 @@ test("claimJob reopens an expired claim when retry budget remains", async () => 
   assert.notEqual(second.sessionId, first.sessionId);
   assert.equal((await stateStore.getSession(first.sessionId)).status, "expired");
   assert.equal((await stateStore.findSessionByJobId(job.id)).sessionId, second.sessionId);
+});
+
+test("claimJob stores on-chain claim expiry when blockchain is enabled", async () => {
+  const stateStore = new MemoryStateStore();
+  const job = makeJob({ claimTtlSeconds: 60 });
+  let getJobCalls = 0;
+  const blockchainGateway = {
+    isEnabled: () => true,
+    toJobId: (jobId) => `chain:${jobId}`,
+    async getJob() {
+      getJobCalls += 1;
+      return getJobCalls === 1
+        ? { state: 0 }
+        : { state: 1, claimExpiry: Date.parse("2026-05-01T10:01:00.000Z") / 1000 };
+    },
+    async ensureJob() {},
+    async ensureClaimStakeLiquidity() {},
+    async claimJob() {}
+  };
+  const service = new JobExecutionService(stateStore, blockchainGateway, () => job);
+
+  const claimed = await service.claimJob(WALLET, job.id, "http", "idemp-chain-expiry");
+
+  assert.equal(claimed.chainClaimExpiresAt, "2026-05-01T10:01:00.000Z");
+  assert.equal(claimExpiresAt(claimed, job), "2026-05-01T10:01:00.000Z");
 });
 
 test("claimJob reports exhausted retry budget after an expired single-attempt job", async () => {


### PR DESCRIPTION
## Summary
- Store the canonical on-chain claim expiry on chain-backed claim sessions when the claim tx has landed.
- Make backend expired-claim detection mirror EscrowCore: submit is still allowed at exactly claimExpiry, timeout/reclaim starts after it.
- Add claim-state/job-execution regression coverage and tighten the spec wording.

## Checks
- node --test mcp-server/src/core/claim-state.test.js mcp-server/src/core/job-execution-service.test.js mcp-server/src/core/platform-service.test.js
- npm --workspace mcp-server test
- forge test --match-test "testClaimTimeoutReopensJobAndSlashesStake|testExpiredClaimCannotSubmitWork|testReclaimedJobGetsFreshClaimExpiry"
- forge test

## Impact
- Backend/session lifecycle: yes
- Contracts: no Solidity changes
- Docs/spec: yes
- Frontend/indexer/Caddy/public site: no
- Environment/VPS secrets: none