### PR TITLE
Harden XCM outcome cursors

### DIFF
--- a/indexer/src/api/index.ts
+++ b/indexer/src/api/index.ts
@@ -4,6 +4,7 @@ import { db } from "ponder:api";
 import schema from "ponder:schema";
 
 import { decodeCursor, listTerminalXcmOutcomes, normalizeLimit } from "./xcm-outcomes";
+import { cursorForSource, type OutcomeCursorMode } from "./xcm-outcome-cursor";
 import { XcmOutcomePublisherService } from "./xcm-outcome-publisher";
 
 const app = new Hono();
@@ -38,9 +39,11 @@ app.get("/xcm/outcomes", async (c) => {
   const limit = normalizeLimit(c.req.query("limit"));
   const cursor = decodeCursor(c.req.query("cursor"));
   const usePublishedFeed = await xcmOutcomePublisher.hasPublishedOutcomes();
+  const sourceMode: OutcomeCursorMode = usePublishedFeed ? "external" : "indexed";
+  const sourceCursor = cursorForSource(cursor, sourceMode);
   const outcomes = usePublishedFeed
-    ? await xcmOutcomePublisher.listPublishedOutcomes({ limit, cursor })
-    : await listTerminalXcmOutcomes({ limit, cursor });
+    ? await xcmOutcomePublisher.listPublishedOutcomes({ limit, cursor: sourceCursor })
+    : await listTerminalXcmOutcomes({ limit, cursor: sourceCursor });
 
   return c.json({
     items: outcomes.items,
@@ -48,7 +51,13 @@ app.get("/xcm/outcomes", async (c) => {
     meta: {
       limit,
       terminalStatuses: ["succeeded", "failed", "cancelled"],
-      source: usePublishedFeed ? "external_xcm_observer_feed" : "indexer_terminal_status_feed"
+      source: usePublishedFeed ? "external_xcm_observer_feed" : "indexer_terminal_status_feed",
+      sourceMode,
+      cursor: {
+        requestedMode: cursor?.mode,
+        accepted: !cursor || Boolean(sourceCursor),
+        reset: Boolean(cursor && !sourceCursor)
+      }
     }
   });
 });

--- a/indexer/src/api/xcm-outcome-cursor.test.ts
+++ b/indexer/src/api/xcm-outcome-cursor.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  cursorForSource,
+  decodeCursor,
+  encodeCursor,
+  normalizeObservedAtIso,
+  toObservedAtIso
+} from "./xcm-outcome-cursor.ts";
+
+const requestId = `0x${"11".repeat(32)}`;
+
+test("XCM outcome cursors round-trip indexed and external modes as strings", () => {
+  const indexed = encodeCursor({
+    mode: "indexed",
+    blockNumber: 123n,
+    requestId
+  });
+  const external = encodeCursor({
+    mode: "external",
+    observedAt: "2026-04-23T12:00:00.000Z",
+    requestId
+  });
+
+  assert.equal(typeof indexed, "string");
+  assert.equal(typeof external, "string");
+  assert.deepEqual(decodeCursor(indexed), {
+    mode: "indexed",
+    blockNumber: 123n,
+    requestId
+  });
+  assert.deepEqual(decodeCursor(external), {
+    mode: "external",
+    observedAt: "2026-04-23T12:00:00.000Z",
+    requestId
+  });
+});
+
+test("XCM outcome cursor decode rejects malformed or mismatched mode payloads", () => {
+  const wrongModePayload = Buffer.from(JSON.stringify({
+    mode: "external",
+    blockNumber: "123",
+    requestId
+  }), "utf8").toString("base64url");
+  const ambiguousLegacyPayload = Buffer.from(JSON.stringify({
+    blockNumber: "123",
+    observedAt: "2026-04-23T12:00:00.000Z",
+    requestId
+  }), "utf8").toString("base64url");
+  const hugeBlockPayload = Buffer.from(JSON.stringify({
+    mode: "indexed",
+    blockNumber: "9223372036854775808",
+    requestId
+  }), "utf8").toString("base64url");
+
+  assert.equal(decodeCursor(wrongModePayload), undefined);
+  assert.equal(decodeCursor(ambiguousLegacyPayload), undefined);
+  assert.equal(decodeCursor(hugeBlockPayload), undefined);
+  assert.equal(decodeCursor("not-json"), undefined);
+});
+
+test("XCM outcome source cursors are only reused against the matching feed", () => {
+  const indexed = decodeCursor(encodeCursor({
+    mode: "indexed",
+    blockNumber: 7n,
+    requestId
+  }));
+  const external = decodeCursor(encodeCursor({
+    mode: "external",
+    observedAt: "2026-04-23T12:00:00.000Z",
+    requestId
+  }));
+
+  assert.equal(cursorForSource(indexed, "indexed"), indexed);
+  assert.equal(cursorForSource(indexed, "external"), undefined);
+  assert.equal(cursorForSource(external, "external"), external);
+  assert.equal(cursorForSource(external, "indexed"), undefined);
+});
+
+test("XCM outcome timestamps normalize safely without unsafe Date overflow", () => {
+  assert.equal(toObservedAtIso(1_712_345_678n), "2024-04-05T19:34:38.000Z");
+  assert.equal(toObservedAtIso(8_640_000_000_001n), undefined);
+  assert.equal(normalizeObservedAtIso("2026-04-23T12:00:00Z"), "2026-04-23T12:00:00.000Z");
+  assert.equal(normalizeObservedAtIso("not-a-date"), undefined);
+});

--- a/indexer/src/api/xcm-outcome-cursor.ts
+++ b/indexer/src/api/xcm-outcome-cursor.ts
@@ -1,0 +1,145 @@
+const MAX_DATABASE_BIGINT = (1n << 63n) - 1n;
+const MAX_JS_TIMESTAMP_SECONDS = 8_640_000_000_000n;
+
+export type OutcomeCursorMode = "indexed" | "external";
+
+export type OutcomeCursor =
+  | {
+    mode: "indexed";
+    blockNumber: bigint;
+    requestId: string;
+  }
+  | {
+    mode: "external";
+    observedAt: string;
+    requestId: string;
+  };
+
+export function decodeCursor(rawCursor: string | undefined): OutcomeCursor | undefined {
+  if (!rawCursor) {
+    return undefined;
+  }
+
+  try {
+    const decoded = JSON.parse(Buffer.from(rawCursor, "base64url").toString("utf8")) as Record<string, unknown>;
+    if (!decoded || typeof decoded !== "object" || Array.isArray(decoded)) {
+      return undefined;
+    }
+
+    const requestId = normalizeRequestId(decoded.requestId);
+    if (!requestId) {
+      return undefined;
+    }
+
+    if (decoded.mode === "indexed") {
+      return decodeIndexedCursor(decoded, requestId);
+    }
+    if (decoded.mode === "external") {
+      return decodeExternalCursor(decoded, requestId);
+    }
+    if (decoded.mode !== undefined) {
+      return undefined;
+    }
+
+    const hasBlockNumber = decoded.blockNumber !== undefined;
+    const hasObservedAt = decoded.observedAt !== undefined;
+    if (hasBlockNumber === hasObservedAt) {
+      return undefined;
+    }
+    return hasBlockNumber
+      ? decodeIndexedCursor(decoded, requestId)
+      : decodeExternalCursor(decoded, requestId);
+  } catch {
+    return undefined;
+  }
+}
+
+export function encodeCursor(cursor: OutcomeCursor) {
+  const payload = cursor.mode === "indexed"
+    ? {
+      mode: "indexed",
+      blockNumber: normalizeDatabaseBigInt(cursor.blockNumber)?.toString(),
+      requestId: normalizeRequestId(cursor.requestId)
+    }
+    : {
+      mode: "external",
+      observedAt: normalizeObservedAtIso(cursor.observedAt),
+      requestId: normalizeRequestId(cursor.requestId)
+    };
+  if (!payload.requestId || ("blockNumber" in payload && !payload.blockNumber) || ("observedAt" in payload && !payload.observedAt)) {
+    throw new Error("Invalid XCM outcome cursor.");
+  }
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
+export function cursorForSource<Mode extends OutcomeCursorMode>(
+  cursor: OutcomeCursor | undefined,
+  mode: Mode
+): Extract<OutcomeCursor, { mode: Mode }> | undefined {
+  return cursor?.mode === mode
+    ? cursor as Extract<OutcomeCursor, { mode: Mode }>
+    : undefined;
+}
+
+export function toObservedAtIso(timestampSeconds: bigint) {
+  const normalized = normalizeDatabaseBigInt(timestampSeconds);
+  if (normalized === undefined || normalized > MAX_JS_TIMESTAMP_SECONDS) {
+    return undefined;
+  }
+  return new Date(Number(normalized) * 1000).toISOString();
+}
+
+export function normalizeObservedAtIso(value: unknown) {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? undefined : value.toISOString();
+  }
+  if (typeof value !== "string" || !value.trim()) {
+    return undefined;
+  }
+  const date = new Date(value.trim());
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+function decodeIndexedCursor(decoded: Record<string, unknown>, requestId: string) {
+  const blockNumber = normalizeDatabaseBigInt(decoded.blockNumber);
+  return blockNumber === undefined
+    ? undefined
+    : {
+      mode: "indexed" as const,
+      blockNumber,
+      requestId
+    };
+}
+
+function decodeExternalCursor(decoded: Record<string, unknown>, requestId: string) {
+  const observedAt = normalizeObservedAtIso(decoded.observedAt);
+  return observedAt === undefined
+    ? undefined
+    : {
+      mode: "external" as const,
+      observedAt,
+      requestId
+    };
+}
+
+function normalizeRequestId(value: unknown) {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  return /^0x[a-fA-F0-9]{64}$/u.test(normalized) ? normalized : undefined;
+}
+
+function normalizeDatabaseBigInt(value: unknown) {
+  let parsed: bigint;
+  if (typeof value === "bigint") {
+    parsed = value;
+  } else if (typeof value === "number") {
+    if (!Number.isSafeInteger(value)) {
+      return undefined;
+    }
+    parsed = BigInt(value);
+  } else if (typeof value === "string" && /^\d+$/u.test(value.trim())) {
+    parsed = BigInt(value.trim());
+  } else {
+    return undefined;
+  }
+  return parsed >= 0n && parsed <= MAX_DATABASE_BIGINT ? parsed : undefined;
+}

--- a/indexer/src/api/xcm-outcome-publisher.ts
+++ b/indexer/src/api/xcm-outcome-publisher.ts
@@ -7,6 +7,12 @@ import {
   type PublishedOutcome,
   type XcmUpstreamSourceAdapter
 } from "./xcm-upstream-source";
+import {
+  cursorForSource,
+  encodeCursor,
+  normalizeObservedAtIso,
+  type OutcomeCursor
+} from "./xcm-outcome-cursor";
 
 const DEFAULT_SCOPE = "xcm-outcome-publisher";
 
@@ -181,7 +187,7 @@ export class XcmOutcomePublisherService {
     return (await this.getPublishedOutcomeCount()) > 0;
   }
 
-  async listPublishedOutcomes({ cursor, limit }: { cursor?: { mode: "external"; observedAt: string; requestId: string } | { mode: "indexed"; blockNumber: bigint; requestId: string }; limit: number }) {
+  async listPublishedOutcomes({ cursor, limit }: { cursor?: OutcomeCursor; limit: number }) {
     if (!this.enabled) {
       return {
         items: [],
@@ -190,10 +196,11 @@ export class XcmOutcomePublisherService {
     }
 
     await this.init();
-    const where = cursor?.mode === "external"
+    const externalCursor = cursorForSource(cursor, "external");
+    const where = externalCursor
       ? sql`
-        WHERE observed_at > ${cursor.observedAt}
-        OR (observed_at = ${cursor.observedAt} AND request_id > ${cursor.requestId})
+        WHERE observed_at > ${externalCursor.observedAt}
+        OR (observed_at = ${externalCursor.observedAt} AND request_id > ${externalCursor.requestId})
       `
       : sql``;
     const result = await db.execute(sql`
@@ -223,11 +230,11 @@ export class XcmOutcomePublisherService {
       source: string;
     }>;
     const nextCursor = rows.length > limit
-      ? {
+      ? encodeCursor({
         mode: "external",
-        observedAt: new Date(page[page.length - 1]!.observed_at).toISOString(),
+        observedAt: requireObservedAtIso(page[page.length - 1]!.observed_at),
         requestId: String(page[page.length - 1]!.request_id)
-      }
+      })
       : undefined;
     return {
       items: page.map((row) => ({
@@ -237,7 +244,7 @@ export class XcmOutcomePublisherService {
         settledShares: String(row.settled_shares),
         remoteRef: row.remote_ref ? String(row.remote_ref) : undefined,
         failureCode: row.failure_code ? String(row.failure_code) : undefined,
-        observedAt: new Date(row.observed_at).toISOString(),
+        observedAt: requireObservedAtIso(row.observed_at),
         source: String(row.source)
       })),
       nextCursor
@@ -433,4 +440,12 @@ export class XcmOutcomePublisherService {
     `);
     return Number(rowsOf(result)[0]?.count ?? 0);
   }
+}
+
+function requireObservedAtIso(value: unknown) {
+  const observedAt = normalizeObservedAtIso(value);
+  if (!observedAt) {
+    throw new Error("Invalid XCM external observed_at timestamp.");
+  }
+  return observedAt;
 }

--- a/indexer/src/api/xcm-outcomes.ts
+++ b/indexer/src/api/xcm-outcomes.ts
@@ -3,21 +3,18 @@ import { and, asc, eq, gt, inArray, or } from "drizzle-orm";
 import { db } from "ponder:api";
 import schema from "ponder:schema";
 
+import {
+  decodeCursor,
+  encodeCursor,
+  toObservedAtIso,
+  type OutcomeCursor as Cursor
+} from "./xcm-outcome-cursor";
+
 const TERMINAL_STATUSES = [2, 3, 4] as const;
 const DEFAULT_LIMIT = 25;
 const MAX_LIMIT = 100;
 
-export type Cursor =
-  | {
-    mode: "indexed";
-    blockNumber: bigint;
-    requestId: string;
-  }
-  | {
-    mode: "external";
-    observedAt: string;
-    requestId: string;
-  };
+export { decodeCursor, encodeCursor, toObservedAtIso, type Cursor };
 
 export function normalizeLimit(rawLimit: string | undefined) {
   const parsed = Number(rawLimit ?? DEFAULT_LIMIT);
@@ -25,55 +22,6 @@ export function normalizeLimit(rawLimit: string | undefined) {
     return DEFAULT_LIMIT;
   }
   return Math.min(Math.trunc(parsed), MAX_LIMIT);
-}
-
-export function decodeCursor(rawCursor: string | undefined): Cursor | undefined {
-  if (!rawCursor) {
-    return undefined;
-  }
-
-  try {
-    const decoded = JSON.parse(Buffer.from(rawCursor, "base64url").toString("utf8"));
-    if (!decoded || typeof decoded !== "object" || !/^0x[a-fA-F0-9]{64}$/u.test(String(decoded.requestId ?? ""))) {
-      return undefined;
-    }
-    if (/^\d+$/u.test(String(decoded.blockNumber ?? ""))) {
-      return {
-        mode: "indexed",
-        blockNumber: BigInt(decoded.blockNumber),
-        requestId: String(decoded.requestId)
-      };
-    }
-    if (typeof decoded.observedAt === "string" && !Number.isNaN(new Date(decoded.observedAt).getTime())) {
-      return {
-        mode: "external",
-        observedAt: new Date(decoded.observedAt).toISOString(),
-        requestId: String(decoded.requestId)
-      };
-    }
-    return undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-export function encodeCursor(cursor: Cursor) {
-  const payload = cursor.mode === "indexed"
-    ? {
-      mode: "indexed",
-      blockNumber: cursor.blockNumber.toString(),
-      requestId: cursor.requestId
-    }
-    : {
-      mode: "external",
-      observedAt: cursor.observedAt,
-      requestId: cursor.requestId
-    };
-  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
-}
-
-export function toObservedAtIso(timestampSeconds: bigint) {
-  return new Date(Number(timestampSeconds) * 1000).toISOString();
 }
 
 export async function listTerminalXcmOutcomes({


### PR DESCRIPTION
## Summary
- Move /xcm/outcomes cursor encoding/decoding into a shared, tested cursor module.
- Return encoded external-feed nextCursor strings instead of raw cursor objects.
- Reset mismatched indexed-vs-external cursors explicitly when the endpoint switches feed source, and expose cursor acceptance/reset metadata.
- Harden observedAt conversion so malformed or out-of-range timestamps do not overflow Date conversion.

## Checks
- npm --workspace indexer run test:api
- npm run typecheck:indexer
- git diff --check

## Impact
- Indexer: yes
- Backend: no
- Frontend: additive metadata only; clients should continue passing nextCursor as a string and can now inspect meta.cursor.reset when feed source changes
- Contracts: no
- Caddy/public site: no
- Env/VPS secrets: no