### PR TITLE
SECURITY: close public unauthenticated SQL relay on indexer

### DIFF
--- a/indexer/src/api/index.ts
+++ b/indexer/src/api/index.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { client, graphql } from "ponder";
+import { graphql } from "ponder";
 import { db } from "ponder:api";
 import schema from "ponder:schema";
 
@@ -31,7 +31,7 @@ app.get("/", (c) =>
   c.json({
     status: "ok",
     service: "agent-platform-indexer",
-    endpoints: ["/graphql", "/sql", "/xcm/outcomes", "/xcm/outcomes/status"]
+    endpoints: ["/graphql", "/xcm/outcomes", "/xcm/outcomes/status"]
   })
 );
 
@@ -67,7 +67,6 @@ app.get("/xcm/outcomes/status", async (c) =>
 );
 
 app.use("/graphql", graphql({ db, schema }));
-app.use("/sql/*", client({ db, schema }));
 
 export default app;
 


### PR DESCRIPTION
## Summary

🔒 **Security fix.** The indexer mounts Ponder's `client({ db, schema })` middleware at `/sql/*` (`indexer/src/api/index.ts:70`), which exposes a SQL-over-HTTP relay to the indexer Postgres. Caddy reverse-proxies the entire `index.averray.com` host with no auth (`deploy/Caddyfile.averray:69-72`), so the surface is reachable from the public internet.

Found during the codebase-wide audit (finding **W5**, escalated from initial scoping). Verified with a benign `SELECT 1`:

```
$ curl 'https://index.averray.com/sql/db?sql=%7B%22json%22%3A%7B%22method%22%3A%22all%22%2C%22params%22%3A%5B%5D%2C%22sql%22%3A%22SELECT+1%22%7D%7D'
HTTP 200
{"command":"SELECT","rowCount":1,"oid":null,"rows":[{"?column?":1}],"fields":[...]}
```

## Bounded surface (mitigating context)

Ponder's SQL validator does reject:
- Schema-qualified queries (`information_schema.tables` → `"Schema name not supported"`)
- Function calls (`current_user`, `version()` → `"Function call not supported"`)

So the readable surface is bounded to the on-chain-derived `onchainTable` set in `indexer/ponder.schema.ts`: `job`, `jobEvent`, `payout`, `badgeMint`, `reputationSnapshot`, `reputationSlash`, `jobStakeEvent`, `treasuryOutflow`, `manifestPublication`, `verifierRegistryEvent`, `disclosureEvent`, `xcmRequest`, `xcmRequestEvent`. No PII, no secrets, all derivable from public chain logs.

## Why this still matters

Bounded surface ≠ safe surface:

1. **Unauthenticated DoS.** No rate limit on `/sql/db`; any internet caller can issue expensive queries against the indexer Postgres.
2. **SQL injection escape path via vulnerable transitive deps.** `npm audit --omit=dev` reports 3 high-severity advisories in Ponder's deps:
   - `drizzle-orm <0.45.2` — GHSA-gpj5-g38j-94v9 (SQL injection via improperly escaped identifiers)
   - `kysely <=0.28.16` — GHSA-wmrf-hv6w-mr66, GHSA-8cpq-38p9-67gx, GHSA-pv5w-4p9q-p3v2 (multiple SQLi)
   - `ponder` depends on both vulnerable versions
   A crafted query through the public `/sql/*` surface could plausibly hit one of these code paths, escaping the prepared-statement contract.
3. **Schema enumeration** leaks the data model and operational signals (latest indexed block, query latency).

## Why I'm comfortable removing the route entirely

No consumer in this repo uses `/sql/*`:

```
$ grep -rln "ponder/client\|@ponder/client\|/sql/db\|/sql/live" \
    app/ frontend/ sdk/ mcp-server/ indexer/ scripts/ docs/
(no matches)
```

The operator app reaches the indexer through Caddy's `/index/*` proxy to `/xcm/outcomes`, `/graphql`, `/ready`, `/status` — never `/sql/*`. The ops scripts (`scripts/ops/check-hosted-stack.sh`, `redeploy-indexer.sh`, `validate-subscan-xcm-source.mjs`) use the documented HTTP endpoints, not the SQL relay.

If a SQL relay is genuinely needed later (operator debugging, custom analytics), the right shape is a bearer-gated proxy in `mcp-server` or Caddy basic-auth in front of `/sql/*` — mirroring the `/metrics` pattern from PR #395.

## What changed

`indexer/src/api/index.ts`, +2 / -3:

- Drop the `client` import (line 2) since it's no longer used.
- Drop `"/sql"` from the advertised endpoint list at line 34 (was a doc/reality drift even before this fix — `GET /sql` already returned 404 because the wildcard handler required a sub-path).
- Drop the `app.use("/sql/*", client(...))` mount at line 70.

`/graphql` is preserved — it's the documented Ponder read interface used by the operator app's indexer queries. Note: `/graphql` is also unauthenticated; whether to gate it the same way is a separate decision tracked in audit finding W1 (SQLi transitive deps).

## Scope

- **One file**, +2 / -3 lines.
- No tests added (indexer has no HTTP integration test pattern in `indexer/src/api/*.test.ts`; existing tests are unit-level).
- No env vars changed, no Caddy changes, no deploy workflow changes.
- No consumers in this repo break (verified by grep).

## Affects

- indexer surface: `/sql/*` removed
- backend / frontend / Caddy / contracts / app: **none**
- Required env or VPS secret changes: **none**

## Test plan

- [x] `npm run typecheck:indexer` passes
- [x] `npm run test:indexer:api` passes (28 tests; unchanged by this edit)
- [x] Diff is exactly 3 lines (one import line + one endpoint list entry + one route mount)
- [ ] After deploy, `curl https://index.averray.com/sql/db?sql=...` → 404 (was 200)
- [ ] After deploy, `curl https://index.averray.com/graphql` still works (preserved)
- [ ] Reviewer confirms the operator app and any internal scripts don't rely on `/sql/*` (verified by grep above, but worth a second pair of eyes)

## Follow-ups (separate, not blocking)

- **W1** Bump Ponder + transitive `drizzle-orm`/`kysely` to fix the 3 high-severity advisories. Belongs in the `agent/dep-bumps-*` lane.
- **`/graphql` auth posture.** Same surface, same unauth concern. If you want to gate it the same way the SQL relay just got gated (by removal), or with a bearer proxy, open a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)