### PR TITLE
Complete INCIDENT_RESPONSE §1 ownership and flip on-call ownership box

### DIFF
--- a/docs/INCIDENT_RESPONSE.md
+++ b/docs/INCIDENT_RESPONSE.md
@@ -19,14 +19,22 @@ Fill these in before calling the system production-ready:
 
 - Primary on-call: <ops@averray.com>
 - Backup on-call: <ops@averray.com>
-- Contract owner signers: `<hot / warm / cold mapping>`
-- Pauser operator: `<name / handle>`
-- External escalation path: `<vendor, consultant, or empty>`
+- Contract owner signers: the three 2-of-3 signatories in
+  [`deployments/testnet-multisig-owner.json`](../deployments/testnet-multisig-owner.json)
+  are currently all hot dev keys (testnet posture). Mainnet adoption of
+  hot / warm / cold custody tiers is a separate launch-readiness item
+  tracked in [`MULTISIG_SETUP.md`](./MULTISIG_SETUP.md).
+- Pauser operator: <ops@averray.com>
+- External escalation path: empty. Intentionally not assigned — no
+  audit firm or incident-response retainer is engaged yet. Update when
+  that changes.
 
-`ops@averray.com` is the operator alias that routes to whoever is on
-duty; both primary and backup land in the same inbox. Contract owner
-signers, pauser operator, and external escalation path are still
-unfilled — see §1 closing line.
+`ops@averray.com` is the operator alias that delivers to whoever is on
+duty; primary on-call, backup on-call, and pauser operator all land in
+the same inbox. The pauser role is `setPaused`-only per
+[`THREAT_MODEL.md`](./THREAT_MODEL.md), so a compromised pauser key can
+grief by pausing but cannot drain funds — sharing the inbox with on-call
+is acceptable for the v1 posture.
 
 If these are blank, you do not have incident ownership yet.
 

--- a/docs/INCIDENT_RESPONSE.md
+++ b/docs/INCIDENT_RESPONSE.md
@@ -17,11 +17,16 @@ Use it together with:
 
 Fill these in before calling the system production-ready:
 
-- Primary on-call: `<name / handle>`
-- Backup on-call: `<name / handle>`
+- Primary on-call: <ops@averray.com>
+- Backup on-call: <ops@averray.com>
 - Contract owner signers: `<hot / warm / cold mapping>`
 - Pauser operator: `<name / handle>`
 - External escalation path: `<vendor, consultant, or empty>`
+
+`ops@averray.com` is the operator alias that routes to whoever is on
+duty; both primary and backup land in the same inbox. Contract owner
+signers, pauser operator, and external escalation path are still
+unfilled — see §1 closing line.
 
 If these are blank, you do not have incident ownership yet.
 
@@ -220,7 +225,7 @@ If the incident required a pause, include:
 
 Before calling the stack truly production-ready:
 
-- [ ] Primary and backup on-call are named
+- [x] Primary and backup on-call are named
 - [ ] A live alert webhook is configured
 - [ ] `check-hosted-stack-and-alert.sh` is running from an external scheduler
 - [ ] Pause path has been rehearsed recently

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -205,7 +205,7 @@ RUN_SUBSCAN_XCM_VALIDATION=1 ./scripts/ops/check-release-readiness.sh testnet
 - [ ] Frontend Sentry runtime config is set if browser error reporting is required.
 - [ ] Structured logs are visible from the current deploy target.
 - [ ] An alert destination is configured for hosted smoke-check failures.
-- [ ] [INCIDENT_RESPONSE.md](./INCIDENT_RESPONSE.md) has named on-call ownership.
+- [x] [INCIDENT_RESPONSE.md](./INCIDENT_RESPONSE.md) has named on-call ownership.
 - [ ] Operator self-report proof is visible after deploy and on schedule. Flip
   this box only when ALL of the following are true against the production stack:
   - The production deploy workflow completes with `run_hermes_post_deploy=1`


### PR DESCRIPTION
## Summary

Closes finding **F5** from the launch-readiness deep dive. Fills every placeholder in `docs/INCIDENT_RESPONSE.md` §1, then flips `PRODUCTION_CHECKLIST.md` §5 line 208 (`INCIDENT_RESPONSE.md has named on-call ownership`) to `[x]`.

## What's filled

| Field | Value |
|---|---|
| Primary on-call | `ops@averray.com` |
| Backup on-call | `ops@averray.com` |
| Contract owner signers | All three 2-of-3 signatories in `deployments/testnet-multisig-owner.json` are currently hot dev keys (testnet posture); mainnet hot/warm/cold custody tier adoption tracked in `MULTISIG_SETUP.md`. |
| Pauser operator | `ops@averray.com` |
| External escalation path | `empty` (intentionally — no audit firm or incident-response retainer engaged yet) |

A short clarifying paragraph notes that on-call, backup, and pauser operator all land in the same `ops@averray.com` inbox by design — acceptable for v1 because the pauser role is `setPaused`-only per `THREAT_MODEL.md`, so a compromised pauser key can grief but cannot drain funds. Mainnet adoption of hot/warm/cold custody for the owner multisig is flagged as a separate launch-readiness item.

The doc-internal §8 checklist item *"Primary and backup on-call are named"* also flips to `[x]`.

## Commits

Two commits in this PR (rebased onto current main after #391 landed):

1. `Fill INCIDENT_RESPONSE on-call to the ops alias` — primary + backup on-call, doc-internal §8 box.
2. `Fill remaining INCIDENT_RESPONSE ownership fields and flip checklist box` — contract owner signers, pauser operator, external escalation, and the §5 line 208 PRODUCTION_CHECKLIST.md box.

Both commits are doc-only; one keeps the surface tight and reviewable, the other rounds out §1 and unblocks the checklist gate.

## Scope

- Two files, +25 / -10:
  - `docs/INCIDENT_RESPONSE.md`: §1 ownership block rewritten with filled values + clarifying paragraph; §8 doc-internal box flipped.
  - `docs/PRODUCTION_CHECKLIST.md`: one `[ ]` → `[x]` at §5 line 208.
- No code, no tests, no contracts, no workflows touched.

## Affects

- backend / frontend / indexer / Caddy / contracts / public site: **none** (docs only)
- Required env or VPS secret changes: **none**

## Test plan

- [x] All five §1 fields are filled (no `<placeholder>` remains)
- [x] Doc-internal §8 box (`Primary and backup on-call are named`) flipped to `[x]`
- [x] `PRODUCTION_CHECKLIST.md` §5 line 208 box flipped to `[x]`
- [ ] Reviewer confirms `ops@averray.com` is the correct alias for production on-call AND pauser routing (the threat model accepts the shared inbox; the doc states this explicitly)
- [ ] Reviewer confirms "external escalation: empty" matches the current posture (no audit firm or retainer engaged yet)

## Follow-ups (not blocking)

After this PR merges, the `PRODUCTION_CHECKLIST.md` §5 observability boxes immediately above and below line 208 remain unchecked — those need deployed-config evidence, not doc edits:

- Backend metrics reachable + bearer-protected
- Backend Sentry configured
- Frontend Sentry runtime config
- Structured logs visible
- Alert destination for hosted smoke-check failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)