### PR TITLE
feat(auth): PR 4b.6 Stage 2B activation — flip JWT_PRIMARY_ALG=kms

### DIFF
--- a/deploy/backend.env.template
+++ b/deploy/backend.env.template
@@ -142,13 +142,28 @@ AUTH_CHAIN_ID=420420417
 # Cutover sequence: hmac → both → kms (see docs/PHASE_4B_KMS_JWT_PLAN.md §7)
 #
 # 2026-05-17 — Stage 1 of the 4b.6 cutover. Bumped from hmac → both.
-# Verify path now accepts both HS256 (legacy sessions) and ES256 (KMS).
-# Sign path stays HS256 because JWT_PRIMARY_ALG is unset (defaults to
-# hmac under JWT_BACKEND=both per parseJwtPrimaryAlg). Existing operator
-# sessions continue working without re-SIWE; the change is purely
-# additive on the verify side and unlocks ES256 admin-JWT minting via
-# scripts/ops/mint-admin-jwt.mjs --use-kms.
+# Verify path accepts both HS256 (legacy sessions) and ES256 (KMS).
+# Existing operator sessions continue working without re-SIWE; the change
+# was purely additive on the verify side and unlocked ES256 admin-JWT
+# minting via scripts/ops/mint-admin-jwt.mjs --use-kms.
 JWT_BACKEND=both
+
+# 2026-05-18 — Stage 2B activation. SIWE + /auth/refresh now mint
+# ES256 tokens via the JWT KMS key (signTokenFromConfig routes to the
+# KMS path under JWT_PRIMARY_ALG=kms). HS256 verify stays enabled
+# under JWT_BACKEND=both so in-flight HS256 sessions naturally migrate
+# as their access tokens expire (15 min for refresh-flow tokens,
+# AUTH_TOKEN_TTL_SECONDS for legacy SIWE).
+#
+# Multi-role: the dispatcher passes payload.roles through unchanged,
+# so admin+verifier wallets keep both capabilities. Verified end-to-end
+# in prod with `mint-admin-jwt.mjs --use-kms --roles admin,verifier`
+# returning 48 capabilities (base + admin + verifier) on /auth/session.
+#
+# Rollback: comment this line out (or set JWT_PRIMARY_ALG=hmac) and
+# redeploy — the dispatcher's HMAC sign branch resumes; existing
+# ES256 tokens continue to verify until their (short) TTL expires.
+JWT_PRIMARY_ALG=kms
 
 # Phase 4b.6 — ES256 verifier TTL ceiling. Capped at 30 days to allow
 # long-lived testnet admin/smoke JWTs (the prod-smoke/admin-jwt 1Password


### PR DESCRIPTION
## Summary

Activates the multi-role ES256 SIWE issuance path that PR #433 (Stage 2B) added the code support for. One-line env template change.

```diff
+JWT_PRIMARY_ALG=kms
```

Under `JWT_BACKEND=both` + `JWT_PRIMARY_ALG=kms`:
- **Verify path**: accepts both HS256 (legacy sessions) AND ES256 (KMS).
- **Sign path**: routes through `KmsJwtSigner` → produces ES256 tokens with multi-role `roles` array.

## Behavior at deploy

The dispatcher's `signTokenFromConfig` now selects the KMS branch for SIWE `/auth/verify`, both `/auth/refresh` flows, and any other call site that switched to the dispatcher in PR #432.

**Migration is gradual.** In-flight HS256 sessions stay valid because verify still accepts both. They naturally migrate as access tokens expire:
- Refresh-cookie flow: 15 min (`ACCESS_TOKEN_TTL_SECONDS=900`)
- Legacy SIWE without refresh: `AUTH_TOKEN_TTL_SECONDS` (24h default)

After all HS256 sessions age out (24h), the population is 100% ES256. Stage 2C (`JWT_BACKEND=kms` + service-token migration) can then retire HS256 verify entirely.

## Verification (already done — 2026-05-18 prod smoke)

```
mint-admin-jwt.mjs --use-kms --roles admin,verifier --quiet
| curl ... /auth/session
→ {"roles": ["admin","verifier"], "capabilityCount": 48}
```

Confirms: KMS sign works, KMS verify works, multi-role propagates through the dispatcher, middleware resolves both admin + verifier capabilities.

## Rollback

Comment out (or revert) the `JWT_PRIMARY_ALG=kms` line and redeploy. The dispatcher's HMAC sign branch resumes for new tokens. Existing ES256 tokens continue to verify under `JWT_BACKEND=both` until their TTL expires. ~3 minute path back to the prior state.

## Risks

- **KMS sign latency**: each `/auth/verify` and `/auth/refresh` adds one `KMS:Sign` call (~50–100ms region-local). Acceptable for a once-per-15-min refresh; not a hot path.
- **KMS regional outage** (eu-central-2): SIWE returns 500 until KMS is back. Mitigated by AWS's regional SLA; multi-region replication is a Phase 5 mainnet-only concern (design doc §11).
- **IAM creds rotation**: if `AWS_JWT_ACCESS_KEY_ID/SECRET_ACCESS_KEY` are rotated without updating 1Password, sign fails. Same failure mode as the blockchain signer; monitored via the same patterns.

## Test plan

- [x] env structural lint passes locally
- [x] Stage 2B end-to-end smoke test in prod ✅ (last comment)
- [ ] CI green
- [ ] Post-deploy: operator app SIWE sign-in still works, returns access token (which is now ES256 — opaque to the frontend)
- [ ] Post-deploy: `/auth/refresh` rotation returns ES256 token
- [ ] Watch KMS CloudWatch sign-volume metric: should match SIWE traffic

## What's NOT in this PR

- **`JWT_BACKEND=kms` flip** — Stage 2C, after service-token migration
- **Service token ES256 migration** — Stage 2C
- **HMAC retirement** (delete `op://prod-backend/auth-jwt-secrets`) — ≥30 days after Stage 2C

🤖 Generated with [Claude Code](https://claude.com/claude-code)