### PR TITLE
fix(auth): PR 4b.6 stage-2 prep — ES256 role/roles normalization + mint --use-kms creds

### DIFF
--- a/mcp-server/src/auth/jwt-dispatcher.test.js
+++ b/mcp-server/src/auth/jwt-dispatcher.test.js
@@ -251,6 +251,56 @@ test("dispatcher kms: verifyTokenFromConfig accepts ES256", async () => {
   assert.equal(claims.role, "admin");
   assert.equal(claims.iss, ISSUER);
   assert.equal(claims.aud, AUDIENCE);
+  // Normalization: ES256 emits singular `role` per design doc §6 but
+  // downstream auth code (capabilities, hasRole) reads plural `roles`.
+  // The dispatcher bridges the two so middleware/handler code is
+  // algorithm-agnostic.
+  assert.deepEqual(claims.roles, ["admin"]);
+});
+
+test("dispatcher kms: verifyTokenFromConfig normalizes role → roles for verifier role", async () => {
+  // Same path as above but with a different role value — proves the
+  // normalization isn't hardcoded to "admin".
+  const cfg = buildAuthConfig({ jwtBackend: "kms", withKms: true });
+  const { token } = await signTokenFromConfig(
+    {},
+    { issuer: ISSUER, audience: AUDIENCE, subject: SUBJECT, role: "verifier", expiresInSeconds: 60 },
+    cfg,
+  );
+  const claims = await verifyTokenFromConfig(token, cfg);
+  assert.equal(claims.role, "verifier");
+  assert.deepEqual(claims.roles, ["verifier"]);
+});
+
+test("dispatcher kms: verifyTokenFromConfig preserves an existing claims.roles array (does not overwrite)", async () => {
+  // Defense-in-depth: if a future ES256 variant carries a `roles`
+  // array alongside `role`, the dispatcher must NOT overwrite the
+  // explicit roles array with `[role]`. Mint with both.
+  const cfg = buildAuthConfig({ jwtBackend: "kms", withKms: true });
+  // Use signAsync directly to inject an extra claim (roles) that the
+  // dispatcher's signTokenFromConfig strips by default.
+  const signer = await (async () => {
+    const { KmsJwtSigner } = await import("./kms-jwt-signer.js");
+    return new KmsJwtSigner({
+      kmsClient: cfg.kmsJwt.kmsClient,
+      region: cfg.kmsJwt.region,
+      keyId: cfg.kmsJwt.keyId,
+      kid: cfg.kmsJwt.kid,
+      publicKeyPem: cfg.kmsJwt.publicKeyPem,
+      expectedIssuer: cfg.kmsJwt.expectedIssuer,
+      expectedAudience: cfg.kmsJwt.expectedAudience,
+      expectedRoles: ["admin", "verifier"],
+      maxTtlSeconds: cfg.kmsJwt.maxTtlSeconds,
+    });
+  })();
+  const token = await signer.signAsync(
+    { roles: ["admin", "verifier"] },
+    { issuer: ISSUER, audience: AUDIENCE, subject: SUBJECT, role: "admin", expiresInSeconds: 60 },
+  );
+  const claims = await verifyTokenFromConfig(token, cfg);
+  assert.equal(claims.role, "admin");
+  // The explicit roles array is preserved as-is — NOT replaced by [claims.role].
+  assert.deepEqual(claims.roles, ["admin", "verifier"]);
 });
 
 test("dispatcher kms: verifyTokenFromConfig rejects HS256 with clear error", async () => {

--- a/mcp-server/src/auth/jwt.js
+++ b/mcp-server/src/auth/jwt.js
@@ -325,7 +325,20 @@ export async function verifyTokenFromConfig(token, authConfig) {
 async function verifyEs256(token, authConfig) {
   const signer = await getKmsSigner(authConfig);
   try {
-    return signer.verify(token);
+    const claims = signer.verify(token);
+    // Bridge ES256's singular `role` claim (per design doc §6) to the
+    // plural `roles` array that the rest of the auth stack expects
+    // (capabilities.resolveCapabilities, config.hasRole, middleware
+    // expandCapabilities — all read claims.roles). The HS256 path
+    // already produces roles: array via the SIWE handler; this keeps
+    // downstream code algorithm-agnostic. If the token already carries
+    // a `roles` array (e.g., a future multi-role variant), we leave it
+    // untouched — `role` is the canonical ES256 shape but we don't
+    // forbid `roles` if present.
+    if (typeof claims.role === "string" && !Array.isArray(claims.roles)) {
+      claims.roles = [claims.role];
+    }
+    return claims;
   } catch (err) {
     // KmsJwtSigner throws plain Error objects with explanatory
     // messages. Convert to AuthenticationError so the HTTP layer

--- a/scripts/ops/mint-admin-jwt.mjs
+++ b/scripts/ops/mint-admin-jwt.mjs
@@ -275,7 +275,25 @@ async function mintViaKms({ wallet, roles, expiresInSeconds, expiresInDays, quie
   }
   const role = roles[0];
 
+  // Construct an explicit KMSClient so the AWS SDK reads the
+  // AWS_JWT_*-prefixed credentials this script's env contract uses.
+  // Without this, the SDK would fall back to its default credential
+  // chain (unprefixed AWS_ACCESS_KEY_ID / shared config / EC2 IMDS),
+  // which doesn't see the AWS_JWT_ACCESS_KEY_ID we read from
+  // 1Password. If those prefixed creds aren't set (e.g., running under
+  // IAM Roles Anywhere or an EC2 instance profile), we still pass
+  // through to the default chain by leaving `credentials` unset.
+  const accessKeyId = process.env.AWS_JWT_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.AWS_JWT_SECRET_ACCESS_KEY;
+  const kmsClientOpts = { region };
+  if (accessKeyId && secretAccessKey) {
+    kmsClientOpts.credentials = { accessKeyId, secretAccessKey };
+  }
+  const { KMSClient } = await import("@aws-sdk/client-kms");
+  const kmsClient = new KMSClient(kmsClientOpts);
+
   const signer = new KmsJwtSigner({
+    kmsClient,
     region,
     keyId,
     kid,


### PR DESCRIPTION
## Summary

Two bugs surfaced during the Stage 1 (`JWT_BACKEND=both`) prod smoke test of PR #430. Both are **blockers for any future cutover to `JWT_BACKEND=kms`** but harmless under the current `both`-mode (no runtime change for HS256 callers).

### Bug 1 — ES256 role claim doesn't propagate

`KmsJwtSigner` emits ES256 tokens with a **singular** `role` claim (per design doc §6), but the rest of the auth stack reads the **plural** `roles` array (`resolveCapabilities`, `hasRole`, `middleware.expandCapabilities`). Result of the prod smoke test against `/auth/session`:

```json
{
  "wallet": "0xFd2EAE...",
  "roles": [],    ← empty
  "capabilities": [...base set only, no admin: capabilities...]
}
```

The token verified, the wallet authenticated, but the admin role was silently dropped.

**Fix**: `verifyEs256` in `mcp-server/src/auth/jwt.js` now bridges `role` → `roles: [role]` if no `roles` array is present. Preserves explicit `roles` arrays if present (defense for a future multi-role ES256 variant).

### Bug 2 — `mint-admin-jwt.mjs --use-kms` ignores AWS_JWT_* creds

The script documents `AWS_JWT_ACCESS_KEY_ID` / `AWS_JWT_SECRET_ACCESS_KEY` in its env contract but doesn't actually thread them into the `KMSClient`. The AWS SDK falls back to its default credential chain (unprefixed `AWS_ACCESS_KEY_ID` / shared config / EC2 IMDS) and `CredentialsProviderError`s when only the prefixed vars are set:

```
mint-admin-jwt failed: CredentialsProviderError: Could not load credentials from any providers
```

Worked around in the operator runbook by exporting unprefixed vars in a subshell, but the runbook + the `--help` text both say `AWS_JWT_*` is sufficient. Fix the script so the docs are right.

**Fix**: `mint-admin-jwt.mjs` now constructs an explicit `KMSClient` with `AWS_JWT_*` creds. Falls through to the default chain if those vars aren't set, so IAM Roles Anywhere / EC2 instance profile paths continue to work (future-mainnet relevant).

### Tests

Three new tests in `mcp-server/src/auth/jwt-dispatcher.test.js`:

- `dispatcher kms: verifyTokenFromConfig accepts ES256` — extended to assert `claims.roles === ["admin"]`
- `dispatcher kms: verifyTokenFromConfig normalizes role → roles for verifier role` — proves not hardcoded to admin
- `dispatcher kms: verifyTokenFromConfig preserves an existing claims.roles array (does not overwrite)` — defense-in-depth for future multi-role variants

## Runtime impact at merge

**Zero for HS256 callers** (the entire current user base under `JWT_BACKEND=both` primary-alg=hmac). The HMAC verify path is byte-for-byte unchanged.

**Strictly positive for ES256 callers** (currently only the `--use-kms` admin-JWT smoke test path):
- Roles propagate correctly → admin capabilities granted
- `--use-kms` works without the subshell credential workaround

## Test plan

- [x] 133/133 local auth tests pass (excluding `jwt-dispatcher` / `kms-jwt-signer` which need `jose` + `@noble/curves` not in this worktree's `node_modules` — CI runs them)
- [x] `node --check` on all 3 modified files: ok
- [ ] CI green (including the 3 new dispatcher tests)
- [ ] Operator re-runs the Stage 1 smoke test without the subshell workaround → `/auth/session` returns `roles: ["admin"]` + full admin capabilities

## What's still deferred for Stage 2 (`JWT_BACKEND=kms`)

This PR is **prep** for Stage 2, not the flip itself. Stage 2 also requires:

- SIWE handler (`/auth/verify`) switching from `signToken` → `signTokenFromConfig` so it mints ES256 under `=kms`
- `/auth/refresh` handlers (both legacy bearer + cookie) doing the same
- Service-token migration (currently HS256-only, would break under `=kms`)

Those are scoped separately. With this PR landed, you can safely keep `JWT_BACKEND=both` indefinitely while we plan the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)