### PR TITLE
[codex] Guard generated deploy output edits

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -36,7 +36,10 @@ if [[ -n "$blocked_env_files" ]]; then
   exit 1
 fi
 
-# ---- 2. Scan staged diff for known secret shapes --------------------------
+# ---- 2. Block accidental generated deploy output edits -------------------
+node scripts/ops/check-generated-output-clean.mjs --staged
+
+# ---- 3. Scan staged diff for known secret shapes --------------------------
 # Collect just the added lines so we don't false-positive on removed secrets.
 # Strip the leading `+` so the body of the line is what the regex sees.
 added_lines=$(git diff --cached --diff-filter=AM -U0 | awk '/^\+[^+]/ { sub(/^\+/, ""); print }')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,32 @@ permissions:
   contents: read
 
 jobs:
+  generated-output-guard:
+    name: Generated output guard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: "22"
+
+      - name: Reject accidental generated deploy output edits
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          set -euo pipefail
+          if [ -z "${BASE_SHA:-}" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            node scripts/ops/check-generated-output-clean.mjs --last-commit
+          else
+            node scripts/ops/check-generated-output-clean.mjs --range "$BASE_SHA..HEAD"
+          fi
+
   solidity:
     name: Solidity — forge test
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,10 @@ reviewable changes and keep production deploys serialized.
 - Do not manually edit generated `_next/static` or `_astro` files.
 - Only touch generated static output when a task explicitly changes the static
   deploy surface itself.
+- The generated-output guard rejects commits or PR ranges that modify
+  `frontend/` or `site/`. If a task intentionally changes those deploy
+  surfaces, use `ALLOW_GENERATED_EDIT=1` locally and include `[allow-generated]`
+  in the commit message so CI has an auditable bypass.
 
 ## Required Checks
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "check:discovery-manifest": "node scripts/ops/sync-discovery-manifest.mjs --check",
     "sync:job-schemas": "node scripts/ops/sync-job-schemas.mjs",
     "check:job-schemas": "node scripts/ops/sync-job-schemas.mjs --check",
+    "check:generated-output": "node scripts/ops/check-generated-output-clean.mjs",
     "check:product-proof": "node scripts/ops/check-product-proof-gate.mjs",
     "product-proof:worker-loop": "node scripts/ops/run-hosted-worker-loop.mjs",
     "dev:app": "npm --workspace averray-app run dev",

--- a/scripts/ops/check-generated-output-clean.mjs
+++ b/scripts/ops/check-generated-output-clean.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+
+const GENERATED_PREFIXES = ["frontend/", "site/"];
+const BYPASS_TAG = "[allow-generated]";
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const repoRoot = git(["rev-parse", "--show-toplevel"]).trim();
+  const mode = resolveMode(options);
+
+  if (process.env.ALLOW_GENERATED_EDIT === "1") {
+    console.log("check-generated-output-clean: bypassed by ALLOW_GENERATED_EDIT=1");
+    return;
+  }
+
+  const changedFiles = listChangedFiles(mode, repoRoot);
+  const generatedFiles = changedFiles.filter(isGeneratedPath);
+  if (generatedFiles.length === 0) {
+    console.log("check-generated-output-clean: ok");
+    return;
+  }
+
+  if (mode.kind !== "staged" && commitMessagesIncludeBypass(mode, repoRoot)) {
+    console.log(`check-generated-output-clean: bypassed by commit message tag ${BYPASS_TAG}`);
+    return;
+  }
+
+  console.error("check-generated-output-clean: generated deploy output changed");
+  console.error("");
+  for (const file of generatedFiles) {
+    console.error(`  ${file}`);
+  }
+  console.error("");
+  console.error("Source changes should usually be made under app/ or marketing/.");
+  console.error("CI and production deploy rebuild frontend/ and site/ from source.");
+  console.error("");
+  console.error("If this task intentionally changes generated static deploy output, rerun with:");
+  console.error("  ALLOW_GENERATED_EDIT=1 <command>");
+  console.error(`or include ${BYPASS_TAG} in the commit message for CI range checks.`);
+  process.exit(1);
+}
+
+function parseArgs(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--staged") {
+      options.staged = true;
+    } else if (arg === "--last-commit") {
+      options.lastCommit = true;
+    } else if (arg === "--range") {
+      options.range = args[index + 1];
+      index += 1;
+    } else if (arg.startsWith("--range=")) {
+      options.range = arg.slice("--range=".length);
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      console.error(`check-generated-output-clean: unknown argument ${arg}`);
+      printHelp();
+      process.exit(2);
+    }
+  }
+  return options;
+}
+
+function resolveMode(options) {
+  const selected = [options.staged, options.lastCommit, Boolean(options.range)].filter(Boolean).length;
+  if (selected > 1) {
+    console.error("check-generated-output-clean: choose only one of --staged, --last-commit, or --range");
+    process.exit(2);
+  }
+  if (options.staged) {
+    return { kind: "staged" };
+  }
+  if (options.lastCommit) {
+    return { kind: "lastCommit" };
+  }
+  if (options.range) {
+    return { kind: "range", range: options.range };
+  }
+  if (process.env.BASE_SHA) {
+    return { kind: "range", range: `${process.env.BASE_SHA}..HEAD` };
+  }
+  return { kind: "staged" };
+}
+
+function listChangedFiles(mode, cwd) {
+  if (mode.kind === "staged") {
+    return splitLines(git(["diff", "--cached", "--name-only", "--diff-filter=ACMR"], { cwd }));
+  }
+  if (mode.kind === "lastCommit") {
+    return splitLines(git(["diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"], { cwd }));
+  }
+  return splitLines(git(["diff", "--name-only", "--diff-filter=ACMR", mode.range], { cwd }));
+}
+
+function commitMessagesIncludeBypass(mode, cwd) {
+  if (mode.kind === "lastCommit") {
+    return git(["log", "-1", "--format=%B"], { cwd }).includes(BYPASS_TAG);
+  }
+  if (mode.kind === "range") {
+    return git(["log", "--format=%B", mode.range], { cwd }).includes(BYPASS_TAG);
+  }
+  return false;
+}
+
+function isGeneratedPath(file) {
+  return GENERATED_PREFIXES.some((prefix) => file === prefix.slice(0, -1) || file.startsWith(prefix));
+}
+
+function git(args, options = {}) {
+  return execFileSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    ...options
+  });
+}
+
+function splitLines(output) {
+  return output.split("\n").map((line) => line.trim()).filter(Boolean);
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/ops/check-generated-output-clean.mjs --staged
+  node scripts/ops/check-generated-output-clean.mjs --range <base..head>
+  node scripts/ops/check-generated-output-clean.mjs --last-commit
+
+Rejects committed changes under frontend/ and site/ unless ALLOW_GENERATED_EDIT=1
+is set or the checked commit range contains ${BYPASS_TAG}.`);
+}
+
+main();

--- a/scripts/ops/check-generated-output-clean.test.mjs
+++ b/scripts/ops/check-generated-output-clean.test.mjs
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const SCRIPT = resolve("scripts/ops/check-generated-output-clean.mjs");
+
+test("generated output guard rejects staged frontend changes", () => {
+  const repo = createRepo();
+  writeFileSync(join(repo, "frontend/index.html"), "changed\n");
+  git(repo, ["add", "frontend/index.html"]);
+
+  const result = runGuard(repo, ["--staged"]);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /frontend\/index\.html/);
+  assert.match(result.stderr, /ALLOW_GENERATED_EDIT=1/);
+});
+
+test("generated output guard allows staged source changes", () => {
+  const repo = createRepo();
+  mkdirSync(join(repo, "app"), { recursive: true });
+  writeFileSync(join(repo, "app/page.tsx"), "export default function Page() { return null; }\n");
+  git(repo, ["add", "app/page.tsx"]);
+
+  const result = runGuard(repo, ["--staged"]);
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /ok/);
+});
+
+test("generated output guard allows explicit env bypass", () => {
+  const repo = createRepo();
+  writeFileSync(join(repo, "site/index.html"), "intentional generated update\n");
+  git(repo, ["add", "site/index.html"]);
+
+  const result = runGuard(repo, ["--staged"], { ALLOW_GENERATED_EDIT: "1" });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /bypassed/);
+});
+
+test("generated output guard allows commit ranges with allow tag", () => {
+  const repo = createRepo();
+  writeFileSync(join(repo, "frontend/index.html"), "intentional generated update\n");
+  git(repo, ["add", "frontend/index.html"]);
+  git(repo, ["commit", "-m", "Update generated surface [allow-generated]"]);
+
+  const result = runGuard(repo, ["--range", "HEAD~1..HEAD"]);
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /allow-generated/);
+});
+
+function createRepo() {
+  const repo = mkdtempSync(join(tmpdir(), "generated-output-guard-"));
+  git(repo, ["init", "-q"]);
+  git(repo, ["config", "user.email", "test@example.com"]);
+  git(repo, ["config", "user.name", "Test User"]);
+  mkdirSync(join(repo, "frontend"), { recursive: true });
+  mkdirSync(join(repo, "site"), { recursive: true });
+  writeFileSync(join(repo, "frontend/index.html"), "initial frontend\n");
+  writeFileSync(join(repo, "site/index.html"), "initial site\n");
+  writeFileSync(join(repo, "README.md"), "initial\n");
+  git(repo, ["add", "."]);
+  git(repo, ["commit", "-m", "Initial"]);
+  return repo;
+}
+
+function git(cwd, args) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+}
+
+function runGuard(cwd, args, env = {}) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, ...env }
+  });
+}


### PR DESCRIPTION
## What changed

- Added `scripts/ops/check-generated-output-clean.mjs` to reject committed changes under generated deploy outputs `frontend/` and `site/`.
- Added tests covering staged generated-output rejection, source-path allowance, `ALLOW_GENERATED_EDIT=1`, and `[allow-generated]` commit-range bypass.
- Wired the guard into `.githooks/pre-commit` and the CI workflow.
- Added `npm run check:generated-output` and documented the bypass in `AGENTS.md`.

## Why

This closes Package H / P3.8 from the remediation board. The repo has source in `app/` and `marketing/`, while `frontend/` and `site/` are generated deploy surfaces. This guard makes the existing rule mechanical so future agents do not accidentally patch generated output and lose the change on the next build.

## Validation

- `node --test scripts/ops/check-generated-output-clean.test.mjs`
- `npm run test:ops`
- `node scripts/ops/check-generated-output-clean.mjs --staged`
- `npm run check:generated-output`
- `node scripts/ops/check-generated-output-clean.mjs --range origin/main..HEAD`
- `git diff --check origin/main..HEAD`
- Manual probe: staged a temporary file under `frontend/`, confirmed the guard rejected it, then removed the probe.

## Impact

Affects CI, local pre-commit hooks, repo collaboration docs, and ops scripts. Does not affect backend runtime, frontend runtime, indexer, contracts, Caddy, or public site behavior. No new VPS secrets or environment variables are required.