### PR TITLE
Add hosted service-token proof workflow

### DIFF
--- a/.github/workflows/hosted-service-token-proof.yml
+++ b/.github/workflows/hosted-service-token-proof.yml
@@ -1,0 +1,134 @@
+name: Hosted Service Token Proof
+
+on:
+  workflow_dispatch:
+    inputs:
+      subject:
+        description: Proof wallet address. Leave blank for the deterministic non-admin smoke subject.
+        required: false
+        default: ""
+        type: string
+      capabilities:
+        description: Comma-separated capabilities for the least-privilege service token.
+        required: false
+        default: jobs:recommend
+        type: string
+      allowed_path:
+        description: Hosted API path that should succeed with the scoped service token.
+        required: false
+        default: /jobs/recommendations
+        type: string
+      denied_paths:
+        description: Comma-separated hosted API paths that must reject the scoped service token.
+        required: false
+        default: /account,/admin/status
+        type: string
+      token_ttl_seconds:
+        description: Service-token TTL for the proof grant.
+        required: false
+        default: "600"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hosted-service-token-proof
+  cancel-in-progress: false
+
+jobs:
+  proof:
+    name: Run hosted scoped service-token proof
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    env:
+      APP_ALLOW_PROTECTED_SHELL: "1"
+      CHECK_INDEXER: "0"
+      CHECK_SERVICE_TOKEN_PROOF: "1"
+      SERVICE_TOKEN_PROOF_EVIDENCE_FILE: artifacts/service-token-proof-hosted-${{ github.run_id }}.json
+      SERVICE_TOKEN_PROOF_SUBJECT: ${{ inputs.subject }}
+      SERVICE_TOKEN_PROOF_CAPABILITIES: ${{ inputs.capabilities }}
+      SERVICE_TOKEN_PROOF_ALLOWED_PATH: ${{ inputs.allowed_path }}
+      SERVICE_TOKEN_PROOF_DENIED_PATHS: ${{ inputs.denied_paths }}
+      SERVICE_TOKEN_PROOF_TOKEN_TTL_SECONDS: ${{ inputs.token_ttl_seconds }}
+      SERVICE_TOKEN_PROOF_IDEMPOTENCY_KEY: github-hosted-service-token-proof-${{ github.run_id }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Load ADMIN_JWT from 1Password (fail-closed)
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE }}
+          ADMIN_JWT_OP: op://prod-smoke/admin-jwt/password
+
+      - name: Verify ADMIN_JWT_OP loaded and shape-valid
+        run: |
+          set -euo pipefail
+          set +x
+
+          if [ -z "${ADMIN_JWT_OP:-}" ]; then
+            echo "::error::ADMIN_JWT_OP is empty after load step — check op://prod-smoke/admin-jwt/password and OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE."
+            exit 1
+          fi
+
+          case "$ADMIN_JWT_OP" in
+            ey*.*.*)
+              echo "ADMIN_JWT_OP: JWT shape valid"
+              ;;
+            *)
+              echo "::error::ADMIN_JWT_OP does not look like a JWT (expected ey<...>.<...>.<...>)"
+              exit 1
+              ;;
+          esac
+
+      - name: Run hosted proof
+        run: |
+          set -euo pipefail
+          set +x
+
+          ADMIN_JWT="$ADMIN_JWT_OP" ./scripts/ops/check-hosted-stack.sh
+
+      - name: Summarize proof evidence
+        if: always()
+        run: |
+          set -euo pipefail
+
+          evidence_file="$SERVICE_TOKEN_PROOF_EVIDENCE_FILE"
+          if [ ! -s "$evidence_file" ]; then
+            echo "No service-token evidence file was produced." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          status="$(jq -r '.status' "$evidence_file")"
+          grant_id="$(jq -r '.issue.grantId' "$evidence_file")"
+          subject="$(jq -r '.subject' "$evidence_file")"
+          capabilities="$(jq -r '.capabilities | join(", ")' "$evidence_file")"
+          allowed_path="$(jq -r '.allowedBeforeRevoke.path' "$evidence_file")"
+          allowed_status="$(jq -r '.allowedBeforeRevoke.status' "$evidence_file")"
+          denied_after_revoke="$(jq -r '.deniedAfterRevoke.status' "$evidence_file")"
+          token_present="$(jq -r '.list.tokenPresent' "$evidence_file")"
+
+          {
+            echo "## Hosted Service-Token Proof"
+            echo
+            echo "- Status: \`${status}\`"
+            echo "- Grant: \`${grant_id}\`"
+            echo "- Subject: \`${subject}\`"
+            echo "- Capabilities: \`${capabilities}\`"
+            echo "- Allowed route: \`${allowed_path}\` -> \`${allowed_status}\`"
+            echo "- Revoked-token route status: \`${denied_after_revoke}\`"
+            echo "- List projection exposes raw token: \`${token_present}\`"
+            echo "- Evidence artifact: \`hosted-service-token-proof-${GITHUB_RUN_ID}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload sanitized service-token proof evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: hosted-service-token-proof-${{ github.run_id }}
+          path: ${{ env.SERVICE_TOKEN_PROOF_EVIDENCE_FILE }}
+          if-no-files-found: error
+          retention-days: 90

--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -370,12 +370,15 @@ across environment config, JWT roles, and route-level decisions.
   `CHECK_SERVICE_TOKEN_PROOF=1 ./scripts/ops/check-hosted-stack.sh` provide an
   opt-in hosted proof for issue -> use -> deny ungranted routes -> revoke ->
   list-redacted behavior
+- `hosted-service-token-proof.yml` runs that proof from the production GitHub
+  environment, loads `ADMIN_JWT` from `op://prod-smoke/admin-jwt/password`, and
+  uploads the sanitized JSON evidence artifact without exposing token material
 
 ### Remaining gaps
 
 - signed tokens are still issued from coarse environment role lists
-- hosted evidence still needs the opt-in service-token proof run against
-  production and attached to the launch evidence pack
+- the first successful `hosted-service-token-proof.yml` run still needs to be
+  attached to the launch evidence pack
 - delegated-wallet UX should expand again once native Substrate auth lands
 
 ### Improve to
@@ -389,9 +392,8 @@ across environment config, JWT roles, and route-level decisions.
 
 ### Concrete next changes
 
-- run the hosted proof with `CHECK_SERVICE_TOKEN_PROOF=1`, an admin JWT, and a
-  `SERVICE_TOKEN_PROOF_EVIDENCE_FILE`, then attach the sanitized JSON evidence
-  to the launch pack
+- dispatch `hosted-service-token-proof.yml`, confirm the artifact status is
+  `passed`, then attach that run/artifact to the launch pack
 - keep the service-token grant cache invalidation covered as the revocation
   path evolves
 - revisit delegated-wallet UX when native Substrate sign-in is accepted by

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -108,7 +108,14 @@ APP_ALLOW_PROTECTED_SHELL=1 ./scripts/ops/check-hosted-stack.sh
 # Optional: include the async XCM operator lane in the smoke check
 ADMIN_JWT='<admin-jwt>' ./scripts/ops/check-hosted-stack.sh
 
-# Optional: include the scoped service-token proof and write sanitized evidence
+# Optional: run the hosted scoped service-token proof from GitHub Actions.
+# The workflow loads ADMIN_JWT from op://prod-smoke/admin-jwt/password and
+# uploads a sanitized JSON artifact named hosted-service-token-proof-<run-id>.
+gh workflow run hosted-service-token-proof.yml -R averray-agent/agent --ref main
+
+# Optional local fallback: include the scoped service-token proof and write
+# sanitized evidence. Prefer the GitHub workflow when you do not already have
+# an admin JWT in your local shell.
 ADMIN_JWT='<admin-jwt>' \
 CHECK_SERVICE_TOKEN_PROOF=1 \
 SERVICE_TOKEN_PROOF_EVIDENCE_FILE=artifacts/service-token-proof.json \

--- a/docs/SERVICE_TOKEN_OPERATOR_PACK.md
+++ b/docs/SERVICE_TOKEN_OPERATOR_PACK.md
@@ -214,6 +214,15 @@ The hosted smoke can exercise the full least-privilege loop without exposing
 the raw service token in logs or evidence:
 
 ```bash
+# Preferred hosted proof: uses the production GitHub environment and
+# op://prod-smoke/admin-jwt/password, then uploads a sanitized evidence
+# artifact named hosted-service-token-proof-<run-id>.
+gh workflow run hosted-service-token-proof.yml -R averray-agent/agent --ref main
+```
+
+For local operator fallback, pass an admin JWT explicitly:
+
+```bash
 CHECK_SERVICE_TOKEN_PROOF=1 \
 ADMIN_JWT="$ADMIN_JWT" \
 SERVICE_TOKEN_PROOF_EVIDENCE_FILE=artifacts/service-token-proof.json \

--- a/docs/SPEC_AUDIT_2026-05-13.md
+++ b/docs/SPEC_AUDIT_2026-05-13.md
@@ -248,10 +248,12 @@ SSH/basic-auth/admin-JWT cutovers, and the basic hosted smoke is green.
   `CHECK_SERVICE_TOKEN_PROOF=1` gate that issues a least-privilege service
   token, proves allowed vs ungranted routes, revokes the grant, confirms the
   old token loses access, and writes sanitized evidence without raw token
-  material.
-- Remaining: run the hosted service-token proof against production and attach
-  its sanitized evidence to the launch pack, then extend delegated-wallet UX
-  once native Substrate auth lands.
+  material. `hosted-service-token-proof.yml` wraps that gate in a production
+  GitHub workflow using `op://prod-smoke/admin-jwt/password` and uploads the
+  sanitized JSON artifact.
+- Remaining: run `hosted-service-token-proof.yml` on `main` and attach its
+  successful artifact to the launch pack, then extend delegated-wallet UX once
+  native Substrate auth lands.
 
 ### Secrets Phase 2+ And Mainnet Custody
 
@@ -318,8 +320,8 @@ correlation and settlement path.
    adoption.
 4. Prove the dispute verdict path live and decide `/release` semantics.
 5. Run the native XCM evidence pack captures.
-6. Run the scoped service-token hosted proof with
-   `CHECK_SERVICE_TOKEN_PROOF=1` and archive the sanitized evidence.
+6. Run `hosted-service-token-proof.yml` and archive the sanitized evidence
+   artifact.
 7. Continue standardizing producer event payloads and finish visible timeline
    filter adoption where still missing.
 8. Continue Phase 2+ secrets cleanup and signer custody hardening.

--- a/scripts/ops/hermes-workflow-artifacts.test.mjs
+++ b/scripts/ops/hermes-workflow-artifacts.test.mjs
@@ -27,3 +27,20 @@ test("Hermes PR handoff keeps the full log as a correlation-id artifact", async 
   assert.match(workflow, /if-no-files-found: error/u);
   assert.match(workflow, /retention-days: 90/u);
 });
+
+test("hosted service-token proof uploads sanitized evidence as a workflow artifact", async () => {
+  const workflow = await readFile(join(REPO_ROOT, ".github/workflows/hosted-service-token-proof.yml"), "utf8");
+
+  assert.match(workflow, /workflow_dispatch:/u);
+  assert.match(workflow, /environment: production/u);
+  assert.match(workflow, /OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE/u);
+  assert.match(workflow, /ADMIN_JWT_OP: op:\/\/prod-smoke\/admin-jwt\/password/u);
+  assert.match(workflow, /CHECK_SERVICE_TOKEN_PROOF: "1"/u);
+  assert.match(workflow, /SERVICE_TOKEN_PROOF_EVIDENCE_FILE: artifacts\/service-token-proof-hosted-\$\{\{ github\.run_id \}\}\.json/u);
+  assert.match(workflow, /ADMIN_JWT="\$ADMIN_JWT_OP" \.\/scripts\/ops\/check-hosted-stack\.sh/u);
+  assert.match(workflow, /uses: actions\/upload-artifact@v7/u);
+  assert.match(workflow, /name: hosted-service-token-proof-\$\{\{ github\.run_id \}\}/u);
+  assert.match(workflow, /path: \$\{\{ env\.SERVICE_TOKEN_PROOF_EVIDENCE_FILE \}\}/u);
+  assert.match(workflow, /if-no-files-found: error/u);
+  assert.match(workflow, /retention-days: 90/u);
+});


### PR DESCRIPTION
## What changed
- Added an on-demand Hosted Service Token Proof workflow that loads ADMIN_JWT from 1Password, runs the hosted service-token smoke gate, and uploads sanitized JSON evidence.
- Documented the GitHub workflow as the preferred proof path, with the local ADMIN_JWT smoke as fallback.
- Added a regression test so the workflow keeps the production environment, 1Password source, proof gate, and artifact upload wired.

## Checks run
- node --test scripts/ops/hermes-workflow-artifacts.test.mjs scripts/ops/check-hosted-stack.test.mjs scripts/ops/check-service-token-proof.test.mjs
- npm run test:ops (relevant tests passed; full suite then hit unrelated missing local @polkadot/util-crypto for scripts/ops/prepare-multisig-owner-record.test.mjs in this fresh worktree)
- git diff --cached --check

## Affected areas
- GitHub Actions / ops smoke evidence
- Docs only for operator checklist and spec status

## Required env/VPS changes
- None. Reuses production environment secret OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE and op://prod-smoke/admin-jwt/password.