### PR TITLE
Keep async XCM pending accounting idempotent

### DIFF
--- a/mcp-server/src/core/account-mutation-service.js
+++ b/mcp-server/src/core/account-mutation-service.js
@@ -386,30 +386,40 @@ export class AccountMutationService {
     const liveAccount = await this.blockchainGateway.requestStrategyDeposit(wallet, strategy, amount, options);
     const account = this.attachStoredTreasuryMetadata(wallet, liveAccount);
     const pending = this.getStrategyPending(account, strategyId, asset);
+    const requestId = liveAccount?.requestId;
     const requestedAssetsRaw = normalizeUnsignedRawAmount(
       liveAccount?.xcmRequest?.requestedAssetsRaw ?? liveAccount?.strategyRequest?.requestedAssetsRaw
     );
-    pending.pendingDepositAssets = Number(pending.pendingDepositAssets ?? 0) + Number(liveAccount?.xcmRequest?.requestedAssets ?? amount);
-    if (requestedAssetsRaw !== undefined) {
-      pending.pendingDepositAssetsRaw = addRawAmount(pending.pendingDepositAssetsRaw, requestedAssetsRaw);
+    const statusLabel = liveAccount?.strategyRequest?.statusLabel ?? liveAccount?.xcmRequest?.statusLabel ?? "pending";
+    pending.pendingDepositRequestIds = normalizeRequestIds(pending.pendingDepositRequestIds);
+    const duplicateRequest = hasRequestId(pending.pendingDepositRequestIds, requestId);
+    const shouldCountPending = statusLabel === "pending" && !duplicateRequest;
+    if (shouldCountPending) {
+      pending.pendingDepositAssets = Number(pending.pendingDepositAssets ?? 0) + Number(liveAccount?.xcmRequest?.requestedAssets ?? amount);
+      if (requestedAssetsRaw !== undefined) {
+        pending.pendingDepositAssetsRaw = addRawAmount(pending.pendingDepositAssetsRaw, requestedAssetsRaw);
+      }
+      pending.pendingDepositRequestIds = addRequestId(pending.pendingDepositRequestIds, requestId);
     }
-    pending.lastRequestId = liveAccount?.requestId;
-    pending.lastStatus = liveAccount?.xcmRequest?.statusLabel ?? "pending";
+    pending.lastRequestId = requestId;
+    pending.lastStatus = statusLabel;
     pending.lastKind = "deposit";
     pending.updatedAt = new Date().toISOString();
     this.markStrategyActivity(account, strategyId, "allocate_requested", amount, asset);
-    this.recordTreasuryEvent(account, {
-      type: "allocate_requested",
-      strategyId,
-      asset,
-      amount,
-      ...(requestedAssetsRaw !== undefined ? { amountRaw: requestedAssetsRaw } : {}),
-      requestId: liveAccount?.requestId
-    });
+    if (shouldCountPending) {
+      this.recordTreasuryEvent(account, {
+        type: "allocate_requested",
+        strategyId,
+        asset,
+        amount,
+        ...(requestedAssetsRaw !== undefined ? { amountRaw: requestedAssetsRaw } : {}),
+        requestId
+      });
+    }
     this.accounts.set(wallet, account);
     return {
       ...account,
-      requestId: liveAccount?.requestId,
+      requestId,
       xcmRequest: liveAccount?.xcmRequest,
       strategyRequest: liveAccount?.strategyRequest
     };
@@ -462,38 +472,48 @@ export class AccountMutationService {
     const liveAccount = await this.blockchainGateway.requestStrategyWithdraw(wallet, strategy, amount, options);
     const account = this.attachStoredTreasuryMetadata(wallet, liveAccount);
     const pending = this.getStrategyPending(account, strategyId, asset);
+    const requestId = liveAccount?.requestId;
     const requestedSharesRaw = normalizeUnsignedRawAmount(
       liveAccount?.strategyRequest?.requestedSharesRaw ??
       liveAccount?.xcmRequest?.requestedSharesRaw ??
       liveAccount?.requestedSharesRaw
     );
-    pending.pendingWithdrawalShares = Number(pending.pendingWithdrawalShares ?? 0) + Number(
-      liveAccount?.strategyRequest?.requestedShares ??
-      liveAccount?.xcmRequest?.requestedShares ??
-      liveAccount?.requestedShares ??
-      amount
-    );
-    if (requestedSharesRaw !== undefined) {
-      pending.pendingWithdrawalSharesRaw = addRawAmount(pending.pendingWithdrawalSharesRaw, requestedSharesRaw);
+    const statusLabel = liveAccount?.strategyRequest?.statusLabel ?? liveAccount?.xcmRequest?.statusLabel ?? "pending";
+    pending.pendingWithdrawalRequestIds = normalizeRequestIds(pending.pendingWithdrawalRequestIds);
+    const duplicateRequest = hasRequestId(pending.pendingWithdrawalRequestIds, requestId);
+    const shouldCountPending = statusLabel === "pending" && !duplicateRequest;
+    if (shouldCountPending) {
+      pending.pendingWithdrawalShares = Number(pending.pendingWithdrawalShares ?? 0) + Number(
+        liveAccount?.strategyRequest?.requestedShares ??
+        liveAccount?.xcmRequest?.requestedShares ??
+        liveAccount?.requestedShares ??
+        amount
+      );
+      if (requestedSharesRaw !== undefined) {
+        pending.pendingWithdrawalSharesRaw = addRawAmount(pending.pendingWithdrawalSharesRaw, requestedSharesRaw);
+      }
+      pending.pendingWithdrawalRequestIds = addRequestId(pending.pendingWithdrawalRequestIds, requestId);
     }
-    pending.lastRequestId = liveAccount?.requestId;
-    pending.lastStatus = liveAccount?.xcmRequest?.statusLabel ?? "pending";
+    pending.lastRequestId = requestId;
+    pending.lastStatus = statusLabel;
     pending.lastKind = "withdraw";
     pending.updatedAt = new Date().toISOString();
     this.markStrategyActivity(account, strategyId, "deallocate_requested", amount, asset);
-    this.recordTreasuryEvent(account, {
-      type: "deallocate_requested",
-      strategyId,
-      asset,
-      amount,
-      requestedShares: pending.pendingWithdrawalShares,
-      ...(requestedSharesRaw !== undefined ? { requestedSharesRaw } : {}),
-      requestId: liveAccount?.requestId
-    });
+    if (shouldCountPending) {
+      this.recordTreasuryEvent(account, {
+        type: "deallocate_requested",
+        strategyId,
+        asset,
+        amount,
+        requestedShares: pending.pendingWithdrawalShares,
+        ...(requestedSharesRaw !== undefined ? { requestedSharesRaw } : {}),
+        requestId
+      });
+    }
     this.accounts.set(wallet, account);
     return {
       ...account,
-      requestId: liveAccount?.requestId,
+      requestId,
       requestedShares: liveAccount?.requestedShares,
       xcmRequest: liveAccount?.xcmRequest,
       strategyRequest: liveAccount?.strategyRequest
@@ -544,6 +564,7 @@ export class AccountMutationService {
         pending.pendingDepositAssetsRaw,
         requestedAssetsRaw ?? settledAssetsRaw
       );
+      pending.pendingDepositRequestIds = removeRequestId(pending.pendingDepositRequestIds, result?.requestId);
       if (status === "succeeded") {
         this.updateStrategyAccountingOnAllocate(account, strategyId, asset, settledAssets || requestedAssets, {
           amountRaw: settledAssetsRaw ?? requestedAssetsRaw
@@ -565,6 +586,7 @@ export class AccountMutationService {
         pending.pendingWithdrawalSharesRaw,
         requestedSharesRaw ?? settledSharesRaw
       );
+      pending.pendingWithdrawalRequestIds = removeRequestId(pending.pendingWithdrawalRequestIds, result?.requestId);
       if (status === "succeeded") {
         this.updateStrategyAccountingOnDeallocate(account, strategyId, asset, settledAssets, {
           assetsReturnedRaw: settledAssetsRaw
@@ -776,6 +798,41 @@ function subtractRawAmount(current, delta) {
   }
   const next = BigInt(normalizedCurrent) - BigInt(normalizedDelta);
   return next > 0n ? next.toString() : "0";
+}
+
+function normalizeRequestId(requestId) {
+  if (typeof requestId !== "string" || !requestId.trim()) {
+    return undefined;
+  }
+  return requestId.trim().toLowerCase();
+}
+
+function normalizeRequestIds(requestIds) {
+  if (!Array.isArray(requestIds)) {
+    return [];
+  }
+  return requestIds.map(normalizeRequestId).filter(Boolean);
+}
+
+function hasRequestId(requestIds, requestId) {
+  const normalized = normalizeRequestId(requestId);
+  return Boolean(normalized && normalizeRequestIds(requestIds).includes(normalized));
+}
+
+function addRequestId(requestIds, requestId) {
+  const normalized = normalizeRequestId(requestId);
+  if (!normalized) {
+    return normalizeRequestIds(requestIds);
+  }
+  return [...new Set([...normalizeRequestIds(requestIds), normalized])];
+}
+
+function removeRequestId(requestIds, requestId) {
+  const normalized = normalizeRequestId(requestId);
+  if (!normalized) {
+    return normalizeRequestIds(requestIds);
+  }
+  return normalizeRequestIds(requestIds).filter((existing) => existing !== normalized);
 }
 
 function addSignedRawAmount(current, delta) {

--- a/mcp-server/src/core/agent-transfer.test.js
+++ b/mcp-server/src/core/agent-transfer.test.js
@@ -192,9 +192,125 @@ test("requestStrategyDeposit delegates async lanes to the blockchain gateway and
   assert.equal(updated.requestId, "0xreq");
   assert.equal(updated.strategyPending["0xstrategy"].pendingDepositAssets, 6);
   assert.equal(updated.strategyPending["0xstrategy"].pendingDepositAssetsRaw, "6000000");
+  assert.deepEqual(updated.strategyPending["0xstrategy"].pendingDepositRequestIds, ["0xreq"]);
   assert.equal(updated.strategyActivity["0xstrategy"].action, "allocate_requested");
   assert.equal(updated.treasuryTimeline[0].type, "allocate_requested");
   assert.equal(updated.treasuryTimeline[0].amountRaw, "6000000");
+});
+
+test("requestStrategyDeposit does not double-count an idempotent async retry", async () => {
+  const calls = [];
+  const gateway = {
+    isEnabled: () => true,
+    requestStrategyDeposit: async (...args) => {
+      calls.push(args);
+      return {
+        wallet: "0xAlice",
+        liquid: { DOT: 14 },
+        reserved: {},
+        strategyAllocated: { DOT: 0 },
+        collateralLocked: {},
+        jobStakeLocked: {},
+        debtOutstanding: {},
+        requestId: "0xreq",
+        xcmRequest: { statusLabel: "pending", requestedAssets: 6, requestedAssetsRaw: "6000000" },
+        strategyRequest: { strategyId: "0xstrategy", requestedAssets: 6, requestedAssetsRaw: "6000000", requestedShares: 0 }
+      };
+    }
+  };
+  const accounts = new Map();
+  const getAccountSummary = async (wallet) => ({
+    wallet,
+    liquid: { DOT: 14 },
+    reserved: {},
+    strategyAllocated: { DOT: 0 },
+    strategyShares: {},
+    strategyActivity: {},
+    strategyPending: {},
+    strategyAccounting: {},
+    treasuryTimeline: [],
+    collateralLocked: {},
+    jobStakeLocked: {},
+    debtOutstanding: {}
+  });
+  const service = new AccountMutationService(accounts, gateway, getAccountSummary);
+
+  await service.requestStrategyDeposit(
+    "0xAlice",
+    "DOT",
+    6,
+    "0xstrategy",
+    { strategyId: "0xstrategy", executionMode: "async_xcm", asset: "0xdot" },
+    { nonce: 7 }
+  );
+  const retry = await service.requestStrategyDeposit(
+    "0xAlice",
+    "DOT",
+    6,
+    "0xstrategy",
+    { strategyId: "0xstrategy", executionMode: "async_xcm", asset: "0xdot" },
+    { nonce: 7 }
+  );
+
+  assert.equal(calls.length, 2);
+  assert.equal(retry.strategyPending["0xstrategy"].pendingDepositAssets, 6);
+  assert.equal(retry.strategyPending["0xstrategy"].pendingDepositAssetsRaw, "6000000");
+  assert.deepEqual(retry.strategyPending["0xstrategy"].pendingDepositRequestIds, ["0xreq"]);
+  assert.equal(retry.treasuryTimeline.filter((event) => event.type === "allocate_requested").length, 1);
+});
+
+test("requestStrategyDeposit does not reopen pending accounting for a settled retry", async () => {
+  const gateway = {
+    isEnabled: () => true,
+    requestStrategyDeposit: async () => ({
+      wallet: "0xAlice",
+      liquid: { DOT: 14 },
+      reserved: {},
+      strategyAllocated: { DOT: 6 },
+      collateralLocked: {},
+      jobStakeLocked: {},
+      debtOutstanding: {},
+      requestId: "0xreq",
+      xcmRequest: { statusLabel: "succeeded", requestedAssets: 6, requestedAssetsRaw: "6000000" },
+      strategyRequest: {
+        strategyId: "0xstrategy",
+        statusLabel: "succeeded",
+        requestedAssets: 6,
+        requestedAssetsRaw: "6000000",
+        requestedShares: 0
+      }
+    })
+  };
+  const accounts = new Map();
+  const getAccountSummary = async (wallet) => ({
+    wallet,
+    liquid: { DOT: 14 },
+    reserved: {},
+    strategyAllocated: { DOT: 6 },
+    strategyShares: { "0xstrategy": 6 },
+    strategyActivity: {},
+    strategyPending: {},
+    strategyAccounting: {},
+    treasuryTimeline: [],
+    collateralLocked: {},
+    jobStakeLocked: {},
+    debtOutstanding: {}
+  });
+  const service = new AccountMutationService(accounts, gateway, getAccountSummary);
+
+  const retry = await service.requestStrategyDeposit(
+    "0xAlice",
+    "DOT",
+    6,
+    "0xstrategy",
+    { strategyId: "0xstrategy", executionMode: "async_xcm", asset: "0xdot" },
+    { nonce: 7 }
+  );
+
+  assert.equal(retry.strategyPending["0xstrategy"].pendingDepositAssets, 0);
+  assert.deepEqual(retry.strategyPending["0xstrategy"].pendingDepositRequestIds, []);
+  assert.equal(retry.strategyPending["0xstrategy"].lastStatus, "succeeded");
+  assert.equal(retry.treasuryTimeline.length, 0);
 });
 
 test("borrow uses live borrow capacity and updates liquid plus debt", async () => {
@@ -293,9 +409,124 @@ test("requestStrategyWithdraw delegates async lanes to the blockchain gateway an
   assert.equal(updated.requestId, "0xwithdraw");
   assert.equal(updated.strategyPending["0xstrategy"].pendingWithdrawalShares, 4);
   assert.equal(updated.strategyPending["0xstrategy"].pendingWithdrawalSharesRaw, "4000000");
+  assert.deepEqual(updated.strategyPending["0xstrategy"].pendingWithdrawalRequestIds, ["0xwithdraw"]);
   assert.equal(updated.strategyActivity["0xstrategy"].action, "deallocate_requested");
   assert.equal(updated.treasuryTimeline[0].type, "deallocate_requested");
   assert.equal(updated.treasuryTimeline[0].requestedSharesRaw, "4000000");
+});
+
+test("requestStrategyWithdraw does not double-count an idempotent async retry", async () => {
+  const gateway = {
+    isEnabled: () => true,
+    requestStrategyWithdraw: async () => ({
+      wallet: "0xAlice",
+      liquid: { DOT: 5 },
+      reserved: {},
+      strategyAllocated: { DOT: 10 },
+      collateralLocked: {},
+      jobStakeLocked: {},
+      debtOutstanding: {},
+      requestId: "0xwithdraw",
+      requestedShares: 4,
+      requestedSharesRaw: "4000000",
+      xcmRequest: { statusLabel: "pending", requestedShares: 4, requestedSharesRaw: "4000000" },
+      strategyRequest: { strategyId: "0xstrategy", requestedAssets: 3, requestedShares: 4, requestedSharesRaw: "4000000" }
+    })
+  };
+  const accounts = new Map();
+  const getAccountSummary = async (wallet) => ({
+    wallet,
+    liquid: { DOT: 5 },
+    reserved: {},
+    strategyAllocated: { DOT: 10 },
+    strategyShares: { "0xstrategy": 10 },
+    strategyActivity: {},
+    strategyPending: {},
+    strategyAccounting: {},
+    treasuryTimeline: [],
+    collateralLocked: {},
+    jobStakeLocked: {},
+    debtOutstanding: {}
+  });
+  const service = new AccountMutationService(accounts, gateway, getAccountSummary);
+
+  await service.requestStrategyWithdraw(
+    "0xAlice",
+    "DOT",
+    3,
+    "0xstrategy",
+    { strategyId: "0xstrategy", executionMode: "async_xcm", asset: "0xdot" },
+    { nonce: 8, recipient: "0xReceiver" }
+  );
+  const retry = await service.requestStrategyWithdraw(
+    "0xAlice",
+    "DOT",
+    3,
+    "0xstrategy",
+    { strategyId: "0xstrategy", executionMode: "async_xcm", asset: "0xdot" },
+    { nonce: 8, recipient: "0xReceiver" }
+  );
+
+  assert.equal(retry.strategyPending["0xstrategy"].pendingWithdrawalShares, 4);
+  assert.equal(retry.strategyPending["0xstrategy"].pendingWithdrawalSharesRaw, "4000000");
+  assert.deepEqual(retry.strategyPending["0xstrategy"].pendingWithdrawalRequestIds, ["0xwithdraw"]);
+  assert.equal(retry.treasuryTimeline.filter((event) => event.type === "deallocate_requested").length, 1);
+});
+
+test("requestStrategyWithdraw does not reopen pending accounting for a settled retry", async () => {
+  const gateway = {
+    isEnabled: () => true,
+    requestStrategyWithdraw: async () => ({
+      wallet: "0xAlice",
+      liquid: { DOT: 9 },
+      reserved: {},
+      strategyAllocated: { DOT: 6 },
+      collateralLocked: {},
+      jobStakeLocked: {},
+      debtOutstanding: {},
+      requestId: "0xwithdraw",
+      requestedShares: 4,
+      requestedSharesRaw: "4000000",
+      xcmRequest: { statusLabel: "succeeded", requestedShares: 4, requestedSharesRaw: "4000000" },
+      strategyRequest: {
+        strategyId: "0xstrategy",
+        statusLabel: "succeeded",
+        requestedAssets: 3,
+        requestedShares: 4,
+        requestedSharesRaw: "4000000"
+      }
+    })
+  };
+  const accounts = new Map();
+  const getAccountSummary = async (wallet) => ({
+    wallet,
+    liquid: { DOT: 9 },
+    reserved: {},
+    strategyAllocated: { DOT: 6 },
+    strategyShares: { "0xstrategy": 6 },
+    strategyActivity: {},
+    strategyPending: {},
+    strategyAccounting: {},
+    treasuryTimeline: [],
+    collateralLocked: {},
+    jobStakeLocked: {},
+    debtOutstanding: {}
+  });
+  const service = new AccountMutationService(accounts, gateway, getAccountSummary);
+
+  const retry = await service.requestStrategyWithdraw(
+    "0xAlice",
+    "DOT",
+    3,
+    "0xstrategy",
+    { strategyId: "0xstrategy", executionMode: "async_xcm", asset: "0xdot" },
+    { nonce: 8, recipient: "0xReceiver" }
+  );
+
+  assert.equal(retry.strategyPending["0xstrategy"].pendingWithdrawalShares, 0);
+  assert.deepEqual(retry.strategyPending["0xstrategy"].pendingWithdrawalRequestIds, []);
+  assert.equal(retry.strategyPending["0xstrategy"].lastStatus, "succeeded");
+  assert.equal(retry.treasuryTimeline.length, 0);
 });
 
 test("recordStrategySnapshots updates mark-to-market and appends a yield event on change", async () => {
@@ -334,6 +565,7 @@ test("recordAsyncStrategySettlement updates accounting and clears pending state"
     asset: "DOT",
     pendingDepositAssets: 6,
     pendingDepositAssetsRaw: "6000000",
+    pendingDepositRequestIds: ["0xreq"],
     pendingWithdrawalShares: 0
   };
   accounts.set("0xAlice", account);
@@ -355,6 +587,7 @@ test("recordAsyncStrategySettlement updates accounting and clears pending state"
 
   assert.equal(updated.strategyPending["0xstrategy"].pendingDepositAssets, 0);
   assert.equal(updated.strategyPending["0xstrategy"].pendingDepositAssetsRaw, "0");
+  assert.deepEqual(updated.strategyPending["0xstrategy"].pendingDepositRequestIds, []);
   assert.equal(updated.strategyAccounting["0xstrategy"].principal, 6.000001);
   assert.equal(updated.strategyAccounting["0xstrategy"].principalRaw, "6000001");
   assert.equal(updated.strategyAccounting["0xstrategy"].markValueRaw, "6000001");
@@ -370,7 +603,8 @@ test("recordAsyncStrategySettlement preserves raw asset accounting when withdraw
     asset: "DOT",
     pendingDepositAssets: 0,
     pendingWithdrawalShares: 4,
-    pendingWithdrawalSharesRaw: "4000000"
+    pendingWithdrawalSharesRaw: "4000000",
+    pendingWithdrawalRequestIds: ["0xwithdraw"]
   };
   account.strategyAccounting["0xstrategy"] = {
     asset: "DOT",
@@ -400,6 +634,7 @@ test("recordAsyncStrategySettlement preserves raw asset accounting when withdraw
 
   assert.equal(updated.strategyPending["0xstrategy"].pendingWithdrawalShares, 0);
   assert.equal(updated.strategyPending["0xstrategy"].pendingWithdrawalSharesRaw, "0");
+  assert.deepEqual(updated.strategyPending["0xstrategy"].pendingWithdrawalRequestIds, []);
   assert.equal(updated.strategyAccounting["0xstrategy"].principal, 6);
   assert.equal(updated.strategyAccounting["0xstrategy"].principalRaw, "6000000");
   assert.equal(updated.strategyAccounting["0xstrategy"].markValueRaw, "6000000");


### PR DESCRIPTION
## Summary
- Track async XCM deposit/withdraw request ids in stored `strategyPending` metadata.
- Avoid incrementing pending deposit/share totals or duplicating treasury timeline events on idempotent request retries.
- Prevent terminal async XCM retries from reopening backend pending accounting, and clear tracked request ids when settlements are recorded.

## Root cause
The contracts and XCM wrapper treat async requests as idempotent by request id/nonce, but the backend pending-accounting layer incremented local `strategyPending` totals every time `requestStrategyDeposit` or `requestStrategyWithdraw` was retried.

## Checks
- `node --test mcp-server/src/core/agent-transfer.test.js`
- `npm --workspace mcp-server test`
- `git diff --check`

## Impact
- Backend: yes
- Contracts: no
- Indexer: no
- Frontend: no
- Caddy/public site: no
- Env/VPS secrets: no
- Contract deployment required: no