### PR TITLE
Print product-proof API failure details

### DIFF
--- a/scripts/ops/run-hosted-worker-loop.mjs
+++ b/scripts/ops/run-hosted-worker-loop.mjs
@@ -200,6 +200,40 @@ export async function runHostedWorkerLoop({
   return evidenceDoc;
 }
 
+export function formatHostedWorkerLoopError(error) {
+  const message = error?.message ?? String(error);
+  const parts = [message];
+  const status = error?.status;
+  const path = error?.path;
+  const code = error?.code;
+  const requestId = error?.payload?.requestId;
+  if (status || path || code || requestId) {
+    parts.push(
+      `API error context: status=${status ?? "unknown"}; path=${path ?? "unknown"}; ` +
+      `code=${code ?? "unknown"}; requestId=${requestId ?? "unknown"}`
+    );
+  }
+  if (error?.details !== undefined) {
+    parts.push(`API error details: ${JSON.stringify(redactDiagnosticValue(error.details))}`);
+  }
+  return parts.join("\n");
+}
+
+function redactDiagnosticValue(value) {
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactDiagnosticValue(entry));
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  return Object.fromEntries(Object.entries(value).map(([key, entry]) => [
+    key,
+    /(?:authorization|password|secret|token|key)/iu.test(key)
+      ? "[redacted]"
+      : redactDiagnosticValue(entry)
+  ]));
+}
+
 function buildProductProofSubmission({ jobId, evidence, timestamp }) {
   const completedAt = new Date(timestamp).toISOString();
   return {
@@ -674,7 +708,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
       console.log(JSON.stringify(result, null, 2));
     })
     .catch((error) => {
-      console.error(error.message);
+      console.error(formatHostedWorkerLoopError(error));
       process.exitCode = 1;
     });
 }

--- a/scripts/ops/run-hosted-worker-loop.test.mjs
+++ b/scripts/ops/run-hosted-worker-loop.test.mjs
@@ -4,7 +4,10 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import test from "node:test";
 
-import { runHostedWorkerLoop } from "./run-hosted-worker-loop.mjs";
+import {
+  formatHostedWorkerLoopError,
+  runHostedWorkerLoop
+} from "./run-hosted-worker-loop.mjs";
 
 test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidence", async () => {
   const calls = [];
@@ -861,6 +864,38 @@ test("runHostedWorkerLoop rejects rewards below the USDC minBalance before mutat
   );
 
   assert.deepEqual(calls.map(([name]) => name), ["getAuthSession", "getAdminStatus"]);
+});
+
+test("formatHostedWorkerLoopError includes sanitized API diagnostics", () => {
+  const error = new Error("Insufficient liquid balance for USDC");
+  error.status = 409;
+  error.path = "/jobs/claim";
+  error.code = "insufficient_liquidity";
+  error.payload = { requestId: "req-123" };
+  error.details = {
+    operation: "ensureJob",
+    account: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+    required: "0.16",
+    available: "0.04",
+    authorization: "Bearer should-not-print",
+    nested: {
+      serviceToken: "also-secret"
+    }
+  };
+
+  const output = formatHostedWorkerLoopError(error);
+
+  assert.match(output, /Insufficient liquid balance for USDC/u);
+  assert.match(output, /status=409/u);
+  assert.match(output, /path=\/jobs\/claim/u);
+  assert.match(output, /code=insufficient_liquidity/u);
+  assert.match(output, /requestId=req-123/u);
+  assert.match(output, /"operation":"ensureJob"/u);
+  assert.match(output, /"required":"0.16"/u);
+  assert.doesNotMatch(output, /should-not-print/u);
+  assert.doesNotMatch(output, /also-secret/u);
+  assert.match(output, /"authorization":"\[redacted\]"/u);
+  assert.match(output, /"serviceToken":"\[redacted\]"/u);
 });
 
 function accountSummary({


### PR DESCRIPTION
## What changed
- Print structured API failure context from the hosted product-proof worker-loop CLI.
- Include status, path, code, requestId, and sanitized details when the API returns an AgentPlatformApiError-shaped response.
- Add redaction coverage for token/key/secret/password/authorization fields.

## Why
The strict hosted product-proof worker-loop proof is still failing at /jobs/claim, but the CLI only printed the top-level message. The backend already returns details; this makes the next production run actionable without leaking secrets.

## Checks
- node --test scripts/ops/run-hosted-worker-loop.test.mjs scripts/ops/check-product-proof-gate.test.mjs
- git diff --check

## Surfaces
Ops script/tests only. No frontend, backend API behavior, indexer, contracts, Caddy, generated output, or secrets changes.