### PR TITLE
[codex] Gate product-proof on signer funding

### DIFF
--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -154,8 +154,10 @@ discipline for custom/off-platform schemas.
   `schema://jobs/product-proof-worker-loop` output contract, validates its
   structured submission before claim, probes an invalid `submission.output`
   wrapper through the read-only validation route, runs verification from the
-  stored structured session submission, and records both validation traces plus
-  the verifier-input mode in the launch evidence gate
+  stored structured session submission, checks configured-signer and worker
+  AgentAccountCore USDC liquidity before mutation/claim, and records both
+  validation traces plus the verifier-input and funding modes in the launch
+  evidence gate
 - the generic claim-and-submit helper now uses the same schema-native readiness
   guard before claim, so the pattern is available outside the product-proof
   smoke loop
@@ -547,7 +549,9 @@ should prioritize live-proof and launch-risk items before adding new product
 surface:
 
 1. complete the hosted worker-loop product-proof evidence gate, including the
-   valid direct-object validation and invalid-wrapper validation proof
+   valid direct-object validation, invalid-wrapper validation proof, configured
+   KMS signer funding proof, and final hosted evidence artifact after the signer
+   has live USDC deposited in AgentAccountCore
 2. close operator self-report proof through Hermes/operator reporting: keep
    `run_hermes_post_deploy=1`, confirm scheduled ops-health and daily-brief
    evidence, and run the hosted smoke's bootstrap instrumentation gate to prove

--- a/docs/PRODUCT_PROOF_GATE.md
+++ b/docs/PRODUCT_PROOF_GATE.md
@@ -52,11 +52,13 @@ before running the required gate. It does not print the token. The worker loop
 fails closed before claim unless the valid schema validation succeeds, the
 invalid schema validation is rejected without a submit attempt, the token
 exposes the full loop capability set, the hosted stack reports canonical v1
-USDC settlement readiness, and the worker wallet has enough AgentAccountCore
-USDC liquidity for the reward. In blockchain mode, `/jobs/preflight` must use
-the live `EscrowCore.workerClaimCount(worker)` value when previewing claim
-economics, so agents see the same onboarding waiver, claim-stake, and claim-fee
-state the eventual `/jobs/claim` mutation will enforce.
+USDC settlement readiness, the configured backend signer has enough
+AgentAccountCore USDC liquidity to fund the reward and claim-lock reserve, and
+the worker wallet has enough AgentAccountCore USDC liquidity for the same
+claim. In blockchain mode, `/jobs/preflight` must use the live
+`EscrowCore.workerClaimCount(worker)` value when previewing claim economics, so
+agents see the same onboarding waiver, claim-stake, and claim-fee state the
+eventual `/jobs/claim` mutation will enforce.
 
 The hosted smoke token must resolve from `/auth/session` with capabilities for:
 `account:read`, `admin:status`, `jobs:create`, `jobs:preflight`, `jobs:claim`,
@@ -111,6 +113,14 @@ The worker-loop command writes a local evidence file like:
     "rewardRaw": "100000",
     "minBalanceRaw": "70000"
   },
+  "signerFundingReadiness": {
+    "signer": "0x...",
+    "asset": "USDC",
+    "rewardRaw": "100000",
+    "totalClaimLockRaw": "0",
+    "requiredRaw": "100000",
+    "availableRaw": "155000"
+  },
   "liquidityReadiness": {
     "wallet": "0x...",
     "asset": "USDC",
@@ -119,6 +129,14 @@ The worker-loop command writes a local evidence file like:
   },
   "claimLiquidityReadiness": {
     "wallet": "0x...",
+    "asset": "USDC",
+    "rewardRaw": "100000",
+    "totalClaimLockRaw": "55000",
+    "requiredRaw": "155000",
+    "availableRaw": "155000"
+  },
+  "claimSignerFundingReadiness": {
+    "signer": "0x...",
     "asset": "USDC",
     "rewardRaw": "100000",
     "totalClaimLockRaw": "55000",
@@ -178,8 +196,10 @@ The script fetches the badge and profile documents and verifies that:
 
 - the evidence host matches the checked API host
 - the evidence proves canonical v1 USDC settlement readiness
-- the reward clears the USDC minBalance and the worker has enough USDC
-  liquidity for both the reward and the claim lock required by preflight
+- the reward clears the USDC minBalance, the configured backend signer has
+  enough USDC to fund the escrowed reward plus claim-lock reserve, and the
+  worker has enough USDC liquidity for both the reward and the claim lock
+  required by preflight
 - the job preflight was eligible and claimable before claim
 - the product-proof submission passed schema validation before claim
 - one intentionally invalid `submission.output` wrapper failed validation before

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -62,6 +62,29 @@ function summarizeSupportedAsset(asset) {
   return summary;
 }
 
+function summarizeAssetPosition(position, asset, toDisplayUnits, toRawString) {
+  const liquid = BigInt(position.liquid ?? 0);
+  const reserved = BigInt(position.reserved ?? 0);
+  const strategyAllocated = BigInt(position.strategyAllocated ?? 0);
+  const collateralLocked = BigInt(position.collateralLocked ?? 0);
+  const jobStakeLocked = BigInt(position.jobStakeLocked ?? 0);
+  const debtOutstanding = BigInt(position.debtOutstanding ?? 0);
+  return {
+    liquid: toDisplayUnits(liquid, asset),
+    liquidRaw: toRawString(liquid),
+    reserved: toDisplayUnits(reserved, asset),
+    reservedRaw: toRawString(reserved),
+    strategyAllocated: toDisplayUnits(strategyAllocated, asset),
+    strategyAllocatedRaw: toRawString(strategyAllocated),
+    collateralLocked: toDisplayUnits(collateralLocked, asset),
+    collateralLockedRaw: toRawString(collateralLocked),
+    jobStakeLocked: toDisplayUnits(jobStakeLocked, asset),
+    jobStakeLockedRaw: toRawString(jobStakeLocked),
+    debtOutstanding: toDisplayUnits(debtOutstanding, asset),
+    debtOutstandingRaw: toRawString(debtOutstanding)
+  };
+}
+
 function canAutoMintAsset(asset) {
   return (asset?.assetClass ?? "custom") === "custom";
 }
@@ -406,6 +429,34 @@ export class BlockchainGateway {
           ? await optionalBool(`approvedAssets(${asset.symbol ?? asset.address})`, this.policyContract.approvedAssets(asset.address))
           : false
       })));
+      const signerFunding = signerAddress ? {
+        account: signerAddress,
+        agentAccountAddress: this.config.agentAccountAddress,
+        assets: await Promise.all((this.config.supportedAssets ?? []).map(async (asset) => {
+          const summary = summarizeSupportedAsset(asset);
+          const position = await optionalRead(
+            `positions(signer,${asset.symbol ?? asset.address})`,
+            this.accountContract.positions(signerAddress, asset.address),
+            undefined
+          );
+          if (!position) {
+            return {
+              ...summary,
+              readable: false
+            };
+          }
+          return {
+            ...summary,
+            readable: true,
+            ...summarizeAssetPosition(
+              position,
+              asset,
+              this.toDisplayUnits.bind(this),
+              this.toRawString.bind(this)
+            )
+          };
+        }))
+      } : undefined;
       const supportedAssetsReady = supportedAssets.length > 0
         && supportedAssets.every((asset) => asset.approved === true);
 
@@ -434,6 +485,7 @@ export class BlockchainGateway {
           escrowIsServiceOperator,
           agentAccountIsServiceOperator
         },
+        signerFunding,
         readErrors,
         risk: this.policyRiskSnapshot({
           dailyOutflowCap,

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -361,6 +361,16 @@ test("getTreasuryPolicyStatus surfaces settlement readiness roles", async () => 
       return 11n;
     }
   };
+  gateway.accountContract = {
+    async positions(account, asset) {
+      assert.equal(account, signerAddress);
+      assert.equal(asset, DOT_ASSET.address);
+      return emptyPosition({
+        liquid: 1_000_000_000_000_000_000n,
+        reserved: 250_000_000_000_000_000n
+      });
+    }
+  };
 
   const status = await gateway.getTreasuryPolicyStatus();
 
@@ -379,6 +389,31 @@ test("getTreasuryPolicyStatus surfaces settlement readiness roles", async () => 
     decimals: 18,
     approved: true
   }]);
+  assert.deepEqual(status.signerFunding, {
+    account: signerAddress,
+    agentAccountAddress: "0x3333333333333333333333333333333333333333",
+    assets: [{
+      symbol: "DOT",
+      address: DOT_ASSET.address,
+      assetClass: "custom",
+      assetId: undefined,
+      foreignAssetIndex: undefined,
+      decimals: 18,
+      readable: true,
+      liquid: 1,
+      liquidRaw: "1000000000000000000",
+      reserved: 0.25,
+      reservedRaw: "250000000000000000",
+      strategyAllocated: 0,
+      strategyAllocatedRaw: "0",
+      collateralLocked: 0,
+      collateralLockedRaw: "0",
+      jobStakeLocked: 0,
+      jobStakeLockedRaw: "0",
+      debtOutstanding: 0,
+      debtOutstandingRaw: "0"
+    }]
+  });
 });
 
 test("getTreasuryPolicyStatus preserves raw policy risk values when numbers are unsafe", async () => {
@@ -445,6 +480,11 @@ test("getTreasuryPolicyStatus preserves raw policy risk values when numbers are 
     },
     async disputeLossReliabilityPenalty() {
       return 50n;
+    }
+  };
+  gateway.accountContract = {
+    async positions() {
+      return emptyPosition();
     }
   };
 
@@ -528,6 +568,11 @@ test("getTreasuryPolicyStatus records individual read errors without hiding role
     },
     async disputeLossReliabilityPenalty() {
       return 11n;
+    }
+  };
+  gateway.accountContract = {
+    async positions() {
+      return emptyPosition();
     }
   };
 

--- a/scripts/ops/check-product-proof-gate.mjs
+++ b/scripts/ops/check-product-proof-gate.mjs
@@ -178,6 +178,7 @@ function assertWorkerLoopCompletionEvidence(evidence, { apiBaseUrl }) {
   assert.equal(settlement.roles?.signerIsVerifier, true, "worker-loop evidence requires signer verifier role");
   assert.equal(settlement.roles?.escrowIsServiceOperator, true, "worker-loop evidence requires EscrowCore service-operator role");
   assert.equal(settlement.roles?.agentAccountIsServiceOperator, true, "worker-loop evidence requires AgentAccountCore service-operator role");
+  assert.ok(settlement.roles?.signerAddress, "worker-loop evidence requires configured signer address");
 
   assert.equal(evidence.rewardReadiness?.asset, REQUIRED_ESCROW_ASSET.symbol, "worker-loop evidence reward readiness must be USDC");
   assertRawAtLeast(
@@ -186,6 +187,23 @@ function assertWorkerLoopCompletionEvidence(evidence, { apiBaseUrl }) {
     "worker-loop evidence reward must clear the USDC minBalance"
   );
   assert.equal(evidence.rewardReadiness?.minBalanceRaw, REQUIRED_ESCROW_ASSET.minBalanceRaw, "worker-loop evidence reward minBalance must match canonical USDC");
+
+  assert.equal(evidence.signerFundingReadiness?.asset, REQUIRED_ESCROW_ASSET.symbol, "worker-loop evidence signer funding readiness must be USDC");
+  assert.equal(
+    String(evidence.signerFundingReadiness?.signer ?? "").toLowerCase(),
+    String(settlement.roles?.signerAddress ?? "").toLowerCase(),
+    "worker-loop evidence signer funding account must match configured signer"
+  );
+  assert.equal(
+    evidence.signerFundingReadiness?.rewardRaw,
+    evidence.rewardReadiness?.rewardRaw,
+    "worker-loop evidence signer funding rewardRaw must match reward readiness"
+  );
+  assertRawAtLeast(
+    evidence.signerFundingReadiness?.availableRaw,
+    evidence.signerFundingReadiness?.requiredRaw,
+    "worker-loop evidence signer funding must cover required reward"
+  );
 
   assert.equal(evidence.liquidityReadiness?.wallet?.toLowerCase(), evidence.wallet.toLowerCase(), "worker-loop evidence liquidity wallet must match worker wallet");
   assert.equal(evidence.liquidityReadiness?.asset, REQUIRED_ESCROW_ASSET.symbol, "worker-loop evidence liquidity readiness must be USDC");
@@ -211,6 +229,23 @@ function assertWorkerLoopCompletionEvidence(evidence, { apiBaseUrl }) {
     evidence.claimLiquidityReadiness?.availableRaw,
     evidence.claimLiquidityReadiness?.requiredRaw,
     "worker-loop evidence claim liquidity must cover reward plus claim lock"
+  );
+
+  assert.equal(evidence.claimSignerFundingReadiness?.asset, REQUIRED_ESCROW_ASSET.symbol, "worker-loop evidence claim signer funding readiness must be USDC");
+  assert.equal(
+    evidence.claimSignerFundingReadiness?.rewardRaw,
+    evidence.rewardReadiness?.rewardRaw,
+    "worker-loop evidence claim signer funding rewardRaw must match reward readiness"
+  );
+  assertRawAtLeast(
+    evidence.claimSignerFundingReadiness?.requiredRaw,
+    evidence.rewardReadiness?.rewardRaw,
+    "worker-loop evidence claim signer funding requirement must include at least the reward"
+  );
+  assertRawAtLeast(
+    evidence.claimSignerFundingReadiness?.availableRaw,
+    evidence.claimSignerFundingReadiness?.requiredRaw,
+    "worker-loop evidence claim signer funding must cover reward plus claim lock"
   );
 
   assert.equal(evidence.preflightReadiness?.jobId, evidence.jobId, "worker-loop evidence preflight jobId must match evidence jobId");

--- a/scripts/ops/check-product-proof-gate.test.mjs
+++ b/scripts/ops/check-product-proof-gate.test.mjs
@@ -303,6 +303,7 @@ function workerLoopEvidence({ wallet, sessionId, jobId }) {
         approved: true
       },
       roles: {
+        signerAddress: wallet,
         signerIsVerifier: true,
         escrowIsServiceOperator: true,
         agentAccountIsServiceOperator: true
@@ -313,6 +314,14 @@ function workerLoopEvidence({ wallet, sessionId, jobId }) {
       rewardRaw: "100000",
       minBalanceRaw: "70000"
     },
+    signerFundingReadiness: {
+      signer: wallet,
+      asset: "USDC",
+      rewardRaw: "100000",
+      totalClaimLockRaw: "0",
+      requiredRaw: "100000",
+      availableRaw: "155000"
+    },
     liquidityReadiness: {
       wallet,
       asset: "USDC",
@@ -321,6 +330,14 @@ function workerLoopEvidence({ wallet, sessionId, jobId }) {
     },
     claimLiquidityReadiness: {
       wallet,
+      asset: "USDC",
+      rewardRaw: "100000",
+      totalClaimLockRaw: "55000",
+      requiredRaw: "155000",
+      availableRaw: "155000"
+    },
+    claimSignerFundingReadiness: {
+      signer: wallet,
       asset: "USDC",
       rewardRaw: "100000",
       totalClaimLockRaw: "55000",

--- a/scripts/ops/run-hosted-worker-loop.mjs
+++ b/scripts/ops/run-hosted-worker-loop.mjs
@@ -60,6 +60,11 @@ export async function runHostedWorkerLoop({
     rewardAmount: rewardAmountInput,
     asset: settlementReadiness.asset
   });
+  const signerFundingReadiness = assertSignerFundingReady({
+    settlementReadiness,
+    rewardAsset,
+    rewardAmount: rewardAmountInput
+  });
   const liquidityReadiness = await assertProductProofLiquidity({
     platform,
     wallet,
@@ -106,6 +111,13 @@ export async function runHostedWorkerLoop({
     preflightReadiness,
     liquidityReadiness: preClaimLiquidityReadiness,
     settlementReadiness
+  });
+  const claimSignerFundingReadiness = assertSignerFundingReady({
+    settlementReadiness,
+    rewardAsset,
+    rewardAmount: rewardAmountInput,
+    totalClaimLock: preflightReadiness.totalClaimLock,
+    phase: "claim"
   });
 
   log(`Validating hosted product-proof submission for ${jobId}`);
@@ -171,8 +183,10 @@ export async function runHostedWorkerLoop({
     authReadiness,
     settlementReadiness,
     rewardReadiness,
+    signerFundingReadiness,
     liquidityReadiness,
     claimLiquidityReadiness,
+    claimSignerFundingReadiness,
     preflightReadiness,
     validationReadiness,
     invalidValidationReadiness,
@@ -330,6 +344,83 @@ async function assertSubmissionValidationReady({ platform, jobId, preflightReadi
     schemaValidates: validation.schemaValidates ?? "payload.submission",
     submissionKind: validation.submissionKind ?? "structured",
     validatedBeforeClaim: true
+  };
+}
+
+function assertSignerFundingReady({
+  settlementReadiness,
+  rewardAsset,
+  rewardAmount,
+  totalClaimLock = 0,
+  phase = "mutation"
+}) {
+  const asset = settlementReadiness.asset;
+  const decimals = Number(asset.decimals);
+  const rewardRaw = toBaseUnits(rewardAmount, decimals);
+  const totalClaimLockRaw = totalClaimLock === null || totalClaimLock === undefined
+    ? 0n
+    : toBaseUnits(totalClaimLock, decimals);
+  const requiredRaw = rewardRaw + totalClaimLockRaw;
+  const signerFunding = settlementReadiness.signerFunding;
+  const signerAddress = settlementReadiness.roles?.signerAddress;
+  const agentAccountAddress = settlementReadiness.contracts?.agentAccountAddress ?? "AgentAccountCore";
+  if (!signerFunding || typeof signerFunding !== "object") {
+    throw new Error(
+      `Hosted product-proof worker loop requires signer AgentAccountCore funding telemetry before ${phase}; ` +
+      `signer=${signerAddress ?? "missing"}; account=${agentAccountAddress}. ` +
+      "Expose maintenance.policy.signerFunding from /admin/status."
+    );
+  }
+  if (signerAddress && signerFunding.account && !sameWallet(signerFunding.account, signerAddress)) {
+    throw new Error(
+      `Hosted product-proof worker loop signer funding account mismatch before ${phase}; ` +
+      `roles.signerAddress=${signerAddress}; signerFunding.account=${signerFunding.account}.`
+    );
+  }
+  const fundingAsset = (signerFunding.assets ?? []).find(
+    (candidate) => normalizeAssetSymbol(candidate.symbol) === rewardAsset
+  );
+  if (!fundingAsset) {
+    throw new Error(
+      `Hosted product-proof worker loop requires ${rewardAsset} signer funding telemetry before ${phase}; ` +
+      `signer=${signerFunding.account ?? signerAddress ?? "missing"}; account=${agentAccountAddress}.`
+    );
+  }
+  if (fundingAsset.readable === false) {
+    throw new Error(
+      `Hosted product-proof worker loop could not read ${rewardAsset} signer funding before ${phase}; ` +
+      `signer=${signerFunding.account ?? signerAddress ?? "missing"}; account=${agentAccountAddress}.`
+    );
+  }
+  const availableRaw = toRawAssetAmount({
+    rawValue: fundingAsset.liquidRaw,
+    displayValue: fundingAsset.liquid,
+    decimals,
+    label: `signer ${rewardAsset} liquid balance`
+  });
+  if (availableRaw < requiredRaw) {
+    throw new Error(
+      `Hosted product-proof worker loop requires funded signer ${rewardAsset} liquidity before ${phase}; ` +
+      `signer=${signerFunding.account ?? signerAddress ?? "missing"}; account=${agentAccountAddress}; ` +
+      `reward=${formatBaseUnits(rewardRaw, decimals)} ${rewardAsset} (raw ${rewardRaw}); ` +
+      `totalClaimLock=${formatBaseUnits(totalClaimLockRaw, decimals)} ${rewardAsset} (raw ${totalClaimLockRaw}); ` +
+      `required=${formatBaseUnits(requiredRaw, decimals)} ${rewardAsset} (raw ${requiredRaw}); ` +
+      `available=${formatBaseUnits(availableRaw, decimals)} ${rewardAsset} (raw ${availableRaw}). ` +
+      `Fund the configured backend signer by approving ${agentAccountAddress} on the canonical ${rewardAsset} ERC20 precompile and depositing into AgentAccountCore.`
+    );
+  }
+  return {
+    signer: signerFunding.account ?? signerAddress ?? null,
+    asset: rewardAsset,
+    rewardRaw: rewardRaw.toString(),
+    totalClaimLockRaw: totalClaimLockRaw.toString(),
+    requiredRaw: requiredRaw.toString(),
+    availableRaw: availableRaw.toString(),
+    reward: formatBaseUnits(rewardRaw, decimals),
+    totalClaimLock: formatBaseUnits(totalClaimLockRaw, decimals),
+    required: formatBaseUnits(requiredRaw, decimals),
+    available: formatBaseUnits(availableRaw, decimals),
+    agentAccountAddress
   };
 }
 
@@ -661,6 +752,7 @@ async function assertSettlementReadiness(platform, rewardAsset) {
       escrowIsServiceOperator: Boolean(policy.roles?.escrowIsServiceOperator),
       agentAccountIsServiceOperator: Boolean(policy.roles?.agentAccountIsServiceOperator)
     },
+    signerFunding: policy.signerFunding,
     contracts: policy.contracts
   };
 }

--- a/scripts/ops/run-hosted-worker-loop.test.mjs
+++ b/scripts/ops/run-hosted-worker-loop.test.mjs
@@ -116,12 +116,19 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
   assert.equal(written.settlementReadiness.settlementReady, true);
   assert.equal(written.rewardReadiness.minBalanceRaw, "70000");
   assert.equal(written.rewardReadiness.rewardRaw, "100000");
+  assert.equal(written.signerFundingReadiness.signer, wallet);
+  assert.equal(written.signerFundingReadiness.requiredRaw, "100000");
+  assert.equal(written.signerFundingReadiness.availableRaw, "200000");
   assert.equal(written.liquidityReadiness.requiredRaw, "100000");
   assert.equal(written.liquidityReadiness.availableRaw, "100000");
   assert.equal(written.claimLiquidityReadiness.rewardRaw, "100000");
   assert.equal(written.claimLiquidityReadiness.totalClaimLockRaw, "0");
   assert.equal(written.claimLiquidityReadiness.requiredRaw, "100000");
   assert.equal(written.claimLiquidityReadiness.availableRaw, "100000");
+  assert.equal(written.claimSignerFundingReadiness.rewardRaw, "100000");
+  assert.equal(written.claimSignerFundingReadiness.totalClaimLockRaw, "0");
+  assert.equal(written.claimSignerFundingReadiness.requiredRaw, "100000");
+  assert.equal(written.claimSignerFundingReadiness.availableRaw, "200000");
   assert.deepEqual(written.authReadiness.roles, ["admin", "verifier"]);
   assert.ok(written.authReadiness.capabilitiesPresent.includes("verifier:run"));
   assert.equal(written.preflightReadiness.eligible, true);
@@ -387,6 +394,78 @@ test("runHostedWorkerLoop fails closed before mutation when AgentAccountCore USD
   assert.deepEqual(calls.map(([name]) => name), ["getAuthSession", "getAdminStatus", "getAccountSummary"]);
 });
 
+test("runHostedWorkerLoop fails closed before mutation when signer funding telemetry is missing", async () => {
+  const calls = [];
+  await assert.rejects(
+    runHostedWorkerLoop({
+      client: {
+        async getAuthSession() {
+          calls.push(["getAuthSession"]);
+          return authSession();
+        },
+        async getAdminStatus() {
+          calls.push(["getAdminStatus"]);
+          return settlementReadyStatus({ signerFunding: null });
+        },
+        async getAccountSummary() {
+          calls.push(["getAccountSummary"]);
+          throw new Error("should not inspect worker liquidity without signer funding telemetry");
+        },
+        async createJob() {
+          calls.push(["createJob"]);
+          throw new Error("should not create a catalog job without signer funding telemetry");
+        }
+      },
+      now: () => 1700000000000,
+      log: () => {},
+      env: { ADMIN_JWT: "token" }
+    }),
+    /requires signer AgentAccountCore funding telemetry before mutation; signer=0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519; account=0x3333333333333333333333333333333333333333/u
+  );
+
+  assert.deepEqual(calls.map(([name]) => name), ["getAuthSession", "getAdminStatus"]);
+});
+
+test("runHostedWorkerLoop fails closed before mutation when signer USDC funding is missing", async () => {
+  const calls = [];
+  await assert.rejects(
+    runHostedWorkerLoop({
+      client: {
+        async getAuthSession() {
+          calls.push(["getAuthSession"]);
+          return authSession();
+        },
+        async getAdminStatus() {
+          calls.push(["getAdminStatus"]);
+          return settlementReadyStatus({
+            signerFunding: signerFundingReady({
+              account: "0x31ad432dFe083B998c69B6dB88A984ec5207ab7F",
+              liquidUsdcRaw: "0"
+            }),
+            roles: {
+              signerAddress: "0x31ad432dFe083B998c69B6dB88A984ec5207ab7F"
+            }
+          });
+        },
+        async getAccountSummary() {
+          calls.push(["getAccountSummary"]);
+          throw new Error("should not inspect worker liquidity before signer funding is ready");
+        },
+        async createJob() {
+          calls.push(["createJob"]);
+          throw new Error("should not create a catalog job without signer USDC liquidity");
+        }
+      },
+      now: () => 1700000000000,
+      log: () => {},
+      env: { ADMIN_JWT: "token" }
+    }),
+    /requires funded signer USDC liquidity before mutation; signer=0x31ad432dFe083B998c69B6dB88A984ec5207ab7F; account=0x3333333333333333333333333333333333333333; reward=0\.1 USDC \(raw 100000\); totalClaimLock=0 USDC \(raw 0\); required=0\.1 USDC \(raw 100000\); available=0 USDC \(raw 0\)/u
+  );
+
+  assert.deepEqual(calls.map(([name]) => name), ["getAuthSession", "getAdminStatus"]);
+});
+
 test("runHostedWorkerLoop fails closed before mutation when account summary wallet mismatches auth session", async () => {
   const calls = [];
   await assert.rejects(
@@ -568,6 +647,61 @@ test("runHostedWorkerLoop fails closed after preflight when reward plus claim lo
       env: { ADMIN_JWT: "token" }
     }),
     /requires funded USDC liquidity before claim; wallet=0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519; account=0x3333333333333333333333333333333333333333; reward=0\.1 USDC \(raw 100000\); totalClaimLock=0\.055 USDC \(raw 55000\); required=0\.155 USDC \(raw 155000\); available=0\.1 USDC \(raw 100000\)/u
+  );
+
+  assert.deepEqual(calls.map(([name]) => name), [
+    "getAuthSession",
+    "getAdminStatus",
+    "getAccountSummary",
+    "createJob",
+    "preflightJob",
+    "getAccountSummary"
+  ]);
+  assert.equal(calls[4][1], jobId);
+});
+
+test("runHostedWorkerLoop fails closed after preflight when signer reward plus claim lock is underfunded", async () => {
+  const calls = [];
+  const jobId = "product-proof-worker-loop-1700000000000";
+  await assert.rejects(
+    runHostedWorkerLoop({
+      client: {
+        async getAuthSession() {
+          calls.push(["getAuthSession"]);
+          return authSession();
+        },
+        async getAdminStatus() {
+          calls.push(["getAdminStatus"]);
+          return settlementReadyStatus({
+            signerFunding: signerFundingReady({ liquidUsdcRaw: "100000" })
+          });
+        },
+        async getAccountSummary() {
+          calls.push(["getAccountSummary"]);
+          return accountSummary({ liquidUsdcRaw: 200_000 });
+        },
+        async createJob(payload) {
+          calls.push(["createJob", payload]);
+          return { id: payload.id };
+        },
+        async preflightJob(id) {
+          calls.push(["preflightJob", id]);
+          return preflightReady({ jobId: id, totalClaimLock: 0.055 });
+        },
+        async validateJobSubmission() {
+          calls.push(["validateJobSubmission"]);
+          throw new Error("should not validate after signer claim-funding preflight fails");
+        },
+        async claimJob() {
+          calls.push(["claimJob"]);
+          throw new Error("should not claim without signer reward plus claim-lock liquidity");
+        }
+      },
+      now: () => 1700000000000,
+      log: () => {},
+      env: { ADMIN_JWT: "token" }
+    }),
+    /requires funded signer USDC liquidity before claim; signer=0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519; account=0x3333333333333333333333333333333333333333; reward=0\.1 USDC \(raw 100000\); totalClaimLock=0\.055 USDC \(raw 55000\); required=0\.155 USDC \(raw 155000\); available=0\.1 USDC \(raw 100000\)/u
   );
 
   assert.deepEqual(calls.map(([name]) => name), [
@@ -981,6 +1115,7 @@ function validationForSubmission({ jobId, submission }) {
 }
 
 function settlementReadyStatus(overrides = {}) {
+  const policyOverrides = overrides.maintenance?.policy ?? overrides;
   const base = {
     maintenance: {
       policy: {
@@ -990,10 +1125,11 @@ function settlementReadyStatus(overrides = {}) {
         settlementReady: true,
         roles: {
           signerAddress: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
-            signerIsVerifier: true,
-            escrowIsServiceOperator: true,
-            agentAccountIsServiceOperator: true
-          },
+          signerIsVerifier: true,
+          escrowIsServiceOperator: true,
+          agentAccountIsServiceOperator: true
+        },
+        signerFunding: signerFundingReady(),
         contracts: {
           escrowCoreAddress: "0x2222222222222222222222222222222222222222",
           agentAccountAddress: "0x3333333333333333333333333333333333333333",
@@ -1022,14 +1158,41 @@ function settlementReadyStatus(overrides = {}) {
         ...(overrides.maintenance?.policy ?? overrides),
         roles: {
           ...base.maintenance.policy.roles,
-          ...((overrides.maintenance?.policy ?? overrides).roles ?? {})
+          ...(policyOverrides.roles ?? {})
         },
+        signerFunding: Object.prototype.hasOwnProperty.call(policyOverrides, "signerFunding")
+          ? policyOverrides.signerFunding
+          : base.maintenance.policy.signerFunding,
         contracts: {
           ...base.maintenance.policy.contracts,
-          ...((overrides.maintenance?.policy ?? overrides).contracts ?? {})
+          ...(policyOverrides.contracts ?? {})
         }
       }
     }
+  };
+}
+
+function signerFundingReady({
+  account = "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+  liquidUsdcRaw = "200000",
+  liquidUsdc = Number(liquidUsdcRaw) / 1_000_000
+} = {}) {
+  return {
+    account,
+    agentAccountAddress: "0x3333333333333333333333333333333333333333",
+    assets: [{
+      symbol: "USDC",
+      address: "0x0000053900000000000000000000000001200000",
+      assetClass: "trust_backed",
+      assetId: 1337,
+      decimals: 6,
+      minBalanceRaw: "70000",
+      readable: true,
+      liquid: liquidUsdc,
+      liquidRaw: String(liquidUsdcRaw),
+      reserved: 0,
+      reservedRaw: "0"
+    }]
   };
 }
 


### PR DESCRIPTION
## What changed
- Expose configured signer AgentAccountCore funding in /admin/status policy readiness.
- Make the hosted product-proof worker loop fail closed on missing/underfunded signer USDC before mutation/claim.
- Require signer funding evidence in the product-proof gate and document the KMS signer funding proof requirement.

## Why
The strict hosted worker-loop proof now fails because the production backend signer moved to KMS and the new signer has 0 USDC liquid in AgentAccountCore. This makes that condition visible and auditable before the worker loop spends mutations.

## Checks
- node --test scripts/ops/run-hosted-worker-loop.test.mjs scripts/ops/check-product-proof-gate.test.mjs
- node --test mcp-server/src/blockchain/gateway.test.js
- npm --workspace mcp-server test
- git diff --check

## Surfaces
Backend status, hosted product-proof ops scripts, docs. No frontend, indexer, Caddy, contracts, or generated static output.