### PR TITLE
Normalize XCM upstream epoch timestamps

### DIFF
--- a/indexer/src/api/xcm-upstream-source.test.ts
+++ b/indexer/src/api/xcm-upstream-source.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   NativePapiXcmSourceAdapter,
+  SubscanXcmSourceAdapter,
   createXcmUpstreamSourceAdapter,
   decodeNativePapiCursor,
   encodeNativePapiCursor,
@@ -105,6 +106,20 @@ test("native PAPI evidence preserves large uint256 settlement amounts exactly", 
   assert.equal(outcome.settledShares, settledShares);
 });
 
+test("native PAPI evidence normalizes epoch-second observedAt timestamps", () => {
+  const outcome = normalizeNativeXcmEvidence({
+    requestId,
+    status: "succeeded",
+    observedAt: 1712345678,
+    correlation: {
+      method: "ledger_join",
+      confidence: "staging"
+    }
+  });
+
+  assert.equal(outcome.observedAt, "2024-04-05T19:34:38.000Z");
+});
+
 test("native PAPI evidence rejects unsafe numeric settlement amounts", () => {
   assert.throws(
     () => normalizeNativeXcmEvidence({
@@ -142,6 +157,21 @@ test("native PAPI evidence accepts SetTopic request-id correlation after Bifrost
 
   assert.equal(outcome.requestId, requestId);
   assert.equal(outcome.source, "native_papi_observer");
+});
+
+test("Subscan source normalizes numeric-string epoch timestamps", () => {
+  const adapter = new SubscanXcmSourceAdapter({
+    apiHost: "https://subscan.example",
+    apiKey: "test"
+  });
+
+  const outcome = adapter.normalizeSubscanEntry({
+    msg_hash: requestId,
+    status: "success",
+    block_timestamp: "1712345678"
+  });
+
+  assert.equal(outcome?.observedAt, "2024-04-05T19:34:38.000Z");
 });
 
 test("native PAPI evidence rejects promoted ledger joins and mismatched topics", () => {

--- a/indexer/src/api/xcm-upstream-source.ts
+++ b/indexer/src/api/xcm-upstream-source.ts
@@ -102,11 +102,38 @@ function normalizeOptionalHex32(value: unknown) {
 }
 
 function normalizeObservedAt(value: unknown) {
-  const observedAt = value ? new Date(value as string | number | Date) : new Date();
+  const observedAt = parseObservedAt(value);
   if (Number.isNaN(observedAt.getTime())) {
-    throw new Error("XCM upstream observedAt must be ISO-8601 when provided.");
+    throw new Error("XCM upstream observedAt must be ISO-8601 or an epoch timestamp when provided.");
   }
   return observedAt.toISOString();
+}
+
+function parseObservedAt(value: unknown) {
+  if (value === undefined || value === null || value === "") {
+    return new Date();
+  }
+  if (value instanceof Date) {
+    return value;
+  }
+  if (typeof value === "number") {
+    return parseEpochTimestamp(value);
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim();
+    if (/^\d+$/u.test(normalized)) {
+      return parseEpochTimestamp(Number(normalized));
+    }
+    return new Date(normalized);
+  }
+  return new Date(value as string | number | Date);
+}
+
+function parseEpochTimestamp(value: number) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    return new Date(Number.NaN);
+  }
+  return new Date(value < 1_000_000_000_000 ? value * 1000 : value);
 }
 
 function normalizeStatus(value: unknown) {


### PR DESCRIPTION
## Summary
- Normalize XCM upstream observedAt values through an explicit parser instead of relying on Date defaults.
- Treat safe numeric epoch timestamps below 1e12 as seconds and larger values as milliseconds.
- Add coverage for native PAPI evidence epoch seconds and Subscan-style numeric-string block timestamps.

## Checks
- npm --workspace indexer run test:api
- npm run typecheck:indexer
- git diff --check

## Impact
- Indexer: yes, XCM upstream source normalization.
- Backend: no.
- Frontend: no.
- Contracts: no.
- Caddy: no.
- Public site: no.
- Env or VPS secret changes: none.