### PR TITLE
Fill AUDIT_PACKAGE §9 contact placeholders

### DIFF
--- a/docs/AUDIT_PACKAGE.md
+++ b/docs/AUDIT_PACKAGE.md
@@ -389,7 +389,7 @@ suites above.
 
 ## 9. Contact
 
-- Primary: <TBD — fill in before sending>
-- Escalation: <TBD>
+- Primary: <pkuriger@averray.com>
+- Escalation: <ops@averray.com>
 - Response SLA: within 2 business days for questions during audit; within
   1 business day for findings classified Critical.


### PR DESCRIPTION
## Summary

Replaces the `<TBD>` primary + escalation contact placeholders in `docs/AUDIT_PACKAGE.md` §9 with the actual addresses, so the audit package can be sent to a firm without an inline "ask us" deliverable. SLA wording unchanged.

```diff
-- Primary: <TBD — fill in before sending>
-- Escalation: <TBD>
++ Primary: <pkuriger@averray.com>
++ Escalation: <ops@averray.com>
```

The §9 placeholders predate this session — they've been in place since the audit package was first drafted. This was the last remaining `<TBD>` on the v1-contract-audit side.

The matching contact block in `docs/STRATEGY_ADAPTER_AUDIT_SCOPE.md` §11 is updated in the same commit on open PR **#380**, so the two docs land in sync regardless of merge order.

## Scope

- Doc-only change, single file, single hunk (+2/-2).
- No code, no tests, no contracts, no workflows touched.
- SLA wording unchanged ("within 2 business days for questions during audit; within 1 business day for findings classified Critical").

## Affects

- backend / frontend / indexer / Caddy / contracts / public site: **none** (docs only)
- Required env or VPS secret changes: **none**

## Test plan

- [x] Diff is exactly 2 lines, no other changes
- [ ] Reviewer confirms the addresses are the canonical inbound surface for external audit firms

🤖 Generated with [Claude Code](https://claude.com/claude-code)