### PR TITLE
Poll eth_getLogs instead of contract.on for chain events

### DIFF
--- a/mcp-server/src/blockchain/event-listener.js
+++ b/mcp-server/src/blockchain/event-listener.js
@@ -1,16 +1,26 @@
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const DEFAULT_POLL_INTERVAL_MS = 4_000;
+const DEFAULT_MAX_BLOCKS_PER_QUERY = 1_000;
+const MIN_RECONNECT_DELAY_MS = 1_000;
+const MAX_RECONNECT_DELAY_MS = 30_000;
 
 export class EventListener {
-  constructor(gateway, eventBus, stateStore = undefined) {
+  constructor(gateway, eventBus, stateStore = undefined, options = {}) {
     this.gateway = gateway;
     this.eventBus = eventBus;
     this.stateStore = stateStore;
     this.running = false;
     this.registrations = [];
+    this.routingTable = new Map();
+    this.eventNameIndex = new Map();
     this.blockTimestampCache = new Map();
-    this.reconnectDelayMs = 1000;
-    this.reconnectTimer = undefined;
-    this.handleProviderError = this.handleProviderError.bind(this);
+    this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.maxBlocksPerQuery = options.maxBlocksPerQuery ?? DEFAULT_MAX_BLOCKS_PER_QUERY;
+    this.confirmations = options.confirmations ?? 0;
+    this.pollTimer = undefined;
+    this.pollInFlight = false;
+    this.reconnectDelayMs = MIN_RECONNECT_DELAY_MS;
+    this.lastBlock = undefined;
   }
 
   async start() {
@@ -20,19 +30,26 @@ export class EventListener {
 
     this.running = true;
     this.attachEventHandlers();
-    this.gateway.provider?.on?.("error", this.handleProviderError);
+
+    try {
+      const head = await this.gateway.provider.getBlockNumber();
+      this.lastBlock = Number(head);
+    } catch (error) {
+      this.publishProviderError(error);
+      this.scheduleReconnect();
+      return;
+    }
+
+    this.scheduleNextPoll(this.pollIntervalMs);
   }
 
   async stop() {
     this.running = false;
-    clearTimeout(this.reconnectTimer);
-    this.reconnectTimer = undefined;
-
-    for (const { contract, eventName, handler } of this.registrations) {
-      contract.off(eventName, handler);
-    }
+    clearTimeout(this.pollTimer);
+    this.pollTimer = undefined;
     this.registrations = [];
-    this.gateway.provider?.off?.("error", this.handleProviderError);
+    this.routingTable.clear();
+    this.eventNameIndex.clear();
   }
 
   attachEventHandlers() {
@@ -411,38 +428,152 @@ export class EventListener {
   }
 
   register(contract, eventName, build) {
-    if (!contract?.on) {
+    if (!contract?.interface || !contract?.target) {
       return;
     }
-    const handler = async (...args) => {
-      if (!this.running) {
+
+    const fragment = contract.interface.getEvent(eventName);
+    if (!fragment?.topicHash) {
+      return;
+    }
+
+    const address = String(contract.target).toLowerCase();
+    const topicHash = String(fragment.topicHash).toLowerCase();
+    const entry = { contract, eventName, build, address, topicHash };
+    this.registrations.push(entry);
+    this.routingTable.set(`${address}:${topicHash}`, entry);
+    this.eventNameIndex.set(eventName, entry);
+  }
+
+  scheduleNextPoll(delayMs = this.pollIntervalMs) {
+    if (!this.running) {
+      return;
+    }
+    clearTimeout(this.pollTimer);
+    this.pollTimer = setTimeout(() => {
+      this.pollOnce().catch((error) => this.publishProviderError(error));
+    }, delayMs);
+    if (typeof this.pollTimer?.unref === "function") {
+      this.pollTimer.unref();
+    }
+  }
+
+  async pollOnce() {
+    if (!this.running || this.pollInFlight) {
+      return;
+    }
+    this.pollInFlight = true;
+    try {
+      const head = Number(await this.gateway.provider.getBlockNumber());
+      const targetBlock = Math.max(0, head - this.confirmations);
+
+      if (this.lastBlock === undefined) {
+        this.lastBlock = targetBlock;
+      }
+
+      let fromBlock = this.lastBlock + 1;
+      const addresses = uniqueAddresses(this.registrations);
+      if (addresses.length === 0 || fromBlock > targetBlock) {
         return;
       }
 
-      try {
-        const payload = args.at(-1);
-        const event = await build({
-          args: payload.args,
-          payload
+      while (fromBlock <= targetBlock) {
+        const chunkTo = Math.min(fromBlock + this.maxBlocksPerQuery - 1, targetBlock);
+        const logs = await this.gateway.provider.getLogs({
+          fromBlock,
+          toBlock: chunkTo,
+          address: addresses.length === 1 ? addresses[0] : addresses
         });
-        if (event) {
-          this.eventBus.publish(event);
-        }
-      } catch (error) {
-        this.eventBus.publish({
-          id: `system-error-${Date.now()}`,
-          topic: "system.listener_error",
-          timestamp: new Date().toISOString(),
-          data: {
-            eventName,
-            message: error?.message ?? "listener_error"
+        sortLogs(logs);
+        for (const log of logs) {
+          if (!this.running) {
+            return;
           }
-        });
+          await this.dispatchLog(log);
+        }
+        this.lastBlock = chunkTo;
+        fromBlock = chunkTo + 1;
       }
-    };
+      this.reconnectDelayMs = MIN_RECONNECT_DELAY_MS;
+    } catch (error) {
+      this.publishProviderError(error);
+      this.scheduleReconnect();
+      return;
+    } finally {
+      this.pollInFlight = false;
+    }
+    this.scheduleNextPoll(this.pollIntervalMs);
+  }
 
-    contract.on(eventName, handler);
-    this.registrations.push({ contract, eventName, handler });
+  async dispatchLog(log) {
+    if (!log) {
+      return;
+    }
+    const address = String(log.address ?? "").toLowerCase();
+    const topic0 = log.topics?.[0] ? String(log.topics[0]).toLowerCase() : undefined;
+    if (!address || !topic0) {
+      return;
+    }
+    const entry = this.routingTable.get(`${address}:${topic0}`);
+    if (!entry) {
+      return;
+    }
+
+    let parsed;
+    try {
+      parsed = entry.contract.interface.parseLog({
+        topics: [...log.topics],
+        data: log.data
+      });
+    } catch (error) {
+      this.publishListenerError(entry.eventName, error);
+      return;
+    }
+    if (!parsed) {
+      return;
+    }
+
+    await this.deliver(entry, parsed.args, log);
+  }
+
+  async dispatch(eventName, args, log = {}) {
+    const entry = this.eventNameIndex.get(eventName);
+    if (!entry) {
+      throw new Error(`no registration for event ${eventName}`);
+    }
+    const fullLog = {
+      transactionHash: log.transactionHash ?? `0x${"00".repeat(32)}`,
+      index: log.index ?? 0,
+      blockNumber: log.blockNumber ?? 0n,
+      address: entry.address,
+      topics: log.topics ?? [entry.topicHash],
+      ...log
+    };
+    await this.deliver(entry, args, fullLog);
+  }
+
+  async deliver(entry, args, log) {
+    try {
+      const payload = { args, log };
+      const event = await entry.build({ args, payload });
+      if (event) {
+        this.eventBus.publish(event);
+      }
+    } catch (error) {
+      this.publishListenerError(entry.eventName, error);
+    }
+  }
+
+  publishListenerError(eventName, error) {
+    this.eventBus.publish({
+      id: `system-error-${Date.now()}`,
+      topic: "system.listener_error",
+      timestamp: new Date().toISOString(),
+      data: {
+        eventName,
+        message: error?.message ?? "listener_error"
+      }
+    });
   }
 
   async readJob(jobId) {
@@ -512,11 +643,7 @@ export class EventListener {
     return timestamp;
   }
 
-  handleProviderError(error) {
-    if (!this.running) {
-      return;
-    }
-
+  publishProviderError(error) {
     this.eventBus.publish({
       id: `system-provider-error-${Date.now()}`,
       topic: "system.provider_error",
@@ -525,22 +652,43 @@ export class EventListener {
         message: error?.message ?? "provider_error"
       }
     });
-
-    clearTimeout(this.reconnectTimer);
-    this.reconnectTimer = setTimeout(async () => {
-      await this.stop();
-      this.reconnectDelayMs = Math.min(this.reconnectDelayMs * 2, 30_000);
-      await this.start();
-      this.eventBus.publish({
-        id: `system-reconnect-${Date.now()}`,
-        topic: "system.reconnect",
-        timestamp: new Date().toISOString(),
-        data: {
-          delayMs: this.reconnectDelayMs
-        }
-      });
-    }, this.reconnectDelayMs);
   }
+
+  scheduleReconnect() {
+    if (!this.running) {
+      return;
+    }
+    this.reconnectDelayMs = Math.min(this.reconnectDelayMs * 2, MAX_RECONNECT_DELAY_MS);
+    this.eventBus.publish({
+      id: `system-reconnect-${Date.now()}`,
+      topic: "system.reconnect",
+      timestamp: new Date().toISOString(),
+      data: {
+        delayMs: this.reconnectDelayMs
+      }
+    });
+    this.scheduleNextPoll(this.reconnectDelayMs);
+  }
+}
+
+function uniqueAddresses(registrations) {
+  const seen = new Set();
+  for (const entry of registrations) {
+    if (entry?.address) {
+      seen.add(entry.address);
+    }
+  }
+  return [...seen];
+}
+
+function sortLogs(logs) {
+  logs.sort((a, b) => {
+    const blockDiff = Number(a.blockNumber ?? 0n) - Number(b.blockNumber ?? 0n);
+    if (blockDiff !== 0) return blockDiff;
+    const ai = Number(a.index ?? a.logIndex ?? 0);
+    const bi = Number(b.index ?? b.logIndex ?? 0);
+    return ai - bi;
+  });
 }
 
 function serializeArgs(args) {

--- a/mcp-server/src/blockchain/event-listener.test.js
+++ b/mcp-server/src/blockchain/event-listener.test.js
@@ -9,43 +9,39 @@ const ASSET = "0x3333333333333333333333333333333333333333";
 const REQUEST_ID = `0x${"aa".repeat(32)}`;
 const STRATEGY_ID = `0x${"bb".repeat(32)}`;
 
-function makeContract() {
-  const handlers = new Map();
+function makeContract({ address, eventTopics = {} } = {}) {
   return {
-    on(eventName, handler) {
-      handlers.set(eventName, handler);
-    },
-    off(eventName, handler) {
-      if (handlers.get(eventName) === handler) {
-        handlers.delete(eventName);
+    target: address,
+    interface: {
+      getEvent(name) {
+        const topicHash = eventTopics[name];
+        return topicHash ? { topicHash } : null;
       }
-    },
-    async emitEvent(eventName, args, log = {}) {
-      const handler = handlers.get(eventName);
-      assert.ok(handler, `missing handler for ${eventName}`);
-      await handler({
-        args,
-        log: {
-          transactionHash: `0x${"12".repeat(32)}`,
-          index: 0,
-          blockNumber: 12345n,
-          ...log
-        }
-      });
     }
   };
 }
 
+const XCM_CONTRACT_ADDRESS = `0x${"ab".repeat(20)}`;
+const XCM_EVENT_TOPICS = {
+  RequestQueued: `0x${"01".repeat(32)}`,
+  RequestPayloadStored: `0x${"02".repeat(32)}`,
+  RequestDispatched: `0x${"03".repeat(32)}`,
+  RequestStatusUpdated: `0x${"04".repeat(32)}`
+};
+
 function makeListener({ gateway = {}, xcmRequest = {} } = {}) {
-  const xcmWrapperContract = makeContract();
+  const xcmWrapperContract = makeContract({
+    address: XCM_CONTRACT_ADDRESS,
+    eventTopics: XCM_EVENT_TOPICS
+  });
   const events = [];
   const listener = new EventListener(
     {
       isEnabled: () => true,
       provider: {
-        on() {},
-        off() {},
-        getBlock: async () => ({ timestamp: 1_700_000_000n })
+        getBlock: async () => ({ timestamp: 1_700_000_000n }),
+        getBlockNumber: async () => 12_345n,
+        getLogs: async () => []
       },
       xcmWrapperContract,
       getXcmRequest: async () => ({
@@ -67,9 +63,21 @@ function makeListener({ gateway = {}, xcmRequest = {} } = {}) {
         events.push(event);
         return event;
       }
-    }
+    },
+    undefined,
+    { pollIntervalMs: 60_000 }
   );
   return { listener, xcmWrapperContract, events };
+}
+
+const DEFAULT_LOG = {
+  transactionHash: `0x${"12".repeat(32)}`,
+  index: 0,
+  blockNumber: 12_345n
+};
+
+async function emit(listener, eventName, args, log = {}) {
+  await listener.dispatch(eventName, args, { ...DEFAULT_LOG, ...log });
 }
 
 test("EventListener preserves unsafe XCM queued nonce as raw string", async () => {
@@ -77,7 +85,7 @@ test("EventListener preserves unsafe XCM queued nonce as raw string", async () =
   await listener.start();
   const unsafeNonce = BigInt(Number.MAX_SAFE_INTEGER) + 99n;
 
-  await xcmWrapperContract.emitEvent("RequestQueued", {
+  await emit(listener, "RequestQueued", {
     requestId: REQUEST_ID,
     strategyId: STRATEGY_ID,
     kind: 0,
@@ -105,7 +113,7 @@ test("EventListener preserves unsafe XCM weight fields as raw strings", async ()
   await listener.start();
   const unsafeRefTime = BigInt(Number.MAX_SAFE_INTEGER) + 123n;
 
-  await xcmWrapperContract.emitEvent("RequestPayloadStored", {
+  await emit(listener, "RequestPayloadStored", {
     requestId: REQUEST_ID,
     destinationHash: `0x${"cc".repeat(32)}`,
     messageHash: `0x${"dd".repeat(32)}`,
@@ -129,7 +137,7 @@ test("EventListener exposes raw settled XCM amounts on status updates", async ()
   const settledAssets = 12_500_000_000_000_000_000n;
   const settledShares = 2_500_000_000_000_000_000n;
 
-  await xcmWrapperContract.emitEvent("RequestStatusUpdated", {
+  await emit(listener, "RequestStatusUpdated", {
     requestId: REQUEST_ID,
     status: 2,
     settledAssets,
@@ -182,4 +190,96 @@ test("EventListener readJob preserves unsafe lifecycle timestamps as raw strings
   assert.equal(job.rejectedAtRaw, "777");
   assert.equal(job.disputedAt, unsafeDisputedAt.toString());
   assert.equal(job.disputedAtRaw, unsafeDisputedAt.toString());
+});
+
+test("EventListener pollOnce queries eth_getLogs and advances lastBlock", async () => {
+  const getLogsCalls = [];
+  const { listener } = makeListener({
+    gateway: {
+      provider: {
+        getBlock: async () => ({ timestamp: 1_700_000_000n }),
+        getBlockNumber: async () => 1_010n,
+        async getLogs(filter) {
+          getLogsCalls.push(filter);
+          return [];
+        }
+      }
+    }
+  });
+
+  listener.running = true;
+  listener.attachEventHandlers();
+  listener.lastBlock = 1_000;
+  await listener.pollOnce();
+
+  assert.equal(getLogsCalls.length, 1);
+  assert.equal(getLogsCalls[0].fromBlock, 1_001);
+  assert.equal(getLogsCalls[0].toBlock, 1_010);
+  assert.equal(getLogsCalls[0].address, XCM_CONTRACT_ADDRESS.toLowerCase());
+  assert.equal(listener.lastBlock, 1_010);
+
+  await listener.stop();
+});
+
+test("EventListener pollOnce skips when head has not advanced", async () => {
+  const getLogsCalls = [];
+  const { listener } = makeListener({
+    gateway: {
+      provider: {
+        getBlock: async () => ({ timestamp: 1_700_000_000n }),
+        getBlockNumber: async () => 1_000n,
+        async getLogs(filter) {
+          getLogsCalls.push(filter);
+          return [];
+        }
+      }
+    }
+  });
+
+  listener.running = true;
+  listener.attachEventHandlers();
+  listener.lastBlock = 1_000;
+  await listener.pollOnce();
+
+  assert.equal(getLogsCalls.length, 0);
+  assert.equal(listener.lastBlock, 1_000);
+
+  await listener.stop();
+});
+
+test("EventListener pollOnce surfaces provider errors and schedules reconnect", async () => {
+  const { listener, events } = makeListener({
+    gateway: {
+      provider: {
+        getBlock: async () => ({ timestamp: 1_700_000_000n }),
+        getBlockNumber: async () => {
+          throw new Error("Method not found");
+        },
+        getLogs: async () => []
+      }
+    }
+  });
+
+  listener.running = true;
+  listener.attachEventHandlers();
+  listener.lastBlock = 0;
+  await listener.pollOnce();
+
+  const providerError = events.find((event) => event.topic === "system.provider_error");
+  const reconnect = events.find((event) => event.topic === "system.reconnect");
+  assert.ok(providerError, "expected provider error event");
+  assert.match(providerError.data.message, /Method not found/u);
+  assert.ok(reconnect, "expected reconnect event");
+  assert.ok(reconnect.data.delayMs >= 1_000);
+
+  await listener.stop();
+});
+
+test("EventListener register skips contracts missing interface or target", () => {
+  const { listener } = makeListener();
+  const before = listener.registrations.length;
+  listener.register(undefined, "JobFunded", async () => null);
+  listener.register({ target: "0x123" }, "JobFunded", async () => null);
+  listener.register({ interface: { getEvent: () => null } }, "JobFunded", async () => null);
+  assert.equal(listener.registrations.length, before);
 });


### PR DESCRIPTION
## Summary
- Replace ethers \`contract.on(eventName, handler)\` filter subscriptions in \`mcp-server/src/blockchain/event-listener.js\` with a polling loop driven by \`eth_getLogs\` over \`(lastBlock, head]\`. Pallet-revive's eth-rpc bridge (https://eth-rpc-testnet.polkadot.io/) does not implement \`eth_newFilter\` / \`eth_getFilterChanges\`, so every escrow / account / reputation / XCM event subscription was emitting \`Method not found (-32601)\` at boot and on each retry.
- Route logs via an \`address:topic0\` table populated from each \`contract.interface.getEvent(name).topicHash\`. Logs are decoded with \`contract.interface.parseLog\` and handed to the existing per-event build functions unchanged.
- Preserve the existing error-event taxonomy (\`system.provider_error\`, \`system.listener_error\`, \`system.reconnect\`) and the exponential reconnect backoff; the timer is now \`unref\`'d so tests and short-lived hosts can exit cleanly.

## What's not changed
- The per-event \`build({args, payload})\` callbacks (escrow, account, reputation, XCM) are untouched; the payload shape (\`{args, log}\`) is preserved.
- Public constructor signature is backwards-compatible: \`new EventListener(gateway, eventBus, stateStore)\` still works; new \`options\` is a fourth, optional arg.
- No state-store hooks for cross-restart block resumption — first start sets \`lastBlock = current head\` (same effective behaviour as filter subs, which only fire on events emitted after subscription).

## Verification
- Polkadot Hub JSON-RPC support list confirmed via the polkadot-docs MCP (\`smart-contracts/for-eth-devs/json-rpc-apis.md\`): \`eth_getLogs\` ✅, \`eth_blockNumber\` ✅; \`eth_newFilter\` not in the supported set.
- \`node --test mcp-server/src/blockchain/event-listener.test.js\` → 8 pass (4 existing XCM raw-field tests preserved + 4 new polling-path tests covering cursor advance, idle skip, provider-error reconnect, and the register guard).
- Full \`npm --workspace mcp-server test\` shows 487 → 487 pre-existing pass and the same 12 pre-existing failures (AWS-SDK-not-installed for KMS, plus \`gateway.test.js\`, \`xcm-message-builder.test.js\`, \`http-config.test.js\`, \`strategies-config.test.js\` — all unchanged by this PR; my 4 new tests bring the total tests count 495 → 499).

## Test plan
- [ ] CI: \`npm --workspace mcp-server test\` shows the 4 new event-listener tests passing alongside the existing XCM raw-field tests.
- [ ] Post-deploy: tail \`agent-backend\` logs and confirm the \`could not coalesce error ... eth_newFilter ... Method not found\` lines stop reappearing.
- [ ] Post-deploy: trigger a JobFunded / JobClaimed event on testnet (or wait for a real one) and confirm a \`escrow.job_funded\` / \`escrow.job_claimed\` event lands on the bus within one poll interval (\`pollIntervalMs\` default 4s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)