### PR TITLE
Surface /health warnings + overview topbar treasury chip (Package B follow-up)

### DIFF
--- a/app/app/(authed)/overview/page.tsx
+++ b/app/app/(authed)/overview/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { useMemo } from "react";
-import { OverviewTopbar } from "@/components/overview/OverviewTopbar";
+import {
+  OverviewTopbar,
+  type CapabilityWarning,
+} from "@/components/overview/OverviewTopbar";
 import { MissionHero } from "@/components/overview/MissionHero";
 import { RoomVitals } from "@/components/overview/RoomVitals";
 import {
@@ -143,10 +146,14 @@ export default function OverviewPage() {
     providerOps,
     publicProviderOps
   );
+  const capabilityWarning = useMemo(
+    () => buildCapabilityWarning(health.data),
+    [health.data]
+  );
 
   return (
     <div className="flex w-full max-w-[1100px] flex-col gap-7">
-      <OverviewTopbar freshness={freshness} />
+      <OverviewTopbar capabilityWarning={capabilityWarning} freshness={freshness} />
       <MissionHero
         // Use the explicit `hasLiveOverview` gate rather than `||`
         // fallbacks — the previous form (`liveJobs.length || 14`) silently
@@ -202,6 +209,38 @@ function extractAlerts(data: unknown): AlertItem[] {
       alerts.push(alert);
       return alerts;
     }, []);
+}
+
+function buildCapabilityWarning(data: unknown): CapabilityWarning | undefined {
+  // Reads the operator-facing `/health` payload (post-#416 / Package B
+  // truth split) and surfaces a single topbar chip when the treasury
+  // capability is unavailable or degraded. Other capability warnings
+  // are intentionally not surfaced in the overview topbar — the topbar
+  // is the cross-cutting truth signal for "can this room actually move
+  // money?". The full warnings[] array remains available to other UI.
+  const root = asRecord(data);
+  if (!root) return undefined;
+  const capabilities = asRecord(root.capabilityHealth);
+  const treasuryState = text(capabilities?.treasuryMutations, "");
+  if (treasuryState !== "unavailable" && treasuryState !== "degraded") {
+    return undefined;
+  }
+
+  const warnings = Array.isArray(root.warnings)
+    ? root.warnings.filter(isRecord)
+    : [];
+  const treasuryWarning = warnings.find((warning) =>
+    text(warning.code, "").startsWith("treasury_mutations_")
+  );
+  const fallback =
+    treasuryState === "unavailable"
+      ? "Treasury mutations are unavailable."
+      : "Treasury mutations are degraded.";
+
+  return {
+    label: treasuryState === "unavailable" ? "Treasury unavailable" : "Treasury degraded",
+    title: text(treasuryWarning?.message, fallback),
+  };
 }
 
 function countPoliciesAppliedToday(data: unknown): number {

--- a/app/components/overview/OverviewTopbar.tsx
+++ b/app/components/overview/OverviewTopbar.tsx
@@ -9,7 +9,18 @@ import {
 
 const pad = (n: number) => String(n).padStart(2, "0");
 
-export function OverviewTopbar({ freshness }: { freshness?: FreshnessState }) {
+export type CapabilityWarning = {
+  label: string;
+  title: string;
+};
+
+export function OverviewTopbar({
+  capabilityWarning,
+  freshness,
+}: {
+  capabilityWarning?: CapabilityWarning;
+  freshness?: FreshnessState;
+}) {
   const [time, setTime] = useState("");
 
   useEffect(() => {
@@ -44,6 +55,17 @@ export function OverviewTopbar({ freshness }: { freshness?: FreshnessState }) {
         </span>
       </div>
       <div className="flex items-center gap-2">
+        {capabilityWarning ? (
+          <span
+            className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-full bg-[var(--avy-warn-soft)] px-2 py-0.5 font-[family-name:var(--font-display)] text-[10px] font-extrabold uppercase text-[var(--avy-warn)]"
+            style={{ letterSpacing: "0.08em" }}
+            title={capabilityWarning.title}
+            data-testid="overview-capability-warning"
+          >
+            <span className="h-1.5 w-1.5 rounded-full bg-[var(--avy-warn)]" />
+            {capabilityWarning.label}
+          </span>
+        ) : null}
         {freshness ? <DataFreshnessPill state={freshness} /> : null}
         <button
           type="button"

--- a/mcp-server/src/core/health-capability.js
+++ b/mcp-server/src/core/health-capability.js
@@ -182,3 +182,65 @@ function resolveGasSponsorStatus(health) {
     ? GAS_SPONSOR_STATUS.ENABLED
     : GAS_SPONSOR_STATUS.DISABLED;
 }
+
+/**
+ * Translate a `capabilityHealth` block into an ordered list of structured
+ * warning entries. Each warning has a stable `code` so operator dashboards
+ * and CLI smoke checks can match on it without parsing prose. Severity is
+ * `critical` only for capabilities that block real treasury action; the
+ * rest are `warning` so an XCM observer that is staged on a trust-core
+ * launch does not page the on-call.
+ *
+ * The shape is deliberately additive: capabilities in their happy state
+ * (blockchain enabled, treasury available, xcm live, indexer synced, gas
+ * sponsor enabled) produce no entry. Operator app code can render the
+ * array as-is or pick out a single capability by `code` prefix.
+ */
+export function buildCapabilityWarnings(capabilityHealth) {
+  if (!capabilityHealth) return [];
+  const warnings = [];
+
+  if (capabilityHealth.blockchain !== BLOCKCHAIN_STATUS.ENABLED) {
+    warnings.push({
+      code: `blockchain_${capabilityHealth.blockchain}`,
+      severity: capabilityHealth.blockchain === BLOCKCHAIN_STATUS.UNHEALTHY ? "critical" : "warning",
+      message: `Blockchain capability is ${capabilityHealth.blockchain}.`
+    });
+  }
+
+  if (capabilityHealth.treasuryMutations !== TREASURY_MUTATIONS_STATUS.AVAILABLE) {
+    warnings.push({
+      code: `treasury_mutations_${capabilityHealth.treasuryMutations}`,
+      severity: capabilityHealth.treasuryMutations === TREASURY_MUTATIONS_STATUS.UNAVAILABLE
+        ? "critical"
+        : "warning",
+      message: `Treasury mutations are ${capabilityHealth.treasuryMutations}.`
+    });
+  }
+
+  if (capabilityHealth.xcmObserver !== XCM_OBSERVER_STATUS.LIVE) {
+    warnings.push({
+      code: `xcm_observer_${capabilityHealth.xcmObserver}`,
+      severity: "warning",
+      message: `XCM observer is ${capabilityHealth.xcmObserver}.`
+    });
+  }
+
+  if (capabilityHealth.indexer !== INDEXER_STATUS.SYNCED) {
+    warnings.push({
+      code: `indexer_${capabilityHealth.indexer}`,
+      severity: "warning",
+      message: `Indexer capability is ${capabilityHealth.indexer}.`
+    });
+  }
+
+  if (capabilityHealth.gasSponsor && capabilityHealth.gasSponsor !== GAS_SPONSOR_STATUS.ENABLED) {
+    warnings.push({
+      code: `gas_sponsor_${capabilityHealth.gasSponsor}`,
+      severity: "warning",
+      message: `Gas sponsor capability is ${capabilityHealth.gasSponsor}.`
+    });
+  }
+
+  return warnings;
+}

--- a/mcp-server/src/core/health-capability.test.js
+++ b/mcp-server/src/core/health-capability.test.js
@@ -7,6 +7,7 @@ import {
   INDEXER_STATUS,
   TREASURY_MUTATIONS_STATUS,
   XCM_OBSERVER_STATUS,
+  buildCapabilityWarnings,
   resolveCapabilityHealth,
   resolveServiceHealth
 } from "./health-capability.js";
@@ -168,4 +169,67 @@ test("resolveCapabilityHealth — blockchain: disabled when health probe omitted
   assert.equal(result.blockchain, BLOCKCHAIN_STATUS.DISABLED);
   assert.equal(result.treasuryMutations, TREASURY_MUTATIONS_STATUS.UNAVAILABLE);
   assert.equal(result.gasSponsor, GAS_SPONSOR_STATUS.DISABLED);
+});
+
+// ─── buildCapabilityWarnings ─────────────────────────────────────────
+
+test("buildCapabilityWarnings — empty array when every capability is in its happy state", () => {
+  const warnings = buildCapabilityWarnings({
+    blockchain: BLOCKCHAIN_STATUS.ENABLED,
+    treasuryMutations: TREASURY_MUTATIONS_STATUS.AVAILABLE,
+    xcmObserver: XCM_OBSERVER_STATUS.LIVE,
+    indexer: INDEXER_STATUS.SYNCED,
+    gasSponsor: GAS_SPONSOR_STATUS.ENABLED
+  });
+  assert.deepEqual(warnings, []);
+});
+
+test("buildCapabilityWarnings — chain-disabled posture: treasury critical, blockchain/xcm/indexer warning", () => {
+  const warnings = buildCapabilityWarnings({
+    blockchain: BLOCKCHAIN_STATUS.DISABLED,
+    treasuryMutations: TREASURY_MUTATIONS_STATUS.UNAVAILABLE,
+    xcmObserver: XCM_OBSERVER_STATUS.UNAVAILABLE,
+    indexer: INDEXER_STATUS.UNAVAILABLE,
+    gasSponsor: GAS_SPONSOR_STATUS.DISABLED
+  });
+  const treasury = warnings.find((w) => w.code === "treasury_mutations_unavailable");
+  assert.ok(treasury);
+  assert.equal(treasury.severity, "critical");
+  const blockchain = warnings.find((w) => w.code === "blockchain_disabled");
+  assert.ok(blockchain);
+  assert.equal(blockchain.severity, "warning");
+  assert.ok(warnings.some((w) => w.code === "xcm_observer_unavailable"));
+  assert.ok(warnings.some((w) => w.code === "indexer_unavailable"));
+  assert.ok(warnings.some((w) => w.code === "gas_sponsor_disabled"));
+});
+
+test("buildCapabilityWarnings — unhealthy chain is critical at the blockchain layer too", () => {
+  const warnings = buildCapabilityWarnings({
+    blockchain: BLOCKCHAIN_STATUS.UNHEALTHY,
+    treasuryMutations: TREASURY_MUTATIONS_STATUS.UNAVAILABLE,
+    xcmObserver: XCM_OBSERVER_STATUS.UNAVAILABLE,
+    indexer: INDEXER_STATUS.UNAVAILABLE,
+    gasSponsor: GAS_SPONSOR_STATUS.ENABLED
+  });
+  const blockchain = warnings.find((w) => w.code === "blockchain_unhealthy");
+  assert.ok(blockchain);
+  assert.equal(blockchain.severity, "critical");
+});
+
+test("buildCapabilityWarnings — degraded treasury (memory-mode dev) is warning, not critical", () => {
+  const warnings = buildCapabilityWarnings({
+    blockchain: BLOCKCHAIN_STATUS.DISABLED,
+    treasuryMutations: TREASURY_MUTATIONS_STATUS.DEGRADED,
+    xcmObserver: XCM_OBSERVER_STATUS.UNAVAILABLE,
+    indexer: INDEXER_STATUS.UNAVAILABLE,
+    gasSponsor: GAS_SPONSOR_STATUS.DISABLED
+  });
+  const treasury = warnings.find((w) => w.code === "treasury_mutations_degraded");
+  assert.ok(treasury);
+  assert.equal(treasury.severity, "warning");
+});
+
+test("buildCapabilityWarnings — null input resolves to empty array (no crash)", () => {
+  assert.deepEqual(buildCapabilityWarnings(undefined), []);
+  assert.deepEqual(buildCapabilityWarnings(null), []);
 });

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -6,6 +6,7 @@ import {
   getMutationBackendStatus
 } from "../../core/mutation-backend.js";
 import {
+  buildCapabilityWarnings,
   resolveCapabilityHealth,
   resolveServiceHealth
 } from "../../core/health-capability.js";
@@ -1709,6 +1710,11 @@ const server = createServer(async (request, response) => {
         auth: { mode: authConfig.mode, domain: authConfig.domain, chainId: authConfig.chainId },
         serviceHealth,
         capabilityHealth,
+        // Structured, codeable warnings derived from capabilityHealth.
+        // Operator dashboards / smoke checks can match on `code` rather
+        // than parsing prose. Empty array when every capability is in
+        // its happy state.
+        warnings: buildCapabilityWarnings(capabilityHealth),
         components: {
           stateStore: storeHealth,
           blockchain: chainHealth,

--- a/mcp-server/src/protocols/http/server.smoke.test.js
+++ b/mcp-server/src/protocols/http/server.smoke.test.js
@@ -179,6 +179,16 @@ test("http smoke: /health separates service liveness from treasury capability", 
     assert.equal(payload.capabilityHealth.xcmObserver, "unavailable");
     assert.equal(payload.capabilityHealth.indexer, "unavailable");
     assert.equal(payload.components.blockchain.enabled, false);
+    // Structured warnings: operator dashboards / smoke checks match on
+    // `code` rather than parsing prose. Treasury unavailable on a
+    // production / chain-required posture must be `critical`.
+    assert.ok(Array.isArray(payload.warnings), "warnings must be an array");
+    const treasury = payload.warnings.find((w) => w.code === "treasury_mutations_unavailable");
+    assert.ok(treasury, "treasury_mutations_unavailable warning must be present");
+    assert.equal(treasury.severity, "critical");
+    const blockchain = payload.warnings.find((w) => w.code === "blockchain_disabled");
+    assert.ok(blockchain);
+    assert.equal(blockchain.severity, "warning");
   });
 });
 


### PR DESCRIPTION
## Summary
Narrow follow-up to Package B (#416 merged) that lands the operator-app surfacing piece — and replaces the substantive content of the now-closed #423 (codex/p1-health-truth-split) without re-implementing #416's backend logic in a parallel module.

- **Backend `/health`** now includes a structured `warnings[]` array alongside `serviceHealth` / `capabilityHealth`. Stable `code` field (`treasury_mutations_unavailable`, `blockchain_disabled`, etc.) so dashboards and smoke checks match without parsing prose. HTTP status still follows `serviceHealth.ok` ALONE — the warnings list is additive truth, not a 503 trigger.
- **Operator overview topbar** renders a "Treasury unavailable" / "Treasury degraded" chip whenever `capabilityHealth.treasuryMutations` is anything other than `available`. Returns null when /health is clean — zero visual cost in the happy state.
- **Helper** `buildCapabilityWarnings(capabilityHealth)` extracted in `mcp-server/src/core/health-capability.js` (the existing #416 module). Pure function, fully unit-tested.

## Why not just rebase #423?
#423 stood up a parallel `health-report.js` module that re-implemented the truth split #416 already shipped via `health-capability.js`. Rebasing would have collided head-on. Closing it and porting the three pieces that #416 did *not* ship — topbar chip, `warnings[]` array, chain-disabled smoke assertion — is the narrow path.

## Verification
- `npm --workspace mcp-server test` → **776 / 776 pass**
- `RUN_HTTP_SMOKE=1 node --test --test-name-pattern "separates service liveness from treasury capability" mcp-server/src/protocols/http/server.smoke.test.js` → **1 / 1 pass**
- `npm run typecheck:app` → clean
- `npm run build:frontend` → built, generated artifacts reverted (per Package H rule)

## Test plan
- [ ] Read `health-capability.js` diff — confirm `buildCapabilityWarnings` is pure, idempotent, and never emits `critical` for non-treasury / non-chain-unhealthy capabilities
- [ ] Read `server.js` `/health` diff — confirm `warnings: buildCapabilityWarnings(capabilityHealth)` is the only addition and HTTP status logic is unchanged
- [ ] Read `OverviewTopbar.tsx` — confirm the chip renders only when the prop is present, and that `data-testid="overview-capability-warning"` is exposed for future Playwright coverage
- [ ] Read `overview/page.tsx` `buildCapabilityWarning` helper — confirm it returns `undefined` (not an empty object) when treasury is `available`

## Impact
- Backend `/health` response gains a new top-level `warnings[]` field. Existing consumers (`serviceHealth`, `capabilityHealth`, legacy `components`) are unchanged.
- Operator overview page imports a typed prop from `OverviewTopbar` and reads `health.data` (already in scope via `useHealth()`). No new network call.
- No contracts, indexer, Caddy, generated deploy output, or env changes.

Closes the substantive content of #423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)