### PR TITLE
Preserve raw async strategy accounting amounts

### DIFF
--- a/mcp-server/src/core/account-mutation-service.js
+++ b/mcp-server/src/core/account-mutation-service.js
@@ -117,21 +117,29 @@ export class AccountMutationService {
     }
   }
 
-  updateStrategyAccountingOnAllocate(account, strategyId, asset, amount) {
+  updateStrategyAccountingOnAllocate(account, strategyId, asset, amount, { amountRaw = undefined } = {}) {
     const entry = this.getStrategyAccounting(account, strategyId, asset);
     entry.principal = Number(entry.principal ?? 0) + amount;
     entry.markValue = Number(entry.markValue ?? 0) + amount;
+    const normalizedAmountRaw = normalizeUnsignedRawAmount(amountRaw);
+    if (normalizedAmountRaw !== undefined) {
+      entry.principalRaw = addRawAmount(entry.principalRaw, normalizedAmountRaw);
+      entry.markValueRaw = addRawAmount(entry.markValueRaw, normalizedAmountRaw);
+    }
     entry.markedAt = new Date().toISOString();
     this.recordTreasuryEvent(account, {
       type: "allocate",
       strategyId,
       asset,
       amount,
-      principalAfter: entry.principal
+      ...(normalizedAmountRaw !== undefined ? { amountRaw: normalizedAmountRaw } : {}),
+      principalAfter: entry.principal,
+      ...(entry.principalRaw !== undefined ? { principalAfterRaw: entry.principalRaw } : {}),
+      ...(entry.markValueRaw !== undefined ? { markValueAfterRaw: entry.markValueRaw } : {})
     });
   }
 
-  updateStrategyAccountingOnDeallocate(account, strategyId, asset, assetsReturned) {
+  updateStrategyAccountingOnDeallocate(account, strategyId, asset, assetsReturned, { assetsReturnedRaw = undefined } = {}) {
     const entry = this.getStrategyAccounting(account, strategyId, asset);
     const principalBefore = Number(entry.principal ?? 0);
     const markValueBefore = Number(entry.markValue ?? principalBefore ?? 0);
@@ -144,6 +152,10 @@ export class AccountMutationService {
     entry.principal = Math.max(principalBefore - principalReleased, 0);
     entry.realizedYield = Number(entry.realizedYield ?? 0) + realizedYieldDelta;
     entry.markValue = Math.max(markValueBefore - assetsReturned, 0);
+    const normalizedAssetsReturnedRaw = normalizeUnsignedRawAmount(assetsReturnedRaw);
+    const rawSettlement = normalizedAssetsReturnedRaw !== undefined
+      ? applyRawDeallocation(entry, normalizedAssetsReturnedRaw)
+      : {};
     entry.markedAt = new Date().toISOString();
 
     this.recordTreasuryEvent(account, {
@@ -151,8 +163,14 @@ export class AccountMutationService {
       strategyId,
       asset,
       amount: assetsReturned,
+      ...(normalizedAssetsReturnedRaw !== undefined ? { amountRaw: normalizedAssetsReturnedRaw } : {}),
       realizedYieldDelta,
-      principalAfter: entry.principal
+      ...(rawSettlement.realizedYieldDeltaRaw !== undefined
+        ? { realizedYieldDeltaRaw: rawSettlement.realizedYieldDeltaRaw }
+        : {}),
+      principalAfter: entry.principal,
+      ...(entry.principalRaw !== undefined ? { principalAfterRaw: entry.principalRaw } : {}),
+      ...(entry.markValueRaw !== undefined ? { markValueAfterRaw: entry.markValueRaw } : {})
     });
   }
 
@@ -188,6 +206,10 @@ export class AccountMutationService {
       entry.asset = asset;
       entry.markValue = currentValue;
       entry.markedAt = recordedAt;
+      const currentValueRaw = normalizeUnsignedRawAmount(snapshot.currentValueRaw ?? snapshot.routedAmountRaw);
+      if (currentValueRaw !== undefined) {
+        entry.markValueRaw = currentValueRaw;
+      }
       if (Number.isFinite(sharePrice)) {
         entry.sharePrice = sharePrice;
       }
@@ -364,7 +386,13 @@ export class AccountMutationService {
     const liveAccount = await this.blockchainGateway.requestStrategyDeposit(wallet, strategy, amount, options);
     const account = this.attachStoredTreasuryMetadata(wallet, liveAccount);
     const pending = this.getStrategyPending(account, strategyId, asset);
+    const requestedAssetsRaw = normalizeUnsignedRawAmount(
+      liveAccount?.xcmRequest?.requestedAssetsRaw ?? liveAccount?.strategyRequest?.requestedAssetsRaw
+    );
     pending.pendingDepositAssets = Number(pending.pendingDepositAssets ?? 0) + Number(liveAccount?.xcmRequest?.requestedAssets ?? amount);
+    if (requestedAssetsRaw !== undefined) {
+      pending.pendingDepositAssetsRaw = addRawAmount(pending.pendingDepositAssetsRaw, requestedAssetsRaw);
+    }
     pending.lastRequestId = liveAccount?.requestId;
     pending.lastStatus = liveAccount?.xcmRequest?.statusLabel ?? "pending";
     pending.lastKind = "deposit";
@@ -375,6 +403,7 @@ export class AccountMutationService {
       strategyId,
       asset,
       amount,
+      ...(requestedAssetsRaw !== undefined ? { amountRaw: requestedAssetsRaw } : {}),
       requestId: liveAccount?.requestId
     });
     this.accounts.set(wallet, account);
@@ -433,12 +462,20 @@ export class AccountMutationService {
     const liveAccount = await this.blockchainGateway.requestStrategyWithdraw(wallet, strategy, amount, options);
     const account = this.attachStoredTreasuryMetadata(wallet, liveAccount);
     const pending = this.getStrategyPending(account, strategyId, asset);
+    const requestedSharesRaw = normalizeUnsignedRawAmount(
+      liveAccount?.strategyRequest?.requestedSharesRaw ??
+      liveAccount?.xcmRequest?.requestedSharesRaw ??
+      liveAccount?.requestedSharesRaw
+    );
     pending.pendingWithdrawalShares = Number(pending.pendingWithdrawalShares ?? 0) + Number(
       liveAccount?.strategyRequest?.requestedShares ??
       liveAccount?.xcmRequest?.requestedShares ??
       liveAccount?.requestedShares ??
       amount
     );
+    if (requestedSharesRaw !== undefined) {
+      pending.pendingWithdrawalSharesRaw = addRawAmount(pending.pendingWithdrawalSharesRaw, requestedSharesRaw);
+    }
     pending.lastRequestId = liveAccount?.requestId;
     pending.lastStatus = liveAccount?.xcmRequest?.statusLabel ?? "pending";
     pending.lastKind = "withdraw";
@@ -450,6 +487,7 @@ export class AccountMutationService {
       asset,
       amount,
       requestedShares: pending.pendingWithdrawalShares,
+      ...(requestedSharesRaw !== undefined ? { requestedSharesRaw } : {}),
       requestId: liveAccount?.requestId
     });
     this.accounts.set(wallet, account);
@@ -487,32 +525,67 @@ export class AccountMutationService {
     const requestedAssets = Number(result?.strategyRequest?.requestedAssets ?? 0);
     const requestedShares = Number(result?.strategyRequest?.requestedShares ?? 0);
     const settledAssets = Number(result?.strategyRequest?.settledAssets ?? result?.settledAssets ?? 0);
+    const requestedAssetsRaw = normalizeUnsignedRawAmount(
+      result?.strategyRequest?.requestedAssetsRaw ?? result?.requestedAssetsRaw
+    );
+    const requestedSharesRaw = normalizeUnsignedRawAmount(
+      result?.strategyRequest?.requestedSharesRaw ?? result?.requestedSharesRaw
+    );
+    const settledAssetsRaw = normalizeUnsignedRawAmount(
+      result?.strategyRequest?.settledAssetsRaw ?? result?.settledAssetsRaw
+    );
+    const settledSharesRaw = normalizeUnsignedRawAmount(
+      result?.strategyRequest?.settledSharesRaw ?? result?.settledSharesRaw
+    );
 
     if (kind === "deposit") {
       pending.pendingDepositAssets = Math.max(Number(pending.pendingDepositAssets ?? 0) - requestedAssets, 0);
+      pending.pendingDepositAssetsRaw = subtractRawAmount(
+        pending.pendingDepositAssetsRaw,
+        requestedAssetsRaw ?? settledAssetsRaw
+      );
       if (status === "succeeded") {
-        this.updateStrategyAccountingOnAllocate(account, strategyId, asset, settledAssets || requestedAssets);
+        this.updateStrategyAccountingOnAllocate(account, strategyId, asset, settledAssets || requestedAssets, {
+          amountRaw: settledAssetsRaw ?? requestedAssetsRaw
+        });
       } else {
         this.recordTreasuryEvent(account, {
           type: "allocate_failed",
           strategyId,
           asset,
           amount: requestedAssets,
+          ...(requestedAssetsRaw !== undefined ? { amountRaw: requestedAssetsRaw } : {}),
           requestId: result?.requestId,
           failureCode: result?.strategyRequest?.failureCodeLabel ?? result?.failureCodeLabel
         });
       }
     } else if (kind === "withdraw") {
       pending.pendingWithdrawalShares = Math.max(Number(pending.pendingWithdrawalShares ?? 0) - requestedShares, 0);
+      pending.pendingWithdrawalSharesRaw = subtractRawAmount(
+        pending.pendingWithdrawalSharesRaw,
+        requestedSharesRaw ?? settledSharesRaw
+      );
       if (status === "succeeded") {
-        this.updateStrategyAccountingOnDeallocate(account, strategyId, asset, settledAssets);
+        this.updateStrategyAccountingOnDeallocate(account, strategyId, asset, settledAssets, {
+          assetsReturnedRaw: settledAssetsRaw
+        });
       } else {
         this.recordTreasuryEvent(account, {
           type: "deallocate_failed",
           strategyId,
           asset,
           amount: settledAssets || requestedAssets,
+          ...(settledAssetsRaw !== undefined
+            ? { amountRaw: settledAssetsRaw }
+            : requestedAssetsRaw !== undefined
+              ? { amountRaw: requestedAssetsRaw }
+              : {}),
           requestedShares,
+          ...(requestedSharesRaw !== undefined
+            ? { requestedSharesRaw }
+            : settledSharesRaw !== undefined
+              ? { requestedSharesRaw: settledSharesRaw }
+              : {}),
           requestId: result?.requestId,
           failureCode: result?.strategyRequest?.failureCodeLabel ?? result?.failureCodeLabel
         });
@@ -632,4 +705,112 @@ export class AccountMutationService {
     this.accounts.set(wallet, account);
     return account;
   }
+}
+
+function normalizeUnsignedRawAmount(value) {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+  if (typeof value === "bigint") {
+    if (value < 0n) {
+      throw new ValidationError("raw amount must be a non-negative integer.");
+    }
+    return value.toString();
+  }
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new ValidationError("raw amount must be an exact non-negative integer.");
+    }
+    return String(value);
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim();
+    if (!/^\d+$/u.test(normalized)) {
+      throw new ValidationError("raw amount must be a non-negative integer string.");
+    }
+    return BigInt(normalized).toString();
+  }
+  throw new ValidationError("raw amount must be a non-negative integer.");
+}
+
+function normalizeSignedRawAmount(value) {
+  if (value === undefined || value === null || value === "") {
+    return 0n;
+  }
+  if (typeof value === "bigint") {
+    return value;
+  }
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value)) {
+      throw new ValidationError("signed raw amount must be an exact integer.");
+    }
+    return BigInt(value);
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim();
+    if (!/^-?\d+$/u.test(normalized)) {
+      throw new ValidationError("signed raw amount must be an integer string.");
+    }
+    return BigInt(normalized);
+  }
+  throw new ValidationError("signed raw amount must be an integer.");
+}
+
+function addRawAmount(current, delta) {
+  const normalizedDelta = normalizeUnsignedRawAmount(delta);
+  if (normalizedDelta === undefined) {
+    return current;
+  }
+  const normalizedCurrent = normalizeUnsignedRawAmount(current);
+  return ((normalizedCurrent === undefined ? 0n : BigInt(normalizedCurrent)) + BigInt(normalizedDelta)).toString();
+}
+
+function subtractRawAmount(current, delta) {
+  const normalizedCurrent = normalizeUnsignedRawAmount(current);
+  if (normalizedCurrent === undefined) {
+    return current;
+  }
+  const normalizedDelta = normalizeUnsignedRawAmount(delta);
+  if (normalizedDelta === undefined) {
+    return normalizedCurrent;
+  }
+  const next = BigInt(normalizedCurrent) - BigInt(normalizedDelta);
+  return next > 0n ? next.toString() : "0";
+}
+
+function addSignedRawAmount(current, delta) {
+  return (normalizeSignedRawAmount(current) + normalizeSignedRawAmount(delta)).toString();
+}
+
+function maxBigInt(...values) {
+  return values.reduce((max, value) => (value > max ? value : max), values[0] ?? 0n);
+}
+
+function minBigInt(...values) {
+  return values.reduce((min, value) => (value < min ? value : min), values[0] ?? 0n);
+}
+
+function applyRawDeallocation(entry, assetsReturnedRaw) {
+  const normalizedAssetsReturnedRaw = normalizeUnsignedRawAmount(assetsReturnedRaw);
+  const normalizedPrincipalRaw = normalizeUnsignedRawAmount(entry.principalRaw);
+  if (normalizedAssetsReturnedRaw === undefined || normalizedPrincipalRaw === undefined) {
+    return {};
+  }
+
+  const assetsReturned = BigInt(normalizedAssetsReturnedRaw);
+  const principalBefore = BigInt(normalizedPrincipalRaw);
+  const markValueBefore = BigInt(normalizeUnsignedRawAmount(entry.markValueRaw ?? entry.principalRaw) ?? "0");
+  const denominator = maxBigInt(markValueBefore, assetsReturned, 0n);
+  const principalReleased = denominator > 0n
+    ? minBigInt(principalBefore, (principalBefore * assetsReturned) / denominator)
+    : minBigInt(principalBefore, assetsReturned);
+  const realizedYieldDeltaRaw = assetsReturned - principalReleased;
+
+  entry.principalRaw = (principalBefore > principalReleased ? principalBefore - principalReleased : 0n).toString();
+  entry.realizedYieldRaw = addSignedRawAmount(entry.realizedYieldRaw, realizedYieldDeltaRaw);
+  entry.markValueRaw = (markValueBefore > assetsReturned ? markValueBefore - assetsReturned : 0n).toString();
+
+  return {
+    realizedYieldDeltaRaw: realizedYieldDeltaRaw.toString()
+  };
 }

--- a/mcp-server/src/core/agent-transfer.test.js
+++ b/mcp-server/src/core/agent-transfer.test.js
@@ -157,8 +157,8 @@ test("requestStrategyDeposit delegates async lanes to the blockchain gateway and
         jobStakeLocked: {},
         debtOutstanding: {},
         requestId: "0xreq",
-        xcmRequest: { statusLabel: "pending", requestedAssets: 6 },
-        strategyRequest: { strategyId: "0xstrategy", requestedAssets: 6, requestedShares: 0 }
+        xcmRequest: { statusLabel: "pending", requestedAssets: 6, requestedAssetsRaw: "6000000" },
+        strategyRequest: { strategyId: "0xstrategy", requestedAssets: 6, requestedAssetsRaw: "6000000", requestedShares: 0 }
       };
     }
   };
@@ -191,8 +191,10 @@ test("requestStrategyDeposit delegates async lanes to the blockchain gateway and
   assert.equal(calls.length, 1);
   assert.equal(updated.requestId, "0xreq");
   assert.equal(updated.strategyPending["0xstrategy"].pendingDepositAssets, 6);
+  assert.equal(updated.strategyPending["0xstrategy"].pendingDepositAssetsRaw, "6000000");
   assert.equal(updated.strategyActivity["0xstrategy"].action, "allocate_requested");
   assert.equal(updated.treasuryTimeline[0].type, "allocate_requested");
+  assert.equal(updated.treasuryTimeline[0].amountRaw, "6000000");
 });
 
 test("borrow uses live borrow capacity and updates liquid plus debt", async () => {
@@ -257,8 +259,9 @@ test("requestStrategyWithdraw delegates async lanes to the blockchain gateway an
       debtOutstanding: {},
       requestId: "0xwithdraw",
       requestedShares: 4,
-      xcmRequest: { statusLabel: "pending", requestedShares: 4 },
-      strategyRequest: { strategyId: "0xstrategy", requestedAssets: 3, requestedShares: 4 }
+      requestedSharesRaw: "4000000",
+      xcmRequest: { statusLabel: "pending", requestedShares: 4, requestedSharesRaw: "4000000" },
+      strategyRequest: { strategyId: "0xstrategy", requestedAssets: 3, requestedShares: 4, requestedSharesRaw: "4000000" }
     })
   };
   const accounts = new Map();
@@ -289,8 +292,10 @@ test("requestStrategyWithdraw delegates async lanes to the blockchain gateway an
 
   assert.equal(updated.requestId, "0xwithdraw");
   assert.equal(updated.strategyPending["0xstrategy"].pendingWithdrawalShares, 4);
+  assert.equal(updated.strategyPending["0xstrategy"].pendingWithdrawalSharesRaw, "4000000");
   assert.equal(updated.strategyActivity["0xstrategy"].action, "deallocate_requested");
   assert.equal(updated.treasuryTimeline[0].type, "deallocate_requested");
+  assert.equal(updated.treasuryTimeline[0].requestedSharesRaw, "4000000");
 });
 
 test("recordStrategySnapshots updates mark-to-market and appends a yield event on change", async () => {
@@ -328,6 +333,7 @@ test("recordAsyncStrategySettlement updates accounting and clears pending state"
   account.strategyPending["0xstrategy"] = {
     asset: "DOT",
     pendingDepositAssets: 6,
+    pendingDepositAssetsRaw: "6000000",
     pendingWithdrawalShares: 0
   };
   accounts.set("0xAlice", account);
@@ -341,11 +347,64 @@ test("recordAsyncStrategySettlement updates accounting and clears pending state"
       kindLabel: "deposit",
       statusLabel: "succeeded",
       requestedAssets: 6,
-      settledAssets: 6
+      requestedAssetsRaw: "6000000",
+      settledAssets: 6.000001,
+      settledAssetsRaw: "6000001"
     }
   });
 
   assert.equal(updated.strategyPending["0xstrategy"].pendingDepositAssets, 0);
-  assert.equal(updated.strategyAccounting["0xstrategy"].principal, 6);
+  assert.equal(updated.strategyPending["0xstrategy"].pendingDepositAssetsRaw, "0");
+  assert.equal(updated.strategyAccounting["0xstrategy"].principal, 6.000001);
+  assert.equal(updated.strategyAccounting["0xstrategy"].principalRaw, "6000001");
+  assert.equal(updated.strategyAccounting["0xstrategy"].markValueRaw, "6000001");
   assert.equal(updated.treasuryTimeline[0].type, "allocate");
+  assert.equal(updated.treasuryTimeline[0].amountRaw, "6000001");
+  assert.equal(updated.treasuryTimeline[0].principalAfterRaw, "6000001");
+});
+
+test("recordAsyncStrategySettlement preserves raw asset accounting when withdrawals settle", async () => {
+  const { service, accounts } = makeService();
+  const account = await service.getAccountSummary("0xAlice");
+  account.strategyPending["0xstrategy"] = {
+    asset: "DOT",
+    pendingDepositAssets: 0,
+    pendingWithdrawalShares: 4,
+    pendingWithdrawalSharesRaw: "4000000"
+  };
+  account.strategyAccounting["0xstrategy"] = {
+    asset: "DOT",
+    principal: 10,
+    markValue: 10,
+    principalRaw: "10000000",
+    markValueRaw: "10000000",
+    realizedYield: 0,
+    realizedYieldRaw: "0"
+  };
+  accounts.set("0xAlice", account);
+
+  const updated = await service.recordAsyncStrategySettlement({
+    requestId: "0xwithdraw",
+    strategyRequest: {
+      account: "0xAlice",
+      strategyId: "0xstrategy",
+      assetSymbol: "DOT",
+      kindLabel: "withdraw",
+      statusLabel: "succeeded",
+      requestedShares: 4,
+      requestedSharesRaw: "4000000",
+      settledAssets: 4,
+      settledAssetsRaw: "4000000"
+    }
+  });
+
+  assert.equal(updated.strategyPending["0xstrategy"].pendingWithdrawalShares, 0);
+  assert.equal(updated.strategyPending["0xstrategy"].pendingWithdrawalSharesRaw, "0");
+  assert.equal(updated.strategyAccounting["0xstrategy"].principal, 6);
+  assert.equal(updated.strategyAccounting["0xstrategy"].principalRaw, "6000000");
+  assert.equal(updated.strategyAccounting["0xstrategy"].markValueRaw, "6000000");
+  assert.equal(updated.strategyAccounting["0xstrategy"].realizedYieldRaw, "0");
+  assert.equal(updated.treasuryTimeline[0].type, "deallocate");
+  assert.equal(updated.treasuryTimeline[0].amountRaw, "4000000");
+  assert.equal(updated.treasuryTimeline[0].principalAfterRaw, "6000000");
 });

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -1238,6 +1238,37 @@ function ratioToBps(numerator, denominator) {
   return Math.round((numerator / denominator) * 10_000);
 }
 
+function normalizeRawIntegerString(value) {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+  if (typeof value === "bigint") {
+    return value >= 0n ? value.toString() : undefined;
+  }
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value >= 0 ? String(value) : undefined;
+  }
+  const normalized = String(value).trim();
+  if (!/^\d+$/u.test(normalized)) {
+    return undefined;
+  }
+  return BigInt(normalized).toString();
+}
+
+function calculateRoutedAmountRaw(sharesRaw, telemetry = {}) {
+  const normalizedSharesRaw = normalizeRawIntegerString(sharesRaw);
+  const totalAssetsRaw = normalizeRawIntegerString(telemetry.totalAssetsRaw);
+  const totalSharesRaw = normalizeRawIntegerString(telemetry.totalSharesRaw);
+  if (normalizedSharesRaw === undefined || totalAssetsRaw === undefined || totalSharesRaw === undefined) {
+    return undefined;
+  }
+  const denominator = BigInt(totalSharesRaw);
+  if (denominator <= 0n) {
+    return undefined;
+  }
+  return ((BigInt(normalizedSharesRaw) * BigInt(totalAssetsRaw)) / denominator).toString();
+}
+
 function resolveAssetSymbol(assetAddress) {
   if (!assetAddress) return "DOT";
   const supportedAssets = gateway?.config?.supportedAssets ?? [];
@@ -1586,7 +1617,13 @@ function normalizeTimelineEntry(entry = {}) {
     strategyId: entry.strategyId,
     asset: entry.asset ?? "DOT",
     amount,
+    ...(entry.amountRaw !== undefined ? { amountRaw: normalizeRawIntegerString(entry.amountRaw) ?? String(entry.amountRaw) } : {}),
     yieldDelta,
+    ...(entry.yieldDeltaRaw !== undefined ? { yieldDeltaRaw: String(entry.yieldDeltaRaw) } : {}),
+    ...(entry.realizedYieldDeltaRaw !== undefined ? { realizedYieldDeltaRaw: String(entry.realizedYieldDeltaRaw) } : {}),
+    ...(entry.principalAfterRaw !== undefined ? { principalAfterRaw: String(entry.principalAfterRaw) } : {}),
+    ...(entry.markValueAfterRaw !== undefined ? { markValueAfterRaw: String(entry.markValueAfterRaw) } : {}),
+    ...(entry.requestedSharesRaw !== undefined ? { requestedSharesRaw: String(entry.requestedSharesRaw) } : {}),
     at: entry.at
   };
 }
@@ -2757,8 +2794,11 @@ const server = createServer(async (request, response) => {
       const positions = strategies.map((strategy) => {
         const shares = Number(sharesByStrategy[strategy.strategyId] ?? 0);
         const pendingPosition = pendingByStrategy[strategy.strategyId] ?? {};
+        const sharesRaw = normalizeRawIntegerString(pendingPosition.sharesRaw);
         const pendingDepositAssets = Number(pendingPosition.pendingDepositAssets ?? 0);
+        const pendingDepositAssetsRaw = normalizeRawIntegerString(pendingPosition.pendingDepositAssetsRaw);
         const pendingWithdrawalShares = Number(pendingPosition.pendingWithdrawalShares ?? 0);
+        const pendingWithdrawalSharesRaw = normalizeRawIntegerString(pendingPosition.pendingWithdrawalSharesRaw);
         const lastMovement = strategyActivity[strategy.strategyId];
         const accounting = strategyAccounting[strategy.strategyId] ?? {};
         const isMock = String(strategy.kind ?? "").includes("mock");
@@ -2766,6 +2806,7 @@ const server = createServer(async (request, response) => {
         const routedAmount = telemetry?.reported && Number.isFinite(Number(telemetry.sharePrice))
           ? shares * Number(telemetry.sharePrice)
           : shares;
+        const routedAmountRaw = calculateRoutedAmountRaw(sharesRaw, telemetry);
         const principalValue = Number(accounting.principal ?? shares);
         const realizedYield = Number(accounting.realizedYield ?? 0);
         const unrealizedYield = routedAmount - principalValue;
@@ -2776,13 +2817,20 @@ const server = createServer(async (request, response) => {
           assetSymbol: resolveStrategyAssetSymbol(strategy),
           executionMode: strategy.executionMode ?? "sync",
           shares,
+          ...(sharesRaw !== undefined ? { sharesRaw } : {}),
           shareCount: shares,
           pendingDepositAssets,
+          ...(pendingDepositAssetsRaw !== undefined ? { pendingDepositAssetsRaw } : {}),
           pendingWithdrawalShares,
+          ...(pendingWithdrawalSharesRaw !== undefined ? { pendingWithdrawalSharesRaw } : {}),
           routedAmount,
+          ...(routedAmountRaw !== undefined ? { routedAmountRaw } : {}),
           principalValue,
+          ...(accounting.principalRaw !== undefined ? { principalValueRaw: String(accounting.principalRaw) } : {}),
+          ...(accounting.markValueRaw !== undefined ? { markValueRaw: String(accounting.markValueRaw) } : {}),
           unrealizedYield,
           realizedYield,
+          ...(accounting.realizedYieldRaw !== undefined ? { realizedYieldRaw: String(accounting.realizedYieldRaw) } : {}),
           totalYield: realizedYield + unrealizedYield,
           statusLabel: pendingDepositAssets > 0
             ? "Pending deposit"
@@ -2797,7 +2845,9 @@ const server = createServer(async (request, response) => {
           sharePrice: telemetry?.sharePrice,
           performanceBps: telemetry?.performanceBps,
           adapterTotalAssets: telemetry?.totalAssets,
+          ...(telemetry?.totalAssetsRaw !== undefined ? { adapterTotalAssetsRaw: String(telemetry.totalAssetsRaw) } : {}),
           adapterTotalShares: telemetry?.totalShares,
+          ...(telemetry?.totalSharesRaw !== undefined ? { adapterTotalSharesRaw: String(telemetry.totalSharesRaw) } : {}),
           adapterLinked: true,
           adapterLinkStatus: shares > 0
             ? "Wallet capital is now settled into the adapter and priced from live adapter reads."
@@ -2839,6 +2889,7 @@ const server = createServer(async (request, response) => {
           assetSymbol: entry.assetSymbol,
           shares: entry.shares,
           currentValue: entry.routedAmount,
+          currentValueRaw: entry.routedAmountRaw,
           sharePrice: entry.sharePrice
         }))
       );


### PR DESCRIPTION
## Summary
- Preserve raw base-unit mirrors for async strategy pending, accounting, and treasury timeline records.
- Carry gateway requested/settled *Raw fields through async strategy deposit and withdrawal request/settlement handling.
- Surface raw strategy position/accounting fields on /account/strategies while keeping the existing display-number fields stable.

## Checks
- node --test mcp-server/src/core/agent-transfer.test.js
- git diff --check
- npm --workspace mcp-server test (first run failed because this fresh worktree had no node_modules for @paraspell/sdk-core and @aws-sdk/client-kms; after npm install: 539 passing)

## Impact
- Backend: yes
- Frontend: no API-breaking changes; new optional raw mirror fields are additive
- Indexer: no
- Contracts: no
- Caddy/public site: no
- Env/VPS secrets: no