### PR TITLE
Make XCM settlement replays idempotent

### DIFF
--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -1213,6 +1213,24 @@ export class BlockchainGateway {
           throw error;
         }
       }
+      if (strategyRequest?.settled) {
+        if (!this.strategySettlementMatches(
+          strategyRequest,
+          normalizedStatus,
+          normalizedSettledAssets,
+          normalizedSettledShares,
+          normalizedRemoteRef,
+          normalizedFailureCode
+        )) {
+          throw new ValidationError("Strategy XCM request is already settled with a different outcome.");
+        }
+        return {
+          ...(await this.getXcmRequest(normalizedRequestId)),
+          strategyRequest,
+          settledVia: "agent_account",
+          alreadySettled: true
+        };
+      }
       this.validateStrategySettlementOutcome(
         strategyRequest,
         normalizedStatus,
@@ -1241,9 +1259,18 @@ export class BlockchainGateway {
       return {
         ...(await this.getXcmRequest(normalizedRequestId)),
         strategyRequest: await this.getStrategyRequest(normalizedRequestId).catch(() => undefined),
-        settledVia: strategyRequest ? "agent_account" : "xcm_wrapper"
+        settledVia: strategyRequest ? "agent_account" : "xcm_wrapper",
+        alreadySettled: false
       };
     });
+  }
+
+  strategySettlementMatches(strategyRequest, status, settledAssets, settledShares, remoteRef, failureCode) {
+    return Number(strategyRequest?.status) === status
+      && BigInt(strategyRequest?.settledAssetsRaw ?? 0) === settledAssets
+      && BigInt(strategyRequest?.settledSharesRaw ?? 0) === settledShares
+      && this.toBytes32Value(strategyRequest?.remoteRef, "remoteRef").toLowerCase() === remoteRef.toLowerCase()
+      && this.toBytes32Value(strategyRequest?.failureCode, "failureCode").toLowerCase() === failureCode.toLowerCase();
   }
 
   validateStrategySettlementOutcome(strategyRequest, status, settledAssets, settledShares) {

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -1056,6 +1056,118 @@ test("finalizeXcmRequest preserves exact uint256 settlement amounts", async () =
   assert.equal(calls[0][3], 18446744073709551616n);
 });
 
+test("finalizeXcmRequest skips matching already-settled strategy requests", async () => {
+  const gateway = new BlockchainGateway({ enabled: false, supportedAssets: [USDC_TRUST_ASSET] });
+  const requestId = `0x${"5".repeat(64)}`;
+  const account = "0x3333333333333333333333333333333333333333";
+  const recipient = "0x4444444444444444444444444444444444444444";
+  let settlementRelayed = false;
+
+  gateway.signer = {};
+  gateway.accountContract = {
+    async strategyRequests(id) {
+      assert.equal(id, requestId);
+      return {
+        strategyId: encodeBytes32String("USDC"),
+        adapter: "0x5555555555555555555555555555555555555555",
+        account,
+        asset: USDC_TRUST_ASSET.address,
+        recipient,
+        kind: 0,
+        status: 2,
+        requestedAssets: 1n,
+        requestedShares: 0n,
+        settledAssets: 5_000_000n,
+        settledShares: 7_000_000n,
+        remoteRef: `0x${"0".repeat(64)}`,
+        failureCode: `0x${"0".repeat(64)}`,
+        settled: true
+      };
+    },
+    async settleStrategyRequest() {
+      settlementRelayed = true;
+      return { async wait() {} };
+    }
+  };
+  gateway.xcmWrapperContract = {
+    async getRequest(id) {
+      assert.equal(id, requestId);
+      return {
+        context: {
+          strategyId: encodeBytes32String("USDC"),
+          kind: 0,
+          account,
+          asset: USDC_TRUST_ASSET.address,
+          recipient,
+          assets: 1n,
+          shares: 0n,
+          nonce: 7n
+        },
+        status: 2,
+        settledAssets: 5_000_000n,
+        settledShares: 7_000_000n,
+        remoteRef: `0x${"0".repeat(64)}`,
+        failureCode: `0x${"0".repeat(64)}`,
+        createdAt: 10n,
+        updatedAt: 12n
+      };
+    }
+  };
+
+  const finalized = await gateway.finalizeXcmRequest(requestId, {
+    status: "succeeded",
+    settledAssets: "5000000",
+    settledShares: "7000000"
+  });
+
+  assert.equal(settlementRelayed, false);
+  assert.equal(finalized.alreadySettled, true);
+  assert.equal(finalized.settledVia, "agent_account");
+  assert.equal(finalized.strategyRequest.settled, true);
+});
+
+test("finalizeXcmRequest rejects conflicting already-settled strategy replays before tx", async () => {
+  const gateway = new BlockchainGateway({ enabled: false, supportedAssets: [USDC_TRUST_ASSET] });
+  const requestId = `0x${"6".repeat(64)}`;
+  let settlementRelayed = false;
+
+  gateway.signer = {};
+  gateway.accountContract = {
+    async strategyRequests() {
+      return {
+        strategyId: encodeBytes32String("USDC"),
+        adapter: "0x5555555555555555555555555555555555555555",
+        account: "0x3333333333333333333333333333333333333333",
+        asset: USDC_TRUST_ASSET.address,
+        recipient: "0x4444444444444444444444444444444444444444",
+        kind: 0,
+        status: 3,
+        requestedAssets: 1n,
+        requestedShares: 0n,
+        settledAssets: 0n,
+        settledShares: 0n,
+        remoteRef: `0x${"0".repeat(64)}`,
+        failureCode: encodeBytes32String("FAILED"),
+        settled: true
+      };
+    },
+    async settleStrategyRequest() {
+      settlementRelayed = true;
+      return { async wait() {} };
+    }
+  };
+
+  await assert.rejects(
+    () => gateway.finalizeXcmRequest(requestId, {
+      status: "succeeded",
+      settledAssets: "5000000",
+      settledShares: "7000000"
+    }),
+    ValidationError
+  );
+  assert.equal(settlementRelayed, false);
+});
+
 test("finalizeXcmRequest rejects unsafe numeric settlement amounts before tx", async () => {
   const gateway = new BlockchainGateway({ enabled: false, supportedAssets: [USDC_TRUST_ASSET] });
   const requestId = `0x${"4".repeat(64)}`;

--- a/mcp-server/src/core/account-mutation-service.js
+++ b/mcp-server/src/core/account-mutation-service.js
@@ -542,6 +542,12 @@ export class AccountMutationService {
     const pending = this.getStrategyPending(account, strategyId, asset);
     const kind = result?.strategyRequest?.kindLabel;
     const status = result?.strategyRequest?.statusLabel ?? result?.statusLabel ?? "unknown";
+    const requestId = result?.requestId;
+    pending.settledRequestIds = normalizeRequestIds(pending.settledRequestIds);
+    if (hasRequestId(pending.settledRequestIds, requestId)) {
+      this.accounts.set(wallet, account);
+      return account;
+    }
     const requestedAssets = Number(result?.strategyRequest?.requestedAssets ?? 0);
     const requestedShares = Number(result?.strategyRequest?.requestedShares ?? 0);
     const settledAssets = Number(result?.strategyRequest?.settledAssets ?? result?.settledAssets ?? 0);
@@ -564,7 +570,7 @@ export class AccountMutationService {
         pending.pendingDepositAssetsRaw,
         requestedAssetsRaw ?? settledAssetsRaw
       );
-      pending.pendingDepositRequestIds = removeRequestId(pending.pendingDepositRequestIds, result?.requestId);
+      pending.pendingDepositRequestIds = removeRequestId(pending.pendingDepositRequestIds, requestId);
       if (status === "succeeded") {
         this.updateStrategyAccountingOnAllocate(account, strategyId, asset, settledAssets || requestedAssets, {
           amountRaw: settledAssetsRaw ?? requestedAssetsRaw
@@ -576,7 +582,7 @@ export class AccountMutationService {
           asset,
           amount: requestedAssets,
           ...(requestedAssetsRaw !== undefined ? { amountRaw: requestedAssetsRaw } : {}),
-          requestId: result?.requestId,
+          requestId,
           failureCode: result?.strategyRequest?.failureCodeLabel ?? result?.failureCodeLabel
         });
       }
@@ -586,7 +592,7 @@ export class AccountMutationService {
         pending.pendingWithdrawalSharesRaw,
         requestedSharesRaw ?? settledSharesRaw
       );
-      pending.pendingWithdrawalRequestIds = removeRequestId(pending.pendingWithdrawalRequestIds, result?.requestId);
+      pending.pendingWithdrawalRequestIds = removeRequestId(pending.pendingWithdrawalRequestIds, requestId);
       if (status === "succeeded") {
         this.updateStrategyAccountingOnDeallocate(account, strategyId, asset, settledAssets, {
           assetsReturnedRaw: settledAssetsRaw
@@ -608,13 +614,14 @@ export class AccountMutationService {
             : settledSharesRaw !== undefined
               ? { requestedSharesRaw: settledSharesRaw }
               : {}),
-          requestId: result?.requestId,
+          requestId,
           failureCode: result?.strategyRequest?.failureCodeLabel ?? result?.failureCodeLabel
         });
       }
     }
 
-    pending.lastRequestId = result?.requestId;
+    pending.settledRequestIds = addRequestId(pending.settledRequestIds, requestId);
+    pending.lastRequestId = requestId;
     pending.lastStatus = status;
     pending.lastKind = kind;
     pending.updatedAt = new Date().toISOString();

--- a/mcp-server/src/core/agent-transfer.test.js
+++ b/mcp-server/src/core/agent-transfer.test.js
@@ -596,6 +596,43 @@ test("recordAsyncStrategySettlement updates accounting and clears pending state"
   assert.equal(updated.treasuryTimeline[0].principalAfterRaw, "6000001");
 });
 
+test("recordAsyncStrategySettlement is idempotent for duplicate settlement results", async () => {
+  const { service, accounts } = makeService();
+  const account = await service.getAccountSummary("0xAlice");
+  account.strategyPending["0xstrategy"] = {
+    asset: "DOT",
+    pendingDepositAssets: 6,
+    pendingDepositAssetsRaw: "6000000",
+    pendingDepositRequestIds: ["0xreq"],
+    pendingWithdrawalShares: 0
+  };
+  accounts.set("0xAlice", account);
+  const settlement = {
+    requestId: "0xreq",
+    strategyRequest: {
+      account: "0xAlice",
+      strategyId: "0xstrategy",
+      assetSymbol: "DOT",
+      kindLabel: "deposit",
+      statusLabel: "succeeded",
+      requestedAssets: 6,
+      requestedAssetsRaw: "6000000",
+      settledAssets: 6,
+      settledAssetsRaw: "6000000"
+    }
+  };
+
+  await service.recordAsyncStrategySettlement(settlement);
+  const replayed = await service.recordAsyncStrategySettlement(settlement);
+
+  assert.equal(replayed.strategyPending["0xstrategy"].pendingDepositAssets, 0);
+  assert.deepEqual(replayed.strategyPending["0xstrategy"].pendingDepositRequestIds, []);
+  assert.deepEqual(replayed.strategyPending["0xstrategy"].settledRequestIds, ["0xreq"]);
+  assert.equal(replayed.strategyAccounting["0xstrategy"].principal, 6);
+  assert.equal(replayed.strategyAccounting["0xstrategy"].principalRaw, "6000000");
+  assert.equal(replayed.treasuryTimeline.filter((event) => event.type === "allocate").length, 1);
+});
+
 test("recordAsyncStrategySettlement preserves raw asset accounting when withdrawals settle", async () => {
   const { service, accounts } = makeService();
   const account = await service.getAccountSummary("0xAlice");

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -1203,7 +1203,7 @@ export class PlatformService {
       throw new ValidationError("XCM request finalization requires the blockchain gateway.");
     }
     const finalized = await this.blockchainGateway.finalizeXcmRequest(requestId, outcome);
-    if (finalized?.strategyRequest?.account) {
+    if (finalized?.strategyRequest?.account && !finalized?.alreadySettled) {
       await this.accountMutationService.recordAsyncStrategySettlement(finalized);
     }
     return finalized;

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -1203,7 +1203,7 @@ export class PlatformService {
       throw new ValidationError("XCM request finalization requires the blockchain gateway.");
     }
     const finalized = await this.blockchainGateway.finalizeXcmRequest(requestId, outcome);
-    if (finalized?.strategyRequest?.account && !finalized?.alreadySettled) {
+    if (finalized?.strategyRequest?.account) {
       await this.accountMutationService.recordAsyncStrategySettlement(finalized);
     }
     return finalized;

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -1090,6 +1090,46 @@ test("finalizeXcmRequest records async treasury settlement when the request is s
   assert.equal(account.treasuryTimeline[0].type, "allocate");
 });
 
+test("finalizeXcmRequest skips local treasury settlement for already-settled replays", async () => {
+  const gateway = {
+    isEnabled: () => true,
+    getAccountSummary: async (wallet) => ({
+      wallet,
+      liquid: { DOT: 10 },
+      reserved: {},
+      strategyAllocated: {},
+      collateralLocked: {},
+      jobStakeLocked: {},
+      debtOutstanding: {}
+    }),
+    finalizeXcmRequest: async () => ({
+      requestId: "0xrequest",
+      alreadySettled: true,
+      strategyRequest: {
+        account: WALLET,
+        strategyId: "0xstrategy",
+        assetSymbol: "DOT",
+        kindLabel: "deposit",
+        statusLabel: "succeeded",
+        requestedAssets: 5,
+        settledAssets: 5
+      }
+    })
+  };
+  const service = makePlatformService(gateway);
+
+  const finalized = await service.finalizeXcmRequest("0xrequest", {
+    status: "succeeded",
+    settledAssets: 5,
+    settledShares: 5
+  });
+  const account = await service.getAccountSummary(WALLET);
+
+  assert.equal(finalized.alreadySettled, true);
+  assert.equal(account.strategyAccounting["0xstrategy"], undefined);
+  assert.equal(account.treasuryTimeline.length, 0);
+});
+
 test("getAdminStatus surfaces XCM observation relay status", async () => {
   const service = makePlatformService();
   service.xcmObservationRelay = {

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -1090,7 +1090,7 @@ test("finalizeXcmRequest records async treasury settlement when the request is s
   assert.equal(account.treasuryTimeline[0].type, "allocate");
 });
 
-test("finalizeXcmRequest skips local treasury settlement for already-settled replays", async () => {
+test("finalizeXcmRequest reconciles local treasury state for already-settled replays", async () => {
   const gateway = {
     isEnabled: () => true,
     getAccountSummary: async (wallet) => ({
@@ -1117,6 +1117,14 @@ test("finalizeXcmRequest skips local treasury settlement for already-settled rep
     })
   };
   const service = makePlatformService(gateway);
+  const pending = await service.getAccountSummary(WALLET);
+  pending.strategyPending["0xstrategy"] = {
+    asset: "DOT",
+    pendingDepositAssets: 5,
+    pendingDepositRequestIds: ["0xrequest"],
+    pendingWithdrawalShares: 0
+  };
+  service.accounts.set(WALLET, pending);
 
   const finalized = await service.finalizeXcmRequest("0xrequest", {
     status: "succeeded",
@@ -1126,8 +1134,20 @@ test("finalizeXcmRequest skips local treasury settlement for already-settled rep
   const account = await service.getAccountSummary(WALLET);
 
   assert.equal(finalized.alreadySettled, true);
-  assert.equal(account.strategyAccounting["0xstrategy"], undefined);
-  assert.equal(account.treasuryTimeline.length, 0);
+  assert.equal(account.strategyAccounting["0xstrategy"].principal, 5);
+  assert.equal(account.strategyPending["0xstrategy"].pendingDepositAssets, 0);
+  assert.deepEqual(account.strategyPending["0xstrategy"].settledRequestIds, ["0xrequest"]);
+  assert.equal(account.treasuryTimeline.filter((event) => event.type === "allocate").length, 1);
+
+  await service.finalizeXcmRequest("0xrequest", {
+    status: "succeeded",
+    settledAssets: 5,
+    settledShares: 5
+  });
+  const replayed = await service.getAccountSummary(WALLET);
+
+  assert.equal(replayed.strategyAccounting["0xstrategy"].principal, 5);
+  assert.equal(replayed.treasuryTimeline.filter((event) => event.type === "allocate").length, 1);
 });
 
 test("getAdminStatus surfaces XCM observation relay status", async () => {


### PR DESCRIPTION
## Summary
- skip strategy settlement transactions when the chain request is already settled with the same terminal outcome
- surface `alreadySettled` from the gateway and skip local treasury accounting for those replayed finalizations
- make local async strategy settlement accounting idempotent per request id

## Checks
- `node --test mcp-server/src/blockchain/gateway.test.js`
- `node --test mcp-server/src/core/platform-service.test.js`
- `node --test mcp-server/src/core/agent-transfer.test.js mcp-server/src/services/xcm-settlement-watcher.test.js`
- `npm --workspace mcp-server test`
- `git diff --check`

## Impact
- Affects: backend blockchain gateway and treasury accounting
- Frontend/indexer/contracts/public site: not touched
- Env/VPS changes: none