### PR TITLE
feat(auth): PR 4b.6 Stage 2C-1 — signServiceToken routes via dispatcher

### DIFF
--- a/mcp-server/src/auth/config.js
+++ b/mcp-server/src/auth/config.js
@@ -1,7 +1,17 @@
 import { ConfigError } from "../core/errors.js";
 
 const VALID_MODES = new Set(["strict", "permissive"]);
-const VALID_ROLES = new Set(["admin", "verifier"]);
+// Roles that may appear in a JWT's `roles` claim. SIWE-issued tokens
+// carry "admin" / "verifier" derived from the wallet-set env vars
+// (AUTH_ADMIN_WALLETS / AUTH_VERIFIER_WALLETS, resolved by
+// resolveRoles below). Service tokens (issued via /admin/service-tokens)
+// carry "service" — added in Phase 4b.6 Stage 2C-1 so KmsJwtSigner's
+// expectedRoles allowlist accepts the canonical ES256 service-token
+// shape. The "service" role is informational only — capabilities for a
+// service token come from the capabilityGrantId lookup, NOT from
+// hasRole(claims, "service"). resolveRoles never emits "service";
+// it can only originate from signServiceToken (server.js L1426).
+const VALID_ROLES = new Set(["admin", "verifier", "service"]);
 const VALID_JWT_BACKENDS = new Set(["hmac", "kms", "both"]);
 const VALID_JWT_PRIMARY_ALGS = new Set(["hmac", "kms"]);
 const DEFAULT_JWT_KID = "jwt-1";

--- a/mcp-server/src/auth/jwt-dispatcher.test.js
+++ b/mcp-server/src/auth/jwt-dispatcher.test.js
@@ -52,7 +52,10 @@ const KID = "jwt-1";
 const ISSUER = "averray-backend-testnet";
 const AUDIENCE = "averray-backend";
 const SUBJECT = "0x000000000000000000000000000000000000abcd";
-const ROLES = ["admin", "verifier"];
+// Mirror VALID_ROLES in mcp-server/src/auth/config.js — "service" was
+// added in Stage 2C-1 (#438) so the dispatcher's expectedRoles allowlist
+// accepts service-token claim shapes minted via signTokenFromConfig.
+const ROLES = ["admin", "verifier", "service"];
 const HMAC_SECRET = "h".repeat(48);
 const LONG_HMAC_SECRET = "L".repeat(48);
 

--- a/mcp-server/src/auth/jwt-dispatcher.test.js
+++ b/mcp-server/src/auth/jwt-dispatcher.test.js
@@ -313,6 +313,75 @@ test("dispatcher kms: legacy single-`role` token (minted pre-2B) still verifies 
   assert.deepEqual(claims.roles, ["admin"]);
 });
 
+test("dispatcher kms: service-token claim shape round-trips (Stage 2C-1)", async () => {
+  // Stage 2C-1 service-token migration — signServiceToken in server.js
+  // now routes through signTokenFromConfig with roles: ["service"]. Under
+  // JWT_BACKEND=kms the dispatcher mints a token carrying:
+  //   - roles: ["service"]               (canonical multi-role shape)
+  //   - tokenKind: "service"             (extra claim, payload spread)
+  //   - serviceToken: true               (extra claim)
+  //   - capabilityGrantId: <id>          (extra claim, used by middleware
+  //                                       to look up the grant)
+  //   - serviceScope: <optional>         (extra claim, advisory)
+  // This test pins all five so a future signer refactor can't silently
+  // strip the extras.
+  const cfg = buildAuthConfig({ jwtBackend: "kms", withKms: true });
+  const { token, claims } = await signTokenFromConfig(
+    {
+      sub: SUBJECT,
+      roles: ["service"],
+      tokenKind: "service",
+      serviceToken: true,
+      capabilityGrantId: "grant_abc123",
+      serviceScope: "hosted-smoke",
+    },
+    { expiresInSeconds: 600 },
+    cfg,
+  );
+  // Issued claims (decoded by dispatcher before return).
+  assert.deepEqual(claims.roles, ["service"]);
+  assert.equal(claims.tokenKind, "service");
+  assert.equal(claims.serviceToken, true);
+  assert.equal(claims.capabilityGrantId, "grant_abc123");
+  assert.equal(claims.serviceScope, "hosted-smoke");
+  // Verify round-trip preserves every extra claim.
+  const verified = await verifyTokenFromConfig(token, cfg);
+  assert.deepEqual(verified.roles, ["service"]);
+  assert.equal(verified.tokenKind, "service");
+  assert.equal(verified.serviceToken, true);
+  assert.equal(verified.capabilityGrantId, "grant_abc123");
+  assert.equal(verified.serviceScope, "hosted-smoke");
+});
+
+test("dispatcher hmac: service-token claim shape (HS256 path, pre-2C-2 default)", async () => {
+  // Under JWT_BACKEND=hmac the same signServiceToken payload routes
+  // through the legacy HMAC signer. Roles claim still ends up as
+  // ["service"] in the issued token — the HS256 signer doesn't enforce
+  // an expectedRoles allowlist, so any roles value passes verify. This
+  // pins the HS256 mint shape so Stage 2C-2 (the JWT_BACKEND=kms flip)
+  // can rely on cross-alg claim-shape uniformity.
+  const cfg = buildAuthConfig({ jwtBackend: "hmac" });
+  const { token, claims } = await signTokenFromConfig(
+    {
+      sub: SUBJECT,
+      roles: ["service"],
+      tokenKind: "service",
+      serviceToken: true,
+      capabilityGrantId: "grant_xyz789",
+    },
+    { expiresInSeconds: 600 },
+    cfg,
+  );
+  assert.deepEqual(claims.roles, ["service"]);
+  assert.equal(claims.tokenKind, "service");
+  assert.equal(claims.serviceToken, true);
+  assert.equal(claims.capabilityGrantId, "grant_xyz789");
+  const verified = await verifyTokenFromConfig(token, cfg);
+  assert.deepEqual(verified.roles, ["service"]);
+  assert.equal(verified.tokenKind, "service");
+  assert.equal(verified.serviceToken, true);
+});
+
 test("dispatcher kms: verifyTokenFromConfig rejects HS256 with clear error", async () => {
   const cfg = buildAuthConfig({ jwtBackend: "kms", withKms: true });
   const { token: hs256Token } = signToken(

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -1423,24 +1423,35 @@ function normalizeServiceTokenTtlSeconds(payload, grant) {
   return Math.max(1, ttlSeconds);
 }
 
-function signServiceToken(grant, payload = {}) {
-  if (!authConfig.signingSecret) {
+async function signServiceToken(grant, payload = {}) {
+  if (!authConfig.signingSecret && authConfig.jwtBackend === "hmac") {
+    // Under JWT_BACKEND=hmac the dispatcher still needs an HMAC secret.
+    // Under kms / both the secret may legitimately be absent (we're past
+    // the HMAC retirement window).
     throw new AuthenticationError(
       "Auth not configured — set AUTH_JWT_SECRETS to issue service tokens.",
       "auth_not_configured"
     );
   }
   const ttlSeconds = normalizeServiceTokenTtlSeconds(payload, grant);
-  return signToken(
+  // Phase 4b.6 Stage 2C-1 — route through the dispatcher so service-token
+  // mint respects JWT_PRIMARY_ALG (HS256 today, ES256 once 2C-2 flips
+  // JWT_BACKEND=kms). The `roles: ["service"]` claim is informational —
+  // capabilities for a service token come from the capabilityGrantId
+  // lookup in middleware.expandCapabilities, not from hasRole. The
+  // "service" entry is in VALID_ROLES (auth/config.js) so KmsJwtSigner's
+  // expectedRoles allowlist accepts the ES256 shape after 2C-2.
+  return await signTokenFromConfig(
     {
       sub: grant.subject,
-      roles: [],
+      roles: ["service"],
       tokenKind: "service",
       serviceToken: true,
       capabilityGrantId: grant.id,
       ...(grant.scope ? { serviceScope: grant.scope } : {})
     },
-    { secret: authConfig.signingSecret, expiresInSeconds: ttlSeconds }
+    { expiresInSeconds: ttlSeconds },
+    authConfig,
   );
 }
 
@@ -4082,7 +4093,7 @@ const server = createServer(async (request, response) => {
       assertIssuerCanGrantCapabilities(grant, auth);
       await stateStore.upsertCapabilityGrant?.(grant);
       authMiddleware.invalidateCapabilityGrantCache?.(grant.subject);
-      const { token, claims } = signServiceToken(grant, payload);
+      const { token, claims } = await signServiceToken(grant, payload);
       const body = serviceTokenIssueResponse({ grant, token, claims });
       await storeIdempotentMutationReceipt({
         bucket: "service_token_issue",
@@ -4160,7 +4171,7 @@ const server = createServer(async (request, response) => {
       });
       await stateStore.upsertCapabilityGrant?.(nextGrant);
       authMiddleware.invalidateCapabilityGrantCache?.(nextGrant.subject);
-      const { token, claims } = signServiceToken(nextGrant, payload);
+      const { token, claims } = await signServiceToken(nextGrant, payload);
       const body = serviceTokenIssueResponse({ grant: nextGrant, token, claims, rotatedFrom: revoked });
       await storeIdempotentMutationReceipt({
         bucket: "service_token_rotate",


### PR DESCRIPTION
## Summary

First of three Stage 2C landings (plan: #435). Migrates the service-token mint path to the dispatcher, paving the way for the `JWT_BACKEND=kms` flip (Stage 2C-2) and HMAC retirement (Stage 2C-3).

## Changes

| File | Change |
|---|---|
| `mcp-server/src/auth/config.js` | Widen `VALID_ROLES` to include `"service"`. Comment spells out the invariant: `resolveRoles` never emits `"service"` — only `signServiceToken` does. |
| `mcp-server/src/protocols/http/server.js` | `signServiceToken` becomes async + routes through `signTokenFromConfig` with `roles: ["service"]`. Two callers gain `await`. `auth_not_configured` precondition scoped to `JWT_BACKEND=hmac` so post-HMAC-retirement boot doesn't require `AUTH_JWT_SECRETS`. |
| `mcp-server/src/auth/jwt-dispatcher.test.js` | Two new tests: service-token claim shape round-trip under `JWT_BACKEND=kms` and `JWT_BACKEND=hmac`. Pin every extra claim (`tokenKind`, `serviceToken`, `capabilityGrantId`, `serviceScope`) + the canonical `roles: ["service"]`. |

## Runtime impact at merge

**Zero observable change.** Under the current prod config (`JWT_BACKEND=both, JWT_PRIMARY_ALG=kms`) the dispatcher already routes through the KMS sign path for SIWE; service tokens now join the same path. The only emitted-claim difference: `roles: [] → roles: ["service"]`. No consumer reads service-token roles (`middleware.expandCapabilities` keys on `tokenKind`/`serviceToken` flags and `capabilityGrantId`), so this is invisible to every caller.

In-flight HS256 service tokens from before #432/#434/2C-1 continue to verify until their TTL expires (default 24h, max 30d).

## Why widen `VALID_ROLES` vs. relax the `KmsJwtSigner` allowlist

Two options from the plan doc (#435 §2):
- **Option A (this PR)**: add `"service"` to `VALID_ROLES` → the verifier's expected-roles allowlist accepts it cleanly. `resolveRoles` is unchanged so SIWE-issued tokens still only carry `admin`/`verifier`.
- Option B (rejected): relax `KmsJwtSigner.verify` to accept tokens with empty roles when they're service tokens. Introduces an alg-side conditional on a non-registered claim — strictly worse for security review.

## Test plan

- [x] `node --check` on all 3 modified files
- [x] 133/133 local auth tests pass
- [ ] CI green (the two new dispatcher tests + existing 783 backend tests)
- [ ] Post-deploy: `check-service-token-proof.mjs` smoke continues to pass (issues fresh token → exercises `/jobs/preflight` → tries denied paths → revokes)
- [ ] Operator can soak under `JWT_BACKEND=both` for 24-48h before Stage 2C-2 flips to `=kms`

## What's NOT in this PR

- **Stage 2C-2 env flip** (`JWT_BACKEND=both → kms`) — separate one-line PR after this soaks
- **Stage 2C-3 HMAC retirement** — ≥30d after 2C-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)