### PR TITLE
Record hosted service-token proof evidence

### DIFF
--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -373,12 +373,15 @@ across environment config, JWT roles, and route-level decisions.
 - `hosted-service-token-proof.yml` runs that proof from the production GitHub
   environment, loads `ADMIN_JWT` from `op://prod-smoke/admin-jwt/password`, and
   uploads the sanitized JSON evidence artifact without exposing token material
+- GitHub Actions run
+  [`25969321980`](https://github.com/averray-agent/agent/actions/runs/25969321980)
+  passed against production on 2026-05-16; the sanitized launch evidence is
+  archived at
+  [`docs/evidence/service-token-proof-hosted-2026-05-16.json`](evidence/service-token-proof-hosted-2026-05-16.json)
 
 ### Remaining gaps
 
 - signed tokens are still issued from coarse environment role lists
-- the first successful `hosted-service-token-proof.yml` run still needs to be
-  attached to the launch evidence pack
 - delegated-wallet UX should expand again once native Substrate auth lands
 
 ### Improve to
@@ -392,8 +395,8 @@ across environment config, JWT roles, and route-level decisions.
 
 ### Concrete next changes
 
-- dispatch `hosted-service-token-proof.yml`, confirm the artifact status is
-  `passed`, then attach that run/artifact to the launch pack
+- keep `hosted-service-token-proof.yml` green as the service-token grant
+  surface evolves
 - keep the service-token grant cache invalidation covered as the revocation
   path evolves
 - revisit delegated-wallet UX when native Substrate sign-in is accepted by

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -91,9 +91,13 @@ Restore procedures:
   1Password SSH/basic-auth/admin-JWT cutovers.
 - [ ] When an admin JWT is available, `/admin/status` reports the async XCM
   watcher lane cleanly.
-- [ ] Hosted scoped service-token proof passes with sanitized evidence:
+- [x] Hosted scoped service-token proof passes with sanitized evidence:
   issue a least-privilege token, prove allowed and denied routes, revoke it,
   and confirm `listServiceTokens` does not expose raw token material.
+  Evidence: GitHub Actions run
+  [`25969321980`](https://github.com/averray-agent/agent/actions/runs/25969321980),
+  archived at
+  [`docs/evidence/service-token-proof-hosted-2026-05-16.json`](evidence/service-token-proof-hosted-2026-05-16.json).
 
 Run:
 

--- a/docs/SERVICE_TOKEN_OPERATOR_PACK.md
+++ b/docs/SERVICE_TOKEN_OPERATOR_PACK.md
@@ -238,6 +238,13 @@ What it proves:
 - revocation removes the route capability on the next request;
 - `GET /admin/service-tokens` lists the revoked grant without a `token` field.
 
+Live proof:
+
+- 2026-05-16 production run:
+  [`25969321980`](https://github.com/averray-agent/agent/actions/runs/25969321980)
+  passed and is archived at
+  [`docs/evidence/service-token-proof-hosted-2026-05-16.json`](evidence/service-token-proof-hosted-2026-05-16.json).
+
 Optional knobs:
 
 - `SERVICE_TOKEN_PROOF_SUBJECT` — proof wallet address; defaults to a

--- a/docs/SPEC_AUDIT_2026-05-13.md
+++ b/docs/SPEC_AUDIT_2026-05-13.md
@@ -250,10 +250,12 @@ SSH/basic-auth/admin-JWT cutovers, and the basic hosted smoke is green.
   old token loses access, and writes sanitized evidence without raw token
   material. `hosted-service-token-proof.yml` wraps that gate in a production
   GitHub workflow using `op://prod-smoke/admin-jwt/password` and uploads the
-  sanitized JSON artifact.
-- Remaining: run `hosted-service-token-proof.yml` on `main` and attach its
-  successful artifact to the launch pack, then extend delegated-wallet UX once
-  native Substrate auth lands.
+  sanitized JSON artifact. GitHub Actions run
+  [`25969321980`](https://github.com/averray-agent/agent/actions/runs/25969321980)
+  passed against production on 2026-05-16; the sanitized launch evidence is
+  archived at
+  [`docs/evidence/service-token-proof-hosted-2026-05-16.json`](evidence/service-token-proof-hosted-2026-05-16.json).
+- Remaining: extend delegated-wallet UX once native Substrate auth lands.
 
 ### Secrets Phase 2+ And Mainnet Custody
 
@@ -320,8 +322,6 @@ correlation and settlement path.
    adoption.
 4. Prove the dispute verdict path live and decide `/release` semantics.
 5. Run the native XCM evidence pack captures.
-6. Run `hosted-service-token-proof.yml` and archive the sanitized evidence
-   artifact.
-7. Continue standardizing producer event payloads and finish visible timeline
+6. Continue standardizing producer event payloads and finish visible timeline
    filter adoption where still missing.
-8. Continue Phase 2+ secrets cleanup and signer custody hardening.
+7. Continue Phase 2+ secrets cleanup and signer custody hardening.

--- a/docs/evidence/service-token-proof-hosted-2026-05-16.json
+++ b/docs/evidence/service-token-proof-hosted-2026-05-16.json
@@ -1,0 +1,73 @@
+{
+  "proof": "scoped-service-token",
+  "apiBaseUrl": "https://api.averray.com",
+  "subject": "0x00000000000000000000000000000000000a11ce",
+  "scope": "hosted-smoke-service-token-proof",
+  "capabilities": [
+    "jobs:recommend"
+  ],
+  "allowedPath": "/jobs/recommendations",
+  "deniedPaths": [
+    "/account",
+    "/admin/status"
+  ],
+  "startedAt": "2026-05-16T18:16:57.013Z",
+  "admin": {
+    "wallet": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+    "roles": [
+      "admin",
+      "verifier"
+    ],
+    "grantCapabilitiesPresent": [
+      "jobs:recommend"
+    ]
+  },
+  "issue": {
+    "status": 201,
+    "grantId": "grant-e2e11741b0a7",
+    "issuedAt": "2026-05-16T18:16:57.670Z",
+    "expiresAt": "2026-05-16T18:26:57.000Z",
+    "tokenAvailable": true
+  },
+  "serviceSession": {
+    "tokenKind": "service",
+    "serviceToken": true,
+    "capabilityGrantId": "grant-e2e11741b0a7",
+    "capabilities": [
+      "jobs:recommend"
+    ],
+    "roles": []
+  },
+  "allowedBeforeRevoke": {
+    "path": "/jobs/recommendations",
+    "status": 200
+  },
+  "deniedBeforeRevoke": [
+    {
+      "path": "/account",
+      "status": 403
+    },
+    {
+      "path": "/admin/status",
+      "status": 403
+    }
+  ],
+  "revoke": {
+    "status": 200,
+    "grantId": "grant-e2e11741b0a7",
+    "grantStatus": "revoked",
+    "alreadyRevoked": false,
+    "revokedAt": "2026-05-16T18:16:58.724Z"
+  },
+  "deniedAfterRevoke": {
+    "path": "/jobs/recommendations",
+    "status": 403
+  },
+  "list": {
+    "status": 200,
+    "tokenAvailable": false,
+    "tokenPresent": false
+  },
+  "completedAt": "2026-05-16T18:16:58.998Z",
+  "status": "passed"
+}


### PR DESCRIPTION
## What changed
- Archived the sanitized hosted service-token proof JSON from GitHub Actions run 25969321980.
- Marked the production checklist service-token proof item complete.
- Updated the roadmap/spec audit/operator pack to point at the live proof run and evidence file.

## Checks run
- jq empty docs/evidence/service-token-proof-hosted-2026-05-16.json
- grep token-shaped material check against docs/evidence/service-token-proof-hosted-2026-05-16.json
- git diff --cached --check

## Affected areas
- Docs / launch evidence only

## Required env/VPS changes
- None.