### PR TITLE
Use Node 24 artifact upload action

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -535,7 +535,7 @@ jobs:
 
       - name: Upload Hermes post-deploy log
         if: always() && env.DEPLOY_RUN_HERMES_POST_DEPLOY == '1' && steps.hermes_post_deploy.outcome != 'skipped'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: hermes-post-deploy-${{ github.run_id }}
           path: hermes-post-deploy.log

--- a/.github/workflows/hermes-pr-handoff.yml
+++ b/.github/workflows/hermes-pr-handoff.yml
@@ -210,7 +210,7 @@ jobs:
 
       - name: Upload Hermes handoff log
         if: always() && steps.pr.outputs.skip != 'true' && steps.hermes.outcome != 'skipped'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: hermes-handoff-${{ steps.pr.outputs.correlation_id }}
           path: hermes-handoff.log

--- a/scripts/ops/hermes-workflow-artifacts.test.mjs
+++ b/scripts/ops/hermes-workflow-artifacts.test.mjs
@@ -10,7 +10,7 @@ test("Hermes post-deploy verification keeps the full log as a workflow artifact"
   const workflow = await readFile(join(REPO_ROOT, ".github/workflows/deploy-production.yml"), "utf8");
 
   assert.match(workflow, /name: Upload Hermes post-deploy log/u);
-  assert.match(workflow, /uses: actions\/upload-artifact@v4/u);
+  assert.match(workflow, /uses: actions\/upload-artifact@v7/u);
   assert.match(workflow, /name: hermes-post-deploy-\$\{\{ github\.run_id \}\}/u);
   assert.match(workflow, /path: hermes-post-deploy\.log/u);
   assert.match(workflow, /if-no-files-found: error/u);
@@ -21,7 +21,7 @@ test("Hermes PR handoff keeps the full log as a correlation-id artifact", async 
   const workflow = await readFile(join(REPO_ROOT, ".github/workflows/hermes-pr-handoff.yml"), "utf8");
 
   assert.match(workflow, /name: Upload Hermes handoff log/u);
-  assert.match(workflow, /uses: actions\/upload-artifact@v4/u);
+  assert.match(workflow, /uses: actions\/upload-artifact@v7/u);
   assert.match(workflow, /name: hermes-handoff-\$\{\{ steps\.pr\.outputs\.correlation_id \}\}/u);
   assert.match(workflow, /path: hermes-handoff\.log/u);
   assert.match(workflow, /if-no-files-found: error/u);


### PR DESCRIPTION
## What changed
- Bump the Hermes log artifact upload steps from `actions/upload-artifact@v4` to `@v7`, the current official release, to avoid the Node 20 deprecation warning from the first artifact-enabled deploy.
- Update the ops assertion test to pin the intended action version.

## Checks
- Passed: `node --test scripts/ops/hermes-workflow-artifacts.test.mjs`
- Passed: `git diff --check`

## Surface
- GitHub Actions only.
- No backend, frontend, indexer, Caddy, contracts, public site, env, or VPS secret changes.