### PR TITLE
Harden backup readiness with a check script + drill runbook + approval gate

### DIFF
--- a/VPS_RUNBOOK.md
+++ b/VPS_RUNBOOK.md
@@ -411,7 +411,28 @@ The script:
 
 ### Postgres restore outline
 
-Restore should be done deliberately and only after confirming the target file:
+A production restore over the live database is destructive. Run the
+**monthly drill** in [docs/BACKUP_RESTORE_DRILL.md](./docs/BACKUP_RESTORE_DRILL.md)
+against a disposable Postgres container first — that path does not
+need the approval gate below.
+
+**Approval gate for a real production restore** (must hold *before*
+any `psql ... <` runs):
+
+1. Named operator on the keyboard. No CI / workflow / agent invokes
+   this path.
+2. A second human acknowledgment in the incident channel quoting the
+   exact backup file path, the reason (incident reference, ticket,
+   or migration window), the expected data-loss window (gap between
+   backup and now), and the agreed rollback plan if the restore
+   makes things worse.
+3. Maintenance window posted to the operator channel before stopping
+   the backend.
+4. Run the readiness check first so the backup file you're about to
+   restore is the one the system claims is current:
+   `./scripts/ops/check-backup-readiness.sh`.
+
+Only after the gate holds:
 
 ```bash
 gunzip -c /srv/agent-stack/backups/postgres/<dump>.sql.gz | \
@@ -420,11 +441,23 @@ docker compose --project-directory /srv/agent-stack -f /srv/agent-stack/docker-c
 ```
 
 Do not restore over a live database unless you mean to replace it.
+Verify `/health` returns 200 and a basic smoke check passes before
+declaring the restore done.
 
 ### Redis restore outline
 
-Restore should be done deliberately because it rewinds nonce, session, lock,
-and token-revocation state. The safest path is:
+A production Redis restore is destructive — it rewinds nonce,
+session, lock, and token-revocation state. Run the drill in
+[docs/BACKUP_RESTORE_DRILL.md](./docs/BACKUP_RESTORE_DRILL.md)
+against a disposable Redis container first; the drill needs no
+approval gate.
+
+The same **approval gate** as the Postgres path above (named
+operator, second human acknowledgment in the incident channel,
+posted maintenance window, readiness check passes) must hold before
+any of the destructive commands below run.
+
+The safest path is:
 
 1. Confirm the target backup file.
 2. Stop the backend so it cannot mutate Redis during the restore.

--- a/docs/BACKUP_RESTORE_DRILL.md
+++ b/docs/BACKUP_RESTORE_DRILL.md
@@ -1,0 +1,187 @@
+# Backup Restore Drill
+
+Operator runbook for the **monthly restore-rehearsal** required by
+[`PRODUCTION_CHECKLIST.md`](./PRODUCTION_CHECKLIST.md) §2 ("Data
+durability"). Confirms that the most-recent Postgres and Redis backups
+are actually usable, without touching production data.
+
+This doc is the rehearsal procedure. For the destructive restore-
+against-production outline (and the approval gate), see
+[`VPS_RUNBOOK.md`](../VPS_RUNBOOK.md) §Backups. **Do not run the
+production restore outline as part of this drill.**
+
+## When to run
+
+- Monthly, on a calendar reminder.
+- After any change that affects backup contents shape: Postgres
+  version bump, Redis config change, new container layout, new
+  storage backend.
+- After any incident where a restore was avoided only because the
+  hot system was still up.
+
+## What "passing" looks like
+
+A successful drill produces three pieces of recorded evidence:
+
+1. The readiness check is green on the production stack:
+   `./scripts/ops/check-backup-readiness.sh --json` reports
+   `overallStatus: "ok"` with both `postgres` and `redis` components
+   `ok` and ages well below the threshold.
+2. The most recent Postgres backup restores cleanly into a
+   throwaway Postgres container, and a quick read query against a
+   small representative table returns the expected row count.
+3. The most recent Redis snapshot restores cleanly into a throwaway
+   Redis container, and `KEYS *` (or a more conservative
+   `DBSIZE`) returns roughly the count recorded at backup time.
+
+All three are written into the operator log for the month with the
+backup-file timestamps quoted.
+
+## Pre-drill checklist
+
+Before running the drill:
+
+- [ ] Confirm you are operating against the *production* backup
+  directory only as a *read source*. The drill restores into a local
+  disposable target — never the production database or Redis service.
+- [ ] Confirm `docker compose` is available locally and you can pull
+  the matching Postgres and Redis images.
+- [ ] Confirm `MAX_AGE_HOURS` for the readiness check matches the
+  documented backup cadence (default 26h for daily backups). If the
+  cadence has changed, update the production checklist before
+  proceeding.
+
+## Drill steps
+
+### 1. Run the readiness check
+
+On the VPS, against the live backup directory:
+
+```bash
+sudo -u <ops-user> /srv/agent-stack/app/scripts/ops/check-backup-readiness.sh --json \
+  > /tmp/backup-readiness-$(date +%Y%m%d).json
+
+cat /tmp/backup-readiness-$(date +%Y%m%d).json
+```
+
+Required: `overallStatus: "ok"`, both components `status: "ok"`, both
+`ageSeconds` below `maxAgeHours * 3600`. If the check fails, stop and
+fix the backup cadence before proceeding — running a drill against a
+stale backup proves nothing.
+
+Record the backup file paths the check selected; those are the files
+the drill will restore.
+
+### 2. Copy the selected backups to a workstation or a disposable VM
+
+```bash
+mkdir -p /tmp/backup-drill && cd /tmp/backup-drill
+
+scp ops-vps:/srv/agent-stack/backups/postgres/agent-<TS>.sql.gz .
+scp ops-vps:/srv/agent-stack/backups/redis/redis-<TS>.rdb.gz .
+```
+
+Operate on **copies**. Never edit, decompress in place, or rename the
+files in the live backup directory.
+
+### 3. Restore Postgres into a throwaway container
+
+```bash
+docker run -d --name drill-postgres \
+  -e POSTGRES_USER=agent \
+  -e POSTGRES_PASSWORD=drill \
+  -e POSTGRES_DB=agent \
+  postgres:16
+
+# Wait for the container to be ready
+until docker exec drill-postgres pg_isready -U agent >/dev/null 2>&1; do
+  sleep 1
+done
+
+gunzip -c agent-<TS>.sql.gz | docker exec -i drill-postgres \
+  psql -U agent -d agent
+
+# Spot-check a representative row count
+docker exec drill-postgres psql -U agent -d agent \
+  -c "select count(*) from submissions;"
+```
+
+Required: the restore exits cleanly and the row count is within a
+reasonable band of the production count (record both).
+
+Cleanup: `docker rm -f drill-postgres`.
+
+### 4. Restore Redis into a throwaway container
+
+```bash
+mkdir -p /tmp/backup-drill/redis-data
+gunzip -c redis-<TS>.rdb.gz > /tmp/backup-drill/redis-data/dump.rdb
+
+docker run -d --name drill-redis \
+  -v /tmp/backup-drill/redis-data:/data \
+  redis:7
+
+# Wait for Redis to load the RDB
+sleep 2
+docker exec drill-redis redis-cli DBSIZE
+```
+
+Required: the container starts without errors, `DBSIZE` returns a
+key count within a reasonable band of the production count.
+
+Cleanup: `docker rm -f drill-redis`.
+
+### 5. Record the drill in the operator log
+
+A successful drill writes one line to the operator log naming:
+
+- Date of the drill.
+- The two backup file paths used (postgres + redis).
+- Ages reported by the readiness check.
+- Row count from the Postgres spot-check.
+- Key count from the Redis DBSIZE check.
+- Operator name and signature (initials).
+
+This is the evidence that closes the `PRODUCTION_CHECKLIST.md` line
+"The monthly restore drill has been run at least once on the current
+stack shape."
+
+## What the drill does NOT do
+
+- It does **not** restore over the production database or Redis.
+- It does **not** verify behavioral parity (the restored snapshot may
+  be missing the last ≤ 26h of writes; that's expected for a
+  daily-backup cadence).
+- It does **not** validate point-in-time recovery (we don't run WAL
+  archiving today; the drill is for whole-snapshot recovery only).
+- It does **not** authorize a real restore. See the approval gate in
+  [`VPS_RUNBOOK.md`](../VPS_RUNBOOK.md) §Backups for the destructive
+  path.
+
+## Approval gate for a real production restore
+
+A drill restores into a disposable container and needs no approval
+beyond the operator running it. A **production restore** — replacing
+the live Postgres or Redis snapshot — is a destructive operation and
+requires:
+
+1. **Named operator on the keyboard.** Production restore is not
+   automated and is never run from CI or a workflow.
+2. **A second human acknowledgment** before any `psql ... <` or any
+   `cp /restore/dump.rdb /data/dump.rdb` command runs. The
+   acknowledgment lives in the incident channel and quotes:
+   - The exact backup file path being restored.
+   - The reason (incident reference, ticket, or migration window).
+   - The expected window of data loss (gap between backup and now).
+   - The agreed rollback plan if the restore makes things worse.
+3. **Maintenance window posted** to the operator channel before the
+   `docker compose stop backend` step.
+4. **Post-restore verification logged**: `/health` returns 200, basic
+   smoke check passes, recent rows visible in the relevant tables.
+
+The destructive restore commands themselves live in
+[`VPS_RUNBOOK.md`](../VPS_RUNBOOK.md) §"Postgres restore outline" and
+§"Redis restore outline". Those sections deliberately omit any
+"just-run-this-one-liner" framing — every step is explicit, and the
+restore is intended to be hand-typed under the approval gate above,
+not pasted from a script.

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -31,18 +31,43 @@ See [MULTISIG_SETUP.md](./MULTISIG_SETUP.md) for the exact rehearsal flow.
 
 ## 2. Data durability
 
-- [ ] Latest Postgres backup exists and is restorable.
-- [ ] Latest Redis backup exists and is restorable.
-- [ ] The monthly restore drill has been run at least once on the current stack shape.
+- [ ] Latest Postgres backup exists and is recent. Evidence:
+  `./scripts/ops/check-backup-readiness.sh --json` reports
+  `components[postgres].status == "ok"` with `ageSeconds <
+  maxAgeHours * 3600`.
+- [ ] Latest Redis backup exists and is recent. Same readiness check,
+  `components[redis].status == "ok"`.
+- [ ] The monthly restore drill has been run on the current stack
+  shape. Evidence: a dated line in the operator log naming both
+  backup file paths used, the row count from the Postgres spot-check,
+  and the key count from `DBSIZE` on the restored Redis container.
+  Procedure: [BACKUP_RESTORE_DRILL.md](./BACKUP_RESTORE_DRILL.md).
 
-Use:
+Run backups (writes new snapshots):
 
 ```bash
 ./scripts/ops/backup-postgres.sh
 ./scripts/ops/backup-redis.sh
 ```
 
-Restore drills are documented in [VPS_RUNBOOK.md](../VPS_RUNBOOK.md).
+Run the readiness check (read-only, never restores or modifies a
+backup file):
+
+```bash
+./scripts/ops/check-backup-readiness.sh
+# or for machine-readable output:
+./scripts/ops/check-backup-readiness.sh --json
+```
+
+Restore procedures:
+
+- **Monthly drill against a disposable target:**
+  [BACKUP_RESTORE_DRILL.md](./BACKUP_RESTORE_DRILL.md).
+- **Production restore (destructive, requires approval gate):**
+  [VPS_RUNBOOK.md](../VPS_RUNBOOK.md) §Backups. Never run a
+  production restore without a named operator on the keyboard, a
+  second human acknowledgment in the incident channel, and a posted
+  maintenance window. The drill never substitutes for that gate.
 
 ---
 

--- a/scripts/ops/check-backup-readiness.sh
+++ b/scripts/ops/check-backup-readiness.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#
+# Non-destructive backup readiness check.
+#
+# Reads filesystem metadata only. Never restores, never deletes, never
+# modifies a backup file. Confirms that the most recent Postgres and
+# Redis backup files exist under the expected layout and are within a
+# configurable age threshold. Exits non-zero with a clear reason when a
+# component is missing or stale.
+#
+# Intended for the Production Checklist §2 "Data durability" evidence
+# step and for the monthly restore-drill prep (see
+# docs/BACKUP_RESTORE_DRILL.md).
+#
+# Env:
+#   BACKUP_DIR             root of backups; default /srv/agent-stack/backups
+#   MAX_AGE_HOURS          max age of the newest file, in hours; default 26
+#                          (daily backups + slack)
+#   POSTGRES_BACKUP_GLOB   glob under $BACKUP_DIR/postgres; default *.sql.gz
+#   REDIS_BACKUP_GLOB      glob under $BACKUP_DIR/redis; default *.rdb.gz
+#   OUTPUT_FORMAT          "text" (default) or "json"
+#
+# Flags:
+#   --json                 shorthand for OUTPUT_FORMAT=json
+#   --max-age-hours N      shorthand for MAX_AGE_HOURS=N
+#   --backup-dir PATH      shorthand for BACKUP_DIR=PATH
+#   -h | --help
+
+set -euo pipefail
+
+BACKUP_DIR=${BACKUP_DIR:-"/srv/agent-stack/backups"}
+MAX_AGE_HOURS=${MAX_AGE_HOURS:-26}
+POSTGRES_BACKUP_GLOB=${POSTGRES_BACKUP_GLOB:-"*.sql.gz"}
+REDIS_BACKUP_GLOB=${REDIS_BACKUP_GLOB:-"*.rdb.gz"}
+OUTPUT_FORMAT=${OUTPUT_FORMAT:-text}
+
+while (($#)); do
+  case "$1" in
+    --json) OUTPUT_FORMAT=json ;;
+    --text) OUTPUT_FORMAT=text ;;
+    --max-age-hours)
+      [[ $# -ge 2 ]] || { echo "--max-age-hours needs a value" >&2; exit 2; }
+      MAX_AGE_HOURS="$2"; shift ;;
+    --backup-dir)
+      [[ $# -ge 2 ]] || { echo "--backup-dir needs a value" >&2; exit 2; }
+      BACKUP_DIR="$2"; shift ;;
+    -h|--help)
+      sed -n '2,/^set -euo/{/^set -euo/!p;}' "$0"
+      exit 0 ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 2 ;;
+  esac
+  shift
+done
+
+if ! [[ "$MAX_AGE_HOURS" =~ ^[0-9]+$ ]] || (( MAX_AGE_HOURS == 0 )); then
+  echo "MAX_AGE_HOURS must be a positive integer; got '$MAX_AGE_HOURS'" >&2
+  exit 2
+fi
+
+now_epoch=$(date +%s)
+max_age_seconds=$(( MAX_AGE_HOURS * 3600 ))
+
+# Portable file mtime (seconds since epoch) for both Linux and macOS.
+file_mtime() {
+  if stat --version >/dev/null 2>&1; then
+    stat -c %Y -- "$1"
+  else
+    stat -f %m -- "$1"
+  fi
+}
+
+newest_in() {
+  local dir="$1"
+  local glob="$2"
+  shopt -s nullglob
+  local files=( "$dir"/$glob )
+  shopt -u nullglob
+  if (( ${#files[@]} == 0 )); then
+    return 1
+  fi
+  local newest=""
+  local newest_mtime=-1
+  for f in "${files[@]}"; do
+    local m
+    m=$(file_mtime "$f")
+    if (( m > newest_mtime )); then
+      newest_mtime=$m
+      newest="$f"
+    fi
+  done
+  printf '%s\t%s\n' "$newest" "$newest_mtime"
+}
+
+check_component() {
+  local label="$1"
+  local subdir="$2"
+  local glob="$3"
+  local path="$BACKUP_DIR/$subdir"
+
+  if [[ ! -d "$path" ]]; then
+    emit "$label" "missing_directory" "" "" "Directory does not exist: $path"
+    return 1
+  fi
+
+  local newest_line
+  if ! newest_line=$(newest_in "$path" "$glob"); then
+    emit "$label" "no_files_match" "" "" "No files in $path match $glob"
+    return 1
+  fi
+
+  local file mtime age_seconds
+  IFS=$'\t' read -r file mtime <<<"$newest_line"
+  age_seconds=$(( now_epoch - mtime ))
+
+  if (( age_seconds > max_age_seconds )); then
+    emit "$label" "stale" "$file" "$age_seconds" \
+      "Newest backup is $(format_hours $age_seconds) old; threshold is ${MAX_AGE_HOURS}h"
+    return 1
+  fi
+
+  emit "$label" "ok" "$file" "$age_seconds" "Newest backup is $(format_hours $age_seconds) old"
+  return 0
+}
+
+format_hours() {
+  awk -v s="$1" 'BEGIN { printf "%.1fh", s/3600 }'
+}
+
+# Result rows are accumulated as TAB-separated triples then rendered at
+# the end. Keeps the JSON and text paths from diverging.
+result_lines=()
+emit() {
+  result_lines+=( "$(printf '%s\t%s\t%s\t%s\t%s' "$1" "$2" "$3" "$4" "$5")" )
+}
+
+overall_status=0
+check_component postgres postgres "$POSTGRES_BACKUP_GLOB" || overall_status=1
+check_component redis redis "$REDIS_BACKUP_GLOB" || overall_status=1
+
+if [[ "$OUTPUT_FORMAT" == "json" ]]; then
+  printf '{\n'
+  printf '  "checkedAt": "%s",\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  printf '  "backupDir": "%s",\n' "$BACKUP_DIR"
+  printf '  "maxAgeHours": %d,\n' "$MAX_AGE_HOURS"
+  printf '  "overallStatus": "%s",\n' "$([[ $overall_status -eq 0 ]] && echo ok || echo not_ok)"
+  printf '  "components": [\n'
+  local_index=0
+  for line in "${result_lines[@]}"; do
+    IFS=$'\t' read -r label status file age_seconds message <<<"$line"
+    if (( local_index > 0 )); then printf ',\n'; fi
+    printf '    {"name":"%s","status":"%s","file":"%s","ageSeconds":%s,"message":"%s"}' \
+      "$label" "$status" "${file//\"/\\\"}" "${age_seconds:-null}" "${message//\"/\\\"}"
+    local_index=$(( local_index + 1 ))
+  done
+  printf '\n  ]\n}\n'
+else
+  echo "Backup readiness check"
+  echo "  backupDir:     $BACKUP_DIR"
+  echo "  maxAgeHours:   $MAX_AGE_HOURS"
+  echo
+  for line in "${result_lines[@]}"; do
+    IFS=$'\t' read -r label status file age_seconds message <<<"$line"
+    printf '  %-9s %-18s %s\n' "$label" "$status" "$message"
+    if [[ -n "$file" ]]; then
+      printf '            file: %s\n' "$file"
+    fi
+  done
+  echo
+  if (( overall_status == 0 )); then
+    echo "Overall: ok"
+  else
+    echo "Overall: not_ok"
+  fi
+fi
+
+exit "$overall_status"

--- a/scripts/ops/check-backup-readiness.test.mjs
+++ b/scripts/ops/check-backup-readiness.test.mjs
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { mkdir, mkdtemp, writeFile, utimes } from "node:fs/promises";
+import { join, resolve, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const execFileAsync = promisify(execFile);
+const scriptPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "check-backup-readiness.sh"
+);
+
+async function setupBackupDir(opts = {}) {
+  const root = await mkdtemp(join(tmpdir(), "backup-readiness-"));
+  if (opts.postgres) {
+    const pgDir = join(root, "postgres");
+    await mkdir(pgDir, { recursive: true });
+    for (const [name, ageHours] of opts.postgres) {
+      const file = join(pgDir, name);
+      await writeFile(file, "placeholder dump\n", "utf8");
+      const mtime = new Date(Date.now() - ageHours * 3600 * 1000);
+      await utimes(file, mtime, mtime);
+    }
+  }
+  if (opts.redis) {
+    const redisDir = join(root, "redis");
+    await mkdir(redisDir, { recursive: true });
+    for (const [name, ageHours] of opts.redis) {
+      const file = join(redisDir, name);
+      await writeFile(file, "placeholder rdb\n", "utf8");
+      const mtime = new Date(Date.now() - ageHours * 3600 * 1000);
+      await utimes(file, mtime, mtime);
+    }
+  }
+  return root;
+}
+
+async function runScript(backupDir, extraArgs = []) {
+  try {
+    const { stdout, stderr } = await execFileAsync(scriptPath, [
+      "--backup-dir",
+      backupDir,
+      ...extraArgs,
+    ]);
+    return { code: 0, stdout, stderr };
+  } catch (err) {
+    return {
+      code: typeof err.code === "number" ? err.code : 1,
+      stdout: err.stdout ?? "",
+      stderr: err.stderr ?? "",
+    };
+  }
+}
+
+test("readiness check passes when both fresh backups are present", async () => {
+  const dir = await setupBackupDir({
+    postgres: [["agent-20260516-010000.sql.gz", 1]],
+    redis: [["redis-20260516-010000.rdb.gz", 2]],
+  });
+  const result = await runScript(dir);
+  assert.equal(result.code, 0, `expected 0, got stderr: ${result.stderr}`);
+  assert.match(result.stdout, /postgres\s+ok/);
+  assert.match(result.stdout, /redis\s+ok/);
+  assert.match(result.stdout, /Overall: ok/);
+});
+
+test("readiness check fails when the postgres directory has no matching files", async () => {
+  const dir = await setupBackupDir({
+    postgres: [], // dir exists, no files
+    redis: [["redis-20260516-010000.rdb.gz", 1]],
+  });
+  const result = await runScript(dir);
+  assert.equal(result.code, 1);
+  assert.match(result.stdout, /postgres\s+no_files_match/);
+  assert.match(result.stdout, /redis\s+ok/);
+  assert.match(result.stdout, /Overall: not_ok/);
+});
+
+test("readiness check fails when the redis directory does not exist at all", async () => {
+  const dir = await setupBackupDir({
+    postgres: [["agent-20260516-010000.sql.gz", 1]],
+    // no redis dir at all
+  });
+  const result = await runScript(dir);
+  assert.equal(result.code, 1);
+  assert.match(result.stdout, /redis\s+missing_directory/);
+});
+
+test("readiness check fails when the newest backup is older than the age threshold", async () => {
+  const dir = await setupBackupDir({
+    // 48h old > default 26h threshold
+    postgres: [["agent-20260514-010000.sql.gz", 48]],
+    redis: [["redis-20260516-010000.rdb.gz", 1]],
+  });
+  const result = await runScript(dir);
+  assert.equal(result.code, 1);
+  assert.match(result.stdout, /postgres\s+stale/);
+  assert.match(result.stdout, /threshold is 26h/);
+});
+
+test("readiness check picks the newest file when multiple candidates exist", async () => {
+  const dir = await setupBackupDir({
+    postgres: [
+      ["agent-old.sql.gz", 200],
+      ["agent-fresh.sql.gz", 1],
+      ["agent-mid.sql.gz", 50],
+    ],
+    redis: [["redis-20260516-010000.rdb.gz", 1]],
+  });
+  const result = await runScript(dir);
+  assert.equal(result.code, 0);
+  // The reported file path must be the fresh one, not the older candidates.
+  assert.match(result.stdout, /agent-fresh\.sql\.gz/);
+});
+
+test("--max-age-hours tightens the threshold and surfaces a stale postgres", async () => {
+  const dir = await setupBackupDir({
+    postgres: [["agent-20260516-010000.sql.gz", 5]],
+    redis: [["redis-20260516-010000.rdb.gz", 5]],
+  });
+  // Tighten to 2h — both backups are now 5h old.
+  const result = await runScript(dir, ["--max-age-hours", "2"]);
+  assert.equal(result.code, 1);
+  assert.match(result.stdout, /postgres\s+stale/);
+  assert.match(result.stdout, /redis\s+stale/);
+  assert.match(result.stdout, /threshold is 2h/);
+});
+
+test("--json mode emits a parseable status document with components and overall verdict", async () => {
+  const dir = await setupBackupDir({
+    postgres: [["agent-20260516-010000.sql.gz", 1]],
+    redis: [["redis-20260516-010000.rdb.gz", 1]],
+  });
+  const result = await runScript(dir, ["--json"]);
+  assert.equal(result.code, 0);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.overallStatus, "ok");
+  assert.equal(parsed.maxAgeHours, 26);
+  assert.equal(parsed.backupDir, dir);
+  assert.equal(parsed.components.length, 2);
+  const byName = Object.fromEntries(parsed.components.map((c) => [c.name, c]));
+  assert.equal(byName.postgres.status, "ok");
+  assert.equal(byName.redis.status, "ok");
+  assert.match(byName.postgres.file, /\.sql\.gz$/);
+});
+
+test("invalid --max-age-hours value fails closed with a non-zero exit", async () => {
+  const dir = await setupBackupDir({
+    postgres: [["agent-20260516-010000.sql.gz", 1]],
+    redis: [["redis-20260516-010000.rdb.gz", 1]],
+  });
+  const result = await runScript(dir, ["--max-age-hours", "0"]);
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /must be a positive integer/);
+});


### PR DESCRIPTION
## Summary

Closes the operator gap behind `PRODUCTION_CHECKLIST.md` §2 ("Data durability"). Three things were missing on main:

1. A mechanical way to confirm "latest backup exists and is recent" — operators had to eyeball `ls -lh`.
2. A formal restore-rehearsal runbook — the destructive restore outlines lived in `VPS_RUNBOOK.md`, but there was no walkthrough for the monthly drill on a disposable target.
3. An explicit approval gate before a production restore — both restore outlines said "should be done deliberately" without naming who must approve or what handshake is needed.

**Non-destructive.** Nothing in this PR runs a production restore or touches a live database/snapshot. The new readiness check only reads filesystem mtimes. The drill runbook restores into throwaway containers.

## What landed

- **`scripts/ops/check-backup-readiness.sh`** (new) — read-only check. Reads filesystem `mtime` only. Confirms the most recent postgres + redis backup files under `$BACKUP_DIR` (default `/srv/agent-stack/backups`) exist and are within `MAX_AGE_HOURS` (default 26h). Reports `missing_directory` / `no_files_match` / `stale` / `ok` per component, plus an `overallStatus`. Exits non-zero on any not-ok. Supports `--json` for the production-checklist evidence path.
- **`scripts/ops/check-backup-readiness.test.mjs`** (new) — 8 tests driving the script against temp backup trees with controlled mtimes. Covers fresh-ok, missing-files, missing-directory, stale (default + tightened threshold), multi-candidate newest-wins, JSON shape, and invalid `--max-age-hours` failing closed.
- **`docs/BACKUP_RESTORE_DRILL.md`** (new) — operator runbook for the monthly rehearsal. Drives the restore into throwaway `postgres:16` and `redis:7` containers, never against production. Defines "passing" as: readiness check green + Postgres row count within expected band + Redis `DBSIZE` within expected band, with a dated line in the operator log naming both file paths used.
- **`docs/PRODUCTION_CHECKLIST.md` §2** — each row now names the exact evidence required to flip the box (`components[postgres].status == "ok"` etc.), and cross-links the new check + drill runbook. The destructive production-restore path is separated from the drill and points at the approval gate in `VPS_RUNBOOK.md`.
- **`VPS_RUNBOOK.md` §Backups** — both Postgres and Redis restore outlines now lead with the approval gate:
  1. Named operator on the keyboard (no CI / workflow / agent).
  2. Second human acknowledgment in the incident channel quoting the exact backup file path, the reason, the expected data-loss window, and the agreed rollback plan.
  3. Posted maintenance window before stopping the backend.
  4. Run the readiness check first so the file being restored is the one the system claims is current.

  Cross-links the drill runbook for the non-destructive rehearsal path.

## Test plan

- [x] `node --test scripts/ops/check-backup-readiness.test.mjs` — 8 tests pass
- [x] Sanity-check the script renders sensibly with `OUTPUT_FORMAT=json` and exits non-zero on a stale fixture
- [ ] Manual on the VPS: `./scripts/ops/check-backup-readiness.sh` against the live backup dir should report ok; flip a backup's mtime back 48h and confirm it surfaces `stale`

## What this PR does NOT do

- Does not run a production restore.
- Does not modify the backup scripts themselves (`backup-postgres.sh`, `backup-redis.sh`) — they already work correctly.
- Does not introduce point-in-time recovery; the drill is for whole-snapshot recovery and the runbook flags this explicitly.
- Does not automate the destructive restore path — the approval gate language is deliberately not enforced by tooling; production restore stays a hand-typed operator action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)