### PR TITLE
Document health capability contract

### DIFF
--- a/discovery/.well-known/agent-tools.json
+++ b/discovery/.well-known/agent-tools.json
@@ -378,7 +378,7 @@
   "publicEndpoints": [
     {
       "path": "/health",
-      "description": "Liveness + component health (state store, blockchain gateway, gas sponsor)."
+      "description": "Liveness plus serviceHealth/capabilityHealth for state store, blockchain, treasury mutations, XCM observer, indexer, and gas sponsor."
     },
     {
       "path": "/metrics",

--- a/discovery/agent-tools.json
+++ b/discovery/agent-tools.json
@@ -378,7 +378,7 @@
   "publicEndpoints": [
     {
       "path": "/health",
-      "description": "Liveness + component health (state store, blockchain gateway, gas sponsor)."
+      "description": "Liveness plus serviceHealth/capabilityHealth for state store, blockchain, treasury mutations, XCM observer, indexer, and gas sponsor."
     },
     {
       "path": "/metrics",

--- a/docs/AUDIT_REMEDIATION.md
+++ b/docs/AUDIT_REMEDIATION.md
@@ -431,6 +431,7 @@ The remediation work should be split into narrow branches so multiple agents can
 **Suggested branch:** `codex/p1-health-capability-truth`
 **Can start:** After Package A exposes or confirms the gateway/mutation mode shape. A design/test stub can start earlier, but final route patch should wait for Package A.
 **Blocks:** Operator warnings in Package E.
+**Backend status:** Implemented on `origin/main` in Package B; `codex/p1-health-capability-truth` adds the documented `/health` contract and avoids a duplicate gateway probe. The wider `P1.1b` finding remains open until Package E surfaces capability warnings in the operator dashboard and external monitoring.
 
 **Owned finding:** `P1.1b`
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -41,7 +41,7 @@
         ],
         "operationId": "getHealth",
         "summary": "Return backend health",
-        "description": "Reports state-store, blockchain, and gas-sponsor health for the current deployment.",
+        "description": "Reports API service liveness separately from live capability health for the current deployment.",
         "responses": {
           "200": {
             "description": "All core components are healthy.",
@@ -54,6 +54,33 @@
                   "ok": {
                     "value": {
                       "status": "ok",
+                      "serviceHealth": {
+                        "ok": true,
+                        "components": {
+                          "api": {
+                            "ok": true,
+                            "mode": "running"
+                          },
+                          "stateStore": {
+                            "ok": true,
+                            "backend": "redis",
+                            "mode": "durable"
+                          },
+                          "auth": {
+                            "ok": true,
+                            "mode": "strict",
+                            "domain": "api.averray.com",
+                            "chainId": 420420417
+                          }
+                        }
+                      },
+                      "capabilityHealth": {
+                        "blockchain": "enabled",
+                        "treasuryMutations": "available",
+                        "xcmObserver": "staged",
+                        "indexer": "unavailable",
+                        "gasSponsor": "disabled"
+                      },
                       "auth": {
                         "mode": "strict",
                         "domain": "api.averray.com",
@@ -798,6 +825,8 @@
         "type": "object",
         "required": [
           "status",
+          "serviceHealth",
+          "capabilityHealth",
           "auth",
           "components"
         ],
@@ -808,6 +837,73 @@
               "ok",
               "degraded"
             ]
+          },
+          "serviceHealth": {
+            "type": "object",
+            "required": [
+              "ok",
+              "components"
+            ],
+            "properties": {
+              "ok": {
+                "type": "boolean"
+              },
+              "components": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          },
+          "capabilityHealth": {
+            "type": "object",
+            "required": [
+              "blockchain",
+              "treasuryMutations",
+              "xcmObserver",
+              "indexer",
+              "gasSponsor"
+            ],
+            "properties": {
+              "blockchain": {
+                "type": "string",
+                "enum": [
+                  "enabled",
+                  "disabled",
+                  "unhealthy"
+                ]
+              },
+              "treasuryMutations": {
+                "type": "string",
+                "enum": [
+                  "available",
+                  "unavailable",
+                  "degraded"
+                ]
+              },
+              "xcmObserver": {
+                "type": "string",
+                "enum": [
+                  "live",
+                  "staged",
+                  "unavailable"
+                ]
+              },
+              "indexer": {
+                "type": "string",
+                "enum": [
+                  "synced",
+                  "lagging",
+                  "unavailable"
+                ]
+              },
+              "gasSponsor": {
+                "type": "string",
+                "enum": [
+                  "enabled",
+                  "disabled"
+                ]
+              }
+            }
           },
           "auth": {
             "type": "object",

--- a/mcp-server/src/core/discovery-manifest.js
+++ b/mcp-server/src/core/discovery-manifest.js
@@ -6,7 +6,7 @@ const DEFAULT_PROFILE_URL = "https://app.averray.com/agents/<wallet>";
 const DEFAULT_OPERATOR_APP_URL = "https://app.averray.com";
 
 const DISCOVERY_PUBLIC_ENDPOINTS = [
-  { path: "/health", description: "Liveness + component health (state store, blockchain gateway, gas sponsor)." },
+  { path: "/health", description: "Liveness plus serviceHealth/capabilityHealth for state store, blockchain, treasury mutations, XCM observer, indexer, and gas sponsor." },
   { path: "/metrics", description: "Prometheus text-format metrics. Optionally bearer-gated via METRICS_BEARER_TOKEN." },
   { path: "/onboarding", description: "Canonical platform capabilities + tool list." },
   { path: "/jobs", description: "Public job catalog (no auth)." },

--- a/mcp-server/src/core/mutation-backend.js
+++ b/mcp-server/src/core/mutation-backend.js
@@ -28,7 +28,12 @@ export function describeMutationBackendStartup(config, gateway) {
   };
 }
 
-export async function getMutationBackendStatus({ gateway, config = loadMutationBackendConfig(), route = undefined } = {}) {
+export async function getMutationBackendStatus({
+  gateway,
+  config = loadMutationBackendConfig(),
+  route = undefined,
+  gatewayStatus = undefined
+} = {}) {
   if (!config.requiresChain) {
     return {
       ok: true,
@@ -49,16 +54,16 @@ export async function getMutationBackendStatus({ gateway, config = loadMutationB
     });
   }
 
-  let health;
+  let health = gatewayStatus;
   try {
-    health = typeof gateway.healthCheck === "function"
+    health = health ?? (typeof gateway.healthCheck === "function"
       ? await gateway.healthCheck()
       : {
           ok: true,
           backend: "blockchain",
           enabled: true,
           mode: "enabled_without_healthcheck"
-        };
+        });
   } catch (error) {
     return unavailable(config, route, error?.message ?? "blockchain gateway health check failed", {
       ok: false,

--- a/mcp-server/src/core/mutation-backend.test.js
+++ b/mcp-server/src/core/mutation-backend.test.js
@@ -89,6 +89,31 @@ test("mutation backend rejects chain mode when health check fails", async () => 
   assert.equal(status.gatewayStatus.error, "rpc unavailable");
 });
 
+test("mutation backend can reuse a precomputed gateway health response", async () => {
+  let probed = false;
+  const status = await getMutationBackendStatus({
+    config: loadMutationBackendConfig({ MUTATION_BACKEND: "required" }),
+    gateway: {
+      isEnabled: () => true,
+      healthCheck: async () => {
+        probed = true;
+        return { ok: false, enabled: true, backend: "blockchain", error: "should not be called" };
+      }
+    },
+    route: "/health",
+    gatewayStatus: {
+      ok: true,
+      enabled: true,
+      backend: "blockchain",
+      blockNumber: 123
+    }
+  });
+
+  assert.equal(probed, false);
+  assert.equal(status.ok, true);
+  assert.equal(status.gatewayStatus.blockNumber, 123);
+});
+
 test("mutation backend allows required mode when gateway health is ok", async () => {
   const status = await assertMutationBackendAvailable({
     config: loadMutationBackendConfig({ MUTATION_BACKEND: "required" }),

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -1785,13 +1785,18 @@ const server = createServer(async (request, response) => {
       // unavailable) still returns 200/"ok" at the liveness layer and
       // surfaces the capability state via `capabilityHealth`. Legacy
       // top-level `components` is preserved for existing consumers.
-      const [storeHealth, chainHealth, gasHealth, xcmWatcherStatus, mutationBackendStatus] = await Promise.all([
+      const [storeHealth, chainHealth, gasHealth, xcmWatcherStatus] = await Promise.all([
         stateStore.healthCheck?.() ?? { ok: true, backend: stateStore.constructor.name },
         gateway?.healthCheck?.() ?? { ok: false, backend: "blockchain", enabled: false, mode: "disabled" },
         pimlicoClient?.healthCheck?.() ?? { ok: true, backend: "pimlico", enabled: false, mode: "disabled" },
-        service?.xcmSettlementWatcher?.getStatus?.()?.catch?.(() => undefined) ?? undefined,
-        getMutationBackendStatus({ gateway, config: mutationBackendConfig }).catch(() => ({ ok: false }))
+        service?.xcmSettlementWatcher?.getStatus?.()?.catch?.(() => undefined) ?? undefined
       ]);
+      const mutationBackendStatus = await getMutationBackendStatus({
+        gateway,
+        config: mutationBackendConfig,
+        route: "/health",
+        gatewayStatus: chainHealth
+      }).catch(() => ({ ok: false, route: "/health" }));
 
       const serviceHealth = resolveServiceHealth({ stateStoreHealth: storeHealth, authConfig });
       const capabilityHealth = resolveCapabilityHealth({

--- a/site/.well-known/agent-tools.json
+++ b/site/.well-known/agent-tools.json
@@ -378,7 +378,7 @@
   "publicEndpoints": [
     {
       "path": "/health",
-      "description": "Liveness + component health (state store, blockchain gateway, gas sponsor)."
+      "description": "Liveness plus serviceHealth/capabilityHealth for state store, blockchain, treasury mutations, XCM observer, indexer, and gas sponsor."
     },
     {
       "path": "/metrics",


### PR DESCRIPTION
## Summary
- document the new /health serviceHealth/capabilityHealth contract in OpenAPI and the discovery manifest
- reuse the already-fetched blockchain gateway health when computing mutation backend status for /health, avoiding a duplicate chain probe
- sync the static discovery manifests generated from buildDiscoveryManifest()
- leave the remediation tracker clear that Package B is implemented on origin/main and the remaining P1.1b work is the operator/dashboard warning slice

## Checks
- node --test mcp-server/src/core/mutation-backend.test.js mcp-server/src/core/health-capability.test.js
- node --test mcp-server/src/jobs/ingest-openapi-specs.test.js
- npm --workspace mcp-server test
- RUN_HTTP_SMOKE=1 node --test mcp-server/src/protocols/http/server.smoke.test.js
- npm run check:discovery-manifest
- git diff --check

## Impact
- Backend: yes, /health avoids duplicate gateway health probing
- API docs/discovery: yes, /health contract documented and manifests synced
- Frontend: no source changes; next frontend slice should consume capabilityHealth for warnings
- Indexer: no
- Caddy: no
- Contracts: no
- Public site: only synced .well-known discovery manifest, required by CI
- Env/VPS secrets: no changes