### PR TITLE
Prove schema-native worker-loop validation

### DIFF
--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -150,11 +150,14 @@ discipline for custom/off-platform schemas.
   mutations (`claimJobAfterValidation` and `submitValidatedWork`)
 - the hosted product-proof worker loop now uses a built-in
   `schema://jobs/product-proof-worker-loop` output contract, validates its
-  structured submission before claim, and records that validation trace in the
-  launch evidence gate
+  structured submission before claim, probes an invalid `submission.output`
+  wrapper through the read-only validation route, and records both validation
+  traces in the launch evidence gate
 
 ### Gaps today
 
+- the hosted evidence gate still needs to be run live after deploy with
+  `PRODUCT_PROOF_REQUIRE_WORKER_LOOP=1`
 - custom/off-platform schema refs are still allowed without signed schema
   registration
 - third-party and non-product-proof helper workflows still need to adopt the
@@ -528,7 +531,8 @@ As of [SPEC_AUDIT_2026-05-13.md](SPEC_AUDIT_2026-05-13.md), the next work
 should prioritize live-proof and launch-risk items before adding new product
 surface:
 
-1. complete the hosted worker-loop product-proof evidence gate
+1. complete the hosted worker-loop product-proof evidence gate, including the
+   valid direct-object validation and invalid-wrapper validation proof
 2. close operator self-report proof through Hermes/operator reporting: keep
    `run_hermes_post_deploy=1`, confirm scheduled ops-health and daily-brief
    evidence, and run the hosted smoke's bootstrap instrumentation gate to prove
@@ -536,7 +540,8 @@ surface:
    provider/API-key-shaped tokens. Branded Resend email delivery remains an
    optional transport to prove later with `bootstrap_self_report_send_now=1`
    after a verified sender domain exists.
-3. tighten schema-native jobs for the first-wave job families
+3. tighten schema-native jobs for the first-wave job families and extend helper
+   adoption beyond the product-proof loop
 4. finish dispute/arbitration launch wiring
 5. capture the native XCM deposit, withdraw, and failure evidence pack
 6. add visible timeline filters to the operator app

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -206,11 +206,14 @@ RUN_SUBSCAN_XCM_VALIDATION=1 ./scripts/ops/check-release-readiness.sh testnet
   `/jobs/validate-submission` and submitted as direct `payload.submission`
   evidence, with no `submission.output` wrapper. The operator-app gate is in
   place: `app/lib/api/guarded-submit.js` short-circuits the submit when the
-  validation response is not `{ valid: true }`. Flip this box after the hosted
-  run-detail surface has been used to validate at least one structured-required
-  job (one valid, one invalid) and the invalid attempt did not consume the
-  session's submit budget. Verify with the regression test:
-  `node --test app/lib/api/guarded-submit.test.mjs`.
+  validation response is not `{ valid: true }`. The hosted worker-loop evidence
+  must include both `validationReadiness` for the direct schema object and
+  `invalidValidationReadiness` for a rejected `submission.output` wrapper with
+  `submitAttempted=false`. Flip this box after the hosted run-detail surface or
+  product-proof worker loop has been used to validate at least one
+  structured-required job (one valid, one invalid) and the invalid attempt did
+  not consume the session's submit budget. Verify with the regression tests:
+  `node --test app/lib/api/guarded-submit.test.mjs scripts/ops/run-hosted-worker-loop.test.mjs scripts/ops/check-product-proof-gate.test.mjs`.
 - [ ] The phase-0 dispute verdict path has been exercised on the hosted stack
   with the configured arbitrator/gateway and a recorded on-chain tx state from
   `POST /disputes/:id/verdict`. Flip this box only after running the dry-run

--- a/docs/PRODUCT_PROOF_GATE.md
+++ b/docs/PRODUCT_PROOF_GATE.md
@@ -28,7 +28,8 @@ The script checks:
 - `https://averray.com/builders/`
 - `https://averray.com/llms.txt`
 - the public badge and profile JSON schemas
-- the job schema index and a sample job schema
+- the job schema index includes the built-in first-wave schemas, plus a sample
+  job schema fetch
 
 The public discovery manifest and API mirror must be byte-for-byte equivalent
 after JSON parsing. This is the check that protects external agents from
@@ -43,13 +44,15 @@ The deploy workflow can generate this evidence itself when run manually with:
 
 That path uses the production `ADMIN_JWT` secret, creates a tiny benchmark job,
 preflights it as the token wallet, validates the structured product-proof
-submission through `/jobs/validate-submission`, claims it, submits matching
-evidence, runs the verifier, and writes the evidence file before running the
-required gate. It does not print the token. The worker loop fails closed before
-claim unless schema validation succeeds, the token exposes the full loop
-capability set, the hosted stack reports canonical v1 USDC settlement
-readiness, and the worker wallet has enough AgentAccountCore USDC liquidity for
-the reward.
+submission through `/jobs/validate-submission`, probes one invalid
+`submission.output` wrapper through the same read-only validation route, claims
+it, submits matching evidence, runs the verifier, and writes the evidence file
+before running the required gate. It does not print the token. The worker loop
+fails closed before claim unless the valid schema validation succeeds, the
+invalid schema validation is rejected without a submit attempt, the token
+exposes the full loop capability set, the hosted stack reports canonical v1
+USDC settlement readiness, and the worker wallet has enough AgentAccountCore
+USDC liquidity for the reward.
 
 The hosted smoke token must resolve from `/auth/session` with capabilities for:
 `account:read`, `admin:status`, `jobs:create`, `jobs:preflight`, `jobs:claim`,
@@ -125,6 +128,17 @@ The worker-loop command writes a local evidence file like:
     "submissionKind": "structured",
     "validatedBeforeClaim": true
   },
+  "invalidValidationReadiness": {
+    "jobId": "product-proof-worker-loop-...",
+    "valid": false,
+    "submitSafe": false,
+    "schemaRef": "schema://jobs/product-proof-worker-loop",
+    "schemaValidates": "payload.submission",
+    "code": "invalid_submission_shape",
+    "path": "payload.submission.output",
+    "checkedBeforeClaim": true,
+    "submitAttempted": false
+  },
   "claimReadiness": {
     "status": "claimed",
     "sessionId": "sess_..."
@@ -150,6 +164,8 @@ The script fetches the badge and profile documents and verifies that:
 - the reward clears the USDC minBalance and the worker has enough USDC liquidity
 - the job preflight was eligible and claimable before claim
 - the product-proof submission passed schema validation before claim
+- one intentionally invalid `submission.output` wrapper failed validation before
+  claim and did not call `/jobs/submit`
 - the submit, verification, and session statuses reached submitted, approved,
   and resolved
 - the badge uses `averray.schemaVersion = "v1"`

--- a/docs/SPEC_AUDIT_2026-05-13.md
+++ b/docs/SPEC_AUDIT_2026-05-13.md
@@ -183,11 +183,16 @@ SSH/basic-auth/admin-JWT cutovers, and the basic hosted smoke is green.
   `app/lib/api/guarded-submit.js` so a structured-required job will not fire
   `POST /jobs/submit` on a draft that fails validation. Regression covered by
   `app/lib/api/guarded-submit.test.mjs` ("structured-required job validates
-  first; invalid response prevents /jobs/submit").
-- Remaining: prove the hosted UI/API path end-to-end against the live stack
-  (one valid + one invalid hosted run), extend the validation-before-claim
-  pattern to remaining third-party/helper workflows, and add signed
-  registration before tightening custom/off-platform schema refs.
+  first; invalid response prevents /jobs/submit"). The product-proof worker
+  loop now records both the valid direct-object validation and a read-only
+  rejected `submission.output` wrapper probe before claim, and the
+  product-proof gate asserts the hosted schema index contains the built-in
+  first-wave registry.
+- Remaining: run the hosted product-proof worker-loop evidence gate against the
+  live stack with the valid + invalid validation traces present, extend the
+  validation-before-claim pattern to remaining third-party/helper workflows,
+  and add signed registration before tightening custom/off-platform schema
+  refs.
 
 ### Verifier Replay Hardening
 
@@ -294,7 +299,8 @@ correlation and settlement path.
    `bootstrap_self_report_send_now=1` plus
    `smoke_check_bootstrap_self_report_sent=1` as an optional branded-email proof
    only after a verified sender domain is configured.
-3. Prove the hosted schema-native validation path and external helper adoption.
+3. Run the hosted schema-native validation proof and extend external helper
+   adoption.
 4. Prove the dispute verdict path live and decide `/release` semantics.
 5. Run the native XCM evidence pack captures.
 6. Continue folding funding/settlement/dispute events into the canonical

--- a/scripts/ops/check-product-proof-gate.mjs
+++ b/scripts/ops/check-product-proof-gate.mjs
@@ -3,10 +3,12 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 import { DEFAULT_ESCROW_ASSET } from "../../mcp-server/src/core/assets.js";
+import { listBuiltinJobSchemas } from "../../mcp-server/src/core/job-schema-registry.js";
 
 const DEFAULT_PUBLIC_SITE_URL = "https://averray.com";
 const DEFAULT_API_BASE_URL = "https://api.averray.com";
 const DEFAULT_SAMPLE_SCHEMA = "wikipedia-citation-repair-output";
+const REQUIRED_FIRST_WAVE_SCHEMA_REFS = listBuiltinJobSchemas().map((schema) => schema.$id);
 const REQUIRED_ESCROW_ASSET = {
   symbol: DEFAULT_ESCROW_ASSET.symbol,
   address: DEFAULT_ESCROW_ASSET.address.toLowerCase(),
@@ -88,8 +90,12 @@ export async function checkProductProofGate({
   assert.ok(Number.isInteger(schemaIndex.count) && schemaIndex.count > 0, "schema index count must be positive");
   assert.ok(Array.isArray(schemaIndex.schemas), "schema index must include schemas array");
   assert.equal(schemaIndex.count, schemaIndex.schemas.length);
+  const schemaRefs = new Set(schemaIndex.schemas.map((entry) => entry.$id));
+  for (const schemaRef of REQUIRED_FIRST_WAVE_SCHEMA_REFS) {
+    assert.ok(schemaRefs.has(schemaRef), `schema index must include first-wave schema ${schemaRef}`);
+  }
   const sampleRef = `schema://jobs/${sampleSchema}`;
-  assert.ok(schemaIndex.schemas.some((entry) => entry.$id === sampleRef), `schema index must include ${sampleRef}`);
+  assert.ok(schemaRefs.has(sampleRef), `schema index must include ${sampleRef}`);
   const sample = await fetchJson(fetchImpl, `${apiBaseUrl}/schemas/jobs/${sampleSchema}.json`);
   assert.equal(sample.$id, sampleRef);
 
@@ -202,6 +208,19 @@ function assertWorkerLoopCompletionEvidence(evidence, { apiBaseUrl }) {
   assert.equal(evidence.validationReadiness?.schemaValidates, "payload.submission", "worker-loop evidence validation must target payload.submission");
   assert.equal(evidence.validationReadiness?.submissionKind, "structured", "worker-loop evidence validation must use structured submission");
   assert.equal(evidence.validationReadiness?.validatedBeforeClaim, true, "worker-loop evidence must prove validation happened before claim");
+
+  assert.ok(evidence.invalidValidationReadiness, "worker-loop evidence requires an invalid schema validation proof");
+  assert.equal(evidence.invalidValidationReadiness.jobId, evidence.jobId, "worker-loop evidence invalid validation jobId must match evidence jobId");
+  assert.equal(evidence.invalidValidationReadiness?.valid, false, "worker-loop evidence requires an invalid schema validation proof");
+  assert.equal(evidence.invalidValidationReadiness?.submitSafe, false, "worker-loop evidence invalid validation must not be submit safe");
+  assert.equal(evidence.invalidValidationReadiness?.schemaRef, "schema://jobs/product-proof-worker-loop", "worker-loop evidence invalid validation schema must match product-proof output schema");
+  assert.equal(evidence.invalidValidationReadiness?.schemaValidates, "payload.submission", "worker-loop evidence invalid validation must target payload.submission");
+  assert.equal(evidence.invalidValidationReadiness?.checkedBeforeClaim, true, "worker-loop evidence invalid validation must happen before claim");
+  assert.equal(evidence.invalidValidationReadiness?.submitAttempted, false, "worker-loop evidence invalid validation must not call submit");
+  assert.ok(
+    evidence.invalidValidationReadiness?.path || evidence.invalidValidationReadiness?.message,
+    "worker-loop evidence invalid validation must include a path or message"
+  );
 
   assert.equal(evidence.claimReadiness?.sessionId, evidence.sessionId, "worker-loop evidence claim sessionId must match evidence sessionId");
   assert.ok(evidence.claimReadiness?.status, "worker-loop evidence requires claim status");

--- a/scripts/ops/check-product-proof-gate.test.mjs
+++ b/scripts/ops/check-product-proof-gate.test.mjs
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { buildDiscoveryManifest } from "../../mcp-server/src/core/discovery-manifest.js";
+import { listBuiltinJobSchemas } from "../../mcp-server/src/core/job-schema-registry.js";
 import { checkProductProofGate } from "./check-product-proof-gate.mjs";
 
 test("checkProductProofGate validates public discovery, pages, and schemas", async () => {
@@ -33,8 +34,7 @@ test("checkProductProofGate validates public discovery, pages, and schemas", asy
       $id: "https://averray.com/schemas/agent-profile-v1.json"
     }],
     ["https://api.averray.com/schemas/jobs", {
-      count: 1,
-      schemas: [{ $id: "schema://jobs/wikipedia-citation-repair-output" }]
+      ...jobSchemaIndex()
     }],
     ["https://api.averray.com/schemas/jobs/wikipedia-citation-repair-output.json", {
       $id: "schema://jobs/wikipedia-citation-repair-output"
@@ -95,8 +95,7 @@ test("checkProductProofGate requires an evidence file when the worker loop is ma
       $id: "https://averray.com/schemas/agent-profile-v1.json"
     }],
     ["https://api.averray.com/schemas/jobs", {
-      count: 1,
-      schemas: [{ $id: "schema://jobs/wikipedia-citation-repair-output" }]
+      ...jobSchemaIndex()
     }],
     ["https://api.averray.com/schemas/jobs/wikipedia-citation-repair-output.json", {
       $id: "schema://jobs/wikipedia-citation-repair-output"
@@ -171,6 +170,31 @@ test("checkProductProofGate rejects minimal evidence when worker-loop proof is r
   );
 });
 
+test("checkProductProofGate rejects worker-loop evidence without invalid schema proof", async () => {
+  const manifest = buildDiscoveryManifest();
+  const tmp = await mkdtemp(join(tmpdir(), "product-proof-gate-"));
+  const evidenceFile = join(tmp, "evidence.json");
+  const evidence = workerLoopEvidence({
+    wallet: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+    sessionId: "session-product-proof",
+    jobId: "product-proof-worker-loop-1700000000000"
+  });
+  delete evidence.invalidValidationReadiness;
+  await writeFile(evidenceFile, `${JSON.stringify(evidence, null, 2)}\n`);
+
+  await assert.rejects(
+    () => checkProductProofGate({
+      env: {
+        PRODUCT_PROOF_REQUIRE_WORKER_LOOP: "1",
+        PRODUCT_PROOF_EVIDENCE_FILE: evidenceFile
+      },
+      fetchImpl: fakeFetch(productProofResponses(manifest)),
+      log: () => {}
+    }),
+    /worker-loop evidence requires an invalid schema validation proof/u
+  );
+});
+
 function fakeFetch(responses) {
   return async (url) => {
     const value = responses.get(String(url));
@@ -214,13 +238,20 @@ function productProofResponses(manifest) {
       $id: "https://averray.com/schemas/agent-profile-v1.json"
     }],
     ["https://api.averray.com/schemas/jobs", {
-      count: 1,
-      schemas: [{ $id: "schema://jobs/wikipedia-citation-repair-output" }]
+      ...jobSchemaIndex()
     }],
     ["https://api.averray.com/schemas/jobs/wikipedia-citation-repair-output.json", {
       $id: "schema://jobs/wikipedia-citation-repair-output"
     }]
   ]);
+}
+
+function jobSchemaIndex() {
+  const schemas = listBuiltinJobSchemas().map(({ $id }) => ({ $id }));
+  return {
+    count: schemas.length,
+    schemas
+  };
 }
 
 function workerLoopEvidence({ wallet, sessionId, jobId }) {
@@ -274,6 +305,20 @@ function workerLoopEvidence({ wallet, sessionId, jobId }) {
       schemaValidates: "payload.submission",
       submissionKind: "structured",
       validatedBeforeClaim: true
+    },
+    invalidValidationReadiness: {
+      jobId,
+      valid: false,
+      submitSafe: false,
+      schemaRef: "schema://jobs/product-proof-worker-loop",
+      schemaValidates: "payload.submission",
+      code: "invalid_submission_shape",
+      message: "Send the structured proposal object directly as submission, not under submission.output.",
+      path: "payload.submission.output",
+      received: "payload.submission.output",
+      hint: "Move the object currently under submission.output up to submission.",
+      checkedBeforeClaim: true,
+      submitAttempted: false
     },
     claimReadiness: {
       status: "claimed",

--- a/scripts/ops/run-hosted-worker-loop.mjs
+++ b/scripts/ops/run-hosted-worker-loop.mjs
@@ -98,6 +98,11 @@ export async function runHostedWorkerLoop({
     preflightReadiness,
     submission
   });
+  const invalidValidationReadiness = await assertInvalidSubmissionBlocked({
+    platform,
+    jobId,
+    preflightReadiness
+  });
 
   log(`Claiming hosted product-proof job ${jobId}`);
   const claim = await platform.claimJob(jobId, idempotencyKey);
@@ -152,6 +157,7 @@ export async function runHostedWorkerLoop({
     liquidityReadiness,
     preflightReadiness,
     validationReadiness,
+    invalidValidationReadiness,
     claimReadiness: {
       status: claim.status ?? null,
       sessionId,
@@ -191,6 +197,50 @@ function buildProductProofSubmission({ jobId, evidence, timestamp }) {
         evidence: `Submission targets ${PRODUCT_PROOF_OUTPUT_SCHEMA_REF}.`
       }
     ]
+  };
+}
+
+async function assertInvalidSubmissionBlocked({ platform, jobId, preflightReadiness }) {
+  if (typeof platform.validateJobSubmission !== "function") {
+    throw new Error("Hosted product-proof worker loop requires /jobs/validate-submission before claim.");
+  }
+  const invalidSubmission = {
+    output: {
+      wrapped_under_submission_output: true
+    }
+  };
+  const validation = await platform.validateJobSubmission(jobId, invalidSubmission);
+  if (!validation || typeof validation !== "object") {
+    throw new Error("Hosted product-proof worker loop requires an invalid validation response before claim.");
+  }
+  if (validation.jobId && validation.jobId !== jobId) {
+    throw new Error(`invalid submission validation job id mismatch: expected ${jobId}, got ${validation.jobId}`);
+  }
+  if (validation.valid !== false || validation.submitSafe !== false) {
+    throw new Error(
+      "invalid product-proof submission unexpectedly passed validation before claim; " +
+      `valid=${String(validation.valid)}; submitSafe=${String(validation.submitSafe)}.`
+    );
+  }
+  const expectedSchemaRef = preflightReadiness.requiredOutputSchema ?? PRODUCT_PROOF_OUTPUT_SCHEMA_REF;
+  if (validation.schemaRef && validation.schemaRef !== expectedSchemaRef) {
+    throw new Error(
+      `invalid submission validation schema mismatch: expected ${expectedSchemaRef}, got ${validation.schemaRef}`
+    );
+  }
+  return {
+    jobId,
+    valid: false,
+    submitSafe: false,
+    schemaRef: validation.schemaRef ?? expectedSchemaRef,
+    schemaValidates: validation.schemaValidates ?? "payload.submission",
+    code: validation.code ?? null,
+    message: validation.message ?? null,
+    path: validation.path ?? validation.errorPaths?.[0] ?? null,
+    received: validation.details?.received ?? null,
+    hint: validation.details?.hint ?? null,
+    checkedBeforeClaim: true,
+    submitAttempted: false
   };
 }
 

--- a/scripts/ops/run-hosted-worker-loop.test.mjs
+++ b/scripts/ops/run-hosted-worker-loop.test.mjs
@@ -36,7 +36,7 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
     },
     async validateJobSubmission(id, submission) {
       calls.push(["validateJobSubmission", id, submission]);
-      return validationReady({ jobId: id });
+      return validationForSubmission({ jobId: id, submission });
     },
     async claimJob(id, idempotencyKey) {
       calls.push(["claimJob", id, idempotencyKey]);
@@ -87,6 +87,7 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
     "createJob",
     "preflightJob",
     "validateJobSubmission",
+    "validateJobSubmission",
     "claimJob",
     "submitWork",
     "runVerifier",
@@ -98,8 +99,9 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
   assert.equal(calls[3][1].rewardAsset, "USDC");
   assert.equal(calls[3][1].rewardAmount, 0.1);
   assert.equal(calls[5][2].summary, `complete verified output for ${jobId}`);
-  assert.equal(calls[6][2], `product-proof:${jobId}`);
-  assert.equal(calls[7][2].status, "complete");
+  assert.deepEqual(calls[6][2], { output: { wrapped_under_submission_output: true } });
+  assert.equal(calls[7][2], `product-proof:${jobId}`);
+  assert.equal(calls[8][2].status, "complete");
 
   const written = JSON.parse(await readFile(evidenceFile, "utf8"));
   assert.equal(written.jobId, jobId);
@@ -119,6 +121,14 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
   assert.equal(written.validationReadiness.schemaValidates, "payload.submission");
   assert.equal(written.validationReadiness.submissionKind, "structured");
   assert.equal(written.validationReadiness.validatedBeforeClaim, true);
+  assert.equal(written.invalidValidationReadiness.valid, false);
+  assert.equal(written.invalidValidationReadiness.submitSafe, false);
+  assert.equal(written.invalidValidationReadiness.schemaRef, "schema://jobs/product-proof-worker-loop");
+  assert.equal(written.invalidValidationReadiness.schemaValidates, "payload.submission");
+  assert.equal(written.invalidValidationReadiness.code, "invalid_submission_shape");
+  assert.equal(written.invalidValidationReadiness.received, "payload.submission.output");
+  assert.equal(written.invalidValidationReadiness.checkedBeforeClaim, true);
+  assert.equal(written.invalidValidationReadiness.submitAttempted, false);
   assert.equal(written.claimReadiness.status, "claimed");
   assert.equal(written.claimReadiness.claimExpiresAt, "2026-01-01T01:00:00.000Z");
   assert.equal(written.submitStatus, "submitted");
@@ -190,8 +200,8 @@ test("runHostedWorkerLoop accepts an explicit positive reward amount", async () 
       calls.push(["preflightJob", id]);
       return preflightReady({ jobId: id });
     },
-    async validateJobSubmission(id) {
-      return validationReady({ jobId: id });
+    async validateJobSubmission(id, submission) {
+      return validationForSubmission({ jobId: id, submission });
     },
     async claimJob(id) {
       return { status: "claimed", sessionId: `${id}:wallet` };
@@ -676,6 +686,33 @@ function validationReady({
     schemaValidates: "payload.submission",
     submissionKind: "structured"
   };
+}
+
+function invalidValidationBlocked({
+  jobId,
+  schemaRef = "schema://jobs/product-proof-worker-loop"
+}) {
+  return {
+    jobId,
+    valid: false,
+    submitSafe: false,
+    schemaRef,
+    schemaValidates: "payload.submission",
+    code: "invalid_submission_shape",
+    message: "Send the structured proposal object directly as submission, not under submission.output.",
+    path: "payload.submission.output",
+    details: {
+      received: "payload.submission.output",
+      hint: "Move the object currently under submission.output up to submission."
+    }
+  };
+}
+
+function validationForSubmission({ jobId, submission }) {
+  if (submission?.output?.wrapped_under_submission_output === true) {
+    return invalidValidationBlocked({ jobId });
+  }
+  return validationReady({ jobId });
 }
 
 function settlementReadyStatus(overrides = {}) {


### PR DESCRIPTION
## Summary
- require the hosted product-proof gate to see the full built-in first-wave schema index
- add a read-only invalid submission.output wrapper probe before claim in the hosted worker loop
- record and gate on invalidValidationReadiness with submitAttempted=false, alongside the valid direct payload.submission proof
- update product-proof/spec docs with the remaining live proof step

## Checks
- node --test scripts/ops/run-hosted-worker-loop.test.mjs scripts/ops/check-product-proof-gate.test.mjs app/lib/api/guarded-submit.test.mjs

## Surface
- Backend/ops scripts and docs only
- No frontend, indexer, Caddy, contracts, or public generated output changes

## Env / deploy notes
- No new env vars or secrets
- After deploy, run the production product-proof workflow with smoke_check_product_proof_gate=1 and product_proof_require_worker_loop=1 to produce the live evidence file containing validationReadiness and invalidValidationReadiness