### PR TITLE
Require XCM upstream failure codes

### DIFF
--- a/indexer/src/api/xcm-upstream-source.test.ts
+++ b/indexer/src/api/xcm-upstream-source.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  HttpFeedSourceAdapter,
   NativePapiXcmSourceAdapter,
   SubscanXcmSourceAdapter,
   createXcmUpstreamSourceAdapter,
@@ -86,6 +87,21 @@ test("native PAPI evidence preserves explicit failure metadata", () => {
   assert.equal(outcome.status, "failed");
   assert.equal(outcome.failureCode, failureCode);
   assert.equal(outcome.source, "native_papi_staging");
+});
+
+test("native PAPI evidence rejects failed outcomes without failureCode", () => {
+  assert.throws(
+    () => normalizeNativeXcmEvidence({
+      requestId,
+      status: "failed",
+      observedAt: "2026-04-23T12:30:00.000Z",
+      correlation: {
+        method: "ledger_join",
+        confidence: "staging"
+      }
+    }),
+    /failed items must include failureCode/u
+  );
 });
 
 test("native PAPI evidence preserves large uint256 settlement amounts exactly", () => {
@@ -205,6 +221,45 @@ test("Subscan source preserves failure code for failed status variants", () => {
 
   assert.equal(outcome?.status, "failed");
   assert.equal(outcome?.failureCode, failureCode);
+});
+
+test("Subscan source rejects failed status variants without failure code", () => {
+  const adapter = new SubscanXcmSourceAdapter({
+    apiHost: "https://subscan.example",
+    apiKey: "test"
+  });
+
+  assert.throws(
+    () => adapter.normalizeSubscanEntry({
+      message_topic: requestId,
+      execution_status: "xcm_failed",
+      block_timestamp: "1712345678"
+    }),
+    /failed items must include failureCode/u
+  );
+});
+
+test("HTTP feed source rejects failed items without failureCode", async () => {
+  const adapter = new HttpFeedSourceAdapter({
+    url: "https://feed.example/xcm",
+    fetchImpl: async () => ({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            requestId,
+            status: "failed",
+            observedAt: "2026-04-23T12:30:00.000Z"
+          }
+        ]
+      })
+    } as Response)
+  });
+
+  await assert.rejects(
+    () => adapter.fetchBatch({ limit: 25 }),
+    /failed items must include failureCode/u
+  );
 });
 
 test("Subscan source ignores uncorrelated message and extrinsic hashes", () => {

--- a/indexer/src/api/xcm-upstream-source.ts
+++ b/indexer/src/api/xcm-upstream-source.ts
@@ -144,6 +144,14 @@ function normalizeStatus(value: unknown) {
   return normalized;
 }
 
+function normalizeFailureCode(value: unknown, status: string) {
+  const failureCode = normalizeOptionalHex32(value);
+  if (status === "failed" && !failureCode) {
+    throw new Error("XCM upstream failed items must include failureCode.");
+  }
+  return failureCode;
+}
+
 function normalizeFeedItem(item: unknown, fallbackSource = "external_xcm_source"): PublishedOutcome {
   if (!item || typeof item !== "object" || Array.isArray(item)) {
     throw new Error("XCM upstream items must be objects.");
@@ -153,13 +161,14 @@ function normalizeFeedItem(item: unknown, fallbackSource = "external_xcm_source"
   if (!/^0x[a-fA-F0-9]{64}$/u.test(requestId)) {
     throw new Error("XCM upstream requestId must be a 0x-prefixed 32-byte hex string.");
   }
+  const status = normalizeStatus(sourceItem.status);
   return {
     requestId,
-    status: normalizeStatus(sourceItem.status),
+    status,
     settledAssets: normalizeAmount(sourceItem.settledAssets),
     settledShares: normalizeAmount(sourceItem.settledShares),
     remoteRef: normalizeOptionalHex32(sourceItem.remoteRef),
-    failureCode: normalizeOptionalHex32(sourceItem.failureCode),
+    failureCode: normalizeFailureCode(sourceItem.failureCode, status),
     observedAt: normalizeObservedAt(sourceItem.observedAt),
     source: typeof sourceItem.source === "string" && sourceItem.source.trim()
       ? sourceItem.source.trim()
@@ -460,7 +469,7 @@ export class SubscanXcmSourceAdapter implements XcmUpstreamSourceAdapter {
       settledShares: "0",
       remoteRef: normalizeOptionalHex32(this.pickString(entry, ["remote_ref", "query_id"])),
       failureCode: status === "failed"
-        ? normalizeOptionalHex32(this.pickString(entry, ["error_code", "failure_code"]))
+        ? normalizeFailureCode(this.pickString(entry, ["error_code", "failure_code"]), status)
         : null,
       observedAt: normalizeObservedAt(this.pickString(entry, ["block_timestamp", "timestamp", "time"])),
       source: "subscan_xcm_api"


### PR DESCRIPTION
## Summary
- require normalized failed XCM upstream outcomes to include a valid 32-byte failureCode
- apply the invariant to HTTP feed, native PAPI evidence, and Subscan status normalization
- add focused indexer API tests for rejected failed outcomes without failureCode

## Checks
- npm --workspace indexer run test:api
- npm --workspace indexer run typecheck
- git diff --check

## Surface
- indexer / XCM external outcome source normalization only
- no environment or VPS secret changes required