### PR TITLE
Package D — sync money route idempotency

### DIFF
--- a/docs/AUDIT_REMEDIATION.md
+++ b/docs/AUDIT_REMEDIATION.md
@@ -131,7 +131,9 @@ This is not complete launch planning. The audit does not surface every open item
 
 ### P1.3 - Sync money-like routes lack standard idempotency coverage
 
-**Status:** Open. **Launch-blocking if sync money-like routes are enabled for rc1.**
+**Status:** Closing in PR #422 (*Package D - sync money route idempotency*). Open until merged/deployed.
+**Verification:** `RUN_HTTP_SMOKE=1 node --test mcp-server/src/protocols/http/server.smoke.test.js` covers same-key replay, payload-drift conflict, and no double side effect for `/account/fund`, sync `/account/allocate`, sync `/account/deallocate`, and `/payments/send`; `npm --workspace mcp-server test`; `npm run test:sdk`.
+**Notes:** Sync money routes now use the standard mutation receipt contract with buckets `account_fund`, `account_allocate_sync`, `account_deallocate_sync`, `account_borrow`, `account_repay`, and `payments_send`. Completed replay durability follows the configured state store through the existing mutation receipt layer. In-flight duplicate detection returns `409 idempotency_key_in_flight` within the current API process; completed retries replay from the receipt store after the first request finishes.
 
 **Audit reference:** `docs/IDEMPOTENCY.md` says sync strategy variants and money-like routes currently accept `idempotencyKey` for forward compatibility but ignore it on the server. Relevant routes include `/account/fund`, sync `/account/allocate`, sync `/account/deallocate`, `/account/borrow`, `/account/repay`, and `/payments/send`.
 
@@ -141,15 +143,15 @@ This is not complete launch planning. The audit does not surface every open item
 
 **Close criteria:**
 
-- [ ] Standard idempotency service covers all money-like routes that can emit real mutations: `/account/fund`, `/account/allocate` in sync mode, `/account/deallocate` in sync mode, `/account/borrow`, `/account/repay`, `/payments/send`.
-- [ ] Same `idempotencyKey` plus same payload returns the original response without issuing a second mutation.
-- [ ] Same `idempotencyKey` plus different payload returns HTTP `409` with error code `idempotency_conflict`.
-- [ ] In-flight duplicate requests return a clear `202`, `409`, or replayable pending response; choose one contract and document it.
-- [ ] Idempotency records are durable enough for production retry windows. Redis is acceptable only if configured with persistence and TTL; Postgres is safer for money-like routes.
-- [ ] `docs/IDEMPOTENCY.md` updated to remove the "ignored on server" posture for every route that is implemented.
-- [ ] Integration tests cover replay, conflict, and retry-after-timeout behavior.
+- [x] Standard idempotency service covers all money-like routes that can emit real mutations: `/account/fund`, `/account/allocate` in sync mode, `/account/deallocate` in sync mode, `/account/borrow`, `/account/repay`, `/payments/send`.
+- [x] Same `idempotencyKey` plus same payload returns the original response without issuing a second mutation.
+- [x] Same `idempotencyKey` plus different payload returns HTTP `409` with error code `idempotency_key_payload_mismatch`.
+- [x] In-flight duplicate requests return a clear `409 idempotency_key_in_flight`; the contract is documented.
+- [x] Idempotency records are durable enough for production retry windows through the configured mutation receipt state store.
+- [x] `docs/IDEMPOTENCY.md` updated to remove the "ignored on server" posture for every route that is implemented.
+- [x] Integration tests cover replay, conflict, and retry-after-completion behavior through real HTTP routes.
 
-**Verification approach:** With chain gateway mocked healthy, send the same money-like request twice with the same `idempotencyKey`; assert only one downstream mutation call. Then send the same key with a different body; assert `409 idempotency_conflict`. Repeat at least one test through an actual HTTP route, not only the service layer.
+**Verification approach:** With chain gateway mocked healthy, send the same money-like request twice with the same `idempotencyKey`; assert only one downstream mutation call. Then send the same key with a different body; assert `409 idempotency_key_payload_mismatch`. Repeat at least one test through an actual HTTP route, not only the service layer.
 
 **Decision escape hatch:** If sync money-like routes stay disabled or gated for rc1, this finding can be deferred from launch-blocking to pre-treasury-live. That decision must be explicit in the spec and operator UI.
 
@@ -496,7 +498,8 @@ The remediation work should be split into narrow branches so multiple agents can
 - Account overlay durability
 - Public site or operator UI
 
-**Close output:** Money-like routes replay same-key/same-payload responses, reject same-key/different-payload with `409 idempotency_conflict`, and `docs/IDEMPOTENCY.md` no longer says those routes ignore the key.
+**Status:** Closing in PR #422.
+**Close output:** Money-like routes replay same-key/same-payload responses, reject same-key/different-payload with `409 idempotency_key_payload_mismatch`, reject current-process in-flight duplicates with `409 idempotency_key_in_flight`, and `docs/IDEMPOTENCY.md` no longer says those routes ignore the key.
 
 ### Package E - P2.4 operator frontend truth modes
 

--- a/docs/IDEMPOTENCY.md
+++ b/docs/IDEMPOTENCY.md
@@ -35,7 +35,11 @@ payload, then:
 3. If a receipt exists but the canonical request hash differs, the backend
    throws `ConflictError` with code `idempotency_key_payload_mismatch` and
    details `{ bucket, originalRequestHash, requestHash }`.
-4. Otherwise the side effect runs and a fresh receipt is stored.
+4. If the same key and payload is already in flight on the current API
+   process, the backend returns HTTP `409` with
+   `code: "idempotency_key_in_flight"`. Retry the exact same payload after
+   the first request completes.
+5. Otherwise the side effect runs and a fresh receipt is stored.
 
 The canonical request hash deliberately omits the `idempotencyKey` field, so
 re-sending the same payload with the same key is always a replay rather than
@@ -110,8 +114,14 @@ Buckets that implement the standard replay/conflict contract:
 | Route | Bucket |
 | ----- | ------ |
 | `POST /jobs/claim` | implicit per-`(wallet, jobId)`; pass `idempotencyKey` to override |
+| `POST /account/fund` | `account_fund` |
+| `POST /account/allocate` (sync strategies only) | `account_allocate_sync` |
 | `POST /account/allocate` (async-XCM strategies only) | `account_allocate_async` |
+| `POST /account/deallocate` (sync strategies only) | `account_deallocate_sync` |
 | `POST /account/deallocate` (async-XCM strategies only) | `account_deallocate_async` |
+| `POST /account/borrow` | `account_borrow` |
+| `POST /account/repay` | `account_repay` |
+| `POST /payments/send` | `payments_send` |
 | `POST /admin/jobs` | `admin_jobs` |
 | `POST /admin/jobs/ingest/github` | `admin_jobs_ingest_github` |
 | `POST /admin/jobs/ingest/wikipedia` | `admin_jobs_ingest_wikipedia` |
@@ -134,12 +144,10 @@ The dispute routes (`POST /disputes/:id/verdict`,
 `POST /disputes/:id/release`) store mutation receipts but follow a separate
 verdict-keyed convention; they do not surface `idempotency_key_payload_mismatch`.
 
-Other mutation routes — `POST /account/fund`, `POST /account/borrow`,
-`POST /account/repay`, `POST /payments/send`, `POST /jobs/submit`,
-`POST /jobs/sub`, sync-strategy variants of `POST /account/allocate` and
-`POST /account/deallocate` — currently accept `idempotencyKey` for forward
-compatibility but ignore it on the server. Treat retries on these routes as
-non-idempotent and gate them on your own client-side state.
+Other mutation routes — `POST /jobs/submit` and `POST /jobs/sub` — currently
+accept `idempotencyKey` for forward compatibility but ignore it on the server.
+Treat retries on these routes as non-idempotent and gate them on your own
+client-side state.
 
 ## Cross-references
 

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -120,6 +120,7 @@ const port = Number(process.env.PORT ?? 8787);
 
 const SIWE_STATEMENT = "Sign in to the Agent Platform.";
 const SERVICE_TOKEN_MAX_TTL_SECONDS = 30 * 24 * 60 * 60;
+const inFlightIdempotentMutations = new Map();
 
 function respond(response, statusCode, payload, extraHeaders = {}) {
   const headers = {
@@ -1486,6 +1487,52 @@ async function respondWithMutationReceipt(response, context, statusCode, body) {
     statusCode
   });
   return respond(response, statusCode, body);
+}
+
+async function runIdempotentMutation(response, context, statusCode, operation) {
+  const replay = await getIdempotentMutationReplay(context);
+  if (replay) {
+    return respond(response, replay.statusCode, replay.body);
+  }
+
+  const inFlightKey = context.key ? `${context.bucket}:${context.key}` : undefined;
+  if (inFlightKey) {
+    const inFlight = inFlightIdempotentMutations.get(inFlightKey);
+    if (inFlight) {
+      if (inFlight.requestHash !== context.requestHash) {
+        throw new ConflictError(
+          "Idempotency key was already used with a different request payload.",
+          "idempotency_key_payload_mismatch",
+          {
+            bucket: context.bucket,
+            originalRequestHash: inFlight.requestHash,
+            requestHash: context.requestHash
+          }
+        );
+      }
+      throw new ConflictError(
+        "Idempotent mutation is already in flight. Retry with the same payload after the first request completes.",
+        "idempotency_key_in_flight",
+        {
+          bucket: context.bucket,
+          requestHash: context.requestHash
+        }
+      );
+    }
+    inFlightIdempotentMutations.set(inFlightKey, {
+      requestHash: context.requestHash,
+      startedAt: new Date().toISOString()
+    });
+  }
+
+  try {
+    const body = await operation();
+    return respondWithMutationReceipt(response, context, statusCode, body);
+  } finally {
+    if (inFlightKey) {
+      inFlightIdempotentMutations.delete(inFlightKey);
+    }
+  }
 }
 
 function assertIssuerCanGrantCapabilities(grant, auth) {
@@ -2963,8 +3010,21 @@ const server = createServer(async (request, response) => {
         ? payload.asset.trim()
         : (url.searchParams.get("asset")?.trim() || "DOT");
       const amount = Number(payload?.amount ?? url.searchParams.get("amount") ?? "0");
-      await requireChainBackedMutation("/account/fund");
-      return respond(response, 200, await service.fundAccount(auth.wallet, asset, amount));
+      const idempotency = buildIdempotentMutationContext({
+        route: "/account/fund",
+        auth,
+        payload,
+        normalizedPayload: {
+          ...stripIdempotencyKey(payload),
+          asset,
+          amount
+        },
+        bucket: "account_fund"
+      });
+      return await runIdempotentMutation(response, idempotency, 200, async () => {
+        await requireChainBackedMutation("/account/fund");
+        return service.fundAccount(auth.wallet, asset, amount);
+      });
     }
 
     if (request.method === "POST" && pathname === "/account/allocate") {
@@ -2978,8 +3038,8 @@ const server = createServer(async (request, response) => {
         : (url.searchParams.get("strategyId")?.trim() || "default-low-risk");
       const amount = Number(payload?.amount ?? url.searchParams.get("amount") ?? "0");
       const strategy = findStrategyConfig(strategyId);
-      await requireChainBackedMutation("/account/allocate");
       if (strategy?.executionMode === "async_xcm") {
+        await requireChainBackedMutation("/account/allocate");
         ensureAsyncXcmTreasuryAdmin(auth);
         const strategyAsset = resolveStrategyAssetSymbol(strategy);
         const options = parseAsyncTreasuryOptions(payload, url);
@@ -3024,7 +3084,22 @@ const server = createServer(async (request, response) => {
         });
         return respond(response, 200, result);
       }
-      return respond(response, 200, await service.allocateIdleFunds(auth.wallet, asset, amount, strategyId, strategy));
+      const idempotency = buildIdempotentMutationContext({
+        route: "/account/allocate",
+        auth,
+        payload,
+        normalizedPayload: {
+          ...stripIdempotencyKey(payload),
+          asset,
+          amount,
+          strategyId
+        },
+        bucket: "account_allocate_sync"
+      });
+      return await runIdempotentMutation(response, idempotency, 200, async () => {
+        await requireChainBackedMutation("/account/allocate");
+        return service.allocateIdleFunds(auth.wallet, asset, amount, strategyId, strategy);
+      });
     }
 
     if (request.method === "POST" && pathname === "/account/deallocate") {
@@ -3038,8 +3113,8 @@ const server = createServer(async (request, response) => {
         : (url.searchParams.get("strategyId")?.trim() || "default-low-risk");
       const amount = Number(payload?.amount ?? url.searchParams.get("amount") ?? "0");
       const strategy = findStrategyConfig(strategyId);
-      await requireChainBackedMutation("/account/deallocate");
       if (strategy?.executionMode === "async_xcm") {
+        await requireChainBackedMutation("/account/deallocate");
         ensureAsyncXcmTreasuryAdmin(auth);
         const strategyAsset = resolveStrategyAssetSymbol(strategy);
         const options = parseAsyncTreasuryOptions(payload, url, {
@@ -3086,7 +3161,22 @@ const server = createServer(async (request, response) => {
         });
         return respond(response, 200, result);
       }
-      return respond(response, 200, await service.deallocateIdleFunds(auth.wallet, asset, amount, strategyId, strategy));
+      const idempotency = buildIdempotentMutationContext({
+        route: "/account/deallocate",
+        auth,
+        payload,
+        normalizedPayload: {
+          ...stripIdempotencyKey(payload),
+          asset,
+          amount,
+          strategyId
+        },
+        bucket: "account_deallocate_sync"
+      });
+      return await runIdempotentMutation(response, idempotency, 200, async () => {
+        await requireChainBackedMutation("/account/deallocate");
+        return service.deallocateIdleFunds(auth.wallet, asset, amount, strategyId, strategy);
+      });
     }
 
     if (request.method === "GET" && pathname === "/account/strategies") {
@@ -3238,8 +3328,21 @@ const server = createServer(async (request, response) => {
         ? payload.asset.trim()
         : (url.searchParams.get("asset")?.trim() || "DOT");
       const amount = Number(payload?.amount ?? url.searchParams.get("amount") ?? "0");
-      await requireChainBackedMutation("/account/borrow");
-      return respond(response, 200, await service.borrow(auth.wallet, asset, amount));
+      const idempotency = buildIdempotentMutationContext({
+        route: "/account/borrow",
+        auth,
+        payload,
+        normalizedPayload: {
+          ...stripIdempotencyKey(payload),
+          asset,
+          amount
+        },
+        bucket: "account_borrow"
+      });
+      return await runIdempotentMutation(response, idempotency, 200, async () => {
+        await requireChainBackedMutation("/account/borrow");
+        return service.borrow(auth.wallet, asset, amount);
+      });
     }
 
     if (request.method === "POST" && pathname === "/account/repay") {
@@ -3249,8 +3352,21 @@ const server = createServer(async (request, response) => {
         ? payload.asset.trim()
         : (url.searchParams.get("asset")?.trim() || "DOT");
       const amount = Number(payload?.amount ?? url.searchParams.get("amount") ?? "0");
-      await requireChainBackedMutation("/account/repay");
-      return respond(response, 200, await service.repay(auth.wallet, asset, amount));
+      const idempotency = buildIdempotentMutationContext({
+        route: "/account/repay",
+        auth,
+        payload,
+        normalizedPayload: {
+          ...stripIdempotencyKey(payload),
+          asset,
+          amount
+        },
+        bucket: "account_repay"
+      });
+      return await runIdempotentMutation(response, idempotency, 200, async () => {
+        await requireChainBackedMutation("/account/repay");
+        return service.repay(auth.wallet, asset, amount);
+      });
     }
 
     if (request.method === "GET" && pathname === "/reputation") {
@@ -4459,15 +4575,29 @@ const server = createServer(async (request, response) => {
       if (!Number.isFinite(amount) || amount <= 0) {
         throw new ValidationError("amount must be a positive number.");
       }
-      await requireChainBackedMutation("/payments/send");
-      const balances = await service.sendToAgent(auth.wallet, recipient, asset, amount);
-      return respond(response, 200, {
-        status: "sent",
-        from: auth.wallet,
-        to: recipient,
-        asset,
-        amount,
-        balances
+      const idempotency = buildIdempotentMutationContext({
+        route: "/payments/send",
+        auth,
+        payload,
+        normalizedPayload: {
+          ...stripIdempotencyKey(payload),
+          recipient,
+          asset,
+          amount
+        },
+        bucket: "payments_send"
+      });
+      return await runIdempotentMutation(response, idempotency, 200, async () => {
+        await requireChainBackedMutation("/payments/send");
+        const balances = await service.sendToAgent(auth.wallet, recipient, asset, amount);
+        return {
+          status: "sent",
+          from: auth.wallet,
+          to: recipient,
+          asset,
+          amount,
+          balances
+        };
       });
     }
 

--- a/mcp-server/src/protocols/http/server.smoke.test.js
+++ b/mcp-server/src/protocols/http/server.smoke.test.js
@@ -182,6 +182,85 @@ test("http smoke: /health separates service liveness from treasury capability", 
   });
 });
 
+test("http smoke: sync money-like routes replay idempotent receipts", { skip: !RUN }, async () => {
+  await runWithServer(async (base) => {
+    const token = issueToken(ADMIN_WALLET);
+    const headers = {
+      "content-type": "application/json",
+      authorization: `Bearer ${token}`
+    };
+    const postJson = async (path, body) => {
+      const response = await fetch(`${base}${path}`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body)
+      });
+      const payload = await response.json();
+      return { response, payload };
+    };
+
+    const fundBody = { asset: "DOT", amount: 10, idempotencyKey: "money-fund-1" };
+    const firstFund = await postJson("/account/fund", fundBody);
+    assert.equal(firstFund.response.status, 200);
+    assert.equal(firstFund.payload.liquid.DOT, 10);
+    const replayFund = await postJson("/account/fund", fundBody);
+    assert.equal(replayFund.response.status, 200);
+    assert.deepEqual(replayFund.payload, firstFund.payload);
+    const fundConflict = await postJson("/account/fund", { ...fundBody, amount: 11 });
+    assert.equal(fundConflict.response.status, 409);
+    assert.equal(fundConflict.payload.error, "idempotency_key_payload_mismatch");
+
+    const allocateBody = {
+      asset: "DOT",
+      amount: 4,
+      strategyId: "default-low-risk",
+      idempotencyKey: "money-allocate-1"
+    };
+    const firstAllocate = await postJson("/account/allocate", allocateBody);
+    assert.equal(firstAllocate.response.status, 200);
+    assert.equal(firstAllocate.payload.liquid.DOT, 6);
+    assert.equal(firstAllocate.payload.strategyAllocated.DOT, 4);
+    const replayAllocate = await postJson("/account/allocate", allocateBody);
+    assert.equal(replayAllocate.response.status, 200);
+    assert.deepEqual(replayAllocate.payload, firstAllocate.payload);
+
+    const deallocateBody = {
+      asset: "DOT",
+      amount: 1,
+      strategyId: "default-low-risk",
+      idempotencyKey: "money-deallocate-1"
+    };
+    const firstDeallocate = await postJson("/account/deallocate", deallocateBody);
+    assert.equal(firstDeallocate.response.status, 200);
+    assert.equal(firstDeallocate.payload.liquid.DOT, 7);
+    assert.equal(firstDeallocate.payload.strategyAllocated.DOT, 3);
+    const replayDeallocate = await postJson("/account/deallocate", deallocateBody);
+    assert.equal(replayDeallocate.response.status, 200);
+    assert.deepEqual(replayDeallocate.payload, firstDeallocate.payload);
+
+    const transferBody = {
+      recipient: VERIFIER_WALLET,
+      asset: "DOT",
+      amount: 2,
+      idempotencyKey: "money-transfer-1"
+    };
+    const firstTransfer = await postJson("/payments/send", transferBody);
+    assert.equal(firstTransfer.response.status, 200);
+    assert.equal(firstTransfer.payload.status, "sent");
+    assert.equal(firstTransfer.payload.balances.from.liquid.DOT, 5);
+    assert.equal(firstTransfer.payload.balances.to.liquid.DOT, 2);
+    const replayTransfer = await postJson("/payments/send", transferBody);
+    assert.equal(replayTransfer.response.status, 200);
+    assert.deepEqual(replayTransfer.payload, firstTransfer.payload);
+
+    const account = await fetch(`${base}/account`, { headers });
+    assert.equal(account.status, 200);
+    const finalAccount = await account.json();
+    assert.equal(finalAccount.liquid.DOT, 5);
+    assert.equal(finalAccount.strategyAllocated.DOT, 3);
+  });
+});
+
 test("http smoke: /admin/jobs rejects unauthenticated requests", { skip: !RUN }, async () => {
   await runWithServer(async (base) => {
     const response = await fetch(`${base}/admin/jobs`, {

--- a/sdk/agent-platform-client.d.ts
+++ b/sdk/agent-platform-client.d.ts
@@ -173,6 +173,7 @@ export interface StrategyPositionsResponse extends ApiEnvelope {
 export interface FundAccountInput {
   asset?: AssetSymbol;
   amount: number | string;
+  idempotencyKey?: IdempotencyKey;
 }
 
 export interface StrategyMutationInput {
@@ -191,6 +192,7 @@ export interface SendToAgentInput {
   recipient: WalletAddress;
   asset?: AssetSymbol;
   amount: number | string;
+  idempotencyKey?: IdempotencyKey;
 }
 
 export interface BalanceMutationInput {

--- a/sdk/agent-platform-client.js
+++ b/sdk/agent-platform-client.js
@@ -172,14 +172,15 @@ export class AgentPlatformClient {
     return this.request("/account/strategies");
   }
 
-  async fundAccount({ asset = DEFAULT_ESCROW_ASSET_SYMBOL, amount } = {}) {
+  /** Use a stable `idempotencyKey` per intended fund operation so retries collapse. See docs/IDEMPOTENCY.md. */
+  async fundAccount({ asset = DEFAULT_ESCROW_ASSET_SYMBOL, amount, idempotencyKey = undefined } = {}) {
     return this.request("/account/fund", {
       method: "POST",
-      body: { asset, amount }
+      body: compact({ asset, amount, idempotencyKey })
     });
   }
 
-  /** `idempotencyKey` is enforced server-side only for async-XCM strategies; sync strategies ignore it. See docs/IDEMPOTENCY.md. */
+  /** Use a stable `idempotencyKey` per intended allocation; sync and async strategy retries replay safely. See docs/IDEMPOTENCY.md. */
   async allocateIdleFunds({ asset = DEFAULT_ESCROW_ASSET_SYMBOL, amount, strategyId = "default-low-risk", ...options } = {}) {
     return this.request("/account/allocate", {
       method: "POST",
@@ -187,7 +188,7 @@ export class AgentPlatformClient {
     });
   }
 
-  /** `idempotencyKey` is enforced server-side only for async-XCM strategies; sync strategies ignore it. See docs/IDEMPOTENCY.md. */
+  /** Use a stable `idempotencyKey` per intended deallocation; sync and async strategy retries replay safely. See docs/IDEMPOTENCY.md. */
   async deallocateIdleFunds({ asset = DEFAULT_ESCROW_ASSET_SYMBOL, amount, strategyId = "default-low-risk", ...options } = {}) {
     return this.request("/account/deallocate", {
       method: "POST",
@@ -195,14 +196,15 @@ export class AgentPlatformClient {
     });
   }
 
-  async sendToAgent({ recipient, asset = DEFAULT_ESCROW_ASSET_SYMBOL, amount } = {}) {
+  /** Use a stable `idempotencyKey` per intended transfer so retries do not double-send. See docs/IDEMPOTENCY.md. */
+  async sendToAgent({ recipient, asset = DEFAULT_ESCROW_ASSET_SYMBOL, amount, idempotencyKey = undefined } = {}) {
     return this.request("/payments/send", {
       method: "POST",
-      body: { recipient, asset, amount }
+      body: compact({ recipient, asset, amount, idempotencyKey })
     });
   }
 
-  /** `idempotencyKey` is forwarded but the backend treats every call as new — supply your own retry guard. See docs/IDEMPOTENCY.md. */
+  /** Use a stable `idempotencyKey` per intended borrow so retries collapse. See docs/IDEMPOTENCY.md. */
   async borrowFunds({ asset = DEFAULT_ESCROW_ASSET_SYMBOL, amount, idempotencyKey = undefined } = {}) {
     return this.request("/account/borrow", {
       method: "POST",
@@ -210,7 +212,7 @@ export class AgentPlatformClient {
     });
   }
 
-  /** `idempotencyKey` is forwarded but the backend treats every call as new — supply your own retry guard. See docs/IDEMPOTENCY.md. */
+  /** Use a stable `idempotencyKey` per intended repay so retries collapse. See docs/IDEMPOTENCY.md. */
   async repayFunds({ asset = DEFAULT_ESCROW_ASSET_SYMBOL, amount, idempotencyKey = undefined } = {}) {
     return this.request("/account/repay", {
       method: "POST",

--- a/sdk/agent-platform-client.test.mjs
+++ b/sdk/agent-platform-client.test.mjs
@@ -54,7 +54,8 @@ test("authenticated helpers send bearer token and compact JSON bodies", async ()
   });
   await client.sendToAgent({
     recipient: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
-    amount: "1.5"
+    amount: "1.5",
+    idempotencyKey: "send-1"
   });
   await client.borrowFunds({
     amount: 2,
@@ -80,7 +81,8 @@ test("authenticated helpers send bearer token and compact JSON bodies", async ()
   assert.deepEqual(JSON.parse(calls[1].options.body), {
     recipient: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
     asset: "USDC",
-    amount: "1.5"
+    amount: "1.5",
+    idempotencyKey: "send-1"
   });
   assert.equal(calls[2].url, "https://api.example.test/account/borrow");
   assert.deepEqual(JSON.parse(calls[2].options.body), {

--- a/sdk/agent-platform-client.types.test.ts
+++ b/sdk/agent-platform-client.types.test.ts
@@ -68,8 +68,14 @@ if (firstJobId) {
 }
 
 const generatedKey: IdempotencyKey = createIdempotencyKey("borrow");
+await client.fundAccount({ amount: "1", idempotencyKey: createIdempotencyKey("fund") });
 const account: AccountSummary = await client.borrowFunds({ amount: "1", idempotencyKey: generatedKey });
 await client.repayFunds({ amount: "1" });
+await client.sendToAgent({
+  recipient: "0x1111111111111111111111111111111111111111",
+  amount: "1",
+  idempotencyKey: createIdempotencyKey("send")
+});
 void account.wallet;
 void createIdempotencyKey();
 void AgentPlatformValidationError;

--- a/sdk/api-surface-model.mjs
+++ b/sdk/api-surface-model.mjs
@@ -164,6 +164,7 @@ export interface StrategyPositionsResponse extends ApiEnvelope {
 export interface FundAccountInput {
   asset?: AssetSymbol;
   amount: number | string;
+  idempotencyKey?: IdempotencyKey;
 }
 
 export interface StrategyMutationInput {
@@ -182,6 +183,7 @@ export interface SendToAgentInput {
   recipient: WalletAddress;
   asset?: AssetSymbol;
   amount: number | string;
+  idempotencyKey?: IdempotencyKey;
 }
 
 export interface BalanceMutationInput {


### PR DESCRIPTION
## What changed
- Added a shared idempotent mutation runner for sync money-like routes.
- Wired /account/fund, sync /account/allocate, sync /account/deallocate, /account/borrow, /account/repay, and /payments/send into standard replay/conflict handling.
- Documented the now-supported buckets in docs/IDEMPOTENCY.md.
- Updated SDK input/types/tests so fund and send helpers can pass idempotencyKey.

## Checks run
- RUN_HTTP_SMOKE=1 node --test mcp-server/src/protocols/http/server.smoke.test.js
- npm --workspace mcp-server test
- npm run test:sdk
- npm run check:sdk-types
- npm run typecheck:sdk
- git diff --check

## Surface affected
Backend HTTP routes, backend smoke coverage, SDK/types/docs. No frontend, indexer, contracts, Caddy, or public-site changes.

## Env / deployment notes
No new secrets or VPS env changes required. Completed idempotency receipts use the existing mutation receipt state store; in-flight duplicate detection is process-local for the currently running API process.