### PR TITLE
Cover session state-machine transition edges

### DIFF
--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -213,20 +213,19 @@ machine.
   settlement, or verification result ingestion
 - sessions persist compact `statusHistory` entries with reason, timestamp, and
   metadata
+- `session-state-machine.test.js` now covers every legal and illegal edge in
+  the current transition table, plus the verifier callback receive guard
 
 ### Remaining gaps
 
 - settlement and dispute posture are still mostly transition outcomes and
   metadata, not separately typed workflow phases
 - retries and re-open semantics still live primarily in claim handling
-- transition coverage is focused on high-risk guards rather than full property
-  coverage across every legal and illegal edge
 
 ### Concrete next changes
 
 - route future settlement, timeout, and dispute actions through dedicated
   state-machine helpers
-- add fixture or property tests for every legal and illegal transition
 - expose richer transition reason taxonomy for operator UI timelines and agent
   diagnostics
 

--- a/docs/SPEC_AUDIT_2026-05-13.md
+++ b/docs/SPEC_AUDIT_2026-05-13.md
@@ -49,7 +49,9 @@ SSH/basic-auth/admin-JWT cutovers, and the basic hosted smoke is green.
 - Verification results are stored with replay inputs, verifier config snapshot,
   config hash, config version, and handler version.
 - Session transitions route through shared state-machine guards for the
-  high-risk claim, submit, verification, expiry, and dispute paths.
+  high-risk claim, submit, verification, expiry, and dispute paths; the current
+  transition table now has exhaustive legal/illegal edge coverage plus
+  verifier callback receive-guard coverage.
 - Duplicate submit and non-verifiable verifier callbacks fail closed before
   replacing submissions or settling.
 

--- a/mcp-server/src/core/session-state-machine.test.js
+++ b/mcp-server/src/core/session-state-machine.test.js
@@ -2,12 +2,29 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  assertSessionCanReceiveVerification,
   assertSessionCanTransition,
   buildSessionLifecycle,
+  canTransitionSession,
   describeSessionStatus,
+  getAllowedSessionTransitions,
   getSessionStateMachineDefinition,
   transitionSession
 } from "./session-state-machine.js";
+
+const EXPECTED_TRANSITIONS = {
+  "__new__": ["claimed"],
+  claimed: ["closed", "expired", "submitted", "timed_out"],
+  submitted: ["closed", "disputed", "rejected", "resolved", "timed_out"],
+  disputed: ["closed", "rejected", "resolved"],
+  resolved: [],
+  rejected: [],
+  closed: [],
+  expired: [],
+  timed_out: []
+};
+
+const PUBLIC_STATUSES = Object.keys(EXPECTED_TRANSITIONS).filter((status) => status !== "__new__");
 
 test("describeSessionStatus exposes the verification phase and allowed transitions", () => {
   const submitted = describeSessionStatus("submitted");
@@ -67,3 +84,91 @@ test("transitionSession rejects duplicate and illegal transitions with operator 
     }
   );
 });
+
+test("session state machine covers every legal and illegal transition edge", () => {
+  for (const [fromStatus, allowedTransitions] of Object.entries(EXPECTED_TRANSITIONS)) {
+    assert.deepEqual(getAllowedSessionTransitions(fromStatus).sort(), allowedTransitions);
+
+    for (const nextStatus of PUBLIC_STATUSES) {
+      const session = sessionForStatus(fromStatus);
+      const allowed = allowedTransitions.includes(nextStatus);
+
+      assert.equal(
+        canTransitionSession(session, nextStatus),
+        allowed,
+        `${fromStatus} -> ${nextStatus} canTransitionSession drifted`
+      );
+
+      if (allowed) {
+        assert.equal(assertSessionCanTransition(session, nextStatus, { reason: "edge_test" }), true);
+        const transitioned = transitionSession(session, nextStatus, {
+          reason: "edge_test",
+          timestamp: "2026-05-16T12:00:00.000Z",
+          metadata: { fromStatus, nextStatus }
+        });
+        assert.equal(transitioned.status, nextStatus);
+        assert.equal(transitioned.statusHistory.at(-1).from, fromStatus === "__new__" ? null : fromStatus);
+        assert.equal(transitioned.statusHistory.at(-1).to, nextStatus);
+        assert.equal(transitioned.statusHistory.at(-1).reason, "edge_test");
+        assert.deepEqual(transitioned.statusHistory.at(-1).metadata, { fromStatus, nextStatus });
+      } else {
+        assert.throws(
+          () => assertSessionCanTransition(session, nextStatus, { reason: "edge_test" }),
+          (error) => {
+            assert.equal(error.code, "invalid_session_transition");
+            assert.equal(error.details.currentStatus, fromStatus);
+            assert.equal(error.details.nextStatus, nextStatus);
+            assert.equal(error.details.reason, "edge_test");
+            assert.deepEqual(error.details.allowedTransitions.sort(), allowedTransitions);
+            assert.equal(error.details.currentPhase, describeSessionStatus(fromStatus).phase);
+            assert.equal(error.details.terminal, describeSessionStatus(fromStatus).terminal);
+            return true;
+          },
+          `${fromStatus} -> ${nextStatus} should be rejected`
+        );
+      }
+    }
+  }
+});
+
+test("verification receive guard is limited to verifiable session states", () => {
+  for (const status of PUBLIC_STATUSES) {
+    const session = sessionForStatus(status);
+    if (status === "submitted" || status === "disputed") {
+      assert.equal(assertSessionCanReceiveVerification(session, { reason: "verifier_callback" }), true);
+      continue;
+    }
+
+    assert.throws(
+      () => assertSessionCanReceiveVerification(session, { reason: "verifier_callback" }),
+      (error) => {
+        assert.equal(error.code, "invalid_session_transition");
+        assert.equal(error.details.currentStatus, status);
+        assert.equal(error.details.nextStatus, "resolved|rejected|disputed");
+        assert.equal(error.details.reason, "verifier_callback");
+        assert.deepEqual(error.details.allowedTransitions.sort(), EXPECTED_TRANSITIONS[status]);
+        assert.equal(error.details.currentPhase, describeSessionStatus(status).phase);
+        assert.equal(error.details.terminal, describeSessionStatus(status).terminal);
+        return true;
+      }
+    );
+  }
+});
+
+function sessionForStatus(status) {
+  if (status === "__new__") {
+    return { sessionId: "new-session" };
+  }
+  return {
+    sessionId: `${status}-session`,
+    status,
+    statusHistory: [
+      {
+        from: null,
+        to: status,
+        reason: "fixture",
+        at: "2026-05-16T11:00:00.000Z"
+      }
+    ]
+  };
+}


### PR DESCRIPTION
## What changed
- Added exhaustive legal/illegal transition edge coverage for the current session state machine.
- Added verifier callback receive-guard coverage across every public session status.
- Updated the roadmap/spec audit to reflect the stronger transition table coverage.

## Checks run
- node --test mcp-server/src/core/session-state-machine.test.js
- git diff --check
- npm --workspace mcp-server test (fails in this local fresh worktree before/away from this change because optional blockchain deps are not installed: @paraspell/sdk-core and @aws-sdk/client-kms)

## Affected areas
- Backend tests / docs only

## Required env/VPS changes
- None.