### PR TITLE
Add POST /auth/refresh — rotate the wallet JWT in place

### DIFF
--- a/discovery/.well-known/agent-tools.json
+++ b/discovery/.well-known/agent-tools.json
@@ -151,6 +151,17 @@
       },
       {
         "method": "POST",
+        "path": "/auth/refresh",
+        "requiresAuth": true,
+        "requiredAction": "refresh_wallet_token",
+        "authScheme": "SIWE_JWT",
+        "walletModes": [
+          "evm-siwe"
+        ],
+        "notes": "Rotates the caller's wallet JWT — revokes the old jti and mints a new one with the same sub + roles. Service tokens cannot be refreshed here."
+      },
+      {
+        "method": "POST",
         "path": "/jobs/claim",
         "requiresAuth": true,
         "requiredAction": "wallet_sign_in",
@@ -348,6 +359,7 @@
     "entrypoints": [
       "/auth/nonce",
       "/auth/verify",
+      "/auth/refresh",
       "/auth/logout"
     ],
     "supportedWalletModes": [
@@ -453,6 +465,10 @@
     {
       "path": "/reputation",
       "description": "Current reputation scores + tier."
+    },
+    {
+      "path": "/auth/refresh",
+      "description": "Rotate the caller's wallet JWT — revokes the old jti and mints a new one with the same sub + roles. Lets operators avoid re-SIWE every AUTH_TOKEN_TTL_SECONDS."
     },
     {
       "path": "/jobs/recommendations",
@@ -683,6 +699,7 @@
     "authEntrypoints": [
       "/auth/nonce",
       "/auth/verify",
+      "/auth/refresh",
       "/auth/logout"
     ],
     "note": "Mutating and financial actions exist on authenticated HTTP and operator-app surfaces but are intentionally excluded from this directory-safe manifest until the trust, policy, and audit posture are ready for broader distribution."

--- a/discovery/agent-tools.json
+++ b/discovery/agent-tools.json
@@ -151,6 +151,17 @@
       },
       {
         "method": "POST",
+        "path": "/auth/refresh",
+        "requiresAuth": true,
+        "requiredAction": "refresh_wallet_token",
+        "authScheme": "SIWE_JWT",
+        "walletModes": [
+          "evm-siwe"
+        ],
+        "notes": "Rotates the caller's wallet JWT — revokes the old jti and mints a new one with the same sub + roles. Service tokens cannot be refreshed here."
+      },
+      {
+        "method": "POST",
         "path": "/jobs/claim",
         "requiresAuth": true,
         "requiredAction": "wallet_sign_in",
@@ -348,6 +359,7 @@
     "entrypoints": [
       "/auth/nonce",
       "/auth/verify",
+      "/auth/refresh",
       "/auth/logout"
     ],
     "supportedWalletModes": [
@@ -453,6 +465,10 @@
     {
       "path": "/reputation",
       "description": "Current reputation scores + tier."
+    },
+    {
+      "path": "/auth/refresh",
+      "description": "Rotate the caller's wallet JWT — revokes the old jti and mints a new one with the same sub + roles. Lets operators avoid re-SIWE every AUTH_TOKEN_TTL_SECONDS."
     },
     {
       "path": "/jobs/recommendations",
@@ -683,6 +699,7 @@
     "authEntrypoints": [
       "/auth/nonce",
       "/auth/verify",
+      "/auth/refresh",
       "/auth/logout"
     ],
     "note": "Mutating and financial actions exist on authenticated HTTP and operator-app surfaces but are intentionally excluded from this directory-safe manifest until the trust, policy, and audit posture are ready for broader distribution."

--- a/mcp-server/src/auth/auth.test.js
+++ b/mcp-server/src/auth/auth.test.js
@@ -230,7 +230,7 @@ test("requireAuth rejects missing token in strict mode", async () => {
       assert.equal(error.details.requiresAuth, true);
       assert.equal(error.details.requiredAction, "wallet_sign_in");
       assert.equal(error.details.authScheme, "SIWE_JWT");
-      assert.deepEqual(error.details.authEntrypoints, ["/auth/nonce", "/auth/verify", "/auth/logout"]);
+      assert.deepEqual(error.details.authEntrypoints, ["/auth/nonce", "/auth/verify", "/auth/refresh", "/auth/logout"]);
       return true;
     }
   );

--- a/mcp-server/src/core/discovery-manifest.js
+++ b/mcp-server/src/core/discovery-manifest.js
@@ -41,6 +41,7 @@ const DISCOVERY_AUTHENTICATED_ENDPOINTS = [
     description: "Signed-in lane positions plus treasury-share and adapter-backed yield/performance posture for each registered strategy adapter."
   },
   { path: "/reputation", description: "Current reputation scores + tier." },
+  { path: "/auth/refresh", description: "Rotate the caller's wallet JWT — revokes the old jti and mints a new one with the same sub + roles. Lets operators avoid re-SIWE every AUTH_TOKEN_TTL_SECONDS." },
   { path: "/jobs/recommendations", description: "Tier-gated recommendation list with fit score + unlock hints." },
   { path: "/jobs/preflight", description: "Per-job eligibility + claim-stake + tier-gate snapshot." },
   { path: "/admin/jobs/timeline", description: "Admin-gated job/session timeline and lineage endpoint." },
@@ -64,7 +65,7 @@ const DISCOVERY_AUTHENTICATED_ENDPOINTS = [
   { path: "/events", description: "SSE stream of platform events. Auth via ?token=." }
 ];
 
-const AUTH_ENTRYPOINTS = ["/auth/nonce", "/auth/verify", "/auth/logout"];
+const AUTH_ENTRYPOINTS = ["/auth/nonce", "/auth/verify", "/auth/refresh", "/auth/logout"];
 
 const WALLET_READINESS_CHECKS = [
   {
@@ -215,6 +216,15 @@ const HTTP_ACTION_REQUIREMENTS = [
     requiresAuth: false,
     requiredAction: "verify_siwe_signature",
     walletModes: ["evm-siwe"]
+  },
+  {
+    method: "POST",
+    path: "/auth/refresh",
+    requiresAuth: true,
+    requiredAction: "refresh_wallet_token",
+    authScheme: "SIWE_JWT",
+    walletModes: ["evm-siwe"],
+    notes: "Rotates the caller's wallet JWT — revokes the old jti and mints a new one with the same sub + roles. Service tokens cannot be refreshed here."
   },
   {
     method: "POST",
@@ -410,7 +420,7 @@ const BASE_MANIFEST = {
   },
   executionSurfaces: {
     operatorApp: DEFAULT_OPERATOR_APP_URL,
-    authEntrypoints: ["/auth/nonce", "/auth/verify", "/auth/logout"],
+    authEntrypoints: ["/auth/nonce", "/auth/verify", "/auth/refresh", "/auth/logout"],
     note:
       "Mutating and financial actions exist on authenticated HTTP and operator-app surfaces but are intentionally excluded from this directory-safe manifest until the trust, policy, and audit posture are ready for broader distribution."
   }

--- a/mcp-server/src/core/discovery-manifest.test.js
+++ b/mcp-server/src/core/discovery-manifest.test.js
@@ -28,6 +28,11 @@ test("buildDiscoveryManifest returns the full public discovery shape", () => {
   assert.ok(manifest.authenticatedEndpoints.some((entry) => entry.path === "/account/borrow-capacity"));
   assert.ok(!manifest.authenticatedEndpoints.some((entry) => entry.path === "/payments/send"));
   assert.ok(!manifest.tools.some((tool) => tool.name === "sendToAgent"));
+  // /auth/refresh rotates the wallet JWT in place — both the entrypoint
+  // list and the authenticated-endpoints list must advertise it so clients
+  // can avoid re-running SIWE every AUTH_TOKEN_TTL_SECONDS.
+  assert.ok(manifest.executionSurfaces.authEntrypoints.includes("/auth/refresh"));
+  assert.ok(manifest.authenticatedEndpoints.some((entry) => entry.path === "/auth/refresh"));
   assert.equal(manifest.tools[0]?.name, "getPlatformCapabilities");
   assert.equal(manifest.executionSurfaces.operatorApp, "https://app.example.com");
   assert.equal(manifest.schemas.agentBadge, "https://averray.com/schemas/agent-badge-v1.json");

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -1686,6 +1686,7 @@ const server = createServer(async (request, response) => {
           "/onboarding",
           "/auth/nonce",
           "/auth/verify",
+          "/auth/refresh",
           "/auth/logout",
           "/auth/session",
           "/events",
@@ -2573,6 +2574,67 @@ const server = createServer(async (request, response) => {
         status: "logged_out",
         wallet: auth.wallet,
         jti
+      });
+    }
+
+    if (request.method === "POST" && pathname === "/auth/refresh") {
+      // Rotate the caller's wallet JWT: revoke the old `jti`, mint a new one
+      // with the same `sub` + `roles`, fresh `iat` / `exp`. The operator app
+      // avoids re-SIWE every AUTH_TOKEN_TTL_SECONDS by calling this when it
+      // notices its token is approaching expiry.
+      //
+      // Hard guardrails:
+      //  - Service tokens are NOT refreshable here. They have their own
+      //    lifecycle via /admin/service-tokens/:id/rotate, signed by an
+      //    admin, and their claims (`capabilities`, `capabilityGrantId`,
+      //    `scope`) are not safe to re-mint from a stale token. Service
+      //    tokens that need a longer life rotate via the admin surface.
+      //  - The old token must currently verify (authMiddleware enforces
+      //    signature + exp + revocation), so a leaked-and-revoked token
+      //    cannot be used to bootstrap a fresh one.
+      //  - We revoke the old jti BEFORE issuing the new one, so there is
+      //    no window where two tokens for the same wallet are both valid
+      //    from a single refresh.
+      const auth = await authMiddleware(request, url);
+      if (auth.claims?.serviceToken === true || auth.claims?.tokenKind === "service") {
+        throw new AuthenticationError(
+          "Service tokens cannot be refreshed via /auth/refresh; rotate them via /admin/service-tokens/:id/rotate.",
+          "service_token_refresh_unsupported"
+        );
+      }
+      await enforceLimit("auth_refresh", auth.wallet, rateLimitConfig.authRefresh);
+      if (!authConfig.signingSecret) {
+        throw new AuthenticationError(
+          "Auth not configured — set AUTH_JWT_SECRETS to issue tokens.",
+          "auth_not_configured"
+        );
+      }
+
+      const oldJti = auth.claims?.jti;
+      const oldExp = auth.claims?.exp;
+      if (oldJti && Number.isFinite(oldExp)) {
+        // Revoke the old jti for whatever remains of its TTL so it can't
+        // be replayed if it leaked between sign and revoke.
+        const ttlSeconds = Math.max(1, oldExp - Math.floor(Date.now() / 1000));
+        await stateStore.revokeToken?.(oldJti, ttlSeconds);
+      }
+
+      // Re-resolve roles at refresh time (an operator may have been added
+      // or removed since the original sign-in).
+      const roles = authConfig.resolveRoles?.(auth.wallet) ?? auth.claims?.roles ?? [];
+      const { token, claims } = signToken(
+        { sub: auth.wallet, roles },
+        { secret: authConfig.signingSecret, expiresInSeconds: authConfig.tokenTtlSeconds }
+      );
+
+      return respond(response, 200, {
+        token,
+        wallet: auth.wallet,
+        roles,
+        capabilities: authCapabilities.resolveCapabilities({ roles }),
+        expiresAt: new Date(claims.exp * 1000).toISOString(),
+        tokenType: "Bearer",
+        rotatedFromJti: oldJti
       });
     }
 

--- a/mcp-server/src/protocols/http/server.smoke.test.js
+++ b/mcp-server/src/protocols/http/server.smoke.test.js
@@ -105,8 +105,8 @@ function stop(child) {
   });
 }
 
-function issueToken(wallet, { roles = [] } = {}) {
-  return signToken({ sub: wallet, roles }, { secret: LONG_SECRET, expiresInSeconds: 60 }).token;
+function issueToken(wallet, { roles = [], ...claims } = {}) {
+  return signToken({ sub: wallet, roles, ...claims }, { secret: LONG_SECRET, expiresInSeconds: 60 }).token;
 }
 
 async function runWithServer(fn) {

--- a/mcp-server/src/protocols/http/server.smoke.test.js
+++ b/mcp-server/src/protocols/http/server.smoke.test.js
@@ -613,6 +613,66 @@ test("http smoke: /auth/logout revokes the current token", { skip: !RUN }, async
   });
 });
 
+test("http smoke: /auth/refresh rotates the wallet token and revokes the old jti", { skip: !RUN }, async () => {
+  await runWithServer(async (base) => {
+    const oldToken = issueToken(ADMIN_WALLET, { roles: ["admin"] });
+    const oldHeader = { authorization: `Bearer ${oldToken}` };
+
+    // Old token works before refresh.
+    const preRefresh = await fetch(`${base}/account`, { headers: oldHeader });
+    assert.equal(preRefresh.status, 200);
+
+    const refresh = await fetch(`${base}/auth/refresh`, { method: "POST", headers: oldHeader });
+    assert.equal(refresh.status, 200);
+    const payload = await refresh.json();
+    assert.equal(payload.tokenType, "Bearer");
+    assert.equal(String(payload.wallet).toLowerCase(), ADMIN_WALLET.toLowerCase());
+    assert.deepEqual(payload.roles, ["admin"]);
+    assert.ok(typeof payload.token === "string" && payload.token.length > 0);
+    assert.notEqual(payload.token, oldToken, "refresh must mint a new token, not echo the old one");
+    assert.ok(typeof payload.rotatedFromJti === "string" && payload.rotatedFromJti.length > 0);
+    assert.ok(typeof payload.expiresAt === "string" && !Number.isNaN(Date.parse(payload.expiresAt)));
+
+    // Old token rejected with token_revoked.
+    const postRefreshOld = await fetch(`${base}/account`, { headers: oldHeader });
+    assert.equal(postRefreshOld.status, 401);
+    const oldErr = await postRefreshOld.json();
+    assert.equal(oldErr.error, "token_revoked");
+
+    // New token works on the same protected route.
+    const newHeader = { authorization: `Bearer ${payload.token}` };
+    const postRefreshNew = await fetch(`${base}/account`, { headers: newHeader });
+    assert.equal(postRefreshNew.status, 200);
+  });
+});
+
+test("http smoke: /auth/refresh rejects service tokens with service_token_refresh_unsupported", { skip: !RUN }, async () => {
+  await runWithServer(async (base) => {
+    // Mint a service-style token directly (mirrors what /admin/service-tokens issues).
+    const serviceToken = issueToken(ADMIN_WALLET, {
+      roles: ["admin"],
+      tokenKind: "service",
+      serviceToken: true,
+      capabilityGrantId: "test-grant"
+    });
+
+    const refresh = await fetch(`${base}/auth/refresh`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${serviceToken}` }
+    });
+    assert.equal(refresh.status, 401);
+    const err = await refresh.json();
+    assert.equal(err.error, "service_token_refresh_unsupported");
+  });
+});
+
+test("http smoke: /auth/refresh rejects an unauthenticated caller", { skip: !RUN }, async () => {
+  await runWithServer(async (base) => {
+    const refresh = await fetch(`${base}/auth/refresh`, { method: "POST" });
+    assert.equal(refresh.status, 401);
+  });
+});
+
 test("http smoke: /account/borrow-capacity returns the signed-in wallet headroom", { skip: !RUN }, async () => {
   await runWithServer(async (base) => {
     const token = issueToken(ADMIN_WALLET, { roles: ["admin"] });

--- a/mcp-server/src/services/bootstrap.js
+++ b/mcp-server/src/services/bootstrap.js
@@ -357,6 +357,11 @@ function loadRateLimitConfig(env = process.env) {
   return {
     authNonce: buildLimit(env, "RATE_LIMIT_AUTH_NONCE", { limit: 10, windowSeconds: 60 }),
     authVerify: buildLimit(env, "RATE_LIMIT_AUTH_VERIFY", { limit: 10, windowSeconds: 60 }),
+    // Refresh has a stricter per-wallet limit than verify because a refresh
+    // call needs a valid token in hand — abusive callers would have to keep
+    // spending tokens to retry. 6/min is enough headroom for a tab that
+    // wakes up after sleep and a couple of background re-syncs.
+    authRefresh: buildLimit(env, "RATE_LIMIT_AUTH_REFRESH", { limit: 6, windowSeconds: 60 }),
     adminJobs: buildLimit(env, "RATE_LIMIT_ADMIN_JOBS", { limit: 60, windowSeconds: 60 }),
     verifierRun: buildLimit(env, "RATE_LIMIT_VERIFIER_RUN", { limit: 120, windowSeconds: 60 }),
     events: buildLimit(env, "RATE_LIMIT_EVENTS", { limit: 30, windowSeconds: 60 })

--- a/site/.well-known/agent-tools.json
+++ b/site/.well-known/agent-tools.json
@@ -151,6 +151,17 @@
       },
       {
         "method": "POST",
+        "path": "/auth/refresh",
+        "requiresAuth": true,
+        "requiredAction": "refresh_wallet_token",
+        "authScheme": "SIWE_JWT",
+        "walletModes": [
+          "evm-siwe"
+        ],
+        "notes": "Rotates the caller's wallet JWT — revokes the old jti and mints a new one with the same sub + roles. Service tokens cannot be refreshed here."
+      },
+      {
+        "method": "POST",
         "path": "/jobs/claim",
         "requiresAuth": true,
         "requiredAction": "wallet_sign_in",
@@ -348,6 +359,7 @@
     "entrypoints": [
       "/auth/nonce",
       "/auth/verify",
+      "/auth/refresh",
       "/auth/logout"
     ],
     "supportedWalletModes": [
@@ -453,6 +465,10 @@
     {
       "path": "/reputation",
       "description": "Current reputation scores + tier."
+    },
+    {
+      "path": "/auth/refresh",
+      "description": "Rotate the caller's wallet JWT — revokes the old jti and mints a new one with the same sub + roles. Lets operators avoid re-SIWE every AUTH_TOKEN_TTL_SECONDS."
     },
     {
       "path": "/jobs/recommendations",
@@ -683,6 +699,7 @@
     "authEntrypoints": [
       "/auth/nonce",
       "/auth/verify",
+      "/auth/refresh",
       "/auth/logout"
     ],
     "note": "Mutating and financial actions exist on authenticated HTTP and operator-app surfaces but are intentionally excluded from this directory-safe manifest until the trust, policy, and audit posture are ready for broader distribution."


### PR DESCRIPTION
## Summary
Pre-this-PR: `AUTH_TOKEN_TTL_SECONDS` defaults to 24 h, the operator app stores the JWT in `localStorage` with a 30 s safety margin, and there's no refresh endpoint. Once 24 h elapse the operator gets a 401 mid-session and has to walk through the SIWE prompt again, even though their wallet session is still legitimate. The frontend audit flagged this as a real UX paper cut.

This PR adds `POST /auth/refresh` — rotate the caller's wallet JWT in place: revoke the old `jti`, mint a new token with the same `sub` + freshly-resolved roles, fresh `iat` / `exp`.

## Hard guardrails

- **Authenticated** — `authMiddleware` enforces signature + `exp` + revocation on the incoming token, so a leaked-and-already-revoked token cannot bootstrap a fresh one.
- **Single-flight rotation** — old `jti` is revoked **before** the new token is issued, so refresh never produces two tokens valid at the same time from one call.
- **Roles re-resolved at refresh time** — an operator removed from `AUTH_ADMIN_WALLETS` between sign-in and refresh will not carry their old admin claim into the new token.
- **Service tokens REJECTED** with `service_token_refresh_unsupported` (401). They have their own lifecycle via `/admin/service-tokens/:id/rotate`, signed by an admin, and their additional claims (`capabilities`, `capabilityGrantId`, `scope`) are not safe to re-mint from a stale token.
- **Per-wallet rate limit** at 6 / min (overridable via `RATE_LIMIT_AUTH_REFRESH`). Stricter than `/auth/verify` (10 / min IP) because each refresh call needs a valid token in hand — abusive callers have to keep spending tokens to retry.

## Response shape

Mirrors `/auth/verify` for drop-in frontend compatibility, plus one extra field:

```json
{
  "token": "...",
  "wallet": "0x...",
  "roles": ["..."],
  "capabilities": [...],
  "expiresAt": "2026-05-18T...",
  "tokenType": "Bearer",
  "rotatedFromJti": "<old-jti>"
}
```

## Manifest
- `/auth/refresh` added to `executionSurfaces.authEntrypoints`, the `authenticatedEndpoints` list, and the per-endpoint description block with `requiresAuth: true` + the `SIWE_JWT` auth scheme.

## Tests
- **`server.smoke.test.js`** — three new `{ skip: !RUN }` cases:
  - Happy path: old `jti` revoked, new token works on the same protected route, response shape verified
  - Service-token rejection with `service_token_refresh_unsupported`
  - Unauthenticated caller → 401
- **`discovery-manifest.test.js`** — asserts `/auth/refresh` appears in both `authEntrypoints` and `authenticatedEndpoints`.
- **`auth.test.js`** — updated the existing missing-token assertion that enumerated `authEntrypoints` verbatim.
- **Full `mcp-server` suite**: 571 / 571 pass.

## Frontend follow-up (not in this PR)
The operator app at `app.averray.com` will need its own change to actually call `/auth/refresh` — e.g. a token-store helper that calls it when `expiresAt` is within ~5 min, and a one-time call on page load if the token is near expiry. That's a separate frontend PR (different repo, different reviewers) and not blocked by this one — once landed, the endpoint is available for any client that wants it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)