### PR TITLE
fix(kms-signer): preserve tx fields when caller passes Transaction instance

### DIFF
--- a/mcp-server/src/blockchain/kms-signer.js
+++ b/mcp-server/src/blockchain/kms-signer.js
@@ -188,25 +188,54 @@ export class KmsSigner extends AbstractSigner {
    * signed transaction (an `0x`-prefixed hex string) ready to broadcast.
    */
   async signTransaction(tx) {
-    // Convert ethers TransactionRequest → Transaction so we can ask
-    // for the unsigned hash. The `from` field is informational here;
-    // ethers normalizes it but the chain doesn't care because the
-    // sender is recovered from the signature.
-    const txCopy = { ...tx };
-    if (txCopy.from != null) {
-      // Confirm the populated `from` matches our address — if it
-      // doesn't, the caller is using us for a tx that wouldn't recover
-      // back to us. Catch the misuse here rather than letting the
-      // chain reject after a wasted gas estimation.
+    // `tx` may arrive as either:
+    //   (a) a TransactionLike POJO (direct callers, our own tests), or
+    //   (b) a Transaction class instance (the AbstractSigner.sendTransaction
+    //       path used by ethers Contracts — pop is wrapped via
+    //       `Transaction.from(pop)` before being passed here).
+    // CRITICAL: `{ ...tx }` returns `{}` for (b) because Transaction
+    // exposes its fields via getters, not as enumerable own properties.
+    // Use `Transaction.from(tx)` which copies fields correctly in both
+    // cases; this normalizes the input before we read `from` or sign.
+    //
+    // Subtlety: ethers' `Transaction.from()` rejects any input (POJO or
+    // instance) whose `.from` is set, with "unsigned transaction cannot
+    // define '.from'". Read `tx.from` (works for both shapes — POJOs
+    // have it as an own property, instances expose it via the same-named
+    // getter) BEFORE coercing, then pass a sanitized POJO without
+    // `from`. For Transaction instances we can't mutate the input
+    // safely; for POJOs we avoid mutating the caller's object too.
+    const callerFrom = tx?.from ?? null;
+    let coercionInput = tx;
+    if (callerFrom != null) {
       const ourAddress = await this.getAddress();
-      if (String(txCopy.from).toLowerCase() !== ourAddress.toLowerCase()) {
+      if (String(callerFrom).toLowerCase() !== ourAddress.toLowerCase()) {
+        // Confirm the populated `from` matches our address — if it
+        // doesn't, the caller is using us for a tx that wouldn't recover
+        // back to us. Catch the misuse here rather than letting the
+        // chain reject after a wasted gas estimation.
         throw new Error(
-          `KmsSigner.signTransaction: tx.from (${txCopy.from}) does not match this signer's address (${ourAddress})`,
+          `KmsSigner.signTransaction: tx.from (${callerFrom}) does not match this signer's address (${ourAddress})`,
         );
       }
-      delete txCopy.from;
+      // Rebuild a plain TransactionLike POJO without `from` so
+      // Transaction.from() doesn't reject. Use the instance's getters
+      // (or the POJO's own properties) to copy each field explicitly.
+      coercionInput = {
+        type: tx.type,
+        chainId: tx.chainId,
+        nonce: tx.nonce,
+        gasLimit: tx.gasLimit,
+        gasPrice: tx.gasPrice,
+        maxFeePerGas: tx.maxFeePerGas,
+        maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
+        to: tx.to,
+        value: tx.value,
+        data: tx.data,
+        accessList: tx.accessList,
+      };
     }
-    const unsignedTx = Transaction.from(txCopy);
+    const unsignedTx = Transaction.from(coercionInput);
     const digest = unsignedTx.unsignedHash;
     const sig = await this.#signDigest(getBytes(digest));
     unsignedTx.signature = sig;

--- a/mcp-server/src/blockchain/kms-signer.test.js
+++ b/mcp-server/src/blockchain/kms-signer.test.js
@@ -215,6 +215,45 @@ test("KmsSigner.signTransaction produces a serialized tx that recovers to our ad
   assert.equal(decoded.chainId, 1n);
 });
 
+test("KmsSigner.signTransaction handles a Transaction class instance (not just POJO) — regression for empty-tx bug", async () => {
+  // Regression: ethers v6 AbstractSigner.sendTransaction (the path used
+  // by every ethers.Contract method call) wraps the populated tx via
+  // `Transaction.from(pop)` before passing it to signTransaction. The
+  // resulting Transaction class instance exposes its fields via
+  // getters, not enumerable own properties, so `{ ...txInstance }`
+  // returns `{}` and `Transaction.from({})` produces an empty tx
+  // (chainId=0, no to, no data, no gas) — which `eth_sendRawTransaction`
+  // rejects as "Invalid transaction". This test exercises the
+  // instance-input path to lock down the fix.
+  const kms = new FakeKMSClient();
+  const signer = new KmsSigner({ kmsClient: kms, keyId: "test-key" });
+
+  const txPojo = {
+    chainId: 1n,
+    nonce: 7,
+    maxFeePerGas: 30_000_000_000n,
+    maxPriorityFeePerGas: 1_000_000_000n,
+    gasLimit: 21_000n,
+    to: "0x0000000000000000000000000000000000000001",
+    value: 0n,
+    data: "0xdeadbeef",
+    type: 2,
+  };
+  const txInstance = Transaction.from(txPojo);
+
+  const signedHex = await signer.signTransaction(txInstance);
+  const decoded = Transaction.from(signedHex);
+  assert.equal(
+    decoded.to,
+    "0x0000000000000000000000000000000000000001",
+    "to must survive the instance → signTransaction → serialized round-trip",
+  );
+  assert.equal(decoded.chainId, 1n, "chainId must survive (bug would give 0)");
+  assert.equal(decoded.nonce, 7, "nonce must survive");
+  assert.equal(decoded.data, "0xdeadbeef", "data must survive (bug would give 0x)");
+  assert.equal(decoded.from, EXPECTED_ADDRESS, "from-recovery matches our address");
+});
+
 test("KmsSigner.signTransaction rejects mismatched from-address", async () => {
   const kms = new FakeKMSClient();
   const signer = new KmsSigner({ kmsClient: kms, keyId: "test-key" });


### PR DESCRIPTION
## Summary

`KmsSigner.signTransaction()` shallow-copied its input with `{ ...tx }` before
coercing via `Transaction.from(...)`. When called via ethers v6's
`AbstractSigner.sendTransaction` (the path used by every `ethers.Contract` call),
the input is a **`Transaction` class instance** rather than a POJO. Transaction
exposes its fields (`to`, `data`, `value`, `chainId`, `nonce`, `maxFeePerGas`,
…) via **getters, not enumerable own properties** — so `{ ...transactionInstance }`
returns `{}`, and `Transaction.from({})` yields an empty unsigned tx
(`chainId=0`, no `to`, no `data`, no gas). The resulting serialized payload is
rejected by `eth_sendRawTransaction` with `"Invalid transaction"`. Every
KMS-signed on-chain transaction routed through an ethers Contract would have
failed.

## Empirical proof

Anyone can reproduce the underlying ethers behaviour without our code:

```bash
node -e 'import("ethers").then(({Transaction})=>{
  const orig = Transaction.from({
    chainId: 420420417n, nonce: 0, type: 2,
    maxFeePerGas: 30_000_000_000n, maxPriorityFeePerGas: 1_000_000_000n,
    gasLimit: 100_000n,
    to: "0x0000053900000000000000000000000001200000",
    value: 0n, data: "0xa9059cbb",
  });
  console.log("spread:", JSON.stringify({...orig}, (k,v)=>typeof v==="bigint"?v.toString():v));
  console.log("Transaction.from:", Transaction.from(orig).to);
});'
# spread: {}                                                       ← BUG path
# Transaction.from: 0x0000053900000000000000000000000001200000     ← what we want
```

## Fix

`mcp-server/src/blockchain/kms-signer.js`:

- Drop the `{ ...tx }` spread + `delete txCopy.from` dance.
- Read `tx.from` directly (works for both POJOs and Transaction instances — the
  instance exposes `.from` via a getter), perform the
  match-against-our-address check using that value, then build a sanitized
  `TransactionLike` POJO (without `from`) by copying each field. Pass that to
  `Transaction.from(...)`. Both POJO and instance inputs now round-trip
  correctly.
- This preserves the previous behaviour (mismatched `from` still throws with
  the same error message) while fixing the empty-tx bug for instance inputs.

## Regression test

Added to `mcp-server/src/blockchain/kms-signer.test.js`:
`"KmsSigner.signTransaction handles a Transaction class instance (not just POJO) — regression for empty-tx bug"`.

It calls `Transaction.from(pojo)` to build an instance, signs it via the
`KmsSigner` (backed by the test's FakeKMSClient), then re-parses the resulting
serialized hex and asserts `to`, `chainId`, `nonce`, and `data` all survive
(the bug would silently produce `to: null` and `data: "0x"`), and that the
recovered `from` matches our signer address.

Verified the test catches the bug by running it against the unpatched
`main` code — it fails on `decoded.to` being `null`. With the fix in place it
passes alongside the two existing `signTransaction` tests.

## Verification (production)

With this fix applied in a local worktree, the first real KMS-signed prod tx
succeeded end-to-end on Paseo Asset Hub:

- **Approve**: `0xde3d…af50` (block 8937494)
- **Deposit**: `0x2a7d…d754` (block 8937497)
- `from` on both = `0x31ad432dFe…7ab7F` (the KMS-derived address)
- `AgentAccountCore.position[0x31ad,USDC].liquid = 0.4` post-deposit ✓

## Test plan

- [ ] CI green
- [x] `npm --workspace mcp-server test -- --test-name-pattern 'KmsSigner'` passes locally — all 10 KmsSigner cases (incl. the new regression test and the two existing `signTransaction` tests) plus the 3 spki helper cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)