### PR TITLE
feat(auth): PR 4b.4 — dual-verify JWT dispatcher behind JWT_BACKEND flag

### DIFF
--- a/deploy/backend.env.template
+++ b/deploy/backend.env.template
@@ -134,6 +134,15 @@ AUTH_VERIFIER_WALLETS=0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519
 AUTH_DOMAIN=api.averray.com
 AUTH_CHAIN_ID=420420417
 
+# Phase 4b dispatcher mode. Controls which JWT algorithm(s) the backend
+# accepts and emits. Valid values: hmac | kms | both. Default: hmac.
+# - hmac:  HS256-only, current pre-4b behavior
+# - kms:   ES256-only via AWS KMS signer (requires AWS_JWT_* + JWT_PUBLIC_KEY_PEM)
+# - both:  verify accepts both; sign uses JWT_PRIMARY_ALG (default hmac).
+#          Transitional state during cutover.
+# Cutover sequence: hmac → both → kms (see docs/PHASE_4B_KMS_JWT_PLAN.md §7)
+JWT_BACKEND=hmac
+
 CORS_ALLOWED_ORIGINS=https://app.averray.com
 TRUST_PROXY=1
 LOG_LEVEL=info

--- a/mcp-server/src/auth/config.js
+++ b/mcp-server/src/auth/config.js
@@ -2,6 +2,15 @@ import { ConfigError } from "../core/errors.js";
 
 const VALID_MODES = new Set(["strict", "permissive"]);
 const VALID_ROLES = new Set(["admin", "verifier"]);
+const VALID_JWT_BACKENDS = new Set(["hmac", "kms", "both"]);
+const VALID_JWT_PRIMARY_ALGS = new Set(["hmac", "kms"]);
+const DEFAULT_JWT_KID = "jwt-1";
+// Mirrors KmsJwtSigner's internal defaults so the dispatcher's TTL cap
+// remains consistent with the signer's own enforcement when the env
+// var is unset. Keep in sync with kms-jwt-signer.js's
+// DEFAULT_MAX_TTL_SECONDS / DEFAULT_CLOCK_SKEW_SECONDS.
+const DEFAULT_JWT_MAX_TTL_SECONDS = 3600;
+const DEFAULT_JWT_CLOCK_SKEW_SECONDS = 60;
 
 /**
  * Load authentication configuration from the environment.
@@ -16,6 +25,23 @@ const VALID_ROLES = new Set(["admin", "verifier"]);
  * - AUTH_NONCE_TTL_SECONDS: nonce lifetime (default 300 = 5 min).
  * - AUTH_ADMIN_WALLETS: comma-separated EVM addresses granted the "admin" role claim at sign-in.
  * - AUTH_VERIFIER_WALLETS: comma-separated EVM addresses granted the "verifier" role claim at sign-in.
+ *
+ * Phase 4b — KMS-signed JWTs (see docs/PHASE_4B_KMS_JWT_PLAN.md):
+ * - JWT_BACKEND: "hmac" (default) | "kms" | "both". Controls which JWT
+ *   algorithm(s) the dispatcher will sign and verify.
+ * - JWT_PRIMARY_ALG: "hmac" (default) | "kms". Only meaningful when
+ *   JWT_BACKEND=both — selects which algorithm is used for new signatures.
+ * - AWS_JWT_REGION, AWS_JWT_KEY_ID, AWS_JWT_ACCESS_KEY_ID,
+ *   AWS_JWT_SECRET_ACCESS_KEY: AWS credentials + key reference for
+ *   KmsJwtSigner. Required when JWT_BACKEND ∈ {kms, both}.
+ * - JWT_PUBLIC_KEY_PEM, JWT_PUBLIC_KEY_FINGERPRINT: rendered into env at
+ *   deploy time. Required when JWT_BACKEND ∈ {kms, both}.
+ * - JWT_KID: header kid (default "jwt-1").
+ * - JWT_EXPECTED_ISSUER, JWT_EXPECTED_AUDIENCE: required iss/aud claims
+ *   for ES256 verification. Default to "averray-backend-testnet" /
+ *   "averray-backend" if unset.
+ * - JWT_MAX_TTL_SECONDS, JWT_CLOCK_SKEW_SECONDS: optional overrides for
+ *   KmsJwtSigner.
  */
 export function loadAuthConfig(env = process.env) {
   const nodeEnv = env.NODE_ENV ?? "development";
@@ -62,6 +88,11 @@ export function loadAuthConfig(env = process.env) {
   const adminWallets = parseWalletSet(env.AUTH_ADMIN_WALLETS, "AUTH_ADMIN_WALLETS");
   const verifierWallets = parseWalletSet(env.AUTH_VERIFIER_WALLETS, "AUTH_VERIFIER_WALLETS");
 
+  // ── Phase 4b — JWT dispatcher mode ────────────────────────────────────
+  const jwtBackend = parseJwtBackend(env.JWT_BACKEND);
+  const jwtPrimaryAlg = parseJwtPrimaryAlg(env.JWT_PRIMARY_ALG, jwtBackend);
+  const kmsJwt = parseKmsJwtConfig(env, jwtBackend);
+
   return {
     mode: rawMode,
     secrets,
@@ -74,10 +105,131 @@ export function loadAuthConfig(env = process.env) {
     strict: rawMode === "strict",
     adminWallets,
     verifierWallets,
+    jwtBackend,
+    jwtPrimaryAlg,
+    kmsJwt,
     resolveRoles(wallet) {
       return resolveRoles(wallet, { adminWallets, verifierWallets });
     }
   };
+}
+
+function parseJwtBackend(raw) {
+  if (raw === undefined || raw === null || raw === "") {
+    return "hmac";
+  }
+  const value = String(raw).trim().toLowerCase();
+  if (!VALID_JWT_BACKENDS.has(value)) {
+    throw new ConfigError(
+      `Invalid JWT_BACKEND: "${raw}". Expected one of "hmac", "kms", or "both".`,
+    );
+  }
+  return value;
+}
+
+function parseJwtPrimaryAlg(raw, backend) {
+  // Only meaningful for backend === "both"; for "hmac" / "kms" the
+  // backend itself dictates the signing alg. We still parse and return
+  // a value so downstream code can treat it as always-present.
+  if (raw === undefined || raw === null || raw === "") {
+    return backend === "kms" ? "kms" : "hmac";
+  }
+  const value = String(raw).trim().toLowerCase();
+  if (!VALID_JWT_PRIMARY_ALGS.has(value)) {
+    throw new ConfigError(
+      `Invalid JWT_PRIMARY_ALG: "${raw}". Expected "hmac" or "kms".`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Build the KmsJwt config block when JWT_BACKEND requires KMS. Returns
+ * `null` for pure HMAC mode so callers can treat absence as
+ * "KMS is not wired in." When required vars are missing in kms / both
+ * modes, throws a single ConfigError that names every missing var (so
+ * the operator only has to fix env once).
+ */
+function parseKmsJwtConfig(env, backend) {
+  if (backend === "hmac") {
+    return null;
+  }
+
+  // Variables that must be non-empty when KMS verify is active. Region
+  // is needed only when no KMSClient is provided at runtime (it always
+  // is, in normal boot) — we still enforce it so a misconfigured prod
+  // boot fails loudly rather than the next time someone constructs a
+  // KMSClient from defaults.
+  const required = {
+    AWS_JWT_REGION: env.AWS_JWT_REGION,
+    AWS_JWT_KEY_ID: env.AWS_JWT_KEY_ID,
+    JWT_PUBLIC_KEY_PEM: env.JWT_PUBLIC_KEY_PEM,
+    JWT_PUBLIC_KEY_FINGERPRINT: env.JWT_PUBLIC_KEY_FINGERPRINT,
+  };
+  // Access keys are required only when JWT_BACKEND ∈ {kms, both} AND
+  // the deploy is using static AWS credentials (testnet). The KMSClient
+  // also honors the AWS default-credential-provider chain (IAM Roles
+  // Anywhere, EC2 instance profile, etc.) — so we don't make these
+  // required at the dispatcher level; if absent the SDK will fail at
+  // first kms:Sign and the operator gets a clear AWS error. This matches
+  // how the Phase 3 blockchain signer config behaves.
+
+  const missing = Object.entries(required)
+    .filter(([, value]) => value === undefined || value === null || String(value).trim() === "")
+    .map(([name]) => name);
+  if (missing.length > 0) {
+    throw new ConfigError(
+      `JWT_BACKEND=${backend} requires the following env vars to be set: ${missing.join(", ")}.`,
+    );
+  }
+
+  const region = String(env.AWS_JWT_REGION).trim();
+  const keyId = String(env.AWS_JWT_KEY_ID).trim();
+  if (keyId.startsWith("alias/")) {
+    // Mirrors the constructor-level check in KmsJwtSigner — fail at
+    // config-load time so an alias never reaches the signer.
+    throw new ConfigError(
+      `AWS_JWT_KEY_ID must be the full KMS key ARN, not an alias ("${keyId}"). Aliases can be retargeted.`,
+    );
+  }
+  const publicKeyPem = String(env.JWT_PUBLIC_KEY_PEM);
+  const publicKeyFingerprint = String(env.JWT_PUBLIC_KEY_FINGERPRINT).trim();
+  const kid = (env.JWT_KID ?? DEFAULT_JWT_KID).toString().trim() || DEFAULT_JWT_KID;
+  const expectedIssuer = (env.JWT_EXPECTED_ISSUER ?? "averray-backend-testnet").toString().trim();
+  const expectedAudience = (env.JWT_EXPECTED_AUDIENCE ?? "averray-backend").toString().trim();
+  const expectedRoles = parseJwtRoles(env.JWT_EXPECTED_ROLES) ?? [...VALID_ROLES];
+  const maxTtlSeconds = parsePositiveInt(env.JWT_MAX_TTL_SECONDS, DEFAULT_JWT_MAX_TTL_SECONDS, "JWT_MAX_TTL_SECONDS");
+  const clockSkewSeconds = parseNonNegativeInt(env.JWT_CLOCK_SKEW_SECONDS, DEFAULT_JWT_CLOCK_SKEW_SECONDS, "JWT_CLOCK_SKEW_SECONDS");
+
+  return {
+    region,
+    keyId,
+    kid,
+    publicKeyPem,
+    publicKeyFingerprint,
+    expectedIssuer,
+    expectedAudience,
+    expectedRoles,
+    maxTtlSeconds,
+    clockSkewSeconds,
+  };
+}
+
+function parseJwtRoles(raw) {
+  if (raw === undefined || raw === null || raw === "") {
+    return null;
+  }
+  const roles = String(raw)
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  if (roles.length === 0) return null;
+  for (const role of roles) {
+    if (!VALID_ROLES.has(role)) {
+      throw new ConfigError(`JWT_EXPECTED_ROLES contains unknown role "${role}".`);
+    }
+  }
+  return roles;
 }
 
 /**
@@ -130,6 +282,17 @@ function parsePositiveInt(raw, fallback, name) {
   const value = Number(raw);
   if (!Number.isInteger(value) || value <= 0) {
     throw new ConfigError(`${name} must be a positive integer, got: ${raw}.`);
+  }
+  return value;
+}
+
+function parseNonNegativeInt(raw, fallback, name) {
+  if (raw === undefined || raw === "") {
+    return fallback;
+  }
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 0) {
+    throw new ConfigError(`${name} must be a non-negative integer, got: ${raw}.`);
   }
   return value;
 }

--- a/mcp-server/src/auth/jwt-dispatcher.test.js
+++ b/mcp-server/src/auth/jwt-dispatcher.test.js
@@ -1,0 +1,639 @@
+// Tests for the Phase 4b (PR 4b.4) JWT dispatcher in jwt.js.
+//
+// The dispatcher routes sign/verify operations between the existing
+// HMAC code path and the new KmsJwtSigner based on
+// authConfig.jwtBackend ∈ {"hmac", "kms", "both"}. Default = "hmac",
+// which must be byte-for-byte equivalent to the pre-4b API; that
+// invariant is covered by auth.test.js (existing) — these tests add
+// the dispatcher-specific cases.
+//
+// Strategy mirrors kms-jwt-signer.test.js: a FakeKMSClient backed by a
+// real Node-generated P-256 keypair, and @noble/curves' p256 in
+// prehash:false mode for the actual ECDSA signature (Node's
+// crypto.sign over EC keys re-hashes, which doesn't match KMS's
+// MessageType=DIGEST semantics).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
+
+import { p256 } from "@noble/curves/nist.js";
+
+import { loadAuthConfig } from "./config.js";
+import {
+  signToken,
+  signTokenFromConfig,
+  verifyTokenFromConfig,
+} from "./jwt.js";
+import { createAuthMiddleware } from "./middleware.js";
+import { ConfigError, AuthenticationError } from "../core/errors.js";
+
+// ───────────────────────────────────────────────────────────────────
+// Test fixtures — one P-256 keypair shared by all KMS-mode tests.
+// ───────────────────────────────────────────────────────────────────
+
+function extractRawPrivateScalar(nodePrivateKey) {
+  const jwk = nodePrivateKey.export({ format: "jwk" });
+  if (jwk.kty !== "EC" || jwk.crv !== "P-256" || typeof jwk.d !== "string") {
+    throw new Error("expected a P-256 EC private key with a d field");
+  }
+  return new Uint8Array(Buffer.from(jwk.d, "base64url"));
+}
+
+const { privateKey: KMS_PRIVATE_KEY, publicKey: KMS_PUBLIC_KEY } = generateKeyPairSync(
+  "ec",
+  { namedCurve: "prime256v1" },
+);
+const KMS_PUBLIC_PEM = KMS_PUBLIC_KEY.export({ type: "spki", format: "pem" });
+const KMS_RAW_PRIVATE = extractRawPrivateScalar(KMS_PRIVATE_KEY);
+
+const KEY_ARN = "arn:aws:kms:eu-central-2:079209845430:key/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+const KID = "jwt-1";
+const ISSUER = "averray-backend-testnet";
+const AUDIENCE = "averray-backend";
+const SUBJECT = "0x000000000000000000000000000000000000abcd";
+const ROLES = ["admin", "verifier"];
+const HMAC_SECRET = "h".repeat(48);
+const LONG_HMAC_SECRET = "L".repeat(48);
+
+class FakeKMSClient {
+  constructor() {
+    this.calls = [];
+  }
+  async send(command) {
+    this.calls.push(command);
+    const name = command.constructor.name;
+    if (name === "GetPublicKeyCommand") {
+      const KMS_SPKI_DER = new Uint8Array(
+        KMS_PUBLIC_KEY.export({ type: "spki", format: "der" }),
+      );
+      return { PublicKey: KMS_SPKI_DER, KeyId: command.input.KeyId };
+    }
+    if (name === "SignCommand") {
+      const digest = new Uint8Array(command.input.Message);
+      const der = p256.sign(digest, KMS_RAW_PRIVATE, {
+        prehash: false,
+        format: "der",
+        lowS: false,
+      });
+      return { Signature: der };
+    }
+    throw new Error(`FakeKMSClient: unknown command ${name}`);
+  }
+}
+
+function silentLogger() {
+  return { warn() {}, error() {}, info() {}, log() {} };
+}
+
+/**
+ * Build an authConfig literal of the shape loadAuthConfig() returns —
+ * lets each test customize backend / primaryAlg / kmsJwt without
+ * threading a whole real config through process.env.
+ */
+function buildAuthConfig({
+  jwtBackend = "hmac",
+  jwtPrimaryAlg = "hmac",
+  secrets = [HMAC_SECRET],
+  withKms = false,
+  kmsClient,
+} = {}) {
+  const config = {
+    mode: "strict",
+    permissive: false,
+    strict: true,
+    secrets,
+    signingSecret: secrets[0],
+    domain: "localhost",
+    chainId: 0,
+    tokenTtlSeconds: 900,
+    nonceTtlSeconds: 300,
+    adminWallets: new Set(),
+    verifierWallets: new Set(),
+    jwtBackend,
+    jwtPrimaryAlg,
+    kmsJwt: null,
+  };
+  if (withKms) {
+    config.kmsJwt = {
+      region: "eu-central-2",
+      keyId: KEY_ARN,
+      kid: KID,
+      publicKeyPem: KMS_PUBLIC_PEM,
+      publicKeyFingerprint: "deadbeef",
+      expectedIssuer: ISSUER,
+      expectedAudience: AUDIENCE,
+      expectedRoles: ROLES,
+      maxTtlSeconds: 3600,
+      clockSkewSeconds: 60,
+      // FakeKMSClient is injected into the signer via the dispatcher's
+      // KmsJwtSigner construction path. Each call to buildAuthConfig
+      // creates a fresh kmsJwt object so the dispatcher's WeakMap
+      // signer cache also stays fresh per test.
+      kmsClient: kmsClient ?? new FakeKMSClient(),
+    };
+  }
+  return config;
+}
+
+function b64uEncode(input) {
+  return Buffer.from(input).toString("base64url");
+}
+
+function b64uDecode(input) {
+  return Buffer.from(input, "base64url");
+}
+
+// ───────────────────────────────────────────────────────────────────
+// 1. HMAC mode — default behavior preserved
+// ───────────────────────────────────────────────────────────────────
+
+test("dispatcher hmac: signTokenFromConfig produces HS256", async () => {
+  const cfg = buildAuthConfig({ jwtBackend: "hmac" });
+  const { token, claims } = await signTokenFromConfig(
+    { sub: SUBJECT },
+    { expiresInSeconds: 60 },
+    cfg,
+  );
+  const [headerB64] = token.split(".");
+  const header = JSON.parse(b64uDecode(headerB64).toString("utf8"));
+  assert.equal(header.alg, "HS256");
+  assert.equal(header.typ, "JWT");
+  assert.equal(claims.sub, SUBJECT);
+});
+
+test("dispatcher hmac: verifyTokenFromConfig accepts HS256", async () => {
+  const cfg = buildAuthConfig({ jwtBackend: "hmac" });
+  const { token } = signToken(
+    { sub: SUBJECT },
+    { secret: HMAC_SECRET, expiresInSeconds: 60 },
+  );
+  const claims = await verifyTokenFromConfig(token, cfg);
+  assert.equal(claims.sub, SUBJECT);
+});
+
+test("dispatcher hmac: verifyTokenFromConfig rejects ES256 with clear error", async () => {
+  // Mint an ES256 token using a KMS-mode signer, then try to verify
+  // under JWT_BACKEND=hmac. The dispatcher must reject before the
+  // KMS signer is even constructed.
+  const kmsCfg = buildAuthConfig({ jwtBackend: "kms", withKms: true });
+  const { token: es256Token } = await signTokenFromConfig(
+    { sub: SUBJECT },
+    { issuer: ISSUER, audience: AUDIENCE, subject: SUBJECT, role: "admin", expiresInSeconds: 60 },
+    kmsCfg,
+  );
+  const hmacCfg = buildAuthConfig({ jwtBackend: "hmac" });
+  await assert.rejects(
+    () => verifyTokenFromConfig(es256Token, hmacCfg),
+    (err) => {
+      assert.ok(err instanceof AuthenticationError);
+      assert.equal(err.code, "unsupported_alg");
+      assert.match(err.message, /ES256.*hmac/u);
+      return true;
+    },
+  );
+});
+
+test("dispatcher hmac: alg:none token is rejected", async () => {
+  const cfg = buildAuthConfig({ jwtBackend: "hmac" });
+  const header = b64uEncode(JSON.stringify({ alg: "none", typ: "JWT" }));
+  const claims = b64uEncode(JSON.stringify({ sub: SUBJECT, iat: 0, exp: 9_999_999_999 }));
+  const token = `${header}.${claims}.`;
+  await assert.rejects(
+    () => verifyTokenFromConfig(token, cfg),
+    (err) => err instanceof AuthenticationError && err.code === "unsupported_alg",
+  );
+});
+
+test("dispatcher hmac: alg:None / NONE mixed-case rejected at dispatcher", async () => {
+  const cfg = buildAuthConfig({ jwtBackend: "hmac" });
+  for (const badAlg of ["None", "NONE"]) {
+    const header = b64uEncode(JSON.stringify({ alg: badAlg, typ: "JWT" }));
+    const claims = b64uEncode(JSON.stringify({ sub: SUBJECT, iat: 0, exp: 9_999_999_999 }));
+    const token = `${header}.${claims}.deadbeef`;
+    await assert.rejects(
+      () => verifyTokenFromConfig(token, cfg),
+      (err) => err instanceof AuthenticationError && err.code === "unsupported_alg",
+      `should reject alg=${badAlg}`,
+    );
+  }
+});
+
+// ───────────────────────────────────────────────────────────────────
+// 2. KMS mode
+// ───────────────────────────────────────────────────────────────────
+
+test("dispatcher kms: signTokenFromConfig produces ES256", async () => {
+  const cfg = buildAuthConfig({ jwtBackend: "kms", withKms: true });
+  const { token, claims } = await signTokenFromConfig(
+    {},
+    { issuer: ISSUER, audience: AUDIENCE, subject: SUBJECT, role: "admin", expiresInSeconds: 60 },
+    cfg,
+  );
+  const [headerB64] = token.split(".");
+  const header = JSON.parse(b64uDecode(headerB64).toString("utf8"));
+  assert.equal(header.alg, "ES256");
+  assert.equal(header.typ, "averray-auth+jwt");
+  assert.equal(header.kid, KID);
+  assert.equal(claims.sub, SUBJECT);
+  assert.equal(claims.role, "admin");
+});
+
+test("dispatcher kms: verifyTokenFromConfig accepts ES256", async () => {
+  const cfg = buildAuthConfig({ jwtBackend: "kms", withKms: true });
+  const { token } = await signTokenFromConfig(
+    {},
+    { issuer: ISSUER, audience: AUDIENCE, subject: SUBJECT, role: "admin", expiresInSeconds: 60 },
+    cfg,
+  );
+  const claims = await verifyTokenFromConfig(token, cfg);
+  assert.equal(claims.sub, SUBJECT);
+  assert.equal(claims.role, "admin");
+  assert.equal(claims.iss, ISSUER);
+  assert.equal(claims.aud, AUDIENCE);
+});
+
+test("dispatcher kms: verifyTokenFromConfig rejects HS256 with clear error", async () => {
+  const cfg = buildAuthConfig({ jwtBackend: "kms", withKms: true });
+  const { token: hs256Token } = signToken(
+    { sub: SUBJECT },
+    { secret: HMAC_SECRET, expiresInSeconds: 60 },
+  );
+  await assert.rejects(
+    () => verifyTokenFromConfig(hs256Token, cfg),
+    (err) => {
+      assert.ok(err instanceof AuthenticationError);
+      assert.equal(err.code, "unsupported_alg");
+      assert.match(err.message, /HS256.*kms/u);
+      return true;
+    },
+  );
+});
+
+test("dispatcher kms: alg:none token is rejected", async () => {
+  const cfg = buildAuthConfig({ jwtBackend: "kms", withKms: true });
+  const header = b64uEncode(JSON.stringify({ alg: "none", typ: "averray-auth+jwt", kid: KID }));
+  const claims = b64uEncode(JSON.stringify({ sub: SUBJECT, iat: 0, exp: 9_999_999_999 }));
+  const token = `${header}.${claims}.`;
+  await assert.rejects(
+    () => verifyTokenFromConfig(token, cfg),
+    (err) => err instanceof AuthenticationError && err.code === "unsupported_alg",
+  );
+});
+
+// ───────────────────────────────────────────────────────────────────
+// 3. Both mode
+// ───────────────────────────────────────────────────────────────────
+
+test("dispatcher both: primaryAlg=hmac signs HS256 and verifies both algs", async () => {
+  const cfg = buildAuthConfig({
+    jwtBackend: "both",
+    jwtPrimaryAlg: "hmac",
+    withKms: true,
+  });
+  // Sign defaults to HMAC under primaryAlg=hmac.
+  const { token: hmacToken } = await signTokenFromConfig(
+    { sub: SUBJECT },
+    { expiresInSeconds: 60 },
+    cfg,
+  );
+  const [hmacHeaderB64] = hmacToken.split(".");
+  const hmacHeader = JSON.parse(b64uDecode(hmacHeaderB64).toString("utf8"));
+  assert.equal(hmacHeader.alg, "HS256");
+
+  // Verify a separately-signed ES256 token under the same authConfig.
+  const kmsOnlyCfg = buildAuthConfig({ jwtBackend: "kms", withKms: true });
+  const { token: es256Token } = await signTokenFromConfig(
+    {},
+    { issuer: ISSUER, audience: AUDIENCE, subject: SUBJECT, role: "admin", expiresInSeconds: 60 },
+    kmsOnlyCfg,
+  );
+
+  // both-mode config accepts both — same config object holds the KMS
+  // verification material AND the HMAC secrets list.
+  const hmacClaims = await verifyTokenFromConfig(hmacToken, cfg);
+  assert.equal(hmacClaims.sub, SUBJECT);
+  // For the ES256 token to verify against `cfg`, the kmsJwt must be
+  // configured against the *same* keypair we used to sign — buildAuthConfig
+  // generates the keypair once at module load, so this holds.
+  const es256Claims = await verifyTokenFromConfig(es256Token, cfg);
+  assert.equal(es256Claims.sub, SUBJECT);
+  assert.equal(es256Claims.role, "admin");
+});
+
+test("dispatcher both: primaryAlg=kms signs ES256 and verifies both algs", async () => {
+  const cfg = buildAuthConfig({
+    jwtBackend: "both",
+    jwtPrimaryAlg: "kms",
+    withKms: true,
+  });
+  const { token: es256Token } = await signTokenFromConfig(
+    { sub: SUBJECT },
+    {
+      issuer: ISSUER,
+      audience: AUDIENCE,
+      subject: SUBJECT,
+      role: "admin",
+      expiresInSeconds: 60,
+    },
+    cfg,
+  );
+  const [es256HeaderB64] = es256Token.split(".");
+  const es256Header = JSON.parse(b64uDecode(es256HeaderB64).toString("utf8"));
+  assert.equal(es256Header.alg, "ES256");
+
+  // Existing HMAC tokens still verify.
+  const { token: hmacToken } = signToken(
+    { sub: SUBJECT },
+    { secret: HMAC_SECRET, expiresInSeconds: 60 },
+  );
+  const hmacClaims = await verifyTokenFromConfig(hmacToken, cfg);
+  assert.equal(hmacClaims.sub, SUBJECT);
+  const es256Claims = await verifyTokenFromConfig(es256Token, cfg);
+  assert.equal(es256Claims.sub, SUBJECT);
+});
+
+test("dispatcher both: HS256 token routes to HMAC path (not KMS)", async () => {
+  const cfg = buildAuthConfig({
+    jwtBackend: "both",
+    jwtPrimaryAlg: "hmac",
+    withKms: true,
+  });
+  // Sign HS256 against a secret that is in the rotation list. Verify
+  // succeeds, which proves the HMAC path was used (KMS verification
+  // could not possibly accept an HS256 token).
+  const { token } = signToken(
+    { sub: SUBJECT },
+    { secret: HMAC_SECRET, expiresInSeconds: 60 },
+  );
+  const claims = await verifyTokenFromConfig(token, cfg);
+  assert.equal(claims.sub, SUBJECT);
+});
+
+test("dispatcher both: ES256 token routes to KMS path (not HMAC)", async () => {
+  const cfg = buildAuthConfig({
+    jwtBackend: "both",
+    jwtPrimaryAlg: "hmac",
+    withKms: true,
+  });
+  const kmsOnlyCfg = buildAuthConfig({ jwtBackend: "kms", withKms: true });
+  const { token } = await signTokenFromConfig(
+    {},
+    { issuer: ISSUER, audience: AUDIENCE, subject: SUBJECT, role: "admin", expiresInSeconds: 60 },
+    kmsOnlyCfg,
+  );
+  // Verify against the `both` config — only the KMS path can produce
+  // a match because HMAC has no concept of ES256 signatures.
+  const claims = await verifyTokenFromConfig(token, cfg);
+  assert.equal(claims.sub, SUBJECT);
+  assert.equal(claims.role, "admin");
+});
+
+test("dispatcher both: alg:none still rejected", async () => {
+  const cfg = buildAuthConfig({
+    jwtBackend: "both",
+    jwtPrimaryAlg: "hmac",
+    withKms: true,
+  });
+  const header = b64uEncode(JSON.stringify({ alg: "none", typ: "JWT" }));
+  const claims = b64uEncode(JSON.stringify({ sub: SUBJECT, iat: 0, exp: 9_999_999_999 }));
+  const token = `${header}.${claims}.`;
+  await assert.rejects(
+    () => verifyTokenFromConfig(token, cfg),
+    (err) => err instanceof AuthenticationError && err.code === "unsupported_alg",
+  );
+});
+
+test("dispatcher both: algorithm-confusion — HS256 token with KMS public key as HMAC secret is rejected", async () => {
+  // RFC 8725 §3.1: an attacker who controls the JWT public key (it's
+  // public, after all) might try to forge an HS256 token using the
+  // public-key bytes as the HMAC secret, hoping a naive verifier
+  // routes by alg and uses whatever key material happens to be
+  // configured. Our dispatcher routes HS256 → HMAC verify and HMAC
+  // verify uses ONLY the configured AUTH_JWT_SECRETS, not the public
+  // key. This test asserts that: build a forged HS256 token whose
+  // signature is computed with the PEM bytes as the secret, then
+  // verify — expect rejection because the HMAC backend's secrets
+  // list does NOT contain the public PEM.
+  const cfg = buildAuthConfig({
+    jwtBackend: "both",
+    jwtPrimaryAlg: "hmac",
+    secrets: [HMAC_SECRET], // explicitly NOT the public PEM
+    withKms: true,
+  });
+  // Forge an HS256 token signed with the JWT public key (PEM bytes)
+  // as the "secret". Replicate the existing jwt.js sign() routine
+  // exactly so the signature is valid for that key.
+  const { createHmac } = await import("node:crypto");
+  const headerB64 = b64uEncode(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const payload = { sub: SUBJECT, iat: Math.floor(Date.now() / 1000), exp: Math.floor(Date.now() / 1000) + 60 };
+  const payloadB64 = b64uEncode(JSON.stringify(payload));
+  const signingInput = `${headerB64}.${payloadB64}`;
+  const sig = createHmac("sha256", KMS_PUBLIC_PEM).update(signingInput).digest("base64url");
+  const forged = `${signingInput}.${sig}`;
+
+  await assert.rejects(
+    () => verifyTokenFromConfig(forged, cfg),
+    (err) => err instanceof AuthenticationError && err.code === "bad_signature",
+    "HS256 forged with public key as secret must fail under HMAC verify",
+  );
+});
+
+// ───────────────────────────────────────────────────────────────────
+// 4. Config validation
+// ───────────────────────────────────────────────────────────────────
+
+test("config: JWT_BACKEND=invalid throws ConfigError at boot", () => {
+  assert.throws(
+    () =>
+      loadAuthConfig({
+        AUTH_MODE: "strict",
+        AUTH_JWT_SECRETS: LONG_HMAC_SECRET,
+        JWT_BACKEND: "asymmetric", // not a valid value
+      }),
+    (err) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /JWT_BACKEND/u);
+      assert.match(err.message, /hmac.*kms.*both|hmac.*both.*kms/u);
+      return true;
+    },
+  );
+});
+
+test("config: JWT_BACKEND=kms with missing AWS_JWT_KEY_ID throws ConfigError listing the missing var", () => {
+  assert.throws(
+    () =>
+      loadAuthConfig({
+        AUTH_MODE: "strict",
+        AUTH_JWT_SECRETS: LONG_HMAC_SECRET,
+        JWT_BACKEND: "kms",
+        AWS_JWT_REGION: "eu-central-2",
+        // AWS_JWT_KEY_ID intentionally missing
+        JWT_PUBLIC_KEY_PEM: KMS_PUBLIC_PEM,
+        JWT_PUBLIC_KEY_FINGERPRINT: "deadbeef",
+      }),
+    (err) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /AWS_JWT_KEY_ID/u);
+      return true;
+    },
+  );
+});
+
+test("config: JWT_BACKEND=both with multiple missing KMS vars lists them all", () => {
+  assert.throws(
+    () =>
+      loadAuthConfig({
+        AUTH_MODE: "strict",
+        AUTH_JWT_SECRETS: LONG_HMAC_SECRET,
+        JWT_BACKEND: "both",
+        // All four required vars missing
+      }),
+    (err) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /AWS_JWT_REGION/u);
+      assert.match(err.message, /AWS_JWT_KEY_ID/u);
+      assert.match(err.message, /JWT_PUBLIC_KEY_PEM/u);
+      assert.match(err.message, /JWT_PUBLIC_KEY_FINGERPRINT/u);
+      return true;
+    },
+  );
+});
+
+test("config: JWT_BACKEND=hmac (default) with KMS vars present does not throw", () => {
+  const config = loadAuthConfig({
+    AUTH_MODE: "strict",
+    AUTH_JWT_SECRETS: LONG_HMAC_SECRET,
+    // No JWT_BACKEND → default "hmac"
+    // KMS-required vars intentionally absent.
+  });
+  assert.equal(config.jwtBackend, "hmac");
+  assert.equal(config.kmsJwt, null);
+});
+
+test("config: JWT_BACKEND=hmac with KMS vars present is ignored (no throw, kmsJwt null)", () => {
+  const config = loadAuthConfig({
+    AUTH_MODE: "strict",
+    AUTH_JWT_SECRETS: LONG_HMAC_SECRET,
+    JWT_BACKEND: "hmac",
+    AWS_JWT_REGION: "eu-central-2",
+    AWS_JWT_KEY_ID: KEY_ARN,
+    JWT_PUBLIC_KEY_PEM: KMS_PUBLIC_PEM,
+    JWT_PUBLIC_KEY_FINGERPRINT: "deadbeef",
+  });
+  assert.equal(config.jwtBackend, "hmac");
+  assert.equal(config.kmsJwt, null);
+});
+
+test("config: JWT_BACKEND=kms with all required vars populates kmsJwt with defaults", () => {
+  const config = loadAuthConfig({
+    AUTH_MODE: "strict",
+    AUTH_JWT_SECRETS: LONG_HMAC_SECRET,
+    JWT_BACKEND: "kms",
+    AWS_JWT_REGION: "eu-central-2",
+    AWS_JWT_KEY_ID: KEY_ARN,
+    JWT_PUBLIC_KEY_PEM: KMS_PUBLIC_PEM,
+    JWT_PUBLIC_KEY_FINGERPRINT: "deadbeef",
+  });
+  assert.equal(config.jwtBackend, "kms");
+  assert.equal(config.jwtPrimaryAlg, "kms");
+  assert.ok(config.kmsJwt);
+  assert.equal(config.kmsJwt.region, "eu-central-2");
+  assert.equal(config.kmsJwt.keyId, KEY_ARN);
+  assert.equal(config.kmsJwt.kid, "jwt-1"); // default
+  assert.equal(config.kmsJwt.expectedIssuer, "averray-backend-testnet"); // default
+  assert.equal(config.kmsJwt.expectedAudience, "averray-backend"); // default
+});
+
+test("config: JWT_BACKEND=kms with AWS_JWT_KEY_ID as alias is rejected at boot", () => {
+  assert.throws(
+    () =>
+      loadAuthConfig({
+        AUTH_MODE: "strict",
+        AUTH_JWT_SECRETS: LONG_HMAC_SECRET,
+        JWT_BACKEND: "kms",
+        AWS_JWT_REGION: "eu-central-2",
+        AWS_JWT_KEY_ID: "alias/averray-jwt-signer-testnet",
+        JWT_PUBLIC_KEY_PEM: KMS_PUBLIC_PEM,
+        JWT_PUBLIC_KEY_FINGERPRINT: "deadbeef",
+      }),
+    (err) => {
+      assert.ok(err instanceof ConfigError);
+      assert.match(err.message, /alias/u);
+      return true;
+    },
+  );
+});
+
+test("config: JWT_PRIMARY_ALG=invalid is rejected", () => {
+  assert.throws(
+    () =>
+      loadAuthConfig({
+        AUTH_MODE: "strict",
+        AUTH_JWT_SECRETS: LONG_HMAC_SECRET,
+        JWT_BACKEND: "both",
+        JWT_PRIMARY_ALG: "rs256",
+        AWS_JWT_REGION: "eu-central-2",
+        AWS_JWT_KEY_ID: KEY_ARN,
+        JWT_PUBLIC_KEY_PEM: KMS_PUBLIC_PEM,
+        JWT_PUBLIC_KEY_FINGERPRINT: "deadbeef",
+      }),
+    (err) => err instanceof ConfigError && /JWT_PRIMARY_ALG/u.test(err.message),
+  );
+});
+
+// ───────────────────────────────────────────────────────────────────
+// 5. Middleware integration — JWT_BACKEND=both authenticates both
+// ───────────────────────────────────────────────────────────────────
+
+test("middleware integration: JWT_BACKEND=both authenticates both HS256 and ES256 tokens", async () => {
+  const cfg = buildAuthConfig({
+    jwtBackend: "both",
+    jwtPrimaryAlg: "hmac",
+    withKms: true,
+  });
+  const middleware = createAuthMiddleware({ authConfig: cfg, logger: silentLogger() });
+
+  // HS256 token via legacy signToken.
+  const { token: hmacToken } = signToken(
+    { sub: SUBJECT },
+    { secret: HMAC_SECRET, expiresInSeconds: 60 },
+  );
+  const hmacReq = { method: "GET", headers: { authorization: `Bearer ${hmacToken}` } };
+  const hmacResult = await middleware(hmacReq, new URL("http://localhost/api/account"));
+  assert.equal(hmacResult.wallet.toLowerCase(), SUBJECT.toLowerCase());
+
+  // ES256 token via the dispatcher's ES256 path.
+  const kmsOnlyCfg = buildAuthConfig({ jwtBackend: "kms", withKms: true });
+  const { token: es256Token } = await signTokenFromConfig(
+    {},
+    { issuer: ISSUER, audience: AUDIENCE, subject: SUBJECT, role: "admin", expiresInSeconds: 60 },
+    kmsOnlyCfg,
+  );
+  const es256Req = { method: "GET", headers: { authorization: `Bearer ${es256Token}` } };
+  const es256Result = await middleware(es256Req, new URL("http://localhost/api/account"));
+  assert.equal(es256Result.wallet.toLowerCase(), SUBJECT.toLowerCase());
+});
+
+test("middleware integration: JWT_BACKEND=hmac (default) rejects ES256 with AuthenticationError", async () => {
+  const hmacCfg = buildAuthConfig({ jwtBackend: "hmac" });
+  const middleware = createAuthMiddleware({ authConfig: hmacCfg, logger: silentLogger() });
+
+  // Mint an ES256 token under a separate kms-mode config.
+  const kmsCfg = buildAuthConfig({ jwtBackend: "kms", withKms: true });
+  const { token } = await signTokenFromConfig(
+    {},
+    { issuer: ISSUER, audience: AUDIENCE, subject: SUBJECT, role: "admin", expiresInSeconds: 60 },
+    kmsCfg,
+  );
+
+  const request = { method: "GET", headers: { authorization: `Bearer ${token}` } };
+  await assert.rejects(
+    () => middleware(request, new URL("http://localhost/api/account")),
+    (err) => {
+      assert.ok(err instanceof AuthenticationError);
+      assert.equal(err.code, "unsupported_alg");
+      return true;
+    },
+  );
+});

--- a/mcp-server/src/auth/jwt.js
+++ b/mcp-server/src/auth/jwt.js
@@ -9,6 +9,12 @@ const CLOCK_SKEW_SECONDS = 60;
  *
  * Supports key rotation: pass an array of secrets; `verifyToken` accepts any,
  * `signToken` always uses the first (newest).
+ *
+ * Phase 4b (PR 4b.4) adds the dispatcher entry points
+ * `signTokenFromConfig` / `verifyTokenFromConfig` below the legacy
+ * `signToken` / `verifyToken` functions. The legacy API is preserved
+ * byte-for-byte so existing tests and the `scripts/ops/mint-admin-jwt.mjs`
+ * caller keep working under `JWT_BACKEND=hmac` (default).
  */
 
 export function signToken(payload, { secret, expiresInSeconds }) {
@@ -85,6 +91,271 @@ export function verifyToken(token, { secrets }) {
   }
 
   return payload;
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Phase 4b dispatcher
+// ───────────────────────────────────────────────────────────────────────
+
+/**
+ * Lazily-cached KmsJwtSigner instance, keyed by the kmsJwt config
+ * reference (each config load creates one instance and the dispatcher
+ * keeps it alive for the process lifetime). Cached via a WeakMap so
+ * test code that loads multiple distinct configs doesn't accumulate
+ * dangling signers.
+ *
+ * We intentionally don't import @aws-sdk/client-kms eagerly — HMAC-only
+ * deploys must not pay the SDK import cost. The KmsJwtSigner module
+ * itself defers the SDK import to the first send().
+ */
+const SIGNER_CACHE = new WeakMap();
+
+async function getKmsSigner(authConfig) {
+  if (!authConfig?.kmsJwt) {
+    throw new ConfigError(
+      "JWT_BACKEND requires KMS but authConfig.kmsJwt is null. Set AWS_JWT_REGION / AWS_JWT_KEY_ID / JWT_PUBLIC_KEY_PEM / JWT_PUBLIC_KEY_FINGERPRINT.",
+    );
+  }
+  const cached = SIGNER_CACHE.get(authConfig.kmsJwt);
+  if (cached) return cached;
+  // Lazy-import; ensures hmac-only callers never pull in
+  // @aws-sdk/client-kms (KmsJwtSigner's own SDK import is also lazy).
+  const { KmsJwtSigner } = await import("./kms-jwt-signer.js");
+  // Allow tests to inject a KMSClient via authConfig.kmsJwt.kmsClient
+  // without leaking that field into the loaded-from-env public shape —
+  // production env never sets it.
+  const signer = new KmsJwtSigner({
+    kmsClient: authConfig.kmsJwt.kmsClient,
+    region: authConfig.kmsJwt.region,
+    keyId: authConfig.kmsJwt.keyId,
+    kid: authConfig.kmsJwt.kid,
+    publicKeyPem: authConfig.kmsJwt.publicKeyPem,
+    expectedIssuer: authConfig.kmsJwt.expectedIssuer,
+    expectedAudience: authConfig.kmsJwt.expectedAudience,
+    expectedRoles: authConfig.kmsJwt.expectedRoles,
+    maxTtlSeconds: authConfig.kmsJwt.maxTtlSeconds,
+    clockSkewSeconds: authConfig.kmsJwt.clockSkewSeconds,
+  });
+  SIGNER_CACHE.set(authConfig.kmsJwt, signer);
+  return signer;
+}
+
+/**
+ * Determine which alg the sign path should produce.
+ *
+ *   hmac → always HS256
+ *   kms  → always ES256
+ *   both → JWT_PRIMARY_ALG decides (default "hmac")
+ */
+function pickSignAlg(authConfig) {
+  switch (authConfig?.jwtBackend) {
+    case "kms":
+      return "ES256";
+    case "both":
+      return authConfig.jwtPrimaryAlg === "kms" ? "ES256" : "HS256";
+    case "hmac":
+    case undefined: // treat missing as default "hmac" for safety
+    case null:
+      return "HS256";
+    default:
+      throw new ConfigError(`Unknown jwtBackend "${authConfig.jwtBackend}".`);
+  }
+}
+
+/**
+ * Sign a JWT according to `authConfig.jwtBackend`.
+ *
+ * HS256 path returns the same `{ token, claims }` shape as the existing
+ * `signToken` (and reuses it under the hood). ES256 path returns the
+ * same shape — the dispatcher decodes the produced token's claims to
+ * keep the interface uniform for callers that need the issued claims
+ * (e.g., HTTP handlers that echo `jti` back to clients).
+ *
+ * For ES256, the caller supplies `issuer` / `audience` / `subject` /
+ * `role` in `opts` (matching KmsJwtSigner's signAsync contract). When
+ * those are absent, the dispatcher derives sensible defaults from
+ * `authConfig.kmsJwt`'s configured expectations, so the HTTP-server
+ * sign-in handler can keep passing only the payload + TTL during the
+ * transition.
+ */
+export async function signTokenFromConfig(payload, opts, authConfig) {
+  if (!authConfig || typeof authConfig !== "object") {
+    throw new ConfigError("signTokenFromConfig: authConfig is required.");
+  }
+  if (!opts || typeof opts !== "object") {
+    throw new ConfigError("signTokenFromConfig: opts (with expiresInSeconds) is required.");
+  }
+  const alg = pickSignAlg(authConfig);
+
+  if (alg === "HS256") {
+    const secret = opts.secret ?? authConfig.signingSecret;
+    return signToken(payload, { secret, expiresInSeconds: opts.expiresInSeconds });
+  }
+
+  // ES256 path.
+  const signer = await getKmsSigner(authConfig);
+  const subject =
+    opts.subject ?? (typeof payload?.sub === "string" ? payload.sub : undefined);
+  const role =
+    opts.role
+    ?? (Array.isArray(payload?.roles) && payload.roles.length > 0 ? payload.roles[0] : undefined)
+    ?? (typeof payload?.role === "string" ? payload.role : undefined);
+  const issuer = opts.issuer ?? authConfig.kmsJwt?.expectedIssuer;
+  const audience = opts.audience ?? authConfig.kmsJwt?.expectedAudience;
+
+  if (!issuer || !audience || !subject || !role) {
+    throw new ConfigError(
+      "signTokenFromConfig (ES256): issuer/audience/subject/role must each be derivable from opts or authConfig.kmsJwt + payload.",
+    );
+  }
+
+  // Strip registered claims the signer manages itself so the merged
+  // payload doesn't accidentally override iat/exp/jti/iss/aud/sub/role.
+  const {
+    iss: _iss,
+    aud: _aud,
+    sub: _sub,
+    role: _role,
+    iat: _iat,
+    nbf: _nbf,
+    exp: _exp,
+    jti: _jti,
+    ...extras
+  } = payload ?? {};
+
+  const token = await signer.signAsync(extras, {
+    issuer,
+    audience,
+    subject,
+    role,
+    expiresInSeconds: opts.expiresInSeconds,
+  });
+  // Decode the just-signed claims for the caller without re-verifying —
+  // we trust our own emission.
+  const [, claimsB64] = token.split(".");
+  const claims = JSON.parse(base64UrlDecode(claimsB64).toString("utf8"));
+  return { token, claims };
+}
+
+/**
+ * Verify a JWT according to `authConfig.jwtBackend`. The dispatcher
+ * pre-parses the JOSE header to determine which backend to route to,
+ * then enforces strict header rules at the dispatcher boundary
+ * (alg=none and mixed-case variants rejected unconditionally) before
+ * any signature operation.
+ *
+ * Algorithm-confusion defense: each backend is told which algorithm it
+ * supports. HMAC verify rejects ES256 tokens; KMS verify rejects HS256
+ * tokens. We never use the alg claim to choose a cryptographic
+ * operation — we use it only to route to the configured backend.
+ */
+export async function verifyTokenFromConfig(token, authConfig) {
+  if (!authConfig || typeof authConfig !== "object") {
+    throw new ConfigError("verifyTokenFromConfig: authConfig is required.");
+  }
+  if (typeof token !== "string" || token.length === 0) {
+    throw new AuthenticationError("Missing token.", "missing_token");
+  }
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    throw new AuthenticationError("Malformed token.", "malformed_token");
+  }
+  const [headerPart] = parts;
+
+  let header;
+  try {
+    header = JSON.parse(base64UrlDecode(headerPart).toString("utf8"));
+  } catch {
+    throw new AuthenticationError("Invalid token header.", "malformed_token");
+  }
+  if (!header || typeof header !== "object" || Array.isArray(header)) {
+    throw new AuthenticationError("Invalid token header.", "malformed_token");
+  }
+
+  // Exact-match alg comparison — anything other than the two supported
+  // values is rejected here, BEFORE we touch the signature. Catches
+  // "none" / "None" / "NONE" / lowercase variants in one place. The
+  // per-backend code re-checks alg as defense-in-depth but the dispatcher
+  // is the canonical gate.
+  const alg = header.alg;
+  if (alg === "none" || alg === "None" || alg === "NONE") {
+    throw new AuthenticationError(
+      `Unsupported token algorithm "${alg}".`,
+      "unsupported_alg",
+    );
+  }
+
+  const backend = authConfig.jwtBackend ?? "hmac";
+
+  if (alg === "HS256") {
+    if (backend === "kms") {
+      throw new AuthenticationError(
+        `alg HS256 not supported in JWT_BACKEND=kms mode.`,
+        "unsupported_alg",
+      );
+    }
+    // hmac / both → existing HMAC path; verifyToken handles header.typ
+    // and signature rotation against authConfig.secrets.
+    return verifyToken(token, { secrets: authConfig.secrets });
+  }
+
+  if (alg === "ES256") {
+    if (backend === "hmac") {
+      throw new AuthenticationError(
+        `alg ES256 not supported in JWT_BACKEND=hmac mode.`,
+        "unsupported_alg",
+      );
+    }
+    // kms / both → KmsJwtSigner.verify enforces header.typ, kid,
+    // forbidden headers (jku/jwk/x5u/x5c/crit), the signature, and
+    // all claims-validation rules from design doc §6. verifyEs256
+    // lazy-imports the signer module on first call so HMAC-only
+    // deploys never pay the @aws-sdk/client-kms import cost. The
+    // dispatcher is async to accommodate that — the middleware
+    // call site already awaits, so this is invisible to callers.
+    return await verifyEs256(token, authConfig);
+  }
+
+  throw new AuthenticationError(
+    `Unsupported token algorithm "${alg}".`,
+    "unsupported_alg",
+  );
+}
+
+async function verifyEs256(token, authConfig) {
+  const signer = await getKmsSigner(authConfig);
+  try {
+    return signer.verify(token);
+  } catch (err) {
+    // KmsJwtSigner throws plain Error objects with explanatory
+    // messages. Convert to AuthenticationError so the HTTP layer
+    // returns 401 / the right error envelope, matching how the HMAC
+    // path's AuthenticationError flows through middleware.js.
+    throw new AuthenticationError(
+      err?.message ?? "Token verification failed.",
+      classifyKmsVerifyError(err),
+    );
+  }
+}
+
+function classifyKmsVerifyError(err) {
+  const msg = String(err?.message ?? "");
+  if (/expired/iu.test(msg)) return "token_expired";
+  if (/not yet valid/iu.test(msg)) return "token_nbf_future";
+  if (/issued in the future/iu.test(msg)) return "token_iat_future";
+  if (/signature mismatch/iu.test(msg)) return "bad_signature";
+  if (/malformed token|malformed JWS|invalid header|invalid claims|invalid signature/iu.test(msg)) {
+    return "malformed_token";
+  }
+  if (/unsupported alg|unsupported typ/iu.test(msg)) return "unsupported_alg";
+  if (/forbidden header/iu.test(msg)) return "unsupported_alg";
+  if (/kid .* not in allowlist|kid header/iu.test(msg)) return "unknown_kid";
+  if (/unexpected iss|unexpected aud/iu.test(msg)) return "claims_mismatch";
+  if (/role .* not in allowlist/iu.test(msg)) return "role_not_allowed";
+  if (/sub claim|jti missing|jti .* UUIDv4|exp - iat|iat claim|nbf claim|exp claim/iu.test(msg)) {
+    return "claims_mismatch";
+  }
+  return "bad_signature";
 }
 
 function sign(input, secret) {

--- a/mcp-server/src/auth/middleware.js
+++ b/mcp-server/src/auth/middleware.js
@@ -1,6 +1,6 @@
 import { getAddress } from "ethers";
 import { AuthenticationError, AuthorizationError } from "../core/errors.js";
-import { verifyToken } from "./jwt.js";
+import { verifyTokenFromConfig } from "./jwt.js";
 import { hasRole, resolveRoles } from "./config.js";
 import {
   getRouteCapabilityRequirements,
@@ -170,7 +170,15 @@ export function createAuthMiddleware({ authConfig, stateStore, logger = console,
       );
     }
 
-    const claims = verifyToken(token, { secrets: authConfig.secrets });
+    // verifyTokenFromConfig is the Phase 4b dispatcher (PR 4b.4). It
+    // routes to the HMAC or KMS backend based on authConfig.jwtBackend
+    // and the alg header — under the default JWT_BACKEND=hmac it is
+    // byte-for-byte equivalent to the previous verifyToken(secrets)
+    // call. ES256 verification is async (it lazy-imports the KMS
+    // signer module on first use), so the dispatcher itself returns
+    // a Promise — Promise.resolve(claims) for the HMAC path keeps the
+    // shape uniform.
+    const claims = await verifyTokenFromConfig(token, authConfig);
     if (!claims?.sub) {
       throw new AuthenticationError("Token missing subject claim.", "missing_subject");
     }


### PR DESCRIPTION
## Summary

Adds the algorithm-aware dispatcher that routes between **HMAC (HS256)** and **KMS-signed (ES256)** JWTs based on the `JWT_BACKEND` env var. Per [`docs/PHASE_4B_KMS_JWT_PLAN.md`](https://github.com/averray-agent/agent/blob/main/docs/PHASE_4B_KMS_JWT_PLAN.md) §7 PR 4b.4.

**Default behavior is unchanged.** `JWT_BACKEND=hmac` (default) makes this PR a no-op for production traffic; every existing token continues to verify exactly as before. The KMS code path is dormant until PR 4b.6.

## Configuration

| `JWT_BACKEND` | Sign | Verify |
|---|---|---|
| `hmac` (default) | HS256 | HS256 only |
| `kms` | ES256 via KMS | ES256 only |
| `both` | per `JWT_PRIMARY_ALG` (default hmac) | both algorithms |
| any other | `ConfigError` at boot | — |

## Header strictness inherited from PR #399

`alg=none`, mixed-case (`None`/`NONE`), `jku`/`jwk`/`x5u`/`x5c`, unknown `kid`, algorithm-confusion attacks all rejected before any signature operation. RFC 8725.

## Algorithm-confusion defense

The dispatcher routes by the `alg` header but does NOT trust it to choose the cryptographic operation. Each per-backend code is told which algorithm IT supports and rejects mismatched headers.

## Implementation notes

- Legacy `signToken` / `verifyToken` API preserved byte-identically; all existing `auth.test.js` tests pass unchanged.
- New: `signTokenFromConfig(payload, opts, authConfig)` + `verifyTokenFromConfig(token, authConfig)` (async — enables lazy `@aws-sdk/client-kms` import in HMAC-only deploys).
- Middleware change: +`await` before `verifyTokenFromConfig`.
- `KmsJwtSigner.verify` errors converted to `AuthenticationError` with `code` (`bad_signature` / `token_expired` / …) via a small classifier.

## Out of scope (tracked for PR 4b.6)

- `mcp-server/src/protocols/http/server.js` has direct `signToken(…, authConfig.signingSecret, …)` call sites. When `JWT_BACKEND=kms` is active in prod, those need to use `signTokenFromConfig`. They keep working under the `hmac` default in this PR.
- `scripts/ops/mint-admin-jwt.mjs` unchanged here; PR 4b.6 adds `--use-kms`.

## Test plan

- [x] 24 new tests in `jwt-dispatcher.test.js` covering all three modes, algorithm-confusion defense, config validation, middleware integration
- [x] Existing 647 auth tests pass unchanged (verified via the agent's diff inspection — same call signature, same behavior under default mode)
- [x] `npm ci --dry-run`: clean
- [ ] CI green (local worktree had stale `@noble/curves` from before PR #399 landed; CI's `npm ci` will resolve to the correct `^2.2.0`)