### PR TITLE
fix(deploy): drop ProtectHome=true from agent-stack-env-render.service

### DIFF
--- a/deploy/agent-stack-env-render.service
+++ b/deploy/agent-stack-env-render.service
@@ -69,11 +69,25 @@ TimeoutStartSec=120
 # capabilities via setuid binaries. PrivateTmp gives the process its
 # own /tmp namespace (op inject writes nothing there, but
 # defense-in-depth).
+#
+# We intentionally do NOT set ProtectHome=true. The 1Password CLI
+# writes its config to $HOME/.config/op/ (i.e., /root/.config/op/
+# under User=root) the first time it's invoked. Under ProtectHome=true,
+# /root is mounted read-only and `op inject` fails with:
+#
+#   cannot create directory "/root/.config/op": read-only file system
+#
+# We considered redirecting op's state via XDG_CONFIG_HOME or
+# HOME=/run/agent-stack, but the cleanest tradeoff for a root-only
+# oneshot with NoNewPrivileges + PrivateTmp + ProtectSystem=strict +
+# ReadWritePaths=/run/agent-stack is just to let op use /root as it
+# expects. There's no user data on this VPS in /root or /home that
+# this service has any business touching, so ProtectHome's value here
+# is marginal.
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ReadWritePaths=/run/agent-stack
-ProtectHome=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Follow-up to #436. The 1Password CLI writes its config to `\$HOME/.config/op/` on first invocation. Under `ProtectHome=true` the unit's `/root` is mounted read-only and `op inject` fails:

\`\`\`
cannot create directory \"/root/.config/op\" and the parent directories:
  mkdir /root/.config: read-only file system
\`\`\`

Surfaced during the operator install on the live VPS — the unit installed cleanly but failed on first `systemctl start`.

## Fix

Drop `ProtectHome=true` from the unit. Keep everything else:
- `NoNewPrivileges=true` (no setuid escalation)
- `PrivateTmp=true` (isolated /tmp namespace)
- `ProtectSystem=strict` (most of /usr, /etc, /boot, /var read-only)
- `ReadWritePaths=/run/agent-stack` (the one path the script needs to write)

For a root-only oneshot with those four protections, `ProtectHome` was the weakest — no user data in /root or /home that this service touches. The remaining three are the load-bearing pieces.

Added an extended comment in the unit explaining why ProtectHome is omitted and what alternative was considered.

## Rejected alternative

Redirect op's state via `XDG_CONFIG_HOME=/var/lib/op` + `StateDirectory=op`. Architecturally cleaner (preserves ProtectHome) but adds two layers of indirection for what amounts to letting a stateless `op inject` call write a cache dir it never reads from again.

## Test plan

- [x] Reviewed unit file syntax
- [ ] CI green
- [ ] After merge + deploy:
  ```bash
  sudo systemctl daemon-reload
  sudo systemctl start agent-stack-env-render.service
  sudo systemctl status agent-stack-env-render.service
  # Expect: active (exited), status=0/SUCCESS
  sudo ls -la /run/agent-stack/
  # Expect: backend.env, indexer.env, mode 0400 ubuntu:ubuntu
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)