### PR TITLE
Document service-token hygiene, self-verify, and bundle derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Launch posture and trust documents:
 - [Product-proof gate](docs/PRODUCT_PROOF_GATE.md)
 - [Arbitration migration](docs/ARBITRATION_MIGRATION.md)
 - [Dispute reason-code registry](docs/DISPUTE_CODES.md)
+- [Service token operator pack](docs/SERVICE_TOKEN_OPERATOR_PACK.md)
 
 The `mcp-server` workspace currently uses a JavaScript runtime source tree. There is no parallel TypeScript build step to maintain.
 

--- a/docs/SERVICE_TOKEN_OPERATOR_PACK.md
+++ b/docs/SERVICE_TOKEN_OPERATOR_PACK.md
@@ -85,6 +85,42 @@ is verified by `examples/service-token-worker/index.test.mjs` to contain
 - `xcm:observe`, `xcm:finalize` — async-XCM relayer authority.
 - `disputes:release`, `disputes:verdict` — arbitrator-only paths.
 
+### Deriving a bundle when none of the presets fit
+
+If your worker shape is not one of the rows above, derive the bundle from the
+route rules instead of guessing:
+
+1. **List the routes** the worker will actually hit. Be honest — a route the
+   worker only hits "for debugging in dev" still leaks if the token is logged
+   in production.
+2. **Look up each route's capability requirement.** The authoritative table is
+   `ROUTE_CAPABILITY_RULES` in
+   [`mcp-server/src/auth/capabilities.js`](../mcp-server/src/auth/capabilities.js),
+   and a live copy is returned by `GET /auth/session` under `capabilityMatrix.routes`
+   for any authenticated wallet.
+3. **Take the union** of the per-route capability lists. That is the smallest
+   bundle that lets the worker run.
+4. **Check against the never-grant list above.** If any capability in the
+   union is operator-only, the worker is calling a route it has no business
+   calling — fix the worker, do not widen the grant.
+
+Worked example. A worker that lists jobs, preflights them, claims them,
+submits work, and reads its own session timeline hits these routes:
+
+| Route | Capability |
+|---|---|
+| `GET /jobs` | `jobs:list` |
+| `GET /jobs/preflight` | `jobs:preflight` |
+| `POST /jobs/claim` | `jobs:claim` |
+| `POST /jobs/submit` | `jobs:submit` |
+| `GET /session` | `session:read` |
+| `GET /session/timeline` | `session:timeline` |
+
+Union: `jobs:list`, `jobs:preflight`, `jobs:claim`, `jobs:submit`,
+`session:read`, `session:timeline`. None are on the never-grant list. This
+is the same bundle as the **schema-aware claimer** preset — converging on
+an existing bundle is a good sign.
+
 ## Lifecycle — issue, use, rotate, revoke
 
 ### Issue (admin → grant + token)
@@ -207,6 +243,111 @@ Useful audit queries:
 
 The `token` field is never returned by `listServiceTokens` — it only
 exists in the issue/rotate response and cannot be recovered.
+
+## Self-verifying a token
+
+Before handing a freshly issued token to a worker, confirm it resolves the
+exact capabilities you intended and nothing else. Three curl calls are
+enough; do them from the operator shell, not from the worker host (the
+worker host should never need the token in argv where it would land in
+process listings or shell history).
+
+```bash
+WORKER_TOKEN='eyJ...'   # paste once, do not export to a child process
+API_BASE=https://api.averray.com
+```
+
+1. **Confirm the token resolves as a service token with the expected
+   capabilities.** `GET /auth/session` returns the live projection — if this
+   does not match the grant you just issued, stop and rotate.
+
+   ```bash
+   curl -sS "$API_BASE/auth/session" \
+     -H "Authorization: Bearer $WORKER_TOKEN" \
+   | jq '{tokenKind, serviceToken, capabilityGrantId, capabilities}'
+   # Expect tokenKind: "service", serviceToken: true,
+   # capabilityGrantId matching the issue response, and capabilities ==
+   # exactly the bundle you requested.
+   ```
+
+2. **Hit one allowed route.** Pick a non-mutating route from the worker's
+   bundle. For a `jobs:recommend` worker, that is `/jobs/recommendations`;
+   for a `jobs:list` worker, that is `/jobs`; for a read-only observer, that
+   is `/agents/<wallet>`. Expect `200`.
+
+   ```bash
+   curl -sS -o /dev/null -w "%{http_code}\n" \
+     "$API_BASE/jobs/recommendations" \
+     -H "Authorization: Bearer $WORKER_TOKEN"
+   # Expect: 200
+   ```
+
+3. **Hit one route the bundle should *not* cover.** A `403` with
+   `code: "missing_capability"` is what proves the grant is bounded. Two
+   safe deny-targets that never need to mutate state: `/account` (requires
+   `account:read`, almost never in a non-account-flow bundle) and
+   `/admin/status` (requires `admin:status`, never in a worker bundle).
+
+   ```bash
+   curl -sS -w "\nHTTP %{http_code}\n" \
+     "$API_BASE/admin/status" \
+     -H "Authorization: Bearer $WORKER_TOKEN"
+   # Expect: HTTP 403, body includes "code":"missing_capability".
+   ```
+
+If step 1 returns `tokenKind: "wallet"` rather than `"service"`, the value
+you have is not a service token (likely the admin JWT — stop). If step 2
+returns `403`, the bundle is missing the capability you intended. If step 3
+returns `200`, the bundle is *wider* than you intended — revoke and
+re-issue. Never deploy a worker whose self-verification produced any of
+these three outcomes.
+
+## Token hygiene rules
+
+Service tokens are bearer credentials with the same blast radius as any
+other bearer credential. The rules below are concrete bans, not
+recommendations.
+
+- **Bearer header only.** Send the token as
+  `Authorization: Bearer <token>`. Do not pass it as a URL query parameter
+  (e.g. `?token=...`). Query parameters land in server access logs, reverse
+  proxy logs, browser history, and referrer headers. The SSE `?token=`
+  surface in this codebase is for browser EventSource only (which cannot
+  set headers) and is explicitly out of scope for service tokens — a
+  worker process always has the `Authorization` header.
+- **Never log the token.** Configure your logger to drop `authorization`
+  headers and any field whose name matches `*token*`, `*secret*`, `*jwt*`,
+  or `*bearer*`. Verify with a deliberate test log — if the token shows up
+  in `journalctl` or `kubectl logs`, fix the redaction before going live.
+- **Never write the token to artifacts.** CI build outputs, deploy logs,
+  cached test results, error-report payloads, and shared scratch
+  directories are all artifacts. If a CI job needs the token, load it from
+  a secret store at the step that needs it and unset it at the step's end —
+  do not echo it, do not write it to a file the workflow uploads.
+- **Never put the token in URLs.** This includes one-shot diagnostic links,
+  Slack/Discord debugging messages, and "just for a minute" preview links.
+  URLs are forwarded, cached, indexed, and screenshotted; once a token is in
+  a URL it is effectively public.
+- **Never share via chat, issue tracker, or PR description.** Chat
+  platforms keep history, issue trackers index search, and PR descriptions
+  are public on open-source forks. Treat any token that touched one of
+  these as compromised and rotate immediately.
+- **Hold the raw token in a secret manager**, keyed by `grant.id`. The
+  issue response returns the JWT exactly once; lose the bytes and you must
+  rotate. Never check the raw token into source control even in encrypted
+  form unless your secret manager *is* an encrypted-in-repo store.
+- **Treat any `401` from the API as terminal.** It means the token expired
+  or the grant was revoked. Do not retry-loop — stop, page the operator,
+  and rotate.
+- **Rotate before TTL expiry, not after.** Schedule rotation at half the
+  configured `tokenTtlSeconds`, so a missed rotation window still leaves
+  time to recover before the worker fails closed.
+
+The hosted proof in the next section enforces a stricter rule mechanically:
+the evidence artifact records grant ids, statuses, capabilities, and HTTP
+status codes — it refuses to write token-shaped material. When you build
+your own operator tooling, mirror that posture: if any code path could write
+a token, it should fail closed before doing so.
 
 ## Hosted proof smoke
 


### PR DESCRIPTION
## Summary

Adds three operator-facing sections to `docs/SERVICE_TOKEN_OPERATOR_PACK.md` and a top-level discoverability link from `README.md`. The existing pack already covered the lifecycle (issue / rotate / revoke / list), the bundle table, the SDK methods, the hosted proof workflow, and a runnable read-only worker example; this PR fills the gaps the task brief named.

- **"Deriving a bundle when none of the presets fit"** — walks the route-to-capability union method with a worked example that converges on the existing schema-aware-claimer preset.
- **"Self-verifying a token"** — three-curl recipe (`/auth/session` shape, an allowed route, a denied route) so a freshly issued token can be bounded-checked from the operator shell before it ships to a worker host.
- **"Token hygiene rules"** — consolidates scattered "never log / never URL / never artifact" guidance into one explicit ban list with rationale, including the SSE `?token=` exception so workers don't misinterpret it as a general escape hatch.
- **README** — links `docs/SERVICE_TOKEN_OPERATOR_PACK.md` alongside the threat model and production checklist so external operators can find the runbook from the top-level doc.

## Audit / what was already there

Existing material (not touched):

- `docs/SERVICE_TOKEN_OPERATOR_PACK.md` — rationale, capability registry pointer, 6-row minimal-bundles table, lifecycle, runbook checklist.
- `docs/SERVICE_TOKENS.md` — short reference card.
- `sdk/README.md` §Service Tokens — SDK quick-start.
- `sdk/agent-platform-client.js` — `issueServiceToken`, `rotateServiceToken`, `revokeServiceToken`, `listServiceTokens`.
- `examples/service-token-worker/{index.mjs,index.test.mjs}` — runnable worker example with bundle-vs-registry drift checks and a `Authorization: Bearer` header assertion.
- `docs/evidence/service-token-proof-hosted-2026-05-16.json` — sanitized hosted proof evidence (linked, not duplicated).
- `docs/CORE_FRAMEWORK_ROADMAP.md` §6 — already records all of the above as "Current implementation"; not touched per the coordination note that the primary checkout holds uncommitted edits to that file.

## Acceptance criteria

- [x] External agents can read **one** doc (`docs/SERVICE_TOKEN_OPERATOR_PACK.md`) and know which scopes to request — runbook, bundle table, and derivation walkthrough all live there.
- [x] At least one read-only token example (the **Discovery-only reader** and **Read-only audit/observer** bundle rows + the runnable `examples/service-token-worker/index.mjs` using read-only endpoints).
- [x] At least one worker-token example (the **Job claimer + submitter** and **Schema-aware claimer** bundle rows + the worked example in the new derivation section).
- [x] All examples use `Authorization: Bearer <token>` — the new self-verify curl recipe is explicit, the SDK forwards as a Bearer header, the existing test asserts this.
- [x] No secrets or real tokens committed — the curl recipe uses a placeholder, the evidence file already records HTTP statuses only.
- [x] Hosted proof evidence linked, not duplicated — the new "Self-verifying a token" section deliberately stops at three manual probes and points to the hosted workflow as the automated version.

## Scope

- Doc-only change. Two files: `docs/SERVICE_TOKEN_OPERATOR_PACK.md` (+141), `README.md` (+1).
- No changes to SDK code, examples code, backend, contracts, frontend, indexer, or scripts.
- No new tests; existing `examples/service-token-worker/index.test.mjs::"every capability mentioned in the operator pack doc exists in the registry"` catches drift on the new capability references and currently passes (22/22).
- Did **not** touch `docs/CORE_FRAMEWORK_ROADMAP.md` (uncommitted edits in primary checkout) or any of the don't-touch Codex paths (`EscrowCore.claimJob`, `mcp-server/src/blockchain/gateway.js`, claim flow).
- Did **not** touch the hosted worker-loop proof gate, current claim/liquidity backend work, contract code, or frontend UI.

## Affects

- backend / frontend / indexer / Caddy / contracts / public site: **none** (docs only)
- SDK / examples / tests: **none** (the existing service-token-worker test suite still passes, no new tests added)
- Required env or VPS secret changes: **none**

## Test plan

- [x] `npm run test:examples` passes after rebase (22/22 — includes the doc-drift test that validates every capability mentioned in the operator pack)
- [ ] Reviewer follows the new "Self-verifying a token" recipe end-to-end against a fresh testnet token to confirm the three-curl flow returns the documented codes (200 / 403 with `missing_capability`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)