### PR TITLE
refactor(auth): PR 4b.6 Stage 2A — SIWE + refresh mints route via dispatcher

### DIFF
--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -19,7 +19,7 @@ import {
 } from "../../core/errors.js";
 import { hashCanonicalContent } from "../../core/canonical-content.js";
 import { buildSiweMessage, verifySiweMessage } from "../../auth/siwe.js";
-import { signToken } from "../../auth/jwt.js";
+import { signToken, signTokenFromConfig } from "../../auth/jwt.js";
 import {
   REFRESH_COOKIE_NAME,
   RefreshError,
@@ -2494,9 +2494,16 @@ const server = createServer(async (request, response) => {
       }
 
       const roles = authConfig.resolveRoles?.(verified.recoveredAddress) ?? [];
-      const { token, claims } = signToken(
+      // Phase 4b.6 Stage 2A — route SIWE mint through the dispatcher so
+      // JWT_PRIMARY_ALG controls the emitted algorithm (default still
+      // hmac under JWT_BACKEND=both). Functionally byte-for-byte
+      // identical to the prior `signToken` call when primary_alg=hmac;
+      // flipping primary_alg=kms in a follow-up makes SIWE start
+      // minting ES256 tokens without further code change.
+      const { token, claims } = await signTokenFromConfig(
         { sub: verified.recoveredAddress, roles },
-        { secret: authConfig.signingSecret, expiresInSeconds: authConfig.tokenTtlSeconds }
+        { expiresInSeconds: authConfig.tokenTtlSeconds },
+        authConfig,
       );
 
       // Phase 4b.5b — also mint an opaque refresh token and return it
@@ -2688,9 +2695,12 @@ const server = createServer(async (request, response) => {
           store: refreshAdapter,
         });
 
-        const { token, claims } = signToken(
+        // Phase 4b.6 Stage 2A — dispatcher-routed mint. See /auth/verify
+        // for the rationale; this is the cookie-refresh sibling.
+        const { token, claims } = await signTokenFromConfig(
           { sub: consumed.record.wallet, roles },
-          { secret: authConfig.signingSecret, expiresInSeconds: authConfig.tokenTtlSeconds }
+          { expiresInSeconds: authConfig.tokenTtlSeconds },
+          authConfig,
         );
 
         return respond(
@@ -2753,9 +2763,13 @@ const server = createServer(async (request, response) => {
       // Re-resolve roles at refresh time (an operator may have been added
       // or removed since the original sign-in).
       const roles = authConfig.resolveRoles?.(auth.wallet) ?? auth.claims?.roles ?? [];
-      const { token, claims } = signToken(
+      // Phase 4b.6 Stage 2A — dispatcher-routed mint for the legacy
+      // bearer-token rotation flow. Same byte-for-byte semantics under
+      // JWT_PRIMARY_ALG=hmac.
+      const { token, claims } = await signTokenFromConfig(
         { sub: auth.wallet, roles },
-        { secret: authConfig.signingSecret, expiresInSeconds: authConfig.tokenTtlSeconds }
+        { expiresInSeconds: authConfig.tokenTtlSeconds },
+        authConfig,
       );
 
       return respond(response, 200, {


### PR DESCRIPTION
## Summary

Architectural move with **zero runtime change**: the three user-facing JWT mint call sites now go through `signTokenFromConfig` (the dispatcher) instead of calling `signToken` directly.

| Call site | What it mints | Before | After |
|---|---|---|---|
| `/auth/verify` (SIWE) | New access token after sign-in | `signToken(...)` | `await signTokenFromConfig(...)` |
| `/auth/refresh` (legacy bearer) | Rotated access token | `signToken(...)` | `await signTokenFromConfig(...)` |
| `/auth/refresh` (cookie flow) | Rotated access token from refresh cookie | `signToken(...)` | `await signTokenFromConfig(...)` |
| `/admin/service-tokens` | Service tokens | `signToken(...)` (unchanged) | `signToken(...)` (unchanged) |

Under the current prod config (`JWT_BACKEND=both`, `JWT_PRIMARY_ALG` unset → defaults to hmac), the dispatcher's HS256 branch calls `signToken(payload, { secret: authConfig.signingSecret, ... })` — **byte-for-byte identical** to the prior code. Verifiable by signing the same payload with the same secret and the same `iat`.

## What this unlocks

Flipping `JWT_PRIMARY_ALG=kms` in a follow-up env-template PR makes SIWE start minting ES256 tokens without further code change. The dispatcher routes to `KmsJwtSigner.signAsync`, which translates the SIWE payload (`sub`, `roles`) into the KMS signer's shape (`subject`, `role`).

Sets up Stage 2B (multi-role ES256 + `JWT_PRIMARY_ALG=kms`) and Stage 2C (service-token migration + `JWT_BACKEND=kms`) as further single-PR landings.

## Out of scope (deferred)

`/admin/service-tokens` mint (`signServiceToken` at L1434) stays on legacy `signToken`. Service tokens carry `tokenKind` / `serviceToken` / `capabilityGrantId` claims that the current ES256 signer doesn't emit, and migrating them is its own audit. They continue to verify fine under `JWT_BACKEND=both` regardless of `JWT_PRIMARY_ALG`.

## Test plan

- [x] `node --check mcp-server/src/protocols/http/server.js` — ok
- [x] 133/133 local auth tests pass
- [ ] CI green (dispatcher tests + smoke tests will exercise the new sign path)
- [ ] Post-deploy: existing SIWE sign-in still works (operator app), token shape unchanged
- [ ] Post-deploy: `/auth/refresh` (both flavors) still rotates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)