### PR TITLE
Preserve exact XCM observer amounts

### DIFF
--- a/mcp-server/src/services/xcm-observation-relay.js
+++ b/mcp-server/src/services/xcm-observation-relay.js
@@ -2,6 +2,7 @@ import { ExternalServiceError, ValidationError } from "../core/errors.js";
 
 const DEFAULT_SCOPE = "xcm-observation-relay";
 const TERMINAL_STATUSES = new Set(["succeeded", "failed", "cancelled"]);
+const UINT256_MAX = (1n << 256n) - 1n;
 
 export class XcmObservationRelayService {
   constructor(
@@ -216,8 +217,8 @@ export class XcmObservationRelayService {
     return {
       requestId,
       status,
-      settledAssets: this.normalizeCount(item.settledAssets),
-      settledShares: this.normalizeCount(item.settledShares),
+      settledAssets: this.normalizeUint256(item.settledAssets, "settledAssets"),
+      settledShares: this.normalizeUint256(item.settledShares, "settledShares"),
       remoteRef: this.normalizeOptionalHex32(item.remoteRef),
       failureCode: this.normalizeOptionalHex32(item.failureCode),
       source: typeof item.source === "string" && item.source.trim() ? item.source.trim() : "xcm_relay_feed",
@@ -226,22 +227,45 @@ export class XcmObservationRelayService {
   }
 
   normalizeStatus(status) {
+    let normalized;
     if (typeof status === "number") {
-      return ["unknown", "pending", "succeeded", "failed", "cancelled"][status] ?? "unknown";
+      normalized = ["unknown", "pending", "succeeded", "failed", "cancelled"][status] ?? "unknown";
+    } else {
+      normalized = String(status ?? "").trim().toLowerCase();
     }
-    const normalized = String(status ?? "").trim().toLowerCase();
     if (!TERMINAL_STATUSES.has(normalized)) {
       throw new ValidationError("XCM observer items must use a terminal status.");
     }
     return normalized;
   }
 
-  normalizeCount(value) {
-    const parsed = Number(value ?? 0);
-    if (!Number.isFinite(parsed) || parsed < 0) {
-      throw new ValidationError("XCM observer amounts must be finite non-negative numbers.");
+  normalizeUint256(value, label) {
+    if (value === undefined || value === null || value === "") {
+      return "0";
     }
-    return parsed;
+
+    let parsed;
+    if (typeof value === "bigint") {
+      parsed = value;
+    } else if (typeof value === "number") {
+      if (!Number.isSafeInteger(value) || value < 0) {
+        throw new ValidationError(`XCM observer ${label} must be an exact non-negative uint256.`);
+      }
+      parsed = BigInt(value);
+    } else if (typeof value === "string") {
+      const normalized = value.trim();
+      if (!/^\d+$/u.test(normalized)) {
+        throw new ValidationError(`XCM observer ${label} must be an exact non-negative uint256.`);
+      }
+      parsed = BigInt(normalized);
+    } else {
+      throw new ValidationError(`XCM observer ${label} must be an exact non-negative uint256.`);
+    }
+
+    if (parsed < 0n || parsed > UINT256_MAX) {
+      throw new ValidationError(`XCM observer ${label} must fit uint256.`);
+    }
+    return parsed.toString();
   }
 
   normalizeOptionalHex32(value) {

--- a/mcp-server/src/services/xcm-observation-relay.test.js
+++ b/mcp-server/src/services/xcm-observation-relay.test.js
@@ -54,10 +54,83 @@ test("pollOnce relays terminal outcomes into the platform watcher and stores cur
   assert.equal(calls.length, 1);
   assert.equal(calls[0][0], REQUEST_ID);
   assert.equal(calls[0][1].status, "succeeded");
+  assert.equal(calls[0][1].settledAssets, "7");
+  assert.equal(calls[0][1].settledShares, "7");
 
   const stored = await stateStore.getServiceState("xcm-observation-relay");
   assert.equal(stored.cursor, "cursor-2");
   assert.equal(stored.lastObservedCount, 1);
+});
+
+test("pollOnce preserves exact uint256 settlement amounts from observer feed", async () => {
+  const calls = [];
+  const relay = new XcmObservationRelayService(
+    {
+      observeXcmOutcome: async (requestId, outcome) => {
+        calls.push([requestId, outcome]);
+        return outcome;
+      }
+    },
+    new MemoryStateStore(),
+    undefined,
+    {
+      enabled: true,
+      feedUrl: "https://observer.example/outcomes",
+      fetchImpl: async () => ({
+        ok: true,
+        async json() {
+          return {
+            items: [
+              {
+                requestId: REQUEST_ID,
+                status: "succeeded",
+                settledAssets: "9007199254740993",
+                settledShares: "18446744073709551616"
+              }
+            ]
+          };
+        }
+      })
+    }
+  );
+
+  const result = await relay.pollOnce();
+
+  assert.equal(result.observedCount, 1);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0][1].settledAssets, "9007199254740993");
+  assert.equal(calls[0][1].settledShares, "18446744073709551616");
+});
+
+test("pollOnce rejects unsafe numeric settlement amounts from observer feed", async () => {
+  const relay = new XcmObservationRelayService(
+    {
+      observeXcmOutcome: async () => undefined
+    },
+    new MemoryStateStore(),
+    undefined,
+    {
+      enabled: true,
+      feedUrl: "https://observer.example/outcomes",
+      fetchImpl: async () => ({
+        ok: true,
+        async json() {
+          return {
+            items: [
+              {
+                requestId: REQUEST_ID,
+                status: "succeeded",
+                settledAssets: Number.MAX_SAFE_INTEGER + 2
+              }
+            ]
+          };
+        }
+      }),
+      logger: { warn() {} }
+    }
+  );
+
+  await assert.rejects(() => relay.pollOnce(), /exact non-negative uint256/u);
 });
 
 test("pollOnce records upstream failures in service state", async () => {
@@ -102,6 +175,36 @@ test("pollOnce rejects non-terminal statuses from the observer feed", async () =
               {
                 requestId: REQUEST_ID,
                 status: "pending"
+              }
+            ]
+          };
+        }
+      }),
+      logger: { warn() {} }
+    }
+  );
+
+  await assert.rejects(() => relay.pollOnce(), /terminal status/u);
+});
+
+test("pollOnce rejects numeric non-terminal statuses from the observer feed", async () => {
+  const relay = new XcmObservationRelayService(
+    {
+      observeXcmOutcome: async () => undefined
+    },
+    new MemoryStateStore(),
+    undefined,
+    {
+      enabled: true,
+      feedUrl: "https://observer.example/outcomes",
+      fetchImpl: async () => ({
+        ok: true,
+        async json() {
+          return {
+            items: [
+              {
+                requestId: REQUEST_ID,
+                status: 1
               }
             ]
           };


### PR DESCRIPTION
## Summary
- Preserve exact uint256 settlement amounts from the XCM observer relay instead of coercing them through JavaScript Number.
- Reject unsafe numeric, non-decimal, and out-of-range observer amounts before they can be stored or finalized.
- Enforce terminal-only observer statuses for both string and numeric status forms.

## Checks
- node --test mcp-server/src/services/xcm-observation-relay.test.js mcp-server/src/services/xcm-settlement-watcher.test.js
- npm --workspace mcp-server test
- git diff --check

## Impact
- Backend: yes, XCM observation relay normalization.
- Frontend: no.
- Indexer: no.
- Contracts: no.
- Caddy: no.
- Public site: no.
- Env or VPS secret changes: none.