### PR TITLE
Use stored structured verifier input in product-proof smoke

### DIFF
--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -151,8 +151,9 @@ discipline for custom/off-platform schemas.
 - the hosted product-proof worker loop now uses a built-in
   `schema://jobs/product-proof-worker-loop` output contract, validates its
   structured submission before claim, probes an invalid `submission.output`
-  wrapper through the read-only validation route, and records both validation
-  traces in the launch evidence gate
+  wrapper through the read-only validation route, runs verification from the
+  stored structured session submission, and records both validation traces plus
+  the verifier-input mode in the launch evidence gate
 
 ### Gaps today
 

--- a/docs/PRODUCT_PROOF_GATE.md
+++ b/docs/PRODUCT_PROOF_GATE.md
@@ -46,7 +46,8 @@ That path uses the production `ADMIN_JWT` secret, creates a tiny benchmark job,
 preflights it as the token wallet, validates the structured product-proof
 submission through `/jobs/validate-submission`, probes one invalid
 `submission.output` wrapper through the same read-only validation route, claims
-it, submits matching evidence, runs the verifier, and writes the evidence file
+it, submits the structured object, runs the verifier against the stored session
+submission without a plain evidence-string override, and writes the evidence file
 before running the required gate. It does not print the token. The worker loop
 fails closed before claim unless the valid schema validation succeeds, the
 invalid schema validation is rejected without a submit attempt, the token
@@ -139,6 +140,11 @@ The worker-loop command writes a local evidence file like:
     "checkedBeforeClaim": true,
     "submitAttempted": false
   },
+  "verificationReadiness": {
+    "schemaRef": "schema://jobs/product-proof-worker-loop",
+    "usesStoredSessionSubmission": true,
+    "evidenceOverrideProvided": false
+  },
   "claimReadiness": {
     "status": "claimed",
     "sessionId": "sess_..."
@@ -166,6 +172,8 @@ The script fetches the badge and profile documents and verifies that:
 - the product-proof submission passed schema validation before claim
 - one intentionally invalid `submission.output` wrapper failed validation before
   claim and did not call `/jobs/submit`
+- the verifier used the stored structured session submission rather than a
+  legacy plain evidence-string override
 - the submit, verification, and session statuses reached submitted, approved,
   and resolved
 - the badge uses `averray.schemaVersion = "v1"`

--- a/scripts/ops/check-product-proof-gate.mjs
+++ b/scripts/ops/check-product-proof-gate.mjs
@@ -222,6 +222,10 @@ function assertWorkerLoopCompletionEvidence(evidence, { apiBaseUrl }) {
     "worker-loop evidence invalid validation must include a path or message"
   );
 
+  assert.equal(evidence.verificationReadiness?.schemaRef, "schema://jobs/product-proof-worker-loop", "worker-loop evidence verifier schema must match product-proof output schema");
+  assert.equal(evidence.verificationReadiness?.usesStoredSessionSubmission, true, "worker-loop evidence verifier must use the stored structured session submission");
+  assert.equal(evidence.verificationReadiness?.evidenceOverrideProvided, false, "worker-loop evidence verifier must not override schema-native input with a plain evidence string");
+
   assert.equal(evidence.claimReadiness?.sessionId, evidence.sessionId, "worker-loop evidence claim sessionId must match evidence sessionId");
   assert.ok(evidence.claimReadiness?.status, "worker-loop evidence requires claim status");
 }

--- a/scripts/ops/check-product-proof-gate.test.mjs
+++ b/scripts/ops/check-product-proof-gate.test.mjs
@@ -195,6 +195,35 @@ test("checkProductProofGate rejects worker-loop evidence without invalid schema 
   );
 });
 
+test("checkProductProofGate rejects worker-loop evidence with a plain verifier evidence override", async () => {
+  const manifest = buildDiscoveryManifest();
+  const tmp = await mkdtemp(join(tmpdir(), "product-proof-gate-"));
+  const evidenceFile = join(tmp, "evidence.json");
+  const evidence = workerLoopEvidence({
+    wallet: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+    sessionId: "session-product-proof",
+    jobId: "product-proof-worker-loop-1700000000000"
+  });
+  evidence.verificationReadiness = {
+    ...evidence.verificationReadiness,
+    usesStoredSessionSubmission: false,
+    evidenceOverrideProvided: true
+  };
+  await writeFile(evidenceFile, `${JSON.stringify(evidence, null, 2)}\n`);
+
+  await assert.rejects(
+    () => checkProductProofGate({
+      env: {
+        PRODUCT_PROOF_REQUIRE_WORKER_LOOP: "1",
+        PRODUCT_PROOF_EVIDENCE_FILE: evidenceFile
+      },
+      fetchImpl: fakeFetch(productProofResponses(manifest)),
+      log: () => {}
+    }),
+    /worker-loop evidence verifier must use the stored structured session submission/u
+  );
+});
+
 function fakeFetch(responses) {
   return async (url) => {
     const value = responses.get(String(url));
@@ -319,6 +348,11 @@ function workerLoopEvidence({ wallet, sessionId, jobId }) {
       hint: "Move the object currently under submission.output up to submission.",
       checkedBeforeClaim: true,
       submitAttempted: false
+    },
+    verificationReadiness: {
+      schemaRef: "schema://jobs/product-proof-worker-loop",
+      usesStoredSessionSubmission: true,
+      evidenceOverrideProvided: false
     },
     claimReadiness: {
       status: "claimed",

--- a/scripts/ops/run-hosted-worker-loop.mjs
+++ b/scripts/ops/run-hosted-worker-loop.mjs
@@ -118,7 +118,7 @@ export async function runHostedWorkerLoop({
   }
 
   log(`Verifying hosted product-proof session ${sessionId}`);
-  const verification = await platform.runVerifier(sessionId, evidence);
+  const verification = await platform.runVerifier(sessionId);
   if (verification?.outcome !== "approved") {
     throw new Error(`expected approved verifier outcome, got ${verification?.outcome ?? "missing"}`);
   }
@@ -158,6 +158,11 @@ export async function runHostedWorkerLoop({
     preflightReadiness,
     validationReadiness,
     invalidValidationReadiness,
+    verificationReadiness: {
+      schemaRef: PRODUCT_PROOF_OUTPUT_SCHEMA_REF,
+      usesStoredSessionSubmission: true,
+      evidenceOverrideProvided: false
+    },
     claimReadiness: {
       status: claim.status ?? null,
       sessionId,

--- a/scripts/ops/run-hosted-worker-loop.test.mjs
+++ b/scripts/ops/run-hosted-worker-loop.test.mjs
@@ -102,6 +102,8 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
   assert.deepEqual(calls[6][2], { output: { wrapped_under_submission_output: true } });
   assert.equal(calls[7][2], `product-proof:${jobId}`);
   assert.equal(calls[8][2].status, "complete");
+  assert.equal(calls[9][1], sessionId);
+  assert.equal(calls[9][2], undefined);
 
   const written = JSON.parse(await readFile(evidenceFile, "utf8"));
   assert.equal(written.jobId, jobId);
@@ -129,6 +131,9 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
   assert.equal(written.invalidValidationReadiness.received, "payload.submission.output");
   assert.equal(written.invalidValidationReadiness.checkedBeforeClaim, true);
   assert.equal(written.invalidValidationReadiness.submitAttempted, false);
+  assert.equal(written.verificationReadiness.schemaRef, "schema://jobs/product-proof-worker-loop");
+  assert.equal(written.verificationReadiness.usesStoredSessionSubmission, true);
+  assert.equal(written.verificationReadiness.evidenceOverrideProvided, false);
   assert.equal(written.claimReadiness.status, "claimed");
   assert.equal(written.claimReadiness.claimExpiresAt, "2026-01-01T01:00:00.000Z");
   assert.equal(written.submitStatus, "submitted");


### PR DESCRIPTION
## Summary
- run the hosted product-proof verifier from the stored structured session submission instead of passing a legacy evidence-string override
- record verifier-input readiness in the worker-loop evidence
- make the product-proof gate reject evidence that still uses a plain verifier evidence override
- update the product-proof gate docs and roadmap note

## Why
The live product-proof smoke reached create, preflight, validate, claim, submit, then failed at verifier execution because the verifier received a non-empty plain evidence string for a schema-native job. Schema-native verification should reuse the submitted structured session payload.

## Checks
- node --test scripts/ops/run-hosted-worker-loop.test.mjs scripts/ops/check-product-proof-gate.test.mjs app/lib/api/guarded-submit.test.mjs

## Surface
- scripts / hosted smoke
- docs
- no frontend, indexer, Caddy, contracts, or public site runtime changes