### PR TITLE
docs: audit roadmap sources

### DIFF
--- a/docs/AUDIT_REMEDIATION.md
+++ b/docs/AUDIT_REMEDIATION.md
@@ -7,7 +7,8 @@
 
 > Current roadmap/status source: [`PROJECT_ROADMAP.md`](./PROJECT_ROADMAP.md).
 > This remediation plan keeps the detailed audit finding definitions and close
-> criteria; several item statuses have since been superseded by merged PRs.
+> criteria. Current sequencing lives in the roadmap.
+> Latest docs-status audit: [`DOCS_AUDIT_2026-05-19.md`](./DOCS_AUDIT_2026-05-19.md).
 
 ---
 
@@ -110,7 +111,9 @@ This is not complete launch planning. The audit does not surface every open item
 
 ### P1.2 - Account overlay state is process memory, not durable state
 
-**Status:** Open. **Launch-blocking.**
+**Status:** Closed on 2026-05-17 in `a36f633` (PR #408 *Package C - account overlay durability*).
+**Verification:** The closure moved account overlay handling into classified, durable, write-through storage semantics and inverted precedence so live account fields win over cached overlay fields. `PROJECT_ROADMAP.md` treats `P1.2` as done.
+**Historical note:** The original audit rationale and close criteria remain below for reference.
 
 **Audit reference:** `mcp-server/src/services/bootstrap.js` (`accounts = new Map(...)`), `mcp-server/src/core/account-mutation-service.js` (`attachStoredTreasuryMetadata`).
 
@@ -194,7 +197,7 @@ This is not complete launch planning. The audit does not surface every open item
 
 ### P2.4 - Operator frontend can mix live API with demo truth
 
-**Status:** Closed on 2026-05-17 in PR #<TBD> (*Package E — operator frontend truth modes*).
+**Status:** Closed on 2026-05-18 in `8a57a12` (PR #425 *Package E - operator frontend truth modes*).
 **Verification:** `npm run test:app` runs `app/lib/ui/page-mode.test.mjs` — 11/11 pass, covering the classifier's precedence (demo > degraded > live-while-loading > empty > live), the `isDemoModeEnabled()` strict-`"true"` check, and a fixture-absence regression that fails if anyone re-adds `app/components/disputes/data.ts` or `app/components/sessions/data.ts`. `npm --workspace app run typecheck` clean against the new `app/lib/ui/page-mode.js` + `<DemoModeBanner />` wiring.
 **Notes:** The mechanical enforcement lives in three small pieces: (a) `app/lib/ui/page-mode.js` is the single classifier any page reaches for to decide `live`/`empty`/`degraded`/`demo`; (b) `<DemoModeBanner />` mounted in the authed layout (`app/app/(authed)/layout.tsx`) renders only when `NEXT_PUBLIC_DEMO_MODE=true`, so demo data can never appear without an unmistakable on-screen marker; (c) the two known-orphaned fixture exports (`DISPUTES`, `SESSIONS`) were already not imported by any live page and are now deleted, so they cannot drift back into a production code path. The classifier + the deletion together make the empty-state contract impossible to bypass silently. Per-page visible mode chips are deliberately not part of this PR — operator pages already drive empty / degraded views through their own copy; the classifier just makes that decision uniform.
 
@@ -222,7 +225,9 @@ This is not complete launch planning. The audit does not surface every open item
 
 ### P2.5 - Public site shows a fake "Live" stream
 
-**Status:** Open. **Launch-blocking.**
+**Status:** Closed on 2026-05-17 in `0c313e3` (PR #405 *Package F - relabel homepage console as Example, not Live*) and reinforced by `5947c01` (PR #409 *Make homepage proof stream explicitly scripted*).
+**Verification:** Path B was chosen for rc1: the deterministic public stream is explicitly example/scripted and no longer presents itself as live platform activity.
+**Historical note:** The original path options remain below for reference.
 
 **Audit reference:** `marketing/src/pages/index.astro` labels the homepage console as live/operator staging; `marketing/public/console-stream.js` contains deterministic scripted output and explicitly says there is no network.
 
@@ -258,7 +263,9 @@ This is not complete launch planning. The audit does not surface every open item
 
 ### P2.5b - Policy state is process-local demo state
 
-**Status:** Open. **Not launch-blocking for bootstrap, but should close before public posters arrive.**
+**Status:** Closed on 2026-05-18 in `b94dd42` (PR #421 *Package G - durable PolicyService + extracted built-in seed*).
+**Verification:** Durable `PolicyService` and extracted built-in seed landed; `PROJECT_ROADMAP.md` treats policy durability as done.
+**Historical note:** The original audit rationale and close criteria remain below for reference.
 
 **Audit reference:** `mcp-server/src/protocols/http/server.js` stores `POLICY_PROPOSALS` in a process-local `Map` and defines built-in policies inline.
 
@@ -330,7 +337,9 @@ This is not complete launch planning. The audit does not surface every open item
 
 ### P3.8 - Generated output beside source
 
-**Status:** Open. **Not launch-blocking, but worth catching now.**
+**Status:** Closed on 2026-05-17 in `17fe61b` (PR #406 *Guard generated deploy output edits*).
+**Verification:** The generated output guard is now a CI check and `AGENTS.md` documents normal source-vs-generated edit rules.
+**Historical note:** The original audit rationale and close criteria remain below for reference.
 
 **Audit reference:** `AGENTS.md`, root scripts, generated `frontend/` and `site/` deploy outputs.
 
@@ -512,7 +521,7 @@ The remediation work should be split into narrow branches so multiple agents can
 
 ### Package E - P2.4 operator frontend truth modes
 
-**Status:** Closed on 2026-05-17 in PR #<TBD>. The mechanical enforcement now lives in `app/lib/ui/page-mode.js`, `<DemoModeBanner />` mounted globally in the authed layout, the `NEXT_PUBLIC_DEMO_MODE` env (defaulting to `false` and inlined at build time by Next.js), and the orphaned fixture exports under `app/components/{disputes,sessions}/data.ts` are deleted with a `node --test` regression that fails if anyone re-adds them or any of the other known fixture re-entry paths.
+**Status:** Closed on 2026-05-18 in `8a57a12` (PR #425 *Package E - operator frontend truth modes*). The mechanical enforcement now lives in `app/lib/ui/page-mode.js`, `<DemoModeBanner />` mounted globally in the authed layout, the `NEXT_PUBLIC_DEMO_MODE` env (defaulting to `false` and inlined at build time by Next.js), and the orphaned fixture exports under `app/components/{disputes,sessions}/data.ts` are deleted with a `node --test` regression that fails if anyone re-adds them or any of the other known fixture re-entry paths.
 
 **Suggested branch:** `codex/p2-operator-demo-truth`
 **Can start:** Yes, but wire health capability warnings after Package B lands.

--- a/docs/AVERRAY_WORKING_SPEC.md
+++ b/docs/AVERRAY_WORKING_SPEC.md
@@ -1052,6 +1052,15 @@ Stripe Link's launch and Stripe Sessions 2026 announcements positioned agents as
 
 For traceability.
 
+### v2.11 (documentation governance pass)
+
+1. **Current status ownership moved to `PROJECT_ROADMAP.md`:** the working spec
+   remains the product and architecture reference, but roadmap status,
+   sequencing, and project completion tracking now live in
+   `PROJECT_ROADMAP.md`.
+2. **Docs audit recorded:** `DOCS_AUDIT_2026-05-19.md` records the stale status
+   corrections and authority rules introduced by the unified roadmap.
+
 ### v2.10 (blockchain audit pass 2)
 
 1. **Native borrow balance-sheet invariant fixed and documented:** debt-backed liquid credit is no longer externally withdrawable, and successful job payouts now repay outstanding debt before crediting surplus liquid. This keeps native launch borrow as over-collateralized balance-sheet credit rather than unbacked cash.
@@ -1081,7 +1090,7 @@ For traceability.
 
 ### v2.7 (spec audit and roadmap reconciliation)
 
-1. **Canonical roadmap alignment:** `CORE_FRAMEWORK_ROADMAP.md` now points at this working spec as the current source of truth, while `RC1_WORKING_SPEC.md` is retained as historical context.
+1. **Canonical roadmap alignment at the time:** `CORE_FRAMEWORK_ROADMAP.md` pointed at this working spec as the current source of truth, while `RC1_WORKING_SPEC.md` was retained as historical context. This status ownership was superseded by `PROJECT_ROADMAP.md` in the v2.11 documentation governance pass.
 2. **USDC-only v1 wording corrected:** the summary now matches the v2.1+ architecture: v1 settlement is USDC-only, with DOT/vDOT yield strategies gated behind week-12 evidence and native XCM correlation proof.
 3. **Bootstrap budget aligned:** the top-level bootstrap model now matches the three-tier Micro/Standard/Substantive receipt-density plan instead of the older Light/Substantive allocation.
 4. **Audit doc published:** `SPEC_AUDIT_2026-05-13.md` records what is complete, what remains, what changed in the main plan, and the remaining production proof gates around the 1Password SSH/basic-auth/admin-JWT cutover path.

--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -7,14 +7,15 @@
 This roadmap turns the current platform framework into a more durable
 production core.
 
-The current product and architecture source document lives in
-[AVERRAY_WORKING_SPEC.md](AVERRAY_WORKING_SPEC.md). Use that spec as the
-roadmap boundary when prioritizing contract, backend, indexer, and operations
-work. [RC1_WORKING_SPEC.md](RC1_WORKING_SPEC.md) is retained as historical
-context only. The PR-sized rc1 execution sequence still lives in
-[RC1_IMPLEMENTATION_PLAN.md](RC1_IMPLEMENTATION_PLAN.md), and the latest
-cross-plan reconciliation lives in
-[SPEC_AUDIT_2026-05-13.md](SPEC_AUDIT_2026-05-13.md).
+The current project status and sequencing boundary lives in
+[PROJECT_ROADMAP.md](PROJECT_ROADMAP.md). The product and architecture source
+document remains [AVERRAY_WORKING_SPEC.md](AVERRAY_WORKING_SPEC.md).
+[RC1_WORKING_SPEC.md](RC1_WORKING_SPEC.md) is retained as historical context
+only. The PR-sized rc1 execution sequence in
+[RC1_IMPLEMENTATION_PLAN.md](RC1_IMPLEMENTATION_PLAN.md) and the
+[SPEC_AUDIT_2026-05-13.md](SPEC_AUDIT_2026-05-13.md) reconciliation are
+historical references unless `PROJECT_ROADMAP.md` explicitly pulls an item
+forward.
 
 It is intentionally grounded in the code that exists today:
 

--- a/docs/DOCS_AUDIT_2026-05-19.md
+++ b/docs/DOCS_AUDIT_2026-05-19.md
@@ -1,0 +1,112 @@
+# Docs Audit - 2026-05-19
+
+- **Status:** current docs-governance audit
+- **Baseline reviewed:** `origin/main` at `163bd76`
+- **Canonical roadmap:** [`PROJECT_ROADMAP.md`](./PROJECT_ROADMAP.md)
+
+This audit records the second-pass review that made
+`PROJECT_ROADMAP.md` the operating guideline for the project.
+
+## Scope
+
+Reviewed:
+
+- all top-level `docs/*.md` files by inventory and targeted search;
+- the roadmap/spec/audit/security/launch docs in detail;
+- current open GitHub PRs and issues;
+- recent merge history around audit closure PRs;
+- Polkadot USDC/ERC20 precompile facts through the Polkadot docs MCP.
+
+Not reviewed line-by-line:
+
+- every schema JSON file;
+- every fixture under `docs/fixtures`;
+- every historical distribution/business note.
+
+This was a roadmap/documentation-consistency audit, not a source-code
+security audit.
+
+## Authority Decision
+
+`PROJECT_ROADMAP.md` is now the active guideline for:
+
+- what is done;
+- what is open;
+- what is deferred;
+- next work sequencing;
+- launch and mainnet readiness layers.
+
+Older docs are allowed to remain as detailed references, but they must not be
+used as the current status source when they conflict with the roadmap.
+
+## Corrections Made In This Pass
+
+| Area | Finding | Correction |
+| --- | --- | --- |
+| Roadmap baseline | `PROJECT_ROADMAP.md` still referenced pre-merge baseline `ca32856`. | Updated baseline to `163bd76`. |
+| Roadmap governance | No explicit rule said the roadmap wins over stale detail docs. | Added `Roadmap Authority` section to `PROJECT_ROADMAP.md`. |
+| Source doc map | The latest docs audit itself was not listed. | Added this audit to the source-doc table. |
+| Framework roadmap | `CORE_FRAMEWORK_ROADMAP.md` still said `AVERRAY_WORKING_SPEC.md` was the roadmap boundary. | Reworded it so `PROJECT_ROADMAP.md` owns status and sequencing, while the working spec owns architecture. |
+| Historical spec audit | `SPEC_AUDIT_2026-05-13.md` said `AVERRAY_WORKING_SPEC.md` v2.9 was the primary source of truth. | Reworded the section as historical source context and pointed current status at `PROJECT_ROADMAP.md`. |
+| Working spec reconciliation log | The v2.7 log said the framework roadmap pointed at the working spec as current source of truth. | Added a v2.11 documentation-governance entry noting that `PROJECT_ROADMAP.md` supersedes status ownership. |
+| Audit remediation stale closures | `AUDIT_REMEDIATION.md` still marked `P1.2`, `P2.5`, `P2.5b`, and `P3.8` open even though later PRs closed them. | Updated their status lines with the closing PR/commit evidence. |
+| Placeholder PR references | `AUDIT_REMEDIATION.md` still had `PR #<TBD>` for Package E. | Replaced with PR `#425`. |
+
+## Current Document Roles
+
+| Document | Role after audit |
+| --- | --- |
+| `PROJECT_ROADMAP.md` | Active status, sequencing, and project completion guideline. |
+| `PRODUCTION_CHECKLIST.md` | Operator go/no-go checklist. Its unchecked boxes remain launch gates until closed. |
+| `AVERRAY_WORKING_SPEC.md` | Product architecture, business model, and long-range strategy. |
+| `CORE_FRAMEWORK_ROADMAP.md` | Framework detail reference for jobs, sessions, verification, SDK, timelines, and operations. |
+| `AUDIT_REMEDIATION.md` | Detailed audit finding rationale and close criteria; not the current sequencing source. |
+| `SPEC_AUDIT_2026-05-13.md` | Historical reconciliation snapshot. |
+| `PRODUCT_PROOF_GATE.md` | Product-proof smoke and hosted evidence reference. |
+| `SECRETS_MIGRATION.md` | Secrets and custody migration detail reference. |
+| `PHASE_4B_STAGE_2C_PLAN.md` | KMS JWT Stage 2C cutover detail reference. |
+| `THREAT_MODEL.md` | Risk and mitigation reference. |
+| `RC1_WORKING_SPEC.md` | Historical design context only. |
+| `RC1_IMPLEMENTATION_PLAN.md` | Historical rc1 slice tracker only. |
+
+## Missing Governance Found
+
+Before this audit, the repo had good detail docs but no explicit rule for which
+one wins when they disagree. That created three practical risks:
+
+- stale audit trackers could reopen work already closed by code;
+- historical plans could look like current sequencing;
+- future agents could update a detail doc without updating the operating
+  roadmap.
+
+The roadmap now carries the rule: status-changing PRs update
+`PROJECT_ROADMAP.md`.
+
+## Remaining Open Work Confirmed
+
+This audit did not discover a new P0 launch blocker beyond the roadmap. The
+current open work remains:
+
+- P0 testnet launch gates in `PRODUCTION_CHECKLIST.md`;
+- KMS JWT Stage 2C-2 draft PR `#439`;
+- Phase 4e security plan PR `#440`;
+- P1 platform hardening items: route split, frontend auth guard, verifier
+  replay hardening, schema registration, dispute/arbitration semantics,
+  timeline UX verification, and workflow generalization;
+- mainnet readiness and native XCM/vDOT gates.
+
+Open GitHub issues in `averray-agent/agent` at audit time: none.
+
+## Polkadot Docs MCP Check
+
+The audit rechecked the USDC/ERC20 precompile facts already carried in
+`PROJECT_ROADMAP.md` against `smart-contracts/precompiles/erc20.md`:
+
+- USDC Trust-Backed Asset ID `1337`;
+- 6 decimals;
+- precompile address `0x0000053900000000000000000000000001200000`;
+- ERC20 precompile implements transfer, transferFrom, approve, allowance,
+  balanceOf, and totalSupply;
+- metadata functions are not implemented.
+
+No roadmap correction was needed for those facts.

--- a/docs/PROJECT_ROADMAP.md
+++ b/docs/PROJECT_ROADMAP.md
@@ -1,13 +1,29 @@
 # Averray Unified Project Roadmap
 
-**Status date:** 2026-05-19  
-**Baseline reviewed:** `origin/main` at `ca32856`  
-**Purpose:** one status and roadmap page for the specs, audits, launch checklists,
-security plans, and product-proof work.
+- **Status date:** 2026-05-19
+- **Baseline reviewed:** `origin/main` at `163bd76`
+- **Latest docs audit:** [`DOCS_AUDIT_2026-05-19.md`](./DOCS_AUDIT_2026-05-19.md)
+- **Purpose:** one status and roadmap page for the specs, audits, launch
+  checklists, security plans, and product-proof work.
 
 This page is the current source of truth for "what is done, what is open, and
 what comes next." The older docs remain useful for deep context, acceptance
 criteria, and implementation notes, but this file owns the unified status.
+
+## Roadmap Authority
+
+Use this file as the operational guideline for sequencing work.
+
+- If another docs file conflicts with this roadmap, this roadmap wins unless
+  code, production evidence, or a newer PR proves otherwise.
+- Detail docs may define implementation criteria, but they do not reopen or
+  close roadmap items by themselves.
+- Any PR that materially changes status, launch readiness, mainnet readiness,
+  security posture, or deferred scope should update this file in the same PR.
+- Historical docs should keep their context, but must point back here instead
+  of claiming to be the active roadmap.
+- Chain-specific claims should be checked against the Polkadot docs MCP or
+  runtime state before they are promoted into this roadmap.
 
 ## Status Terms
 
@@ -59,6 +75,7 @@ Polkadot-specific USDC facts were checked against the Polkadot docs MCP:
 | [`AUDIT_REMEDIATION.md`](./AUDIT_REMEDIATION.md) | Detailed audit finding definitions and acceptance criteria. Some statuses are now stale; use this roadmap for current status. |
 | [`CORE_FRAMEWORK_ROADMAP.md`](./CORE_FRAMEWORK_ROADMAP.md) | Framework implementation detail for jobs, sessions, verification, SDK, timelines, and operations. |
 | [`SPEC_AUDIT_2026-05-13.md`](./SPEC_AUDIT_2026-05-13.md) | Historical reconciliation audit. Superseded for current status, still useful for rationale. |
+| [`DOCS_AUDIT_2026-05-19.md`](./DOCS_AUDIT_2026-05-19.md) | Latest audit of roadmap/spec/checklist doc drift and missing governance. |
 | [`PRODUCTION_CHECKLIST.md`](./PRODUCTION_CHECKLIST.md) | Operator launch gate. Still authoritative for go/no-go checkboxes. |
 | [`PRODUCT_PROOF_GATE.md`](./PRODUCT_PROOF_GATE.md) | Product-proof evidence and smoke command references. |
 | [`PHASE_4B_STAGE_2C_PLAN.md`](./PHASE_4B_STAGE_2C_PLAN.md) | Current KMS JWT cutover plan. |
@@ -271,4 +288,3 @@ The project should be tracked in three completion layers:
 3. **Business thesis complete:** week-12 acceptance gate passes, pilot
    integrations exist, and the receipt/reputation network is useful without
    relying on token speculation or unproven yield.
-

--- a/docs/SPEC_AUDIT_2026-05-13.md
+++ b/docs/SPEC_AUDIT_2026-05-13.md
@@ -8,10 +8,11 @@ This audit reconciles the current spec and roadmap after the recent framework,
 USDC, discovery, secrets, product-proof, lineage, event-log, schema-native,
 idempotency, dispute, and async-XCM foundation work.
 
-Primary source of truth:
+Historical source context at the time of this audit:
 
-- [AVERRAY_WORKING_SPEC.md](./AVERRAY_WORKING_SPEC.md) - current v2.9 product
-  and launch spec.
+- [AVERRAY_WORKING_SPEC.md](./AVERRAY_WORKING_SPEC.md) - then-current product
+  and launch spec. Current status now lives in
+  [PROJECT_ROADMAP.md](./PROJECT_ROADMAP.md).
 - [CORE_FRAMEWORK_ROADMAP.md](./CORE_FRAMEWORK_ROADMAP.md) - framework
   implementation tracker.
 - [RC1_IMPLEMENTATION_PLAN.md](./RC1_IMPLEMENTATION_PLAN.md) - historical rc1
@@ -276,8 +277,9 @@ SSH/basic-auth/admin-JWT cutovers, and the basic hosted smoke is green.
 ## Missed Or Upgraded Plan Items
 
 1. `CORE_FRAMEWORK_ROADMAP.md` still referenced `RC1_WORKING_SPEC.md` as the
-   roadmap boundary. The current source of truth is `AVERRAY_WORKING_SPEC.md`;
-   `RC1_WORKING_SPEC.md` is historical context.
+   roadmap boundary. At the time of this audit, the current source of truth was
+   `AVERRAY_WORKING_SPEC.md`; `PROJECT_ROADMAP.md` now owns current status and
+   sequencing.
 2. The current spec summary still implied wallet yield as if it were live. This
    audit updates it to reflect the v2.2 decision: v1 is USDC-only; yield is
    post-week-12 and post-native-XCM proof.


### PR DESCRIPTION
## What changed
- Added docs/DOCS_AUDIT_2026-05-19.md as the second-pass audit of roadmap/spec/checklist doc drift.
- Made docs/PROJECT_ROADMAP.md explicitly authoritative for current status, sequencing, and project completion tracking.
- Corrected stale source-of-truth wording in the framework roadmap, working spec reconciliation log, and historical spec audit.
- Updated stale audit-remediation statuses for P1.2, P2.5, P2.5b, P3.8, and the Package E PR reference.

## Checks
- git diff --cached --check

## Polkadot docs MCP
- Rechecked the USDC/ERC20 precompile facts against smart-contracts/precompiles/erc20.md before recording the docs-audit note.

## Impact
- Docs only.
- No backend, frontend, indexer, Caddy, contracts, or public site runtime changes.
- No environment or VPS secret changes required.