### PR TITLE
Validate XCM observations before storing

### DIFF
--- a/mcp-server/src/services/xcm-settlement-watcher.js
+++ b/mcp-server/src/services/xcm-settlement-watcher.js
@@ -1,6 +1,7 @@
 import { ValidationError } from "../core/errors.js";
 
 const UINT256_MAX = (1n << 256n) - 1n;
+const TERMINAL_STATUSES = new Set(["succeeded", "failed", "cancelled"]);
 
 export class XcmSettlementWatcherService {
   constructor(
@@ -55,13 +56,13 @@ export class XcmSettlementWatcherService {
     const normalizedRequestId = this.requireRequestId(requestId);
     const incoming = {
       requestId: normalizedRequestId,
-      status: outcome.status,
+      status: normalizeObservationStatus(outcome.status),
       settledAssets: normalizeObservationAmount(outcome.settledAssets, "settledAssets"),
       settledShares: normalizeObservationAmount(outcome.settledShares, "settledShares"),
       remoteRef: outcome.remoteRef,
       failureCode: outcome.failureCode,
       source: typeof outcome.source === "string" && outcome.source.trim() ? outcome.source.trim() : "observer",
-      observedAt: outcome.observedAt ?? new Date().toISOString(),
+      observedAt: normalizeObservationObservedAt(outcome.observedAt),
       processed: false
     };
     const existing = await this.stateStore.getXcmObservation?.(normalizedRequestId);
@@ -179,6 +180,16 @@ export class XcmSettlementWatcherService {
   }
 }
 
+function normalizeObservationStatus(status) {
+  const normalized = typeof status === "number"
+    ? ["unknown", "pending", "succeeded", "failed", "cancelled"][status] ?? "unknown"
+    : String(status ?? "").trim().toLowerCase();
+  if (!TERMINAL_STATUSES.has(normalized)) {
+    throw new ValidationError("XCM observations must use a terminal status.");
+  }
+  return normalized;
+}
+
 function normalizeObservationAmount(value, label) {
   if (value === undefined || value === null || value === "") {
     return "0";
@@ -206,4 +217,15 @@ function normalizeObservationAmount(value, label) {
     throw new ValidationError(`${label} must fit uint256.`);
   }
   return parsed.toString();
+}
+
+function normalizeObservationObservedAt(value) {
+  if (value === undefined || value === null || value === "") {
+    return new Date().toISOString();
+  }
+  const observedAt = new Date(value);
+  if (Number.isNaN(observedAt.getTime())) {
+    throw new ValidationError("observedAt must be ISO-8601 when provided.");
+  }
+  return observedAt.toISOString();
 }

--- a/mcp-server/src/services/xcm-settlement-watcher.test.js
+++ b/mcp-server/src/services/xcm-settlement-watcher.test.js
@@ -105,6 +105,25 @@ test("observeOutcome preserves large uint256 settlement amounts exactly", async 
   assert.equal(observation.settledShares, "18446744073709551616");
 });
 
+test("observeOutcome normalizes numeric terminal statuses and observedAt", async () => {
+  const stateStore = new MemoryStateStore();
+  const watcher = new XcmSettlementWatcherService(
+    { finalizeXcmRequest: async () => ({}) },
+    stateStore,
+    undefined,
+    { enabled: false }
+  );
+
+  const observation = await watcher.observeOutcome(REQUEST_ID, {
+    status: 2,
+    settledAssets: 5,
+    observedAt: "2026-05-14T12:00:00Z"
+  });
+
+  assert.equal(observation.status, "succeeded");
+  assert.equal(observation.observedAt, "2026-05-14T12:00:00.000Z");
+});
+
 test("observeOutcome rejects unsafe numeric settlement amounts", async () => {
   const stateStore = new MemoryStateStore();
   const watcher = new XcmSettlementWatcherService(
@@ -121,6 +140,57 @@ test("observeOutcome rejects unsafe numeric settlement amounts", async () => {
     }),
     ValidationError
   );
+});
+
+test("observeOutcome rejects missing or non-terminal statuses before storing", async () => {
+  const stateStore = new MemoryStateStore();
+  const eventBus = new EventBus();
+  const events = [];
+  eventBus.subscribe({ topics: ["xcm.outcome_observed"] }, (event) => events.push(event));
+  const watcher = new XcmSettlementWatcherService(
+    { finalizeXcmRequest: async () => ({}) },
+    stateStore,
+    eventBus,
+    { enabled: false }
+  );
+
+  await assert.rejects(
+    () => watcher.observeOutcome(REQUEST_ID, {
+      settledAssets: 5
+    }),
+    ValidationError
+  );
+  await assert.rejects(
+    () => watcher.observeOutcome(REQUEST_ID, {
+      status: "pending",
+      settledAssets: 5
+    }),
+    ValidationError
+  );
+
+  assert.equal(await stateStore.getXcmObservation(REQUEST_ID), undefined);
+  assert.equal(events.length, 0);
+});
+
+test("observeOutcome rejects invalid observedAt before storing", async () => {
+  const stateStore = new MemoryStateStore();
+  const watcher = new XcmSettlementWatcherService(
+    { finalizeXcmRequest: async () => ({}) },
+    stateStore,
+    undefined,
+    { enabled: false }
+  );
+
+  await assert.rejects(
+    () => watcher.observeOutcome(REQUEST_ID, {
+      status: "succeeded",
+      settledAssets: 5,
+      observedAt: "not-a-date"
+    }),
+    ValidationError
+  );
+
+  assert.equal(await stateStore.getXcmObservation(REQUEST_ID), undefined);
 });
 
 test("runPendingSettlements keeps failed observations pending for retry", async () => {


### PR DESCRIPTION
## Summary
- Validate manual/watcher XCM observations before writing pending settlement state.
- Normalize terminal numeric statuses and observedAt timestamps at the watcher boundary.
- Add regression coverage so missing, pending, or malformed observations do not get stored or emitted.

## Checks
- node --test mcp-server/src/services/xcm-settlement-watcher.test.js
- node --test mcp-server/src/services/xcm-observation-relay.test.js mcp-server/src/services/xcm-settlement-watcher.test.js mcp-server/src/protocols/http/server.smoke.test.js
- npm --workspace mcp-server test
- git diff --check

## Impact
- Backend: yes
- Indexer: no
- Frontend: no
- Contracts: no
- Caddy/public site: no
- Env/VPS secrets: no