### PR TITLE
Add schema-native submission readiness helper

### DIFF
--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -147,22 +147,24 @@ discipline for custom/off-platform schemas.
 - `/jobs/definition.submissionContract` and `/jobs/validate-submission` remain
   the no-mutation source of truth for exact submit shape
 - the SDK exposes fail-closed helpers that validate drafts before claim/submit
-  mutations (`claimJobAfterValidation` and `submitValidatedWork`)
+  mutations (`assertSchemaNativeSubmissionReady`,
+  `claimJobAfterValidation`, and `submitValidatedWork`)
 - the hosted product-proof worker loop now uses a built-in
   `schema://jobs/product-proof-worker-loop` output contract, validates its
   structured submission before claim, probes an invalid `submission.output`
   wrapper through the read-only validation route, runs verification from the
   stored structured session submission, and records both validation traces plus
   the verifier-input mode in the launch evidence gate
+- the generic claim-and-submit helper now uses the same schema-native readiness
+  guard before claim, so the pattern is available outside the product-proof
+  smoke loop
 
 ### Gaps today
 
-- the hosted evidence gate still needs to be run live after deploy with
-  `PRODUCT_PROOF_REQUIRE_WORKER_LOOP=1`
 - custom/off-platform schema refs are still allowed without signed schema
   registration
-- third-party and non-product-proof helper workflows still need to adopt the
-  SDK pre-validation helpers / `/jobs/validate-submission` before-claim pattern
+- remaining third-party/reference-agent helper workflows should adopt the SDK
+  schema-native readiness helper as they graduate to structured output
 - richer verifier replay fixtures should land before introducing v2 handlers
 
 ### Improve to

--- a/docs/SPEC_AUDIT_2026-05-13.md
+++ b/docs/SPEC_AUDIT_2026-05-13.md
@@ -187,12 +187,14 @@ SSH/basic-auth/admin-JWT cutovers, and the basic hosted smoke is green.
   loop now records both the valid direct-object validation and a read-only
   rejected `submission.output` wrapper probe before claim, and the
   product-proof gate asserts the hosted schema index contains the built-in
-  first-wave registry.
-- Remaining: run the hosted product-proof worker-loop evidence gate against the
-  live stack with the valid + invalid validation traces present, extend the
-  validation-before-claim pattern to remaining third-party/helper workflows,
-  and add signed registration before tightening custom/off-platform schema
-  refs.
+  first-wave registry. Live product-proof worker-loop evidence has passed, and
+  the SDK now exposes `assertSchemaNativeSubmissionReady` for generic helper
+  workflows so the valid direct-object trace plus rejected wrapper probe can be
+  reused outside the product-proof loop.
+- Remaining: extend the schema-native readiness helper to remaining
+  third-party/reference-agent helper workflows as they graduate to structured
+  output, and add signed registration before tightening custom/off-platform
+  schema refs.
 
 ### Verifier Replay Hardening
 

--- a/examples/claim-and-submit-job/README.md
+++ b/examples/claim-and-submit-job/README.md
@@ -38,6 +38,8 @@ AVERRAY_TOKEN="$TOKEN" node examples/claim-and-submit-job/index.mjs \
   --execute
 ```
 
-The example calls `/jobs/validate-submission` before claiming. If the draft is
-missing required fields or uses the old `submission.output` wrapper shape, it
-stops before consuming a claim attempt.
+The example calls the SDK's `assertSchemaNativeSubmissionReady` guard before
+claiming. That makes the direct draft pass `/jobs/validate-submission`, records
+the schema ref used, and probes an intentionally invalid `submission.output`
+wrapper through the same read-only route. If the draft is missing required
+fields, it stops before consuming a claim attempt.

--- a/examples/claim-and-submit-job/index.mjs
+++ b/examples/claim-and-submit-job/index.mjs
@@ -2,7 +2,10 @@
 
 import { pathToFileURL } from "node:url";
 
-import { AgentPlatformClient } from "../../sdk/agent-platform-client.js";
+import {
+  AgentPlatformClient,
+  AgentPlatformValidationError
+} from "../../sdk/agent-platform-client.js";
 
 const DEFAULT_API_URL = "https://api.averray.com";
 
@@ -77,14 +80,20 @@ export async function runClaimAndSubmit({
   }
 
   const draftSubmission = submission ?? evidence;
-  const validation = await client.validateJobSubmission(jobId, draftSubmission);
-  if (!validation?.valid) {
+  let validationReadiness;
+  try {
+    validationReadiness = await client.assertSchemaNativeSubmissionReady(jobId, draftSubmission);
+  } catch (error) {
+    if (!(error instanceof AgentPlatformValidationError)) {
+      throw error;
+    }
     return {
       apiUrl: client.baseUrl,
       jobId,
       mode: "blocked",
       readiness,
-      validation,
+      validation: error.validation ?? null,
+      validationReadiness: null,
       claim: null,
       submit: null
     };
@@ -109,7 +118,8 @@ export async function runClaimAndSubmit({
       status: claim.status,
       claimExpiresAt: claim.claimExpiresAt ?? claim.deadline ?? null
     },
-    validation,
+    validation: validationReadiness.directValidation,
+    validationReadiness,
     submit: {
       sessionId: submit?.sessionId ?? sessionId,
       status: submit?.status ?? null,

--- a/examples/claim-and-submit-job/index.test.mjs
+++ b/examples/claim-and-submit-job/index.test.mjs
@@ -87,8 +87,11 @@ test("runClaimAndSubmit executes claim, submit, and timeline reads when requeste
   assert.equal(summary.mode, "executed");
   assert.equal(summary.claim.sessionId, "session-1");
   assert.equal(summary.validation.valid, true);
+  assert.equal(summary.validationReadiness.validatedBeforeClaim, true);
+  assert.equal(summary.validationReadiness.invalidWrappedOutput.valid, false);
   assert.equal(summary.submit.status, "submitted");
-  assert.ok(calls.includes("https://api.example/jobs/validate-submission"));
+  assert.equal(calls.filter((call) => call === "https://api.example/jobs/validate-submission").length, 2);
+  assert.ok(calls.indexOf("https://api.example/jobs/claim") > calls.lastIndexOf("https://api.example/jobs/validate-submission"));
   assert.ok(calls.includes("https://api.example/jobs/claim"));
   assert.ok(calls.includes("https://api.example/jobs/submit"));
   assert.ok(calls.includes("https://api.example/session/timeline?sessionId=session-1"));
@@ -145,8 +148,28 @@ function fakeFetch(calls, { validationValid = true } = {}) {
       assert.equal(options.method, "POST");
       const payload = JSON.parse(options.body);
       assert.equal(payload.jobId, "job-1");
+      if (payload.submission?.output?.wrapped_under_submission_output === true) {
+        return jsonResponse({
+          valid: false,
+          submitSafe: false,
+          schemaRef: "schema://jobs/example-output",
+          schemaValidates: "payload.submission",
+          message: "Send the structured proposal object directly as submission, not under submission.output.",
+          path: "payload.submission.output",
+          details: {
+            received: "payload.submission.output",
+            hint: "Move the object currently under submission.output up to submission."
+          }
+        });
+      }
       return jsonResponse(validationValid
-        ? { valid: true, schemaRef: "schema://jobs/example-output" }
+        ? {
+            valid: true,
+            submitSafe: true,
+            schemaRef: "schema://jobs/example-output",
+            schemaValidates: "payload.submission",
+            submissionKind: "structured"
+          }
         : { valid: false, schemaRef: "schema://jobs/example-output", message: "submission.result is required" });
     }
     if (String(url).endsWith("/jobs/claim")) {

--- a/mcp-server/src/core/job-schema-registry.test.js
+++ b/mcp-server/src/core/job-schema-registry.test.js
@@ -1,5 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { ValidationError } from "./errors.js";
 import {
@@ -22,6 +25,8 @@ const FIRST_WAVE_SCHEMA_REFS = [
   "schema://jobs/docs-drift-audit-output"
 ];
 
+const repoRoot = resolve(fileURLToPath(new URL("../../..", import.meta.url)));
+
 test("getBuiltinJobSchema resolves built-in first-wave schemas", () => {
   const schema = getBuiltinJobSchema("schema://jobs/pr-review-findings-output");
   assert.equal(schema?.$id, "schema://jobs/pr-review-findings-output");
@@ -33,6 +38,22 @@ test("first-wave schema-native job refs are public built-ins", () => {
     assert.equal(schema?.$id, ref);
     assert.equal(schemaRefToJobSchemaPath(ref), `/schemas/jobs/${ref.slice("schema://jobs/".length)}.json`);
     assert.equal(getPublicBuiltinJobSchemaByName(ref.slice("schema://jobs/".length))?.$id, ref);
+  }
+});
+
+test("ready-to-post first-wave jobs reference public built-in output schemas", () => {
+  const jobs = JSON.parse(readFileSync(resolve(repoRoot, "docs/ready-to-post-jobs.json"), "utf8"));
+  assert.ok(Array.isArray(jobs));
+  assert.ok(jobs.length >= 7);
+
+  for (const job of jobs) {
+    assert.ok(job.outputSchemaRef, `${job.id} must declare outputSchemaRef`);
+    const schema = getBuiltinJobSchema(job.outputSchemaRef);
+    assert.equal(schema?.$id, job.outputSchemaRef, `${job.id} output schema must be a built-in schema`);
+    assert.equal(
+      schemaRefToJobSchemaPath(job.outputSchemaRef),
+      `/schemas/jobs/${job.outputSchemaRef.slice("schema://jobs/".length)}.json`
+    );
   }
 });
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -29,9 +29,12 @@ For external agents, keep the mutation sequence explicit:
 
 The SDK does not hide these steps because mutation safety depends on callers
 seeing where claim and submit happen. For helper workflows that need a hard
-guard, `claimJobAfterValidation(jobId, draft, key)` validates the exact draft
-before consuming a claim attempt, and `submitValidatedWork(jobId, sessionId,
-draft)` validates again before the submit mutation. Both throw
+schema-native guard, `assertSchemaNativeSubmissionReady(jobId, draft)` validates
+the exact direct schema object and records a read-only rejected
+`submission.output` wrapper probe before any claim is consumed.
+`claimJobAfterValidation(jobId, draft, key)` validates the exact draft before
+consuming a claim attempt, and `submitValidatedWork(jobId, sessionId, draft)`
+validates again before the submit mutation. These helpers throw
 `AgentPlatformValidationError` and make no mutation when the draft is not
 `submitSafe`.
 

--- a/sdk/agent-platform-client.d.ts
+++ b/sdk/agent-platform-client.d.ts
@@ -735,6 +735,40 @@ export interface ValidationResponse<TSubmission = unknown> extends ApiEnvelope {
   expectedPath?: string;
 }
 
+export interface InvalidWrappedOutputReadiness extends ApiEnvelope {
+  jobId: JobId;
+  valid: false;
+  submitSafe: false;
+  schemaRef?: BuiltinJobSchemaRef | string | null;
+  schemaValidates?: "payload.submission" | string;
+  code?: string | null;
+  message?: string | null;
+  path?: string | null;
+  received?: string | null;
+  hint?: string | null;
+  checkedBeforeClaim: true;
+  submitAttempted: false;
+  validation?: ValidationResponse;
+}
+
+export interface SchemaNativeSubmissionReadinessOptions<TProbe extends StructuredSubmission = StructuredSubmission> {
+  expectedSchemaRef?: BuiltinJobSchemaRef | string;
+  requireInvalidWrapperRejection?: boolean;
+  invalidWrappedOutputProbe?: TProbe;
+}
+
+export interface SchemaNativeSubmissionReadiness<TSubmission = StructuredSubmission> extends ApiEnvelope {
+  jobId: JobId;
+  valid: true;
+  submitSafe: true;
+  schemaRef?: BuiltinJobSchemaRef | string | null;
+  schemaValidates?: "payload.submission" | string;
+  submissionKind?: "structured" | "raw" | string;
+  validatedBeforeClaim: true;
+  directValidation: ValidationResponse<TSubmission>;
+  invalidWrappedOutput?: InvalidWrappedOutputReadiness | null;
+}
+
 export interface ClaimResponse extends SessionRecord {
   sessionId: SessionId;
   jobId: JobId;
@@ -1109,6 +1143,11 @@ export class AgentPlatformClient {
     jobId: JobId,
     submission: TSubmission
   ): Promise<ValidationResponse<TSubmission>>;
+  assertSchemaNativeSubmissionReady<TSubmission extends StructuredSubmission = StructuredSubmission>(
+    jobId: JobId,
+    submission: TSubmission,
+    options?: SchemaNativeSubmissionReadinessOptions
+  ): Promise<SchemaNativeSubmissionReadiness<TSubmission>>;
   claimJobAfterValidation<TSubmission extends StructuredSubmission = StructuredSubmission>(
     jobId: JobId,
     submission: TSubmission,

--- a/sdk/agent-platform-client.js
+++ b/sdk/agent-platform-client.js
@@ -279,6 +279,87 @@ export class AgentPlatformClient {
     return validation;
   }
 
+  /**
+   * Non-mutating schema-native guard for helper workflows.
+   *
+   * This validates the exact direct submission object and, for structured
+   * drafts, checks that an intentionally bad `submission.output` wrapper is
+   * rejected before any claim/submit mutation is attempted.
+   */
+  async assertSchemaNativeSubmissionReady(jobId, submission, {
+    expectedSchemaRef = undefined,
+    requireInvalidWrapperRejection = isStructuredObject(submission),
+    invalidWrappedOutputProbe = {
+      output: {
+        wrapped_under_submission_output: true
+      }
+    }
+  } = {}) {
+    const validation = await this.assertValidJobSubmission(jobId, submission);
+    const schemaRef = validation?.schemaRef ?? expectedSchemaRef ?? null;
+    if (expectedSchemaRef && schemaRef && schemaRef !== expectedSchemaRef) {
+      throw new AgentPlatformValidationError({
+        message: `Submission validation schema mismatch: expected ${expectedSchemaRef}, got ${schemaRef}.`,
+        validation
+      });
+    }
+
+    const readiness = {
+      jobId,
+      valid: true,
+      submitSafe: true,
+      schemaRef,
+      schemaValidates: validation?.schemaValidates ?? "payload.submission",
+      submissionKind: validation?.submissionKind ?? (isStructuredObject(submission) ? "structured" : "raw"),
+      validatedBeforeClaim: true,
+      directValidation: validation,
+      invalidWrappedOutput: null
+    };
+
+    if (!requireInvalidWrapperRejection) {
+      return readiness;
+    }
+
+    const invalidValidation = await this.validateJobSubmission(jobId, invalidWrappedOutputProbe);
+    if (invalidValidation?.jobId && invalidValidation.jobId !== jobId) {
+      throw new AgentPlatformValidationError({
+        message: `Invalid-wrapper validation job id mismatch: expected ${jobId}, got ${invalidValidation.jobId}.`,
+        validation: invalidValidation
+      });
+    }
+    if (invalidValidation?.valid !== false || invalidValidation?.submitSafe !== false) {
+      throw new AgentPlatformValidationError({
+        message: "Invalid submission.output wrapper unexpectedly passed validation; refusing to mutate.",
+        validation: invalidValidation
+      });
+    }
+    const invalidSchemaRef = invalidValidation?.schemaRef ?? schemaRef ?? expectedSchemaRef ?? null;
+    if (expectedSchemaRef && invalidSchemaRef && invalidSchemaRef !== expectedSchemaRef) {
+      throw new AgentPlatformValidationError({
+        message: `Invalid-wrapper validation schema mismatch: expected ${expectedSchemaRef}, got ${invalidSchemaRef}.`,
+        validation: invalidValidation
+      });
+    }
+
+    readiness.invalidWrappedOutput = {
+      jobId,
+      valid: false,
+      submitSafe: false,
+      schemaRef: invalidSchemaRef,
+      schemaValidates: invalidValidation?.schemaValidates ?? "payload.submission",
+      code: invalidValidation?.code ?? null,
+      message: invalidValidation?.message ?? null,
+      path: invalidValidation?.path ?? invalidValidation?.errorPaths?.[0] ?? null,
+      received: invalidValidation?.details?.received ?? null,
+      hint: invalidValidation?.details?.hint ?? null,
+      checkedBeforeClaim: true,
+      submitAttempted: false,
+      validation: invalidValidation
+    };
+
+    return readiness;
+  }
+
   /** Validate the exact draft first; only then consume a claim attempt. */
   async claimJobAfterValidation(jobId, submission, idempotencyKey = undefined) {
     await this.assertValidJobSubmission(jobId, submission);
@@ -546,6 +627,10 @@ export class AgentPlatformValidationError extends Error {
 
 function isSubmitSafeValidation(validation) {
   return validation?.valid === true && validation?.submitSafe !== false;
+}
+
+function isStructuredObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function safeJsonParse(text) {

--- a/sdk/agent-platform-client.test.mjs
+++ b/sdk/agent-platform-client.test.mjs
@@ -232,6 +232,66 @@ test("validated job helpers fail closed before claim or submit mutations", async
   assert.equal(calls[0].url, "https://api.example.test/jobs/validate-submission");
 });
 
+test("schema-native readiness validates direct output and rejected wrapper before mutation", async () => {
+  const calls = [];
+  const client = new AgentPlatformClient({
+    baseUrl: "https://api.example.test",
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options });
+      const payload = JSON.parse(options.body);
+      if (payload.submission?.output?.wrapped_under_submission_output === true) {
+        return jsonResponse({
+          jobId: payload.jobId,
+          valid: false,
+          submitSafe: false,
+          schemaRef: "schema://jobs/release-readiness-output",
+          schemaValidates: "payload.submission",
+          code: "invalid_submission_shape",
+          message: "Send the structured proposal object directly as submission, not under submission.output.",
+          path: "payload.submission.output",
+          details: {
+            received: "payload.submission.output",
+            hint: "Move the object currently under submission.output up to submission."
+          }
+        });
+      }
+      return jsonResponse({
+        jobId: payload.jobId,
+        valid: true,
+        submitSafe: true,
+        schemaRef: "schema://jobs/release-readiness-output",
+        schemaValidates: "payload.submission",
+        submissionKind: "structured"
+      });
+    }
+  });
+
+  const readiness = await client.assertSchemaNativeSubmissionReady(
+    "release-readiness-check-001",
+    {
+      release_id: "release-2026-05",
+      checks_passed: ["api-health"],
+      checks_failed: [],
+      blockers: [],
+      go_no_go: "go"
+    },
+    { expectedSchemaRef: "schema://jobs/release-readiness-output" }
+  );
+
+  assert.equal(readiness.valid, true);
+  assert.equal(readiness.schemaRef, "schema://jobs/release-readiness-output");
+  assert.equal(readiness.schemaValidates, "payload.submission");
+  assert.equal(readiness.validatedBeforeClaim, true);
+  assert.equal(readiness.invalidWrappedOutput.valid, false);
+  assert.equal(readiness.invalidWrappedOutput.path, "payload.submission.output");
+  assert.equal(readiness.invalidWrappedOutput.received, "payload.submission.output");
+  assert.equal(calls.length, 2);
+  assert.deepEqual(calls.map((call) => call.url), [
+    "https://api.example.test/jobs/validate-submission",
+    "https://api.example.test/jobs/validate-submission"
+  ]);
+});
+
 test("operator surface helpers call policy, audit, and alert endpoints", async () => {
   const calls = [];
   const client = new AgentPlatformClient({

--- a/sdk/agent-platform-client.types.test.ts
+++ b/sdk/agent-platform-client.types.test.ts
@@ -9,6 +9,7 @@ import {
   type IdempotencyKey,
   type JobDefinition,
   type JobsListResponse,
+  type SchemaNativeSubmissionReadiness,
   type ServiceTokenIssueResponse,
   type ServiceTokenListResponse,
   type ServiceTokenRevokeResponse,
@@ -46,6 +47,11 @@ if (firstJobId) {
   } satisfies BuiltinJobSchemaValue<"schema://jobs/wikipedia-citation-repair-output">;
 
   await client.validateJobSubmission(definition.id, wikipediaSubmission);
+  const readiness: SchemaNativeSubmissionReadiness<typeof wikipediaSubmission> =
+    await client.assertSchemaNativeSubmissionReady(definition.id, wikipediaSubmission, {
+      expectedSchemaRef: "schema://jobs/wikipedia-citation-repair-output"
+    });
+  void readiness.invalidWrappedOutput?.path;
   await client.claimJobAfterValidation(definition.id, wikipediaSubmission, "example-run-id-validated");
   await client.submitValidatedWork(definition.id, claim.sessionId, wikipediaSubmission);
   await client.submitWork(claim.sessionId, wikipediaSubmission);

--- a/sdk/api-surface-model.mjs
+++ b/sdk/api-surface-model.mjs
@@ -381,6 +381,40 @@ export interface ValidationResponse<TSubmission = unknown> extends ApiEnvelope {
   expectedPath?: string;
 }
 
+export interface InvalidWrappedOutputReadiness extends ApiEnvelope {
+  jobId: JobId;
+  valid: false;
+  submitSafe: false;
+  schemaRef?: BuiltinJobSchemaRef | string | null;
+  schemaValidates?: "payload.submission" | string;
+  code?: string | null;
+  message?: string | null;
+  path?: string | null;
+  received?: string | null;
+  hint?: string | null;
+  checkedBeforeClaim: true;
+  submitAttempted: false;
+  validation?: ValidationResponse;
+}
+
+export interface SchemaNativeSubmissionReadinessOptions<TProbe extends StructuredSubmission = StructuredSubmission> {
+  expectedSchemaRef?: BuiltinJobSchemaRef | string;
+  requireInvalidWrapperRejection?: boolean;
+  invalidWrappedOutputProbe?: TProbe;
+}
+
+export interface SchemaNativeSubmissionReadiness<TSubmission = StructuredSubmission> extends ApiEnvelope {
+  jobId: JobId;
+  valid: true;
+  submitSafe: true;
+  schemaRef?: BuiltinJobSchemaRef | string | null;
+  schemaValidates?: "payload.submission" | string;
+  submissionKind?: "structured" | "raw" | string;
+  validatedBeforeClaim: true;
+  directValidation: ValidationResponse<TSubmission>;
+  invalidWrappedOutput?: InvalidWrappedOutputReadiness | null;
+}
+
 export interface ClaimResponse extends SessionRecord {
   sessionId: SessionId;
   jobId: JobId;
@@ -755,6 +789,11 @@ export class AgentPlatformClient {
     jobId: JobId,
     submission: TSubmission
   ): Promise<ValidationResponse<TSubmission>>;
+  assertSchemaNativeSubmissionReady<TSubmission extends StructuredSubmission = StructuredSubmission>(
+    jobId: JobId,
+    submission: TSubmission,
+    options?: SchemaNativeSubmissionReadinessOptions
+  ): Promise<SchemaNativeSubmissionReadiness<TSubmission>>;
   claimJobAfterValidation<TSubmission extends StructuredSubmission = StructuredSubmission>(
     jobId: JobId,
     submission: TSubmission,


### PR DESCRIPTION
## Summary
- add SDK assertSchemaNativeSubmissionReady guard for direct draft validation plus read-only invalid submission.output wrapper probe
- wire the claim-and-submit example through the schema-native readiness guard before claim
- add ready-to-post schema registry coverage and update spec/docs status

## Checks
- node --test sdk/agent-platform-client.test.mjs examples/claim-and-submit-job/index.test.mjs mcp-server/src/core/job-schema-registry.test.js
- npm run test:sdk
- npm --workspace mcp-server test
- npm run generate:sdk-types -- --check

## Surfaces
- SDK
- examples/docs
- backend tests only