### PR TITLE
Package F — relabel homepage console as Example, not Live (P2.5)

### DIFF
--- a/marketing/public/console-stream.js
+++ b/marketing/public/console-stream.js
@@ -1,9 +1,12 @@
 /* ================================================================
-   Averray homepage — live-feel console stream.
-   Renders a faux SSE feed of a run moving through the lifecycle:
-   claimed → submitted → verified → settled, then cycles.
-   Topics mirror the operator app's real SSE channel names.
-   No network, deterministic, respects prefers-reduced-motion.
+   Averray homepage — example console stream.
+   Scripted, deterministic animation that illustrates the platform
+   lifecycle (claimed → submitted → verified → settled, then cycles).
+   Topics mirror the operator app's real SSE channel names so a viewer
+   sees the *shape* of a real run, but no data here is real and no
+   network call is made. The DOM is labeled "Example" so a fresh
+   visitor cannot reasonably conclude the stream is live operations.
+   Respects prefers-reduced-motion.
    ================================================================ */
 (function () {
   const streamEl = document.getElementById("stream");

--- a/marketing/src/pages/index.astro
+++ b/marketing/src/pages/index.astro
@@ -188,7 +188,7 @@ const capital = [
       </a>
     </nav>
 
-    <!-- 2. HERO — with live console on the right -->
+    <!-- 2. HERO — with example console on the right -->
     <section class="hero" id="top">
       <div class="hero__left">
         <p class="eyebrow">For work done by agents</p>
@@ -206,17 +206,17 @@ const capital = [
           <a class="btn btn--ghost" href="#receipts">See the public record</a>
         </div>
         <div class="hero__meta">
-          <span><b>Live</b> · operator staging</span>
+          <span><b>Example</b> · how the platform works</span>
           <span><b>SIWE</b> · wallet-authenticated</span>
           <span><b>Polkadot</b> · settlement layer</span>
         </div>
       </div>
 
-      <aside class="console" aria-label="Live run receipt feed">
+      <aside class="console" aria-label="Example run receipt feed — scripted demo of the platform lifecycle, not a live SSE stream">
         <div class="console__bar">
           <span class="console__dots" aria-hidden="true"><span></span><span></span><span></span></span>
-          <span class="console__path">sse · api.averray.com/session/stream</span>
-          <span class="console__tag"><span class="live-dot"></span>Live</span>
+          <span class="console__path">example · scripted lifecycle preview</span>
+          <span class="console__tag">Example</span>
         </div>
 
         <div class="console__body">
@@ -421,6 +421,6 @@ const capital = [
     </footer>
   </main>
 
-  <!-- live-feel hero console — vanilla JS, reduced-motion aware, no framework -->
+  <!-- example hero console — vanilla JS, reduced-motion aware, no framework, no network -->
   <script is:inline src="/console-stream.js?v=20260424"></script>
 </BaseLayout>

--- a/marketing/src/styles/global.css
+++ b/marketing/src/styles/global.css
@@ -284,17 +284,6 @@ a:hover { color: var(--avy-ink); }
   color: #8ee0b4;
   display: inline-flex; align-items: center; gap: 6px;
 }
-.console__tag .live-dot {
-  width: 6px; height: 6px; border-radius: 50%;
-  background: #8ee0b4;
-  box-shadow: 0 0 0 0 rgba(142, 224, 180, 0.7);
-  animation: pulse 1.8s var(--ease) infinite;
-}
-@keyframes pulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(142, 224, 180, 0.55); }
-  50%      { box-shadow: 0 0 0 6px rgba(142, 224, 180, 0); }
-}
-
 .console__body { position: relative; z-index: 1; display: flex; flex-direction: column; flex: 1; min-height: 0; }
 
 /* --- Lifecycle rail (top of console) --- */


### PR DESCRIPTION
## Summary

Owns Package F on the `docs/AUDIT_REMEDIATION.md` board — closes finding **P2.5** (public site shows a fake "Live" stream). This is the Path B option from the board (explicit example labeling), chosen because:

- Path A (real public proof feed) is substantially more work and depends on a new backend endpoint
- Path B is the safe-and-fast launch-blocker close; the board explicitly lists it as acceptable for `v1.0.0-rc1` if Path A is too much work
- Path C (remove the console) loses too much marketing surface

The board allows individual packages to pick Path A/B/C; this PR commits to B.

## Truth-boundary finding it closes

The homepage console at `marketing/src/pages/index.astro` was labeled:

- visible badge: **`Live · operator staging`** at hero meta
- ARIA: **`aria-label="Live run receipt feed"`** on the console aside
- console path advertised: **`sse · api.averray.com/session/stream`**
- pulsing visible tag: **`Live`** with a heartbeat-style dot (`@keyframes pulse` on `.live-dot`)

The underlying `marketing/public/console-stream.js` is deterministic scripted animation. No SSE, no network, no real run data — the script's own header acknowledged it as a faux SSE feed. The shipped UI did not. A fresh visitor could reasonably conclude they were watching real platform operations.

## Close criteria checklist (Path B)

- [x] Keep deterministic stream but label it as `Example: how the platform works`
- [x] Remove every "Live" label, tooltip, aria description, and visual badge from the homepage stream
- [x] A fresh visitor cannot reasonably conclude the animation is real operations

Verified by sweep:

```
$ grep -rn -i '\bLive\b' marketing/src/ marketing/public/
marketing/src/pages/index.astro:6:    // to a live profile read. (unrelated comment about /agents/<wallet>)
marketing/src/pages/index.astro:215:    aria-label="Example run receipt feed — scripted demo of the platform lifecycle, not a live SSE stream"
marketing/src/pages/index.astro:241:    <div class="stream" id="stream" aria-live="polite">  (a11y attr, kept)
marketing/public/console-stream.js:8:    "cannot reasonably conclude the stream is live operations"  (explanatory negation)
```

The remaining `live` mentions are accessibility attributes (`aria-live="polite"` is a screen-reader hint, not a label), negations clarifying it's NOT live, or unrelated to the homepage console.

## What changed

### `marketing/src/pages/index.astro` (+6 / -6 across the hero block)

| Before | After |
|---|---|
| `<span><b>Live</b> · operator staging</span>` | `<span><b>Example</b> · how the platform works</span>` |
| `aria-label="Live run receipt feed"` | `aria-label="Example run receipt feed — scripted demo of the platform lifecycle, not a live SSE stream"` |
| `<span class="console__path">sse · api.averray.com/session/stream</span>` | `<span class="console__path">example · scripted lifecycle preview</span>` |
| `<span class="console__tag"><span class="live-dot"></span>Live</span>` | `<span class="console__tag">Example</span>` |
| two internal HTML comments mentioning "live console" / "live-feel hero console" | both updated to "example console" with a note that no network is involved |

### `marketing/src/styles/global.css` (-11 / 0)

- Removed `.console__tag .live-dot` rule (the pulsing heartbeat dot)
- Removed `@keyframes pulse` (used only by `.live-dot`; the separate `pulse-warm` keyframes elsewhere are unrelated and stay)

### `marketing/public/console-stream.js` (+8 / -5)

- File header reframed from `"live-feel console stream"` to `"example console stream"` with explicit statements that no data is real and no network call is made
- Script behavior unchanged

## What this PR does NOT do

- **Does not commit regenerated `site/` output.** Per `AGENTS.md`, the marketing `site/` is generated. `npm run build:site` runs cleanly (`1 page(s) built in 617ms`) producing updated `site/index.html`, `site/console-stream.js`, and a new `_astro` CSS hash — those land at CI/deploy time, not in this PR.
- **Does not implement Path A** (real public proof feed). That's a larger scope: needs `/public/recent-receipts` or similar backend endpoint and a real hydration client. If you want Path A later, this PR's relabeling stays useful as the safe default until the proof feed is wired.
- **Does not touch any other "Live"-ish surface** outside the homepage console — the audit board's P2.5 is scoped to the homepage stream specifically. Other operator-app demo-mode work is Package E.

## Scope

- Three files in `marketing/`:
  - `marketing/src/pages/index.astro` (hero + footer comments)
  - `marketing/src/styles/global.css` (CSS rule + keyframes removal)
  - `marketing/public/console-stream.js` (header comment)
- +14 / -22 total
- No backend / app / indexer / contracts / Caddy / deploy / docs (other than the PR description here) touched
- Branch prefix is `claude/` because this is owned by Claude; the board suggested `codex/p2-public-site-proof-feed`. Both prefixes are valid per `AGENTS.md`.

## AUDIT_REMEDIATION.md status update

I have not edited `docs/AUDIT_REMEDIATION.md` in this PR because that doc is not yet on `origin/main` (it currently lives in the `.codex/worktrees/audit-remediation-plan/` worktree). The coordinator can add Package F's status row pointing at this PR once the board doc lands.

## Affects

- backend / app / indexer / Caddy / contracts: **none**
- public-site rendered surface: **homepage hero console relabeled from Live → Example**
- Required env or VPS secret changes: **none**

## Test plan

- [x] `npm run build:site` succeeds (`1 page(s) built in 617ms`, no errors)
- [x] Sweep for "Live" labels in `marketing/src/` + `marketing/public/`: only accessibility/negation/unrelated mentions remain
- [x] No remaining `live-dot` class references
- [x] No remaining `@keyframes pulse` usages (only `pulse-warm` remains, unrelated)
- [ ] Reviewer loads the rendered homepage and confirms the hero console reads as "Example", not "Live"
- [ ] Visual regression: badge + tag + aria-label all show "Example" copy; pulsing dot is gone

## Coordination — board context

This is the first board package I've owned. Notes for the coordinator:

- **Parallel-safe starter** per the memory board, no blockers required
- **No file overlap** with other in-flight packages (Package A is PR #403, touches `mcp-server/`; this PR touches `marketing/` only)
- **Does not touch `mcp-server/src/protocols/http/server.js`** (would be Package J territory; reserved for that owner)
- **Does not touch generated `frontend/` or `site/`** (reserved for Package H if a guard lands there)

## Related

| | |
|---|---|
| **#403** | Package A — P1.1 mutation backend gate (Codex, in flight, doesn't overlap) |
| **#402** | Indexer /graphql Bearer gate (outside board) |
| **#400** | Indexer /sql relay close (outside board) |
| **#395** | Observability env vars + §5 evidence (outside board) |
| **#390** | INCIDENT_RESPONSE §1 ownership (outside board) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)