### PR TITLE
feat(deploy): PR 2.6b — boot-time env render systemd service

### DIFF
--- a/deploy/agent-stack-env-render.service
+++ b/deploy/agent-stack-env-render.service
@@ -1,0 +1,79 @@
+# systemd oneshot that re-renders /run/agent-stack/{backend,indexer}.env
+# from the in-repo templates BEFORE docker.service starts.
+#
+# Install location on VPS: /etc/systemd/system/agent-stack-env-render.service
+# Activate with:
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable agent-stack-env-render.service
+#
+# Why this exists
+# ────────────────
+# `/run/agent-stack/` is tmpfs (created at boot by
+# /etc/tmpfiles.d/agent-stack.conf, mode 0750 root:ubuntu). The rendered
+# env files inside it are wiped on every reboot. Before this service,
+# the deploy pipeline was the ONLY thing that populated them — so a
+# bare reboot left the backend in a degraded state until a manual
+# deploy ran.
+#
+# This unit closes that gap: at every boot, the env files are
+# re-rendered from `op://` references via the same `render-vps-env.sh`
+# script the deploy uses. Containers then come up with fresh env on
+# the first docker.service start of the boot.
+#
+# Coupling to docker.service
+# ──────────────────────────
+# `Before=docker.service` orders this unit ahead of docker, so docker
+# only sees the populated /run/agent-stack/*.env. We do NOT use
+# `Requires=` or `BindsTo=` on docker — a render failure leaves
+# docker.service to start anyway and fail at compose `env_file:`
+# validation, surfacing the issue via the docker side rather than a
+# black-box failed boot. To tighten this to "render must succeed
+# before docker starts", drop a /etc/systemd/system/docker.service.d/
+# override that adds `Requires=agent-stack-env-render.service`.
+#
+# Failure mode
+# ────────────
+# render-vps-env.sh is strictly fail-closed: it writes to a temp file,
+# validates that NO `op://` references remain unresolved, then mv's
+# into place atomically. If it fails (op inject error, network down,
+# token rotated and not refreshed, etc.) the live env file is NEVER
+# replaced with a partial. The unit enters failed state; `journalctl
+# -u agent-stack-env-render.service` shows the operator-facing error.
+
+[Unit]
+Description=Render agent-stack runtime env files from 1Password before docker
+Documentation=https://github.com/averray-agent/agent/blob/main/docs/SECRETS_MIGRATION.md
+Wants=network-online.target
+After=network-online.target systemd-tmpfiles-setup.service
+Before=docker.service
+ConditionPathExists=/etc/agent-stack/op-backend.env
+ConditionPathExists=/etc/agent-stack/op-indexer.env
+ConditionPathExists=/srv/agent-stack/app/scripts/ops/render-vps-env-all.sh
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# Run as root — /etc/agent-stack/op-*.env are mode 0400 root:root and
+# /run/agent-stack/ is mode 0750 root:ubuntu (created by tmpfiles.d).
+User=root
+Group=root
+# render-vps-env.sh outputs counts + byte lengths only; no rendered
+# content reaches stderr/stdout. systemd captures whatever it does
+# emit to journal under this unit name.
+ExecStart=/srv/agent-stack/app/scripts/ops/render-vps-env-all.sh
+# If render fails after a partial success on one of the two files,
+# the next deploy will re-render both atomically. No cleanup needed.
+TimeoutStartSec=120
+# Standard hardening for a one-shot that only reads/writes well-known
+# paths. NoNewPrivileges blocks the process from gaining additional
+# capabilities via setuid binaries. PrivateTmp gives the process its
+# own /tmp namespace (op inject writes nothing there, but
+# defense-in-depth).
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ReadWritePaths=/run/agent-stack
+ProtectHome=true
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/SECRETS_MIGRATION.md
+++ b/docs/SECRETS_MIGRATION.md
@@ -1544,6 +1544,119 @@ read backend, indexer, or CI vaults.
 - [ ] Calendar entry's `expires_at` updated to the new mint's 30-day
       expiry
 
+### PR 2.6b operator runbook — boot-time env render service
+
+**When**: after the PR shipping
+`deploy/agent-stack-env-render.service` + `scripts/ops/render-vps-env-all.sh`
+lands. One-time per VPS, then it stays installed across reboots.
+
+**Why this exists**: Phase 2 PR 2.5's cutover moved
+`/run/agent-stack/{backend,indexer}.env` to tmpfs. Tmpfs is wiped on
+every reboot. The deploy pipeline re-renders these files on every
+deploy, but the deploy pipeline does NOT run at boot. Without a
+boot-time render service, a bare reboot leaves docker-compose
+unable to find its `env_file:` paths — the backend stays down until
+an operator manually re-renders or triggers a deploy.
+
+This service closes that gap: at every boot, BEFORE `docker.service`
+starts, a systemd oneshot re-renders the env files via the same
+`render-vps-env.sh` script the deploy uses. Containers come up clean
+on the first try.
+
+**Pre-flight (verify the VPS already has the prerequisites from PR 2.3)**:
+
+```bash
+# All four must exist for the service to do anything useful.
+ls -la /etc/agent-stack/op-backend.env /etc/agent-stack/op-indexer.env
+ls -la /etc/tmpfiles.d/agent-stack.conf
+ls -la /srv/agent-stack/app/scripts/ops/render-vps-env.sh
+test -d /run/agent-stack && echo "runtime dir OK"
+```
+
+If any of these are missing, follow the PR 2.3 operator runbook
+("VPS bootstrap + atomic render script") first.
+
+**Install**:
+
+```bash
+# 1. Link the unit file from the in-repo source. Using `link` rather
+#    than `cp` means future updates to the unit ride along with
+#    deploys — no need to re-copy.
+sudo systemctl link /srv/agent-stack/app/deploy/agent-stack-env-render.service
+
+# 2. Reload systemd so it sees the new unit.
+sudo systemctl daemon-reload
+
+# 3. Enable it to start at boot.
+sudo systemctl enable agent-stack-env-render.service
+
+# 4. Test it WITHOUT rebooting — start it manually, confirm exit 0,
+#    confirm the env files have been re-rendered.
+sudo systemctl start agent-stack-env-render.service
+sudo systemctl status agent-stack-env-render.service
+# Expect: "active (exited); ... Process: ... ExecStart=...
+#          render-vps-env-all.sh ... status=0/SUCCESS"
+
+# 5. Verify both env files now exist with the expected size + perms.
+sudo ls -la /run/agent-stack/
+# Expect: backend.env and indexer.env, mode 0400 ubuntu:ubuntu,
+#         non-zero size.
+```
+
+**Verification under realistic conditions** (optional but recommended):
+
+```bash
+# Simulate a reboot's effect on tmpfs: wipe both env files, restart
+# the unit, confirm containers can still start.
+sudo rm /run/agent-stack/backend.env /run/agent-stack/indexer.env
+sudo systemctl restart agent-stack-env-render.service
+sudo ls -la /run/agent-stack/
+# Files should be back, fresh content.
+```
+
+**Coupling to docker.service** (tighter, optional):
+
+The shipped unit uses `Before=docker.service` without `Requires=`.
+That means docker starts AFTER our render, but a render FAILURE
+doesn't prevent docker from starting (it'll fail later at
+`env_file:` validation, surfacing the error there). To make the
+render a hard prerequisite — i.e., docker refuses to start until
+render succeeds — add a drop-in:
+
+```bash
+sudo mkdir -p /etc/systemd/system/docker.service.d
+sudo tee /etc/systemd/system/docker.service.d/agent-stack-env-render.conf >/dev/null <<'CONF'
+[Unit]
+Requires=agent-stack-env-render.service
+CONF
+sudo systemctl daemon-reload
+```
+
+This is recommended for prod once you've watched a few real reboots
+go clean.
+
+**Rollback** (if the unit causes problems):
+
+```bash
+sudo systemctl disable agent-stack-env-render.service
+sudo systemctl stop agent-stack-env-render.service
+# Optionally remove the symlink:
+sudo systemctl unlink agent-stack-env-render.service  # newer systemd
+# OR
+sudo rm /etc/systemd/system/agent-stack-env-render.service
+sudo systemctl daemon-reload
+```
+
+The system returns to "deploy is the only env-render path" — the
+state before this PR. Reboots once again leave prod down until a
+deploy runs, but nothing is corrupted.
+
+**Future**: when the deploy pipeline is taught to re-run
+`systemctl daemon-reload` after every push (so unit-file changes
+in the repo propagate automatically), this whole runbook becomes
+"one PR + one redeploy" instead of "PR + manual operator install".
+Tracked as a follow-up.
+
 ---
 
 ## Legacy Phase 2 implementation reference

--- a/scripts/ops/render-vps-env-all.sh
+++ b/scripts/ops/render-vps-env-all.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# render-vps-env-all.sh — render every runtime env file (backend +
+# indexer) from its in-repo template via 1Password.
+#
+# Thin wrapper around render-vps-env.sh. Iterates the known runtimes,
+# renders each, exits 0 only if ALL renders succeed.
+#
+# Called from two places:
+#   1. The agent-stack-env-render.service systemd unit at boot
+#      (before docker.service starts)
+#   2. Operator hands during ad-hoc maintenance (e.g., after rotating
+#      a 1Password value out-of-band)
+#
+# The deploy pipeline's render_runtime_envs in deploy-production.sh
+# does NOT call this script — it has additional logic (drift
+# detection, force-recreate flags for changed env content) that
+# doesn't apply at boot. Keep that logic in deploy-production.sh; this
+# wrapper is the minimal "fill in the files" path.
+#
+# Failure semantics:
+#   • render-vps-env.sh is fail-closed per-runtime — a failure of
+#     either runtime aborts immediately with the underlying exit
+#     status.
+#   • Pre-flight checks (token files exist, template files exist,
+#     /run/agent-stack/ exists) match the deploy-pipeline's
+#     conditions so a boot-time failure mirrors what the deploy
+#     would see.
+#
+# Usage (on VPS, typically via systemd as root):
+#   sudo /srv/agent-stack/app/scripts/ops/render-vps-env-all.sh
+#
+# Exit codes:
+#   0   every runtime rendered successfully
+#   1   at least one render failed
+#   2   pre-flight check failed (missing token / template / runtime dir)
+
+set -euo pipefail
+set +x
+umask 077
+
+APP_ROOT="${AGENT_STACK_APP_ROOT:-/srv/agent-stack/app}"
+RUNTIME_DIR="${AGENT_STACK_RUNTIME_DIR:-/run/agent-stack}"
+TOKEN_DIR="${AGENT_STACK_TOKEN_DIR:-/etc/agent-stack}"
+RENDER_SCRIPT="$APP_ROOT/scripts/ops/render-vps-env.sh"
+# Add new runtimes here as they're introduced. Each entry expands to a
+# template at $APP_ROOT/deploy/<name>.env.template, a target at
+# $RUNTIME_DIR/<name>.env, and a token at $TOKEN_DIR/op-<name>.env.
+RUNTIMES=(backend indexer)
+
+log()  { echo "render-vps-env-all.sh: $*"; }
+fail() { echo "render-vps-env-all.sh: $*" >&2; exit "${2:-1}"; }
+
+# ── Pre-flight ─────────────────────────────────────────────────────────────
+
+[ -x "$RENDER_SCRIPT" ] || fail "render-vps-env.sh missing or not executable at $RENDER_SCRIPT" 2
+[ -d "$RUNTIME_DIR" ]   || fail "$RUNTIME_DIR does not exist (install /etc/tmpfiles.d/agent-stack.conf and run systemd-tmpfiles --create)" 2
+
+for runtime in "${RUNTIMES[@]}"; do
+  template="$APP_ROOT/deploy/${runtime}.env.template"
+  token="$TOKEN_DIR/op-${runtime}.env"
+  [ -f "$template" ] || fail "missing template: $template" 2
+  [ -f "$token" ]    || fail "missing op-token file: $token (drop the service-account token per SECRETS_MIGRATION.md)" 2
+done
+
+# ── Render each runtime ────────────────────────────────────────────────────
+
+failed=()
+for runtime in "${RUNTIMES[@]}"; do
+  template="$APP_ROOT/deploy/${runtime}.env.template"
+  target="$RUNTIME_DIR/${runtime}.env"
+  token="$TOKEN_DIR/op-${runtime}.env"
+  log "rendering $runtime: $template -> $target"
+  if ! bash "$RENDER_SCRIPT" "$template" "$target" "$token"; then
+    log "render FAILED for $runtime"
+    failed+=("$runtime")
+  fi
+done
+
+if [ "${#failed[@]}" -gt 0 ]; then
+  fail "render failed for: ${failed[*]}"
+fi
+
+log "all renders succeeded: ${RUNTIMES[*]}"
+exit 0


### PR DESCRIPTION
## Summary

Closes the gap that today's `System restart required` flag surfaced: `/run/agent-stack/{backend,indexer}.env` are tmpfs files, wiped on every reboot, but the deploy pipeline is the **only** thing that re-renders them. Without this PR, a bare reboot leaves the backend down until a deploy runs.

After this lands + the operator installs the unit once per VPS, reboots become hands-off:
1. Boot → systemd-tmpfiles creates `/run/agent-stack/`
2. `agent-stack-env-render.service` runs `op inject` to repopulate the env files
3. `docker.service` starts → compose finds the env files → containers come up clean
4. `/health` returns 200 within ~90s of the boot

## Files

| File | Purpose |
|---|---|
| `deploy/agent-stack-env-render.service` | The systemd unit. `Type=oneshot, RemainAfterExit=yes`, `Before=docker.service`, runs as root, hardened with `NoNewPrivileges` / `PrivateTmp` / `ProtectSystem=strict + ReadWritePaths=/run/agent-stack`. |
| `scripts/ops/render-vps-env-all.sh` | Thin wrapper around `render-vps-env.sh` that iterates the runtimes (currently `backend` + `indexer`). Used by the systemd unit at boot AND callable by hand. |
| `docs/SECRETS_MIGRATION.md` (+113 lines) | "PR 2.6b operator runbook" section with install, verification, optional tighter-coupling drop-in, and rollback. |

## Coupling decision: `Before=` only, not `Requires=`

The shipped unit uses `Before=docker.service` without making docker depend on it. A transient render failure (e.g., 1Password briefly unreachable) does not block docker entirely — docker starts and fails at compose `env_file:` validation, surfacing the issue through normal compose error paths.

Trade-off:
- **Loose coupling** (this PR): less binary outage shape, same observability, easier to diagnose
- **Tight coupling** (drop-in documented in the runbook): docker refuses to start until render succeeds; cleaner state machine but harder to recover from a 1Password outage

Recommend tightening to `Requires=` once a handful of real reboots have run clean. The drop-in template is in the runbook.

## Pre-flight already satisfied on the live VPS

Confirmed earlier this session:
- ✅ `/etc/tmpfiles.d/agent-stack.conf` installed (creates `/run/agent-stack/` at boot)
- ✅ `/etc/agent-stack/op-backend.env` + `op-indexer.env` exist with valid OP service-account tokens
- ✅ `/srv/agent-stack/app/scripts/ops/render-vps-env.sh` present + executable
- ✅ `docker` service is enabled
- ✅ All 5 docker-compose services have `restart: unless-stopped`

So this PR is genuinely "drop in the unit and enable it" with zero new infra.

## Test plan

- [x] `bash -n` on the wrapper script + unit-file structural check
- [x] env-template lint (`check-env-template-structure.mjs`) — passes (no template-surface change)
- [ ] CI green
- [ ] Operator one-time install per the new runbook:
  1. `sudo systemctl link /srv/agent-stack/app/deploy/agent-stack-env-render.service`
  2. `sudo systemctl daemon-reload && sudo systemctl enable agent-stack-env-render.service`
  3. `sudo systemctl start agent-stack-env-render.service` → expect `active (exited); ExecStart=...status=0/SUCCESS`
  4. `sudo ls -la /run/agent-stack/` → both env files present with mode 0400 ubuntu:ubuntu
  5. Optional: nuke + restart test — `sudo rm /run/agent-stack/{backend,indexer}.env && sudo systemctl restart agent-stack-env-render.service && sudo ls -la /run/agent-stack/`
- [ ] After install: `sudo apt upgrade -y && sudo reboot`, wait 90s, `curl /health` → 200

## What's NOT in this PR (intentionally)

- **Auto-install hook in `deploy-production.sh`** — could be added so the unit re-syncs on every deploy. Deferred to a follow-up because the unit file is stable and re-running `systemctl link` per deploy is wasted work. If the unit needs to change, we'll know via the PR review.
- **The actual VPS reboot** — operator does this in a maintenance window once the unit is installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)