### PR TITLE
docs: add roadmap update protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,22 @@ Run the smallest relevant set locally before opening a PR:
 
 CI is the merge gate. Do not bypass failing checks.
 
+## Roadmap Coordination
+
+- `docs/PROJECT_ROADMAP.md` is the canonical project roadmap and status file.
+- Parallel agents should avoid broad rewrites of the roadmap. Keep roadmap edits
+  scoped to the exact item or section owned by the PR.
+- If another active PR is already editing the same roadmap section, or if the
+  update is a handoff/status note rather than the implementing PR itself, add a
+  fragment under `docs/roadmap-updates/` instead of editing the canonical file.
+- Use the template and rules in
+  [docs/roadmap-updates/README.md](./docs/roadmap-updates/README.md).
+- Do not mark roadmap work `Done` or `Proofed` without evidence. At minimum,
+  include the merged PR, passing CI/checks, and hosted/chain/operator proof when
+  the item changes deployed behavior.
+- Chain-specific roadmap claims must cite Polkadot docs MCP findings, runtime
+  state, or transaction evidence before being promoted into the roadmap.
+
 ## Hermes PR Handoff
 
 - After PR CI passes, `.github/workflows/hermes-pr-handoff.yml` asks the

--- a/docs/PROJECT_ROADMAP.md
+++ b/docs/PROJECT_ROADMAP.md
@@ -24,6 +24,9 @@ Use this file as the operational guideline for sequencing work.
   of claiming to be the active roadmap.
 - Chain-specific claims should be checked against the Polkadot docs MCP or
   runtime state before they are promoted into this roadmap.
+- Parallel agents should not use this file as a shared scratchpad. If a status
+  update is not part of a narrow implementing PR, capture it as a fragment in
+  [`roadmap-updates/`](./roadmap-updates/) for later steward consolidation.
 
 ## Status Terms
 
@@ -31,9 +34,31 @@ Use this file as the operational guideline for sequencing work.
   deployable product surface.
 - **Proofed:** done and backed by a hosted smoke, real workflow, chain proof, or
   durable operator evidence.
+- **Ready for proof:** implementation has landed, but hosted, chain, or
+  operator evidence is still missing.
+- **Blocked:** not actionable until an explicit external dependency, operator
+  action, secret, deploy, wallet action, or design decision is complete.
+- **In progress:** currently owned by an active PR or assigned worktree.
 - **Open:** not implemented, not fully verified, or still blocked by an
   operational prerequisite.
 - **Deferred:** intentionally out of v1 or blocked on a later phase gate.
+
+## Parallel Update Protocol
+
+`PROJECT_ROADMAP.md` remains the single source of truth, but parallel agents
+should usually submit small update fragments first. This avoids two agents
+rewriting the same tables and makes consolidation reviewable.
+
+- Use [`docs/roadmap-updates/README.md`](./roadmap-updates/README.md) for the
+  fragment template, file naming, and pasteable agent instruction.
+- An implementing PR may directly update the exact roadmap row it closes or
+  moves, provided it owns that item and includes evidence.
+- A research, audit, design, or handoff PR should usually add a roadmap-update
+  fragment instead of editing this file.
+- The roadmap steward consolidates accepted fragments into this file and deletes
+  or archives consumed fragments in a separate narrow PR.
+- Avoid formatting-only changes, table reshuffles, or broad wording edits unless
+  the task is explicitly a roadmap-steward consolidation.
 
 ## Current Product Posture
 

--- a/docs/roadmap-updates/README.md
+++ b/docs/roadmap-updates/README.md
@@ -1,0 +1,111 @@
+# Roadmap Update Fragments
+
+`docs/PROJECT_ROADMAP.md` is the canonical project roadmap. This folder is the
+low-conflict intake lane for parallel agents to propose status changes,
+evidence, blockers, or next actions without rewriting the roadmap at the same
+time.
+
+Use a fragment when:
+
+- another PR is already editing the same roadmap section;
+- the work is research, audit, design, or operator evidence rather than the
+  implementing code PR;
+- the update affects several sections and needs steward consolidation;
+- you are unsure whether the item is ready to move status.
+
+An implementing PR may edit the exact roadmap row it owns directly when the
+change is narrow and evidence is included.
+
+## File Naming
+
+Use:
+
+```text
+docs/roadmap-updates/YYYY-MM-DD-<agent>-<roadmap-item>.md
+```
+
+Examples:
+
+```text
+docs/roadmap-updates/2026-05-19-codex-metrics-auth.md
+docs/roadmap-updates/2026-05-19-design-agent-timeline-filters.md
+```
+
+## Fragment Template
+
+```md
+# Roadmap Update: <item title or stable ID>
+
+- **Date:** YYYY-MM-DD
+- **Agent:** <agent name / branch>
+- **Roadmap section:** <section heading in PROJECT_ROADMAP.md>
+- **Item:** <exact row title or proposed new item>
+- **Related PRs/issues:** <links or `none`>
+- **Proposed status:** Open | In progress | Blocked | Ready for proof | Done | Proofed | Deferred
+- **Owner:** <who should act next>
+
+## Summary
+
+<One short paragraph explaining what changed or was learned.>
+
+## Evidence
+
+- <PR, CI, hosted smoke, chain tx, operator report, docs MCP finding, or runtime evidence>
+
+## Blockers Or Caveats
+
+- <Anything preventing Done/Proofed, or `none`>
+
+## Requested Roadmap Change
+
+<Exact row edit, new row, status change, or note the steward should apply.>
+```
+
+## Rules
+
+- Do not mark an item `Done` unless the relevant PR is merged or the current
+  branch is the implementing PR and CI/checks prove the behavior.
+- Do not mark an item `Proofed` without hosted smoke, real workflow, chain
+  transaction, or durable operator evidence.
+- Chain-specific claims must cite Polkadot docs MCP findings, runtime state, or
+  transaction evidence.
+- Keep fragments scoped to one roadmap item or one clearly named section.
+- Avoid broad rewording of `PROJECT_ROADMAP.md` from worker-agent PRs.
+- If your PR changes production behavior, include the required secret/env/VPS
+  follow-up before asking the steward to close the item.
+
+## Pasteable Agent Instruction
+
+Give this to any agent working on Averray:
+
+```text
+You are working in the averray-agent/agent repo with multiple parallel agents.
+
+Before changing roadmap status:
+1. Read AGENTS.md, docs/PROJECT_ROADMAP.md, and docs/roadmap-updates/README.md.
+2. Own one narrow roadmap item or section only.
+3. Do not broad-rewrite docs/PROJECT_ROADMAP.md.
+4. If your implementing PR clearly closes or moves one exact roadmap row, update
+   only that row and include evidence in the PR body.
+5. If your work is research, audit, design, operator proof, or overlaps another
+   roadmap PR, create a fragment under docs/roadmap-updates/ using the template.
+6. Use only these statuses: Open, In progress, Blocked, Ready for proof, Done,
+   Proofed, Deferred.
+7. Never mark Done without merged/merge-ready implementation evidence and
+   passing checks. Never mark Proofed without hosted, chain, workflow, or
+   durable operator evidence.
+8. For Polkadot-specific claims, verify against Polkadot docs MCP, runtime
+   state, or transaction evidence before adding them to the roadmap.
+9. Keep your PR narrow and list any roadmap row or fragment you touched.
+```
+
+## Steward Consolidation
+
+The roadmap steward periodically:
+
+1. Reviews open fragments in this folder.
+2. Applies accepted changes to `docs/PROJECT_ROADMAP.md`.
+3. Keeps rejected or superseded fragments only if they contain useful audit
+   evidence.
+4. Deletes consumed fragments when their evidence is fully represented in the
+   canonical roadmap or linked detail docs.


### PR DESCRIPTION
## What changed
- Add a Roadmap Coordination section to `AGENTS.md` so every agent sees the same roadmap rules.
- Extend `docs/PROJECT_ROADMAP.md` with the parallel update protocol and intermediate statuses.
- Add `docs/roadmap-updates/README.md` with fragment naming, template, rules, steward consolidation flow, and a pasteable instruction block for worker agents.

## Checks
- `git diff --cached --check`

## Impact
- Docs/process only.
- No backend, frontend, indexer, contracts, Caddy, or public-site runtime changes.
- No env/VPS secret changes.

## How to use
Give worker agents the Pasteable Agent Instruction from `docs/roadmap-updates/README.md`. They should use fragments unless their implementing PR owns one exact roadmap row and includes evidence.