### PR TITLE
SECURITY: gate indexer /graphql with optional Bearer token

### DIFF
--- a/deploy/indexer.env.template
+++ b/deploy/indexer.env.template
@@ -30,3 +30,16 @@ DATABASE_SCHEMA=agent_indexer_20260516080108
 # PORT defined):
 NODE_OPTIONS=--max-old-space-size=2048
 PORT=42069
+
+# Optional Bearer token for the /graphql route. When unset, /graphql
+# (and its GraphiQL playground at GET /graphql) is publicly reachable
+# from index.averray.com — the indexer logs a startup warning to this
+# effect. When set, every request to /graphql must carry
+# `Authorization: Bearer <token>`. Set this to a high-entropy random
+# string (>=32 chars) and configure any internal consumer to send the
+# Bearer header. Verify with:
+#   curl -sS -o /dev/null -w "%{http_code}\n" https://index.averray.com/graphql
+#   curl -sS -o /dev/null -w "%{http_code}\n" \
+#     -H "Authorization: Bearer <token>" https://index.averray.com/graphql
+# Expect 401 unauthenticated, 200 with bearer.
+# GRAPHQL_BEARER_TOKEN=1Password ref for prod-indexer/graphql-bearer-token

--- a/indexer/src/api/index.ts
+++ b/indexer/src/api/index.ts
@@ -7,6 +7,19 @@ import { decodeCursor, listTerminalXcmOutcomes, normalizeLimit } from "./xcm-out
 import { cursorForSource, type OutcomeCursorMode } from "./xcm-outcome-cursor";
 import { XcmOutcomePublisherService } from "./xcm-outcome-publisher";
 
+const GRAPHQL_BEARER_TOKEN = process.env.GRAPHQL_BEARER_TOKEN?.trim() || undefined;
+if (!GRAPHQL_BEARER_TOKEN) {
+  // Loud warning rather than silent open route: /graphql exposes the full
+  // indexer schema (including the GraphiQL playground) and is reverse-proxied
+  // by Caddy on `index.averray.com` with no perimeter auth. Set
+  // GRAPHQL_BEARER_TOKEN to gate the endpoint; until then a startup line
+  // here records that the route is intentionally public.
+  // eslint-disable-next-line no-console
+  console.warn(
+    "[indexer] WARNING: /graphql is publicly reachable — GRAPHQL_BEARER_TOKEN is unset. Set it in deploy/indexer.env.template (see header comments) to require Bearer auth."
+  );
+}
+
 const app = new Hono();
 const xcmExternalSourceType = process.env.XCM_EXTERNAL_SOURCE_TYPE?.trim() || "feed";
 const xcmOutcomePublisher = new XcmOutcomePublisherService({
@@ -66,7 +79,25 @@ app.get("/xcm/outcomes/status", async (c) =>
   c.json(await xcmOutcomePublisher.getStatus())
 );
 
-app.use("/graphql", graphql({ db, schema }));
+app.use(
+  "/graphql",
+  async (c, next) => {
+    // Optional Bearer gate. When GRAPHQL_BEARER_TOKEN is unset, the route
+    // remains publicly reachable for backward compatibility (a startup
+    // warning is logged in that case). When set, every request must carry
+    // `Authorization: Bearer <token>` — both POST queries and the GET
+    // GraphiQL playground are gated through the same middleware.
+    if (!GRAPHQL_BEARER_TOKEN) {
+      return next();
+    }
+    const header = c.req.header("authorization") ?? "";
+    if (header !== `Bearer ${GRAPHQL_BEARER_TOKEN}`) {
+      return c.json({ error: "unauthorized" }, 401);
+    }
+    return next();
+  },
+  graphql({ db, schema })
+);
 
 export default app;
 


### PR DESCRIPTION
## Summary

🔒 **Security fix — same shape as #400 but applied to `/graphql`.** The indexer mounts Ponder's `graphql({ db, schema })` middleware at `/graphql` with no auth (`indexer/src/api/index.ts:69`). Caddy reverse-proxies the entire `index.averray.com` host with no perimeter auth (`deploy/Caddyfile.averray:69-72`), so the route is reachable from the public internet:

```
$ curl -sS -o /dev/null -w "GET HTTP %{http_code}\n" https://index.averray.com/graphql
GET HTTP 200    (GraphiQL playground HTML, 1952 bytes)

$ curl -sS -X POST -H "Content-Type: application/json" \
    -d '{"query":"{ __schema { types { name } } }"}' \
    https://index.averray.com/graphql | jq '.data.__schema.types[].name' | head -10
"JSON"
"BigInt"
"PageInfo"
"Boolean"
"String"
"ViewPageInfo"
"Meta"
"Query"
"job"
"Int"
...
```

Same Caddy perimeter, same underlying Postgres, and the same kysely + drizzle-orm SQLi advisories in Ponder's transitive deps (audit finding **W1**) as PR #400's `/sql/*` relay. GraphQL is even more featureful than `/sql/*` because the schema includes filters, pagination, and join relations.

## Audit context

This finding came out of the codebase-wide audit pass; see PR #400 for the sister fix on `/sql/*`. The two PRs are scoped independently because:
- `/sql/*` had no operator-side use case, so PR #400 removes the mount entirely.
- `/graphql` could plausibly be used by external integrators or future operator tooling, so this PR adds an auth gate rather than removing the route. The user explicitly chose "auth gating" over removal for this surface.

This is NOT one of the packages on `docs/AUDIT_REMEDIATION.md` (A–J cover `mcp-server` + frontend; the indexer security gap is outside that board). Following the same narrow-PR coordination as PR #400.

## What changed

### `indexer/src/api/index.ts` (+33 / -1)

Mirror of the `METRICS_BEARER_TOKEN` pattern from PR #395:

- **Read `GRAPHQL_BEARER_TOKEN` at module load.** If unset, log a loud startup warning naming the env var and pointing at `deploy/indexer.env.template`. The route stays publicly reachable until the env is set — preserves backward compatibility for any unknown external consumer while making the gap visible.
- **Wrap the `/graphql` handler with a Bearer middleware.** Both `POST /graphql` (queries) and `GET /graphql` (GraphiQL playground) pass through the same gate. Mismatched/missing header → `401 { "error": "unauthorized" }`.

### `deploy/indexer.env.template` (+13 / -0)

Adds `GRAPHQL_BEARER_TOKEN` as a commented-out entry with:
- Why it matters
- A 1Password reference placeholder (prose form, no literal `op://` — the `op inject` constraint from `backend.env.template` applies here too)
- A curl verification recipe (without bearer → 401; with bearer → 200)

## Why optional, not required-in-production

Hard-failing-closed at deploy would break any unknown external consumer. The optional pattern lets the operator set the env var in the same deploy as the code lands, which flips the gate without an outage window. Once set, the gate is enforced; if no external consumer surfaces, a follow-up PR can drop the optional escape and make the token required.

## Independence from PR #400

PR #400 removes `app.use("/sql/*", client(...))` and the `client` import. This PR adds middleware around `app.use("/graphql", graphql(...))`. The edits touch different lines in the same file:

- PR #400 lines: `2` (import), `34` (advertised endpoints), `70` (route mount)
- This PR lines: `9` (env read + warning), `79` (route wrap)

They can land in either order. Whichever lands second will rebase cleanly because neither touches the other's lines.

## Scope

- Two files, +45 / -1:
  - `indexer/src/api/index.ts`: middleware + startup warning
  - `deploy/indexer.env.template`: documented env var
- No code, no contracts, no other docs, no workflows, no Caddy config, no `mcp-server` touched.
- No `op://` literals added (preserves the `op inject` constraint).
- No TODO markers added (preserves `validate-env-render.sh --strict`).
- Not on the `docs/AUDIT_REMEDIATION.md` package board (A–J cover `mcp-server` + frontend). Following the narrow-PR convention used by PR #400 and PR #395 for outside-board security fixes.

## Affects

- backend / frontend / Caddy / contracts / app: **none**
- indexer surface: `/graphql` gains an optional Bearer gate
- Required env or VPS secret changes: **none required by this PR** (the env var is commented out by default). Operator sets `GRAPHQL_BEARER_TOKEN` to flip the gate.

## Test plan

- [x] `npm run typecheck:indexer` passes (`tsc --noEmit`)
- [x] `npm run test:indexer:api` passes 28/28 (no test for the new middleware; the indexer has no HTTP integration test pattern — its `api/*.test.ts` files are unit-level)
- [x] No `op://` literals in `deploy/indexer.env.template` comments
- [x] No TODO markers added
- [ ] After deploy with `GRAPHQL_BEARER_TOKEN` set:
  - `curl https://index.averray.com/graphql` → 401
  - `curl -H "Authorization: Bearer $TOKEN" https://index.averray.com/graphql` → 200
- [ ] Reviewer confirms no internal tooling relies on direct unauthenticated `/graphql` access (verified by grep, but worth a second pair of eyes)

## Follow-ups (separate, not blocking)

- **W1 dep bumps.** `agent/dep-bumps-*` lane: fix the kysely + drizzle-orm SQLi advisories in Ponder's transitive deps. Still relevant — Bearer-gating reduces the surface but doesn't fix the underlying SQLi.
- **Tighten the gate to required-in-production** once any unknown external consumer has had a window to switch. Mirror the eventual hardening I'd recommend for `METRICS_BEARER_TOKEN` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)