### PR TITLE
Align preflight claim economics with chain state

### DIFF
--- a/docs/PRODUCT_PROOF_GATE.md
+++ b/docs/PRODUCT_PROOF_GATE.md
@@ -53,7 +53,10 @@ fails closed before claim unless the valid schema validation succeeds, the
 invalid schema validation is rejected without a submit attempt, the token
 exposes the full loop capability set, the hosted stack reports canonical v1
 USDC settlement readiness, and the worker wallet has enough AgentAccountCore
-USDC liquidity for the reward.
+USDC liquidity for the reward. In blockchain mode, `/jobs/preflight` must use
+the live `EscrowCore.workerClaimCount(worker)` value when previewing claim
+economics, so agents see the same onboarding waiver, claim-stake, and claim-fee
+state the eventual `/jobs/claim` mutation will enforce.
 
 The hosted smoke token must resolve from `/auth/session` with capabilities for:
 `account:read`, `admin:status`, `jobs:create`, `jobs:preflight`, `jobs:claim`,

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -307,6 +307,15 @@ export class BlockchainGateway {
     });
   }
 
+  async getWorkerClaimCount(wallet) {
+    return this.withGatewayError("getWorkerClaimCount", async () => {
+      if (typeof this.escrowContract?.workerClaimCount !== "function") {
+        return 0;
+      }
+      return Number(await this.escrowContract.workerClaimCount(wallet));
+    });
+  }
+
   async getTreasuryPolicyStatus() {
     return this.withGatewayError("getTreasuryPolicyStatus", async () => {
       if (!this.isEnabled()) {

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -275,6 +275,21 @@ test("getClaimEconomicsConfig converts chain min fees back to display units", as
   });
 });
 
+test("getWorkerClaimCount reads the escrow contract counter", async () => {
+  const gateway = gatewayWithDot();
+  gateway.escrowContract = {
+    async workerClaimCount(wallet) {
+      assert.equal(wallet, "0x3333333333333333333333333333333333333333");
+      return 4n;
+    }
+  };
+
+  assert.equal(
+    await gateway.getWorkerClaimCount("0x3333333333333333333333333333333333333333"),
+    4
+  );
+});
+
 test("getTreasuryPolicyStatus surfaces settlement readiness roles", async () => {
   const gateway = new BlockchainGateway({
     enabled: true,

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -1060,7 +1060,10 @@ export class PlatformService {
   }
 
   async getClaimEconomicsPreview(wallet, job) {
-    const priorClaimCount = countClaimedSessions(await this.jobExecutionService.collectSessionHistory(wallet));
+    const priorClaimCount = this.blockchainGateway?.isEnabled()
+      && typeof this.blockchainGateway.getWorkerClaimCount === "function"
+      ? await this.blockchainGateway.getWorkerClaimCount(wallet)
+      : countClaimedSessions(await this.jobExecutionService.collectSessionHistory(wallet));
     return computeClaimEconomics({
       rewardAmount: job.rewardAmount,
       rewardAsset: job.rewardAsset,

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -374,6 +374,54 @@ test("listJobsWithSessions and definition expose expired claim affordances", asy
   assert.match(definition.claimStatus.lifecycleStatusMeaning, /check claimStatus/u);
 });
 
+test("preflight uses chain worker claim count for claim economics in blockchain mode", async () => {
+  const blockchainGateway = {
+    isEnabled() {
+      return true;
+    },
+    async getAccountSummary(wallet) {
+      assert.equal(wallet, WALLET);
+      return {
+        wallet,
+        liquid: { DOT: 10 },
+        reserved: {},
+        strategyAllocated: {},
+        collateralLocked: {},
+        jobStakeLocked: {},
+        debtOutstanding: {}
+      };
+    },
+    async getReputation(wallet) {
+      assert.equal(wallet, WALLET);
+      return { skill: 50, reliability: 50, economic: 50 };
+    },
+    async getDefaultClaimStakeBps() {
+      return 500;
+    },
+    async getClaimEconomicsConfig() {
+      return {
+        claimFeeBps: 200,
+        claimFeeVerifierBps: 7000,
+        onboardingWaiverClaimCount: 3,
+        minClaimFeeByAsset: { DOT: 0.05 }
+      };
+    },
+    async getWorkerClaimCount(wallet) {
+      assert.equal(wallet, WALLET);
+      return 3;
+    }
+  };
+  const service = makePlatformService(blockchainGateway);
+
+  const preflight = await service.preflightJob(WALLET, "parent-job-001");
+
+  assert.equal(preflight.claimNumber, 4);
+  assert.equal(preflight.claimEconomicsWaived, false);
+  assert.equal(preflight.claimStake, 0.25);
+  assert.equal(preflight.claimFee, 0.1);
+  assert.equal(preflight.totalClaimLock, 0.35);
+});
+
 test("validateJobSubmission gives a non-mutating schema-native verdict", () => {
   const service = makePlatformService();
 


### PR DESCRIPTION
## Summary
- read EscrowCore.workerClaimCount for chain-enabled claim-economics previews
- make /jobs/preflight report the same waiver/stake/fee state that /jobs/claim enforces
- document the product-proof gate expectation and add gateway/platform coverage

## Checks
- node --test mcp-server/src/blockchain/gateway.test.js mcp-server/src/core/platform-service.test.js scripts/ops/run-hosted-worker-loop.test.mjs scripts/ops/check-product-proof-gate.test.mjs
- npm --workspace mcp-server test

## Surface
- Backend/API preflight
- Blockchain gateway read surface
- Docs only for product-proof gate expectation

## Env / VPS
- No new secrets or env vars required