### PR TITLE
Align claim economics with chain worker count

### DIFF
--- a/mcp-server/src/core/job-execution-service.js
+++ b/mcp-server/src/core/job-execution-service.js
@@ -160,7 +160,10 @@ export class JobExecutionService {
         ? this.blockchainGateway.toJobId(jobId)
         : jobId;
       let chainClaimTiming = {};
-      const priorClaimCount = countClaimedSessions(await this.collectSessionHistory(wallet));
+      const priorClaimCount = this.blockchainGateway?.isEnabled()
+        && typeof this.blockchainGateway.getWorkerClaimCount === "function"
+        ? await this.blockchainGateway.getWorkerClaimCount(wallet)
+        : countClaimedSessions(await this.collectSessionHistory(wallet));
       const claimEconomicsConfig = await this.getClaimEconomicsConfig();
       let claimEconomics = computeClaimEconomics({
         rewardAmount: job.rewardAmount,

--- a/mcp-server/src/core/job-execution-service.test.js
+++ b/mcp-server/src/core/job-execution-service.test.js
@@ -296,6 +296,56 @@ test("claimJob stores on-chain claim expiry when blockchain is enabled", async (
   assert.equal(claimExpiresAt(claimed, job), "2026-05-01T10:01:00.000Z");
 });
 
+test("claimJob uses chain worker claim count before ensuring a chain job", async () => {
+  const stateStore = new MemoryStateStore();
+  const job = makeJob({ rewardAmount: 5 });
+  let ensuredClaimLock;
+  let checkedClaimLock;
+  const blockchainGateway = {
+    isEnabled: () => true,
+    toJobId: (jobId) => `chain:${jobId}`,
+    async getWorkerClaimCount(wallet) {
+      assert.equal(wallet, WALLET);
+      return 3;
+    },
+    async getJob() {
+      return { state: 0 };
+    },
+    async ensureJob(jobInput, instanceJobId, claimLock) {
+      assert.equal(jobInput.id, job.id);
+      assert.equal(instanceJobId, job.id);
+      ensuredClaimLock = claimLock;
+    },
+    async ensureClaimStakeLiquidity(wallet, asset, claimLock) {
+      assert.equal(wallet, WALLET);
+      assert.equal(asset, "DOT");
+      checkedClaimLock = claimLock;
+    },
+    async claimJob(jobId, wallet) {
+      assert.equal(jobId, job.id);
+      assert.equal(wallet, WALLET);
+    }
+  };
+  const service = new JobExecutionService(
+    stateStore,
+    blockchainGateway,
+    () => job,
+    undefined,
+    undefined,
+    async () => 1000,
+    () => job,
+    async () => ({ minClaimFeeByAsset: { DOT: 0.05 } })
+  );
+
+  const claimed = await service.claimJob(WALLET, job.id, "http", "idemp-chain-count");
+
+  assert.equal(ensuredClaimLock, 0.6);
+  assert.equal(checkedClaimLock, 0.6);
+  assert.equal(claimed.claimNumber, 4);
+  assert.equal(claimed.claimEconomicsWaived, false);
+  assert.equal(claimed.totalClaimLock, 0.6);
+});
+
 test("claimJob reports exhausted retry budget after an expired single-attempt job", async () => {
   const stateStore = new MemoryStateStore();
   const job = makeJob({


### PR DESCRIPTION
## What changed
- Use the chain workerClaimCount as the claim-time prior-claim source when blockchain mode is enabled.
- Keep local session-history counting as the fallback for non-chain/dev mode.
- Add a regression test that proves claimJob passes the chain-derived claim lock into ensureJob and liquidity checks.

## Why
The hosted product-proof worker loop preflight was already using chain claim counts, but the claim path still used local session history before ensureJob. That could make preflight and claim disagree about required USDC lock/liquidity, causing the production worker-loop evidence gate to fail at claim time with Insufficient liquid balance for USDC.

## Checks
- node --test mcp-server/src/core/job-execution-service.test.js mcp-server/src/core/platform-service.test.js scripts/ops/run-hosted-worker-loop.test.mjs scripts/ops/check-product-proof-gate.test.mjs
- npm --workspace mcp-server test
- git diff --check

## Surfaces
Backend/product-proof proof path only. No frontend, indexer, contracts, Caddy, generated output, or secrets changes.