### PR TITLE
Accept display-unit product-proof liquidity

### DIFF
--- a/scripts/ops/run-hosted-worker-loop.mjs
+++ b/scripts/ops/run-hosted-worker-loop.mjs
@@ -291,7 +291,12 @@ async function assertProductProofLiquidity({ platform, wallet, rewardAsset, rewa
   const asset = settlementReadiness.asset;
   const decimals = Number(asset.decimals);
   const requiredRaw = toBaseUnits(rewardAmount, decimals);
-  const availableRaw = toBigIntAmount(account?.liquid?.[rewardAsset], `${rewardAsset} liquid balance`);
+  const availableRaw = toRawAssetAmount({
+    rawValue: account?.raw?.liquid?.[rewardAsset],
+    displayValue: account?.liquid?.[rewardAsset],
+    decimals,
+    label: `${rewardAsset} liquid balance`
+  });
   if (availableRaw < requiredRaw) {
     const agentAccountAddress = settlementReadiness.contracts?.agentAccountAddress ?? "AgentAccountCore";
     throw new Error(
@@ -309,6 +314,16 @@ async function assertProductProofLiquidity({ platform, wallet, rewardAsset, rewa
     required: formatBaseUnits(requiredRaw, decimals),
     available: formatBaseUnits(availableRaw, decimals)
   };
+}
+
+function toRawAssetAmount({ rawValue, displayValue, decimals, label }) {
+  if (rawValue !== undefined && rawValue !== null && rawValue !== "") {
+    return toBigIntAmount(rawValue, `${label} raw balance`);
+  }
+  if (displayValue === undefined || displayValue === null || displayValue === "") {
+    throw new Error(`${label} must be present as either account.raw.liquid or account.liquid.`);
+  }
+  return toBaseUnits(displayValue, decimals);
 }
 
 function assertRewardClearsAssetMinBalance({ rewardAsset, rewardAmount, asset }) {

--- a/scripts/ops/run-hosted-worker-loop.test.mjs
+++ b/scripts/ops/run-hosted-worker-loop.test.mjs
@@ -236,6 +236,59 @@ test("runHostedWorkerLoop accepts an explicit positive reward amount", async () 
   assert.equal(calls[0][1].rewardAmount, 0.07);
 });
 
+test("runHostedWorkerLoop accepts display-unit account liquidity when raw balance is unavailable", async () => {
+  const calls = [];
+  const client = {
+    async getAuthSession() {
+      return authSession();
+    },
+    async getAdminStatus() {
+      return settlementReadyStatus();
+    },
+    async getAccountSummary() {
+      return accountSummary({ liquidUsdc: 0.1, includeRaw: false });
+    },
+    async createJob(payload) {
+      calls.push(["createJob", payload]);
+      return { id: payload.id };
+    },
+    async preflightJob(id) {
+      return preflightReady({ jobId: id });
+    },
+    async validateJobSubmission(id, submission) {
+      return validationForSubmission({ jobId: id, submission });
+    },
+    async claimJob(id) {
+      return { status: "claimed", sessionId: `${id}:wallet` };
+    },
+    async submitWork(id) {
+      return { status: "submitted", sessionId: id };
+    },
+    async runVerifier() {
+      return { outcome: "approved" };
+    },
+    async getSession(id) {
+      return { status: "resolved", sessionId: id };
+    },
+    async getAgentBadge(id) {
+      return { averray: { sessionId: id, jobId: "product-proof-worker-loop-1700000000000" } };
+    },
+    async getAgentProfile() {
+      return { badges: [{ sessionId: "product-proof-worker-loop-1700000000000:wallet", jobId: "product-proof-worker-loop-1700000000000" }] };
+    }
+  };
+
+  const result = await runHostedWorkerLoop({
+    client,
+    now: () => 1700000000000,
+    log: () => {},
+    env: { ADMIN_JWT: "token" }
+  });
+
+  assert.equal(calls[0][1].rewardAmount, 0.1);
+  assert.equal(result.liquidityReadiness.availableRaw, "100000");
+});
+
 test("runHostedWorkerLoop fails closed before mutation when AgentAccountCore USDC liquidity is missing", async () => {
   const calls = [];
   const wallet = "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519";
@@ -644,17 +697,25 @@ test("runHostedWorkerLoop rejects rewards below the USDC minBalance before mutat
 
 function accountSummary({
   wallet = "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
-  liquidUsdcRaw
+  liquidUsdcRaw,
+  liquidUsdc = liquidUsdcRaw,
+  includeRaw = true
 }) {
-  return {
+  const summary = {
     wallet,
-    liquid: { USDC: liquidUsdcRaw },
+    liquid: { USDC: liquidUsdc },
     reserved: { USDC: 0 },
     strategyAllocated: {},
     collateralLocked: {},
     jobStakeLocked: {},
     debtOutstanding: {}
   };
+  if (includeRaw) {
+    summary.raw = {
+      liquid: { USDC: String(liquidUsdcRaw) }
+    };
+  }
+  return summary;
 }
 
 function preflightReady({


### PR DESCRIPTION
## Summary
- let the hosted product-proof worker-loop liquidity check prefer account.raw.liquid when present
- fall back to converting display-unit account.liquid values to raw asset units, matching the live /account shape
- add regression coverage for decimal display-unit USDC liquidity

## Checks
- node --test scripts/ops/run-hosted-worker-loop.test.mjs scripts/ops/check-product-proof-gate.test.mjs app/lib/api/guarded-submit.test.mjs

## Surface
- Ops smoke/product-proof scripts only
- No backend API, frontend, indexer, Caddy, contracts, or public site changes

## Env / deploy notes
- No env or secret changes
- This unblocks the hosted product-proof worker-loop live proof after the failed run saw account.liquid.USDC=9.599999