### PR TITLE
Expose operator timeline filters

### DIFF
--- a/app/components/runs/JobTimelinePanel.tsx
+++ b/app/components/runs/JobTimelinePanel.tsx
@@ -46,6 +46,8 @@ export function JobTimelinePanel({ jobId }: { jobId: string }) {
     () => ({
       sources: filters.source ? [filters.source] : undefined,
       topics: filters.topic ? [filters.topic] : undefined,
+      phases: filters.phase ? [filters.phase] : undefined,
+      severities: filters.severity ? [filters.severity] : undefined,
       wallet: filters.wallet || undefined,
       correlationId: filters.correlationId || undefined,
     }),
@@ -53,6 +55,11 @@ export function JobTimelinePanel({ jobId }: { jobId: string }) {
   );
   const request = useJobTimeline(jobId, apiFilters);
   const data = useMemo(() => buildJobTimeline(request.data), [request.data]);
+  const visibleTimeline = useMemo(
+    () => filterTimelineEntries(data.timeline, filters),
+    [data.timeline, filters]
+  );
+  const hiddenCount = data.timeline.length - visibleTimeline.length;
   const unauthenticated =
     request.error instanceof ApiError &&
     (request.error.status === 401 || request.error.status === 403);
@@ -93,6 +100,8 @@ export function JobTimelinePanel({ jobId }: { jobId: string }) {
         </div>
         <TimelineSummary
           data={data}
+          visibleCount={visibleTimeline.length}
+          filtersActive={filtersActive}
           loading={Boolean(request.isLoading)}
           unauthenticated={unauthenticated}
         />
@@ -105,7 +114,7 @@ export function JobTimelinePanel({ jobId }: { jobId: string }) {
       />
 
       <ul className="flex flex-col">
-        {data.timeline.length === 0 ? (
+        {visibleTimeline.length === 0 ? (
           <EmptyRow
             unauthenticated={unauthenticated}
             loading={Boolean(request.isLoading)}
@@ -115,15 +124,24 @@ export function JobTimelinePanel({ jobId }: { jobId: string }) {
             }
           />
         ) : (
-          data.timeline.map((entry, idx) => (
+          visibleTimeline.map((entry, idx) => (
             <TimelineRow
               key={entry.id}
               entry={entry}
-              isLast={idx === data.timeline.length - 1}
+              isLast={idx === visibleTimeline.length - 1}
             />
           ))
         )}
       </ul>
+
+      {filtersActive && hiddenCount > 0 ? (
+        <p
+          className="m-0 font-[family-name:var(--font-mono)] text-[11px] text-[var(--avy-muted)]"
+          style={{ letterSpacing: 0 }}
+        >
+          {hiddenCount} hidden by filter — clear filters to see the full timeline.
+        </p>
+      ) : null}
 
       {data.summary.eventBusGap ? (
         <p
@@ -139,10 +157,14 @@ export function JobTimelinePanel({ jobId }: { jobId: string }) {
 
 function TimelineSummary({
   data,
+  visibleCount,
+  filtersActive,
   loading,
   unauthenticated,
 }: {
   data: ReturnType<typeof buildJobTimeline>;
+  visibleCount: number;
+  filtersActive: boolean;
   loading: boolean;
   unauthenticated: boolean;
 }) {
@@ -168,6 +190,9 @@ function TimelineSummary({
   }
   const { summary, lineage } = data;
   const segments: string[] = [];
+  if (filtersActive) {
+    segments.push(`${visibleCount} shown`);
+  }
   if (summary.sessionCount > 0) {
     segments.push(
       `${summary.sessionCount} session${summary.sessionCount === 1 ? "" : "s"}`
@@ -350,6 +375,41 @@ function formatTimestamp(iso: string | undefined): string {
     second: "2-digit",
     hour12: false,
   }).format(t);
+}
+
+function filterTimelineEntries(
+  entries: TimelineEntry[],
+  filters: TimelineEventFilterValue
+): TimelineEntry[] {
+  const source = normalizeFilterText(filters.source);
+  const topic = normalizeFilterText(filters.topic);
+  const phase = normalizeFilterText(filters.phase);
+  const severity = normalizeFilterText(filters.severity);
+  const wallet = normalizeFilterText(filters.wallet);
+  const correlationId = normalizeFilterText(filters.correlationId);
+  if (!source && !topic && !phase && !severity && !wallet && !correlationId) {
+    return entries;
+  }
+  return entries.filter((entry) => {
+    if (source && normalizeFilterText(entry.source) !== source) return false;
+    if (topic && normalizeFilterText(entry.topic) !== topic) return false;
+    if (phase && normalizeFilterText(entry.phase) !== phase) return false;
+    if (severity && normalizeFilterText(entry.severity) !== severity) return false;
+    if (wallet && normalizeFilterText(entry.wallet).indexOf(wallet) === -1) {
+      return false;
+    }
+    if (
+      correlationId &&
+      normalizeFilterText(entry.correlationId) !== correlationId
+    ) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function normalizeFilterText(value: unknown): string {
+  return String(value ?? "").trim().toLowerCase();
 }
 
 // Re-export the empty constant for callers that want to render a

--- a/app/components/runs/TimelineEventFilters.tsx
+++ b/app/components/runs/TimelineEventFilters.tsx
@@ -5,16 +5,18 @@ import { useCallback } from "react";
 /**
  * Visible filter controls for the timeline event panels (job and
  * session). The backend `/admin/jobs/timeline` endpoint accepts
- * `sources`, `topics`, `eventWallet`, and `correlationId` query
- * params; this rail surfaces those four knobs so an auditor can slice
- * a long timeline without leaving the page. The same control set is
- * reused on the session drawer (client-side filter — see
+ * `sources`, `topics`, `phases`, `severities`, `eventWallet`, and
+ * `correlationId` query params; this rail surfaces those knobs so an
+ * auditor can slice a long timeline without leaving the page. The same
+ * control set is reused on the session drawer (client-side filter — see
  * SessionDrawerBody for the why).
  */
 
 export interface TimelineEventFilterValue {
   source: string;
   topic: string;
+  phase: string;
+  severity: string;
   wallet: string;
   correlationId: string;
 }
@@ -22,6 +24,8 @@ export interface TimelineEventFilterValue {
 export const EMPTY_TIMELINE_EVENT_FILTERS: TimelineEventFilterValue = {
   source: "",
   topic: "",
+  phase: "",
+  severity: "",
   wallet: "",
   correlationId: "",
 };
@@ -30,6 +34,8 @@ export function isTimelineEventFilterActive(value: TimelineEventFilterValue): bo
   return Boolean(
     value.source.trim() ||
       value.topic.trim() ||
+      value.phase.trim() ||
+      value.severity.trim() ||
       value.wallet.trim() ||
       value.correlationId.trim()
   );
@@ -68,13 +74,30 @@ export function TimelineEventFilters({
         placeholder="state, event_bus…"
         value={value.source}
         onChange={(v) => set("source", v)}
+        options={SOURCE_OPTIONS}
       />
       <Field
         id={`${idPrefix}-topic`}
         label="Topic"
-        placeholder="job.claimed, session…"
+        placeholder="settlement.session_resolved"
         value={value.topic}
         onChange={(v) => set("topic", v)}
+        options={TOPIC_OPTIONS}
+      />
+      <Field
+        id={`${idPrefix}-phase`}
+        label="Phase"
+        placeholder="funding, settlement…"
+        value={value.phase}
+        onChange={(v) => set("phase", v)}
+        options={PHASE_OPTIONS}
+      />
+      <SelectField
+        id={`${idPrefix}-severity`}
+        label="Severity"
+        value={value.severity}
+        onChange={(v) => set("severity", v)}
+        options={SEVERITY_OPTIONS}
       />
       <Field
         id={`${idPrefix}-wallet`}
@@ -109,13 +132,17 @@ function Field({
   placeholder,
   value,
   onChange,
+  options,
 }: {
   id: string;
   label: string;
   placeholder: string;
   value: string;
   onChange: (next: string) => void;
+  options?: string[];
 }) {
+  const optionValues = options ?? [];
+  const listId = optionValues.length ? `${id}-options` : undefined;
   return (
     <label htmlFor={id} className="flex min-w-[150px] flex-1 flex-col gap-1">
       <span
@@ -129,18 +156,64 @@ function Field({
         type="text"
         spellCheck={false}
         autoComplete="off"
+        list={listId}
         placeholder={placeholder}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         className="h-8 w-full rounded-[6px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-2 font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-ink)] placeholder:text-[var(--avy-muted)] focus:border-[color:rgba(30,102,66,0.3)] focus:outline focus:outline-2 focus:outline-offset-1 focus:outline-[color:rgba(30,102,66,0.26)]"
         style={{ letterSpacing: 0 }}
       />
+      {listId ? (
+        <datalist id={listId}>
+          {optionValues.map((option) => (
+            <option key={option} value={option} />
+          ))}
+        </datalist>
+      ) : null}
+    </label>
+  );
+}
+
+function SelectField({
+  id,
+  label,
+  value,
+  onChange,
+  options,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (next: string) => void;
+  options: Array<{ label: string; value: string }>;
+}) {
+  return (
+    <label htmlFor={id} className="flex min-w-[132px] flex-1 flex-col gap-1">
+      <span
+        className="font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-muted)]"
+        style={{ letterSpacing: "0.14em" }}
+      >
+        {label}
+      </span>
+      <select
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="h-8 w-full rounded-[6px] border border-[var(--avy-line)] bg-[var(--avy-paper-solid)] px-2 font-[family-name:var(--font-mono)] text-[12px] text-[var(--avy-ink)] focus:border-[color:rgba(30,102,66,0.3)] focus:outline focus:outline-2 focus:outline-offset-1 focus:outline-[color:rgba(30,102,66,0.26)]"
+        style={{ letterSpacing: 0 }}
+      >
+        {options.map((option) => (
+          <option key={option.value || "any"} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
     </label>
   );
 }
 
 /**
- * Parse the four params from a URLSearchParams-compatible source. Used
+ * Parse the timeline filter params from a URLSearchParams-compatible source. Used
  * by both the runs/detail page and the sessions page so a refresh /
  * shared link reproduces the filtered view. Accepts Next.js'
  * `ReadonlyURLSearchParams` because that's what `useSearchParams()`
@@ -155,10 +228,12 @@ export function parseTimelineEventFilters(
 ): TimelineEventFilterValue {
   if (!params) return EMPTY_TIMELINE_EVENT_FILTERS;
   return {
-    source: params.get("source")?.trim() ?? "",
-    topic: params.get("topic")?.trim() ?? "",
-    wallet: params.get("wallet")?.trim() ?? "",
-    correlationId: params.get("correlationId")?.trim() ?? "",
+    source: readFirstParam(params, ["source", "sources"]),
+    topic: readFirstParam(params, ["topic", "topics"]),
+    phase: readFirstParam(params, ["phase", "phases"]),
+    severity: readFirstParam(params, ["severity", "severities"]),
+    wallet: readFirstParam(params, ["wallet", "eventWallet"]),
+    correlationId: readFirstParam(params, ["correlationId"]),
   };
 }
 
@@ -172,6 +247,8 @@ export function applyTimelineEventFiltersToParams(
   const fields: Array<keyof TimelineEventFilterValue> = [
     "source",
     "topic",
+    "phase",
+    "severity",
     "wallet",
     "correlationId",
   ];
@@ -182,3 +259,56 @@ export function applyTimelineEventFiltersToParams(
   }
   return params;
 }
+
+function readFirstParam(params: ReadableSearchParams, names: string[]): string {
+  for (const name of names) {
+    const value = params.get(name)?.trim();
+    if (value) return value.split(",")[0]?.trim() ?? "";
+  }
+  return "";
+}
+
+const SOURCE_OPTIONS = [
+  "state",
+  "verification",
+  "event_bus",
+  "lineage",
+  "schedule",
+  "chain",
+  "settlement",
+  "ingestion",
+  "system",
+];
+
+const PHASE_OPTIONS = [
+  "funding",
+  "claim",
+  "session",
+  "verification",
+  "settlement",
+  "dispute",
+  "lineage",
+  "schedule",
+  "ingestion",
+];
+
+const TOPIC_OPTIONS = [
+  "funding.claim_lock_recorded",
+  "escrow.job_funded",
+  "session.claimed",
+  "verification.submitted",
+  "verification.accepted",
+  "verification.rejected",
+  "settlement.session_resolved",
+  "settlement.session_rejected",
+  "dispute.opened",
+  "dispute.verdict_recorded",
+  "dispute.stake_released",
+];
+
+const SEVERITY_OPTIONS = [
+  { label: "Any", value: "" },
+  { label: "Info", value: "info" },
+  { label: "Warn", value: "warn" },
+  { label: "Error", value: "error" },
+];

--- a/app/components/sessions/SessionDrawerBody.tsx
+++ b/app/components/sessions/SessionDrawerBody.tsx
@@ -221,9 +221,13 @@ function filterMovements(
 ): EscrowMovement[] {
   const source = filters.source.trim().toLowerCase();
   const topic = filters.topic.trim().toLowerCase();
+  const phase = filters.phase.trim().toLowerCase();
+  const severity = filters.severity.trim().toLowerCase();
   const wallet = filters.wallet.trim().toLowerCase();
   const correlationId = filters.correlationId.trim().toLowerCase();
-  if (!source && !topic && !wallet && !correlationId) return movements;
+  if (!source && !topic && !phase && !severity && !wallet && !correlationId) {
+    return movements;
+  }
   return movements.filter((movement) => {
     if (source && (movement.source ?? "").toLowerCase() !== source) return false;
     if (topic) {
@@ -233,6 +237,9 @@ function filterMovements(
       const movementTopic = (movement.topic ?? movement.label ?? "").toLowerCase();
       if (!movementTopic.includes(topic)) return false;
     }
+    if (phase && (movement.phase ?? "").toLowerCase() !== phase) return false;
+    if (severity && (movement.severity ?? "").toLowerCase() !== severity)
+      return false;
     if (wallet) {
       const haystack = [movement.wallet, movement.from, movement.to]
         .map((v) => (v ?? "").toLowerCase())

--- a/app/components/sessions/types.ts
+++ b/app/components/sessions/types.ts
@@ -49,6 +49,8 @@ export interface EscrowMovement {
    *  movements predate the timeline-event filter rail. */
   source?: string;
   topic?: string;
+  phase?: string;
+  severity?: string;
   wallet?: string;
   correlationId?: string;
 }

--- a/app/lib/api/session-adapters.ts
+++ b/app/lib/api/session-adapters.ts
@@ -355,6 +355,8 @@ export function mergeSessionTimeline(
         const data = asRecord(entry.data);
         const source = text(entry.source);
         const topic = text(entry.topic);
+        const phase = text(entry.phase);
+        const severity = text(entry.severity);
         const wallet = text(entry.wallet ?? data.wallet);
         const correlationId = text(entry.correlationId);
         return {
@@ -367,6 +369,8 @@ export function mergeSessionTimeline(
           tone: movementTone(entry.phase ?? entry.type),
           ...(source ? { source } : {}),
           ...(topic ? { topic } : {}),
+          ...(phase ? { phase } : {}),
+          ...(severity ? { severity } : {}),
           ...(wallet ? { wallet } : {}),
           ...(correlationId ? { correlationId } : {}),
         };

--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -313,6 +313,9 @@ emit into it with the same topic taxonomy.
 - `/events` and `/admin/jobs/timeline` accept source, topic, phase, severity,
   and correlation-id filters; the frontend client hook can pass the same filter
   shape through to the backend
+- the operator app exposes visible job/session timeline controls for source,
+  topic, phase, severity, wallet, and correlation-id filters, and keeps the
+  filtered state in the URL for refreshable evidence links
 - local claim-lock funding, verification settlement/rejection, disputed
   verification, dispute verdict, and stake-release receipts emit canonical
   `settlement` source events with funding, settlement, and dispute phases plus
@@ -323,8 +326,6 @@ emit into it with the same topic taxonomy.
 ### Remaining gaps
 
 - not every producer emits a canonical topic and payload shape yet
-- operator UI still needs visible timeline filter controls for source, topic,
-  wallet, and correlation id
 
 ### Improve to
 
@@ -336,8 +337,8 @@ emit into it with the same topic taxonomy.
 ### Concrete next changes
 
 - standardize the remaining platform event topics and payload shapes
-- expose visible operator controls for source, topic, wallet, and correlation-id
-  filters
+- keep operator filter presets in step with new canonical source, phase, and
+  topic names as producer coverage expands
 
 ### What this unlocks
 

--- a/docs/SPEC_AUDIT_2026-05-13.md
+++ b/docs/SPEC_AUDIT_2026-05-13.md
@@ -231,9 +231,11 @@ SSH/basic-auth/admin-JWT cutovers, and the basic hosted smoke is green.
   claim-lock funding, verification settlement/rejection, disputed verification,
   dispute verdict, and stake-release receipts now emit canonical settlement
   timeline events with direct job/session/wallet/correlation fields instead of
-  being visible only through state transitions or chain-shaped topics.
-- Remaining: standardize any remaining producer topics/payloads and finish
-  exposing the filter controls coherently across the operator app.
+  being visible only through state transitions or chain-shaped topics. The
+  operator app now exposes URL-backed job/session timeline filters for source,
+  topic, phase, severity, wallet, and correlation id.
+- Remaining: standardize any remaining producer topics/payloads and keep filter
+  presets aligned with the canonical event taxonomy.
 
 ### Capability Model
 


### PR DESCRIPTION
## What changed
- Expanded the reusable timeline filter rail to include phase and severity alongside source, topic, wallet, and correlation id.
- Applied active filters to the rendered job timeline, so built-in timeline rows are hidden consistently with replayed event-bus rows.
- Carried phase/severity metadata into session drawer timeline movements and updated the roadmap/audit status.

## Checks run
- npm run typecheck:app
- npm run build:frontend
- git diff --check
- Browser smoke via bundled Playwright against localhost with mocked API responses: verified URL-backed source/phase/severity values and nonmatching timeline rows hidden.

## Impact
- Frontend/operator app and docs only.
- No backend, indexer, contract, Caddy, public-site, or production secret changes.
- Generated frontend output was restored and is not included.