### PR TITLE
PR 4b.5b — HTTP refresh-cookie flow + SIWE issuance

### DIFF
--- a/mcp-server/src/auth/refresh-cookie.js
+++ b/mcp-server/src/auth/refresh-cookie.js
@@ -1,0 +1,139 @@
+/**
+ * HTTP-layer helpers for the refresh-token cookie flow.
+ *
+ * Phase 4b.5b per docs/PHASE_4B_KMS_JWT_PLAN.md §8. Kept in a small
+ * dedicated module so the parsing + Set-Cookie construction can be
+ * exercised in isolation and reused by /auth/verify (initial mint),
+ * /auth/refresh (rotation), and /auth/logout (clear).
+ *
+ * Cookie attributes are fixed per the design doc:
+ *   HttpOnly; Secure; SameSite=Strict; Path=/auth/refresh
+ *
+ * Domain is intentionally NOT set → host-only cookie on api.averray.com
+ * (resolved §12 of the design doc).
+ */
+
+import {
+  REFRESH_COOKIE_NAME,
+  DEFAULT_REFRESH_TTL_SECONDS,
+} from "./refresh.js";
+
+/**
+ * Parse a single cookie value out of a Cookie header. Tolerates extra
+ * spaces and other cookies in the same header.
+ *
+ * @param {string} cookieHeader  The raw value of `request.headers.cookie`.
+ * @param {string} name  Cookie name to look up.
+ * @returns {string | null}  The cookie's value, or null if not present.
+ */
+export function parseCookie(cookieHeader, name) {
+  if (typeof cookieHeader !== "string" || cookieHeader.length === 0) {
+    return null;
+  }
+  if (typeof name !== "string" || name.length === 0) {
+    return null;
+  }
+  const target = `${name}=`;
+  // Split on `;` because a Cookie header concatenates multiple cookies
+  // with `; ` (RFC 6265 §5.4). Trim whitespace per part.
+  for (const part of cookieHeader.split(";")) {
+    const trimmed = part.trim();
+    if (trimmed.startsWith(target)) {
+      const value = trimmed.slice(target.length);
+      // Reject empty values; reject obviously truncated/malformed inputs.
+      if (value.length === 0) return null;
+      // Cookie values may be quoted per RFC 6265 §4.1.1; strip surrounding
+      // double-quotes if present.
+      if (value.length >= 2 && value.startsWith("\"") && value.endsWith("\"")) {
+        return value.slice(1, -1);
+      }
+      return value;
+    }
+  }
+  return null;
+}
+
+/**
+ * Build a Set-Cookie header value for issuing or rotating a refresh
+ * token. The cookie is host-only (no Domain), HttpOnly, Secure,
+ * SameSite=Strict, and scoped to Path=/auth/refresh.
+ *
+ * @param {string} rawToken  The base64url-encoded refresh token.
+ * @param {object} [opts]
+ * @param {number} [opts.maxAgeSeconds]  Cookie Max-Age (in seconds).
+ *   Defaults to DEFAULT_REFRESH_TTL_SECONDS (30 days).
+ * @returns {string}  Value to put in the `Set-Cookie` response header.
+ */
+export function buildSetCookieHeader(rawToken, { maxAgeSeconds = DEFAULT_REFRESH_TTL_SECONDS } = {}) {
+  if (typeof rawToken !== "string" || rawToken.length === 0) {
+    throw new Error("buildSetCookieHeader: rawToken must be a non-empty string");
+  }
+  // Disallow CR/LF in token (defense-in-depth; CSPRNG output is base64url
+  // so this should never trigger, but a corrupted token from elsewhere
+  // could enable header injection).
+  if (/[\r\n]/.test(rawToken)) {
+    throw new Error("buildSetCookieHeader: rawToken contains illegal CRLF");
+  }
+  const parts = [
+    `${REFRESH_COOKIE_NAME}=${rawToken}`,
+    "HttpOnly",
+    "Secure",
+    "SameSite=Strict",
+    "Path=/auth/refresh",
+    `Max-Age=${Math.max(1, Math.floor(maxAgeSeconds))}`,
+  ];
+  return parts.join("; ");
+}
+
+/**
+ * Build a Set-Cookie header value that immediately clears the refresh
+ * cookie. Used by /auth/logout.
+ *
+ * @returns {string}
+ */
+export function buildClearCookieHeader() {
+  return [
+    `${REFRESH_COOKIE_NAME}=`,
+    "HttpOnly",
+    "Secure",
+    "SameSite=Strict",
+    "Path=/auth/refresh",
+    "Max-Age=0",
+  ].join("; ");
+}
+
+/**
+ * Adapter that exposes the state-store's `getRefreshRecord` /
+ * `upsertRefreshRecord` methods as the generic `{ get, set }` interface
+ * that `refresh.js` expects.
+ *
+ * Strips the `auth:refresh:` namespace prefix the refresh module
+ * embeds in its keys (the state-store backend handles its own
+ * namespacing).
+ *
+ * @param {object} stateStore  The state-store instance.
+ * @returns {{ get: (key: string) => Promise<object|null>, set: (key: string, value: object, ttlSeconds: number) => Promise<void> }}
+ */
+export function makeRefreshStoreAdapter(stateStore) {
+  if (!stateStore || typeof stateStore.getRefreshRecord !== "function") {
+    throw new Error("makeRefreshStoreAdapter: stateStore missing getRefreshRecord");
+  }
+  if (typeof stateStore.upsertRefreshRecord !== "function") {
+    throw new Error("makeRefreshStoreAdapter: stateStore missing upsertRefreshRecord");
+  }
+  const PREFIX = "auth:refresh:";
+  function hashFromKey(key) {
+    if (typeof key !== "string" || !key.startsWith(PREFIX)) {
+      throw new Error(`makeRefreshStoreAdapter: expected key to start with ${PREFIX}, got ${key}`);
+    }
+    return key.slice(PREFIX.length);
+  }
+  return {
+    async get(key) {
+      return stateStore.getRefreshRecord(hashFromKey(key));
+    },
+    async set(key, value, ttlSeconds) {
+      return stateStore.upsertRefreshRecord(hashFromKey(key), value, ttlSeconds);
+    },
+  };
+}

--- a/mcp-server/src/auth/refresh-cookie.test.js
+++ b/mcp-server/src/auth/refresh-cookie.test.js
@@ -1,0 +1,158 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildClearCookieHeader,
+  buildSetCookieHeader,
+  makeRefreshStoreAdapter,
+  parseCookie,
+} from "./refresh-cookie.js";
+
+import {
+  REFRESH_COOKIE_NAME,
+  consumeRefreshToken,
+  issueRefreshToken,
+  rotateRefreshToken,
+} from "./refresh.js";
+
+import { MemoryStateStore } from "../core/state-store.js";
+
+test("parseCookie: finds the named cookie in a single-cookie header", () => {
+  assert.equal(parseCookie("refresh_token=abc123", "refresh_token"), "abc123");
+});
+
+test("parseCookie: finds the named cookie among many", () => {
+  const header = "session=xyz; refresh_token=abc123; csrf=def";
+  assert.equal(parseCookie(header, "refresh_token"), "abc123");
+});
+
+test("parseCookie: tolerates spaces around separators", () => {
+  assert.equal(parseCookie("foo=1;  refresh_token=abc;  bar=2", "refresh_token"), "abc");
+});
+
+test("parseCookie: strips surrounding double-quotes per RFC 6265", () => {
+  assert.equal(parseCookie('refresh_token="abc123"', "refresh_token"), "abc123");
+});
+
+test("parseCookie: returns null for missing cookie / empty header / non-string", () => {
+  assert.equal(parseCookie("", "refresh_token"), null);
+  assert.equal(parseCookie("foo=bar", "refresh_token"), null);
+  assert.equal(parseCookie(null, "refresh_token"), null);
+  assert.equal(parseCookie(undefined, "refresh_token"), null);
+  assert.equal(parseCookie("refresh_token=", "refresh_token"), null);
+});
+
+test("parseCookie: returns null when name is empty/non-string", () => {
+  assert.equal(parseCookie("refresh_token=abc", ""), null);
+  assert.equal(parseCookie("refresh_token=abc", null), null);
+});
+
+test("parseCookie: does not match cookies whose name STARTS with the target", () => {
+  // "refresh_token_other=..." should not match a lookup for "refresh_token"
+  assert.equal(parseCookie("refresh_token_other=abc", "refresh_token"), null);
+});
+
+test("buildSetCookieHeader: includes all required attributes", () => {
+  const header = buildSetCookieHeader("abc123");
+  assert.ok(header.startsWith(`${REFRESH_COOKIE_NAME}=abc123`), "starts with name=value");
+  assert.ok(header.includes("HttpOnly"), "HttpOnly attribute present");
+  assert.ok(header.includes("Secure"), "Secure attribute present");
+  assert.ok(header.includes("SameSite=Strict"), "SameSite=Strict attribute present");
+  assert.ok(header.includes("Path=/auth/refresh"), "Path=/auth/refresh present");
+  assert.ok(/Max-Age=\d+/.test(header), "Max-Age present");
+  assert.ok(!header.includes("Domain="), "Domain MUST NOT be set (host-only cookie)");
+});
+
+test("buildSetCookieHeader: honors custom maxAgeSeconds", () => {
+  const header = buildSetCookieHeader("xyz", { maxAgeSeconds: 600 });
+  assert.ok(header.includes("Max-Age=600"));
+});
+
+test("buildSetCookieHeader: rejects empty / non-string token", () => {
+  assert.throws(() => buildSetCookieHeader(""), /non-empty string/);
+  assert.throws(() => buildSetCookieHeader(null), /non-empty string/);
+});
+
+test("buildSetCookieHeader: rejects CR/LF in token (defense against header injection)", () => {
+  assert.throws(() => buildSetCookieHeader("abc\r\nSet-Cookie: evil=1"), /illegal CRLF/);
+  assert.throws(() => buildSetCookieHeader("abc\nfoo"), /illegal CRLF/);
+});
+
+test("buildClearCookieHeader: empties the cookie with Max-Age=0 and same attributes", () => {
+  const header = buildClearCookieHeader();
+  assert.ok(header.startsWith(`${REFRESH_COOKIE_NAME}=;`) || header.startsWith(`${REFRESH_COOKIE_NAME}=`));
+  assert.ok(header.includes("Max-Age=0"));
+  assert.ok(header.includes("HttpOnly"));
+  assert.ok(header.includes("Secure"));
+  assert.ok(header.includes("SameSite=Strict"));
+  assert.ok(header.includes("Path=/auth/refresh"));
+});
+
+test("makeRefreshStoreAdapter: round-trips an issue → consume → rotate cycle via MemoryStateStore", async () => {
+  const stateStore = new MemoryStateStore();
+  const adapter = makeRefreshStoreAdapter(stateStore);
+
+  // Issue
+  const issued = await issueRefreshToken({
+    wallet: "0xaaaa",
+    role: "admin",
+    store: adapter,
+  });
+  assert.ok(issued.rawToken);
+  assert.equal(issued.record.wallet, "0xaaaa");
+
+  // Confirm the state-store has it under the un-prefixed hash key
+  const direct = await stateStore.getRefreshRecord(issued.hash);
+  assert.ok(direct, "state-store should hold the record under the hash key");
+  assert.equal(direct.wallet, "0xaaaa");
+
+  // Consume
+  const consumed = await consumeRefreshToken({ rawToken: issued.rawToken, store: adapter });
+  assert.equal(consumed.record.wallet, "0xaaaa");
+
+  // Rotate
+  const rotated = await rotateRefreshToken({
+    oldRecord: consumed.record,
+    oldHash: consumed.hash,
+    store: adapter,
+  });
+  assert.notEqual(rotated.rawToken, issued.rawToken);
+  assert.deepEqual(rotated.record.ancestorHashes, [issued.hash]);
+
+  // The new record exists in the state-store
+  const newDirect = await stateStore.getRefreshRecord(rotated.hash);
+  assert.ok(newDirect);
+});
+
+test("makeRefreshStoreAdapter: replay detection works end-to-end through the adapter", async () => {
+  const stateStore = new MemoryStateStore();
+  const adapter = makeRefreshStoreAdapter(stateStore);
+
+  const t1 = await issueRefreshToken({ wallet: "0xaaaa", role: "admin", store: adapter });
+  const c1 = await consumeRefreshToken({ rawToken: t1.rawToken, store: adapter });
+  await rotateRefreshToken({ oldRecord: c1.record, oldHash: t1.hash, store: adapter });
+
+  // Replay t1 — should detect, throw refresh_replay_detected, and revoke chain.
+  await assert.rejects(
+    () => consumeRefreshToken({ rawToken: t1.rawToken, store: adapter }),
+    (err) => err.code === "refresh_replay_detected",
+  );
+
+  // Both records are revoked in the underlying state-store.
+  const t1Record = await stateStore.getRefreshRecord(t1.hash);
+  assert.ok(t1Record?.revokedAt, "t1 should be revoked in state-store");
+});
+
+test("makeRefreshStoreAdapter: rejects state-stores missing the new methods", () => {
+  assert.throws(() => makeRefreshStoreAdapter({}), /getRefreshRecord/);
+  assert.throws(
+    () => makeRefreshStoreAdapter({ getRefreshRecord: () => null }),
+    /upsertRefreshRecord/,
+  );
+});
+
+test("makeRefreshStoreAdapter: rejects keys not in the auth:refresh: namespace", async () => {
+  const stateStore = new MemoryStateStore();
+  const adapter = makeRefreshStoreAdapter(stateStore);
+  await assert.rejects(() => adapter.get("foo:bar"), /expected key to start with auth:refresh:/);
+});

--- a/mcp-server/src/core/state-store.js
+++ b/mcp-server/src/core/state-store.js
@@ -397,6 +397,32 @@ export class MemoryStateStore {
       mode: "ephemeral"
     };
   }
+
+  // ── Phase 4b.5b: refresh-token persistence ─────────────────────────────
+  // Keyed by SHA-256(rawToken) hex. TTL = refresh-TTL + forensic grace
+  // (see mcp-server/src/auth/refresh.js for the design).
+  _evictExpiredRefreshRecords() {
+    if (!this.refreshRecords) return;
+    const now = Date.now();
+    for (const [hash, entry] of this.refreshRecords) {
+      if (entry.expiresAtMs <= now) this.refreshRecords.delete(hash);
+    }
+  }
+
+  async getRefreshRecord(hash) {
+    if (!this.refreshRecords) return null;
+    this._evictExpiredRefreshRecords();
+    const entry = this.refreshRecords.get(hash);
+    return entry ? entry.value : null;
+  }
+
+  async upsertRefreshRecord(hash, record, ttlSeconds) {
+    if (!this.refreshRecords) this.refreshRecords = new Map();
+    this.refreshRecords.set(hash, {
+      value: record,
+      expiresAtMs: Date.now() + ttlSeconds * 1000,
+    });
+  }
 }
 
 export class RedisStateStore {
@@ -816,6 +842,29 @@ export class RedisStateStore {
     await this.connect();
     const reply = await this.client.get(this.key("revoked", jti));
     return reply !== null && reply !== undefined;
+  }
+
+  // ── Phase 4b.5b: refresh-token persistence ─────────────────────────────
+  // Stores RefreshRecord JSON under `auth:refresh:<hash>` with explicit TTL.
+  // Keyspace + payload shape defined in mcp-server/src/auth/refresh.js.
+  async getRefreshRecord(hash) {
+    await this.connect();
+    const raw = await this.client.get(this.key("auth", "refresh", hash));
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+
+  async upsertRefreshRecord(hash, record, ttlSeconds) {
+    await this.connect();
+    await this.client.set(
+      this.key("auth", "refresh", hash),
+      JSON.stringify(record),
+      { EX: Math.max(1, Math.ceil(ttlSeconds)) },
+    );
   }
 
   async healthCheck() {

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -14,6 +14,21 @@ import {
 import { hashCanonicalContent } from "../../core/canonical-content.js";
 import { buildSiweMessage, verifySiweMessage } from "../../auth/siwe.js";
 import { signToken } from "../../auth/jwt.js";
+import {
+  REFRESH_COOKIE_NAME,
+  RefreshError,
+  consumeRefreshToken,
+  hashRefreshToken,
+  issueRefreshToken,
+  revokeChain,
+  rotateRefreshToken,
+} from "../../auth/refresh.js";
+import {
+  buildClearCookieHeader,
+  buildSetCookieHeader,
+  makeRefreshStoreAdapter,
+  parseCookie,
+} from "../../auth/refresh-cookie.js";
 import { extractClientKey } from "../../auth/rate-limit.js";
 import { hasRole } from "../../auth/config.js";
 import { resolveRequestId } from "../../core/logger.js";
@@ -2549,14 +2564,48 @@ const server = createServer(async (request, response) => {
         { secret: authConfig.signingSecret, expiresInSeconds: authConfig.tokenTtlSeconds }
       );
 
-      return respond(response, 200, {
-        token,
-        wallet: verified.recoveredAddress,
-        roles,
-        capabilities: authCapabilities.resolveCapabilities({ roles }),
-        expiresAt: new Date(claims.exp * 1000).toISOString(),
-        tokenType: "Bearer"
-      });
+      // Phase 4b.5b — also mint an opaque refresh token and return it
+      // as an HttpOnly cookie. The state-store exposes refresh-record
+      // CRUD via `makeRefreshStoreAdapter`. If the store backend doesn't
+      // implement the refresh methods (e.g. an older test harness), we
+      // skip cookie issuance silently and fall back to access-token-only
+      // behavior so the SIWE path itself doesn't fail.
+      let setCookieHeader = null;
+      try {
+        if (typeof stateStore?.getRefreshRecord === "function" &&
+            typeof stateStore?.upsertRefreshRecord === "function") {
+          const refreshAdapter = makeRefreshStoreAdapter(stateStore);
+          const refreshIssue = await issueRefreshToken({
+            wallet: verified.recoveredAddress,
+            role: roles[0] ?? "user",
+            store: refreshAdapter,
+          });
+          setCookieHeader = buildSetCookieHeader(refreshIssue.rawToken);
+        }
+      } catch (err) {
+        // Refresh-cookie issuance is best-effort here — if it fails for
+        // any reason, log and continue. The client just won't get a
+        // refresh cookie and will have to re-SIWE when the access token
+        // expires (the legacy behavior, fully backward compatible).
+        logger?.warn?.(
+          { err, wallet: verified.recoveredAddress },
+          "auth_verify.refresh_issue_failed"
+        );
+      }
+
+      return respond(
+        response,
+        200,
+        {
+          token,
+          wallet: verified.recoveredAddress,
+          roles,
+          capabilities: authCapabilities.resolveCapabilities({ roles }),
+          expiresAt: new Date(claims.exp * 1000).toISOString(),
+          tokenType: "Bearer"
+        },
+        setCookieHeader ? { "Set-Cookie": setCookieHeader } : {}
+      );
     }
 
     if (request.method === "GET" && pathname === "/auth/session") {
@@ -2582,14 +2631,149 @@ const server = createServer(async (request, response) => {
         const ttlSeconds = Math.max(1, exp - Math.floor(Date.now() / 1000));
         await stateStore.revokeToken?.(jti, ttlSeconds);
       }
-      return respond(response, 200, {
-        status: "logged_out",
-        wallet: auth.wallet,
-        jti
-      });
+
+      // Phase 4b.5b — best-effort: if the caller also carries a refresh
+      // cookie, revoke the entire refresh chain and clear the cookie. We
+      // never fail logout because of a refresh-token error; the access-
+      // token revocation above is the source of truth for "logged out".
+      const refreshCookie = parseCookie(request.headers?.cookie ?? null, REFRESH_COOKIE_NAME);
+      if (refreshCookie &&
+          typeof stateStore?.getRefreshRecord === "function" &&
+          typeof stateStore?.upsertRefreshRecord === "function") {
+        try {
+          const refreshAdapter = makeRefreshStoreAdapter(stateStore);
+          // We can't use consumeRefreshToken here because it throws on
+          // already-revoked / expired records. We hash-and-revoke directly.
+          const hash = hashRefreshToken(refreshCookie);
+          await revokeChain({
+            hash,
+            store: refreshAdapter,
+            reason: "logout",
+          });
+        } catch (err) {
+          logger?.warn?.({ err, wallet: auth.wallet }, "auth_logout.refresh_chain_revoke_failed");
+        }
+      }
+
+      return respond(
+        response,
+        200,
+        {
+          status: "logged_out",
+          wallet: auth.wallet,
+          jti
+        },
+        // Always clear the refresh cookie on logout, even if the caller
+        // didn't send one — defense-in-depth for stale browser state.
+        { "Set-Cookie": buildClearCookieHeader() }
+      );
     }
 
     if (request.method === "POST" && pathname === "/auth/refresh") {
+      // Phase 4b.5b — dual-mode dispatcher.
+      //
+      // NEW FLOW (preferred): an HttpOnly `refresh_token` cookie carries
+      // an opaque token. We consume it, re-resolve roles, rotate the
+      // refresh record, mint a fresh short-lived access token, and emit
+      // a new Set-Cookie. Replay of a previously-rotated cookie revokes
+      // the entire chain (see auth/refresh.js strict-replay semantics).
+      //
+      // LEGACY FLOW (fallback): an Authorization Bearer header carries
+      // a still-valid wallet JWT. We revoke its jti and mint a fresh
+      // one with the same sub. Maintained for backward compat with the
+      // operator app prior to the cookie cutover.
+      const refreshCookie = parseCookie(request.headers?.cookie ?? null, REFRESH_COOKIE_NAME);
+
+      if (refreshCookie &&
+          typeof stateStore?.getRefreshRecord === "function" &&
+          typeof stateStore?.upsertRefreshRecord === "function") {
+        // ── NEW FLOW: opaque refresh cookie ─────────────────────────
+        await enforceLimit("auth_refresh", clientIp(request), rateLimitConfig.authRefresh);
+        if (!authConfig.signingSecret) {
+          throw new AuthenticationError(
+            "Auth not configured — set AUTH_JWT_SECRETS to issue tokens.",
+            "auth_not_configured"
+          );
+        }
+
+        const refreshAdapter = makeRefreshStoreAdapter(stateStore);
+
+        let consumed;
+        try {
+          consumed = await consumeRefreshToken({ rawToken: refreshCookie, store: refreshAdapter });
+        } catch (err) {
+          // On any refresh-token failure, clear the cookie so the client
+          // doesn't keep retrying with a known-bad token. Map the refresh
+          // error to an AuthenticationError with a stable error code.
+          response.setHeader?.("Set-Cookie", buildClearCookieHeader());
+          if (err instanceof RefreshError) {
+            const code = err.code === "refresh_replay_detected"
+              ? "refresh_replay_detected"
+              : err.code === "refresh_expired"
+                ? "refresh_expired"
+                : err.code === "refresh_revoked"
+                  ? "refresh_revoked"
+                  : "invalid_refresh_token";
+            logger?.warn?.(
+              { code, hashPrefix: err.details?.hashPrefix },
+              "auth_refresh.cookie_rejected"
+            );
+            throw new AuthenticationError(err.message, code);
+          }
+          throw err;
+        }
+
+        // Role-recheck hook: re-resolve roles at refresh time so a wallet
+        // that lost its admin/verifier role since issue-time cannot keep
+        // refreshing into a privileged session.
+        const roles = authConfig.resolveRoles?.(consumed.record.wallet) ?? [];
+        if (roles.length === 0) {
+          // Wallet lost all roles since issue — revoke the chain and
+          // reject. The client will be forced back to SIWE.
+          await revokeChain({
+            hash: consumed.hash,
+            store: refreshAdapter,
+            reason: "no_roles_at_refresh",
+          });
+          response.setHeader?.("Set-Cookie", buildClearCookieHeader());
+          logger?.warn?.(
+            { wallet: consumed.record.wallet },
+            "auth_refresh.no_roles_chain_revoked"
+          );
+          throw new AuthenticationError(
+            "Wallet has no roles at refresh time.",
+            "no_roles_at_refresh"
+          );
+        }
+
+        const primaryRole = roles[0];
+        const rotated = await rotateRefreshToken({
+          oldRecord: { ...consumed.record, role: primaryRole },
+          oldHash: consumed.hash,
+          store: refreshAdapter,
+        });
+
+        const { token, claims } = signToken(
+          { sub: consumed.record.wallet, roles },
+          { secret: authConfig.signingSecret, expiresInSeconds: authConfig.tokenTtlSeconds }
+        );
+
+        return respond(
+          response,
+          200,
+          {
+            token,
+            wallet: consumed.record.wallet,
+            roles,
+            capabilities: authCapabilities.resolveCapabilities({ roles }),
+            expiresAt: new Date(claims.exp * 1000).toISOString(),
+            tokenType: "Bearer"
+          },
+          { "Set-Cookie": buildSetCookieHeader(rotated.rawToken) }
+        );
+      }
+
+      // ── LEGACY FLOW: access-token rotation via Authorization header ─
       // Rotate the caller's wallet JWT: revoke the old `jti`, mint a new one
       // with the same `sub` + `roles`, fresh `iat` / `exp`. The operator app
       // avoids re-SIWE every AUTH_TOKEN_TTL_SECONDS by calling this when it


### PR DESCRIPTION
## Summary

Wires the opaque refresh-token core service (PR 4b.5a, #410) into the HTTP surface — Phase 4b.5b of `docs/PHASE_4B_KMS_JWT_PLAN.md` §8.

- **`/auth/verify`** (SIWE): on successful sign-in, mints a refresh token alongside the access token and returns it as an HttpOnly cookie (`HttpOnly; Secure; SameSite=Strict; Path=/auth/refresh; Max-Age=2592000`).
- **`/auth/refresh`**: dual-mode dispatcher
  - **New flow** — `refresh_token` cookie present → `consumeRefreshToken` → role-recheck via `authConfig.resolveRoles` → `rotateRefreshToken` → fresh access token + new cookie. Strict-replay: re-presenting an already-rotated cookie revokes the entire chain.
  - **Legacy flow** — no cookie → unchanged Authorization-Bearer access-token rotation.
  - On any refresh failure (replay / expired / revoked / malformed): cookie cleared, stable error code returned.
  - **Role-recheck hook** — a wallet stripped of all roles since issue-time revokes the chain and forces re-SIWE.
- **`/auth/logout`**: best-effort revoke the refresh chain + always clear the cookie. Access-token jti revocation remains the source of truth.
- **`state-store`** (`MemoryStateStore` + `RedisStateStore`): new `getRefreshRecord` / `upsertRefreshRecord` methods. Memory: lazy-evict expired entries on read. Redis: `EX` TTL under `auth:refresh:<hash>`.
- **`refresh-cookie.js`** (new): `parseCookie` (RFC 6265 + quoted-value handling), `buildSetCookieHeader` (rejects CRLF in token), `buildClearCookieHeader`, `makeRefreshStoreAdapter` (bridges state-store's namespaced refresh methods to refresh.js's generic `{ get, set }` interface).

Fully backward compatible: if the configured state-store doesn't expose the new methods, cookie issuance is silently skipped and the legacy access-token-only path remains in force.

## Test plan
- [x] `node --test mcp-server/src/auth/refresh.test.js mcp-server/src/auth/refresh-cookie.test.js` — 38/38 pass
- [x] `node --test mcp-server/src/core/state-store.test.js` — 13/13 pass
- [x] All other auth/* tests — 124/124 pass (excluding `jwt-dispatcher` and `kms-jwt-signer` which need local `jose` + `@noble/curves` installs unrelated to this PR)
- [x] `node --check mcp-server/src/protocols/http/server.js` — syntax OK
- [ ] CI green
- [ ] Smoke: post-deploy SIWE returns Set-Cookie; legacy /auth/refresh still rotates Bearer tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)