### PR TITLE
Classify policy/capability/service-token topics as governance events

### DIFF
--- a/mcp-server/src/core/event-bus.js
+++ b/mcp-server/src/core/event-bus.js
@@ -244,6 +244,31 @@ function classifyEventTopic(topic, data = {}) {
       severity: sessionSeverity(data)
     };
   }
+  if (topic.startsWith("policy.")) {
+    return {
+      source: "governance",
+      phase: "governance",
+      severity: "info"
+    };
+  }
+  if (topic.startsWith("capability.")) {
+    return {
+      source: "governance",
+      phase: "capability",
+      // Revoke is the load-bearing trust-removal signal; treat as a
+      // higher-attention event than the routine grant/list flow.
+      severity: topic === "capability.revoke" ? "warn" : "info"
+    };
+  }
+  if (topic.startsWith("service-token.")) {
+    return {
+      source: "governance",
+      phase: "service_token",
+      // Same shape as capability.revoke: revocation is the signal an
+      // operator wants to see in the timeline immediately.
+      severity: topic === "service-token.revoke" ? "warn" : "info"
+    };
+  }
   return {
     source: "event_bus",
     phase: topic || "event",

--- a/mcp-server/src/core/event-bus.test.js
+++ b/mcp-server/src/core/event-bus.test.js
@@ -117,6 +117,69 @@ test("EventBus preserves canonical timeline fields and classifies chain topics",
   assert.equal(localDispute.severity, "warn");
 });
 
+test("EventBus classifies governance topics (policy, capability, service-token)", () => {
+  const bus = new EventBus();
+
+  const policy = bus.publish({
+    id: "policy-1",
+    topic: "policy.proposed",
+    wallet: "0xadmin",
+    timestamp: "2026-01-01T00:00:00.000Z"
+  });
+  assert.equal(policy.source, "governance");
+  assert.equal(policy.phase, "governance");
+  assert.equal(policy.severity, "info");
+
+  const grant = bus.publish({
+    id: "grant-1",
+    topic: "capability.grant",
+    wallet: "0xadmin",
+    timestamp: "2026-01-01T00:00:01.000Z"
+  });
+  assert.equal(grant.source, "governance");
+  assert.equal(grant.phase, "capability");
+  assert.equal(grant.severity, "info");
+
+  // Revoke is the trust-removal signal; classifier escalates severity.
+  const revoke = bus.publish({
+    id: "revoke-1",
+    topic: "capability.revoke",
+    wallet: "0xadmin",
+    timestamp: "2026-01-01T00:00:02.000Z"
+  });
+  assert.equal(revoke.source, "governance");
+  assert.equal(revoke.phase, "capability");
+  assert.equal(revoke.severity, "warn");
+
+  const tokenIssue = bus.publish({
+    id: "token-issue-1",
+    topic: "service-token.issue",
+    wallet: "0xadmin",
+    timestamp: "2026-01-01T00:00:03.000Z"
+  });
+  assert.equal(tokenIssue.source, "governance");
+  assert.equal(tokenIssue.phase, "service_token");
+  assert.equal(tokenIssue.severity, "info");
+
+  const tokenRotate = bus.publish({
+    id: "token-rotate-1",
+    topic: "service-token.rotate",
+    wallet: "0xadmin",
+    timestamp: "2026-01-01T00:00:04.000Z"
+  });
+  assert.equal(tokenRotate.severity, "info");
+
+  const tokenRevoke = bus.publish({
+    id: "token-revoke-1",
+    topic: "service-token.revoke",
+    wallet: "0xadmin",
+    timestamp: "2026-01-01T00:00:05.000Z"
+  });
+  assert.equal(tokenRevoke.source, "governance");
+  assert.equal(tokenRevoke.phase, "service_token");
+  assert.equal(tokenRevoke.severity, "warn");
+});
+
 test("EventBus persists events and replays durable filters beyond the ring buffer", async () => {
   const store = new MemoryStateStore();
   const bus = new EventBus({ bufferSize: 1, eventStore: store });


### PR DESCRIPTION
## Summary

Follow-up #1 from the event-taxonomy audit ([#346](https://github.com/averray-agent/agent/pull/346) §Gap A). Three topic prefixes — `policy.`, `capability.`, `service-token.` — were not registered in `classifyEventTopic` and fell through to the default `{ source: "event_bus", phase: <topic>, severity: "info" }` bucket. Six existing publish sites are affected.

This patch extends the classifier with explicit branches. No producer source-files change; the events those six sites already emit will now classify into a real bucket on the bus.

## Mappings

| Topic prefix | `source` | `phase` | `severity` |
|---|---|---|---|
| `policy.*` | `governance` | `governance` | `info` |
| `capability.grant`, `capability.*` (other) | `governance` | `capability` | `info` |
| `capability.revoke` | `governance` | `capability` | `warn` |
| `service-token.issue`, `service-token.rotate` | `governance` | `service_token` | `info` |
| `service-token.revoke` | `governance` | `service_token` | `warn` |

The `revoke` topics escalate to `warn` because revocation is the load-bearing trust-removal signal — the one an operator wants surfaced in the timeline immediately.

The phase identifier `service_token` uses underscore inside the phase even though the topic stays `service-token.*`. The hyphen in the topic is a separate naming decision (Gap C in #346); this PR does not migrate topic shape, only assigns each topic a canonical phase that aligns with the rest of the taxonomy.

## Behavior delta for consumers

Strictly additive. Events that previously reported `source: "event_bus", phase: "<topic>", severity: "info"` now report governance/governance/info etc. Any consumer filtering by the default bucket for these topics would need to update its filter to the new phase — no consumer in this repo does that today.

## Test plan

- [x] `npm --workspace mcp-server test` — 546 tests pass
- [x] New test `EventBus classifies governance topics (policy, capability, service-token)` exercises source/phase/severity for all six topic shapes including the two warn-escalated revoke variants

## Out of scope

- Topic-naming overhaul (`service-token` vs `service_token`) — flagged as Gap C in [#346](https://github.com/averray-agent/agent/pull/346) for a separate decision.
- Promoting `requestId → correlationId` on the XCM publish sites — that's Gap B and ships as its own focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)