### PR TITLE
[codex] Split health service and capability status

### DIFF
--- a/app/app/(authed)/overview/page.tsx
+++ b/app/app/(authed)/overview/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { useMemo } from "react";
-import { OverviewTopbar } from "@/components/overview/OverviewTopbar";
+import {
+  OverviewTopbar,
+  type CapabilityWarning,
+} from "@/components/overview/OverviewTopbar";
 import { MissionHero } from "@/components/overview/MissionHero";
 import { RoomVitals } from "@/components/overview/RoomVitals";
 import {
@@ -143,10 +146,14 @@ export default function OverviewPage() {
     providerOps,
     publicProviderOps
   );
+  const capabilityWarning = useMemo(
+    () => buildCapabilityWarning(health.data),
+    [health.data]
+  );
 
   return (
     <div className="flex w-full max-w-[1100px] flex-col gap-7">
-      <OverviewTopbar freshness={freshness} />
+      <OverviewTopbar capabilityWarning={capabilityWarning} freshness={freshness} />
       <MissionHero
         // Use the explicit `hasLiveOverview` gate rather than `||`
         // fallbacks — the previous form (`liveJobs.length || 14`) silently
@@ -202,6 +209,31 @@ function extractAlerts(data: unknown): AlertItem[] {
       alerts.push(alert);
       return alerts;
     }, []);
+}
+
+function buildCapabilityWarning(data: unknown): CapabilityWarning | undefined {
+  const root = asRecord(data);
+  const capabilities = asRecord(root?.capabilityHealth);
+  const treasuryState = text(capabilities?.treasuryMutations, "");
+  if (treasuryState !== "unavailable" && treasuryState !== "degraded") {
+    return undefined;
+  }
+
+  const warnings = Array.isArray(root?.warnings)
+    ? root.warnings.filter(isRecord)
+    : [];
+  const treasuryWarning = warnings.find((warning) =>
+    text(warning.code, "").startsWith("treasury_mutations_")
+  );
+  const fallback =
+    treasuryState === "unavailable"
+      ? "Treasury mutations are unavailable."
+      : "Treasury mutations are degraded.";
+
+  return {
+    label: treasuryState === "unavailable" ? "Treasury unavailable" : "Treasury degraded",
+    title: text(treasuryWarning?.message, fallback),
+  };
 }
 
 function countPoliciesAppliedToday(data: unknown): number {

--- a/app/components/overview/OverviewTopbar.tsx
+++ b/app/components/overview/OverviewTopbar.tsx
@@ -9,7 +9,18 @@ import {
 
 const pad = (n: number) => String(n).padStart(2, "0");
 
-export function OverviewTopbar({ freshness }: { freshness?: FreshnessState }) {
+export type CapabilityWarning = {
+  label: string;
+  title: string;
+};
+
+export function OverviewTopbar({
+  capabilityWarning,
+  freshness,
+}: {
+  capabilityWarning?: CapabilityWarning;
+  freshness?: FreshnessState;
+}) {
   const [time, setTime] = useState("");
 
   useEffect(() => {
@@ -44,6 +55,16 @@ export function OverviewTopbar({ freshness }: { freshness?: FreshnessState }) {
         </span>
       </div>
       <div className="flex items-center gap-2">
+        {capabilityWarning ? (
+          <span
+            className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-full bg-[var(--avy-warn-soft)] px-2 py-0.5 font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-warn)]"
+            style={{ letterSpacing: "0.08em" }}
+            title={capabilityWarning.title}
+          >
+            <span className="h-1.5 w-1.5 rounded-full bg-[var(--avy-warn)]" />
+            {capabilityWarning.label}
+          </span>
+        ) : null}
         {freshness ? <DataFreshnessPill state={freshness} /> : null}
         <button
           type="button"

--- a/mcp-server/src/core/discovery-manifest.js
+++ b/mcp-server/src/core/discovery-manifest.js
@@ -6,7 +6,7 @@ const DEFAULT_PROFILE_URL = "https://app.averray.com/agents/<wallet>";
 const DEFAULT_OPERATOR_APP_URL = "https://app.averray.com";
 
 const DISCOVERY_PUBLIC_ENDPOINTS = [
-  { path: "/health", description: "Liveness + component health (state store, blockchain gateway, gas sponsor)." },
+  { path: "/health", description: "Service health plus honest capability health (blockchain, treasury mutations, XCM observer, indexer)." },
   { path: "/metrics", description: "Prometheus text-format metrics. Optionally bearer-gated via METRICS_BEARER_TOKEN." },
   { path: "/onboarding", description: "Canonical platform capabilities + tool list." },
   { path: "/jobs", description: "Public job catalog (no auth)." },

--- a/mcp-server/src/core/health-report.js
+++ b/mcp-server/src/core/health-report.js
@@ -1,0 +1,202 @@
+import { getMutationBackendStatus } from "./mutation-backend.js";
+
+const DEFAULT_CHAIN_HEALTH = {
+  ok: true,
+  backend: "blockchain",
+  enabled: false,
+  mode: "disabled"
+};
+
+const DEFAULT_GAS_HEALTH = {
+  ok: true,
+  backend: "pimlico",
+  enabled: false,
+  mode: "disabled"
+};
+
+const DEFAULT_XCM_OBSERVER_STATUS = {
+  enabled: false,
+  running: false,
+  syncing: false
+};
+
+export async function buildHealthReport({
+  stateStore,
+  gateway,
+  pimlicoClient,
+  mutationBackendConfig,
+  authConfig,
+  xcmObservationRelay = undefined
+} = {}) {
+  const [storeHealth, chainHealth, gasHealth, mutationStatus, xcmObserverStatus] = await Promise.all([
+    stateStore?.healthCheck?.() ?? { ok: true, backend: stateStore?.constructor?.name ?? "unknown" },
+    gateway?.healthCheck?.() ?? DEFAULT_CHAIN_HEALTH,
+    pimlicoClient?.healthCheck?.() ?? DEFAULT_GAS_HEALTH,
+    getMutationBackendStatus({
+      gateway,
+      config: mutationBackendConfig,
+      route: "/health"
+    }),
+    readXcmObserverStatus(xcmObservationRelay)
+  ]);
+
+  const serviceComponents = {
+    api: { ok: true, mode: "http" },
+    stateStore: storeHealth,
+    auth: {
+      ok: Boolean(authConfig?.mode),
+      mode: authConfig?.mode,
+      domain: authConfig?.domain,
+      chainId: authConfig?.chainId
+    },
+    runtime: { ok: true, node: "running" }
+  };
+  const serviceOk = Object.values(serviceComponents).every((component) => component?.ok !== false);
+
+  const capabilityHealth = {
+    blockchain: summarizeBlockchain(chainHealth),
+    treasuryMutations: summarizeTreasuryMutations(mutationStatus),
+    xcmObserver: summarizeXcmObserver(xcmObserverStatus, chainHealth),
+    indexer: summarizeIndexer()
+  };
+
+  if (gasHealth.enabled || gasHealth.ok === false) {
+    capabilityHealth.gasSponsor = summarizeGasSponsor(gasHealth);
+  }
+
+  const warnings = buildCapabilityWarnings(capabilityHealth, {
+    chainHealth,
+    gasHealth,
+    mutationStatus,
+    xcmObserverStatus
+  });
+
+  return {
+    status: serviceOk ? "ok" : "degraded",
+    serviceHealth: serviceOk ? "ok" : "degraded",
+    capabilityHealth,
+    warnings,
+    auth: {
+      mode: authConfig?.mode,
+      domain: authConfig?.domain,
+      chainId: authConfig?.chainId
+    },
+    serviceComponents,
+    capabilityDetails: {
+      blockchain: chainHealth,
+      treasuryMutations: mutationStatus,
+      xcmObserver: xcmObserverStatus,
+      indexer: {
+        checked: false,
+        reason: "indexer health is checked by hosted-stack smoke until an indexer status URL is configured"
+      },
+      gasSponsor: gasHealth
+    },
+    // Legacy component shape kept for existing health consumers while new
+    // monitors move to serviceHealth/capabilityHealth.
+    components: {
+      stateStore: storeHealth,
+      blockchain: chainHealth,
+      gasSponsor: gasHealth
+    }
+  };
+}
+
+async function readXcmObserverStatus(xcmObservationRelay) {
+  if (!xcmObservationRelay?.getStatus) {
+    return DEFAULT_XCM_OBSERVER_STATUS;
+  }
+  try {
+    return await xcmObservationRelay.getStatus();
+  } catch (error) {
+    return {
+      ...DEFAULT_XCM_OBSERVER_STATUS,
+      enabled: Boolean(xcmObservationRelay.enabled),
+      running: Boolean(xcmObservationRelay.running),
+      syncing: Boolean(xcmObservationRelay.syncing),
+      error: error?.message ?? "xcm_observer_status_unavailable"
+    };
+  }
+}
+
+function summarizeBlockchain(chainHealth) {
+  if (chainHealth?.enabled === false) return "disabled";
+  if (chainHealth?.ok === false) return "unhealthy";
+  return "enabled";
+}
+
+function summarizeTreasuryMutations(mutationStatus) {
+  if (mutationStatus?.ok && mutationStatus.chainAvailable) return "available";
+  if (mutationStatus?.ok && mutationStatus.chainRequired === false) return "degraded";
+  return "unavailable";
+}
+
+function summarizeXcmObserver(xcmObserverStatus, chainHealth) {
+  if (xcmObserverStatus?.enabled && xcmObserverStatus?.running && !xcmObserverStatus?.lastError && !xcmObserverStatus?.error) {
+    return "live";
+  }
+  if (chainHealth?.enabled && (chainHealth?.xcmWrapperConfigured || xcmObserverStatus?.enabled)) {
+    return "staged";
+  }
+  return "unavailable";
+}
+
+function summarizeIndexer() {
+  return "unavailable";
+}
+
+function summarizeGasSponsor(gasHealth) {
+  if (gasHealth?.enabled === false) return "unavailable";
+  if (gasHealth?.ok === false) return "degraded";
+  return "available";
+}
+
+function buildCapabilityWarnings(capabilityHealth, details) {
+  const warnings = [];
+
+  if (capabilityHealth.blockchain !== "enabled") {
+    warnings.push({
+      code: `blockchain_${capabilityHealth.blockchain}`,
+      severity: capabilityHealth.blockchain === "unhealthy" ? "critical" : "warning",
+      message: `Blockchain capability is ${capabilityHealth.blockchain}.`,
+      details: details.chainHealth
+    });
+  }
+
+  if (capabilityHealth.treasuryMutations !== "available") {
+    warnings.push({
+      code: `treasury_mutations_${capabilityHealth.treasuryMutations}`,
+      severity: capabilityHealth.treasuryMutations === "unavailable" ? "critical" : "warning",
+      message: `Treasury mutations are ${capabilityHealth.treasuryMutations}.`,
+      details: details.mutationStatus
+    });
+  }
+
+  if (capabilityHealth.xcmObserver !== "live") {
+    warnings.push({
+      code: `xcm_observer_${capabilityHealth.xcmObserver}`,
+      severity: "warning",
+      message: `XCM observer is ${capabilityHealth.xcmObserver}.`,
+      details: details.xcmObserverStatus
+    });
+  }
+
+  if (capabilityHealth.indexer !== "synced") {
+    warnings.push({
+      code: `indexer_${capabilityHealth.indexer}`,
+      severity: "warning",
+      message: `Indexer capability is ${capabilityHealth.indexer}.`
+    });
+  }
+
+  if (capabilityHealth.gasSponsor && capabilityHealth.gasSponsor !== "available") {
+    warnings.push({
+      code: `gas_sponsor_${capabilityHealth.gasSponsor}`,
+      severity: "warning",
+      message: `Gas sponsor capability is ${capabilityHealth.gasSponsor}.`,
+      details: details.gasHealth
+    });
+  }
+
+  return warnings;
+}

--- a/mcp-server/src/core/health-report.test.js
+++ b/mcp-server/src/core/health-report.test.js
@@ -1,0 +1,143 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildHealthReport } from "./health-report.js";
+import { loadMutationBackendConfig } from "./mutation-backend.js";
+
+const AUTH_CONFIG = {
+  mode: "strict",
+  domain: "health.test",
+  chainId: "1"
+};
+
+const STATE_STORE_OK = {
+  async healthCheck() {
+    return { ok: true, backend: "memory", mode: "ephemeral" };
+  }
+};
+
+const PIMLICO_DISABLED = {
+  async healthCheck() {
+    return { ok: true, backend: "pimlico", enabled: false, mode: "disabled" };
+  }
+};
+
+test("health report keeps service healthy while required treasury capability is unavailable", async () => {
+  const gateway = {
+    isEnabled: () => false,
+    async healthCheck() {
+      return { ok: true, backend: "blockchain", enabled: false, mode: "disabled" };
+    }
+  };
+
+  const report = await buildHealthReport({
+    stateStore: STATE_STORE_OK,
+    gateway,
+    pimlicoClient: PIMLICO_DISABLED,
+    mutationBackendConfig: loadMutationBackendConfig({
+      NODE_ENV: "production",
+      MUTATION_BACKEND: "required"
+    }),
+    authConfig: AUTH_CONFIG
+  });
+
+  assert.equal(report.status, "ok");
+  assert.equal(report.serviceHealth, "ok");
+  assert.equal(report.serviceComponents.stateStore.ok, true);
+  assert.equal(report.capabilityHealth.blockchain, "disabled");
+  assert.equal(report.capabilityHealth.treasuryMutations, "unavailable");
+  assert.equal(report.capabilityDetails.treasuryMutations.reason, "blockchain gateway is disabled");
+  assert.ok(report.warnings.some((warning) => warning.code === "treasury_mutations_unavailable"));
+});
+
+test("health report labels memory mutation mode as degraded rather than chain-backed", async () => {
+  const gateway = {
+    isEnabled: () => false,
+    async healthCheck() {
+      return { ok: true, backend: "blockchain", enabled: false, mode: "disabled" };
+    }
+  };
+
+  const report = await buildHealthReport({
+    stateStore: STATE_STORE_OK,
+    gateway,
+    pimlicoClient: PIMLICO_DISABLED,
+    mutationBackendConfig: loadMutationBackendConfig({
+      NODE_ENV: "development",
+      MUTATION_BACKEND: "memory"
+    }),
+    authConfig: AUTH_CONFIG
+  });
+
+  assert.equal(report.serviceHealth, "ok");
+  assert.equal(report.capabilityHealth.blockchain, "disabled");
+  assert.equal(report.capabilityHealth.treasuryMutations, "degraded");
+  assert.equal(report.capabilityDetails.treasuryMutations.reason, "memory backend allowed");
+});
+
+test("health report marks chain-backed treasury and running XCM observer as live", async () => {
+  const gateway = {
+    isEnabled: () => true,
+    async healthCheck() {
+      return {
+        ok: true,
+        backend: "blockchain",
+        enabled: true,
+        blockNumber: 123,
+        signerConfigured: true,
+        xcmWrapperConfigured: true
+      };
+    }
+  };
+
+  const report = await buildHealthReport({
+    stateStore: STATE_STORE_OK,
+    gateway,
+    pimlicoClient: PIMLICO_DISABLED,
+    mutationBackendConfig: loadMutationBackendConfig({
+      NODE_ENV: "production",
+      MUTATION_BACKEND: "required"
+    }),
+    authConfig: AUTH_CONFIG,
+    xcmObservationRelay: {
+      async getStatus() {
+        return { enabled: true, running: true, syncing: false, feedUrl: "https://index.example/xcm" };
+      }
+    }
+  });
+
+  assert.equal(report.serviceHealth, "ok");
+  assert.equal(report.capabilityHealth.blockchain, "enabled");
+  assert.equal(report.capabilityHealth.treasuryMutations, "available");
+  assert.equal(report.capabilityHealth.xcmObserver, "live");
+  assert.equal(
+    report.warnings.some((warning) => warning.code.startsWith("treasury_mutations_")),
+    false
+  );
+});
+
+test("health report degrades service health when state store is unavailable", async () => {
+  const report = await buildHealthReport({
+    stateStore: {
+      async healthCheck() {
+        return { ok: false, backend: "redis", mode: "durable", error: "down" };
+      }
+    },
+    gateway: {
+      isEnabled: () => false,
+      async healthCheck() {
+        return { ok: true, backend: "blockchain", enabled: false, mode: "disabled" };
+      }
+    },
+    pimlicoClient: PIMLICO_DISABLED,
+    mutationBackendConfig: loadMutationBackendConfig({
+      NODE_ENV: "production",
+      MUTATION_BACKEND: "required"
+    }),
+    authConfig: AUTH_CONFIG
+  });
+
+  assert.equal(report.status, "degraded");
+  assert.equal(report.serviceHealth, "degraded");
+  assert.equal(report.serviceComponents.stateStore.ok, false);
+});

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -4,6 +4,7 @@ import { createPlatformRuntime } from "../../services/bootstrap.js";
 import {
   assertMutationBackendAvailable
 } from "../../core/mutation-backend.js";
+import { buildHealthReport } from "../../core/health-report.js";
 import {
   AuthenticationError,
   AuthorizationError,
@@ -1773,21 +1774,15 @@ const server = createServer(async (request, response) => {
     }
 
     if (request.method === "GET" && pathname === "/health") {
-      const [storeHealth, chainHealth, gasHealth] = await Promise.all([
-        stateStore.healthCheck?.() ?? { ok: true, backend: stateStore.constructor.name },
-        gateway?.healthCheck?.() ?? { ok: true, backend: "blockchain", enabled: false, mode: "disabled" },
-        pimlicoClient?.healthCheck?.() ?? { ok: true, backend: "pimlico", enabled: false, mode: "disabled" }
-      ]);
-      const overallOk = Boolean(storeHealth.ok) && Boolean(chainHealth.ok) && Boolean(gasHealth.ok);
-      return respond(response, overallOk ? 200 : 503, {
-        status: overallOk ? "ok" : "degraded",
-        auth: { mode: authConfig.mode, domain: authConfig.domain, chainId: authConfig.chainId },
-        components: {
-          stateStore: storeHealth,
-          blockchain: chainHealth,
-          gasSponsor: gasHealth
-        }
+      const healthReport = await buildHealthReport({
+        stateStore,
+        gateway,
+        pimlicoClient,
+        mutationBackendConfig,
+        authConfig,
+        xcmObservationRelay: service.xcmObservationRelay
       });
+      return respond(response, healthReport.serviceHealth === "ok" ? 200 : 503, healthReport);
     }
 
     if (request.method === "GET" && pathname === "/status/providers") {

--- a/mcp-server/src/protocols/http/server.smoke.test.js
+++ b/mcp-server/src/protocols/http/server.smoke.test.js
@@ -164,6 +164,24 @@ test("http smoke: production money-like routes require a chain backend", { skip:
   });
 });
 
+test("http smoke: /health separates service health from treasury capability state", { skip: !RUN }, async () => {
+  await runWithServerEnv({
+    NODE_ENV: "production",
+    MUTATION_BACKEND: "required"
+  }, async (base) => {
+    const response = await fetch(`${base}/health`);
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+
+    assert.equal(payload.status, "ok");
+    assert.equal(payload.serviceHealth, "ok");
+    assert.equal(payload.capabilityHealth.blockchain, "disabled");
+    assert.equal(payload.capabilityHealth.treasuryMutations, "unavailable");
+    assert.equal(payload.components.blockchain.enabled, false);
+    assert.ok(payload.warnings.some((warning) => warning.code === "treasury_mutations_unavailable"));
+  });
+});
+
 test("http smoke: /admin/jobs rejects unauthenticated requests", { skip: !RUN }, async () => {
   await runWithServer(async (base) => {
     const response = await fetch(`${base}/admin/jobs`, {


### PR DESCRIPTION
## Summary
- Adds a dedicated health report builder that splits `/health` into `serviceHealth` and `capabilityHealth`.
- Keeps the legacy `components` payload while surfacing honest capability states for blockchain, treasury mutations, XCM observer, indexer, and gas sponsor.
- Adds warnings when treasury mutations are unavailable/degraded and shows the treasury warning in the operator overview topbar.
- Updates the public discovery manifest wording for `/health` and adds smoke/unit coverage for the production chain-disabled case.

## Verification
- `npm --workspace mcp-server test`
- `RUN_HTTP_SMOKE=1 node --test mcp-server/src/protocols/http/server.smoke.test.js`
- `npm run typecheck:app`
- `npm run build:frontend`
- `git diff --check`

## Impact
- Backend `/health` response shape adds new fields while preserving legacy `components`.
- Operator app overview now reflects treasury capability warnings from `/health`.
- Public discovery manifest text updated.
- No contracts, indexer, Caddy, generated deploy output, or environment changes.