### PR TITLE
Harden product-proof claim liquidity preflight

### DIFF
--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -257,7 +257,9 @@ RUN_SUBSCAN_XCM_VALIDATION=1 ./scripts/ops/check-release-readiness.sh testnet
   validation response is not `{ valid: true }`. The hosted worker-loop evidence
   must include both `validationReadiness` for the direct schema object and
   `invalidValidationReadiness` for a rejected `submission.output` wrapper with
-  `submitAttempted=false`. Flip this box after the hosted run-detail surface or
+  `submitAttempted=false`, plus `claimLiquidityReadiness` proving the worker's
+  USDC liquid balance covered reward plus preflight claim lock before claim.
+  Flip this box after the hosted run-detail surface or
   product-proof worker loop has been used to validate at least one
   structured-required job (one valid, one invalid) and the invalid attempt did
   not consume the session's submit budget. Verify with the regression tests:

--- a/docs/PRODUCT_PROOF_GATE.md
+++ b/docs/PRODUCT_PROOF_GATE.md
@@ -112,7 +112,15 @@ The worker-loop command writes a local evidence file like:
     "wallet": "0x...",
     "asset": "USDC",
     "requiredRaw": "100000",
-    "availableRaw": "100000"
+    "availableRaw": "155000"
+  },
+  "claimLiquidityReadiness": {
+    "wallet": "0x...",
+    "asset": "USDC",
+    "rewardRaw": "100000",
+    "totalClaimLockRaw": "55000",
+    "requiredRaw": "155000",
+    "availableRaw": "155000"
   },
   "preflightReadiness": {
     "jobId": "product-proof-worker-loop-...",
@@ -167,7 +175,8 @@ The script fetches the badge and profile documents and verifies that:
 
 - the evidence host matches the checked API host
 - the evidence proves canonical v1 USDC settlement readiness
-- the reward clears the USDC minBalance and the worker has enough USDC liquidity
+- the reward clears the USDC minBalance and the worker has enough USDC
+  liquidity for both the reward and the claim lock required by preflight
 - the job preflight was eligible and claimable before claim
 - the product-proof submission passed schema validation before claim
 - one intentionally invalid `submission.output` wrapper failed validation before

--- a/scripts/ops/check-product-proof-gate.mjs
+++ b/scripts/ops/check-product-proof-gate.mjs
@@ -195,6 +195,24 @@ function assertWorkerLoopCompletionEvidence(evidence, { apiBaseUrl }) {
     "worker-loop evidence liquidity must cover required reward"
   );
 
+  assert.equal(evidence.claimLiquidityReadiness?.wallet?.toLowerCase(), evidence.wallet.toLowerCase(), "worker-loop evidence claim liquidity wallet must match worker wallet");
+  assert.equal(evidence.claimLiquidityReadiness?.asset, REQUIRED_ESCROW_ASSET.symbol, "worker-loop evidence claim liquidity readiness must be USDC");
+  assert.equal(
+    evidence.claimLiquidityReadiness?.rewardRaw,
+    evidence.rewardReadiness?.rewardRaw,
+    "worker-loop evidence claim liquidity rewardRaw must match reward readiness"
+  );
+  assertRawAtLeast(
+    evidence.claimLiquidityReadiness?.requiredRaw,
+    evidence.rewardReadiness?.rewardRaw,
+    "worker-loop evidence claim liquidity requirement must include at least the reward"
+  );
+  assertRawAtLeast(
+    evidence.claimLiquidityReadiness?.availableRaw,
+    evidence.claimLiquidityReadiness?.requiredRaw,
+    "worker-loop evidence claim liquidity must cover reward plus claim lock"
+  );
+
   assert.equal(evidence.preflightReadiness?.jobId, evidence.jobId, "worker-loop evidence preflight jobId must match evidence jobId");
   assert.equal(String(evidence.preflightReadiness?.wallet ?? "").toLowerCase(), evidence.wallet.toLowerCase(), "worker-loop evidence preflight wallet must match worker wallet");
   assert.equal(evidence.preflightReadiness?.eligible, true, "worker-loop evidence requires eligible preflight");

--- a/scripts/ops/check-product-proof-gate.test.mjs
+++ b/scripts/ops/check-product-proof-gate.test.mjs
@@ -317,7 +317,15 @@ function workerLoopEvidence({ wallet, sessionId, jobId }) {
       wallet,
       asset: "USDC",
       requiredRaw: "100000",
-      availableRaw: "100000"
+      availableRaw: "155000"
+    },
+    claimLiquidityReadiness: {
+      wallet,
+      asset: "USDC",
+      rewardRaw: "100000",
+      totalClaimLockRaw: "55000",
+      requiredRaw: "155000",
+      availableRaw: "155000"
     },
     preflightReadiness: {
       wallet,

--- a/scripts/ops/run-hosted-worker-loop.mjs
+++ b/scripts/ops/run-hosted-worker-loop.mjs
@@ -90,6 +90,14 @@ export async function runHostedWorkerLoop({
   log(`Preflighting hosted product-proof job ${jobId}`);
   const preflight = await platform.preflightJob(jobId);
   const preflightReadiness = assertClaimPreflightReady({ preflight, jobId, wallet });
+  const claimLiquidityReadiness = assertClaimLiquidityReady({
+    wallet,
+    rewardAsset,
+    rewardAmount: rewardAmountInput,
+    preflightReadiness,
+    liquidityReadiness,
+    settlementReadiness
+  });
 
   log(`Validating hosted product-proof submission for ${jobId}`);
   const validationReadiness = await assertSubmissionValidationReady({
@@ -155,6 +163,7 @@ export async function runHostedWorkerLoop({
     settlementReadiness,
     rewardReadiness,
     liquidityReadiness,
+    claimLiquidityReadiness,
     preflightReadiness,
     validationReadiness,
     invalidValidationReadiness,
@@ -316,6 +325,47 @@ async function assertProductProofLiquidity({ platform, wallet, rewardAsset, rewa
     asset: rewardAsset,
     requiredRaw: requiredRaw.toString(),
     availableRaw: availableRaw.toString(),
+    required: formatBaseUnits(requiredRaw, decimals),
+    available: formatBaseUnits(availableRaw, decimals)
+  };
+}
+
+function assertClaimLiquidityReady({
+  wallet,
+  rewardAsset,
+  rewardAmount,
+  preflightReadiness,
+  liquidityReadiness,
+  settlementReadiness
+}) {
+  const asset = settlementReadiness.asset;
+  const decimals = Number(asset.decimals);
+  const rewardRaw = toBaseUnits(rewardAmount, decimals);
+  const totalClaimLockRaw = preflightReadiness.totalClaimLock === null || preflightReadiness.totalClaimLock === undefined
+    ? 0n
+    : toBaseUnits(preflightReadiness.totalClaimLock, decimals);
+  const requiredRaw = rewardRaw + totalClaimLockRaw;
+  const availableRaw = toBigIntAmount(liquidityReadiness.availableRaw, `${rewardAsset} liquid balance raw`);
+  if (availableRaw < requiredRaw) {
+    const agentAccountAddress = settlementReadiness.contracts?.agentAccountAddress ?? "AgentAccountCore";
+    throw new Error(
+      `Hosted product-proof worker loop requires funded ${rewardAsset} liquidity before claim; ` +
+      `wallet=${wallet}; account=${agentAccountAddress}; reward=${formatBaseUnits(rewardRaw, decimals)} ${rewardAsset} ` +
+      `(raw ${rewardRaw}); totalClaimLock=${formatBaseUnits(totalClaimLockRaw, decimals)} ${rewardAsset} ` +
+      `(raw ${totalClaimLockRaw}); required=${formatBaseUnits(requiredRaw, decimals)} ${rewardAsset} ` +
+      `(raw ${requiredRaw}); available=${formatBaseUnits(availableRaw, decimals)} ${rewardAsset} (raw ${availableRaw}). ` +
+      `Fund by approving ${agentAccountAddress} on the canonical ${rewardAsset} ERC20 precompile and depositing into AgentAccountCore.`
+    );
+  }
+  return {
+    wallet,
+    asset: rewardAsset,
+    rewardRaw: rewardRaw.toString(),
+    totalClaimLockRaw: totalClaimLockRaw.toString(),
+    requiredRaw: requiredRaw.toString(),
+    availableRaw: availableRaw.toString(),
+    reward: formatBaseUnits(rewardRaw, decimals),
+    totalClaimLock: formatBaseUnits(totalClaimLockRaw, decimals),
     required: formatBaseUnits(requiredRaw, decimals),
     available: formatBaseUnits(availableRaw, decimals)
   };

--- a/scripts/ops/run-hosted-worker-loop.test.mjs
+++ b/scripts/ops/run-hosted-worker-loop.test.mjs
@@ -114,6 +114,10 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
   assert.equal(written.rewardReadiness.rewardRaw, "100000");
   assert.equal(written.liquidityReadiness.requiredRaw, "100000");
   assert.equal(written.liquidityReadiness.availableRaw, "100000");
+  assert.equal(written.claimLiquidityReadiness.rewardRaw, "100000");
+  assert.equal(written.claimLiquidityReadiness.totalClaimLockRaw, "0");
+  assert.equal(written.claimLiquidityReadiness.requiredRaw, "100000");
+  assert.equal(written.claimLiquidityReadiness.availableRaw, "100000");
   assert.deepEqual(written.authReadiness.roles, ["admin", "verifier"]);
   assert.ok(written.authReadiness.capabilitiesPresent.includes("verifier:run"));
   assert.equal(written.preflightReadiness.eligible, true);
@@ -404,6 +408,58 @@ test("runHostedWorkerLoop fails closed after job creation when preflight blocks 
       env: { ADMIN_JWT: "token" }
     }),
     /preflight failed: eligible=false; claimable=false; currentWalletCanClaim=false; reason=tier_gate/u
+  );
+
+  assert.deepEqual(calls.map(([name]) => name), [
+    "getAuthSession",
+    "getAdminStatus",
+    "getAccountSummary",
+    "createJob",
+    "preflightJob"
+  ]);
+  assert.equal(calls[4][1], jobId);
+});
+
+test("runHostedWorkerLoop fails closed after preflight when reward plus claim lock is underfunded", async () => {
+  const calls = [];
+  const jobId = "product-proof-worker-loop-1700000000000";
+  await assert.rejects(
+    runHostedWorkerLoop({
+      client: {
+        async getAuthSession() {
+          calls.push(["getAuthSession"]);
+          return authSession();
+        },
+        async getAdminStatus() {
+          calls.push(["getAdminStatus"]);
+          return settlementReadyStatus();
+        },
+        async getAccountSummary() {
+          calls.push(["getAccountSummary"]);
+          return accountSummary({ liquidUsdcRaw: 100_000 });
+        },
+        async createJob(payload) {
+          calls.push(["createJob", payload]);
+          return { id: payload.id };
+        },
+        async preflightJob(id) {
+          calls.push(["preflightJob", id]);
+          return preflightReady({ jobId: id, totalClaimLock: 0.055 });
+        },
+        async validateJobSubmission() {
+          calls.push(["validateJobSubmission"]);
+          throw new Error("should not validate after claim-liquidity preflight fails");
+        },
+        async claimJob() {
+          calls.push(["claimJob"]);
+          throw new Error("should not claim without reward plus claim-lock liquidity");
+        }
+      },
+      now: () => 1700000000000,
+      log: () => {},
+      env: { ADMIN_JWT: "token" }
+    }),
+    /requires funded USDC liquidity before claim; wallet=0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519; account=0x3333333333333333333333333333333333333333; reward=0\.1 USDC \(raw 100000\); totalClaimLock=0\.055 USDC \(raw 55000\); required=0\.155 USDC \(raw 155000\); available=0\.1 USDC \(raw 100000\)/u
   );
 
   assert.deepEqual(calls.map(([name]) => name), [
@@ -725,7 +781,8 @@ function accountSummary({
 
 function preflightReady({
   jobId,
-  wallet = "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519"
+  wallet = "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+  totalClaimLock = 0
 }) {
   return {
     jobId,
@@ -736,7 +793,7 @@ function preflightReady({
     reason: "claimable",
     requiredOutputSchema: "schema://jobs/product-proof-worker-loop",
     verifierMode: "benchmark",
-    totalClaimLock: 0,
+    totalClaimLock,
     claimEconomicsWaived: true
   };
 }


### PR DESCRIPTION
## Summary
- add claimLiquidityReadiness to hosted worker-loop evidence so proof checks reward plus preflight claim lock liquidity
- fail closed after preflight and before claim when AgentAccountCore USDC liquidity cannot cover reward + totalClaimLock
- update product-proof gate/docs to require claim-liquidity evidence

## Checks
- node --test scripts/ops/run-hosted-worker-loop.test.mjs scripts/ops/check-product-proof-gate.test.mjs scripts/ops/check-hosted-stack.test.mjs
- git diff --cached --check
- npm run test:ops (fails locally on existing missing @polkadot/util-crypto for scripts/ops/prepare-multisig-owner-record.test.mjs after relevant tests pass)

## Surface
- ops scripts/docs only; no backend/frontend/indexer/contracts changes