### PR TITLE
Promote requestId to correlationId on XCM observer events

### DIFF
--- a/mcp-server/src/services/xcm-observation-relay.js
+++ b/mcp-server/src/services/xcm-observation-relay.js
@@ -90,6 +90,7 @@ export class XcmObservationRelayService {
         this.eventBus?.publish({
           id: `xcm-observer-relayed-${normalized.requestId}-${Date.now()}`,
           topic: "xcm.outcome_relayed",
+          correlationId: normalized.requestId,
           timestamp: new Date().toISOString(),
           data: {
             requestId: normalized.requestId,

--- a/mcp-server/src/services/xcm-observation-relay.test.js
+++ b/mcp-server/src/services/xcm-observation-relay.test.js
@@ -60,6 +60,8 @@ test("pollOnce relays terminal outcomes into the platform watcher and stores cur
   assert.equal(calls[0][1].settledAssets, "7");
   assert.equal(calls[0][1].settledShares, "7");
   assert.equal(events.length, 1);
+  assert.equal(events[0].topic, "xcm.outcome_relayed");
+  assert.equal(events[0].correlationId, REQUEST_ID);
   assert.equal(events[0].data.settledAssets, "7");
   assert.equal(events[0].data.settledAssetsRaw, "7");
   assert.equal(events[0].data.settledShares, "7");

--- a/mcp-server/src/services/xcm-settlement-watcher.js
+++ b/mcp-server/src/services/xcm-settlement-watcher.js
@@ -73,6 +73,7 @@ export class XcmSettlementWatcherService {
     this.eventBus?.publish({
       id: `xcm-outcome-observed-${normalizedRequestId}-${Date.now()}`,
       topic: "xcm.outcome_observed",
+      correlationId: normalizedRequestId,
       timestamp: new Date().toISOString(),
       data: {
         requestId: normalizedRequestId,
@@ -112,6 +113,7 @@ export class XcmSettlementWatcherService {
           topic: "xcm.request_auto_finalized",
           wallet: finalized?.strategyRequest?.account ?? finalized?.account,
           wallets: [finalized?.strategyRequest?.account ?? finalized?.account].filter(Boolean),
+          correlationId: observation.requestId,
           timestamp: new Date().toISOString(),
           data: {
             requestId: observation.requestId,
@@ -132,6 +134,7 @@ export class XcmSettlementWatcherService {
         this.eventBus?.publish({
           id: `xcm-auto-finalize-failed-${observation.requestId}-${Date.now()}`,
           topic: "xcm.request_finalize_failed",
+          correlationId: observation.requestId,
           timestamp: new Date().toISOString(),
           data: {
             requestId: observation.requestId,

--- a/mcp-server/src/services/xcm-settlement-watcher.test.js
+++ b/mcp-server/src/services/xcm-settlement-watcher.test.js
@@ -31,6 +31,7 @@ test("observeOutcome stores a pending observation and emits an event", async () 
   assert.equal(observation.processed, false);
   assert.equal(events.length, 1);
   assert.equal(events[0].topic, "xcm.outcome_observed");
+  assert.equal(events[0].correlationId, REQUEST_ID);
   assert.equal(events[0].data.settledAssets, "5");
   assert.equal(events[0].data.settledAssetsRaw, "5");
   assert.equal(events[0].data.settledShares, "0");
@@ -79,11 +80,39 @@ test("runPendingSettlements finalizes stored observations and marks them process
   assert.equal(stored.processed, true);
   assert.equal(stored.result.settledVia, "agent_account");
   assert.equal(events.length, 1);
+  assert.equal(events[0].topic, "xcm.request_auto_finalized");
+  assert.equal(events[0].correlationId, REQUEST_ID);
   assert.equal(events[0].data.settledAssets, "5");
   assert.equal(events[0].data.settledAssetsRaw, "5");
   assert.equal(events[0].data.settledShares, "5");
   assert.equal(events[0].data.settledSharesRaw, "5");
   assert.equal(events[0].data.source, "observer");
+});
+
+test("runPendingSettlements emits a request_finalize_failed event with correlationId on errors", async () => {
+  const stateStore = new MemoryStateStore();
+  const eventBus = new EventBus();
+  const events = [];
+  eventBus.subscribe({ topics: ["xcm.request_finalize_failed"] }, (event) => events.push(event));
+  const watcher = new XcmSettlementWatcherService(
+    {
+      finalizeXcmRequest: async () => {
+        throw new Error("downstream settle failed");
+      }
+    },
+    stateStore,
+    eventBus,
+    { enabled: false, logger: { warn: () => {} } }
+  );
+
+  await watcher.observeOutcome(REQUEST_ID, { status: "succeeded", settledAssets: 5 });
+  await watcher.runPendingSettlements();
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0].topic, "xcm.request_finalize_failed");
+  assert.equal(events[0].correlationId, REQUEST_ID);
+  assert.equal(events[0].data.requestId, REQUEST_ID);
+  assert.match(events[0].data.message, /downstream settle failed/u);
 });
 
 test("observeOutcome preserves large uint256 settlement amounts exactly", async () => {


### PR DESCRIPTION
## Summary
- Set `correlationId = requestId` on the four XCM observer/watcher publish sites: `xcm.outcome_observed`, `xcm.outcome_relayed`, `xcm.request_auto_finalized`, `xcm.request_finalize_failed`.
- Without this the bus correlation fallback (`sessionId || jobId`) left `correlationId` undefined across the entire `queued → observed → finalized` lifecycle, so operators could not thread the events by correlation id even though `requestId` was already present inside `data`.
- Second of two follow-ups from the event-producer taxonomy audit (#346). First follow-up (governance classifier extension) is #347.

## Test plan
- [x] `npm --workspace mcp-server test` — 546 / 546 pass
- [x] Existing assertions on `xcm.outcome_observed` and `xcm.outcome_relayed` extended with `correlationId === requestId` checks
- [x] New test exercises the previously uncovered `xcm.request_finalize_failed` branch and asserts both topic and correlationId

🤖 Generated with [Claude Code](https://claude.com/claude-code)