### PR TITLE
Require correlated Subscan XCM request ids

### DIFF
--- a/indexer/src/api/xcm-upstream-source.test.ts
+++ b/indexer/src/api/xcm-upstream-source.test.ts
@@ -166,12 +166,46 @@ test("Subscan source normalizes numeric-string epoch timestamps", () => {
   });
 
   const outcome = adapter.normalizeSubscanEntry({
-    msg_hash: requestId,
+    message_topic: requestId,
     status: "success",
     block_timestamp: "1712345678"
   });
 
   assert.equal(outcome?.observedAt, "2024-04-05T19:34:38.000Z");
+});
+
+test("Subscan source accepts explicit SetTopic request-id fields", () => {
+  const adapter = new SubscanXcmSourceAdapter({
+    apiHost: "https://subscan.example",
+    apiKey: "test"
+  });
+
+  const outcome = adapter.normalizeSubscanEntry({
+    setTopic: requestId,
+    status: "success",
+    block_timestamp: "1712345678"
+  });
+
+  assert.equal(outcome?.requestId, requestId);
+  assert.equal(outcome?.source, "subscan_xcm_api");
+});
+
+test("Subscan source ignores uncorrelated message and extrinsic hashes", () => {
+  const adapter = new SubscanXcmSourceAdapter({
+    apiHost: "https://subscan.example",
+    apiKey: "test"
+  });
+
+  const outcome = adapter.normalizeSubscanEntry({
+    msg_hash: requestId,
+    message_hash: requestId,
+    extrinsic_hash: remoteRef,
+    hash: failureCode,
+    status: "success",
+    block_timestamp: "1712345678"
+  });
+
+  assert.equal(outcome, undefined);
 });
 
 test("native PAPI evidence rejects promoted ledger joins and mismatched topics", () => {

--- a/indexer/src/api/xcm-upstream-source.ts
+++ b/indexer/src/api/xcm-upstream-source.ts
@@ -350,6 +350,9 @@ type SubscanXcmRecord = Record<string, unknown>;
  * - Exact field names inside `data.list` are inferred from Subscan's common
  *   list conventions because the paid-plan payload could not be live-validated
  *   from this environment. Parsing is intentionally defensive.
+ * - Only rows carrying an explicit Averray request id / XCM SetTopic field are
+ *   published. Generic message, extrinsic, or record hashes are not local
+ *   request ids and are intentionally ignored.
  */
 export class SubscanXcmSourceAdapter implements XcmUpstreamSourceAdapter {
   type = "subscan_xcm";
@@ -426,10 +429,13 @@ export class SubscanXcmSourceAdapter implements XcmUpstreamSourceAdapter {
 
   normalizeSubscanEntry(entry: SubscanXcmRecord): PublishedOutcome | undefined {
     const requestId = this.pickString(entry, [
-      "msg_hash",
-      "message_hash",
-      "extrinsic_hash",
-      "hash"
+      "requestId",
+      "request_id",
+      "messageTopic",
+      "message_topic",
+      "setTopic",
+      "set_topic",
+      "topic"
     ]);
     if (!requestId || !/^0x[a-fA-F0-9]{64}$/u.test(requestId)) {
       return undefined;


### PR DESCRIPTION
## Summary
- Require Subscan XCM rows to carry an explicit Averray requestId / SetTopic field before publishing an outcome.
- Stop treating generic Subscan message, extrinsic, or record hashes as local Averray request IDs.
- Add indexer API tests for SetTopic/request-id acceptance and uncorrelated hash rejection.

## Checks
- npm --workspace indexer run test:api
- npm run typecheck:indexer
- git diff --check

## Impact
- Indexer: yes
- Backend: no
- Frontend: no
- Contracts: no
- Caddy/public site: no
- Env/VPS secrets: no