### PR TITLE
Serve discovery manifest at the RFC 8615 .well-known path

### DIFF
--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -1160,6 +1160,7 @@ function metricPathLabel(pathname) {
     "/health",
     "/metrics",
     "/agent-tools.json",
+    "/.well-known/agent-tools.json",
     "/onboarding",
     "/jobs",
     "/jobs/definition",
@@ -1793,11 +1794,18 @@ const server = createServer(async (request, response) => {
       return respond(response, 200, service.getPlatformCapabilities());
     }
 
-    if (request.method === "GET" && pathname === "/agent-tools.json") {
+    if (
+      request.method === "GET"
+      && (pathname === "/agent-tools.json" || pathname === "/.well-known/agent-tools.json")
+    ) {
       // Discovery manifest. The canonical copy is served by the static
       // site at https://averray.com/.well-known/agent-tools.json — this
       // API mirror lets MCP clients that only know the api host still
-      // find the capability listing. Bumps refer to
+      // find the capability listing. Both `/agent-tools.json` and the
+      // RFC 8615-conformant `/.well-known/agent-tools.json` are served
+      // from the same handler so a spec-following MCP client can
+      // discover the same manifest at the same path it uses on the
+      // canonical host. Bumps refer to
       // discovery/.well-known/agent-tools.json in the repo.
       return respond(
         response,

--- a/mcp-server/src/protocols/http/server.smoke.test.js
+++ b/mcp-server/src/protocols/http/server.smoke.test.js
@@ -1729,3 +1729,20 @@ test("http smoke: /metrics emits Prometheus text format with baseline series", {
     assert.match(body, /state_store_backend\{backend="MemoryStateStore"\} 1/);
   });
 });
+
+test("http smoke: discovery manifest is served at both /agent-tools.json and the RFC 8615 .well-known path", { skip: !RUN }, async () => {
+  await runWithServer(async (base) => {
+    const [canonical, wellKnown] = await Promise.all([
+      fetch(`${base}/agent-tools.json`),
+      fetch(`${base}/.well-known/agent-tools.json`)
+    ]);
+    assert.equal(canonical.status, 200);
+    assert.equal(wellKnown.status, 200);
+    assert.match(canonical.headers.get("content-type") ?? "", /application\/json/);
+    assert.match(wellKnown.headers.get("content-type") ?? "", /application\/json/);
+    const [canonicalBody, wellKnownBody] = await Promise.all([canonical.json(), wellKnown.json()]);
+    assert.deepEqual(canonicalBody, wellKnownBody, "well-known alias must return the same manifest");
+    assert.equal(typeof canonicalBody.name, "string");
+    assert.ok(Array.isArray(canonicalBody.protocols));
+  });
+});


### PR DESCRIPTION
## Summary

Closes finding **F2** from the launch-readiness deep dive: the API discovery mirror was reachable at `https://api.averray.com/agent-tools.json` (200, 25k JSON) but returned `404 not_found` at `https://api.averray.com/.well-known/agent-tools.json` — the RFC 8615 / MCP convention path that the canonical static site at `averray.com` already uses.

`PRODUCTION_CHECKLIST.md` §7 line 309 has *"Canonical public discovery manifest matches the API mirror"* as `[ ]`. That box now becomes flippable at the URL convention level (the operator still needs to record evidence to flip the `[x]`).

## What changed

- **`mcp-server/src/protocols/http/server.js:1796`** — the existing `GET /agent-tools.json` route now also matches `/.well-known/agent-tools.json`. Both paths share the same handler, so the response body is byte-identical. The route comment was expanded to explain the dual-path support.
- **`mcp-server/src/protocols/http/server.js:1162`** — added `/.well-known/agent-tools.json` to `metricPathLabel`'s known-path set so Prometheus scrapes don't bucket the new alias as `"other"`.
- **`mcp-server/src/protocols/http/server.smoke.test.js`** — one new smoke test that fetches both paths concurrently, asserts `200 + application/json`, and `deepEqual`s the bodies.

The `/health` endpoint listing at line 1685 deliberately still advertises only `/agent-tools.json` — `.well-known/` is an RFC-conformant alias, not a separate endpoint. Clients learn the manifest either from the listing or from the well-known convention; both routes resolve to the same content.

## Caddy / static site

The canonical surface at `averray.com/.well-known/agent-tools.json` is served by Caddy's `file_server` from `/srv/site/.well-known/agent-tools.json` (see `deploy/Caddyfile.averray:7-19`). Nothing on the public-site side changes.

`api.averray.com` is a pure `reverse_proxy backend:8787` (`deploy/Caddyfile.averray:53-66`), so this fix lands entirely in the backend route table — no Caddy config change needed.

## Scope

- Two files, both under `mcp-server/src/protocols/http/`. +27 / -2.
- No contracts, no auth code, no claim/liquidity surface, no other docs, no workflows, no Caddy.
- Out of `EscrowCore.claimJob/claimJobFor`, `mcp-server/src/blockchain/gateway.js`, and the job claim flow (Codex's standing lane). The HTTP discovery route hasn't been touched since #341 (5 days ago).

## Affects

- backend: **yes** (one route handler condition + one metric label)
- frontend / indexer / Caddy / contracts / public site: **none**
- Required env or VPS secret changes: **none**

## Test plan

- [x] `npm --workspace mcp-server test` → 571 passed (unchanged)
- [x] `RUN_HTTP_SMOKE=1 node --test mcp-server/src/protocols/http/server.smoke.test.js` → 41 passed (was 40; the new test passes in ~426ms)
- [x] `forge test` → 97 passed (unaffected, sanity)
- [ ] After deploy, `curl -sS https://api.averray.com/.well-known/agent-tools.json` returns the manifest (200, byte-identical to `https://averray.com/.well-known/agent-tools.json` modulo `PUBLIC_BASE_URL` interpolation differences)
- [ ] Once the deploy is verified, flip the `[x]` on `PRODUCTION_CHECKLIST.md` §7 line 309 in a separate doc-only PR

## Notes for the operator

Per the deploy-production manual-dispatch caveats (`PRODUCTION_CHECKLIST.md` §13 just merged in #375): this PR is purely a route addition, so a `workflow_run` auto-deploy after CI is sufficient. No need to set `product_proof_require_worker_loop=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)