### PR TITLE
PR 4b.6 Stage 1 — flip JWT_BACKEND hmac → both

### DIFF
--- a/deploy/backend.env.template
+++ b/deploy/backend.env.template
@@ -140,7 +140,15 @@ AUTH_CHAIN_ID=420420417
 # - both:  verify accepts both; sign uses JWT_PRIMARY_ALG (default hmac).
 #          Transitional state during cutover.
 # Cutover sequence: hmac → both → kms (see docs/PHASE_4B_KMS_JWT_PLAN.md §7)
-JWT_BACKEND=hmac
+#
+# 2026-05-17 — Stage 1 of the 4b.6 cutover. Bumped from hmac → both.
+# Verify path now accepts both HS256 (legacy sessions) and ES256 (KMS).
+# Sign path stays HS256 because JWT_PRIMARY_ALG is unset (defaults to
+# hmac under JWT_BACKEND=both per parseJwtPrimaryAlg). Existing operator
+# sessions continue working without re-SIWE; the change is purely
+# additive on the verify side and unlocks ES256 admin-JWT minting via
+# scripts/ops/mint-admin-jwt.mjs --use-kms.
+JWT_BACKEND=both
 
 # Phase 4b.6 — ES256 verifier TTL ceiling. Capped at 30 days to allow
 # long-lived testnet admin/smoke JWTs (the prod-smoke/admin-jwt 1Password


### PR DESCRIPTION
## Summary

Flips the JWT verifier into dual-mode per `docs/PHASE_4B_KMS_JWT_PLAN.md` §7 PR 4b.6 (and the operator runbook in `docs/SECRETS_MIGRATION.md`).

**Change is a single env-template line.** Diff:

```diff
-JWT_BACKEND=hmac
+JWT_BACKEND=both
```

## Behavior change

| Path | Before (`hmac`) | After (`both`) |
|---|---|---|
| Verify HS256 (legacy) | ✅ accepted | ✅ accepted |
| Verify ES256 (KMS) | ❌ rejected | ✅ accepted |
| Sign new SIWE token | HS256 | HS256 (because `JWT_PRIMARY_ALG` unset → defaults to hmac) |

**Net effect: zero impact on existing user sessions.** Purely additive on the verify side. Unlocks `scripts/ops/mint-admin-jwt.mjs --use-kms` for end-to-end KMS-signed admin JWT smoke testing against the running backend.

## Risk

Low. The KMS verifier was wired in by PR #407 (4b.4) and has been receiving zero verify calls in prod (JWT_BACKEND=hmac). Activating it exercises:
- `parseKmsJwtConfig` — fails the boot loudly if any of `AWS_JWT_REGION` / `AWS_JWT_KEY_ID` / `JWT_PUBLIC_KEY_PEM_BASE64` / `JWT_PUBLIC_KEY_FINGERPRINT` are missing. (Confirmed populated; PR #427 deploy verified the env render.)
- `KmsJwtSigner` constructor + lazy KMS client. Lazy — won't actually hit KMS until first verify of an ES256 token, which doesn't happen on the current workload.

## Rollback

`git revert` this commit; the auto-deploy on revert restores `JWT_BACKEND=hmac` (~3 min).

## Test plan

- [x] `node scripts/ops/check-env-template-structure.mjs` — ok
- [x] `node scripts/ops/check-template-matches-manifest.mjs` — ok
- [x] `mcp-server` auth tests — 133/133 (excluding `jwt-dispatcher` / `kms-jwt-signer` pre-existing dep-missing in this worktree)
- [ ] CI green
- [ ] Post-merge deploy succeeds + `/health` 200
- [ ] Operator smoke-test: `mint-admin-jwt.mjs --use-kms` → ES256 token → `curl /auth/session` returns 200

## Operator follow-up

After this deploys clean, run the smoke test from the operator runbook in `docs/SECRETS_MIGRATION.md` → "PR 4b.6 operator runbook — JWT_BACKEND cutover":

```bash
export AWS_JWT_REGION=$(op read 'op://prod-backend/aws-jwt-signer-testnet/aws-region')
export AWS_JWT_KEY_ID=$(op read 'op://prod-backend/aws-jwt-signer-testnet/kms-key-id')
export AWS_JWT_ACCESS_KEY_ID=$(op read 'op://prod-backend/aws-jwt-signer-testnet/access-key-id')
export AWS_JWT_SECRET_ACCESS_KEY=$(op read 'op://prod-backend/aws-jwt-signer-testnet/secret-access-key')
export JWT_PUBLIC_KEY_PEM=$(op read 'op://prod-backend/aws-jwt-signer-testnet/public-key-pem')
ES256_JWT=$(node scripts/ops/mint-admin-jwt.mjs --profile testnet --expires-in-days 1 --use-kms --quiet)
curl -sS -H "Authorization: Bearer $ES256_JWT" https://api.averray.com/auth/session | jq .
```

Then 24-48h soak before Stage 2 (`JWT_BACKEND=kms`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)