### PR TITLE
fix(metrics): require hosted metrics auth

### DIFF
--- a/deploy/backend.env.template
+++ b/deploy/backend.env.template
@@ -260,16 +260,17 @@ JOB_STALE_SWEEPER_MAX_JOBS_PER_RUN=25
 # boxes). These env vars wire to code paths that already exist; both are
 # commented out because each is operator-controlled.
 
-# Bearer token gating /metrics on the public surface. When unset (the
-# current default) /metrics is reachable from anyone who can reach
-# api.averray.com - that leaks request-path histograms, status-code
-# distributions, and operational signals. Set this to a high-entropy
-# random token (>= 32 chars) and configure the Prometheus scraper to send
+# Bearer token gating /metrics on the public surface. Production fails closed
+# when METRICS_AUTH_REQUIRED=1 and METRICS_BEARER_TOKEN is unset, because public
+# metrics leak request-path histograms, status-code distributions, and
+# operational signals. Set METRICS_BEARER_TOKEN to a high-entropy random token
+# (>= 32 chars) and configure the Prometheus scraper to send
 # `Authorization: Bearer <token>`. Verify with:
 #   curl -sS -o /dev/null -w "%{http_code}\n" https://api.averray.com/metrics
 #   curl -sS -o /dev/null -w "%{http_code}\n" \
 #     -H "Authorization: Bearer <token>" https://api.averray.com/metrics
 # Expect 401 unauthenticated, 200 with bearer.
+METRICS_AUTH_REQUIRED=1
 # METRICS_BEARER_TOKEN=1Password ref for prod-backend/metrics-bearer-token
 
 # Backend error reporting via Sentry. Optional - the `@sentry/node`

--- a/discovery/.well-known/agent-tools.json
+++ b/discovery/.well-known/agent-tools.json
@@ -382,7 +382,7 @@
     },
     {
       "path": "/metrics",
-      "description": "Prometheus text-format metrics. Optionally bearer-gated via METRICS_BEARER_TOKEN."
+      "description": "Prometheus text-format metrics. Bearer-gated in production via METRICS_BEARER_TOKEN."
     },
     {
       "path": "/onboarding",

--- a/discovery/agent-tools.json
+++ b/discovery/agent-tools.json
@@ -382,7 +382,7 @@
     },
     {
       "path": "/metrics",
-      "description": "Prometheus text-format metrics. Optionally bearer-gated via METRICS_BEARER_TOKEN."
+      "description": "Prometheus text-format metrics. Bearer-gated in production via METRICS_BEARER_TOKEN."
     },
     {
       "path": "/onboarding",

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -203,7 +203,7 @@ RUN_SUBSCAN_XCM_VALIDATION=1 ./scripts/ops/check-release-readiness.sh testnet
 
 ## 5. Observability
 
-- [ ] Backend metrics are reachable and, if public, bearer-protected.
+- [ ] Backend metrics are bearer-protected and reachable with the scraper token.
 - [ ] Backend Sentry is configured for the active environment.
 - [ ] Frontend Sentry runtime config is set if browser error reporting is required.
 - [ ] Structured logs are visible from the current deploy target.
@@ -244,13 +244,17 @@ deployed-config evidence that lives outside the repo. The wiring exists in
 code; only the production env vars need to be set. Concrete verification
 commands per box:
 
-- **Backend metrics reachable and bearer-protected.** Verify reachable:
-  `curl -sS -o /dev/null -w "%{http_code}\n" https://api.averray.com/metrics`
-  must return `200`. Verify bearer-gated: the same request **without** a
-  bearer must return `401` once `METRICS_BEARER_TOKEN` is set in
-  `deploy/backend.env.template`. Current state (2026-05-17): reachable
-  `200`, **not** bearer-gated. Flip after the env var is set and a
-  no-bearer request returns `401`.
+- **Backend metrics bearer-protected and reachable.** Production now fails
+  closed when metrics auth is required but no token is configured. Flip this
+  box only after `METRICS_BEARER_TOKEN` is configured in the production backend
+  environment and this hosted gate passes:
+  ```bash
+  METRICS_BEARER_TOKEN='<metrics-scraper-token>' \
+  CHECK_METRICS_AUTH=1 \
+  ./scripts/ops/check-hosted-stack.sh
+  ```
+  The gate requires unauthenticated `/metrics` to return `401` and the same
+  request with `Authorization: Bearer <token>` to return `200`.
 - **Backend Sentry configured for the active environment.** Set
   `SENTRY_DSN` (and optionally `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`,
   `SENTRY_TRACES_SAMPLE_RATE`) in `deploy/backend.env.template`, then

--- a/docs/PROJECT_ROADMAP.md
+++ b/docs/PROJECT_ROADMAP.md
@@ -133,7 +133,7 @@ externally ready.
 | Redis backup readiness | Open | `check-backup-readiness.sh --json` reports recent Redis backup if Redis contains non-rebuildable state. |
 | Restore drill | Open | Restore drill performed and documented with date, source backup, and target. |
 | Hosted `/admin/status` async XCM smoke | Open | Run hosted check with live admin JWT and verify async XCM watcher lane. |
-| Metrics auth | Open | Backend metrics endpoint is bearer-protected or otherwise not public. |
+| Metrics auth | Open | Backend metrics endpoint fails closed when unconfigured in production and `CHECK_METRICS_AUTH=1` proves unauthenticated `401` plus scraper-token `200` against the hosted stack. |
 | Sentry/logging decision | Open | Backend Sentry configured or explicitly deferred; frontend decision recorded; structured logs visible. |
 | Alert destination | Open | At least one deploy/health failure path reaches the operator. |
 | Operator self-report evidence | Open | Hermes/operator report proof replaces optional Resend email proof. Evidence should include correlation ID and durable destination. |

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -208,8 +208,10 @@ Current mitigation:
 - `/graphql` accepts an optional `GRAPHQL_BEARER_TOKEN` Bearer gate; when the
   env is unset a loud startup warning records that the route is intentionally
   public
-- `/metrics` on `api.averray.com` accepts an optional `METRICS_BEARER_TOKEN`
-  Bearer gate; the env var is documented in
+- `/metrics` on `api.averray.com` is bearer-gated in production by
+  `METRICS_BEARER_TOKEN`; if production is configured to require metrics auth
+  and no token is present, the route fails closed instead of serving metrics.
+  The env vars are documented in
   [`deploy/backend.env.template`](../deploy/backend.env.template)
 - Ponder's SQL validator rejects schema-qualified queries
   (`information_schema.tables`) and function calls (`current_user`,
@@ -273,7 +275,7 @@ Follow-up:
 - finish Package E — operator pages adopt explicit `live` / `empty` /
   `degraded` / `demo` modes with a persistent banner when
   `NEXT_PUBLIC_DEMO_MODE=true`
-- gate `/metrics` and `/graphql` in production by setting the bearer tokens
+- keep `/metrics` and `/graphql` gated in production by setting the bearer tokens
   documented in `deploy/backend.env.template` and
   `deploy/indexer.env.template`
 - continue documenting `<TBD>` placeholders as work items, not as silent

--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -234,10 +234,11 @@ AUTH_CHAIN_ID=420420417
 # LOG_LEVEL=info
 
 # --- Observability ------------------------------------------------------------
-# Prometheus text-format metrics live at /metrics. Leave METRICS_BEARER_TOKEN
-# unset for the standard "scrape any network peer" convention, or set a random
-# token when /metrics is publicly reachable. Scrapers then send
-# `Authorization: Bearer <token>`.
+# Prometheus text-format metrics live at /metrics. Production requires a bearer
+# token by default and fails closed when no token is configured. Non-production
+# can keep METRICS_AUTH_REQUIRED=0 for local scrape-any-peer workflows. Scrapers
+# send `Authorization: Bearer <token>`.
+# METRICS_AUTH_REQUIRED=1
 # METRICS_BEARER_TOKEN=
 
 # Sentry is opt-in: the @sentry/node package is NOT a required dependency. To

--- a/mcp-server/src/core/discovery-manifest.js
+++ b/mcp-server/src/core/discovery-manifest.js
@@ -7,7 +7,7 @@ const DEFAULT_OPERATOR_APP_URL = "https://app.averray.com";
 
 const DISCOVERY_PUBLIC_ENDPOINTS = [
   { path: "/health", description: "Liveness plus serviceHealth/capabilityHealth for state store, blockchain, treasury mutations, XCM observer, indexer, and gas sponsor." },
-  { path: "/metrics", description: "Prometheus text-format metrics. Optionally bearer-gated via METRICS_BEARER_TOKEN." },
+  { path: "/metrics", description: "Prometheus text-format metrics. Bearer-gated in production via METRICS_BEARER_TOKEN." },
   { path: "/onboarding", description: "Canonical platform capabilities + tool list." },
   { path: "/jobs", description: "Public job catalog (no auth)." },
   { path: "/jobs/definition?jobId=X", description: "Canonical job definition by id." },

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -1,5 +1,5 @@
 import { createServer } from "node:http";
-import { randomBytes } from "node:crypto";
+import { randomBytes, timingSafeEqual } from "node:crypto";
 import { createPlatformRuntime } from "../../services/bootstrap.js";
 import {
   assertMutationBackendAvailable,
@@ -119,6 +119,10 @@ metrics.gauge("state_store_backend", "1 when state store backend matches the lab
 );
 
 const METRICS_BEARER_TOKEN = process.env.METRICS_BEARER_TOKEN?.trim() || undefined;
+const METRICS_AUTH_REQUIRED = parseRequiredFlag(
+  process.env.METRICS_AUTH_REQUIRED,
+  process.env.NODE_ENV === "production" ? "1" : "0"
+);
 const port = Number(process.env.PORT ?? 8787);
 
 const SIWE_STATEMENT = "Sign in to the Agent Platform.";
@@ -136,6 +140,20 @@ function respond(response, statusCode, payload, extraHeaders = {}) {
   }
   response.writeHead(statusCode, headers);
   response.end(JSON.stringify(payload, null, 2));
+}
+
+function bearerTokenMatches(header, expectedToken) {
+  const prefix = "Bearer ";
+  if (!header.startsWith(prefix)) return false;
+  const actualToken = header.slice(prefix.length);
+  const actual = Buffer.from(actualToken);
+  const expected = Buffer.from(expectedToken);
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+}
+
+function parseRequiredFlag(value, defaultValue) {
+  const normalized = String(value ?? defaultValue).trim().toLowerCase();
+  return !["0", "false", "no", "off"].includes(normalized);
 }
 
 function respondSse(response) {
@@ -1744,12 +1762,14 @@ const server = createServer(async (request, response) => {
     }
 
     if (request.method === "GET" && pathname === "/metrics") {
-      // Optionally gated. Leave METRICS_BEARER_TOKEN unset for the standard
-      // Prometheus "scrape any network peer" convention; set it to a random
-      // token when /metrics is reachable from the public internet.
-      if (METRICS_BEARER_TOKEN) {
+      // Fail closed in production: public metrics reveal request paths,
+      // status-code mix, and operational posture.
+      if (METRICS_AUTH_REQUIRED && !METRICS_BEARER_TOKEN) {
+        return respond(response, 503, { error: "metrics_auth_unconfigured" });
+      }
+      if (METRICS_AUTH_REQUIRED) {
         const header = request.headers.authorization ?? "";
-        if (header !== `Bearer ${METRICS_BEARER_TOKEN}`) {
+        if (!bearerTokenMatches(header, METRICS_BEARER_TOKEN)) {
           return respond(response, 401, { error: "unauthorized" });
         }
       }

--- a/mcp-server/src/protocols/http/server.smoke.test.js
+++ b/mcp-server/src/protocols/http/server.smoke.test.js
@@ -2008,6 +2008,45 @@ test("http smoke: /metrics emits Prometheus text format with baseline series", {
   });
 });
 
+test("http smoke: /metrics is bearer-gated when metrics auth is required", { skip: !RUN }, async () => {
+  await runWithServerEnv(
+    {
+      METRICS_AUTH_REQUIRED: "1",
+      METRICS_BEARER_TOKEN: "metrics-smoke-token-1234567890"
+    },
+    async (base) => {
+      const noBearer = await fetch(`${base}/metrics`);
+      assert.equal(noBearer.status, 401);
+
+      const wrongBearer = await fetch(`${base}/metrics`, {
+        headers: { authorization: "Bearer wrong-token" }
+      });
+      assert.equal(wrongBearer.status, 401);
+
+      const response = await fetch(`${base}/metrics`, {
+        headers: { authorization: "Bearer metrics-smoke-token-1234567890" }
+      });
+      assert.equal(response.status, 200);
+      assert.match(response.headers.get("content-type") ?? "", /text\/plain/);
+      assert.match(await response.text(), /# HELP http_requests_total/);
+    }
+  );
+});
+
+test("http smoke: production /metrics fails closed when token is missing", { skip: !RUN }, async () => {
+  await runWithServerEnv(
+    {
+      NODE_ENV: "production",
+      METRICS_BEARER_TOKEN: ""
+    },
+    async (base) => {
+      const response = await fetch(`${base}/metrics`);
+      assert.equal(response.status, 503);
+      assert.deepEqual(await response.json(), { error: "metrics_auth_unconfigured" });
+    }
+  );
+});
+
 test("http smoke: discovery manifest is served at both /agent-tools.json and the RFC 8615 .well-known path", { skip: !RUN }, async () => {
   await runWithServer(async (base) => {
     const [canonical, wellKnown] = await Promise.all([

--- a/scripts/ops/check-hosted-stack.sh
+++ b/scripts/ops/check-hosted-stack.sh
@@ -8,6 +8,7 @@ APP_URL=${APP_URL:-https://app.averray.com/}
 API_HEALTH_URL=${API_HEALTH_URL:-https://api.averray.com/health}
 API_ONBOARDING_URL=${API_ONBOARDING_URL:-https://api.averray.com/onboarding}
 API_ADMIN_STATUS_URL=${API_ADMIN_STATUS_URL:-https://api.averray.com/admin/status}
+API_METRICS_URL=${API_METRICS_URL:-https://api.averray.com/metrics}
 INDEXER_URL=${INDEXER_URL:-https://index.averray.com/}
 INDEXER_READY_URL=${INDEXER_READY_URL:-https://index.averray.com/ready}
 INDEXER_STATUS_URL=${INDEXER_STATUS_URL:-https://index.averray.com/status}
@@ -34,6 +35,8 @@ SERVICE_TOKEN_PROOF_ALLOWED_PATH=${SERVICE_TOKEN_PROOF_ALLOWED_PATH:-}
 SERVICE_TOKEN_PROOF_DENIED_PATHS=${SERVICE_TOKEN_PROOF_DENIED_PATHS:-}
 SERVICE_TOKEN_PROOF_TOKEN_TTL_SECONDS=${SERVICE_TOKEN_PROOF_TOKEN_TTL_SECONDS:-}
 SERVICE_TOKEN_PROOF_IDEMPOTENCY_KEY=${SERVICE_TOKEN_PROOF_IDEMPOTENCY_KEY:-}
+CHECK_METRICS_AUTH=${CHECK_METRICS_AUTH:-0}
+METRICS_BEARER_TOKEN=${METRICS_BEARER_TOKEN:-}
 TIMEOUT_SEC=${TIMEOUT_SEC:-20}
 APP_BASIC_AUTH_USER=${APP_BASIC_AUTH_USER:-}
 APP_BASIC_AUTH_PASSWORD=${APP_BASIC_AUTH_PASSWORD:-}
@@ -182,6 +185,28 @@ echo "Checking onboarding contract"
 onboarding_json="$(fetch "$API_ONBOARDING_URL")"
 jq -e '.name | length > 0' >/dev/null <<<"$onboarding_json"
 jq -e '.protocols | index("http") != null' >/dev/null <<<"$onboarding_json"
+
+if enabled "$CHECK_METRICS_AUTH"; then
+  if [[ -z "$METRICS_BEARER_TOKEN" ]]; then
+    echo "CHECK_METRICS_AUTH=1 requires METRICS_BEARER_TOKEN." >&2
+    exit 1
+  fi
+
+  echo "Checking metrics bearer gate"
+  metrics_status_without_bearer="$(curl -sS --max-time "$TIMEOUT_SEC" -o /dev/null -w "%{http_code}" "$API_METRICS_URL")"
+  if [[ "$metrics_status_without_bearer" != "401" ]]; then
+    echo "Expected unauthenticated /metrics to return 401, got HTTP $metrics_status_without_bearer." >&2
+    exit 1
+  fi
+
+  metrics_status_with_bearer="$(curl -sS --max-time "$TIMEOUT_SEC" -o /dev/null -w "%{http_code}" \
+    -H "authorization: Bearer $METRICS_BEARER_TOKEN" \
+    "$API_METRICS_URL")"
+  if [[ "$metrics_status_with_bearer" != "200" ]]; then
+    echo "Expected bearer-authenticated /metrics to return 200, got HTTP $metrics_status_with_bearer." >&2
+    exit 1
+  fi
+fi
 
 if enabled "$CHECK_INDEXER"; then
   echo "Checking indexer root"

--- a/scripts/ops/check-hosted-stack.test.mjs
+++ b/scripts/ops/check-hosted-stack.test.mjs
@@ -145,3 +145,33 @@ test("scoped service-token proof gate is opt-in, admin-gated, and supports evide
     "docker fallback should mount service-token evidence at the same absolute path"
   );
 });
+
+test("metrics auth gate is opt-in and verifies both denied and allowed scrapes", async () => {
+  const script = await readFile(CHECK_SCRIPT, "utf8");
+
+  assert.match(
+    script,
+    /CHECK_METRICS_AUTH=\$\{CHECK_METRICS_AUTH:-0\}/u,
+    "metrics auth proof should be opt-in"
+  );
+  assert.match(
+    script,
+    /CHECK_METRICS_AUTH=1 requires METRICS_BEARER_TOKEN/u,
+    "metrics auth proof should fail closed without the scraper token"
+  );
+  assert.match(
+    script,
+    /Expected unauthenticated \/metrics to return 401/u,
+    "metrics auth proof should require no-bearer requests to be denied"
+  );
+  assert.match(
+    script,
+    /authorization: Bearer \$METRICS_BEARER_TOKEN/u,
+    "metrics auth proof should send the scraper bearer token"
+  );
+  assert.match(
+    script,
+    /Expected bearer-authenticated \/metrics to return 200/u,
+    "metrics auth proof should require bearer-authenticated scrapes to work"
+  );
+});

--- a/site/.well-known/agent-tools.json
+++ b/site/.well-known/agent-tools.json
@@ -382,7 +382,7 @@
     },
     {
       "path": "/metrics",
-      "description": "Prometheus text-format metrics. Optionally bearer-gated via METRICS_BEARER_TOKEN."
+      "description": "Prometheus text-format metrics. Bearer-gated in production via METRICS_BEARER_TOKEN."
     },
     {
       "path": "/onboarding",


### PR DESCRIPTION
## What changed
- Make `/metrics` fail closed in production when metrics auth is required but `METRICS_BEARER_TOKEN` is missing.
- Keep local/non-production scrape-any-peer behavior unless `METRICS_AUTH_REQUIRED=1` is set.
- Add timing-safe bearer verification for authenticated scrapes.
- Add `CHECK_METRICS_AUTH=1` to the hosted stack smoke so unauthenticated `/metrics` must return 401 and bearer-authenticated `/metrics` must return 200.
- Update env templates, threat model, production checklist, discovery manifest, roadmap close criteria, and synced discovery-manifest copies.

## Checks
- `RUN_HTTP_SMOKE=1 node --test mcp-server/src/protocols/http/server.smoke.test.js`
- `node --test scripts/ops/check-hosted-stack.test.mjs`
- `npm --workspace mcp-server test`
- `npm run check:discovery-manifest`
- `node scripts/ops/check-generated-output-clean.mjs --last-commit`
- `git diff --check`
- CI: all checks passing

## Impact
- Backend: yes, `/metrics` auth behavior.
- Ops smoke: yes, new opt-in hosted metrics proof gate.
- Deploy env template: yes, production should set `METRICS_BEARER_TOKEN` before closing the roadmap item.
- Public site: only the synced `.well-known/agent-tools.json` discovery manifest copy.
- Frontend/indexer/contracts: no.

## Follow-up
The roadmap item remains open until the production scraper token is configured and the hosted check passes with:

```bash
METRICS_BEARER_TOKEN='<metrics-scraper-token>' \
CHECK_METRICS_AUTH=1 \
./scripts/ops/check-hosted-stack.sh
```