### PR TITLE
Persist Hermes operator report logs

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -533,6 +533,15 @@ jobs:
 
           exit "$status"
 
+      - name: Upload Hermes post-deploy log
+        if: always() && env.DEPLOY_RUN_HERMES_POST_DEPLOY == '1' && steps.hermes_post_deploy.outcome != 'skipped'
+        uses: actions/upload-artifact@v4
+        with:
+          name: hermes-post-deploy-${{ github.run_id }}
+          path: hermes-post-deploy.log
+          if-no-files-found: error
+          retention-days: 90
+
       - name: Fail if Hermes post-deploy verification failed
         if: always() && env.DEPLOY_RUN_HERMES_POST_DEPLOY == '1' && steps.hermes_post_deploy.outcome != 'skipped' && steps.hermes_post_deploy.outputs.exit_status != '0'
         run: |

--- a/.github/workflows/hermes-pr-handoff.yml
+++ b/.github/workflows/hermes-pr-handoff.yml
@@ -208,6 +208,15 @@ jobs:
 
           exit "$status"
 
+      - name: Upload Hermes handoff log
+        if: always() && steps.pr.outputs.skip != 'true' && steps.hermes.outcome != 'skipped'
+        uses: actions/upload-artifact@v4
+        with:
+          name: hermes-handoff-${{ steps.pr.outputs.correlation_id }}
+          path: hermes-handoff.log
+          if-no-files-found: error
+          retention-days: 90
+
       - name: Comment PR with Hermes handoff summary
         if: always() && steps.pr.outputs.skip != 'true' && steps.hermes.outcome != 'skipped'
         env:

--- a/docs/HERMES_OPERATOR_REPORTS.md
+++ b/docs/HERMES_OPERATOR_REPORTS.md
@@ -30,9 +30,10 @@ two do not.
 - **Correlation ID format:** `github-pr-${pr_number}-${head_sha}-${run_id}`
 - Evidence destinations (most to least durable):
   1. **PR comment** — best evidence path. Idempotent edit-or-create, anchored to a hidden HTML marker `<!-- hermes-pr-handoff:<correlation-id> -->` so the workflow finds and updates the same comment on retries instead of stacking duplicates. Lives in the PR thread for the life of the repo.
-  2. **`$GITHUB_STEP_SUMMARY`** — last 260 lines of `hermes-handoff.log`. Durable while GitHub retains the workflow run (default ~90 days).
-  3. **`hermes-handoff.log`** — runner-local file, ephemeral; reaped with the runner.
-  4. **Hermes-container audit trail** — whatever Hermes itself records under the correlation id. Outside this repo's evidence model; audit from `averray-reference-agent`.
+  2. **Workflow artifact** — full `hermes-handoff.log`, uploaded as `hermes-handoff-<correlation-id>` with 90-day retention.
+  3. **`$GITHUB_STEP_SUMMARY`** — last 260 lines of `hermes-handoff.log`. Durable while GitHub retains the workflow run (default ~90 days).
+  4. **Runner-local `hermes-handoff.log`** — ephemeral; reaped with the runner after artifact upload.
+  5. **Hermes-container audit trail** — whatever Hermes itself records under the correlation id. Outside this repo's evidence model; audit from `averray-reference-agent`.
 - Comment posting is best-effort. If the workflow lacks the GitHub permission to read/write PR comments, the step summary still carries the full Hermes output and the run is not failed by the comment skip.
 - Outcomes:
   - `success` — Hermes returned a verdict (exit 0).
@@ -46,10 +47,11 @@ two do not.
 - Hermes invocation: `averray_invoke_agent_task` with `intent='testbed_suite'`, `testSuiteId='post_deploy'`, cases `TBE2E-001`/`002`/`003`/`006`/`007`/`008`/`009`/`010`. Fallback path: `averray_handle_operator_command` with `text='testbed e2e suite'`.
 - **Correlation ID format:** `github-deploy-${run_id}-${head_sha}`
 - Evidence destinations:
-  1. **`$GITHUB_STEP_SUMMARY`** — first 220 lines of `hermes-post-deploy.log`, including correlation id, deployed sha, outcome. Durable while GitHub retains the workflow run.
-  2. **`hermes-post-deploy.log`** — runner-local file, ephemeral.
-  3. **Hermes-container audit trail** — outside this repo's evidence model.
-- **Asymmetry vs. PR handoff:** there is **no PR comment / external thread** to anchor evidence to on this side. The step summary is the only GitHub-durable record. If a Hermes-side audit is unavailable and the GitHub run has been reaped, the post-deploy verification result is not recoverable.
+  1. **Workflow artifact** — full `hermes-post-deploy.log`, uploaded as `hermes-post-deploy-<run-id>` with 90-day retention.
+  2. **`$GITHUB_STEP_SUMMARY`** — first 220 lines of `hermes-post-deploy.log`, including correlation id, deployed sha, outcome. Durable while GitHub retains the workflow run.
+  3. **Runner-local `hermes-post-deploy.log`** — ephemeral; reaped with the runner after artifact upload.
+  4. **Hermes-container audit trail** — outside this repo's evidence model.
+- **Asymmetry vs. PR handoff:** there is **no PR comment / external thread** to anchor evidence to on this side. The artifact plus step summary are the GitHub-durable records. If both are reaped and the Hermes-side audit is unavailable, the post-deploy verification result is not recoverable.
 - Outcomes:
   - `success` — exit 0.
   - `timeout` — `HERMES_POST_DEPLOY_TIMEOUT=12m` elapsed (exit 124). The deploy itself already completed at this point; the verification result is what becomes uncertain.
@@ -99,15 +101,13 @@ a single id:
   check the GitHub Actions step summary for that run.
 - For a deploy verification, quote
   `github-deploy-<run-id>-<head-sha>` and locate the workflow run by
-  `run-id`; read the step summary. (There is no comment thread on
-  this side.)
+  `run-id`; download the `hermes-post-deploy-<run-id>` artifact for
+  full output, then read the step summary for the compact verdict.
+  There is no comment thread on this side.
 
-## Follow-up hardening (not in this PR)
+## Remaining follow-up hardening
 
-- **Upload `hermes-post-deploy.log` (and `hermes-handoff.log`) as
-  workflow artifacts** so the full output is durable independently of
-  the step-summary truncation and of Hermes-container persistence.
-  Currently those logs are ephemeral on the runner; only a
-  truncated tail survives. This is a small workflow change but it is
-  intentionally out of scope for this PR — this PR is audit/runbook
-  only.
+- Confirm the scheduled Hermes ops-health and daily operator brief
+  routines in `averray-reference-agent` have their own durable
+  correlation ids and retention policy. This repo can prove deploy and
+  PR Hermes invocations; the scheduled routines live outside this repo.

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -167,6 +167,9 @@ RUN_SUBSCAN_XCM_VALIDATION=1 ./scripts/ops/check-release-readiness.sh testnet
     and the GitHub Actions summary contains a Hermes post-deploy verification
     report with final verdict, hosted health, requested test cases, and safety
     outcome.
+  - The same workflow run includes the `hermes-post-deploy-<run-id>`
+    artifact, which preserves the full `hermes-post-deploy.log` beyond the
+    truncated summary.
   - The Hermes/operator surface has scheduled ops-health and daily-brief
     evidence available for the current deployment window.
   - This command passes:

--- a/docs/RC1_IMPLEMENTATION_PLAN.md
+++ b/docs/RC1_IMPLEMENTATION_PLAN.md
@@ -195,6 +195,8 @@ generation are implemented as backend foundations.
   close reasons.
 - [x] Add an opt-in hosted smoke gate that proves the daily poller and optional
   self-report status are present and sanitized.
+- [x] Preserve Hermes PR-handoff and post-deploy verification logs as GitHub
+  workflow artifacts so operator proof is not limited to truncated summaries.
 - [ ] Close the operator-visible self-report proof through Hermes post-deploy
   verification plus scheduled ops-health / daily-brief evidence.
 - [ ] Optional: wire branded email delivery once a verified sender domain,

--- a/scripts/ops/hermes-workflow-artifacts.test.mjs
+++ b/scripts/ops/hermes-workflow-artifacts.test.mjs
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+
+test("Hermes post-deploy verification keeps the full log as a workflow artifact", async () => {
+  const workflow = await readFile(join(REPO_ROOT, ".github/workflows/deploy-production.yml"), "utf8");
+
+  assert.match(workflow, /name: Upload Hermes post-deploy log/u);
+  assert.match(workflow, /uses: actions\/upload-artifact@v4/u);
+  assert.match(workflow, /name: hermes-post-deploy-\$\{\{ github\.run_id \}\}/u);
+  assert.match(workflow, /path: hermes-post-deploy\.log/u);
+  assert.match(workflow, /if-no-files-found: error/u);
+  assert.match(workflow, /retention-days: 90/u);
+});
+
+test("Hermes PR handoff keeps the full log as a correlation-id artifact", async () => {
+  const workflow = await readFile(join(REPO_ROOT, ".github/workflows/hermes-pr-handoff.yml"), "utf8");
+
+  assert.match(workflow, /name: Upload Hermes handoff log/u);
+  assert.match(workflow, /uses: actions\/upload-artifact@v4/u);
+  assert.match(workflow, /name: hermes-handoff-\$\{\{ steps\.pr\.outputs\.correlation_id \}\}/u);
+  assert.match(workflow, /path: hermes-handoff\.log/u);
+  assert.match(workflow, /if-no-files-found: error/u);
+  assert.match(workflow, /retention-days: 90/u);
+});


### PR DESCRIPTION
## What changed
- Upload the full Hermes post-deploy verification log as a 90-day GitHub Actions artifact.
- Upload the full Hermes PR handoff log as a correlation-id artifact.
- Update the Hermes operator-report runbook, production checklist, and RC1 plan so the self-report proof path points at durable artifacts rather than only truncated summaries.
- Add an ops test that guards the artifact upload steps.

## Checks
- Passed: `node --test scripts/ops/hermes-workflow-artifacts.test.mjs scripts/ops/check-hosted-stack.test.mjs`
- Passed: `git diff --check`
- Full `npm run test:ops` was attempted, but this fresh task worktree has no installed `@polkadot/util-crypto`, so the unrelated `prepare-multisig-owner-record.test.mjs` import failed before dependency-backed tests could complete. The new Hermes artifact tests passed in that run and in the targeted rerun.

## Surface
- Affects GitHub Actions workflows and docs only.
- No backend, frontend, indexer, Caddy, contracts, or public site runtime changes.
- No env/VPS secret changes required.