### PR TITLE
Fold settlement traces into job timeline

### DIFF
--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -51,7 +51,8 @@ What is still thin:
   discipline
 - first-wave job schemas need stricter runtime enforcement
 - settlement, timeout, and dispute phases need fuller state-machine coverage
-- funding, settlement, and dispute events are not fully folded into one trace
+- remaining producer event payloads still need taxonomy cleanup after funding,
+  settlement, and dispute receipts were folded into the shared trace
 - visible operator filters lag the backend timeline filter surface
 - native XCM/vDOT remains gated on real evidence capture, not implementation
   scaffolding alone
@@ -312,13 +313,16 @@ emit into it with the same topic taxonomy.
 - `/events` and `/admin/jobs/timeline` accept source, topic, phase, severity,
   and correlation-id filters; the frontend client hook can pass the same filter
   shape through to the backend
+- local claim-lock funding, verification settlement/rejection, disputed
+  verification, dispute verdict, and stake-release receipts emit canonical
+  `settlement` source events with funding, settlement, and dispute phases plus
+  direct job/session/wallet/correlation fields
 - recurring template fire history is reconstructed through derivative jobs,
   and sub-job lineage is reconstructed through `parentSessionId`
 
 ### Remaining gaps
 
 - not every producer emits a canonical topic and payload shape yet
-- funding and settlement state are not fully folded into the same timeline
 - operator UI still needs visible timeline filter controls for source, topic,
   wallet, and correlation id
 
@@ -332,7 +336,6 @@ emit into it with the same topic taxonomy.
 ### Concrete next changes
 
 - standardize the remaining platform event topics and payload shapes
-- merge funding, settlement, and dispute state into the same job/session trace
 - expose visible operator controls for source, topic, wallet, and correlation-id
   filters
 

--- a/docs/SPEC_AUDIT_2026-05-13.md
+++ b/docs/SPEC_AUDIT_2026-05-13.md
@@ -227,9 +227,12 @@ SSH/basic-auth/admin-JWT cutovers, and the basic hosted smoke is green.
 ### Timeline And Operator UX
 
 - Status: backend and client timeline surfaces support source, topic, phase,
-  severity, correlation-id, wallet filters, and persisted event replay.
-- Remaining: fold funding, settlement, and dispute state into the same
-  canonical trace, standardize remaining producer topics/payloads, and finish
+  severity, correlation-id, wallet filters, and persisted event replay. Local
+  claim-lock funding, verification settlement/rejection, disputed verification,
+  dispute verdict, and stake-release receipts now emit canonical settlement
+  timeline events with direct job/session/wallet/correlation fields instead of
+  being visible only through state transitions or chain-shaped topics.
+- Remaining: standardize any remaining producer topics/payloads and finish
   exposing the filter controls coherently across the operator app.
 
 ### Capability Model
@@ -315,6 +318,6 @@ correlation and settlement path.
 5. Run the native XCM evidence pack captures.
 6. Run the scoped service-token hosted proof with
    `CHECK_SERVICE_TOKEN_PROOF=1` and archive the sanitized evidence.
-7. Continue folding funding/settlement/dispute events into the canonical
-   timeline and finish visible filter adoption where still missing.
+7. Continue standardizing producer event payloads and finish visible timeline
+   filter adoption where still missing.
 8. Continue Phase 2+ secrets cleanup and signer custody hardening.

--- a/mcp-server/src/core/event-bus.js
+++ b/mcp-server/src/core/event-bus.js
@@ -188,6 +188,27 @@ function classifyEventTopic(topic, data = {}) {
       severity: xcmSeverity(topic, data)
     };
   }
+  if (topic.startsWith("funding.")) {
+    return {
+      source: "settlement",
+      phase: "funding",
+      severity: fundingSeverity(topic, data)
+    };
+  }
+  if (topic.startsWith("settlement.")) {
+    return {
+      source: "settlement",
+      phase: "settlement",
+      severity: settlementSeverity(topic, data)
+    };
+  }
+  if (topic.startsWith("dispute.")) {
+    return {
+      source: "settlement",
+      phase: "dispute",
+      severity: disputeSeverity(topic, data)
+    };
+  }
   if (topic.startsWith("verification.")) {
     return {
       source: "verification",
@@ -258,6 +279,28 @@ function accountPhase(topic) {
 function xcmSeverity(topic, data) {
   const status = normalizeText(data?.statusLabel) || normalizeText(data?.status);
   if (topic.includes("failed") || status.toLowerCase().includes("failed")) return "error";
+  return "info";
+}
+
+function fundingSeverity(topic, data) {
+  const status = normalizeText(data?.status);
+  if (topic.includes("failed") || status === "failed") return "error";
+  return "info";
+}
+
+function settlementSeverity(topic, data) {
+  const status = normalizeText(data?.status);
+  const outcome = normalizeText(data?.outcome);
+  if (topic.includes("failed") || status === "rejected" || outcome === "rejected") return "error";
+  if (status === "disputed" || outcome === "disputed") return "warn";
+  return "info";
+}
+
+function disputeSeverity(topic, data) {
+  const verdict = normalizeText(data?.verdict);
+  const status = normalizeText(data?.status);
+  if (topic.includes("failed") || status === "failed") return "error";
+  if (topic.includes("opened") || verdict === "upheld" || verdict === "split") return "warn";
   return "info";
 }
 

--- a/mcp-server/src/core/event-bus.test.js
+++ b/mcp-server/src/core/event-bus.test.js
@@ -81,6 +81,40 @@ test("EventBus preserves canonical timeline fields and classifies chain topics",
   assert.equal(rejected.phase, "settlement");
   assert.equal(rejected.severity, "error");
   assert.equal(rejected.correlationId, "session-3");
+
+  const localFunding = bus.publish({
+    id: "funding-1",
+    topic: "funding.claim_lock_recorded",
+    jobId: "job-4",
+    sessionId: "session-4",
+    timestamp: "2026-01-01T00:00:03.000Z"
+  });
+  assert.equal(localFunding.source, "settlement");
+  assert.equal(localFunding.phase, "funding");
+  assert.equal(localFunding.severity, "info");
+
+  const localSettlement = bus.publish({
+    id: "settlement-1",
+    topic: "settlement.session_rejected",
+    jobId: "job-5",
+    sessionId: "session-5",
+    timestamp: "2026-01-01T00:00:04.000Z",
+    data: { status: "rejected" }
+  });
+  assert.equal(localSettlement.source, "settlement");
+  assert.equal(localSettlement.phase, "settlement");
+  assert.equal(localSettlement.severity, "error");
+
+  const localDispute = bus.publish({
+    id: "dispute-1",
+    topic: "dispute.opened",
+    jobId: "job-6",
+    sessionId: "session-6",
+    timestamp: "2026-01-01T00:00:05.000Z"
+  });
+  assert.equal(localDispute.source, "settlement");
+  assert.equal(localDispute.phase, "dispute");
+  assert.equal(localDispute.severity, "warn");
 });
 
 test("EventBus persists events and replays durable filters beyond the ring buffer", async () => {

--- a/mcp-server/src/core/job-execution-service.js
+++ b/mcp-server/src/core/job-execution-service.js
@@ -213,6 +213,7 @@ export class JobExecutionService {
       const persisted = await this.stateStore.upsertSession(session);
       await this.stateStore.upsertFundedJob?.(buildFundedJobFromClaim({ job, session: persisted }));
       this.publishSessionEvent("session.claimed", persisted);
+      this.publishClaimFundingEvent(persisted, job, claimEconomics);
       return persisted;
     } finally {
       await this.stateStore.releaseClaimLock?.(sessionLockId, lockOwner);
@@ -497,6 +498,40 @@ export class JobExecutionService {
         phase: describeSessionStatus(session.status).phase,
         protocolHistory: session.protocolHistory,
         ...data
+      }
+    });
+  }
+
+  publishClaimFundingEvent(session, job, claimEconomics) {
+    if (!this.eventBus || this.blockchainGateway?.isEnabled?.()) {
+      return;
+    }
+
+    const amount = Number(claimEconomics?.totalClaimLock ?? 0);
+    if (!Number.isFinite(amount) || amount < 0) {
+      return;
+    }
+
+    this.eventBus.publish({
+      id: `platform-funding-claim-lock-${session.sessionId}-${Date.now()}`,
+      topic: "funding.claim_lock_recorded",
+      wallet: session.wallet,
+      wallets: [session.wallet],
+      jobId: session.jobId,
+      sessionId: session.sessionId,
+      timestamp: new Date().toISOString(),
+      correlationId: session.sessionId,
+      data: {
+        sessionId: session.sessionId,
+        wallet: session.wallet,
+        jobId: session.jobId,
+        asset: job.rewardAsset,
+        amount,
+        claimStake: claimEconomics.claimStake,
+        claimFee: claimEconomics.claimFee,
+        totalClaimLock: claimEconomics.totalClaimLock,
+        claimEconomicsWaived: claimEconomics.claimEconomicsWaived,
+        source: "local_claim_lock"
       }
     });
   }

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -537,6 +537,22 @@ test("getJobTimeline stitches sessions, verification, events, and child lineage"
   assert.equal(claimedEvent.source, "state");
   assert.equal(claimedEvent.jobId, "parent-job-001");
   assert.equal(claimedEvent.sessionId, submitted.sessionId);
+  const claimFundingEvent = timeline.timeline.find((entry) => entry.topic === "funding.claim_lock_recorded");
+  assert.equal(claimFundingEvent.type, "event_bus");
+  assert.equal(claimFundingEvent.source, "settlement");
+  assert.equal(claimFundingEvent.phase, "funding");
+  assert.equal(claimFundingEvent.correlationId, submitted.sessionId);
+  assert.equal(claimFundingEvent.data.source, "local_claim_lock");
+  assert.equal(claimFundingEvent.data.asset, "DOT");
+  assert.equal(claimFundingEvent.data.totalClaimLock, 0);
+  assert.equal(claimFundingEvent.data.claimEconomicsWaived, true);
+  const settlementEvent = timeline.timeline.find((entry) => entry.topic === "settlement.session_resolved");
+  assert.equal(settlementEvent.type, "event_bus");
+  assert.equal(settlementEvent.source, "settlement");
+  assert.equal(settlementEvent.phase, "settlement");
+  assert.equal(settlementEvent.correlationId, submitted.sessionId);
+  assert.equal(settlementEvent.data.status, "resolved");
+  assert.equal(settlementEvent.data.reasonCode, "BENCHMARK_THRESHOLD_MET");
   const fundedEvent = timeline.timeline.find((entry) => entry.topic === "escrow.job_funded");
   assert.equal(fundedEvent.type, "event_bus");
   assert.equal(fundedEvent.source, "chain");
@@ -544,6 +560,41 @@ test("getJobTimeline stitches sessions, verification, events, and child lineage"
   assert.equal(fundedEvent.severity, "info");
   assert.equal(fundedEvent.correlationId, "parent-job-001");
   assert.equal(fundedEvent.data.txHash, "0xabc");
+});
+
+test("getJobTimeline folds disputed verification into the canonical dispute trace", async () => {
+  const eventBus = new EventBus();
+  const service = makePlatformService(undefined, eventBus);
+  const session = await service.claimJob(WALLET, "parent-job-001", "http", "job-timeline-dispute-claim");
+  const submitted = await service.submitWork(session.sessionId, "http", {
+    summary: "Timeline run needs review.",
+    output: "Human fallback requested.",
+    status: "complete"
+  });
+  await service.ingestVerification(submitted.sessionId, {
+    jobId: submitted.jobId,
+    handler: "benchmark",
+    handlerVersion: 1,
+    outcome: "disputed",
+    reasonCode: "HUMAN_REVIEW_REQUIRED"
+  });
+
+  const timeline = await service.getJobTimeline("parent-job-001", {
+    wallet: WALLET,
+    phases: ["dispute"],
+    limit: 25
+  });
+  const disputeEvent = timeline.timeline.find((entry) => entry.topic === "dispute.opened");
+  assert.equal(disputeEvent.type, "event_bus");
+  assert.equal(disputeEvent.source, "settlement");
+  assert.equal(disputeEvent.phase, "dispute");
+  assert.equal(disputeEvent.severity, "warn");
+  assert.equal(disputeEvent.jobId, submitted.jobId);
+  assert.equal(disputeEvent.sessionId, submitted.sessionId);
+  assert.equal(disputeEvent.correlationId, submitted.sessionId);
+  assert.match(disputeEvent.data.disputeId, /^dispute-[a-f0-9]{12}$/u);
+  assert.equal(disputeEvent.data.reasonCode, "HUMAN_REVIEW_REQUIRED");
+  assert.deepEqual(timeline.summary.eventFilters.phases, ["dispute"]);
 });
 
 test("getJobTimeline reads durable event log and applies event filters", async () => {

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -2277,6 +2277,7 @@ const server = createServer(async (request, response) => {
         id,
         disputeId: id,
         sessionId: dispute.sessionId,
+        jobId: session.jobId,
         chainJobId: session.chainJobId,
         verdict: resolution.verdict,
         workerPayout: resolution.workerPayout,
@@ -2312,13 +2313,22 @@ const server = createServer(async (request, response) => {
       }
       eventBus?.publish({
         id: `dispute-verdict-${id}-${Date.now()}`,
-        topic: "escrow.dispute_resolved",
+        topic: "dispute.verdict_recorded",
         wallet: dispute.claimant,
         wallets: [dispute.claimant, auth.wallet],
+        jobId: session.jobId,
         sessionId: dispute.sessionId,
         timestamp: receipt.decidedAt,
+        correlationId: dispute.sessionId,
+        txHash: receipt.txHash,
+        blockNumber: receipt.blockNumber,
+        source: "settlement",
+        phase: "dispute",
+        severity: resolution.verdict === "dismissed" ? "info" : "warn",
         data: {
           disputeId: id,
+          jobId: session.jobId,
+          chainJobId: session.chainJobId,
           openedAt: dispute.openedAt,
           windowEndsAt: dispute.windowEndsAt,
           slaSeconds: dispute.slaSeconds,
@@ -2380,10 +2390,13 @@ const server = createServer(async (request, response) => {
       if (dispute.release) {
         return respondWithMutationReceipt(response, idempotency, 200, dispute);
       }
+      const session = await service.resumeSession(dispute.sessionId).catch(() => undefined);
       const receipt = {
         id,
         disputeId: id,
         sessionId: dispute.sessionId,
+        jobId: session?.jobId,
+        chainJobId: session?.chainJobId,
         action: typeof payload?.action === "string" && payload.action.trim() ? payload.action.trim() : "release",
         amount: Number(payload?.amount ?? dispute.stakedAmount ?? 0),
         chainStatus: dispute.txHash ? "settled_by_verdict" : "local_only",
@@ -2394,13 +2407,21 @@ const server = createServer(async (request, response) => {
       await stateStore.upsertMutationReceipt?.("dispute_release", id, receipt);
       eventBus?.publish({
         id: `dispute-release-${id}-${Date.now()}`,
-        topic: "account.job_stake_released",
+        topic: "settlement.stake_release_recorded",
         wallet: dispute.claimant,
         wallets: [dispute.claimant, auth.wallet],
+        jobId: session?.jobId,
         sessionId: dispute.sessionId,
         timestamp: receipt.releasedAt,
+        correlationId: dispute.sessionId,
+        txHash: receipt.txHash,
+        source: "settlement",
+        phase: "settlement",
+        severity: "info",
         data: {
           disputeId: id,
+          jobId: session?.jobId,
+          chainJobId: session?.chainJobId,
           openedAt: dispute.openedAt,
           windowEndsAt: dispute.windowEndsAt,
           amount: receipt.amount,

--- a/mcp-server/src/services/verification-ingestion-service.js
+++ b/mcp-server/src/services/verification-ingestion-service.js
@@ -4,6 +4,7 @@ import {
 } from "../core/session-state-machine.js";
 import { updateFundedJobFromSession } from "../core/funded-jobs.js";
 import { buildVerificationAuditFields } from "../core/verifier-contract.js";
+import { disputeIdForSession } from "../core/dispute-resolution.js";
 
 export class VerificationIngestionService {
   constructor(stateStore, eventBus = undefined, getJobDefinition = undefined) {
@@ -69,6 +70,7 @@ export class VerificationIngestionService {
         resolvedAt: updatedSession.resolvedAt
       }
     });
+    const eventTimestamp = new Date().toISOString();
     this.eventBus?.publish({
       id: `platform-verification-${updatedSession.sessionId}-${Date.now()}`,
       topic: "verification.resolved",
@@ -76,7 +78,8 @@ export class VerificationIngestionService {
       wallets: [updatedSession.wallet],
       jobId: updatedSession.jobId,
       sessionId: updatedSession.sessionId,
-      timestamp: new Date().toISOString(),
+      timestamp: eventTimestamp,
+      correlationId: updatedSession.sessionId,
       data: {
         outcome: verdict.outcome,
         reasonCode: verdict.reasonCode,
@@ -86,6 +89,7 @@ export class VerificationIngestionService {
         verifierConfigVersion: auditFields.verifierConfigVersion
       }
     });
+    this.publishWorkflowOutcomeEvent(updatedSession, verdict, auditFields, status, eventTimestamp);
     return updatedSession;
   }
 
@@ -99,5 +103,41 @@ export class VerificationIngestionService {
     } catch {
       return undefined;
     }
+  }
+
+  publishWorkflowOutcomeEvent(session, verdict, auditFields, status, timestamp) {
+    if (!this.eventBus) {
+      return;
+    }
+
+    const disputed = status === "disputed";
+    const topic = disputed
+      ? "dispute.opened"
+      : status === "resolved"
+        ? "settlement.session_resolved"
+        : "settlement.session_rejected";
+
+    this.eventBus.publish({
+      id: `platform-${topic}-${session.sessionId}-${Date.now()}`,
+      topic,
+      wallet: session.wallet,
+      wallets: [session.wallet],
+      jobId: session.jobId,
+      sessionId: session.sessionId,
+      timestamp,
+      correlationId: session.sessionId,
+      data: {
+        sessionId: session.sessionId,
+        wallet: session.wallet,
+        jobId: session.jobId,
+        status,
+        outcome: verdict.outcome,
+        reasonCode: verdict.reasonCode,
+        handler: verdict.handler,
+        handlerVersion: auditFields.handlerVersion ?? verdict.handlerVersion,
+        verifierConfigVersion: auditFields.verifierConfigVersion,
+        disputeId: disputed ? disputeIdForSession(session.sessionId) : undefined
+      }
+    });
   }
 }


### PR DESCRIPTION
## Summary
- classify local funding, settlement, and dispute event topics into the canonical timeline taxonomy
- emit local claim-lock, verification outcome, dispute verdict, and stake-release traces with job/session/wallet/correlation fields
- update roadmap/spec audit status for the timeline workstream

## Checks
- npm --workspace mcp-server test
- node --test mcp-server/src/core/event-bus.test.js mcp-server/src/core/platform-service.test.js
- node --check mcp-server/src/core/job-execution-service.js
- node --check mcp-server/src/services/verification-ingestion-service.js
- node --check mcp-server/src/protocols/http/server.js
- git diff --check

## Impact
- Backend: yes
- Frontend: no
- Indexer: no
- Caddy: no
- Contracts: no
- Public site: no

## Env / deploy
- No environment or VPS secret changes required.
- Installed worktree dependencies locally before running the full backend suite; no lockfile changes.