### PR TITLE
Normalize product-proof claim lock decimals

### DIFF
--- a/scripts/ops/run-hosted-worker-loop.mjs
+++ b/scripts/ops/run-hosted-worker-loop.mjs
@@ -492,13 +492,22 @@ function toBaseUnits(amount, decimals) {
   if (!Number.isInteger(decimals) || decimals < 0 || decimals > 30) {
     throw new Error(`Settlement asset decimals must be an integer in [0, 30]; got ${JSON.stringify(decimals)}.`);
   }
-  const normalized = normalizeDecimalString(amount);
+  const normalized = typeof amount === "number"
+    ? normalizeDisplayNumber(amount, decimals)
+    : normalizeDecimalString(amount);
   const [whole, fractional = ""] = normalized.split(".");
   if (fractional.length > decimals) {
     throw new Error(`PRODUCT_PROOF_REWARD_AMOUNT must fit ${decimals} decimal places; got ${normalized}.`);
   }
   return BigInt(whole) * (10n ** BigInt(decimals))
     + BigInt(fractional.padEnd(decimals, "0") || "0");
+}
+
+function normalizeDisplayNumber(value, decimals) {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`PRODUCT_PROOF_REWARD_AMOUNT must be a positive decimal amount; got ${JSON.stringify(value)}.`);
+  }
+  return value.toFixed(decimals).replace(/(?:\.0+|(\.\d*?)0+)$/u, "$1");
 }
 
 function normalizeDecimalString(value) {

--- a/scripts/ops/run-hosted-worker-loop.test.mjs
+++ b/scripts/ops/run-hosted-worker-loop.test.mjs
@@ -298,6 +298,58 @@ test("runHostedWorkerLoop accepts display-unit account liquidity when raw balanc
   assert.equal(result.liquidityReadiness.availableRaw, "100000");
 });
 
+test("runHostedWorkerLoop normalizes floating preflight claim lock display values", async () => {
+  const client = {
+    async getAuthSession() {
+      return authSession();
+    },
+    async getAdminStatus() {
+      return settlementReadyStatus();
+    },
+    async getAccountSummary() {
+      return accountSummary({ liquidUsdcRaw: 160_000 });
+    },
+    async createJob(payload) {
+      return { id: payload.id };
+    },
+    async preflightJob(id) {
+      return preflightReady({ jobId: id, totalClaimLock: 0.060000000000000005 });
+    },
+    async validateJobSubmission(id, submission) {
+      return validationForSubmission({ jobId: id, submission });
+    },
+    async claimJob(id) {
+      return { status: "claimed", sessionId: `${id}:wallet` };
+    },
+    async submitWork(id) {
+      return { status: "submitted", sessionId: id };
+    },
+    async runVerifier() {
+      return { outcome: "approved" };
+    },
+    async getSession(id) {
+      return { status: "resolved", sessionId: id };
+    },
+    async getAgentBadge(id) {
+      return { averray: { sessionId: id, jobId: "product-proof-worker-loop-1700000000000" } };
+    },
+    async getAgentProfile() {
+      return { badges: [{ sessionId: "product-proof-worker-loop-1700000000000:wallet", jobId: "product-proof-worker-loop-1700000000000" }] };
+    }
+  };
+
+  const result = await runHostedWorkerLoop({
+    client,
+    now: () => 1700000000000,
+    log: () => {},
+    env: { ADMIN_JWT: "token" }
+  });
+
+  assert.equal(result.claimLiquidityReadiness.rewardRaw, "100000");
+  assert.equal(result.claimLiquidityReadiness.totalClaimLockRaw, "60000");
+  assert.equal(result.claimLiquidityReadiness.requiredRaw, "160000");
+});
+
 test("runHostedWorkerLoop fails closed before mutation when AgentAccountCore USDC liquidity is missing", async () => {
   const calls = [];
   const wallet = "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519";


### PR DESCRIPTION
## Summary
- normalize numeric preflight totalClaimLock values to the settlement asset decimals before raw-unit conversion
- cover the observed 0.060000000000000005 display-value case from the hosted product-proof run

## Checks
- node --test scripts/ops/run-hosted-worker-loop.test.mjs scripts/ops/check-product-proof-gate.test.mjs scripts/ops/check-hosted-stack.test.mjs
- git diff --cached --check

## Surface
- ops script only; no backend/frontend/indexer/contracts changes