### PR TITLE
Preserve exact XCM request metadata

### DIFF
--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -1068,7 +1068,8 @@ export class BlockchainGateway {
         requestedAssetsRaw: this.toRawString(record.context.assets),
         requestedShares: this.toDisplayUnits(record.context.shares, this.assetForAddress(record.context.asset)),
         requestedSharesRaw: this.toRawString(record.context.shares),
-        nonce: Number(record.context.nonce),
+        nonce: this.toSafeIntegerOrRaw(record.context.nonce, "nonce"),
+        nonceRaw: this.toRawString(record.context.nonce),
         status: Number(record.status),
         statusLabel: REQUEST_STATUS_LABELS[Number(record.status)] ?? "unknown",
         settledAssets: this.toDisplayUnits(record.settledAssets, this.assetForAddress(record.context.asset)),
@@ -1079,8 +1080,10 @@ export class BlockchainGateway {
         remoteRefLabel: this.decodeBytes32Label(record.remoteRef),
         failureCode: this.normalizeOptionalBytes32(record.failureCode),
         failureCodeLabel: this.decodeBytes32Label(record.failureCode),
-        createdAt: Number(record.createdAt),
-        updatedAt: Number(record.updatedAt)
+        createdAt: this.toSafeIntegerOrRaw(record.createdAt, "createdAt"),
+        createdAtRaw: this.toRawString(record.createdAt),
+        updatedAt: this.toSafeIntegerOrRaw(record.updatedAt, "updatedAt"),
+        updatedAtRaw: this.toRawString(record.updatedAt)
       };
     });
   }
@@ -1265,6 +1268,15 @@ export class BlockchainGateway {
       return "0";
     }
     return BigInt(amount).toString();
+  }
+
+  toSafeIntegerOrRaw(value, label) {
+    const raw = this.toRawString(value);
+    const parsed = BigInt(raw);
+    if (parsed < 0n) {
+      throw new ValidationError(`${label} must be non-negative.`);
+    }
+    return parsed <= MAX_SAFE_INTEGER_BIGINT ? Number(parsed) : raw;
   }
 
   policyRiskSnapshot(values) {

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -775,11 +775,58 @@ test("async XCM request readers return display amounts and raw base-unit fields"
   assert.equal(xcmRequest.requestedAssets, 1.25);
   assert.equal(xcmRequest.requestedAssetsRaw, "1250000");
   assert.equal(xcmRequest.requestedShares, 0.5);
+  assert.equal(xcmRequest.nonce, 7);
+  assert.equal(xcmRequest.nonceRaw, "7");
+  assert.equal(xcmRequest.createdAt, 10);
+  assert.equal(xcmRequest.createdAtRaw, "10");
+  assert.equal(xcmRequest.updatedAt, 12);
+  assert.equal(xcmRequest.updatedAtRaw, "12");
   assert.equal(xcmRequest.settledAssets, 0.25);
   assert.equal(strategyRequest.requestedAssets, 1.25);
   assert.equal(strategyRequest.requestedAssetsRaw, "1250000");
   assert.equal(strategyRequest.settledShares, 0.1);
   assert.equal(strategyRequest.settledSharesRaw, "100000");
+});
+
+test("async XCM request reader preserves unsafe uint64 metadata as raw strings", async () => {
+  const gateway = new BlockchainGateway({ enabled: false, supportedAssets: [USDC_TRUST_ASSET] });
+  const requestId = `0x${"2".repeat(64)}`;
+  const unsafeNonce = BigInt(Number.MAX_SAFE_INTEGER) + 42n;
+  const unsafeCreatedAt = BigInt(Number.MAX_SAFE_INTEGER) + 100n;
+  const unsafeUpdatedAt = BigInt(Number.MAX_SAFE_INTEGER) + 101n;
+  gateway.xcmWrapperContract = {
+    async getRequest(id) {
+      assert.equal(id, requestId);
+      return {
+        context: {
+          strategyId: encodeBytes32String("USDC"),
+          kind: 0,
+          account: "0x3333333333333333333333333333333333333333",
+          asset: USDC_TRUST_ASSET.address,
+          recipient: "0x4444444444444444444444444444444444444444",
+          assets: 1n,
+          shares: 1n,
+          nonce: unsafeNonce
+        },
+        status: 1,
+        settledAssets: 0n,
+        settledShares: 0n,
+        remoteRef: `0x${"0".repeat(64)}`,
+        failureCode: `0x${"0".repeat(64)}`,
+        createdAt: unsafeCreatedAt,
+        updatedAt: unsafeUpdatedAt
+      };
+    }
+  };
+
+  const xcmRequest = await gateway.getXcmRequest(requestId);
+
+  assert.equal(xcmRequest.nonce, unsafeNonce.toString());
+  assert.equal(xcmRequest.nonceRaw, unsafeNonce.toString());
+  assert.equal(xcmRequest.createdAt, unsafeCreatedAt.toString());
+  assert.equal(xcmRequest.createdAtRaw, unsafeCreatedAt.toString());
+  assert.equal(xcmRequest.updatedAt, unsafeUpdatedAt.toString());
+  assert.equal(xcmRequest.updatedAtRaw, unsafeUpdatedAt.toString());
 });
 
 test("finalizeXcmRequest rejects successful strategy withdrawals with zero settled assets before tx", async () => {

--- a/mcp-server/src/services/xcm-observation-relay.js
+++ b/mcp-server/src/services/xcm-observation-relay.js
@@ -94,6 +94,13 @@ export class XcmObservationRelayService {
           data: {
             requestId: normalized.requestId,
             status: normalized.status,
+            settledAssets: normalized.settledAssets,
+            settledAssetsRaw: normalized.settledAssets,
+            settledShares: normalized.settledShares,
+            settledSharesRaw: normalized.settledShares,
+            remoteRef: normalized.remoteRef,
+            failureCode: normalized.failureCode,
+            observedAt: normalized.observedAt,
             source: normalized.source
           }
         });

--- a/mcp-server/src/services/xcm-observation-relay.test.js
+++ b/mcp-server/src/services/xcm-observation-relay.test.js
@@ -9,7 +9,10 @@ const REQUEST_ID = "0x2222222222222222222222222222222222222222222222222222222222
 
 test("pollOnce relays terminal outcomes into the platform watcher and stores cursor state", async () => {
   const calls = [];
+  const events = [];
   const stateStore = new MemoryStateStore();
+  const eventBus = new EventBus();
+  eventBus.subscribe({ topics: ["xcm.outcome_relayed"] }, (event) => events.push(event));
   const relay = new XcmObservationRelayService(
     {
       observeXcmOutcome: async (requestId, outcome) => {
@@ -18,7 +21,7 @@ test("pollOnce relays terminal outcomes into the platform watcher and stores cur
       }
     },
     stateStore,
-    new EventBus(),
+    eventBus,
     {
       enabled: true,
       feedUrl: "https://observer.example/outcomes",
@@ -56,6 +59,13 @@ test("pollOnce relays terminal outcomes into the platform watcher and stores cur
   assert.equal(calls[0][1].status, "succeeded");
   assert.equal(calls[0][1].settledAssets, "7");
   assert.equal(calls[0][1].settledShares, "7");
+  assert.equal(events.length, 1);
+  assert.equal(events[0].data.settledAssets, "7");
+  assert.equal(events[0].data.settledAssetsRaw, "7");
+  assert.equal(events[0].data.settledShares, "7");
+  assert.equal(events[0].data.settledSharesRaw, "7");
+  assert.equal(events[0].data.remoteRef, "0x3333333333333333333333333333333333333333333333333333333333333333");
+  assert.equal(events[0].data.observedAt, "2026-04-22T10:00:00.000Z");
 
   const stored = await stateStore.getServiceState("xcm-observation-relay");
   assert.equal(stored.cursor, "cursor-2");

--- a/mcp-server/src/services/xcm-settlement-watcher.js
+++ b/mcp-server/src/services/xcm-settlement-watcher.js
@@ -78,7 +78,12 @@ export class XcmSettlementWatcherService {
         requestId: normalizedRequestId,
         status: observation.status,
         settledAssets: observation.settledAssets,
+        settledAssetsRaw: observation.settledAssets,
         settledShares: observation.settledShares,
+        settledSharesRaw: observation.settledShares,
+        remoteRef: observation.remoteRef,
+        failureCode: observation.failureCode,
+        observedAt: observation.observedAt,
         source: observation.source
       }
     });
@@ -111,6 +116,13 @@ export class XcmSettlementWatcherService {
           data: {
             requestId: observation.requestId,
             status: finalized?.strategyRequest?.statusLabel ?? finalized?.statusLabel ?? observation.status,
+            settledAssets: observation.settledAssets,
+            settledAssetsRaw: observation.settledAssets,
+            settledShares: observation.settledShares,
+            settledSharesRaw: observation.settledShares,
+            remoteRef: observation.remoteRef,
+            failureCode: observation.failureCode,
+            source: observation.source,
             settledVia: finalized?.settledVia
           }
         });

--- a/mcp-server/src/services/xcm-settlement-watcher.test.js
+++ b/mcp-server/src/services/xcm-settlement-watcher.test.js
@@ -31,11 +31,18 @@ test("observeOutcome stores a pending observation and emits an event", async () 
   assert.equal(observation.processed, false);
   assert.equal(events.length, 1);
   assert.equal(events[0].topic, "xcm.outcome_observed");
+  assert.equal(events[0].data.settledAssets, "5");
+  assert.equal(events[0].data.settledAssetsRaw, "5");
+  assert.equal(events[0].data.settledShares, "0");
+  assert.equal(events[0].data.settledSharesRaw, "0");
+  assert.equal(events[0].data.observedAt, observation.observedAt);
 });
 
 test("runPendingSettlements finalizes stored observations and marks them processed", async () => {
   const stateStore = new MemoryStateStore();
   const eventBus = new EventBus();
+  const events = [];
+  eventBus.subscribe({ topics: ["xcm.request_auto_finalized"] }, (event) => events.push(event));
   const finalizedCalls = [];
   const watcher = new XcmSettlementWatcherService(
     {
@@ -71,6 +78,12 @@ test("runPendingSettlements finalizes stored observations and marks them process
   assert.equal(finalizedCalls[0][1].settledShares, "5");
   assert.equal(stored.processed, true);
   assert.equal(stored.result.settledVia, "agent_account");
+  assert.equal(events.length, 1);
+  assert.equal(events[0].data.settledAssets, "5");
+  assert.equal(events[0].data.settledAssetsRaw, "5");
+  assert.equal(events[0].data.settledShares, "5");
+  assert.equal(events[0].data.settledSharesRaw, "5");
+  assert.equal(events[0].data.source, "observer");
 });
 
 test("observeOutcome preserves large uint256 settlement amounts exactly", async () => {


### PR DESCRIPTION
## Summary
- Preserve exact raw async XCM request metadata for uint64 nonce, createdAt, and updatedAt instead of forcing unsafe values through Number(...).
- Keep safe metadata numeric for existing consumers while exposing nonceRaw, createdAtRaw, and updatedAtRaw.
- Carry exact settlement decimal strings through XCM observation relayed/observed/auto-finalized events so operator timelines do not lose the raw settlement context.

## Checks
- node --test mcp-server/src/blockchain/gateway.test.js
- node --test mcp-server/src/services/xcm-settlement-watcher.test.js mcp-server/src/services/xcm-observation-relay.test.js
- git diff --check
- npm --workspace mcp-server test

## Impact
- Backend: yes
- Frontend: additive fields only; existing safe numbers stay numeric, unsafe uint64 metadata is returned as exact strings
- Indexer: no code changes; this keeps backend observer/event data aligned with indexer stringified outcome amounts
- Contracts: no
- Caddy/public site: no
- Env/VPS secrets: no