### PR TITLE
Relay on-chain job claims to worker wallets

### DIFF
--- a/contracts/EscrowCore.sol
+++ b/contracts/EscrowCore.sol
@@ -323,6 +323,15 @@ contract EscrowCore is ReentrancyGuard {
     }
 
     function claimJob(bytes32 jobId) external whenNotPaused nonReentrant {
+        _claimJob(jobId, msg.sender);
+    }
+
+    function claimJobFor(bytes32 jobId, address worker) external whenNotPaused nonReentrant onlyOperator {
+        _claimJob(jobId, worker);
+    }
+
+    function _claimJob(bytes32 jobId, address worker) internal {
+        if (worker == address(0)) revert Unauthorized();
         JobEscrow storage job = _jobs[jobId];
         if (job.state == JobState.None) revert UnknownJob();
         if (job.state != JobState.Open) revert InvalidState();
@@ -334,14 +343,14 @@ contract EscrowCore is ReentrancyGuard {
             uint16 claimFeeBps,
             bool waived,
             uint256 claimNumber
-        ) = _computeClaimEconomics(msg.sender, job);
+        ) = _computeClaimEconomics(worker, job);
 
         uint256 totalLocked = claimStake + claimFee;
         if (totalLocked > 0) {
-            accounts.lockJobStake(msg.sender, job.asset, totalLocked);
+            accounts.lockJobStake(worker, job.asset, totalLocked);
         }
 
-        job.worker = msg.sender;
+        job.worker = worker;
         job.claimStake = claimStake;
         job.claimStakeBps = claimStakeBps;
         job.claimFee = claimFee;
@@ -350,9 +359,9 @@ contract EscrowCore is ReentrancyGuard {
         job.rejectingVerifier = address(0);
         job.claimExpiry = block.timestamp + claimTtls[jobId];
         job.state = JobState.Claimed;
-        workerClaimCount[msg.sender] = claimNumber;
-        emit JobClaimed(jobId, msg.sender, job.claimExpiry, claimStake);
-        emit ClaimEconomicsLocked(jobId, msg.sender, claimStake, claimFee, waived, claimNumber);
+        workerClaimCount[worker] = claimNumber;
+        emit JobClaimed(jobId, worker, job.claimExpiry, claimStake);
+        emit ClaimEconomicsLocked(jobId, worker, claimStake, claimFee, waived, claimNumber);
     }
 
     function submitWork(bytes32 jobId, bytes32 evidenceHash) external whenNotPaused {

--- a/mcp-server/src/blockchain/abis.js
+++ b/mcp-server/src/blockchain/abis.js
@@ -36,6 +36,7 @@ export const ESCROW_CORE_ABI = [
   "function createSinglePayoutJob(bytes32 jobId, address asset, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 claimTtl, bytes32 verifierMode, bytes32 category, bytes32 specHash)",
   "function createSinglePayoutJobFromRecurringReserve((bytes32 jobId, bytes32 templateId, address poster, address asset, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 claimTtl, bytes32 verifierMode, bytes32 category, bytes32 specHash) params)",
   "function claimJob(bytes32 jobId)",
+  "function claimJobFor(bytes32 jobId, address worker)",
   "function handleClaimTimeout(bytes32 jobId)",
   "function submitWork(bytes32 jobId, bytes32 evidenceHash)",
   "function resolveSinglePayout(bytes32 jobId, bool approved, bytes32 reasonCode, string metadataURI, bytes32 reasoningHash)",

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -472,7 +472,7 @@ export class BlockchainGateway {
     });
   }
 
-  async ensureClaimStakeLiquidity(assetSymbol, amount) {
+  async ensureClaimStakeLiquidity(wallet, assetSymbol, amount) {
     return this.withGatewayError("ensureClaimStakeLiquidity", async () => {
       if (amount <= 0) {
         return true;
@@ -480,14 +480,14 @@ export class BlockchainGateway {
       this.requireSigner("ensureClaimStakeLiquidity");
       const asset = this.requireAsset(assetSymbol);
       const required = this.toBaseUnits(amount, asset, "claim lock amount");
-      const signerAddress = await this.signer.getAddress();
-      const position = await this.accountContract.positions(signerAddress, asset.address);
+      const account = wallet || await this.signer.getAddress();
+      const position = await this.accountContract.positions(account, asset.address);
       const available = BigInt(position.liquid);
       if (available < required) {
         throw new InsufficientLiquidityError(assetSymbol, {
           required: amount,
           available: this.toDisplayUnits(available, asset),
-          account: signerAddress
+          account
         });
       }
       return true;
@@ -710,10 +710,14 @@ export class BlockchainGateway {
     });
   }
 
-  async claimJob(jobId) {
+  async claimJob(jobId, wallet) {
     return this.withGatewayError("claimJob", async () => {
       this.requireSigner("claimJob");
-      const tx = await this.escrowContract.claimJob(this.toJobId(jobId));
+      const chainJobId = this.toJobId(jobId);
+      const signerAddress = await this.signer.getAddress();
+      const tx = wallet && wallet.toLowerCase() !== signerAddress.toLowerCase()
+        ? await this.escrowContract.claimJobFor(chainJobId, wallet)
+        : await this.escrowContract.claimJob(chainJobId);
       await tx.wait();
     });
   }

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -115,6 +115,58 @@ test("handleClaimTimeout reopens the canonical chain job id", async () => {
   assert.deepEqual(calls, [[gateway.toJobId("wiki-job")]]);
 });
 
+test("claimJob relays the authenticated wallet when the signer is an operator", async () => {
+  const gateway = new BlockchainGateway({ enabled: false });
+  const worker = "0x3333333333333333333333333333333333333333";
+  const calls = [];
+  gateway.signer = {
+    async getAddress() {
+      return "0x9999999999999999999999999999999999999999";
+    }
+  };
+  gateway.escrowContract = {
+    async claimJob() {
+      throw new Error("operator signer must not become the worker");
+    },
+    async claimJobFor(...args) {
+      calls.push(args);
+      return {
+        async wait() {}
+      };
+    }
+  };
+
+  await gateway.claimJob("wiki-job", worker);
+
+  assert.deepEqual(calls, [[gateway.toJobId("wiki-job"), worker]]);
+});
+
+test("claimJob uses direct claim when the signer is the authenticated wallet", async () => {
+  const gateway = new BlockchainGateway({ enabled: false });
+  const worker = "0x3333333333333333333333333333333333333333";
+  const calls = [];
+  gateway.signer = {
+    async getAddress() {
+      return worker.toUpperCase();
+    }
+  };
+  gateway.escrowContract = {
+    async claimJob(...args) {
+      calls.push(args);
+      return {
+        async wait() {}
+      };
+    },
+    async claimJobFor() {
+      throw new Error("direct wallet claims should not use claimJobFor");
+    }
+  };
+
+  await gateway.claimJob("wiki-job", worker);
+
+  assert.deepEqual(calls, [[gateway.toJobId("wiki-job")]]);
+});
+
 test("getJob falls back to the legacy escrow struct when rc1 decoding fails", async () => {
   const gateway = gatewayWithDot();
   gateway.escrowContract = {
@@ -542,7 +594,7 @@ test("ensureClaimStakeLiquidity checks fractional display locks against base-uni
   const gateway = gatewayWithDot();
   gateway.signer = {
     async getAddress() {
-      return "0x3333333333333333333333333333333333333333";
+      return "0x9999999999999999999999999999999999999999";
     }
   };
   gateway.accountContract = {
@@ -553,7 +605,10 @@ test("ensureClaimStakeLiquidity checks fractional display locks against base-uni
     }
   };
 
-  assert.equal(await gateway.ensureClaimStakeLiquidity("DOT", 0.48), true);
+  assert.equal(
+    await gateway.ensureClaimStakeLiquidity("0x3333333333333333333333333333333333333333", "DOT", 0.48),
+    true
+  );
 });
 
 test("fundAccount rejects non-mock settlement assets before minting", async () => {

--- a/mcp-server/src/core/job-execution-service.js
+++ b/mcp-server/src/core/job-execution-service.js
@@ -180,8 +180,8 @@ export class JobExecutionService {
         if (typeof this.blockchainGateway.previewClaimEconomics === "function") {
           claimEconomics = await this.blockchainGateway.previewClaimEconomics(wallet, jobId).catch(() => claimEconomics);
         }
-        await this.blockchainGateway.ensureClaimStakeLiquidity?.(job.rewardAsset, claimEconomics.totalClaimLock);
-        await this.blockchainGateway.claimJob(jobId);
+        await this.blockchainGateway.ensureClaimStakeLiquidity?.(wallet, job.rewardAsset, claimEconomics.totalClaimLock);
+        await this.blockchainGateway.claimJob(jobId, wallet);
         chainClaimTiming = this.buildChainClaimTiming(
           await this.blockchainGateway.getJob(jobId).catch(() => undefined)
         );

--- a/mcp-server/src/core/job-execution-service.test.js
+++ b/mcp-server/src/core/job-execution-service.test.js
@@ -280,8 +280,13 @@ test("claimJob stores on-chain claim expiry when blockchain is enabled", async (
         : { state: 1, claimExpiry: Date.parse("2026-05-01T10:01:00.000Z") / 1000 };
     },
     async ensureJob() {},
-    async ensureClaimStakeLiquidity() {},
-    async claimJob() {}
+    async ensureClaimStakeLiquidity(wallet) {
+      assert.equal(wallet, WALLET);
+    },
+    async claimJob(jobId, wallet) {
+      assert.equal(jobId, job.id);
+      assert.equal(wallet, WALLET);
+    }
   };
   const service = new JobExecutionService(stateStore, blockchainGateway, () => job);
 

--- a/test/AgentPlatform.t.sol
+++ b/test/AgentPlatform.t.sol
@@ -104,6 +104,26 @@ contract AgentPlatformTest is Test {
         assertEq(reputation.balanceOf(worker), 1);
     }
 
+    function testOperatorRelayedClaimUsesWorkerWalletForStakeAndReceipt() public {
+        bytes32 jobId = keccak256("job/relayed-claim/1");
+
+        vm.prank(poster);
+        escrow.createSinglePayoutJob(
+            jobId, address(dot), 100 ether, 10 ether, 5 ether, 1 days, bytes32("AUTO"), bytes32("CODING"), SPEC_HASH
+        );
+
+        escrow.claimJobFor(jobId, worker);
+
+        EscrowCore.JobEscrow memory claimedJob = escrow.jobs(jobId);
+        (uint256 workerLiquid,,,, uint256 workerJobStake,) = accounts.positions(worker, address(dot));
+        (,,,, uint256 operatorJobStake,) = accounts.positions(address(this), address(dot));
+
+        assertEq(claimedJob.worker, worker);
+        assertEq(workerLiquid, WORKER_DEPOSIT - 5 ether);
+        assertEq(workerJobStake, 5 ether);
+        assertEq(operatorJobStake, 0);
+    }
+
     function testDisputeWindowAndArbitratorSlaMatchSpec() public view {
         assertEq(escrow.DISPUTE_WINDOW(), 7 days);
         assertEq(escrow.ARBITRATOR_SLA(), 14 days);


### PR DESCRIPTION
## Summary
- Add an operator-gated EscrowCore.claimJobFor(jobId, worker) relay path so backend-sponsored claims record the authenticated worker wallet on chain.
- Make blockchain claim staking/liquidity checks read the worker wallet's AgentAccountCore position instead of the backend signer position.
- Update backend claim relay calls and ABI/tests so direct wallet claims still use claimJob while operator relays use claimJobFor.

## Checks
- forge test --match-path test/AgentPlatform.t.sol
- node --test mcp-server/src/blockchain/gateway.test.js mcp-server/src/core/job-execution-service.test.js
- forge test
- forge build
- npm --workspace mcp-server test
- git diff --check

## Impact
- Contracts: yes
- Backend: yes
- Indexer: no
- Frontend: no
- Caddy/public site: no
- Env/VPS secrets: no
- Contract deployment required: yes, this changes EscrowCore bytecode; backend should only rely on claimJobFor after the matching contract deployment.