### PR TITLE
Surface observability env vars and §5 verification recipes

### DIFF
--- a/deploy/backend.env.template
+++ b/deploy/backend.env.template
@@ -175,6 +175,33 @@ JOB_STALE_SWEEPER_ACTION=archive
 JOB_STALE_SWEEPER_INTERVAL_MS=3600000
 JOB_STALE_SWEEPER_MAX_JOBS_PER_RUN=25
 
+# Observability (opt-in; required to flip PRODUCTION_CHECKLIST.md section 5
+# boxes). These env vars wire to code paths that already exist; both are
+# commented out because each is operator-controlled.
+
+# Bearer token gating /metrics on the public surface. When unset (the
+# current default) /metrics is reachable from anyone who can reach
+# api.averray.com - that leaks request-path histograms, status-code
+# distributions, and operational signals. Set this to a high-entropy
+# random token (>= 32 chars) and configure the Prometheus scraper to send
+# `Authorization: Bearer <token>`. Verify with:
+#   curl -sS -o /dev/null -w "%{http_code}\n" https://api.averray.com/metrics
+#   curl -sS -o /dev/null -w "%{http_code}\n" \
+#     -H "Authorization: Bearer <token>" https://api.averray.com/metrics
+# Expect 401 unauthenticated, 200 with bearer.
+# METRICS_BEARER_TOKEN=1Password ref for prod-backend/metrics-bearer-token
+
+# Backend error reporting via Sentry. Optional - the `@sentry/node`
+# package is also optional (`npm install @sentry/node` in mcp-server to
+# enable). When SENTRY_DSN is unset, `mcp-server/src/core/observability.js`
+# falls back to structured-log capture so call sites never branch on
+# Sentry availability. When the DSN is set but the package isn't
+# installed, the backend logs a warning and continues without Sentry.
+# SENTRY_DSN=1Password ref for prod-backend-external/sentry-backend-dsn
+# SENTRY_ENVIRONMENT=production
+# SENTRY_RELEASE=
+# SENTRY_TRACES_SAMPLE_RATE=0
+
 # NODE_OPTIONS and PORT are intentionally NOT set for the backend —
 # the live /srv/agent-stack/backend.env doesn't define them; the
 # backend container uses its built-in defaults. They live only in

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -234,6 +234,42 @@ RUN_SUBSCAN_XCM_VALIDATION=1 ./scripts/ops/check-release-readiness.sh testnet
     values and require `lastAttemptedAt`, `lastSuccessfulAt`, and the latest
     provider id.
 
+### How to verify each §5 box
+
+The first five boxes are intentionally not auto-flipped — they need
+deployed-config evidence that lives outside the repo. The wiring exists in
+code; only the production env vars need to be set. Concrete verification
+commands per box:
+
+- **Backend metrics reachable and bearer-protected.** Verify reachable:
+  `curl -sS -o /dev/null -w "%{http_code}\n" https://api.averray.com/metrics`
+  must return `200`. Verify bearer-gated: the same request **without** a
+  bearer must return `401` once `METRICS_BEARER_TOKEN` is set in
+  `deploy/backend.env.template`. Current state (2026-05-17): reachable
+  `200`, **not** bearer-gated. Flip after the env var is set and a
+  no-bearer request returns `401`.
+- **Backend Sentry configured for the active environment.** Set
+  `SENTRY_DSN` (and optionally `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`,
+  `SENTRY_TRACES_SAMPLE_RATE`) in `deploy/backend.env.template`, then
+  `npm install @sentry/node` in `mcp-server`. The backend log line
+  `observability.sentry_ready` confirms init. Flip when that log line is
+  present in the current deploy.
+- **Frontend Sentry runtime config.** Conditional. v1 has no frontend
+  Sentry scaffolding. Two valid postures: (a) flip with the inline note
+  *"N/A — frontend error reporting not required for v1"* if that is the
+  decision, or (b) leave unchecked until frontend Sentry is scaffolded.
+- **Structured logs visible from the current deploy target.**
+  `LOG_LEVEL=info` is set; the backend writes structured JSON via the
+  default logger. Verify the operator can read backend logs (via
+  `journalctl`, `docker logs`, or the platform's log surface), then flip.
+- **Alert destination for hosted smoke-check failures.** Set
+  `ALERT_WEBHOOK_URL` (and optionally `ALERT_SERVICE_NAME`,
+  `ALERT_ENVIRONMENT`) in the environment that runs
+  [`scripts/ops/check-hosted-stack-and-alert.sh`](../scripts/ops/check-hosted-stack-and-alert.sh).
+  Verify with a deliberate smoke failure (e.g. point `API_BASE_URL` at a
+  non-existent host) and confirm the webhook receives the JSON payload.
+  Flip after one verified delivery.
+
 ---
 
 ## 6. Launch Documentation


### PR DESCRIPTION
## Summary

Closes the doc/template side of finding **F4** from the launch-readiness deep dive: `PRODUCTION_CHECKLIST.md` §5 had 6+ unchecked observability boxes that operators couldn't flip because the relevant env vars (`METRICS_BEARER_TOKEN`, `SENTRY_DSN`, etc.) are referenced in code but not surfaced in `deploy/backend.env.template`. After this PR, the wiring is operator-discoverable and the boxes have concrete verification commands.

## What changed

### `deploy/backend.env.template`

Added an **Observability** section near the end of the template with two commented-out blocks:

- **`METRICS_BEARER_TOKEN`** — gates `/metrics` on the public surface. The code at `mcp-server/src/protocols/http/server.js:1777` already enforces the bearer when the env var is set; the gap was that operators had no way to discover the env var existed.
- **`SENTRY_DSN`** + companion vars (`SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`, `SENTRY_TRACES_SAMPLE_RATE`) — wires `mcp-server/src/core/observability.js` to a real Sentry project. Optional, gracefully degrades to structured-log capture when unset.

Both blocks carry inline guidance on what to set and how to verify. The entries use prose 1Password references ("1Password ref for ...") rather than literal `op://` strings, per the template's existing constraint at lines 28–31.

### `docs/PRODUCTION_CHECKLIST.md` §5

Added a **"How to verify each §5 box"** subsection with curl + log-line assertions for the five unchecked boxes:

| Box | Verification |
|---|---|
| Backend metrics reachable + bearer-protected | `curl /metrics` → 200; same without bearer → 401 (once `METRICS_BEARER_TOKEN` is set) |
| Backend Sentry configured | log line `observability.sentry_ready` present |
| Frontend Sentry runtime config | conditional ("if browser error reporting is required") — flip as N/A for v1 or scaffold first |
| Structured logs visible | operator-side check via `journalctl` / `docker logs` |
| Alert destination for smoke failures | `ALERT_WEBHOOK_URL` set; one deliberate-failure delivery verified |

Each entry names a concrete env var so an operator doesn't have to grep code.

## Critical operational note

**`/metrics` on `api.averray.com` is currently publicly reachable with NO bearer gate.** I verified by `curl` at audit time — returns `200` and full Prometheus text. The bearer-gating code path exists in production but the env var is unset, so the gate is open. The doc and template now make the fix self-discoverable; operator needs to set `METRICS_BEARER_TOKEN` and re-deploy.

This is **information leakage** (request-path histograms, status-code distributions, state-store backend, signer-configured boolean, blockchain block number) — not a fund-at-risk vulnerability, but worth tightening before launch.

## Scope

- Two files, +63 lines, no deletions:
  - `deploy/backend.env.template`: +27 lines (observability section)
  - `docs/PRODUCTION_CHECKLIST.md`: +36 lines (§5 verification recipes)
- No code, no contracts, no tests, no workflows.
- No `op://` literals added to env template (preserves the `op inject` constraint).
- No TODO markers added (preserves `validate-env-render.sh --strict` invariant).
- Sanity: backend tests still pass 571/571 (no code change, just confirming nothing structural is affected).

## What this PR does NOT do

- **Does not flip any §5 box.** All five remain `[ ]` because the deployed env vars are still unset. The boxes become flippable once an operator sets the env vars and re-deploys.
- **Does not deploy any config.** The template lines are commented out by design — each entry is opt-in and operator-controlled.
- **Does not add Sentry or @sentry/node to the runtime dependency tree.** The observability seam in `observability.js` keeps `@sentry/node` as a deferred dynamic import; operators install it locally if/when they want Sentry.
- **Does not touch the indexer or frontend observability surface.** The indexer's `deploy/indexer.env.template` has no observability gap I could identify; the frontend has no Sentry scaffolding at all (separate decision).

## Affects

- backend / frontend / indexer / Caddy / contracts / public site: **none** (docs + env template only)
- Required env or VPS secret changes: **none required by this PR** (the new template entries are commented out). Operator action to set them is a separate step.

## Test plan

- [x] `npm install` + `npm --workspace mcp-server test` → 571/571 passed (no code change, this just confirms nothing structural broke)
- [x] No `op://` literals in `deploy/backend.env.template` comments (preserves `op inject` constraint)
- [x] No TODO markers added (preserves `validate-env-render.sh --strict`)
- [ ] Reviewer confirms the verification recipes match how the production stack actually exposes each signal (the doc is the contract an operator quotes when ticking the box)
- [ ] Operator sets `METRICS_BEARER_TOKEN` in production env and verifies `curl /metrics` → 401 without bearer, 200 with bearer

## Audit-prep + launch-readiness lane status

| PR | What |
|---|---|
| #380 | strategy-adapter audit scope + §11 contacts |
| #382 | AUDIT_PACKAGE §9 contacts |
| #386 | AUDIT_PACKAGE §6 params + §7 test counts |
| #388 | discovery `.well-known/` alias (closes F2) |
| #390 | INCIDENT_RESPONSE §1 + checklist flip (closes F5) |
| **#NEW** | this — observability env-template + §5 evidence (closes doc side of F4) |

Remaining deep-dive findings:
- **F3** stale `testnet.json#verifier` — operator update post-KMS-cutover
- **F6** mainnet pauser separation — resolves at mainnet deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)