### PR TITLE
Guard XCM publisher against stale replays

### DIFF
--- a/indexer/src/api/xcm-outcome-publisher-sql.test.ts
+++ b/indexer/src/api/xcm-outcome-publisher-sql.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildUpsertExternalOutcomeSql } from "./xcm-outcome-publisher-sql.ts";
+
+const outcome = {
+  requestId: `0x${"11".repeat(32)}`,
+  status: "succeeded",
+  settledAssets: "5",
+  settledShares: "7",
+  remoteRef: `0x${"22".repeat(32)}`,
+  failureCode: null,
+  observedAt: "2026-04-23T12:00:00.000Z",
+  source: "external_xcm_source"
+};
+
+test("external outcome upsert ignores stale observedAt replays", () => {
+  const query = buildUpsertExternalOutcomeSql(outcome);
+  const text = sqlText(query);
+
+  assert.match(text, /ON CONFLICT \(request_id\) DO UPDATE SET/u);
+  assert.match(text, /WHERE xcm_external_outcomes\.observed_at <= EXCLUDED\.observed_at/u);
+  assert.deepEqual(sqlParams(query), [
+    outcome.requestId,
+    outcome.status,
+    outcome.settledAssets,
+    outcome.settledShares,
+    outcome.remoteRef,
+    outcome.failureCode,
+    outcome.observedAt,
+    outcome.source
+  ]);
+});
+
+function sqlText(query: { queryChunks: unknown[] }) {
+  return query.queryChunks
+    .map((chunk) => isStringChunk(chunk) ? chunk.value.join("") : "?")
+    .join("")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+function sqlParams(query: { queryChunks: unknown[] }) {
+  return query.queryChunks.filter((chunk) => !isStringChunk(chunk));
+}
+
+function isStringChunk(chunk: unknown): chunk is { value: string[] } {
+  return Boolean(
+    chunk &&
+    typeof chunk === "object" &&
+    Array.isArray((chunk as { value?: unknown }).value)
+  );
+}

--- a/indexer/src/api/xcm-outcome-publisher-sql.ts
+++ b/indexer/src/api/xcm-outcome-publisher-sql.ts
@@ -1,0 +1,37 @@
+import { sql } from "drizzle-orm";
+
+import type { PublishedOutcome } from "./xcm-upstream-source";
+
+export function buildUpsertExternalOutcomeSql(outcome: PublishedOutcome) {
+  return sql`
+    INSERT INTO xcm_external_outcomes (
+      request_id,
+      status,
+      settled_assets,
+      settled_shares,
+      remote_ref,
+      failure_code,
+      observed_at,
+      source
+    ) VALUES (
+      ${outcome.requestId},
+      ${outcome.status},
+      ${outcome.settledAssets},
+      ${outcome.settledShares},
+      ${outcome.remoteRef},
+      ${outcome.failureCode},
+      ${outcome.observedAt},
+      ${outcome.source}
+    )
+    ON CONFLICT (request_id) DO UPDATE SET
+      status = EXCLUDED.status,
+      settled_assets = EXCLUDED.settled_assets,
+      settled_shares = EXCLUDED.settled_shares,
+      remote_ref = EXCLUDED.remote_ref,
+      failure_code = EXCLUDED.failure_code,
+      observed_at = EXCLUDED.observed_at,
+      source = EXCLUDED.source,
+      ingested_at = now()
+    WHERE xcm_external_outcomes.observed_at <= EXCLUDED.observed_at
+  `;
+}

--- a/indexer/src/api/xcm-outcome-publisher.ts
+++ b/indexer/src/api/xcm-outcome-publisher.ts
@@ -13,6 +13,7 @@ import {
   normalizeObservedAtIso,
   type OutcomeCursor
 } from "./xcm-outcome-cursor";
+import { buildUpsertExternalOutcomeSql } from "./xcm-outcome-publisher-sql";
 
 const DEFAULT_SCOPE = "xcm-outcome-publisher";
 
@@ -401,36 +402,7 @@ export class XcmOutcomePublisherService {
   }
 
   async upsertOutcome(outcome: PublishedOutcome) {
-    await db.execute(sql`
-      INSERT INTO xcm_external_outcomes (
-        request_id,
-        status,
-        settled_assets,
-        settled_shares,
-        remote_ref,
-        failure_code,
-        observed_at,
-        source
-      ) VALUES (
-        ${outcome.requestId},
-        ${outcome.status},
-        ${outcome.settledAssets},
-        ${outcome.settledShares},
-        ${outcome.remoteRef},
-        ${outcome.failureCode},
-        ${outcome.observedAt},
-        ${outcome.source}
-      )
-      ON CONFLICT (request_id) DO UPDATE SET
-        status = EXCLUDED.status,
-        settled_assets = EXCLUDED.settled_assets,
-        settled_shares = EXCLUDED.settled_shares,
-        remote_ref = EXCLUDED.remote_ref,
-        failure_code = EXCLUDED.failure_code,
-        observed_at = EXCLUDED.observed_at,
-        source = EXCLUDED.source,
-        ingested_at = now()
-    `);
+    await db.execute(buildUpsertExternalOutcomeSql(outcome));
   }
 
   async getPublishedOutcomeCount() {


### PR DESCRIPTION
## Summary
- add an observedAt conflict guard to external XCM outcome upserts so older replays cannot overwrite newer outcomes
- extract the publisher upsert SQL into a focused builder that can be tested without a live Ponder DB
- add an indexer API test covering the conflict guard and parameter binding

## Checks
- npm --workspace indexer run test:api
- npm --workspace indexer run typecheck
- git diff --check

## Surface
- indexer / XCM external outcome publisher only
- no environment or VPS secret changes required