### PR TITLE
ci(security): Phase 4a/4c workflow hardening — pin actions to SHAs + minimum permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,19 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Phase 4c: default to least privilege. None of the CI jobs publish
+# artifacts, write to the repo, or comment on PRs — they only check
+# out code and run tests/lints. Jobs that need more must elevate
+# explicitly via a per-job `permissions:` block.
+permissions:
+  contents: read
+
 jobs:
   solidity:
     name: Solidity — forge test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Install Foundry
         # Phase 2 PR 2.9 follow-up: pinned to commit SHA (not moving @v1
@@ -41,10 +48,10 @@ jobs:
     name: Backend — node --test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "22"
           cache: npm
@@ -79,12 +86,12 @@ jobs:
     name: Operator app — static export
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 2
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "22"
           cache: npm
@@ -102,12 +109,12 @@ jobs:
     name: Public site — static export
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 2
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "22"
           cache: npm
@@ -122,10 +129,10 @@ jobs:
     name: Indexer — typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "22"
           cache: npm
@@ -147,10 +154,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "22"
           cache: npm
@@ -229,7 +236,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           # gitleaks-action wants the full history to scan new commits
           # against base; default fetch-depth=1 would miss everything

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -535,7 +535,7 @@ jobs:
 
       - name: Upload Hermes post-deploy log
         if: always() && env.DEPLOY_RUN_HERMES_POST_DEPLOY == '1' && steps.hermes_post_deploy.outcome != 'skipped'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: hermes-post-deploy-${{ github.run_id }}
           path: hermes-post-deploy.log

--- a/.github/workflows/hermes-pr-handoff.yml
+++ b/.github/workflows/hermes-pr-handoff.yml
@@ -210,7 +210,7 @@ jobs:
 
       - name: Upload Hermes handoff log
         if: always() && steps.pr.outputs.skip != 'true' && steps.hermes.outcome != 'skipped'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: hermes-handoff-${{ steps.pr.outputs.correlation_id }}
           path: hermes-handoff.log

--- a/.github/workflows/hosted-service-token-proof.yml
+++ b/.github/workflows/hosted-service-token-proof.yml
@@ -54,7 +54,7 @@ jobs:
       SERVICE_TOKEN_PROOF_TOKEN_TTL_SECONDS: ${{ inputs.token_ttl_seconds }}
       SERVICE_TOKEN_PROOF_IDEMPOTENCY_KEY: github-hosted-service-token-proof-${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Load ADMIN_JWT from 1Password (fail-closed)
         uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
@@ -126,7 +126,7 @@ jobs:
 
       - name: Upload sanitized service-token proof evidence
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: hosted-service-token-proof-${{ github.run_id }}
           path: ${{ env.SERVICE_TOKEN_PROOF_EVIDENCE_FILE }}

--- a/.github/workflows/publish-discovery-manifest.yml
+++ b/.github/workflows/publish-discovery-manifest.yml
@@ -17,6 +17,14 @@ concurrency:
   group: discovery-registry-publish
   cancel-in-progress: false
 
+# Phase 4c: least privilege. The "publish" job's name is misleading —
+# it publishes a hash to an on-chain discovery registry via RPC + a
+# private key from GH secrets, NOT to git. There is no repo push,
+# tag, or PR comment, so `contents: read` (for the checkout step) is
+# the maximum permission this workflow needs from GITHUB_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Publish discovery hash
@@ -31,10 +39,10 @@ jobs:
       RPC_URL: ${{ secrets.RPC_URL }}
       DISCOVERY_PUBLISHER_PRIVATE_KEY: ${{ secrets.DISCOVERY_PUBLISHER_PRIVATE_KEY }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "22"
           cache: npm

--- a/scripts/ops/hermes-workflow-artifacts.test.mjs
+++ b/scripts/ops/hermes-workflow-artifacts.test.mjs
@@ -10,7 +10,10 @@ test("Hermes post-deploy verification keeps the full log as a workflow artifact"
   const workflow = await readFile(join(REPO_ROOT, ".github/workflows/deploy-production.yml"), "utf8");
 
   assert.match(workflow, /name: Upload Hermes post-deploy log/u);
-  assert.match(workflow, /uses: actions\/upload-artifact@v7/u);
+  // Accept either tag-pinned (@v7) or SHA-pinned with v7 tag comment
+  // (e.g., `@<40-char-sha> # v7`). Phase 4c moved this repo to SHA pins
+  // for supply-chain hardening; the comment preserves audit traceability.
+  assert.match(workflow, /uses: actions\/upload-artifact@(?:v7\b|[a-f0-9]{40} # v7\b)/u);
   assert.match(workflow, /name: hermes-post-deploy-\$\{\{ github\.run_id \}\}/u);
   assert.match(workflow, /path: hermes-post-deploy\.log/u);
   assert.match(workflow, /if-no-files-found: error/u);
@@ -21,7 +24,10 @@ test("Hermes PR handoff keeps the full log as a correlation-id artifact", async 
   const workflow = await readFile(join(REPO_ROOT, ".github/workflows/hermes-pr-handoff.yml"), "utf8");
 
   assert.match(workflow, /name: Upload Hermes handoff log/u);
-  assert.match(workflow, /uses: actions\/upload-artifact@v7/u);
+  // Accept either tag-pinned (@v7) or SHA-pinned with v7 tag comment
+  // (e.g., `@<40-char-sha> # v7`). Phase 4c moved this repo to SHA pins
+  // for supply-chain hardening; the comment preserves audit traceability.
+  assert.match(workflow, /uses: actions\/upload-artifact@(?:v7\b|[a-f0-9]{40} # v7\b)/u);
   assert.match(workflow, /name: hermes-handoff-\$\{\{ steps\.pr\.outputs\.correlation_id \}\}/u);
   assert.match(workflow, /path: hermes-handoff\.log/u);
   assert.match(workflow, /if-no-files-found: error/u);
@@ -38,7 +44,10 @@ test("hosted service-token proof uploads sanitized evidence as a workflow artifa
   assert.match(workflow, /CHECK_SERVICE_TOKEN_PROOF: "1"/u);
   assert.match(workflow, /SERVICE_TOKEN_PROOF_EVIDENCE_FILE: artifacts\/service-token-proof-hosted-\$\{\{ github\.run_id \}\}\.json/u);
   assert.match(workflow, /ADMIN_JWT="\$ADMIN_JWT_OP" \.\/scripts\/ops\/check-hosted-stack\.sh/u);
-  assert.match(workflow, /uses: actions\/upload-artifact@v7/u);
+  // Accept either tag-pinned (@v7) or SHA-pinned with v7 tag comment
+  // (e.g., `@<40-char-sha> # v7`). Phase 4c moved this repo to SHA pins
+  // for supply-chain hardening; the comment preserves audit traceability.
+  assert.match(workflow, /uses: actions\/upload-artifact@(?:v7\b|[a-f0-9]{40} # v7\b)/u);
   assert.match(workflow, /name: hosted-service-token-proof-\$\{\{ github\.run_id \}\}/u);
   assert.match(workflow, /path: \$\{\{ env\.SERVICE_TOKEN_PROOF_EVIDENCE_FILE \}\}/u);
   assert.match(workflow, /if-no-files-found: error/u);


### PR DESCRIPTION
## Summary

Closes the remaining **Phase 4a/4c** workflow-hardening gaps from `docs/SECRETS_MIGRATION.md`.

## Changes

**Pin first-party Actions to commit SHAs** (defends against tag-move attacks):

| Action | Pinned SHA |
|---|---|
| `actions/checkout@v5` (9 refs) | `93cb6efe18208431cddfb8368fd83d5badbf9bfd` |
| `actions/setup-node@v5` (6 refs) | `a0853c24544627f65ddf259abe73b1d18a591444` |
| `actions/upload-artifact@v7` (3 refs) | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` |

Verified via `gh api repos/actions/<name>/git/refs/tags/<tag>`. All three returned `type: commit` (no annotated-tag dereferencing needed).

**Top-level `permissions: contents: read`** added to the two workflows that didn't already have one:
- `ci.yml`
- `publish-discovery-manifest.yml` (despite the name, this does on-chain RPC, not git publish — `contents: read` is sufficient)

The other three workflows (`hermes-pr-handoff.yml`, `deploy-production.yml`, `hosted-service-token-proof.yml`) already had top-level permissions blocks.

**Verification**
- `grep -rE "uses: [^@]+@(v[0-9]|main|master|latest)" .github/workflows/` → zero matches
- Every workflow has at least one `permissions:` line

**Out of scope** (tracked separately):
- GitHub UI: push protection toggle, custom secret patterns, workflow-file CODEOWNERS
- Phase 4b: KMS-signed JWTs
- Phase 4e: hardware MFA

## Test plan

- [ ] CI green (changes only affect future workflow runs; this PR's own CI runs against the base-branch workflow files per GitHub semantics, so this should pass cleanly).