### PR TITLE
Harden XCM feed cursor progress

### DIFF
--- a/indexer/src/api/xcm-feed-cursor.test.ts
+++ b/indexer/src/api/xcm-feed-cursor.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { normalizeAdvancingNextCursor } from "./xcm-feed-cursor.ts";
+
+test("XCM feed cursor normalization accepts empty end-of-feed pages", () => {
+  assert.equal(normalizeAdvancingNextCursor(undefined, 0, "test source"), undefined);
+  assert.equal(normalizeAdvancingNextCursor("   ", 0, "test source"), undefined);
+});
+
+test("XCM feed cursor normalization trims advancing cursors", () => {
+  assert.equal(normalizeAdvancingNextCursor(" cursor-2 ", 1, "test source"), "cursor-2");
+});
+
+test("XCM feed cursor normalization rejects non-empty batches without nextCursor", () => {
+  assert.throws(
+    () => normalizeAdvancingNextCursor(undefined, 1, "test source"),
+    /non-empty XCM batches must advance the cursor/u
+  );
+});

--- a/indexer/src/api/xcm-feed-cursor.ts
+++ b/indexer/src/api/xcm-feed-cursor.ts
@@ -1,0 +1,13 @@
+export function normalizeAdvancingNextCursor(
+  rawNextCursor: unknown,
+  itemCount: number,
+  sourceLabel = "XCM feed"
+) {
+  const nextCursor = typeof rawNextCursor === "string" && rawNextCursor.trim()
+    ? rawNextCursor.trim()
+    : undefined;
+  if (itemCount > 0 && !nextCursor) {
+    throw new Error(`${sourceLabel} returned items without nextCursor; non-empty XCM batches must advance the cursor.`);
+  }
+  return nextCursor;
+}

--- a/indexer/src/api/xcm-outcome-publisher.ts
+++ b/indexer/src/api/xcm-outcome-publisher.ts
@@ -13,6 +13,7 @@ import {
   normalizeObservedAtIso,
   type OutcomeCursor
 } from "./xcm-outcome-cursor";
+import { normalizeAdvancingNextCursor } from "./xcm-feed-cursor";
 import { buildUpsertExternalOutcomeSql } from "./xcm-outcome-publisher-sql";
 
 const DEFAULT_SCOPE = "xcm-outcome-publisher";
@@ -272,6 +273,11 @@ export class XcmOutcomePublisherService {
         limit: this.batchSize
       });
       const items = Array.isArray(payload?.items) ? payload.items : [];
+      const nextCursor = normalizeAdvancingNextCursor(
+        payload?.nextCursor,
+        items.length,
+        "XCM outcome publisher source"
+      );
       let observedCount = 0;
 
       for (const outcome of items) {
@@ -280,9 +286,7 @@ export class XcmOutcomePublisherService {
       }
 
       await this.setState({
-        cursor: typeof payload?.nextCursor === "string" && payload.nextCursor.trim()
-          ? payload.nextCursor.trim()
-          : state.cursor,
+        cursor: nextCursor ?? state.cursor,
         lastObservedCount: observedCount,
         lastSyncedAt: new Date().toISOString(),
         lastError: undefined
@@ -290,9 +294,7 @@ export class XcmOutcomePublisherService {
 
       return {
         observedCount,
-        cursor: typeof payload?.nextCursor === "string" && payload.nextCursor.trim()
-          ? payload.nextCursor.trim()
-          : state.cursor
+        cursor: nextCursor ?? state.cursor
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : "xcm_outcome_publisher_failed";

--- a/indexer/src/api/xcm-upstream-source.test.ts
+++ b/indexer/src/api/xcm-upstream-source.test.ts
@@ -223,6 +223,54 @@ test("Subscan source preserves failure code for failed status variants", () => {
   assert.equal(outcome?.failureCode, failureCode);
 });
 
+test("Subscan source advances after a non-empty final page", async () => {
+  const adapter = new SubscanXcmSourceAdapter({
+    apiHost: "https://subscan.example",
+    apiKey: "test",
+    fetchImpl: async () => ({
+      ok: true,
+      json: async () => ({
+        code: 0,
+        data: {
+          list: [
+            {
+              message_topic: requestId,
+              status: "success",
+              block_timestamp: "1712345678"
+            }
+          ]
+        }
+      })
+    } as Response)
+  });
+
+  const payload = await adapter.fetchBatch({ limit: 25 });
+
+  assert.equal(payload.items.length, 1);
+  assert.equal(adapter.decodePageCursor(payload.nextCursor), 1);
+});
+
+test("Subscan source omits nextCursor for empty end-of-feed pages", async () => {
+  const adapter = new SubscanXcmSourceAdapter({
+    apiHost: "https://subscan.example",
+    apiKey: "test",
+    fetchImpl: async () => ({
+      ok: true,
+      json: async () => ({
+        code: 0,
+        data: {
+          list: []
+        }
+      })
+    } as Response)
+  });
+
+  const payload = await adapter.fetchBatch({ limit: 25 });
+
+  assert.deepEqual(payload.items, []);
+  assert.equal(payload.nextCursor, undefined);
+});
+
 test("Subscan source rejects failed status variants without failure code", () => {
   const adapter = new SubscanXcmSourceAdapter({
     apiHost: "https://subscan.example",

--- a/indexer/src/api/xcm-upstream-source.ts
+++ b/indexer/src/api/xcm-upstream-source.ts
@@ -414,7 +414,7 @@ export class SubscanXcmSourceAdapter implements XcmUpstreamSourceAdapter {
     const items = list
       .map((entry) => this.normalizeSubscanEntry(entry as SubscanXcmRecord))
       .filter((entry): entry is PublishedOutcome => Boolean(entry));
-    const nextCursor = list.length >= limit ? this.encodePageCursor(page + 1) : undefined;
+    const nextCursor = list.length > 0 ? this.encodePageCursor(page + 1) : undefined;
     return {
       items,
       nextCursor

--- a/mcp-server/src/services/xcm-observation-relay.js
+++ b/mcp-server/src/services/xcm-observation-relay.js
@@ -82,6 +82,7 @@ export class XcmObservationRelayService {
       const state = await this.stateStore.getServiceState?.(this.stateScope) ?? {};
       const payload = await this.fetchFeed(state.cursor);
       const items = Array.isArray(payload?.items) ? payload.items : [];
+      const nextCursor = this.normalizeNextCursor(payload?.nextCursor, items.length);
       let observedCount = 0;
 
       for (const item of items) {
@@ -109,9 +110,7 @@ export class XcmObservationRelayService {
       }
 
       const nextState = await this.stateStore.upsertServiceState?.(this.stateScope, {
-        cursor: typeof payload?.nextCursor === "string" && payload.nextCursor.trim()
-          ? payload.nextCursor.trim()
-          : state.cursor,
+        cursor: nextCursor ?? state.cursor,
         lastObservedCount: observedCount,
         lastSyncedAt: new Date().toISOString(),
         lastError: undefined
@@ -245,6 +244,14 @@ export class XcmObservationRelayService {
       throw new ValidationError("XCM observer items must use a terminal status.");
     }
     return normalized;
+  }
+
+  normalizeNextCursor(value, itemCount) {
+    const nextCursor = typeof value === "string" && value.trim() ? value.trim() : undefined;
+    if (itemCount > 0 && !nextCursor) {
+      throw new ValidationError("XCM observer feed returned items without nextCursor; non-empty XCM batches must advance the cursor.");
+    }
+    return nextCursor;
   }
 
   normalizeFailureCode(value, status) {

--- a/mcp-server/src/services/xcm-observation-relay.test.js
+++ b/mcp-server/src/services/xcm-observation-relay.test.js
@@ -100,7 +100,8 @@ test("pollOnce preserves exact uint256 settlement amounts from observer feed", a
                 settledAssets: "9007199254740993",
                 settledShares: "18446744073709551616"
               }
-            ]
+            ],
+            nextCursor: "cursor-1"
           };
         }
       })
@@ -135,7 +136,8 @@ test("pollOnce rejects unsafe numeric settlement amounts from observer feed", as
                 status: "succeeded",
                 settledAssets: Number.MAX_SAFE_INTEGER + 2
               }
-            ]
+            ],
+            nextCursor: "cursor-1"
           };
         }
       }),
@@ -189,7 +191,8 @@ test("pollOnce rejects non-terminal statuses from the observer feed", async () =
                 requestId: REQUEST_ID,
                 status: "pending"
               }
-            ]
+            ],
+            nextCursor: "cursor-1"
           };
         }
       }),
@@ -219,7 +222,8 @@ test("pollOnce rejects numeric non-terminal statuses from the observer feed", as
                 requestId: REQUEST_ID,
                 status: 1
               }
-            ]
+            ],
+            nextCursor: "cursor-1"
           };
         }
       }),
@@ -253,7 +257,8 @@ test("pollOnce rejects failed observer outcomes without failureCode", async () =
                 requestId: REQUEST_ID,
                 status: "failed"
               }
-            ]
+            ],
+            nextCursor: "cursor-1"
           };
         }
       }),
@@ -292,7 +297,8 @@ test("pollOnce relays failed observer outcomes with failureCode", async () => {
                 status: "failed",
                 failureCode: FAILURE_CODE
               }
-            ]
+            ],
+            nextCursor: "cursor-1"
           };
         }
       })
@@ -308,4 +314,76 @@ test("pollOnce relays failed observer outcomes with failureCode", async () => {
   assert.equal(events.length, 1);
   assert.equal(events[0].data.status, "failed");
   assert.equal(events[0].data.failureCode, FAILURE_CODE);
+});
+
+test("pollOnce rejects non-empty observer feed batches without nextCursor before relaying", async () => {
+  const calls = [];
+  const stateStore = new MemoryStateStore();
+  const relay = new XcmObservationRelayService(
+    {
+      observeXcmOutcome: async (requestId, outcome) => {
+        calls.push([requestId, outcome]);
+        return outcome;
+      }
+    },
+    stateStore,
+    undefined,
+    {
+      enabled: true,
+      feedUrl: "https://observer.example/outcomes",
+      fetchImpl: async () => ({
+        ok: true,
+        async json() {
+          return {
+            items: [
+              {
+                requestId: REQUEST_ID,
+                status: "succeeded"
+              }
+            ]
+          };
+        }
+      }),
+      logger: { warn() {} }
+    }
+  );
+
+  await assert.rejects(
+    () => relay.pollOnce(),
+    /non-empty XCM batches must advance the cursor/u
+  );
+  assert.equal(calls.length, 0);
+  const stored = await stateStore.getServiceState("xcm-observation-relay");
+  assert.match(stored.lastError, /non-empty XCM batches must advance the cursor/u);
+});
+
+test("pollOnce accepts empty observer feed end-of-feed pages without nextCursor", async () => {
+  const stateStore = new MemoryStateStore();
+  await stateStore.upsertServiceState("xcm-observation-relay", { cursor: "cursor-2" });
+  const relay = new XcmObservationRelayService(
+    {
+      observeXcmOutcome: async () => {
+        throw new Error("unexpected relay");
+      }
+    },
+    stateStore,
+    undefined,
+    {
+      enabled: true,
+      feedUrl: "https://observer.example/outcomes",
+      fetchImpl: async () => ({
+        ok: true,
+        async json() {
+          return {
+            items: []
+          };
+        }
+      })
+    }
+  );
+
+  const result = await relay.pollOnce();
+
+  assert.equal(result.observedCount, 0);
+  assert.equal(result.cursor, "cursor-2");
 });


### PR DESCRIPTION
## Summary
- require non-empty XCM publisher and observer feed batches to provide an advancing `nextCursor` before any side effects
- let Subscan advance after any non-empty raw page so only the following empty page ends the feed
- add indexer and backend coverage for cursor normalization, Subscan final pages, and observer relay fail-fast behavior

## Checks
- `node --test mcp-server/src/services/xcm-observation-relay.test.js`
- `npm --workspace indexer run test:api`
- `npm --workspace indexer run typecheck`
- `npm --workspace mcp-server test`
- `git diff --check`

## Impact
- Affects: backend, indexer
- Generated frontend/site output: not touched
- Env/VPS changes: none