### PR TITLE
Document signer USDC preflight for manual deploys

### DIFF
--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -414,3 +414,56 @@ npm run validate:subscan-xcm -- --require-published
 
 Until this is green, Subscan or manual observation can help staging, but the
 native observer is not production settlement truth.
+
+---
+
+## 13. Manual deploy: signer USDC liquidity preflight
+
+Auto-triggered deploys (`workflow_run` events fired after CI on `main`) leave
+`PRODUCT_PROOF_REQUIRE_WORKER_LOOP=0` and never claim a job. **Manual
+`workflow_dispatch` deploys that set `product_proof_require_worker_loop=1`
+run a real hosted product-proof worker loop against production**, which
+calls `EscrowCore.claimJob` with the active backend signer. If that signer
+has no liquid USDC inside `AgentAccountCore`, the deploy fails at the
+worker-loop step *after* `Deploy production`'s smoke check has already
+acquired the production lock, with this signature in the log:
+
+```
+Insufficient liquid balance for USDC
+status=409; path=/jobs/claim; code=insufficient_liquidity
+account: <signer wallet>, asset: USDC, assetClass: trust_backed
+```
+
+USDC is trust-backed (not auto-minted), so the loop fails closed rather
+than minting; no chain or contract code is wrong.
+
+**Before manually dispatching a deploy with the worker loop enabled:**
+
+1. Identify the **active** backend signer wallet. After the 2026-05-16 KMS
+   cutover (see
+   [`docs/SECRETS_MIGRATION.md`](./SECRETS_MIGRATION.md)) the active signer
+   is the KMS-derived EVM address, not the `verifier` field still recorded
+   in [`deployments/testnet.json`](../deployments/testnet.json). The
+   authoritative current value is the `account` field printed in a prior
+   failing deploy log, or the address read from the KMS public key via
+   `node scripts/ops/derive-kms-signer-address.mjs`.
+2. Confirm that wallet's USDC position covers the worker-loop reward plus
+   the configured claim-stake basis points. The exact minimum is the
+   `required` value the failure log prints; current default is
+   `0.16 USDC`.
+3. If the position is short, top up the wallet via the playbook in
+   [`docs/TESTNET_FUND_SIGNER.md`](./TESTNET_FUND_SIGNER.md). Note that
+   doc's "read signer from `deployments/testnet.json#verifier`" line is
+   stale post-KMS-cutover and should be cross-referenced against step 1 of
+   this section before depositing — funding the old signer wallet will
+   silently *not* unblock the deploy.
+4. Re-run **Deploy Production** with the same dispatch parameters. The
+   product-proof worker loop will create, claim, submit, and settle a job
+   against the funded signer and write evidence under
+   `PRODUCT_PROOF_EVIDENCE_FILE`.
+
+If the worker loop is not the point of this particular dispatch, set
+`product_proof_require_worker_loop=0` in the **Run workflow** form and
+re-trigger; the deploy will skip the loop entirely. This is the right
+choice for a non-functional dispatch (Caddy-only change, hotfix smoke,
+cache invalidation) where the worker loop is not part of the test plan.


### PR DESCRIPTION
## Summary

Adds §13 to `docs/PRODUCTION_CHECKLIST.md` documenting the `code: insufficient_liquidity` failure that manually-dispatched **Deploy Production** runs now hit when the worker-loop flag is on. Caught after run [#25973801427](https://github.com/averray-agent/agent/actions/runs/25973801427) (Deploy Production #435) failed with this signature; runs #424 and #430 have the same root cause.

## Cause

The 2026-05-16 KMS verifier cutover (`docs/SECRETS_MIGRATION.md`, multisig tx at block 8,922,707) rotated the active backend signer from `0xFd2E…6519` to the KMS-derived `0x31ad…ab7F`. The new wallet has no liquid USDC inside `AgentAccountCore`, so the hosted product-proof worker loop fails closed at `EscrowCore.claimJob` with `required: 0.16, available: 0`. The chain code is correct — USDC is trust-backed and the loop refuses to mint.

The doc gap was that:

1. `PRODUCTION_CHECKLIST.md` had no preflight nudge for manual `workflow_dispatch` callers.
2. `docs/TESTNET_FUND_SIGNER.md` still tells operators to "read signer from `deployments/testnet.json#verifier`", which now points at the **old** wallet. Funding that wallet does not unblock the deploy.

§13 documents both, gives the operator a step-by-step preflight (identify active signer → confirm balance → top up via existing playbook → re-run), and notes the explicit out: dispatch with `product_proof_require_worker_loop=0` when the worker loop is not the point of the deploy.

## Scope

- Doc-only change, one file: `docs/PRODUCTION_CHECKLIST.md` (+53 lines).
- Did **not** modify `scripts/ops/run-hosted-worker-loop.mjs` or any preflight code (currently churning in Codex's lane — 16 recent PRs touching it, including #359, #360, #370, #372).
- Did **not** edit `docs/TESTNET_FUND_SIGNER.md` to correct the stale `deployments/testnet.json#verifier` reference; that's a related but separate doc fix and belongs in its own narrow PR (probably in the secrets/KMS lane that owns the cutover).
- Did **not** modify `.github/workflows/deploy-production.yml` to add a fail-fast balance check; that crosses into the active preflight code path and should be Codex's call.
- Did **not** touch contracts, frontend, backend, indexer, or generated output.

## Affects

- backend / frontend / indexer / Caddy / contracts / public site: **none** (docs only)
- Required env or VPS secret changes: **none**

## Test plan

- [x] Cited script `scripts/ops/derive-kms-signer-address.mjs` exists at HEAD
- [x] Cited workflow inputs (`product_proof_require_worker_loop`, default `"0"`) match `.github/workflows/deploy-production.yml`
- [x] Cited failure signature copied verbatim from run 25973801427's failing step
- [ ] Reviewer can trace the chain: failing log → §13 → identify active signer → `docs/TESTNET_FUND_SIGNER.md` → top up → re-run

## Follow-ups (separate PRs, not blocking this one)

- Update `docs/TESTNET_FUND_SIGNER.md`'s "read signer from `deployments/testnet.json#verifier`" line to point at the KMS-derived wallet (or to a procedure for finding the current active signer).
- Consider whether `deployments/testnet.json#verifier` should be updated to the new KMS address, or whether the field is intentionally a historical deploy record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)