### PR TITLE
Package G — durable PolicyService + extracted built-in seed (P2.5b)

### DIFF
--- a/mcp-server/src/core/builtin-policies.js
+++ b/mcp-server/src/core/builtin-policies.js
@@ -1,0 +1,181 @@
+/**
+ * Built-in policy seed data — Package G (P2.5b).
+ *
+ * Previously these policies + their helper constructors lived inline in
+ * `mcp-server/src/protocols/http/server.js` as route-local constants.
+ * Package G's close output requires that built-in policies become seed
+ * data loaded into a service at startup, so the seed set lives here
+ * and `PolicyService` consumes it.
+ *
+ * Operator-proposed policies are NOT in this file — they land in
+ * `PolicyService.cache` and are mirrored out to the state-store. See
+ * `policy-service.js`.
+ *
+ * Re-exported helpers (`OPERATOR_SIGNERS`, `signerApproval`,
+ * `makePolicy`) are public because `buildPolicyProposal` in `server.js`
+ * still uses them to shape an HTTP-payload-driven proposal record. They
+ * are intentionally pure functions of their inputs; the only impure
+ * piece is the env-driven default addresses in `OPERATOR_SIGNERS`.
+ */
+
+export const OPERATOR_SIGNERS = {
+  fd2e: {
+    role: "primary operator",
+    addr: process.env.DEFAULT_POSTER_ADDRESS ?? "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+    initials: "FD",
+    hue: 148
+  },
+  "9a13": {
+    role: "co-signer",
+    addr: process.env.DEFAULT_VERIFIER_ADDRESS ?? "0x9A13C20000000000000000000000000000000CB2",
+    initials: "9A",
+    hue: 214
+  },
+  "3e42": {
+    role: "verifier",
+    addr: process.env.DEFAULT_VERIFIER_ADDRESS ?? "0x3E420000000000000000000000000000000008D1",
+    initials: "V2",
+    hue: 196
+  }
+};
+
+export function signerApproval(key, state = "signed", at = "2026-04-24 14:08 UTC") {
+  const signer = OPERATOR_SIGNERS[key] ?? OPERATOR_SIGNERS.fd2e;
+  return {
+    key,
+    ...signer,
+    state,
+    ...(state === "signed" ? { at, sig: `0x${key}...signed` } : {})
+  };
+}
+
+export function makePolicy({
+  id,
+  tag,
+  scope,
+  scopeLabel,
+  severity,
+  state,
+  revision,
+  handler,
+  gates,
+  rooms,
+  activeSince,
+  lastChange,
+  rule,
+  attachedJobs = [],
+  signerKeys = ["fd2e", "9a13", "3e42"],
+  signersReq = 2
+}) {
+  return {
+    id,
+    tag,
+    scope,
+    scopeLabel,
+    severity,
+    signersReq,
+    signersTotal: signerKeys.length,
+    signerKeys,
+    activeSince,
+    lastChange,
+    state,
+    revision,
+    rooms,
+    handler,
+    gates,
+    attachedJobs,
+    rule,
+    approvals: signerKeys.map((key, index) => signerApproval(key, index < signersReq ? "signed" : "pending")),
+    history: [
+      {
+        rev: revision,
+        author: lastChange.author,
+        at: String(lastChange.at ?? "").slice(0, 10),
+        summary: lastChange.text,
+        active: true
+      }
+    ]
+  };
+}
+
+export const BUILTIN_POLICIES = [
+  makePolicy({
+    id: "p-claim-deps-sec-only",
+    tag: "claim/deps-sec-only@v4",
+    scope: "claim",
+    scopeLabel: "Claim",
+    severity: "gating",
+    state: "Active",
+    revision: 4,
+    activeSince: "2026-03-11",
+    handler: "verifier/deps_sec_only.ts",
+    gates: "Auto-claim on dependency bumps where only security advisories changed.",
+    rooms: ["runs/coding/*", "runs/deps-bump/*"],
+    attachedJobs: [{ id: "starter-coding-001", title: "Starter coding verification", at: "live" }],
+    lastChange: {
+      text: "Raised max-cvss ceiling to 7.5 for staged dependency work.",
+      author: "fd2e",
+      at: "2026-04-24 14:08 UTC"
+    },
+    rule: {
+      v4: JSON.stringify({
+        kind: "claim.auto",
+        scope: "deps-bump",
+        require: { advisory_type: "security", semver_delta: ["patch", "minor"], max_cvss: 7.5 },
+        deny: { lockfile_drift: true, transitive_majors: true },
+        receipt: { co_sign: ["verifier_handler"], attach_cvss_trail: true }
+      }, null, 2)
+    }
+  }),
+  makePolicy({
+    id: "p-settle-receipt-before-payout",
+    tag: "settle/receipt-before-payout@v1",
+    scope: "settle",
+    scopeLabel: "Settle",
+    severity: "hard-stop",
+    state: "Active",
+    revision: 1,
+    activeSince: "2026-04-17",
+    handler: "settlement/receipt_gate.ts",
+    gates: "Release stake and reward only after verifier receipt exists.",
+    rooms: ["sessions/*", "treasury/settlement/*"],
+    lastChange: {
+      text: "Initial settlement gate for operator launch.",
+      author: "9a13",
+      at: "2026-04-24 14:08 UTC"
+    },
+    rule: {
+      v1: JSON.stringify({
+        kind: "settle.gate",
+        require: { receipt_signed: true, verifier_result: "approved" },
+        deny: { open_dispute: true }
+      }, null, 2)
+    }
+  }),
+  makePolicy({
+    id: "p-dispute-human-review",
+    tag: "dispute/human-review-window@v1",
+    scope: "co-sign",
+    scopeLabel: "Co-sign",
+    severity: "gating",
+    state: "Active",
+    revision: 1,
+    activeSince: "2026-04-17",
+    handler: "disputes/human_review.ts",
+    gates: "Disputed sessions hold stake until a verifier verdict is recorded.",
+    rooms: ["disputes/*"],
+    lastChange: {
+      text: "Set 72 hour review window before stake release.",
+      author: "3e42",
+      at: "2026-04-24 14:08 UTC"
+    },
+    rule: {
+      v1: JSON.stringify({
+        kind: "dispute.review",
+        window_hours: 72,
+        verdicts: ["upheld", "dismissed", "split"],
+        release_requires: ["verdict", "operator"]
+      }, null, 2)
+    }
+  })
+];

--- a/mcp-server/src/core/policy-service.js
+++ b/mcp-server/src/core/policy-service.js
@@ -1,0 +1,152 @@
+/**
+ * PolicyService — Package G (P2.5b) close.
+ *
+ * Built-in policies + operator-proposed policies previously lived
+ * inline in `mcp-server/src/protocols/http/server.js` as a route-local
+ * `BUILTIN_POLICIES` array plus a process-local `POLICY_PROPOSALS`
+ * Map. Proposals disappeared on every restart — fine while only one
+ * operator was proposing, but the audit board flags this as the
+ * blocking gap before external operators or posters arrive.
+ *
+ * This service mirrors the write-through pattern Package C established
+ * for `AccountOverlayStore`:
+ *
+ *   - Built-in policies are read-only seed data loaded from
+ *     `builtin-policies.js` at construction time.
+ *   - Proposals live in an in-memory cache for fast reads and a
+ *     state-store backing for durability.
+ *   - Every `propose()` updates the cache synchronously and enqueues
+ *     a per-tag persist against the state-store.
+ *   - `hydrate()` runs once at bootstrap and reloads persisted
+ *     proposals into the cache before the HTTP server accepts
+ *     requests.
+ *
+ * Lookups (`listAll`, `findByTagOrId`) combine seed + cache; the seed
+ * set appears first so the route response matches the legacy
+ * `[...BUILTIN_POLICIES, ...POLICY_PROPOSALS.values()]` ordering.
+ *
+ * Multi-process consistency notes are the same as
+ * `AccountOverlayStore`: two backend replicas pointing at the same
+ * Redis state-store both hydrate at boot but their caches diverge as
+ * soon as either takes writes. Single-process v1 deploys are
+ * unaffected.
+ */
+
+export class PolicyService {
+  /**
+   * @param {object} options
+   * @param {object} [options.stateStore] — implements
+   *   `getPolicyProposal`, `upsertPolicyProposal`,
+   *   `listPolicyProposalTags`. Optional; when missing, the service
+   *   degrades to an in-memory store (the pre-Package-G behavior).
+   * @param {object[]} [options.seedPolicies] — built-in policy array,
+   *   defaults to `[]`. Pass `BUILTIN_POLICIES` from `builtin-policies.js`
+   *   in production.
+   * @param {object} [options.logger] — pino-style logger; persist
+   *   failures land at `warn` level. Defaults to console.
+   */
+  constructor({ stateStore = undefined, seedPolicies = [], logger = console } = {}) {
+    this.stateStore = stateStore;
+    this.seedPolicies = Array.isArray(seedPolicies) ? seedPolicies : [];
+    this.logger = logger;
+    /** @type {Map<string, object>} tag → proposal (operator-created) */
+    this.cache = new Map();
+    /** @type {Map<string, Promise<void>>} per-tag persist serialization */
+    this.persistQueues = new Map();
+  }
+
+  /**
+   * Return every policy known to the service: built-in seeds first,
+   * then proposals. Mirrors the legacy
+   * `[...BUILTIN_POLICIES, ...POLICY_PROPOSALS.values()]` order.
+   */
+  listAll() {
+    return [...this.seedPolicies, ...this.cache.values()];
+  }
+
+  /**
+   * Find a policy by `tag` (e.g. `claim/deps-sec-only@v4`) or `id`
+   * (e.g. `p-claim-deps-sec-only`). Matches the legacy `findPolicy`.
+   */
+  findByTagOrId(value) {
+    if (!value) return undefined;
+    return this.listAll().find(
+      (policy) => policy.tag === value || policy.id === value
+    );
+  }
+
+  /**
+   * Return only the operator-proposed policies (no built-ins).
+   * Useful for admin status surfaces that want to render the
+   * pending/awaiting-approval set.
+   */
+  listProposals() {
+    return Array.from(this.cache.values());
+  }
+
+  /**
+   * Add or replace a proposal. The cache is updated synchronously;
+   * the durable persist is enqueued per-tag. Returns the proposal so
+   * route handlers can keep their existing return-the-proposal shape.
+   */
+  propose(proposal) {
+    if (!proposal || typeof proposal !== "object") {
+      throw new Error("PolicyService.propose requires a proposal object");
+    }
+    const tag = proposal.tag;
+    if (!tag) {
+      throw new Error("PolicyService.propose requires proposal.tag");
+    }
+    this.cache.set(tag, proposal);
+    this._enqueuePersist(tag, proposal);
+    return proposal;
+  }
+
+  /**
+   * Load every persisted proposal from the state-store into the
+   * in-memory cache. Idempotent. No-op when the state-store is
+   * missing or doesn't expose the policy-proposal methods.
+   */
+  async hydrate() {
+    if (
+      !this.stateStore?.listPolicyProposalTags
+      || !this.stateStore?.getPolicyProposal
+    ) {
+      return { hydrated: 0, skipped: 0, reason: "state-store unavailable" };
+    }
+    let hydrated = 0;
+    const tags = await this.stateStore.listPolicyProposalTags();
+    for (const tag of tags) {
+      const proposal = await this.stateStore.getPolicyProposal(tag);
+      if (proposal) {
+        this.cache.set(tag, proposal);
+        hydrated += 1;
+      }
+    }
+    return { hydrated, skipped: tags.length - hydrated };
+  }
+
+  /**
+   * Wait for every pending persist to drain. Used by tests so the
+   * state-store contents can be asserted right after a `.propose()`.
+   */
+  async flush() {
+    await Promise.all(Array.from(this.persistQueues.values()));
+  }
+
+  _enqueuePersist(tag, proposal) {
+    if (!this.stateStore?.upsertPolicyProposal) {
+      return;
+    }
+    const previous = this.persistQueues.get(tag) ?? Promise.resolve();
+    const next = previous.then(() =>
+      this.stateStore.upsertPolicyProposal(tag, proposal).catch((error) => {
+        this.logger?.warn?.(
+          { tag, error: error?.message ?? String(error) },
+          "policy.persist_failed"
+        );
+      })
+    );
+    this.persistQueues.set(tag, next);
+  }
+}

--- a/mcp-server/src/core/policy-service.test.js
+++ b/mcp-server/src/core/policy-service.test.js
@@ -1,0 +1,176 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { PolicyService } from "./policy-service.js";
+import { BUILTIN_POLICIES } from "./builtin-policies.js";
+import { MemoryStateStore } from "./state-store.js";
+
+function silentLogger() {
+  return { warn() {}, info() {}, error() {}, debug() {} };
+}
+
+const SAMPLE_PROPOSAL = {
+  id: "p-proposed-abcdef01",
+  tag: "operator/sample-proposal@v1",
+  scope: "claim",
+  scopeLabel: "Claim",
+  severity: "gating",
+  state: "Pending",
+  revision: 1,
+  signersReq: 2,
+  signersTotal: 3,
+  signerKeys: ["fd2e", "9a13", "3e42"],
+  activeSince: null,
+  lastChange: { text: "Proposed by smoke test", author: "fd2e", at: "2026-05-18 12:00:00 UTC" },
+  rule: { v1: "{}" },
+  history: []
+};
+
+test("PolicyService — listAll returns built-in seeds before proposals", () => {
+  const service = new PolicyService({ seedPolicies: BUILTIN_POLICIES });
+  service.propose({ ...SAMPLE_PROPOSAL });
+  const all = service.listAll();
+  // Every seed policy must still come first.
+  assert.equal(all.length, BUILTIN_POLICIES.length + 1);
+  for (let i = 0; i < BUILTIN_POLICIES.length; i += 1) {
+    assert.equal(all[i].tag, BUILTIN_POLICIES[i].tag);
+  }
+  assert.equal(all[all.length - 1].tag, SAMPLE_PROPOSAL.tag);
+});
+
+test("PolicyService — findByTagOrId matches both the tag and the id field", () => {
+  const service = new PolicyService({ seedPolicies: BUILTIN_POLICIES });
+  service.propose({ ...SAMPLE_PROPOSAL });
+
+  // built-in lookup by id
+  const builtinById = service.findByTagOrId("p-claim-deps-sec-only");
+  assert.ok(builtinById);
+  assert.equal(builtinById.tag, "claim/deps-sec-only@v4");
+
+  // built-in lookup by tag
+  const builtinByTag = service.findByTagOrId("settle/receipt-before-payout@v1");
+  assert.ok(builtinByTag);
+  assert.equal(builtinByTag.id, "p-settle-receipt-before-payout");
+
+  // proposal lookup by tag
+  const proposalByTag = service.findByTagOrId(SAMPLE_PROPOSAL.tag);
+  assert.equal(proposalByTag?.id, SAMPLE_PROPOSAL.id);
+
+  // proposal lookup by id
+  const proposalById = service.findByTagOrId(SAMPLE_PROPOSAL.id);
+  assert.equal(proposalById?.tag, SAMPLE_PROPOSAL.tag);
+
+  // unknown
+  assert.equal(service.findByTagOrId("does-not-exist"), undefined);
+  assert.equal(service.findByTagOrId(undefined), undefined);
+});
+
+test("PolicyService — every propose() mirrors out to the state-store", async () => {
+  const stateStore = new MemoryStateStore();
+  const service = new PolicyService({ stateStore, seedPolicies: [] });
+  service.propose({ ...SAMPLE_PROPOSAL });
+  service.propose({ ...SAMPLE_PROPOSAL, tag: "operator/second@v1", id: "p-second" });
+  await service.flush();
+
+  const tags = await stateStore.listPolicyProposalTags();
+  assert.deepEqual(tags.sort(), ["operator/sample-proposal@v1", "operator/second@v1"]);
+  const fetched = await stateStore.getPolicyProposal(SAMPLE_PROPOSAL.tag);
+  assert.equal(fetched.scope, "claim");
+});
+
+test("PolicyService — sequential proposes for the same tag persist in order", async () => {
+  const stateStore = new MemoryStateStore();
+  const service = new PolicyService({ stateStore, seedPolicies: [] });
+  service.propose({ ...SAMPLE_PROPOSAL, revision: 1 });
+  service.propose({ ...SAMPLE_PROPOSAL, revision: 2 });
+  service.propose({ ...SAMPLE_PROPOSAL, revision: 3 });
+  await service.flush();
+  const fetched = await stateStore.getPolicyProposal(SAMPLE_PROPOSAL.tag);
+  // The final persist wins, not an arbitrary mid-state.
+  assert.equal(fetched.revision, 3);
+});
+
+test("PolicyService — hydrate loads every persisted proposal into the cache", async () => {
+  const stateStore = new MemoryStateStore();
+  await stateStore.upsertPolicyProposal("operator/persisted-a@v1", {
+    ...SAMPLE_PROPOSAL,
+    tag: "operator/persisted-a@v1"
+  });
+  await stateStore.upsertPolicyProposal("operator/persisted-b@v1", {
+    ...SAMPLE_PROPOSAL,
+    tag: "operator/persisted-b@v1"
+  });
+
+  const service = new PolicyService({ stateStore, seedPolicies: [] });
+  assert.equal(service.findByTagOrId("operator/persisted-a@v1"), undefined);
+
+  const result = await service.hydrate();
+  assert.equal(result.hydrated, 2);
+  assert.equal(result.skipped, 0);
+
+  const all = service.listAll();
+  const tags = all.map((p) => p.tag).sort();
+  assert.deepEqual(tags, ["operator/persisted-a@v1", "operator/persisted-b@v1"]);
+});
+
+test("PolicyService — degrades to in-memory when state-store is missing", async () => {
+  const service = new PolicyService({ seedPolicies: [] });
+  service.propose({ ...SAMPLE_PROPOSAL });
+  await service.flush(); // must not throw
+  const result = await service.hydrate();
+  assert.equal(result.hydrated, 0);
+  assert.match(result.reason, /state-store unavailable/u);
+  assert.equal(service.findByTagOrId(SAMPLE_PROPOSAL.tag).id, SAMPLE_PROPOSAL.id);
+});
+
+test("PolicyService — persist failure is logged but does not crash the caller", async () => {
+  const stateStore = {
+    upsertPolicyProposal: async () => {
+      throw new Error("redis_unavailable");
+    }
+  };
+  const captured = [];
+  const logger = {
+    warn: (payload, message) => captured.push({ payload, message }),
+    info() {},
+    error() {},
+    debug() {}
+  };
+  const service = new PolicyService({ stateStore, seedPolicies: [], logger });
+  service.propose({ ...SAMPLE_PROPOSAL });
+  await service.flush();
+  assert.equal(captured.length, 1);
+  assert.equal(captured[0].message, "policy.persist_failed");
+  assert.equal(captured[0].payload.tag, SAMPLE_PROPOSAL.tag);
+  // Cache still has the value even though persist failed.
+  assert.equal(service.findByTagOrId(SAMPLE_PROPOSAL.tag).id, SAMPLE_PROPOSAL.id);
+});
+
+test("PolicyService — restart simulation: propose, drop the service, rebuild from state-store, proposal survives", async () => {
+  // This is the audit-board close-output integration check for Package G:
+  // "Integration test: propose a policy, restart the server, assert the
+  // proposal is still visible." Same shape as the AccountOverlayStore
+  // restart simulation from Package C.
+  const stateStore = new MemoryStateStore();
+  const before = new PolicyService({ stateStore, seedPolicies: BUILTIN_POLICIES, logger: silentLogger() });
+
+  before.propose({
+    ...SAMPLE_PROPOSAL,
+    tag: "operator/restart-proof@v1",
+    id: "p-restart-proof",
+    lastChange: { text: "Persists across restart", author: "fd2e", at: "2026-05-18 12:00:00 UTC" }
+  });
+  await before.flush();
+
+  // Simulated restart: discard `before`, build a fresh service sharing
+  // the same state-store, hydrate.
+  const after = new PolicyService({ stateStore, seedPolicies: BUILTIN_POLICIES, logger: silentLogger() });
+  await after.hydrate();
+
+  // Built-in policies must still be present (seed survives).
+  assert.ok(after.findByTagOrId("claim/deps-sec-only@v4"));
+  // Proposal must be present (persisted to state-store and reloaded).
+  const proposal = after.findByTagOrId("operator/restart-proof@v1");
+  assert.ok(proposal, "operator-proposed policy must survive restart");
+  assert.equal(proposal.id, "p-restart-proof");
+});

--- a/mcp-server/src/core/state-store.js
+++ b/mcp-server/src/core/state-store.js
@@ -52,6 +52,30 @@ export class MemoryStateStore {
     this.capabilityGrants = new Map();
     this.eventLog = [];
     this.accountOverlays = new Map();
+    this.policyProposals = new Map();
+  }
+
+  // ── policy proposals (Package G) ──────────────────────────────────
+  //
+  // Backs the PolicyService write-through cache. Built-in policies are
+  // seed data loaded from builtin-policies.js; only operator-proposed
+  // policies land here. Mirrors the account-overlay storage shape:
+  // async API + deep-clone on the way in and out so callers cannot
+  // mutate the internal Map.
+
+  async getPolicyProposal(tag) {
+    if (!tag) return undefined;
+    const stored = this.policyProposals.get(String(tag));
+    return stored ? JSON.parse(JSON.stringify(stored)) : undefined;
+  }
+
+  async upsertPolicyProposal(tag, proposal) {
+    if (!tag) return;
+    this.policyProposals.set(String(tag), JSON.parse(JSON.stringify(proposal ?? {})));
+  }
+
+  async listPolicyProposalTags() {
+    return Array.from(this.policyProposals.keys());
   }
 
   // ── account overlays (Package C Phase 2) ───────────────────────────
@@ -458,6 +482,32 @@ export class RedisStateStore {
   async listAccountOverlayWallets() {
     await this.connect();
     return await this.client.hKeys(this.key("account-overlay", "all"));
+  }
+
+  // ── policy proposals (Package G) ──────────────────────────────────
+  // Mirrors the account-overlay shape: single hash
+  // `<namespace>:policy-proposal` keyed by tag.
+
+  async getPolicyProposal(tag) {
+    if (!tag) return undefined;
+    await this.connect();
+    const raw = await this.client.hGet(this.key("policy-proposal", "all"), String(tag));
+    return raw ? JSON.parse(raw) : undefined;
+  }
+
+  async upsertPolicyProposal(tag, proposal) {
+    if (!tag) return;
+    await this.connect();
+    await this.client.hSet(
+      this.key("policy-proposal", "all"),
+      String(tag),
+      JSON.stringify(proposal ?? {})
+    );
+  }
+
+  async listPolicyProposalTags() {
+    await this.connect();
+    return await this.client.hKeys(this.key("policy-proposal", "all"));
   }
 
   async getSession(sessionId) {

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -86,9 +86,11 @@ import {
 import { ingestStandardsSpecs, parseSpecs as parseStandardsSpecs } from "../../jobs/ingest-standards-specs.js";
 import { ingestWikipediaMaintenance, parseCategories } from "../../jobs/ingest-wikipedia-maintenance.js";
 import { buildPublicJobsResponse } from "./jobs-response.js";
+import { makePolicy } from "../../core/builtin-policies.js";
 
 const {
   platformService: service,
+  policyService,
   verifierService,
   stateStore,
   contentRecoveryLog,
@@ -565,176 +567,21 @@ function compactObject(value) {
   );
 }
 
-const OPERATOR_SIGNERS = {
-  fd2e: {
-    role: "primary operator",
-    addr: process.env.DEFAULT_POSTER_ADDRESS ?? "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
-    initials: "FD",
-    hue: 148
-  },
-  "9a13": {
-    role: "co-signer",
-    addr: process.env.DEFAULT_VERIFIER_ADDRESS ?? "0x9A13C20000000000000000000000000000000CB2",
-    initials: "9A",
-    hue: 214
-  },
-  "3e42": {
-    role: "verifier",
-    addr: process.env.DEFAULT_VERIFIER_ADDRESS ?? "0x3E420000000000000000000000000000000008D1",
-    initials: "V2",
-    hue: 196
-  }
-};
-
-const POLICY_PROPOSALS = new Map();
-
-function signerApproval(key, state = "signed", at = "2026-04-24 14:08 UTC") {
-  const signer = OPERATOR_SIGNERS[key] ?? OPERATOR_SIGNERS.fd2e;
-  return {
-    key,
-    ...signer,
-    state,
-    ...(state === "signed" ? { at, sig: `0x${key}...signed` } : {})
-  };
-}
-
-function makePolicy({
-  id,
-  tag,
-  scope,
-  scopeLabel,
-  severity,
-  state,
-  revision,
-  handler,
-  gates,
-  rooms,
-  activeSince,
-  lastChange,
-  rule,
-  attachedJobs = [],
-  signerKeys = ["fd2e", "9a13", "3e42"],
-  signersReq = 2
-}) {
-  return {
-    id,
-    tag,
-    scope,
-    scopeLabel,
-    severity,
-    signersReq,
-    signersTotal: signerKeys.length,
-    signerKeys,
-    activeSince,
-    lastChange,
-    state,
-    revision,
-    rooms,
-    handler,
-    gates,
-    attachedJobs,
-    rule,
-    approvals: signerKeys.map((key, index) => signerApproval(key, index < signersReq ? "signed" : "pending")),
-    history: [
-      {
-        rev: revision,
-        author: lastChange.author,
-        at: String(lastChange.at ?? "").slice(0, 10),
-        summary: lastChange.text,
-        active: true
-      }
-    ]
-  };
-}
-
-const BUILTIN_POLICIES = [
-  makePolicy({
-    id: "p-claim-deps-sec-only",
-    tag: "claim/deps-sec-only@v4",
-    scope: "claim",
-    scopeLabel: "Claim",
-    severity: "gating",
-    state: "Active",
-    revision: 4,
-    activeSince: "2026-03-11",
-    handler: "verifier/deps_sec_only.ts",
-    gates: "Auto-claim on dependency bumps where only security advisories changed.",
-    rooms: ["runs/coding/*", "runs/deps-bump/*"],
-    attachedJobs: [{ id: "starter-coding-001", title: "Starter coding verification", at: "live" }],
-    lastChange: {
-      text: "Raised max-cvss ceiling to 7.5 for staged dependency work.",
-      author: "fd2e",
-      at: "2026-04-24 14:08 UTC"
-    },
-    rule: {
-      v4: JSON.stringify({
-        kind: "claim.auto",
-        scope: "deps-bump",
-        require: { advisory_type: "security", semver_delta: ["patch", "minor"], max_cvss: 7.5 },
-        deny: { lockfile_drift: true, transitive_majors: true },
-        receipt: { co_sign: ["verifier_handler"], attach_cvss_trail: true }
-      }, null, 2)
-    }
-  }),
-  makePolicy({
-    id: "p-settle-receipt-before-payout",
-    tag: "settle/receipt-before-payout@v1",
-    scope: "settle",
-    scopeLabel: "Settle",
-    severity: "hard-stop",
-    state: "Active",
-    revision: 1,
-    activeSince: "2026-04-17",
-    handler: "settlement/receipt_gate.ts",
-    gates: "Release stake and reward only after verifier receipt exists.",
-    rooms: ["sessions/*", "treasury/settlement/*"],
-    lastChange: {
-      text: "Initial settlement gate for operator launch.",
-      author: "9a13",
-      at: "2026-04-24 14:08 UTC"
-    },
-    rule: {
-      v1: JSON.stringify({
-        kind: "settle.gate",
-        require: { receipt_signed: true, verifier_result: "approved" },
-        deny: { open_dispute: true }
-      }, null, 2)
-    }
-  }),
-  makePolicy({
-    id: "p-dispute-human-review",
-    tag: "dispute/human-review-window@v1",
-    scope: "co-sign",
-    scopeLabel: "Co-sign",
-    severity: "gating",
-    state: "Active",
-    revision: 1,
-    activeSince: "2026-04-17",
-    handler: "disputes/human_review.ts",
-    gates: "Disputed sessions hold stake until a verifier verdict is recorded.",
-    rooms: ["disputes/*"],
-    lastChange: {
-      text: "Set 72 hour review window before stake release.",
-      author: "3e42",
-      at: "2026-04-24 14:08 UTC"
-    },
-    rule: {
-      v1: JSON.stringify({
-        kind: "dispute.review",
-        window_hours: 72,
-        verdicts: ["upheld", "dismissed", "split"],
-        release_requires: ["verdict", "operator"]
-      }, null, 2)
-    }
-  })
-];
+// Package G (P2.5b) — policy state is now owned by `policyService`.
+// `OPERATOR_SIGNERS`, `signerApproval`, `makePolicy`, and the
+// `BUILTIN_POLICIES` seed array moved to
+// `mcp-server/src/core/builtin-policies.js`; operator proposals live
+// in the durable `PolicyService` store. Two thin wrappers below
+// preserve the legacy `listPolicies()` / `findPolicy()` call sites in
+// the rest of this file without each call having to know about the
+// service object.
 
 function listPolicies() {
-  return [...BUILTIN_POLICIES, ...POLICY_PROPOSALS.values()];
+  return policyService.listAll();
 }
 
 function findPolicy(tag) {
-  return listPolicies().find((policy) => policy.tag === tag || policy.id === tag);
+  return policyService.findByTagOrId(tag);
 }
 
 function buildPolicyProposal(payload, auth) {
@@ -2215,8 +2062,10 @@ const server = createServer(async (request, response) => {
       const auth = await authMiddleware(request, url, { requireRole: "admin" });
       const payload = await readJsonBody(request);
       const proposal = buildPolicyProposal(payload, auth);
-      POLICY_PROPOSALS.set(proposal.tag, proposal);
-      await stateStore.upsertMutationReceipt?.("policy_proposal", proposal.tag, proposal);
+      // Package G — PolicyService.propose updates the cache
+      // synchronously and enqueues a write-through persist against the
+      // state-store, so a server restart no longer loses the proposal.
+      policyService.propose(proposal);
       eventBus?.publish({
         id: `policy-proposal-${proposal.id}-${Date.now()}`,
         topic: "policy.proposed",

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -86,7 +86,7 @@ import {
 import { ingestStandardsSpecs, parseSpecs as parseStandardsSpecs } from "../../jobs/ingest-standards-specs.js";
 import { ingestWikipediaMaintenance, parseCategories } from "../../jobs/ingest-wikipedia-maintenance.js";
 import { buildPublicJobsResponse } from "./jobs-response.js";
-import { makePolicy } from "../../core/builtin-policies.js";
+import { OPERATOR_SIGNERS, makePolicy } from "../../core/builtin-policies.js";
 
 const {
   platformService: service,

--- a/mcp-server/src/services/bootstrap.js
+++ b/mcp-server/src/services/bootstrap.js
@@ -1,6 +1,8 @@
 import { PlatformService } from "../core/platform-service.js";
 import { createStateStore } from "../core/state-store.js";
 import { AccountOverlayStore } from "../core/account-overlay-store.js";
+import { PolicyService } from "../core/policy-service.js";
+import { BUILTIN_POLICIES } from "../core/builtin-policies.js";
 import { BlockchainGateway } from "../blockchain/gateway.js";
 import { VerifierService } from "./verifier-service.js";
 import { loadLocalEnv } from "./env-loader.js";
@@ -189,6 +191,13 @@ export async function createPlatformRuntime() {
   // demo fixture.
   const overlayHydration = await accounts.hydrate();
   logger.info?.(overlayHydration, "account-overlay.hydrate");
+  const policyService = initStep("init-policy-service", logger, () =>
+    new PolicyService({ stateStore, seedPolicies: BUILTIN_POLICIES, logger })
+  );
+  // Hydrate operator-proposed policies before any /policies route is
+  // exposed. Built-in policies are seed data and don't need hydration.
+  const policyHydration = await policyService.hydrate();
+  logger.info?.(policyHydration, "policy.hydrate");
   const platformService = initStep(
     "init-platform-service",
     logger,
@@ -324,6 +333,7 @@ export async function createPlatformRuntime() {
   }
   return {
     platformService,
+    policyService,
     verifierService,
     gateway,
     mutationBackendConfig,


### PR DESCRIPTION
## Summary

Owns Package G on `docs/AUDIT_REMEDIATION.md`. Closes finding **P2.5b**: built-in policies and operator proposals previously lived inline in `mcp-server/src/protocols/http/server.js` as a route-local `BUILTIN_POLICIES` array plus a process-local `POLICY_PROPOSALS` Map. Proposals disappeared on every restart — fine while only Pascal was proposing, but the audit board flags this as the blocking gap before external operators or posters arrive.

Mirrors the write-through pattern Package C established for `AccountOverlayStore` so the architecture is consistent across durability packages.

## Close-criteria status

| Criterion | Status |
|---|---|
| `PolicyService` backed by Redis or Postgres | ✅ Redis-backed in prod via state-store; Memory in dev |
| Built-in policies become seed data at startup, not route-local constants | ✅ `BUILTIN_POLICIES` moved to `core/builtin-policies.js`, passed to the service as `seedPolicies` |
| Policy proposals persist across restarts | ✅ write-through to state-store; bootstrap awaits `policyService.hydrate()` before the HTTP server accepts requests |
| Admin/audit endpoint surfaces every proposal including pending ones | ✅ existing `/admin/status` / `/audit` / `/alerts` consumers call the legacy `listPolicies()` wrapper which now reads from the service — no contract change for those routes |
| Integration test: propose, restart, assert proposal survives | ✅ `PolicyService — restart simulation: propose, drop the service, rebuild from state-store, proposal survives` |

## What changed

| File | Change |
|---|---|
| `mcp-server/src/core/builtin-policies.js` (new, 181 lines) | Holds `OPERATOR_SIGNERS`, `signerApproval`, `makePolicy`, and the three-entry `BUILTIN_POLICIES` seed array. Pure module — no state, no side effects beyond reading two env vars at module-load time |
| `mcp-server/src/core/policy-service.js` (new, 152 lines) | `PolicyService` class with `listAll`, `findByTagOrId`, `listProposals`, `propose`, `hydrate`, `flush`, per-tag persist serialization, and silent fall-through when the state-store is missing |
| `mcp-server/src/core/policy-service.test.js` (new, 176 lines) | 8 unit tests including the close-output restart simulation |
| `mcp-server/src/core/state-store.js` (+50 / 0) | `getPolicyProposal`, `upsertPolicyProposal`, `listPolicyProposalTags` on both `MemoryStateStore` (deep-clone in/out of a Map) and `RedisStateStore` (single hash `<namespace>:policy-proposal`) |
| `mcp-server/src/services/bootstrap.js` (+10 / 0) | Constructs `PolicyService` with `BUILTIN_POLICIES` as the seed set, awaits `policyService.hydrate()`, exposes `policyService` on the runtime object |
| `mcp-server/src/protocols/http/server.js` (+16 / -167) | Drops the inline policy state. Two thin wrappers `listPolicies()` / `findPolicy()` remain so the existing call sites in `/admin/status`, `/audit`, `/alerts`, and `/policies/:tag` don't need to change. `POST /policies` now calls `policyService.propose()` instead of `POLICY_PROPOSALS.set()` + the unscoped `stateStore.upsertMutationReceipt` call |

Net diff: **+585 / -167** across 6 files. The server.js shrinks by 167 lines because the policy seed data and helpers moved out.

## Why this matches Package C's pattern

The implementation is deliberately isomorphic with `AccountOverlayStore`:

- Map-like cache + state-store backing
- `hydrate()` at bootstrap
- Per-key persist queues for ordering
- Silent fall-through when the state-store is missing
- Persist failures log + degrade rather than crash

The audit board called this out explicitly: *"Either extract `PolicyService` first and move routes later, or do it as part of the route split. Focused state extraction first is less risky."* This PR is the focused state extraction; routes still live in the monolith. Package J (P2.3) can later move `/policies` into its own route module without touching the service.

## Tests

8 new unit tests in `mcp-server/src/core/policy-service.test.js`:

1. `listAll` — seeds first, then proposals (locks ordering)
2. `findByTagOrId` — works for built-in by id, built-in by tag, proposal by tag, proposal by id, unknown values
3. Write-through — every `propose()` mirrors to state-store
4. Sequential proposes — per-tag serialization preserves final-write-wins
5. `hydrate` — loads every persisted proposal into the cache
6. Degradation — service still functions in-memory when state-store is missing
7. Persist failure — logged via `policy.persist_failed`, no caller crash
8. **Restart simulation** — propose, drop service, rebuild with the same state-store, hydrate, assert built-in seeds + persisted proposal both visible

Full backend suite: **761/761** pass on rebased state. No regressions from the server.js refactor.

## Scope

- Six files, +585 / -167. Three new modules in `mcp-server/src/core/`, one helper added to bootstrap, additions to state-store, focused removal from server.js.
- **Does not** touch money-route handlers (Package A/D territory).
- **Does not** touch the `/health` response shape (Package B territory).
- **Does not** broadly refactor `server.js` — the `listPolicies()` / `findPolicy()` wrappers preserve every existing call site (Package J can move policy routes into a module later without re-touching state).
- **Does not** change the `/policies` route shape — same response, same status codes, only the storage path changed.
- Branch prefix `claude/`.

## Affects

- backend: yes — policy proposals now survive restart; built-in policies behave identically (same shape, same content)
- app / indexer / Caddy / contracts: **none**
- Required env or VPS secret changes: **none** (Redis is already required in production for the rest of the state-store backing)
- Externally observable behavior: a proposal posted before a restart now appears in `GET /policies` after the restart instead of disappearing

## Test plan

- [x] `node --test mcp-server/src/core/policy-service.test.js` → 8/8 pass
- [x] `npm --workspace mcp-server test` → 761/761 pass (full backend on rebased state)
- [x] Restart simulation asserts the close output: propose → drop service → rebuild from state-store → proposal survives + built-in seeds still present
- [x] `server.js` thin wrappers `listPolicies()` / `findPolicy()` keep the existing call sites in `/admin/status`, `/audit`, `/alerts`, and `/policies/:tag` working without changes
- [ ] After deploy, propose a policy via `POST /policies`, restart the backend, assert the proposal appears in `GET /policies`

## Related

| | |
|---|---|
| **#408** | Package C — overlay durability (merged; same write-through pattern reused here) |
| **#403** | Package A — mutation backend gate (merged) |
| **#416** | Package B — /health truth split (merged) |
| **#419** | Package D — money-route idempotency (mine, open) |
| **#413** | Package I — launch docs (merged) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)