### PR TITLE
Preserve Subscan XCM failure codes

### DIFF
--- a/indexer/src/api/xcm-upstream-source.test.ts
+++ b/indexer/src/api/xcm-upstream-source.test.ts
@@ -190,6 +190,23 @@ test("Subscan source accepts explicit SetTopic request-id fields", () => {
   assert.equal(outcome?.source, "subscan_xcm_api");
 });
 
+test("Subscan source preserves failure code for failed status variants", () => {
+  const adapter = new SubscanXcmSourceAdapter({
+    apiHost: "https://subscan.example",
+    apiKey: "test"
+  });
+
+  const outcome = adapter.normalizeSubscanEntry({
+    message_topic: requestId,
+    execution_status: "xcm_failed",
+    error_code: failureCode,
+    block_timestamp: "1712345678"
+  });
+
+  assert.equal(outcome?.status, "failed");
+  assert.equal(outcome?.failureCode, failureCode);
+});
+
 test("Subscan source ignores uncorrelated message and extrinsic hashes", () => {
   const adapter = new SubscanXcmSourceAdapter({
     apiHost: "https://subscan.example",

--- a/indexer/src/api/xcm-upstream-source.ts
+++ b/indexer/src/api/xcm-upstream-source.ts
@@ -459,7 +459,7 @@ export class SubscanXcmSourceAdapter implements XcmUpstreamSourceAdapter {
       settledAssets: "0",
       settledShares: "0",
       remoteRef: normalizeOptionalHex32(this.pickString(entry, ["remote_ref", "query_id"])),
-      failureCode: rawStatus === "failed"
+      failureCode: status === "failed"
         ? normalizeOptionalHex32(this.pickString(entry, ["error_code", "failure_code"]))
         : null,
       observedAt: normalizeObservedAt(this.pickString(entry, ["block_timestamp", "timestamp", "time"])),


### PR DESCRIPTION
## Summary
- Preserve Subscan XCM failure metadata for status variants such as `xcm_failed` and `execution_failed`.
- Use the normalized terminal status when deciding whether to carry `failureCode`.
- Add a regression test for a failed Subscan row with explicit SetTopic request correlation.

## Root cause
The Subscan adapter mapped any status containing `fail` to Averray's terminal `failed` state, but only copied `error_code`/`failure_code` when the raw status was exactly `failed`. Real upstream failure strings could therefore publish failed outcomes with no failure evidence.

## Checks
- `node --test indexer/src/api/xcm-upstream-source.test.ts`
- `npm run typecheck:indexer`
- `git diff --check`

## Impact
- Backend: no
- Indexer: yes
- Contracts: no
- Frontend: no
- Caddy/public site: no
- Env/VPS secrets: no
- Contract deployment required: no