### PR TITLE
Fix production workflow dispatch YAML

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -56,7 +56,7 @@ on:
           - "0"
           - "1"
       bootstrap_self_report_send_now:
-        description: Optional branded-email proof: send one bootstrap self-report through the admin API before hosted smoke checks.
+        description: "Optional branded-email proof: send one bootstrap self-report through the admin API before hosted smoke checks."
         required: false
         default: "0"
         type: choice
@@ -72,7 +72,7 @@ on:
           - "0"
           - "1"
       smoke_check_bootstrap_self_report_sent:
-        description: Optional branded-email proof: require the bootstrap self-report last run to be sent.
+        description: "Optional branded-email proof: require the bootstrap self-report last run to be sent."
         required: false
         default: "0"
         type: choice


### PR DESCRIPTION
## Summary
- quote workflow_dispatch descriptions containing colons so the deploy workflow YAML parses correctly
- restores GitHub recognition of workflow_dispatch for the production deploy workflow

## Checks
- ruby -ryaml -e 'data=YAML.load_file(".github/workflows/deploy-production.yml"); p data.keys; p data["on"] || data[true]'

## Surface
- GitHub Actions workflow only
- No backend, frontend, indexer, Caddy, contracts, or public site changes

## Env / deploy notes
- No env or secret changes
- This unblocks manual production workflow dispatch for the schema-native/product-proof live proof