### PR TITLE
Serialize XCM settlement watcher runs

### DIFF
--- a/mcp-server/src/services/xcm-settlement-watcher.js
+++ b/mcp-server/src/services/xcm-settlement-watcher.js
@@ -19,6 +19,8 @@ export class XcmSettlementWatcherService {
     this.running = false;
     this.timer = undefined;
     this.unsubscribe = undefined;
+    this.settlementRunPromise = undefined;
+    this.settlementRunQueued = false;
   }
 
   start() {
@@ -47,6 +49,7 @@ export class XcmSettlementWatcherService {
     return {
       enabled: this.enabled,
       running: this.running,
+      settling: Boolean(this.settlementRunPromise),
       pendingCount: pending.length,
       pending: pending.slice(0, 10)
     };
@@ -104,6 +107,30 @@ export class XcmSettlementWatcherService {
   }
 
   async runPendingSettlements(limit = 20) {
+    if (this.settlementRunPromise) {
+      this.settlementRunQueued = true;
+      return this.settlementRunPromise;
+    }
+
+    this.settlementRunPromise = this.drainPendingSettlements(limit);
+    try {
+      return await this.settlementRunPromise;
+    } finally {
+      this.settlementRunPromise = undefined;
+      this.settlementRunQueued = false;
+    }
+  }
+
+  async drainPendingSettlements(limit) {
+    const results = [];
+    do {
+      this.settlementRunQueued = false;
+      results.push(...await this.runPendingSettlementBatch(limit));
+    } while (this.settlementRunQueued);
+    return results;
+  }
+
+  async runPendingSettlementBatch(limit) {
     const pending = await this.stateStore.listPendingXcmObservations?.(limit) ?? [];
     const results = [];
 

--- a/mcp-server/src/services/xcm-settlement-watcher.test.js
+++ b/mcp-server/src/services/xcm-settlement-watcher.test.js
@@ -7,6 +7,7 @@ import { XcmSettlementWatcherService } from "./xcm-settlement-watcher.js";
 import { ValidationError } from "../core/errors.js";
 
 const REQUEST_ID = "0x1111111111111111111111111111111111111111111111111111111111111111";
+const REQUEST_ID_2 = "0x2222222222222222222222222222222222222222222222222222222222222222";
 
 test("observeOutcome stores a pending observation and emits an event", async () => {
   const stateStore = new MemoryStateStore();
@@ -87,6 +88,72 @@ test("runPendingSettlements finalizes stored observations and marks them process
   assert.equal(events[0].data.settledShares, "5");
   assert.equal(events[0].data.settledSharesRaw, "5");
   assert.equal(events[0].data.source, "observer");
+});
+
+test("runPendingSettlements serializes concurrent triggers and drains queued observations", async () => {
+  const stateStore = new MemoryStateStore();
+  const finalizedCalls = [];
+  let releaseFirstFinalize;
+  const firstFinalizeReleased = new Promise((resolve) => {
+    releaseFirstFinalize = resolve;
+  });
+  let firstFinalizeStarted;
+  const firstFinalizeStartedPromise = new Promise((resolve) => {
+    firstFinalizeStarted = resolve;
+  });
+
+  const watcher = new XcmSettlementWatcherService(
+    {
+      finalizeXcmRequest: async (requestId, outcome) => {
+        finalizedCalls.push([requestId, outcome]);
+        if (requestId === REQUEST_ID) {
+          firstFinalizeStarted();
+          await firstFinalizeReleased;
+        }
+        return {
+          requestId,
+          settledVia: "agent_account",
+          strategyRequest: {
+            account: "0xabc",
+            statusLabel: outcome.status
+          }
+        };
+      }
+    },
+    stateStore,
+    undefined,
+    { enabled: false }
+  );
+
+  await watcher.observeOutcome(REQUEST_ID, {
+    status: "succeeded",
+    settledAssets: 5
+  });
+
+  const firstRun = watcher.runPendingSettlements();
+  await firstFinalizeStartedPromise;
+
+  await watcher.observeOutcome(REQUEST_ID_2, {
+    status: "succeeded",
+    settledAssets: 7
+  });
+  const concurrentRun = watcher.runPendingSettlements();
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(finalizedCalls.length, 1);
+
+  releaseFirstFinalize();
+  const [firstResults, concurrentResults] = await Promise.all([firstRun, concurrentRun]);
+  const storedFirst = await stateStore.getXcmObservation(REQUEST_ID);
+  const storedSecond = await stateStore.getXcmObservation(REQUEST_ID_2);
+
+  assert.equal(finalizedCalls.length, 2);
+  assert.equal(finalizedCalls[0][0], REQUEST_ID);
+  assert.equal(finalizedCalls[1][0], REQUEST_ID_2);
+  assert.equal(firstResults.length, 2);
+  assert.equal(concurrentResults.length, 2);
+  assert.equal(storedFirst.processed, true);
+  assert.equal(storedSecond.processed, true);
 });
 
 test("runPendingSettlements emits a request_finalize_failed event with correlationId on errors", async () => {


### PR DESCRIPTION
## Summary
- serialize XCM settlement watcher runs behind one in-flight promise
- queue one follow-up settlement pass when another trigger arrives mid-run
- expose the in-flight state in watcher status and cover concurrent trigger behavior in tests

## Checks
- node --test mcp-server/src/services/xcm-settlement-watcher.test.js
- npm --workspace mcp-server test
- git diff --check

## Surface
- backend / XCM settlement watcher only
- no environment or VPS secret changes required