### PR TITLE
Guard XCM dispatch on precompile readiness

### DIFF
--- a/contracts/XcmWrapper.sol
+++ b/contracts/XcmWrapper.sol
@@ -49,6 +49,7 @@ contract XcmWrapper is IXcmWrapper, ReentrancyGuard {
     error InvalidTransition();
     error InvalidSetTopic();
     error InvalidWeight();
+    error XcmPrecompileUnavailable();
     error PayloadMismatch();
     error XcmDispatchFailed(bytes reason);
 
@@ -83,12 +84,11 @@ contract XcmWrapper is IXcmWrapper, ReentrancyGuard {
     }
 
     function weighMessage(bytes calldata message) external view override returns (Weight memory weight) {
-        (bool ok, bytes memory data) = xcmPrecompile.staticcall(abi.encodeCall(IXcmPrecompile.weighMessage, (message)));
-        if (!ok || data.length == 0) {
+        (bool ok, Weight memory quoted) = _tryWeighMessage(message);
+        if (!ok) {
             return Weight({refTime: 0, proofSize: 0});
         }
-
-        return abi.decode(data, (Weight));
+        return quoted;
     }
 
     function queueRequest(
@@ -113,6 +113,8 @@ contract XcmWrapper is IXcmWrapper, ReentrancyGuard {
             }
             return requestId;
         }
+
+        _validateXcmPrecompileAvailable(message);
 
         requests[requestId] = RequestRecord({
             context: RequestContext({
@@ -205,6 +207,29 @@ contract XcmWrapper is IXcmWrapper, ReentrancyGuard {
     function _dispatchXcm(bytes calldata destination, bytes calldata message) internal {
         (bool ok, bytes memory data) = xcmPrecompile.call(abi.encodeCall(IXcmPrecompile.send, (destination, message)));
         if (!ok) revert XcmDispatchFailed(data);
+    }
+
+    function _validateXcmPrecompileAvailable(bytes calldata message) internal view {
+        (bool ok, Weight memory quoted) = _tryWeighMessage(message);
+        if (!ok || quoted.refTime == 0) revert XcmPrecompileUnavailable();
+    }
+
+    function _tryWeighMessage(bytes calldata message) internal view returns (bool ok, Weight memory weight) {
+        (bool callOk, bytes memory data) =
+            xcmPrecompile.staticcall(abi.encodeCall(IXcmPrecompile.weighMessage, (message)));
+        if (!callOk || data.length < 64) {
+            return (false, Weight({refTime: 0, proofSize: 0}));
+        }
+        uint256 refTime;
+        uint256 proofSize;
+        assembly {
+            refTime := mload(add(data, 32))
+            proofSize := mload(add(data, 64))
+        }
+        if (refTime > type(uint64).max || proofSize > type(uint64).max) {
+            return (false, Weight({refTime: 0, proofSize: 0}));
+        }
+        return (true, Weight({refTime: uint64(refTime), proofSize: uint64(proofSize)}));
     }
 
     function _validateRequestContext(RequestContext calldata context) internal pure {

--- a/test/AgentAccountAsyncStrategy.t.sol
+++ b/test/AgentAccountAsyncStrategy.t.sol
@@ -11,11 +11,20 @@ import {XcmWrapper} from "../contracts/XcmWrapper.sol";
 import {IXcmWrapper} from "../contracts/interfaces/IXcmWrapper.sol";
 import {XcmVdotAdapter} from "../contracts/strategies/XcmVdotAdapter.sol";
 
+contract AsyncStrategyMockXcmPrecompile {
+    function send(bytes calldata, bytes calldata) external {}
+
+    function weighMessage(bytes calldata message) external pure returns (IXcmWrapper.Weight memory) {
+        return IXcmWrapper.Weight({refTime: uint64(message.length * 10), proofSize: uint64(message.length)});
+    }
+}
+
 contract AgentAccountAsyncStrategyTest is Test {
     TreasuryPolicy internal policy;
     StrategyAdapterRegistry internal registry;
     AgentAccountCore internal accounts;
     MockERC20 internal dot;
+    AsyncStrategyMockXcmPrecompile internal precompile;
     XcmWrapper internal wrapper;
     XcmVdotAdapter internal adapter;
 
@@ -29,7 +38,8 @@ contract AgentAccountAsyncStrategyTest is Test {
         registry = new StrategyAdapterRegistry(policy);
         accounts = new AgentAccountCore(policy, registry);
         dot = new MockERC20("Mock DOT", "mDOT");
-        wrapper = new XcmWrapper(policy, address(0));
+        precompile = new AsyncStrategyMockXcmPrecompile();
+        wrapper = new XcmWrapper(policy, address(precompile));
         adapter = new XcmVdotAdapter(policy, address(dot), STRATEGY_ID, wrapper);
 
         policy.setApprovedAsset(address(dot), true);

--- a/test/XcmVdotAdapter.t.sol
+++ b/test/XcmVdotAdapter.t.sol
@@ -10,9 +10,18 @@ import {IXcmStrategyAdapter} from "../contracts/interfaces/IXcmStrategyAdapter.s
 import {XcmWrapper} from "../contracts/XcmWrapper.sol";
 import {XcmVdotAdapter} from "../contracts/strategies/XcmVdotAdapter.sol";
 
+contract VdotAdapterMockXcmPrecompile {
+    function send(bytes calldata, bytes calldata) external {}
+
+    function weighMessage(bytes calldata message) external pure returns (IXcmWrapper.Weight memory) {
+        return IXcmWrapper.Weight({refTime: uint64(message.length * 10), proofSize: uint64(message.length)});
+    }
+}
+
 contract XcmVdotAdapterTest is Test {
     TreasuryPolicy internal policy;
     MockERC20 internal asset;
+    VdotAdapterMockXcmPrecompile internal precompile;
     XcmWrapper internal wrapper;
     XcmVdotAdapter internal adapter;
 
@@ -25,7 +34,8 @@ contract XcmVdotAdapterTest is Test {
     function setUp() public {
         policy = new TreasuryPolicy();
         asset = new MockERC20("DOT", "DOT");
-        wrapper = new XcmWrapper(policy, address(0));
+        precompile = new VdotAdapterMockXcmPrecompile();
+        wrapper = new XcmWrapper(policy, address(precompile));
         adapter = new XcmVdotAdapter(policy, address(asset), STRATEGY_ID, IXcmWrapper(address(wrapper)));
 
         policy.setServiceOperator(operator, true);

--- a/test/XcmWrapper.t.sol
+++ b/test/XcmWrapper.t.sol
@@ -31,6 +31,18 @@ contract MockXcmPrecompile {
     }
 }
 
+contract MockMalformedXcmPrecompile {
+    fallback() external {
+        assembly {
+            mstore(0x00, not(0))
+            mstore(0x20, 0)
+            return(0x00, 0x40)
+        }
+    }
+
+    function send(bytes calldata, bytes calldata) external {}
+}
+
 contract XcmWrapperTest is Test {
     TreasuryPolicy internal policy;
     MockXcmPrecompile internal precompile;
@@ -113,6 +125,28 @@ contract XcmWrapperTest is Test {
         assertEq(record.context.account, address(0));
         require(wrapper.requestDestinationHash(requestId) == bytes32(0), "DEST_HASH_SHOULD_ROLL_BACK");
         require(wrapper.requestMessageHash(requestId) == bytes32(0), "MESSAGE_HASH_SHOULD_ROLL_BACK");
+    }
+
+    function testQueueRequestRejectsMissingPrecompileBeforeRecording() public {
+        XcmWrapper badWrapper = new XcmWrapper(policy, address(0xA11CE));
+        IXcmWrapper.RequestContext memory context = _context(25 ether, 0, 1);
+        bytes32 requestId = badWrapper.previewRequestId(context);
+        bytes memory message = _depositMessage(requestId);
+
+        vm.prank(operator);
+        (bool ok, bytes memory data) = address(badWrapper)
+            .call(
+                abi.encodeCall(
+                    badWrapper.queueRequest,
+                    (context, hex"0102", message, IXcmWrapper.Weight({refTime: 1, proofSize: 2}))
+                )
+            );
+        _assertCustomError(ok, data, XcmWrapper.XcmPrecompileUnavailable.selector);
+
+        IXcmWrapper.RequestRecord memory record = badWrapper.getRequest(requestId);
+        assertEq(record.context.account, address(0));
+        require(badWrapper.requestDestinationHash(requestId) == bytes32(0), "DEST_HASH_SHOULD_NOT_BE_RECORDED");
+        require(badWrapper.requestMessageHash(requestId) == bytes32(0), "MESSAGE_HASH_SHOULD_NOT_BE_RECORDED");
     }
 
     function testQueueRequestRejectsPayloadMismatchForSameContext() public {
@@ -334,6 +368,15 @@ contract XcmWrapperTest is Test {
         IXcmWrapper.Weight memory weight = wrapper.weighMessage(hex"aabbcc");
         assertEq(weight.refTime, 30);
         assertEq(weight.proofSize, 3);
+    }
+
+    function testWeighMessageReturnsZeroForMalformedPrecompileQuote() public {
+        XcmWrapper badWrapper = new XcmWrapper(policy, address(new MockMalformedXcmPrecompile()));
+
+        IXcmWrapper.Weight memory weight = badWrapper.weighMessage(hex"aabbcc");
+
+        assertEq(weight.refTime, 0);
+        assertEq(weight.proofSize, 0);
     }
 
     function _context(uint256 assets, uint256 shares, uint64 nonce)


### PR DESCRIPTION
## Summary
- Require XcmWrapper to receive a valid nonzero `weighMessage` quote from the configured XCM precompile before recording a new dispatched request.
- Make wrapper `weighMessage` return zero for missing/malformed precompile responses instead of trusting ABI decode.
- Update async XCM tests to use explicit mock precompiles and cover the no-code/malformed-precompile failure paths.

## Checks
- forge test --match-path test/XcmWrapper.t.sol
- forge test --match-path test/XcmVdotAdapter.t.sol
- forge test --match-path test/AgentAccountAsyncStrategy.t.sol
- forge test
- forge build
- git diff --check

## Impact
- Contracts: yes
- Backend: no
- Indexer: no
- Frontend: no
- Caddy/public site: no
- Env/VPS secrets: no
- Contract deployment required: yes, this changes XcmWrapper bytecode; deploy only with an explicit contract deployment plan.