### PR TITLE
Harden capability grant revocation cache

### DIFF
--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -366,10 +366,9 @@ across environment config, JWT roles, and route-level decisions.
 ### Remaining gaps
 
 - signed tokens are still issued from coarse environment role lists
-- future fine-grained delegated scopes are supported by the resolver, but do
-  not yet have an operator grant/revoke workflow
-- some public discovery docs still describe auth action requirements separately
-  from the runtime capability matrix
+- hosted evidence still needs one least-privilege service token to run a real
+  external-agent flow end to end without an admin wallet token
+- delegated-wallet UX should expand again once native Substrate auth lands
 
 ### Improve to
 
@@ -382,12 +381,12 @@ across environment config, JWT roles, and route-level decisions.
 
 ### Concrete next changes
 
-- add an operator-facing grant/revoke flow for scoped service tokens or
-  delegated wallets
-- align public onboarding action requirements with the versioned auth policy
-  payload
-- extend frontend controls to hide/disable actions from `authPolicy.uiControls`
-- add audit events when capability grants change
+- run a hosted proof with an operator-issued service token that only carries
+  the worker capabilities it needs
+- keep the service-token grant cache invalidation covered as the revocation
+  path evolves
+- revisit delegated-wallet UX when native Substrate sign-in is accepted by
+  protected HTTP routes
 
 ### What this unlocks
 

--- a/docs/SPEC_AUDIT_2026-05-13.md
+++ b/docs/SPEC_AUDIT_2026-05-13.md
@@ -234,11 +234,15 @@ SSH/basic-auth/admin-JWT cutovers, and the basic hosted smoke is green.
 
 ### Capability Model
 
-- Status: typed SDK surface and docs for scoped service tokens are present.
-- Remaining: add operator grant/revoke runtime flows for scoped service tokens
-  or delegated wallets, align public onboarding action requirements with the
-  runtime auth-policy payload, hide or disable frontend controls from
-  `authPolicy.uiControls`, and emit audit events when capability grants change.
+- Status: typed SDK surface, docs, operator grant/revoke runtime flows,
+  grant-backed service-token issue/rotate/revoke APIs, public onboarding
+  guidance, `authPolicy.uiControls` UI gating, and audit events are present.
+  Grant-cache invalidation now makes operator-issued revokes effective on the
+  next request in the serving process, with the middleware TTL only as a
+  cross-process backstop.
+- Remaining: add hosted/live smoke evidence for a scoped external-agent token
+  using only its least-privilege capabilities, and extend delegated-wallet UX
+  once native Substrate auth lands.
 
 ### Secrets Phase 2+ And Mainnet Custody
 

--- a/mcp-server/src/auth/auth.test.js
+++ b/mcp-server/src/auth/auth.test.js
@@ -573,6 +573,52 @@ test("requireAuth ignores revoked grants when expanding capabilities", async () 
   );
 });
 
+test("requireAuth exposes grant-cache invalidation for immediate operator revokes", async () => {
+  const subject = "0xcccccccccccccccccccccccccccccccccccccccc";
+  const issuedBy = "0x1111111111111111111111111111111111111111";
+  const stateStore = new MemoryStateStore();
+  await stateStore.upsertCapabilityGrant({
+    id: "grant-cache",
+    subject,
+    status: "active",
+    capabilities: ["jobs:lifecycle"],
+    issuedAt: new Date().toISOString(),
+    issuedBy
+  });
+  const authConfig = {
+    secrets: [LONG_SECRET],
+    signingSecret: LONG_SECRET,
+    permissive: false,
+    strict: true
+  };
+  const middleware = createAuthMiddleware({ authConfig, stateStore, logger: silentLogger() });
+  const { token } = signToken({ sub: subject, roles: [] }, {
+    secret: LONG_SECRET,
+    expiresInSeconds: 60
+  });
+  const request = { method: "POST", headers: { authorization: `Bearer ${token}` } };
+  const url = new URL("http://localhost/admin/jobs/lifecycle");
+
+  assert.ok((await middleware(request, url)).capabilities.includes("jobs:lifecycle"));
+
+  await stateStore.upsertCapabilityGrant({
+    id: "grant-cache",
+    subject,
+    status: "revoked",
+    capabilities: ["jobs:lifecycle"],
+    issuedAt: new Date().toISOString(),
+    issuedBy,
+    revokedAt: new Date().toISOString(),
+    revokedBy: issuedBy
+  });
+  middleware.invalidateCapabilityGrantCache(subject);
+
+  await assert.rejects(
+    () => middleware(request, url),
+    (error) => error instanceof AuthorizationError && error.code === "missing_capability"
+  );
+});
+
 test("requireAuth binds service tokens to exactly one active grant without base capabilities", async () => {
   const subject = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
   const stateStore = new MemoryStateStore();

--- a/mcp-server/src/auth/middleware.js
+++ b/mcp-server/src/auth/middleware.js
@@ -37,8 +37,10 @@ export function createAuthMiddleware({ authConfig, stateStore, logger = console,
   // Per-subject grant cache. The grant list is stable for the
   // lifetime of a JWT and lookups happen on every authed request,
   // so a 15s in-process cache keeps the steady-state cost of
-  // capability merging at zero. Revokes invalidate via TTL — admins
-  // should expect up to 15s lag from revoke-call to enforcement.
+  // capability merging low. Grant/revoke routes explicitly invalidate
+  // touched subjects so operator-initiated revokes take effect on the
+  // next request in this process; the TTL remains a cross-process
+  // backstop.
   const grantCache = new Map();
 
   async function loadActiveGrantsFor(wallet) {
@@ -95,7 +97,15 @@ export function createAuthMiddleware({ authConfig, stateStore, logger = console,
     return mergeGrantCapabilities(baseCapabilities, grants, { now });
   }
 
-  return async function requireAuth(
+  function invalidateCapabilityGrantCache(subject = undefined) {
+    if (subject === undefined || subject === null || String(subject).trim() === "*") {
+      grantCache.clear();
+      return;
+    }
+    grantCache.delete(String(subject).trim().toLowerCase());
+  }
+
+  async function requireAuth(
     request,
     url,
     {
@@ -184,7 +194,10 @@ export function createAuthMiddleware({ authConfig, stateStore, logger = console,
       capabilityRequirements: requiredCapabilities,
       via: headerToken ? "header" : "query_token"
     };
-  };
+  }
+
+  requireAuth.invalidateCapabilityGrantCache = invalidateCapabilityGrantCache;
+  return requireAuth;
 }
 
 function isServiceTokenClaims(claims = {}) {

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -1526,6 +1526,7 @@ async function revokeCapabilityGrantRecord({ grantId, auth, note }) {
   });
   if (!alreadyRevoked) {
     await stateStore.upsertCapabilityGrant?.(record);
+    authMiddleware.invalidateCapabilityGrantCache?.(record.subject);
   }
   return { current, record, alreadyRevoked };
 }
@@ -3619,6 +3620,7 @@ const server = createServer(async (request, response) => {
       });
       assertIssuerCanGrantCapabilities(grant, auth);
       await stateStore.upsertCapabilityGrant?.(grant);
+      authMiddleware.invalidateCapabilityGrantCache?.(grant.subject);
       const projection = projectGrant(grant);
       await storeIdempotentMutationReceipt({
         bucket: "capability_grant",
@@ -3686,6 +3688,7 @@ const server = createServer(async (request, response) => {
       });
       assertIssuerCanGrantCapabilities(grant, auth);
       await stateStore.upsertCapabilityGrant?.(grant);
+      authMiddleware.invalidateCapabilityGrantCache?.(grant.subject);
       const { token, claims } = signServiceToken(grant, payload);
       const body = serviceTokenIssueResponse({ grant, token, claims });
       await storeIdempotentMutationReceipt({
@@ -3763,6 +3766,7 @@ const server = createServer(async (request, response) => {
         note: payload?.revokeNote ?? "rotated service token"
       });
       await stateStore.upsertCapabilityGrant?.(nextGrant);
+      authMiddleware.invalidateCapabilityGrantCache?.(nextGrant.subject);
       const { token, claims } = signServiceToken(nextGrant, payload);
       const body = serviceTokenIssueResponse({ grant: nextGrant, token, claims, rotatedFrom: revoked });
       await storeIdempotentMutationReceipt({
@@ -3882,6 +3886,7 @@ const server = createServer(async (request, response) => {
       });
       if (!alreadyRevoked) {
         await stateStore.upsertCapabilityGrant?.(record);
+        authMiddleware.invalidateCapabilityGrantCache?.(record.subject);
       }
       const projection = projectGrant(record);
       await storeIdempotentMutationReceipt({


### PR DESCRIPTION
## What changed
- Added explicit capability-grant cache invalidation to the auth middleware.
- Invalidated affected subjects on grant issue, service-token issue/rotate/revoke, and direct grant revoke.
- Added an auth regression test proving a cached delegated capability is removed immediately after operator invalidation.
- Updated the roadmap/spec audit to reflect the current scoped service-token runtime and the remaining hosted proof work.

## Checks
- npm install
- npm --workspace mcp-server test
- node --test src/auth/auth.test.js src/auth/capabilities.test.js src/core/capability-grants.test.js
- node --test sdk/agent-platform-client.test.mjs
- git diff --check

## Surface
- Backend auth/API behavior
- Docs/spec audit
- No frontend, indexer, Caddy, contract, or public-site changes

## Env / VPS changes
- None