### PR TITLE
Guard XCM observations against stale replays

### DIFF
--- a/mcp-server/src/services/xcm-settlement-watcher.js
+++ b/mcp-server/src/services/xcm-settlement-watcher.js
@@ -66,8 +66,14 @@ export class XcmSettlementWatcherService {
       processed: false
     };
     const existing = await this.stateStore.getXcmObservation?.(normalizedRequestId);
-    if (existing && this.isEquivalentObservation(existing, incoming)) {
-      return existing;
+    if (existing) {
+      if (
+        this.isEquivalentObservation(existing, incoming) ||
+        existing.processed ||
+        this.isStaleObservation(existing, incoming)
+      ) {
+        return existing;
+      }
     }
     const observation = await this.stateStore.upsertXcmObservation(incoming);
 
@@ -180,6 +186,14 @@ export class XcmSettlementWatcherService {
         === normalizeObservationAmount(incoming.settledShares, "settledShares")
       && String(existing.remoteRef ?? "") === String(incoming.remoteRef ?? "")
       && String(existing.failureCode ?? "") === String(incoming.failureCode ?? "");
+  }
+
+  isStaleObservation(existing, incoming) {
+    const existingObservedAt = Date.parse(existing?.observedAt ?? "");
+    const incomingObservedAt = Date.parse(incoming?.observedAt ?? "");
+    return Number.isFinite(existingObservedAt) &&
+      Number.isFinite(incomingObservedAt) &&
+      incomingObservedAt <= existingObservedAt;
   }
 }
 

--- a/mcp-server/src/services/xcm-settlement-watcher.test.js
+++ b/mcp-server/src/services/xcm-settlement-watcher.test.js
@@ -278,3 +278,86 @@ test("observeOutcome does not requeue an equivalent processed observation", asyn
   const pending = await stateStore.listPendingXcmObservations(10);
   assert.equal(pending.length, 0);
 });
+
+test("observeOutcome ignores stale conflicting observations for the same request", async () => {
+  const stateStore = new MemoryStateStore();
+  const eventBus = new EventBus();
+  const events = [];
+  eventBus.subscribe({ topics: ["xcm.outcome_observed"] }, (event) => events.push(event));
+  const watcher = new XcmSettlementWatcherService(
+    { finalizeXcmRequest: async () => ({}) },
+    stateStore,
+    eventBus,
+    { enabled: false }
+  );
+
+  await watcher.observeOutcome(REQUEST_ID, {
+    status: "succeeded",
+    settledAssets: 5,
+    observedAt: "2026-05-14T12:00:00Z"
+  });
+
+  const replayed = await watcher.observeOutcome(REQUEST_ID, {
+    status: "failed",
+    settledAssets: 0,
+    failureCode: "STALE_FAILURE",
+    observedAt: "2026-05-14T11:59:59Z"
+  });
+  const stored = await stateStore.getXcmObservation(REQUEST_ID);
+
+  assert.equal(replayed.status, "succeeded");
+  assert.equal(stored.status, "succeeded");
+  assert.equal(stored.settledAssets, "5");
+  assert.equal(stored.observedAt, "2026-05-14T12:00:00.000Z");
+  assert.equal(events.length, 1);
+});
+
+test("observeOutcome does not reopen a processed request with a conflicting replay", async () => {
+  const stateStore = new MemoryStateStore();
+  const eventBus = new EventBus();
+  const observedEvents = [];
+  const finalizedCalls = [];
+  eventBus.subscribe({ topics: ["xcm.outcome_observed"] }, (event) => observedEvents.push(event));
+  const watcher = new XcmSettlementWatcherService(
+    {
+      finalizeXcmRequest: async (requestId, outcome) => {
+        finalizedCalls.push([requestId, outcome]);
+        return {
+          requestId,
+          settledVia: "agent_account",
+          strategyRequest: {
+            account: "0xabc",
+            statusLabel: outcome.status
+          }
+        };
+      }
+    },
+    stateStore,
+    eventBus,
+    { enabled: false }
+  );
+
+  await watcher.observeOutcome(REQUEST_ID, {
+    status: "succeeded",
+    settledAssets: 5,
+    observedAt: "2026-05-14T12:00:00Z"
+  });
+  await watcher.runPendingSettlements();
+
+  const replayed = await watcher.observeOutcome(REQUEST_ID, {
+    status: "failed",
+    settledAssets: 0,
+    failureCode: "CONFLICTING_REPLAY",
+    observedAt: "2026-05-14T12:01:00Z"
+  });
+  const stored = await stateStore.getXcmObservation(REQUEST_ID);
+  const pending = await stateStore.listPendingXcmObservations(10);
+
+  assert.equal(replayed.processed, true);
+  assert.equal(stored.processed, true);
+  assert.equal(stored.status, "succeeded");
+  assert.equal(stored.settledAssets, "5");
+  assert.equal(pending.length, 0);
+  assert.equal(observedEvents.length, 1);
+  assert.equal(finalizedCalls.length, 1);
+});


### PR DESCRIPTION
## Summary
- Keep XCM observation state monotonic for a request id.
- Ignore stale conflicting observer outcomes instead of overwriting newer pending observations.
- Prevent contradictory replays from reopening an already processed XCM request and re-entering the pending watcher queue.

## Root cause
The watcher accepted any non-equivalent terminal observer item for an existing request id. After a request had already been finalized, a later contradictory replay could mark the durable observation as unprocessed again, causing the watcher to retry an immutable chain transition forever.

## Checks
- `node --test mcp-server/src/services/xcm-settlement-watcher.test.js`
- `npm --workspace mcp-server test`
- `git diff --check`

## Impact
- Backend: yes
- Contracts: no
- Indexer: no
- Frontend: no
- Caddy/public site: no
- Env/VPS secrets: no
- Contract deployment required: no