### PR TITLE
Require failure codes for XCM failed observations

### DIFF
--- a/mcp-server/src/services/xcm-settlement-watcher.js
+++ b/mcp-server/src/services/xcm-settlement-watcher.js
@@ -57,13 +57,14 @@ export class XcmSettlementWatcherService {
 
   async observeOutcome(requestId, outcome = {}) {
     const normalizedRequestId = this.requireRequestId(requestId);
+    const status = normalizeObservationStatus(outcome.status);
     const incoming = {
       requestId: normalizedRequestId,
-      status: normalizeObservationStatus(outcome.status),
+      status,
       settledAssets: normalizeObservationAmount(outcome.settledAssets, "settledAssets"),
       settledShares: normalizeObservationAmount(outcome.settledShares, "settledShares"),
       remoteRef: outcome.remoteRef,
-      failureCode: outcome.failureCode,
+      failureCode: normalizeObservationFailureCode(outcome.failureCode, status),
       source: typeof outcome.source === "string" && outcome.source.trim() ? outcome.source.trim() : "observer",
       observedAt: normalizeObservationObservedAt(outcome.observedAt),
       processed: false
@@ -261,6 +262,17 @@ function normalizeObservationAmount(value, label) {
     throw new ValidationError(`${label} must fit uint256.`);
   }
   return parsed.toString();
+}
+
+function normalizeObservationFailureCode(value, status) {
+  const failureCode = typeof value === "string" && value.trim() ? value.trim() : undefined;
+  if (status === "failed" && !failureCode) {
+    throw new ValidationError("XCM failed observations must include failureCode.");
+  }
+  if (value !== undefined && value !== null && value !== "" && typeof value !== "string") {
+    throw new ValidationError("failureCode must be a non-empty string when provided.");
+  }
+  return failureCode;
 }
 
 function normalizeObservationObservedAt(value) {

--- a/mcp-server/src/services/xcm-settlement-watcher.test.js
+++ b/mcp-server/src/services/xcm-settlement-watcher.test.js
@@ -268,6 +268,53 @@ test("observeOutcome rejects missing or non-terminal statuses before storing", a
   assert.equal(events.length, 0);
 });
 
+test("observeOutcome rejects failed observations without failureCode before storing", async () => {
+  const stateStore = new MemoryStateStore();
+  const eventBus = new EventBus();
+  const events = [];
+  eventBus.subscribe({ topics: ["xcm.outcome_observed"] }, (event) => events.push(event));
+  const watcher = new XcmSettlementWatcherService(
+    { finalizeXcmRequest: async () => ({}) },
+    stateStore,
+    eventBus,
+    { enabled: false }
+  );
+
+  await assert.rejects(
+    () => watcher.observeOutcome(REQUEST_ID, {
+      status: "failed"
+    }),
+    /failed observations must include failureCode/u
+  );
+  await assert.rejects(
+    () => watcher.observeOutcome(REQUEST_ID, {
+      status: "failed",
+      failureCode: "   "
+    }),
+    /failed observations must include failureCode/u
+  );
+
+  assert.equal(await stateStore.getXcmObservation(REQUEST_ID), undefined);
+  assert.equal(events.length, 0);
+});
+
+test("observeOutcome trims failed observation failureCode", async () => {
+  const stateStore = new MemoryStateStore();
+  const watcher = new XcmSettlementWatcherService(
+    { finalizeXcmRequest: async () => ({}) },
+    stateStore,
+    undefined,
+    { enabled: false }
+  );
+
+  const observation = await watcher.observeOutcome(REQUEST_ID, {
+    status: "failed",
+    failureCode: " XCM_FAILED "
+  });
+
+  assert.equal(observation.failureCode, "XCM_FAILED");
+});
+
 test("observeOutcome rejects invalid observedAt before storing", async () => {
   const stateStore = new MemoryStateStore();
   const watcher = new XcmSettlementWatcherService(


### PR DESCRIPTION
**Summary**
- Require direct failed XCM observations to include a non-empty string `failureCode` before state is written or events are emitted.
- Trim accepted observer failure codes so stored evidence matches the relay contract.
- Add watcher tests for missing, blank, and trimmed failure-code handling.

**Checks**
- `npm --workspace mcp-server test`
- `git diff --check`

**Impact**
- Backend only.
- Frontend/indexer/contracts/public site not touched.
- No environment or VPS secret changes required.