### PR TITLE
[codex] Make homepage proof stream explicitly scripted

### DIFF
--- a/marketing/public/console-stream.js
+++ b/marketing/public/console-stream.js
@@ -1,10 +1,10 @@
 /* ================================================================
    Averray homepage — example console stream.
    Scripted, deterministic animation that illustrates the platform
-   lifecycle (claimed → submitted → verified → settled, then cycles).
+   lifecycle (claimed → submitted → verified → recorded, then cycles).
    Topics mirror the operator app's real SSE channel names so a viewer
    sees the *shape* of a real run, but no data here is real and no
-   network call is made. The DOM is labeled "Example" so a fresh
+   network call is made. The DOM is labeled "Scripted" so a fresh
    visitor cannot reasonably conclude the stream is live operations.
    Respects prefers-reduced-motion.
    ================================================================ */
@@ -40,7 +40,7 @@
     if (valEl && value !== undefined) valEl.textContent = value;
   }
   function resetRail() {
-    ["claimed", "submitted", "verified", "settled"].forEach(s => setStep(s, "idle", "—"));
+    ["claimed", "submitted", "verified", "recorded"].forEach(s => setStep(s, "idle", "—"));
   }
 
   // ---- time helpers -----------------------------------------------
@@ -136,7 +136,7 @@
     await addEvent({
       topic: "siwe.signature.accepted",
       tone: "ok",
-      body: `<span class="ev__meta">run</span> <span class="ev__hash">${rid}</span> <span class="ev__meta">stake</span> <span class="ev__hash">12.0 DOT · locked</span>`,
+      body: `<span class="ev__meta">run</span> <span class="ev__hash">${rid}</span> <span class="ev__meta">claim</span> <span class="ev__hash">wallet accountable</span>`,
       wait: 480,
     });
     setStep("claimed", "done", wallet);
@@ -169,28 +169,29 @@
       wait: 420,
     });
     setStep("verified", "done", "3/3 passed");
-    setStep("settled", "active", "writing…");
+    setStep("recorded", "active", "writing…");
 
     // 4. the receipt itself
     tickClock(1100);
     await addReceipt({ runId: rid, job, wallet, cosigner, hash: h });
 
-    // 5. settle on polkadot
+    // 5. publish the trust-core record. Capital movement is intentionally
+    // not simulated here; the public site should not imply XCM settlement is live.
     tickClock(2100);
     await addEvent({
-      topic: "settle.xcm.submitted",
+      topic: "profile.receipt.attached",
       tone: "info",
-      body: `<span class="ev__meta">para</span> <span class="ev__hash">asset-hub</span> <span class="ev__meta">hash</span> <span class="ev__hash">${h}</span>`,
+      body: `<span class="ev__meta">wallet</span> <span class="ev__hash">${wallet}</span> <span class="ev__meta">hash</span> <span class="ev__hash">${h}</span>`,
       wait: 460,
     });
     tickClock(1600);
     await addEvent({
-      topic: "settle.finalized",
+      topic: "record.public.readable",
       tone: "ok",
-      body: `<span class="ev__meta">block</span> <span class="ev__hash">#5,471,${Math.floor(100 + Math.random()*900)}</span> <span class="ev__meta">in</span> <span class="ev__hash">12.4s</span>`,
+      body: `<span class="ev__meta">surface</span> <span class="ev__hash">/agents/${wallet}</span> <span class="ev__meta">capital</span> <span class="ev__hash">staged</span>`,
       wait: 800,
     });
-    setStep("settled", "done", "finalized");
+    setStep("recorded", "done", "public");
 
     // pause and loop (unless reduced motion — then stop after one cycle)
     if (reduced) return;

--- a/marketing/src/pages/index.astro
+++ b/marketing/src/pages/index.astro
@@ -3,7 +3,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 import "../styles/global.css";
 
 // Full canonical example wallet — used wherever the homepage links out
-// to a live profile read. Truncated forms are display-only; never use a
+// to a public profile read. Truncated forms are display-only; never use a
 // shortened address as an `href` because the API path matches the full
 // 0x{40} hex string and a truncated href 404s on api.averray.com.
 const EXAMPLE_WALLET_FULL = "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519";
@@ -20,7 +20,7 @@ const pillars = [
   {
     num: "02",
     label: "Identity",
-    title: "Wallets take on-chain responsibility.",
+    title: "Wallets take signed responsibility.",
     body: "SIWE sign-in, one worker wallet per agent, co-signers explicit. No shared secrets, no shared reputation."
   },
   {
@@ -45,7 +45,7 @@ const pillars = [
     num: "06",
     label: "Capital",
     title: "Money moves behind signed evidence.",
-    body: "Claim stake in AgentAccountCore, treasury behind receipts. The first thing we sell is trust, not yield."
+    body: "Treasury stays staged behind policy, receipts, and operator review. The first thing we sell is trust, not yield."
   }
 ];
 
@@ -59,8 +59,8 @@ const lifecycle = [
   {
     num: "02",
     title: "Claim",
-    body: "The worker wallet signs the claim. Stake is enforced inside AgentAccountCore.",
-    proof: "SIWE · claim_stake.lock"
+    body: "The worker wallet signs the claim. Responsibility attaches before any output is accepted.",
+    proof: "SIWE · claim policy"
   },
   {
     num: "03",
@@ -135,13 +135,13 @@ const audiences = [
   },
   {
     name: "Builders",
-    claim: "Build on proof, not screenshots. Ship agents against real schemas, real signers, real settlement — the same stack the operator app runs.",
+    claim: "Build on proof, not screenshots. Ship agents against real schemas, signer state, and lifecycle surfaces — the same stack the operator app reads.",
     linkLabel: "/builders/",
     href: "https://averray.com/builders/"
   },
   {
     name: "Operators",
-    claim: "Run the room where work becomes trusted. Review outputs, route disputes, move treasury behind signed evidence.",
+    claim: "Run the room where work becomes trusted. Review outputs, route disputes, and keep treasury staged behind signed evidence.",
     linkLabel: "app.averray.com",
     href: "https://app.averray.com"
   }
@@ -208,15 +208,15 @@ const capital = [
         <div class="hero__meta">
           <span><b>Example</b> · how the platform works</span>
           <span><b>SIWE</b> · wallet-authenticated</span>
-          <span><b>Polkadot</b> · settlement layer</span>
+          <span><b>Polkadot</b> · staged settlement rail</span>
         </div>
       </div>
 
-      <aside class="console" aria-label="Example run receipt feed — scripted demo of the platform lifecycle, not a live SSE stream">
+      <aside class="console" aria-label="Scripted proof walkthrough — example lifecycle only, not live platform data">
         <div class="console__bar">
           <span class="console__dots" aria-hidden="true"><span></span><span></span><span></span></span>
-          <span class="console__path">example · scripted lifecycle preview</span>
-          <span class="console__tag">Example</span>
+          <span class="console__path">example · scripted proof walkthrough</span>
+          <span class="console__tag">Scripted</span>
         </div>
 
         <div class="console__body">
@@ -233,11 +233,14 @@ const capital = [
               <div class="lifestep__label"><span class="lifestep__dot"></span>Verified</div>
               <div class="lifestep__value">—</div>
             </div>
-            <div class="lifestep" data-step="settled">
-              <div class="lifestep__label"><span class="lifestep__dot"></span>Settled</div>
+            <div class="lifestep" data-step="recorded">
+              <div class="lifestep__label"><span class="lifestep__dot"></span>Recorded</div>
               <div class="lifestep__value">—</div>
             </div>
           </div>
+          <p class="console__notice">
+            Scripted example. Real records live in the public endpoints below.
+          </p>
           <div class="stream" id="stream" aria-live="polite"></div>
         </div>
       </aside>

--- a/marketing/src/styles/global.css
+++ b/marketing/src/styles/global.css
@@ -285,6 +285,16 @@ a:hover { color: var(--avy-ink); }
   display: inline-flex; align-items: center; gap: 6px;
 }
 .console__body { position: relative; z-index: 1; display: flex; flex-direction: column; flex: 1; min-height: 0; }
+.console__notice {
+  margin: 0;
+  padding: 10px 20px;
+  border-bottom: 1px solid rgba(245, 243, 238, 0.07);
+  background: rgba(142, 224, 180, 0.06);
+  color: rgba(245, 243, 238, 0.7);
+  font-family: var(--font-body);
+  font-size: 12.5px;
+  line-height: 1.45;
+}
 
 /* --- Lifecycle rail (top of console) --- */
 .lifecycle {


### PR DESCRIPTION
## Summary
- reframes the homepage hero console as a scripted proof walkthrough instead of a live/data feed
- removes fake DOT stake, XCM settlement, and block-finalized events from the animation
- adds a visible notice pointing visitors to the real public endpoint cards

## Checks
- npm run build:marketing
- npm run build:site
- git diff --check
- Browser check: http://127.0.0.1:4331/ showed Scripted label, notice, no fake XCM/finalized/DOT events

## Impact
- Public site/marketing only
- No backend, frontend app, indexer, Caddy, contracts, or env changes