### PR TITLE
Bump hono and postcss for security advisories

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -37,7 +37,7 @@
     "@types/react-dom": "19.0.2",
     "eslint": "9.18.0",
     "eslint-config-next": "15.5.15",
-    "postcss": "8.5.1",
+    "postcss": "8.5.10",
     "tailwindcss": "^4.1.0",
     "typescript": "5.7.3"
   }

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "hono": "^4.5.0",
+    "hono": "^4.12.18",
     "ponder": "^0.16.6",
     "viem": "^2.21.3"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "lucide-react": "0.469.0",
-        "next": "^15.5.18",
+        "next": "15.5.18",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-markdown": "^9.1.0",
@@ -52,7 +52,7 @@
         "@types/react-dom": "19.0.2",
         "eslint": "9.18.0",
         "eslint-config-next": "15.5.15",
-        "postcss": "8.5.1",
+        "postcss": "8.5.10",
         "tailwindcss": "^4.1.0",
         "typescript": "5.7.3"
       }
@@ -198,35 +198,6 @@
         }
       }
     },
-    "app/node_modules/postcss": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
-      "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.8",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "app/node_modules/typescript": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
@@ -304,7 +275,7 @@
       "name": "@polkadot/agent-platform-indexer",
       "version": "0.1.0",
       "dependencies": {
-        "hono": "^4.5.0",
+        "hono": "^4.12.18",
         "ponder": "^0.16.6",
         "viem": "^2.21.3"
       },
@@ -13026,9 +12997,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -17412,9 +17383,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
## Summary

Clean manual replacement for [#322](https://github.com/averray-agent/agent/pull/322), which dependabot bundled with unrelated and destructive edits (`indexer/ponder` `^0.16.6` → `^0.0.1`, a stray `next@^9.3.3` in `app/`, plus undisclosed bumps to `astro`/`chopsticks`/`eslint`) that broke CI consistently across five jobs. #322 is closed with the audit notes.

This PR ships **only the actual security bumps**.

## What this PR fixes

- **`indexer/hono`: `^4.5.0` → `^4.12.18`** — three published advisories from honojs:
  - [GHSA-p77w-8qqv-26rm](https://github.com/honojs/hono/security/advisories/GHSA-p77w-8qqv-26rm): Cache middleware ignored `Vary: Authorization` / `Vary: Cookie`, leaking responses across authenticated users.
  - [GHSA-qp7p-654g-cw7p](https://github.com/honojs/hono/security/advisories/GHSA-qp7p-654g-cw7p): `hono/jsx` missed CSS-context escape on style-object values and property names, allowing CSS-only declaration injection.
  - [GHSA-hm8q-7f3q-5f36](https://github.com/honojs/hono/security/advisories/GHSA-hm8q-7f3q-5f36): JWT `verify()` accepted falsy / non-finite / non-numeric `exp` / `nbf` / `iat` values, silently bypassing time-based checks per RFC 7519.
- **`app/postcss`: `8.5.1` → `8.5.10`** — for the corresponding postcss advisory window.

## What this PR explicitly avoids vs. #322

| Issue in #322 | This PR |
|---|---|
| `indexer/ponder` `^0.16.6` → `^0.0.1` (lockfile resolves to `ponder@0.0.1` — a ~16-minor downgrade) | ✅ ponder stays at `0.16.6` |
| `app/node_modules/next@^9.3.3` added alongside `next@15.5.x` | ✅ no stray `next@9` in the lockfile |
| Undisclosed bumps to `astro`, `chopsticks`, `eslint` | ✅ untouched |
| 24,272 lockfile additions | ✅ net lockfile delta is ~11 insertions / 40 deletions |

## Test plan

- [x] `npm --workspace mcp-server test` — 529 tests pass
- [x] `npm --workspace indexer run test:api` — 8 tests pass
- [x] `npm run typecheck:indexer` — clean
- [x] `npm run typecheck:app` — clean
- [ ] CI runs (Backend, Indexer, Operator app, Public site, env template lint) once posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)