### PR TITLE
docs: close Package D — P1.3 money-route idempotency

### DIFF
--- a/docs/AUDIT_REMEDIATION.md
+++ b/docs/AUDIT_REMEDIATION.md
@@ -131,9 +131,9 @@ This is not complete launch planning. The audit does not surface every open item
 
 ### P1.3 - Sync money-like routes lack standard idempotency coverage
 
-**Status:** Closing in PR #422 (*Package D - sync money route idempotency*). Open until merged/deployed.
-**Verification:** `RUN_HTTP_SMOKE=1 node --test mcp-server/src/protocols/http/server.smoke.test.js` covers same-key replay, payload-drift conflict, and no double side effect for `/account/fund`, sync `/account/allocate`, sync `/account/deallocate`, and `/payments/send`; `npm --workspace mcp-server test`; `npm run test:sdk`.
-**Notes:** Sync money routes now use the standard mutation receipt contract with buckets `account_fund`, `account_allocate_sync`, `account_deallocate_sync`, `account_borrow`, `account_repay`, and `payments_send`. Completed replay durability follows the configured state store through the existing mutation receipt layer. In-flight duplicate detection returns `409 idempotency_key_in_flight` within the current API process; completed retries replay from the receipt store after the first request finishes.
+**Status:** Closed on 2026-05-17 in `4447780` (PR #422 *Package D - sync money route idempotency*).
+**Verification:** `RUN_HTTP_SMOKE=1 node --test mcp-server/src/protocols/http/server.smoke.test.js` covers same-key replay, payload-drift conflict, and no double side effect for `/account/fund`, sync `/account/allocate`, sync `/account/deallocate`, `/account/borrow`, `/account/repay`, and `/payments/send`; `npm --workspace mcp-server test`; `npm run test:sdk`. The duplicate branch at `claude/p1-money-route-idempotency` (PR #419, lower-level primitives) was closed without merge once the helper-based pattern in #422 landed first.
+**Notes:** All six money routes go through the shared `buildIdempotentMutationContext()` + `runIdempotentMutation()` helper at `mcp-server/src/protocols/http/server.js` (call sites at lines 2873 fund, 2953 allocate, 3030 deallocate, 3196 borrow, 3220 repay, 4444 payments/send). Buckets `account_fund`, `account_allocate_sync`, `account_deallocate_sync`, `account_borrow`, `account_repay`, and `payments_send` route through the configured state-store receipt layer for durability. In-flight duplicate detection returns `409 idempotency_key_in_flight` within the current API process; completed retries replay from the receipt store. **Naming variance worth noting for spec consumers:** the original audit spec called for error code `idempotency_conflict`; the implementation and updated close criteria use `idempotency_key_payload_mismatch` (more specific — distinguishes payload drift from in-flight clashes which use `idempotency_key_in_flight`). Semantics match; if an external SDK or doc reader was pinned to the original `idempotency_conflict` string, treat that as a follow-up rename/alias decision, not a re-open of P1.3.
 
 **Audit reference:** `docs/IDEMPOTENCY.md` says sync strategy variants and money-like routes currently accept `idempotencyKey` for forward compatibility but ignore it on the server. Relevant routes include `/account/fund`, sync `/account/allocate`, sync `/account/deallocate`, `/account/borrow`, `/account/repay`, and `/payments/send`.
 
@@ -482,6 +482,8 @@ The remediation work should be split into narrow branches so multiple agents can
 
 ### Package D - P1.3 sync mutation idempotency
 
+**Status:** Closed on 2026-05-17 in `4447780` (PR #422). Sync money-like routes can be enabled for rc1 — the close-criteria gate is satisfied. The parallel branch `claude/p1-money-route-idempotency` (PR #419) was closed without merge as a duplicate once #422 landed first; coordination note for future work: the helper pattern (`buildIdempotentMutationContext` + `runIdempotentMutation`) is the canonical surface, not the lower-level `parseIdempotencyKey` + `getIdempotentMutationReplay` primitives.
+
 **Suggested branch:** `codex/p1-money-route-idempotency`
 **Can start:** Design and service tests can start now. Route integration waits until Package A lands to avoid conflicts in the same handlers.
 **Blocks:** Enabling sync money-like routes in rc1.
@@ -502,7 +504,7 @@ The remediation work should be split into narrow branches so multiple agents can
 - Public site or operator UI
 
 **Status:** Closing in PR #422.
-**Close output:** Money-like routes replay same-key/same-payload responses, reject same-key/different-payload with `409 idempotency_key_payload_mismatch`, reject current-process in-flight duplicates with `409 idempotency_key_in_flight`, and `docs/IDEMPOTENCY.md` no longer says those routes ignore the key.
+**Close output:** Money-like routes replay same-key/same-payload responses, reject same-key/different-payload with `409 idempotency_key_payload_mismatch`, reject current-process in-flight duplicates with `409 idempotency_key_in_flight`, and `docs/IDEMPOTENCY.md` no longer says those routes ignore the key. **Achieved** — see the P1.3 finding section above for the full verification trail.
 
 ### Package E - P2.4 operator frontend truth modes
 


### PR DESCRIPTION
## Summary
Closes **Package D (P1.3 sync money-route idempotency)** from [`docs/AUDIT_REMEDIATION.md`](docs/AUDIT_REMEDIATION.md). The implementation already landed in `4447780` (PR #422 *Package D — sync money route idempotency*). The doc still read *"Closing in PR #422 — Open until merged/deployed"*; #422 has merged and all close-criteria are met on current `origin/main`. **Doc-only** PR — no code changes.

## Verification on `origin/main`

| Money route | `runIdempotentMutation` call site |
|---|---|
| `/account/fund` | [`server.js:2873`](mcp-server/src/protocols/http/server.js#L2873) |
| `/account/allocate` | [`server.js:2953`](mcp-server/src/protocols/http/server.js#L2953) |
| `/account/deallocate` | [`server.js:3030`](mcp-server/src/protocols/http/server.js#L3030) |
| `/account/borrow` | [`server.js:3196`](mcp-server/src/protocols/http/server.js#L3196) |
| `/account/repay` | [`server.js:3220`](mcp-server/src/protocols/http/server.js#L3220) |
| `/payments/send` | [`server.js:4444`](mcp-server/src/protocols/http/server.js#L4444) |

- Error code `idempotency_key_payload_mismatch` defined at [`server.js:1306`](mcp-server/src/protocols/http/server.js#L1306) and `:1352`; asserted across the smoke suite at `server.smoke.test.js:211`, `:692`, `:1153`, `:1218`, `:1540`, `:1590`.
- [`docs/IDEMPOTENCY.md`](docs/IDEMPOTENCY.md) exists; no longer says these routes ignore the key.
- Smoke coverage runs under `RUN_HTTP_SMOKE=1`.

## Naming variance worth flagging (not a re-open)

The original audit spec used error code `idempotency_conflict`. The implementation + updated close criteria use `idempotency_key_payload_mismatch` — more specific, distinguishes payload-drift from in-flight clashes (which use `idempotency_key_in_flight`). Semantics match.

If an external SDK or doc reader was pinned to the original `idempotency_conflict` string, that's a follow-up rename/alias decision — not a re-open of P1.3. The Package D notes now call this out explicitly so the next reader doesn't trip over it.

## Coordination note added to Package D board entry

The duplicate branch `claude/p1-money-route-idempotency` (PR #419, lower-level primitives) was closed without merge once the helper-based pattern in #422 landed first. The Package D board entry now records that the helper pattern (`buildIdempotentMutationContext` + `runIdempotentMutation`) is the canonical surface, not the lower-level `parseIdempotencyKey` + `getIdempotentMutationReplay` primitives — so future work in this area builds on the same foundation.

## Coordination posture
- Branch started from fresh `origin/main` via `./scripts/ops/start-agent-worktree.sh claude/p1-3-doc-closure`.
- File scope respected: only `docs/AUDIT_REMEDIATION.md`.
- Polkadot MCP standing-rule context check ran — nothing Polkadot-primitive-relevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)