### PR TITLE
Wire operator app to /auth/refresh — keep operators signed in past 24h

### DIFF
--- a/app/app/(authed)/layout.tsx
+++ b/app/app/(authed)/layout.tsx
@@ -1,6 +1,7 @@
 import { OperatorRail } from "@/components/shell/OperatorRail";
 import { PaperGridBackground } from "@/components/runs/PaperGridBackground";
 import { LiveDataBridge } from "@/components/shell/LiveDataBridge";
+import { AuthRefreshBridge } from "@/components/shell/AuthRefreshBridge";
 
 export default function AuthedLayout({
   children,
@@ -9,6 +10,7 @@ export default function AuthedLayout({
 }) {
   return (
     <>
+      <AuthRefreshBridge />
       <LiveDataBridge />
       <PaperGridBackground />
       <div className="relative z-[1] mx-auto w-full max-w-[1440px] px-6 py-6">

--- a/app/components/shell/AuthRefreshBridge.tsx
+++ b/app/components/shell/AuthRefreshBridge.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useEffect } from "react";
+import { startAuthRefreshManager } from "@/lib/auth/auth-refresh-manager";
+
+/**
+ * Mounts the background JWT refresh manager once per authed app instance.
+ *
+ * Boot is decoupled from <LiveDataBridge /> because the refresh manager is
+ * useful even before the event stream connects (and survives a stream that
+ * fails to connect). Both components are mounted from the authed layout.
+ */
+export function AuthRefreshBridge() {
+  useEffect(() => {
+    const stop = startAuthRefreshManager();
+    return stop;
+  }, []);
+  return null;
+}

--- a/app/lib/auth/auth-refresh-decisions.js
+++ b/app/lib/auth/auth-refresh-decisions.js
@@ -1,0 +1,90 @@
+/**
+ * Pure-logic helpers for the wallet JWT refresh manager.
+ *
+ * Network and DOM concerns live in auth-refresh-manager.ts; this module
+ * is the side-effect-free core that decides:
+ *   - whether a given session is close enough to expiry to refresh now
+ *   - how long until the next scheduled refresh should fire
+ *   - which RefreshOutcome reasons should clear the local session
+ *
+ * Kept as plain JS with JSDoc so it matches the project's existing
+ * test-runner pattern (`.mjs` files via `node --test`, no TS loader).
+ */
+
+/**
+ * @typedef {Object} AuthSnapshotLike
+ * @property {boolean} authenticated
+ * @property {string} [expiresAt]   ISO-8601 timestamp from the server's
+ *                                  /auth/verify or /auth/refresh response.
+ */
+
+/**
+ * Refresh when the remaining lifetime is at or below this many ms.
+ * 10 minutes leaves enough headroom for: a sleeping tab to wake, a
+ * polling tick, AND the request itself to round-trip before the token
+ * actually expires.
+ */
+export const AUTH_REFRESH_THRESHOLD_MS = 10 * 60 * 1000;
+
+/**
+ * Belt-and-suspenders poll cadence. Short enough that a tab kept open
+ * for hours with throttled timers still gets a chance; long enough that
+ * a healthy session does not hit the endpoint pointlessly.
+ */
+export const AUTH_REFRESH_CHECK_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * Never schedule a one-shot refresh sooner than this many ms — guards
+ * against tight loops if expiresAt is in the past somehow.
+ */
+export const AUTH_REFRESH_MIN_SCHEDULE_DELAY_MS = 5_000;
+
+/**
+ * @param {AuthSnapshotLike} snapshot
+ * @param {number} [nowMs=Date.now()]
+ * @returns {boolean}
+ */
+export function shouldRefreshNow(snapshot, nowMs = Date.now()) {
+  if (!snapshot || !snapshot.authenticated || !snapshot.expiresAt) return false;
+  const expiresMs = Date.parse(snapshot.expiresAt);
+  if (!Number.isFinite(expiresMs)) return false;
+  return expiresMs - nowMs <= AUTH_REFRESH_THRESHOLD_MS;
+}
+
+/**
+ * Compute the delay (in ms) until the one-shot refresh timer should
+ * fire for a given session. Returns `undefined` when no schedule is
+ * possible (no session, invalid expiry).
+ *
+ * The intent is to fire ~AUTH_REFRESH_THRESHOLD_MS before expiry, but
+ * never sooner than AUTH_REFRESH_MIN_SCHEDULE_DELAY_MS — to keep things
+ * resilient if expiresAt is slightly in the past due to clock skew.
+ *
+ * @param {AuthSnapshotLike} snapshot
+ * @param {number} [nowMs=Date.now()]
+ * @returns {number | undefined}
+ */
+export function scheduleDelayMs(snapshot, nowMs = Date.now()) {
+  if (!snapshot || !snapshot.authenticated || !snapshot.expiresAt) return undefined;
+  const expiresMs = Date.parse(snapshot.expiresAt);
+  if (!Number.isFinite(expiresMs)) return undefined;
+  const target = expiresMs - AUTH_REFRESH_THRESHOLD_MS;
+  const delay = target - nowMs;
+  return Math.max(AUTH_REFRESH_MIN_SCHEDULE_DELAY_MS, delay);
+}
+
+/**
+ * @typedef {"no_session" | "endpoint_missing" | "unauthorized" | "network" | "shape"} RefreshFailReason
+ */
+
+/**
+ * Return `true` for outcomes that should clear the local session. Only
+ * `unauthorized` qualifies — the others are soft misses (transient
+ * network failure, backend not deployed, response shape didn't match).
+ *
+ * @param {RefreshFailReason} reason
+ * @returns {boolean}
+ */
+export function shouldClearSession(reason) {
+  return reason === "unauthorized";
+}

--- a/app/lib/auth/auth-refresh-decisions.test.mjs
+++ b/app/lib/auth/auth-refresh-decisions.test.mjs
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  AUTH_REFRESH_CHECK_INTERVAL_MS,
+  AUTH_REFRESH_THRESHOLD_MS,
+  AUTH_REFRESH_MIN_SCHEDULE_DELAY_MS,
+  scheduleDelayMs,
+  shouldClearSession,
+  shouldRefreshNow,
+} from "./auth-refresh-decisions.js";
+
+const NOW = Date.parse("2026-05-17T12:00:00.000Z");
+
+function snapshot(expiresInMs, opts = {}) {
+  return {
+    authenticated: opts.authenticated ?? true,
+    expiresAt: new Date(NOW + expiresInMs).toISOString(),
+  };
+}
+
+test("shouldRefreshNow: true when remaining lifetime is below threshold", () => {
+  // 5 minutes left — below 10-minute threshold.
+  assert.equal(shouldRefreshNow(snapshot(5 * 60_000), NOW), true);
+});
+
+test("shouldRefreshNow: false when there is plenty of lifetime left", () => {
+  // 1h left.
+  assert.equal(shouldRefreshNow(snapshot(60 * 60_000), NOW), false);
+});
+
+test("shouldRefreshNow: true at the boundary (exactly THRESHOLD remaining)", () => {
+  assert.equal(shouldRefreshNow(snapshot(AUTH_REFRESH_THRESHOLD_MS), NOW), true);
+});
+
+test("shouldRefreshNow: true when already expired (defensive — we will refresh and 401 will clear)", () => {
+  assert.equal(shouldRefreshNow(snapshot(-30_000), NOW), true);
+});
+
+test("shouldRefreshNow: false when not authenticated", () => {
+  assert.equal(shouldRefreshNow({ authenticated: false }, NOW), false);
+});
+
+test("shouldRefreshNow: false when expiresAt is missing or unparseable", () => {
+  assert.equal(shouldRefreshNow({ authenticated: true }, NOW), false);
+  assert.equal(shouldRefreshNow({ authenticated: true, expiresAt: "not-a-date" }, NOW), false);
+});
+
+test("scheduleDelayMs: schedules ~ (lifetime - threshold) when ample time remains", () => {
+  // 30 min remaining, 10 min threshold -> 20 min delay.
+  const delay = scheduleDelayMs(snapshot(30 * 60_000), NOW);
+  assert.equal(delay, 20 * 60_000);
+});
+
+test("scheduleDelayMs: clamps to MIN_SCHEDULE_DELAY_MS when target is in the past", () => {
+  // 5 minutes remaining, threshold = 10 min, target is 5 min in the past.
+  const delay = scheduleDelayMs(snapshot(5 * 60_000), NOW);
+  assert.equal(delay, AUTH_REFRESH_MIN_SCHEDULE_DELAY_MS);
+});
+
+test("scheduleDelayMs: returns undefined when there is no session", () => {
+  assert.equal(scheduleDelayMs({ authenticated: false }, NOW), undefined);
+  assert.equal(scheduleDelayMs({ authenticated: true }, NOW), undefined);
+  assert.equal(scheduleDelayMs({ authenticated: true, expiresAt: "garbage" }, NOW), undefined);
+});
+
+test("shouldClearSession: only 'unauthorized' clears", () => {
+  assert.equal(shouldClearSession("unauthorized"), true);
+  assert.equal(shouldClearSession("endpoint_missing"), false);
+  assert.equal(shouldClearSession("network"), false);
+  assert.equal(shouldClearSession("shape"), false);
+  assert.equal(shouldClearSession("no_session"), false);
+});
+
+test("constants are sensible — threshold < typical 24h TTL, check < threshold", () => {
+  assert.ok(AUTH_REFRESH_THRESHOLD_MS < 24 * 60 * 60_000, "threshold must fit inside a 24h TTL");
+  assert.ok(AUTH_REFRESH_CHECK_INTERVAL_MS < AUTH_REFRESH_THRESHOLD_MS, "poll must run more often than the threshold");
+  assert.ok(AUTH_REFRESH_MIN_SCHEDULE_DELAY_MS > 0, "min schedule must be positive");
+});

--- a/app/lib/auth/auth-refresh-manager.ts
+++ b/app/lib/auth/auth-refresh-manager.ts
@@ -1,0 +1,150 @@
+"use client";
+
+/**
+ * Background refresh manager for the wallet JWT.
+ *
+ * Pairs with the backend's POST /auth/refresh endpoint. Keeps an operator
+ * signed in across long sessions by rotating the JWT *before* it expires,
+ * so they never get a 401 mid-flow and never have to walk through the
+ * SIWE prompt again until they actively sign out.
+ *
+ * Strategy:
+ *   - On mount, if the current token expires within REFRESH_THRESHOLD_MS,
+ *     refresh now.
+ *   - Otherwise schedule a one-shot timer for (expiresAt - margin),
+ *     plus a poll every CHECK_INTERVAL_MS as a belt-and-suspenders.
+ *   - On `visibilitychange` (tab regains focus after sleep), re-check
+ *     and refresh if the timer missed while the page was hidden.
+ *   - The manager is idempotent: calling start() while running is a no-op.
+ *
+ * Failure modes (see refreshAuthToken's RefreshOutcome):
+ *   - `endpoint_missing` (backend not deployed) → silent no-op; the
+ *     session keeps working and the operator will re-SIWE on natural expiry.
+ *   - `unauthorized` → the session was already revoked server-side;
+ *     refreshAuthToken clears local state, which will trigger the
+ *     existing unauthenticated-redirect logic in the operator app.
+ *   - `network` / `shape` / `no_session` → silent no-op; we'll try
+ *     again at the next interval / visibility change.
+ */
+
+import { getAuthSnapshot, onAuthChange, type AuthSnapshot } from "./token-store";
+import { refreshAuthToken } from "./siwe";
+import {
+  AUTH_REFRESH_CHECK_INTERVAL_MS as CHECK_INTERVAL_MS,
+  AUTH_REFRESH_THRESHOLD_MS as REFRESH_THRESHOLD_MS,
+  scheduleDelayMs,
+  shouldRefreshNow as decideShouldRefresh,
+} from "./auth-refresh-decisions.js";
+
+type Stop = () => void;
+
+let activeStop: Stop | null = null;
+
+export function startAuthRefreshManager(): Stop {
+  if (activeStop) return activeStop;
+  if (typeof window === "undefined") return () => {};
+
+  let pollTimer: ReturnType<typeof setInterval> | undefined;
+  let nextTokenTimer: ReturnType<typeof setTimeout> | undefined;
+  let refreshing = false;
+  let unsubscribeAuth: (() => void) | undefined;
+  let visibilityListener: (() => void) | undefined;
+  let stopped = false;
+
+  function clearScheduledTimer() {
+    if (nextTokenTimer !== undefined) {
+      clearTimeout(nextTokenTimer);
+      nextTokenTimer = undefined;
+    }
+  }
+
+  function shouldRefreshNow(snapshot: AuthSnapshot): boolean {
+    return decideShouldRefresh(snapshot);
+  }
+
+  async function attemptRefresh(reason: string) {
+    if (refreshing || stopped) return;
+    refreshing = true;
+    try {
+      const outcome = await refreshAuthToken();
+      if (outcome.ok) {
+        // eslint-disable-next-line no-console
+        console.debug(`[auth-refresh] rotated (${reason}); new expiry ${outcome.session.expiresAt}`);
+        // The success path re-fires the auth listener via writeSession,
+        // which re-runs scheduleForCurrentSession with the new expiry.
+      } else if (outcome.reason === "unauthorized") {
+        // eslint-disable-next-line no-console
+        console.info(`[auth-refresh] unauthorized; session cleared (${reason})`);
+      }
+      // Other outcomes are silent — soft misses, will retry on the next tick.
+    } finally {
+      refreshing = false;
+    }
+  }
+
+  function scheduleForCurrentSession() {
+    clearScheduledTimer();
+    if (stopped) return;
+    const snapshot = getAuthSnapshot();
+    if (!snapshot.authenticated || !snapshot.expiresAt) return;
+    if (shouldRefreshNow(snapshot)) {
+      void attemptRefresh("threshold");
+      return;
+    }
+    const delay = scheduleDelayMs(snapshot);
+    if (delay === undefined) return;
+    nextTokenTimer = setTimeout(() => {
+      void attemptRefresh("scheduled");
+    }, delay);
+  }
+
+  // 1. Initial check on mount.
+  scheduleForCurrentSession();
+
+  // 2. Belt-and-suspenders poll every CHECK_INTERVAL_MS — handles long-running
+  //    tabs where the one-shot timer might drift, and catches the case where
+  //    a new session is written by sign-in flow.
+  pollTimer = setInterval(() => {
+    const snapshot = getAuthSnapshot();
+    if (shouldRefreshNow(snapshot)) {
+      void attemptRefresh("poll");
+    }
+  }, CHECK_INTERVAL_MS);
+
+  // 3. Re-check on visibilitychange. Tabs that are backgrounded for hours
+  //    have their setTimeout / setInterval throttled aggressively, so the
+  //    timer above can miss. When the operator returns to the tab, we
+  //    refresh immediately if we're inside the threshold.
+  visibilityListener = () => {
+    if (document.visibilityState === "visible") {
+      const snapshot = getAuthSnapshot();
+      if (shouldRefreshNow(snapshot)) {
+        void attemptRefresh("visibility");
+      } else {
+        // Reschedule the one-shot in case it was throttled away.
+        scheduleForCurrentSession();
+      }
+    }
+  };
+  document.addEventListener("visibilitychange", visibilityListener);
+
+  // 4. React to sign-in / sign-out / cross-tab session writes by rescheduling.
+  unsubscribeAuth = onAuthChange(() => scheduleForCurrentSession());
+
+  const stop: Stop = () => {
+    if (stopped) return;
+    stopped = true;
+    clearScheduledTimer();
+    if (pollTimer !== undefined) clearInterval(pollTimer);
+    if (visibilityListener) document.removeEventListener("visibilitychange", visibilityListener);
+    if (unsubscribeAuth) unsubscribeAuth();
+    activeStop = null;
+  };
+
+  activeStop = stop;
+  return stop;
+}
+
+// Re-export the constants so callers can render the same thresholds in
+// debug panels without reaching into the .js helper module.
+export { AUTH_REFRESH_THRESHOLD_MS, AUTH_REFRESH_CHECK_INTERVAL_MS } from "./auth-refresh-decisions.js";

--- a/app/lib/auth/siwe.ts
+++ b/app/lib/auth/siwe.ts
@@ -113,3 +113,74 @@ export async function signOut(): Promise<void> {
   clearSession();
   setClientToken(undefined);
 }
+
+export type RefreshOutcome =
+  | { ok: true; session: AuthSession }
+  | { ok: false; reason: "no_session" | "endpoint_missing" | "unauthorized" | "network" | "shape" };
+
+/**
+ * Rotate the wallet JWT in place via POST /auth/refresh — the operator
+ * keeps their session without re-running SIWE.
+ *
+ * Fail-soft: if the endpoint is not yet deployed (404), or the network
+ * is unavailable, we leave the existing session alone and report the
+ * reason. Only `unauthorized` clears the session — that means the
+ * token is genuinely revoked / expired and the operator must re-SIWE.
+ */
+export async function refreshAuthToken(): Promise<RefreshOutcome> {
+  const token = getStoredToken();
+  if (!token) return { ok: false, reason: "no_session" };
+
+  let response: Response;
+  try {
+    response = await fetch(apiUrl("/auth/refresh"), {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+    });
+  } catch {
+    return { ok: false, reason: "network" };
+  }
+
+  // Backend may not be deployed yet — fall through silently. The existing
+  // session keeps working; the operator will re-SIWE once it expires.
+  if (response.status === 404 || response.status === 405) {
+    return { ok: false, reason: "endpoint_missing" };
+  }
+
+  // Token revoked / expired / service-token attempt — clear the session
+  // and surface the reason so the UI can prompt re-SIWE.
+  if (response.status === 401 || response.status === 403) {
+    clearSession("token_refresh_rejected");
+    setClientToken(undefined);
+    return { ok: false, reason: "unauthorized" };
+  }
+
+  if (!response.ok) {
+    // Treat anything else (rate-limit, server error) as a soft miss —
+    // don't drop the existing session.
+    return { ok: false, reason: "network" };
+  }
+
+  const payload = (await response.json().catch(() => ({}))) as {
+    token?: string;
+    wallet?: string;
+    expiresAt?: string;
+    roles?: unknown;
+  };
+  if (!payload.token || !payload.expiresAt || !payload.wallet) {
+    return { ok: false, reason: "shape" };
+  }
+
+  const session: AuthSession = {
+    token: payload.token,
+    wallet: payload.wallet,
+    expiresAt: payload.expiresAt,
+    roles: Array.isArray(payload.roles)
+      ? payload.roles.filter((r): r is string => typeof r === "string")
+      : [],
+  };
+
+  writeSession(session);
+  setClientToken(session.token);
+  return { ok: true, session };
+}


### PR DESCRIPTION
## Summary
Pairs with #394 (backend `POST /auth/refresh`). Today the operator app stores the SIWE JWT in `localStorage` with a 30 s safety margin and forces re-SIWE every `AUTH_TOKEN_TTL_SECONDS` (24 h default). With the backend now able to rotate a still-valid JWT in place, the frontend keeps an on-call operator signed in across long sessions.

## New helper — [`app/lib/auth/siwe.ts`](app/lib/auth/siwe.ts)

`refreshAuthToken()` posts to `/auth/refresh` with the current Bearer and writes the returned session via `writeSession` + `setClientToken`. Returns a discriminated union:

| Outcome | Behavior |
|---|---|
| `{ ok: true, session }` | Token rotated; new session stored, listeners notified |
| `{ ok: false, reason: "endpoint_missing" }` | 404 / 405 → keep existing session (covers the deploy window before #394 lands) |
| `{ ok: false, reason: "unauthorized" }` | 401 / 403 → `clearSession("token_refresh_rejected")` (triggers existing unauthenticated-redirect logic) |
| `{ ok: false, reason: "network" \| "shape" \| "no_session" }` | Soft miss; next tick retries |

## Background manager — [`app/lib/auth/auth-refresh-manager.ts`](app/lib/auth/auth-refresh-manager.ts) + [`app/components/shell/AuthRefreshBridge.tsx`](app/components/shell/AuthRefreshBridge.tsx)

`startAuthRefreshManager()` is idempotent and boots:
- **One-shot timer** scheduled for `(expiresAt - 10 min)`.
- **5-minute belt-and-suspenders poll** for throttled tabs where `setTimeout` drifts.
- **`visibilitychange` listener** that re-checks when a backgrounded tab regains focus — handles the long-sleep case where the browser throttled timers away.
- **`onAuthChange` subscription** that reschedules whenever the session updates (sign-in, cross-tab write, our own `writeSession`).

`AuthRefreshBridge` is a tiny `"use client"` component that mounts the manager on the authed layout, alongside `LiveDataBridge`.

## Pure-logic split — [`app/lib/auth/auth-refresh-decisions.js`](app/lib/auth/auth-refresh-decisions.js)

`shouldRefreshNow(snapshot, now)` / `scheduleDelayMs(snapshot, now)` / `shouldClearSession(reason)` sit in a side-effect-free `.js` module with JSDoc so they match the project's existing test-runner pattern (mirrors [`app/lib/api/guarded-submit.js`](app/lib/api/guarded-submit.js) / [`.test.mjs`](app/lib/api/guarded-submit.test.mjs)). The manager imports them.

## Tests — [`app/lib/auth/auth-refresh-decisions.test.mjs`](app/lib/auth/auth-refresh-decisions.test.mjs)

11 cases covering:
- threshold boundary (exact, below, well above)
- past-expiry defensive case
- unauthenticated / malformed-expiry inputs
- schedule-delay clamp (past target → `MIN_SCHEDULE_DELAY_MS`)
- the fail-reason → clearSession decision table
- constant sanity checks

```
✔ 11 / 11 cases pass · node --test · <100 ms
✔ npm --workspace app run typecheck — clean
```

## Graceful degradation

If #394 has not landed yet when this PR deploys, `refreshAuthToken` hits 404 → `"endpoint_missing"`, the manager silently keeps polling, and the session continues to expire naturally at 24 h exactly as today. **No regression** — this PR is safe to merge before or after the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)