### PR TITLE
Add --use-kms mode to fund-signer-usdc-deposit + KMS variant runbook

### DIFF
--- a/docs/TESTNET_FUND_SIGNER.md
+++ b/docs/TESTNET_FUND_SIGNER.md
@@ -166,13 +166,38 @@ sweep mechanism that retroactively credits a position.
 
 ### 3a. Use the in-repo script
 
+The helper supports two signing backends — pick the one that matches
+your deployment's `SIGNER_BACKEND`:
+
+- **`SIGNER_BACKEND=local`** (pre-Phase 3): raw `PRIVATE_KEY` env
+- **`SIGNER_BACKEND=kms`** (Phase 3 default after 2026-05-16):
+  `--use-kms` with `KMS_KEY_ID` + `AWS_REGION` env
+
+Both modes share the same `--dry-run` default. Dry-run is read-only,
+prints the encoded calldata, and exits without signing.
+
 ```bash
 cd /path/to/your/agent/clone
+```
 
-# Dry-run first (no key needed) — prints planned txs + preconditions
+#### Dry-run — works without a private key or KMS creds
+
+```bash
+# Read state for the canonical verifier address from deployments/<profile>.json:
 node scripts/ops/fund-signer-usdc-deposit.mjs --amount 10000000
 
-# Commit (requires PRIVATE_KEY env). One-line, key never enters shell history if cleared.
+# Read state for the KMS-derived address (one kms:GetPublicKey call, no kms:Sign):
+KMS_KEY_ID=arn:aws:kms:<region>:<account>:key/<id> AWS_REGION=<region> \
+  node scripts/ops/fund-signer-usdc-deposit.mjs --amount 10000000 --use-kms
+
+# Hard-code the signer address (audits without AWS creds):
+SIGNER_ADDRESS_OVERRIDE=0x31ad432dFe083B998c69B6dB88A984ec5207ab7F \
+  node scripts/ops/fund-signer-usdc-deposit.mjs --amount 10000000
+```
+
+#### Commit — raw key path (`SIGNER_BACKEND=local`)
+
+```bash
 PRIVATE_KEY=0x<deployer-key> node scripts/ops/fund-signer-usdc-deposit.mjs \
   --amount 10000000 --commit
 
@@ -180,12 +205,50 @@ PRIVATE_KEY=0x<deployer-key> node scripts/ops/fund-signer-usdc-deposit.mjs \
 fc -p
 ```
 
-The script:
-1. Verifies signer's USDC balance ≥ amount
-2. Calls `usdc.approve(agentAccountCore, amount)`
-3. Calls `agentAccountCore.deposit(usdc, amount)`
-4. Verifies `positions.liquid` increased by `amount`
-5. Exits non-zero on any precondition / postcondition failure
+#### Commit — KMS path (`SIGNER_BACKEND=kms`)
+
+This is the Phase 3 flow (post 2026-05-16 cutover, see
+[`docs/SECRETS_MIGRATION.md`](SECRETS_MIGRATION.md) §"Phase 3 — AWS
+KMS for the backend signer"). The KMS key has no exportable private
+material; the helper calls `kms:Sign` for each tx via the same
+`KmsSigner` ([`mcp-server/src/blockchain/kms-signer.js`](../mcp-server/src/blockchain/kms-signer.js))
+the runtime backend uses.
+
+```bash
+# IAM creds must be visible to the AWS SDK (env, ~/.aws/credentials, or
+# an attached role). The IAM principal needs kms:GetPublicKey + kms:Sign
+# on the key with SigningAlgorithm=ECDSA_SHA_256, MessageType=DIGEST.
+export KMS_KEY_ID=arn:aws:kms:<region>:<account>:key/<id>
+export AWS_REGION=<region>
+# Optional if not already in your environment:
+# export AWS_ACCESS_KEY_ID=...
+# export AWS_SECRET_ACCESS_KEY=...
+
+node scripts/ops/fund-signer-usdc-deposit.mjs \
+  --amount 10000000 --use-kms --commit
+```
+
+What happens under the hood (per
+[`mcp-server/src/blockchain/kms-signer.js`](../mcp-server/src/blockchain/kms-signer.js)):
+
+1. `KmsSigner` calls `kms:GetPublicKey` once and caches the
+   secp256k1 public point → derives the EVM address.
+2. For each of `approve` + `deposit`, ethers populates the unsigned
+   tx (nonce, gas, chainId), `KmsSigner.signTransaction` computes the
+   RLP unsigned hash, then calls `kms:Sign(MessageType=DIGEST,
+   SigningAlgorithm=ECDSA_SHA_256)`.
+3. The DER signature is parsed, `s` is normalised to the low half of
+   the group order (EIP-2), and the recovery byte is brute-forced
+   against the cached address.
+4. The signed RLP tx is broadcast normally; postcondition check runs
+   the same way as the raw-key path.
+
+Both modes:
+1. Verify signer's USDC balance ≥ amount
+2. Call `usdc.approve(agentAccountCore, amount)`
+3. Call `agentAccountCore.deposit(usdc, amount)`
+4. Verify `positions.liquid` increased by `amount`
+5. Exit non-zero on any precondition / postcondition failure
 
 ### 3b. Or use `cast` directly (no Node deps required)
 

--- a/scripts/ops/fund-signer-usdc-deposit.mjs
+++ b/scripts/ops/fund-signer-usdc-deposit.mjs
@@ -36,12 +36,34 @@
  *   --dry-run     (default)   Reads everything, prints the planned
  *                             txs, exits without signing.
  *   --commit                  Actually sends the approve + deposit
- *                             transactions. Requires PRIVATE_KEY env.
+ *                             transactions. Requires PRIVATE_KEY env
+ *                             (or --use-kms, see below).
+ *   --use-kms                 Sign approve + deposit via the AWS KMS
+ *                             signer (Phase 3 path). When combined
+ *                             with --commit, signs each tx with one
+ *                             kms:Sign call; without --commit, just
+ *                             resolves the signer address from KMS so
+ *                             the dry-run reports state for the real
+ *                             KMS-derived wallet.
+ *                             Requires KMS_KEY_ID + AWS_REGION env
+ *                             plus IAM creds the AWS SDK can pick up
+ *                             (env, ~/.aws/credentials, or an attached
+ *                             role).
  *
  * Usage
  * -----
+ *   # Raw-key path (pre-Phase-3 / SIGNER_BACKEND=local):
  *   PRIVATE_KEY=0x... node scripts/ops/fund-signer-usdc-deposit.mjs \
  *     --amount 10000000 --commit
+ *
+ *   # KMS path (Phase 3 / SIGNER_BACKEND=kms):
+ *   KMS_KEY_ID=arn:aws:kms:eu-central-2:...:key/... AWS_REGION=eu-central-2 \
+ *     node scripts/ops/fund-signer-usdc-deposit.mjs \
+ *     --amount 10000000 --use-kms --commit
+ *
+ *   # KMS-aware dry-run (reads state for the real KMS address, no signing):
+ *   KMS_KEY_ID=... AWS_REGION=... \
+ *     node scripts/ops/fund-signer-usdc-deposit.mjs --amount 10000000 --use-kms
  *
  * `--amount` is in USDC base units (6 decimals). `10000000` = 10 USDC.
  *
@@ -49,13 +71,17 @@
  * -----
  * The script is read-only by default for safety. The dry-run output
  * includes the calldata so it can be cross-checked against an
- * independent encoder before committing.
+ * independent encoder before committing. With --use-kms, the only AWS
+ * API calls the dry-run path makes are kms:GetPublicKey (to derive the
+ * address) — no kms:Sign.
  */
 
 import { JsonRpcProvider, Wallet, Contract, Interface } from "ethers";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
+
+import { KmsSigner } from "../../mcp-server/src/blockchain/kms-signer.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "..", "..");
@@ -70,12 +96,13 @@ const AGENT_ACCOUNT_DEPOSIT_ABI = [
   "function positions(address account, address asset) view returns (uint256 liquid, uint256 reserved, uint256 strategyAllocated, uint256 collateralLocked, uint256 jobStakeLocked, uint256 debtOutstanding)"
 ];
 
-function parseArgs(argv) {
-  const args = { dryRun: true, amount: undefined, profile: "testnet" };
+export function parseArgs(argv) {
+  const args = { dryRun: true, amount: undefined, profile: "testnet", useKms: false };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--commit") args.dryRun = false;
     else if (arg === "--dry-run") args.dryRun = true;
+    else if (arg === "--use-kms") args.useKms = true;
     else if (arg === "--amount") args.amount = argv[++i];
     else if (arg === "--profile") args.profile = argv[++i];
     else if (arg === "--help" || arg === "-h") args.help = true;
@@ -93,10 +120,27 @@ function printUsage() {
       "                         e.g. --amount 10000000 for 10 USDC.",
       "  --profile <name>       deployments/<profile>.json. Default: testnet.",
       "  --dry-run              (default) Read-only; prints planned txs.",
-      "  --commit               Sends approve + deposit txs. Requires PRIVATE_KEY.",
+      "  --commit               Sends approve + deposit txs.",
+      "                         Requires PRIVATE_KEY env (unless --use-kms).",
+      "  --use-kms              Sign via AWS KMS instead of a local private key.",
+      "                         Resolves the signer address from KMS_KEY_ID.",
+      "                         Combine with --commit to actually send the txs;",
+      "                         on its own, runs a KMS-aware dry-run.",
       "",
       "Env:",
-      "  PRIVATE_KEY            0x-prefixed signer key. Required only with --commit."
+      "  PRIVATE_KEY                0x-prefixed signer key. Required for --commit",
+      "                             without --use-kms.",
+      "  KMS_KEY_ID                 AWS KMS key id, ARN, or alias. Required with",
+      "                             --use-kms.",
+      "  AWS_REGION                 AWS region the KMS key lives in. Required with",
+      "                             --use-kms.",
+      "  AWS_ACCESS_KEY_ID,         Standard AWS SDK credential discovery; supply",
+      "  AWS_SECRET_ACCESS_KEY      via env, ~/.aws/credentials, or an attached IAM",
+      "                             role. Needed only when --use-kms is in effect.",
+      "  SIGNER_ADDRESS_OVERRIDE    Force the signer address used by dry-run output",
+      "                             (debugging / KMS audits without AWS creds).",
+      "                             Ignored when --commit or --use-kms supply their",
+      "                             own address from the key/KMS."
     ].join("\n")
   );
 }
@@ -137,28 +181,61 @@ async function main() {
 
   const provider = new JsonRpcProvider(rpcUrl);
 
-  // Resolve the signer address from PRIVATE_KEY when committing.
-  // In dry-run mode, accept --signer override or fall back to the
-  // deployment file's `verifier` field, which is the canonical signer
-  // wallet address on testnet.
-  let signerAddress = String(process.env.SIGNER_ADDRESS_OVERRIDE ?? deployments.verifier ?? "").trim();
-  let wallet;
-  if (!args.dryRun) {
+  // Resolve the signer address. Precedence:
+  //   1. --use-kms  -> kms:GetPublicKey via KmsSigner (Phase 3 path).
+  //   2. --commit (without --use-kms) -> derive from PRIVATE_KEY env.
+  //   3. dry-run    -> SIGNER_ADDRESS_OVERRIDE, then deployments.verifier.
+  let signerAddress = "";
+  let signerBackend = "deployments.verifier";
+  let wallet = null;
+  let kmsSigner = null;
+
+  if (args.useKms) {
+    const keyId = String(process.env.KMS_KEY_ID ?? "").trim();
+    const region = String(process.env.AWS_REGION ?? "").trim();
+    if (!keyId) {
+      console.error("--use-kms requires KMS_KEY_ID env (key id, ARN, or alias).");
+      process.exitCode = 1;
+      return;
+    }
+    if (!region) {
+      console.error("--use-kms requires AWS_REGION env (the region the KMS key lives in).");
+      process.exitCode = 1;
+      return;
+    }
+    kmsSigner = new KmsSigner({ keyId, region, provider });
+    try {
+      signerAddress = await kmsSigner.getAddress();
+    } catch (error) {
+      console.error(`KMS GetPublicKey failed: ${error?.message ?? error}. Confirm IAM creds + KMS_KEY_ID.`);
+      process.exitCode = 1;
+      return;
+    }
+    signerBackend = "kms";
+  } else if (!args.dryRun) {
     const privateKey = String(process.env.PRIVATE_KEY ?? "").trim();
     if (!/^0x[a-fA-F0-9]{64}$/u.test(privateKey)) {
-      console.error("PRIVATE_KEY env (0x-prefixed 32-byte hex) is required with --commit.");
+      console.error("PRIVATE_KEY env (0x-prefixed 32-byte hex) is required with --commit. Use --use-kms for KMS-backed signers.");
       process.exitCode = 1;
       return;
     }
     wallet = new Wallet(privateKey, provider);
     signerAddress = wallet.address;
+    signerBackend = "private-key";
+  } else {
+    signerAddress = String(process.env.SIGNER_ADDRESS_OVERRIDE ?? deployments.verifier ?? "").trim();
+    signerBackend = process.env.SIGNER_ADDRESS_OVERRIDE ? "override" : "deployments.verifier";
   }
 
   if (!/^0x[a-fA-F0-9]{40}$/u.test(signerAddress)) {
-    console.error("Could not resolve signer address. Set SIGNER_ADDRESS_OVERRIDE or use --commit with PRIVATE_KEY.");
+    console.error("Could not resolve signer address. Set SIGNER_ADDRESS_OVERRIDE for dry-run, or pass --commit + PRIVATE_KEY, or --use-kms + KMS_KEY_ID/AWS_REGION.");
     process.exitCode = 1;
     return;
   }
+
+  const modeLabel = args.dryRun
+    ? (args.useKms ? "dry-run (kms-aware)" : "dry-run")
+    : (args.useKms ? "commit (kms)" : "commit");
 
   console.log(`# fund-signer-usdc-deposit`);
   console.log(`profile:           ${args.profile}`);
@@ -166,9 +243,10 @@ async function main() {
   console.log(`usdc:              ${usdcAddress}`);
   console.log(`agentAccountCore:  ${agentAccountAddress}`);
   console.log(`signer:            ${signerAddress}`);
+  console.log(`signer backend:    ${signerBackend}`);
   console.log(`amount (base):     ${amountWei.toString()}`);
   console.log(`amount (USDC):     ${formatUsdc(amountWei)}`);
-  console.log(`mode:              ${args.dryRun ? "dry-run" : "commit"}`);
+  console.log(`mode:              ${modeLabel}`);
   console.log("");
 
   const usdc = new Contract(usdcAddress, ERC20_READ_ABI, provider);
@@ -215,13 +293,17 @@ async function main() {
   console.log("");
 
   if (args.dryRun) {
-    console.log("Dry-run only. Re-run with --commit (and PRIVATE_KEY env) to send.");
+    const resumeHint = args.useKms
+      ? "Re-run with --use-kms --commit to send."
+      : "Re-run with --commit (and PRIVATE_KEY env) to send.";
+    console.log("Dry-run only. " + resumeHint);
     return;
   }
 
-  // Commit path.
-  const usdcWriter = new Contract(usdcAddress, ERC20_APPROVE_ABI, wallet);
-  const agentWriter = new Contract(agentAccountAddress, AGENT_ACCOUNT_DEPOSIT_ABI, wallet);
+  // Commit path. Use whichever signer the caller selected (--use-kms or PRIVATE_KEY).
+  const signer = args.useKms ? kmsSigner : wallet;
+  const usdcWriter = new Contract(usdcAddress, ERC20_APPROVE_ABI, signer);
+  const agentWriter = new Contract(agentAccountAddress, AGENT_ACCOUNT_DEPOSIT_ABI, signer);
 
   console.log(`## Sending`);
   console.log(`approve…`);
@@ -266,7 +348,10 @@ function formatUsdc(baseUnits) {
   return fractionText ? `${whole}.${fractionText}` : whole.toString();
 }
 
-main().catch((error) => {
-  console.error(`fund-signer-usdc-deposit failed: ${error?.stack ?? error?.message ?? error}`);
-  process.exitCode = 1;
-});
+// Only run main() when invoked as a CLI — not when imported (e.g. by tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(`fund-signer-usdc-deposit failed: ${error?.stack ?? error?.message ?? error}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ops/fund-signer-usdc-deposit.test.mjs
+++ b/scripts/ops/fund-signer-usdc-deposit.test.mjs
@@ -1,0 +1,111 @@
+// Tests for scripts/ops/fund-signer-usdc-deposit.mjs.
+//
+// Two layers:
+//   1. Pure parseArgs unit tests — argument parsing matrix.
+//   2. CLI-level error-path tests — spawn the script and assert the
+//      KMS-mode validation errors surface before any network/AWS call.
+//
+// Neither layer hits AWS or the chain. The full happy path is exercised
+// indirectly by run-hosted-worker-loop integration smoke tests; locally
+// the dry-run is the regression contract.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+import { parseArgs } from "./fund-signer-usdc-deposit.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const scriptPath = resolve(here, "fund-signer-usdc-deposit.mjs");
+
+test("parseArgs: dry-run is the default and useKms is off", () => {
+  const args = parseArgs([]);
+  assert.equal(args.dryRun, true);
+  assert.equal(args.useKms, false);
+  assert.equal(args.profile, "testnet");
+  assert.equal(args.amount, undefined);
+});
+
+test("parseArgs: --commit flips dryRun off", () => {
+  const args = parseArgs(["--commit", "--amount", "10000000"]);
+  assert.equal(args.dryRun, false);
+  assert.equal(args.useKms, false);
+  assert.equal(args.amount, "10000000");
+});
+
+test("parseArgs: --use-kms is independent of --commit", () => {
+  // KMS-aware dry-run: --use-kms without --commit.
+  const dryRun = parseArgs(["--use-kms", "--amount", "100000"]);
+  assert.equal(dryRun.useKms, true);
+  assert.equal(dryRun.dryRun, true);
+
+  // KMS-signed commit: both flags set.
+  const commit = parseArgs(["--use-kms", "--commit", "--amount", "100000"]);
+  assert.equal(commit.useKms, true);
+  assert.equal(commit.dryRun, false);
+});
+
+test("parseArgs: --profile picks a non-default deployments file", () => {
+  const args = parseArgs(["--profile", "mainnet", "--amount", "1"]);
+  assert.equal(args.profile, "mainnet");
+});
+
+test("parseArgs: --help is captured even when other flags are present", () => {
+  const args = parseArgs(["--commit", "--help", "--amount", "1"]);
+  assert.equal(args.help, true);
+});
+
+// --- CLI-level error paths (no AWS, no chain) -----------------------------
+
+test("CLI: --use-kms without KMS_KEY_ID exits 1 before any AWS call", () => {
+  const result = spawnSync("node", [scriptPath, "--amount", "1", "--use-kms"], {
+    env: {
+      ...process.env,
+      KMS_KEY_ID: "",
+      AWS_REGION: "eu-central-2",
+      AWS_ACCESS_KEY_ID: "",
+      AWS_SECRET_ACCESS_KEY: "",
+    },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 1, result.stderr);
+  assert.match(result.stderr, /--use-kms requires KMS_KEY_ID/u);
+});
+
+test("CLI: --use-kms without AWS_REGION exits 1 before any AWS call", () => {
+  const result = spawnSync("node", [scriptPath, "--amount", "1", "--use-kms"], {
+    env: {
+      ...process.env,
+      KMS_KEY_ID: "alias/dummy",
+      AWS_REGION: "",
+    },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 1, result.stderr);
+  assert.match(result.stderr, /--use-kms requires AWS_REGION/u);
+});
+
+test("CLI: --commit (no --use-kms) without PRIVATE_KEY exits 1 and hints at KMS path", () => {
+  const result = spawnSync("node", [scriptPath, "--amount", "1", "--commit"], {
+    env: {
+      ...process.env,
+      PRIVATE_KEY: "",
+    },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 1, result.stderr);
+  assert.match(result.stderr, /PRIVATE_KEY env .* is required with --commit/u);
+  assert.match(result.stderr, /Use --use-kms for KMS-backed signers/u);
+});
+
+test("CLI: --help prints both signer backends and SIGNER_ADDRESS_OVERRIDE", () => {
+  const result = spawnSync("node", [scriptPath, "--help"], { encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /--use-kms/u);
+  assert.match(result.stdout, /PRIVATE_KEY/u);
+  assert.match(result.stdout, /KMS_KEY_ID/u);
+  assert.match(result.stdout, /AWS_REGION/u);
+  assert.match(result.stdout, /SIGNER_ADDRESS_OVERRIDE/u);
+});


### PR DESCRIPTION
## Summary
After the Phase 3 KMS cutover (2026-05-16) the backend signer `0x31ad432dFe083B998c69B6dB88A984ec5207ab7F` has no exportable private key. The helper at [scripts/ops/fund-signer-usdc-deposit.mjs](https://github.com/averray-agent/agent/blob/main/scripts/ops/fund-signer-usdc-deposit.mjs) only knew about raw `PRIVATE_KEY`, so the documented Step 3 in [docs/TESTNET_FUND_SIGNER.md](https://github.com/averray-agent/agent/blob/main/docs/TESTNET_FUND_SIGNER.md) no longer worked for the live signer.

`POST /account/fund` and the in-job `ensureJob` deposit both gate on `requireAutoMintableAsset` ([gateway.js:88-90](https://github.com/averray-agent/agent/blob/main/mcp-server/src/blockchain/gateway.js#L88)) which only allows `assetClass === "custom"` — USDC is `trust_backed`, so neither path can be used. That left no in-tree way to make the KMS signer call `approve + deposit`. This PR closes the gap.

## Changes

### Helper ([scripts/ops/fund-signer-usdc-deposit.mjs](scripts/ops/fund-signer-usdc-deposit.mjs))
- Import the existing `KmsSigner` ([mcp-server/src/blockchain/kms-signer.js](mcp-server/src/blockchain/kms-signer.js)) — same one the runtime uses, ABI-compatible with ethers `AbstractSigner`.
- **New `--use-kms` flag.** When set, the script resolves the signer address via `kms:GetPublicKey`; paired with `--commit` it signs each of `approve` + `deposit` with one `kms:Sign` call. On its own it runs a KMS-aware dry-run reading state for the real KMS-derived address with no `kms:Sign` calls.
- Signer-resolution precedence: `--use-kms` > `--commit` w/ `PRIVATE_KEY` > `SIGNER_ADDRESS_OVERRIDE` > `deployments.verifier`. Logged as a new `signer backend:` line in dry-run output so it's self-evident which path was used.
- Document `SIGNER_ADDRESS_OVERRIDE` in `--help` (was undocumented escape hatch).
- Gate `main()` under `import.meta.url === file://${process.argv[1]}` so tests can import `parseArgs` without triggering a run.
- Export `parseArgs`.

### Runbook ([docs/TESTNET_FUND_SIGNER.md](docs/TESTNET_FUND_SIGNER.md))
- Rewrite Step 3a to present both signing backends side-by-side. `--use-kms` block matches `SIGNER_BACKEND=kms` from the deploy template, and walks through what `KmsSigner` does on each tx: `GetPublicKey` caching, RLP unsigned hash, `kms:Sign(DIGEST, ECDSA_SHA_256)`, EIP-2 low-s normalisation, recovery byte brute-force vs the cached address.
- Add a KMS-aware dry-run example and a `SIGNER_ADDRESS_OVERRIDE` audit example to the dry-run section.
- Cross-reference [docs/SECRETS_MIGRATION.md](docs/SECRETS_MIGRATION.md) §"Phase 3" and the canonical `KmsSigner` wiring.

### Tests ([scripts/ops/fund-signer-usdc-deposit.test.mjs](scripts/ops/fund-signer-usdc-deposit.test.mjs) — new)
9 cases under `node --test`, all complete in <1 s with no AWS / no chain access:
- `parseArgs` matrix for the new `--use-kms` flag (independent of `--commit` and `--dry-run`).
- CLI-level error paths: `--use-kms` without `KMS_KEY_ID`, `--use-kms` without `AWS_REGION`, `--commit` without `PRIVATE_KEY` (asserts the error now hints at `--use-kms`).
- `--help` mentions both signer backends + `SIGNER_ADDRESS_OVERRIDE`.

## Verification
- `node --test scripts/ops/fund-signer-usdc-deposit.test.mjs` — **9 / 9 pass**
- Sanity dry-run against live Paseo Asset Hub testnet via `SIGNER_ADDRESS_OVERRIDE=0x31ad...` produces the same `approve` + `deposit` calldata as the earlier audit run, plus the new `signer backend: override` line.
- USDC + AgentAccountCore + chain IDs cross-checked against Polkadot docs: `smart-contracts/precompiles/erc20.md` confirms asset id `1337` → `0x00000539...01200000`, 6 decimals; `smart-contracts/connect.md` confirms `eth-rpc-testnet.polkadot.io` for Polkadot Hub TestNet chain id `420420417`.

## Out of scope (flagged in audit, deferred)
- `deployments/testnet.json#verifier` is still the old verifier wallet — leave until the 24-48 h grace window closes and `setVerifier(0xFd2EAE..., false)` is executed; that's a separate config bump.
- `AUTH_VERIFIER_WALLETS` in [backend.env.template](deploy/backend.env.template) is still the old wallet only — same window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)