### PR TITLE
feat(auth): Phase 5a cutover code — KMSClient credentials via Roles Anywhere (flag-gated)

### DIFF
--- a/docs/PHASE_5A_IAM_ROLES_ANYWHERE_PLAN.md
+++ b/docs/PHASE_5A_IAM_ROLES_ANYWHERE_PLAN.md
@@ -403,7 +403,36 @@ still in use** — we haven't told the backend to switch yet.
 
 ### 5.5 Mount into the backend container
 
-In `docker-compose.yml` for the backend service, add:
+**The "open implementation question" called out in v1 of this doc is
+RESOLVED.** Both signers now accept an optional `credentialsProvider`
+constructor option that the lazy KMSClient passes to its `credentials`
+field when set. The plumbing lives in a single small helper:
+
+- `mcp-server/src/services/aws-credentials.js` — exports
+  `buildKmsCredentialsProvider({ profile })`. Reads
+  `AWS_USE_ROLES_ANYWHERE` env var; returns `fromIni({ profile })` when
+  the flag is `"true"`, returns `null` otherwise. Profile constants
+  `PROFILE_BLOCKCHAIN_SIGNER` and `PROFILE_JWT_SIGNER` are exported and
+  match the section names in `/etc/agent-stack/aws-config` (§5.3).
+- `mcp-server/src/auth/jwt.js` `getKmsSigner` — builds the JWT-side
+  provider and passes it to `KmsJwtSigner`.
+- `mcp-server/src/blockchain/gateway.js` `createSigner` — builds the
+  blockchain-side provider and passes it to `KmsSigner`.
+
+Both `KmsJwtSigner` and `KmsSigner` constructors take the optional
+`credentialsProvider` and pass it through to `new KMSClient({...})`
+only when set. When unset (`AWS_USE_ROLES_ANYWHERE` not `"true"`), the
+KMSClient gets no explicit credentials and falls through to the SDK's
+default chain — preserving pre-5a behavior.
+
+**Why a flag instead of always-on**: the backend hasn't been deployed
+with the docker-compose mounts yet. The first deploy of this code
+ships with the flag default-off, so it's a pure no-op. The operator
+flips the flag and adds the mounts in a single controlled change.
+
+#### Docker-compose mounts (operator step, on the VPS)
+
+Edit `/srv/agent-stack/docker-compose.yml`, add to the backend service:
 
 ```yaml
 services:
@@ -411,57 +440,25 @@ services:
     volumes:
       - /etc/agent-stack/aws-config:/root/.aws/config:ro
       - /etc/agent-stack/roles-anywhere:/etc/agent-stack/roles-anywhere:ro
+      - /usr/local/bin/aws_signing_helper:/usr/local/bin/aws_signing_helper:ro
     environment:
-      # AWS_PROFILE per role isn't ideal because the backend uses one
-      # SDK process for both signers. Two reasonable patterns:
-      #   (a) Set AWS_PROFILE for ONE role and pass `credentials` per
-      #       KMSClient in code (cleanest, requires code change).
-      #   (b) Use the `default` profile for one signer; second signer
-      #       uses code-level explicit profile via the SDK.
-      # Recommend pattern (b) initially — minimize code change.
-      AWS_PROFILE: averray-jwt-signer
+      AWS_USE_ROLES_ANYWHERE: "true"
       AWS_CONFIG_FILE: /root/.aws/config
 ```
 
-**Open implementation question, do not ship until resolved**: the
-backend uses two distinct KMS keys with two distinct IAM roles in the
-same Node process. The AWS SDK's default credential chain is
-single-profile-per-process. Three resolution paths:
+Three read-only mounts:
+- `aws-config` → `~/.aws/config` (SDK reads it via `AWS_CONFIG_FILE`)
+- `roles-anywhere/` cert+key dir at the exact path referenced by
+  `credential_process` directives in `aws-config`
+- `aws_signing_helper` binary at the exact path referenced by
+  `credential_process` directives
 
-1. Set `AWS_PROFILE=averray-jwt-signer` (default) and have `KmsSigner`
-   (blockchain) explicitly construct its KMSClient with `credentials:
-   fromIni({ profile: "averray-signer" })`. Requires a small backend
-   code change.
-2. Same as #1 but other way around (`AWS_PROFILE=averray-signer`
-   default, `KmsJwtSigner` overrides).
-3. Use a single Roles Anywhere profile / IAM role that has policies
-   for both KMS keys. **Rejected** — collapses the key-separation
-   invariant we deliberately built into Phase 3 + 4b.
-
-Recommend path #1. The code change is ~10 lines in
-`mcp-server/src/blockchain/kms-signer.js`:
-
-```js
-// Before:
-this.#kmsClient = new KMSClient({ region: this.#region });
-
-// After:
-const { fromIni } = await import("@aws-sdk/credential-providers");
-this.#kmsClient = new KMSClient({
-  region: this.#region,
-  credentials: fromIni({ profile: "averray-signer" }),
-});
-```
-
-This change is **safe to ship today** even before Roles Anywhere is
-active — `fromIni({ profile: "averray-signer" })` falls back to the
-default chain if the profile doesn't exist, so the existing static
-`AWS_ACCESS_KEY_ID` path keeps working until the operator wires the
-profile in.
-
-Same change pattern goes into
-`mcp-server/src/auth/kms-jwt-signer.js` for the JWT signer with
-`profile: "averray-jwt-signer"`.
+The `AWS_USE_ROLES_ANYWHERE=true` env activates the code path added
+in this PR. The static `AWS_*_ACCESS_KEY_*` env vars remain in the
+rendered `/run/agent-stack/backend.env` during the soak — both paths
+are wired but only Roles Anywhere is reached because each signer's
+KMSClient gets an explicit `credentials` field that wins over default
+chain lookups.
 
 ## 6. Migration phases
 
@@ -476,21 +473,50 @@ Same change pattern goes into
 - New 1Password inventory rows in `deploy/secrets-inventory.md` for
   the future client certs (status: deferred until 5a-cutover).
 
-### Phase 5a-cutover (operator-led, separate PR after AWS setup)
+### Phase 5a-cutover-code (this PR's follow-up; ships the dispatcher wiring)
 
-- Operator completes §4 (AWS setup) + §5 (VPS setup) on a Wednesday
-  morning maintenance window.
-- Operator opens a small follow-up PR that:
-  - Adds the `KMSClient({ credentials: fromIni(...) })` change in both
-    signer modules (~10 lines per signer).
-  - Comments out the four `AWS_*_ACCESS_KEY_*` op:// refs in
-    `deploy/backend.env.template`.
-  - Updates `secrets-inventory.md` to ✅ yes for the new cert rows
-    and ⚠️ no (retired) for the static-key rows.
-- Verify with `aws sts get-caller-identity` from inside the backend
-  container post-deploy: returned `Arn` should be
-  `arn:aws:sts::079209845430:assumed-role/averray-signer-testnet/<session-id>`
-  (note `assumed-role`, NOT `user`).
+- Adds `mcp-server/src/services/aws-credentials.js` (the flag-gated
+  `fromIni` provider builder).
+- Both signers (`KmsJwtSigner`, `KmsSigner`) accept an optional
+  `credentialsProvider` constructor option, lazy KMSClient passes it
+  through to `new KMSClient({ credentials })` when non-null.
+- Both signer factories (`getKmsSigner` in jwt.js, `createSigner` in
+  gateway.js) call `buildKmsCredentialsProvider` to populate the option.
+- Flag (`AWS_USE_ROLES_ANYWHERE`) default-off — zero runtime change at
+  merge. Operator flips on the VPS post-deploy.
+
+### Phase 5a-cutover-flip (operator-led, on the VPS)
+
+After §4 (AWS) + §5 (VPS cert install + aws-config) + §5.5 (docker-
+compose mounts) are all in place:
+
+1. Set `AWS_USE_ROLES_ANYWHERE=true` in the rendered `/run/agent-stack/backend.env`.
+   Either via a small env-template PR (preferred; tracked in git) or by
+   adding the flag directly to the docker-compose `environment:` block
+   so it's set at container start regardless of the env file.
+2. Restart the backend container: `docker compose -f /srv/agent-stack/docker-compose.yml up -d --force-recreate agent-backend`.
+3. Verify from inside the running container:
+   ```bash
+   sudo docker compose -f /srv/agent-stack/docker-compose.yml exec agent-backend \
+     node -e "import('@aws-sdk/client-sts').then(({STSClient,GetCallerIdentityCommand})=>new STSClient({region:'eu-central-2',credentials:require('@aws-sdk/credential-provider-ini').fromIni({profile:'averray-jwt-signer'})}).send(new GetCallerIdentityCommand({}))).then(r=>console.log(r.Arn))"
+   ```
+   Expected `Arn`:
+   `arn:aws:sts::079209845430:assumed-role/averray-jwt-signer-testnet-role/<session-id>`
+   The `assumed-role` (not `user`) prefix is the proof Roles Anywhere
+   is in use.
+4. Watch the backend logs + CloudWatch metrics. SIWE should keep
+   working (signs ES256 via Roles Anywhere now), and the backend's
+   boot-time JWT-KMS credential validation (added in #444) should
+   print `jwt-kms-credential-check.ok` with the same key metadata.
+
+### Phase 5a-cutover-retire-static-env (small follow-up PR)
+
+After the cutover-flip has been clean for ≥ 24h:
+- Comment out the four `AWS_*_ACCESS_KEY_*` op:// refs in
+  `deploy/backend.env.template`.
+- Update `secrets-inventory.md` to mark them ⚠️ no (no longer in
+  template). The 1Password items stay for now — IAM keys remain in
+  AWS for rollback.
 
 ### Phase 5a-retire (≥30 days after 5a-cutover)
 

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-kms": "^3.700.0",
+    "@aws-sdk/credential-provider-ini": "^3.700.0",
     "@paraspell/sdk-core": "^13.4.0",
     "ethers": "^6.16.0",
     "redis": "^5.11.0"

--- a/mcp-server/src/auth/jwt.js
+++ b/mcp-server/src/auth/jwt.js
@@ -121,6 +121,13 @@ async function getKmsSigner(authConfig) {
   // Lazy-import; ensures hmac-only callers never pull in
   // @aws-sdk/client-kms (KmsJwtSigner's own SDK import is also lazy).
   const { KmsJwtSigner } = await import("./kms-jwt-signer.js");
+  // Phase 5a: when AWS_USE_ROLES_ANYWHERE=true, plumb an SDK credential
+  // provider keyed to the JWT-signer shared-config profile. Null
+  // otherwise — KmsJwtSigner falls through to the SDK's default chain.
+  const { buildKmsCredentialsProvider, PROFILE_JWT_SIGNER } = await import(
+    "../services/aws-credentials.js"
+  );
+  const credentialsProvider = buildKmsCredentialsProvider({ profile: PROFILE_JWT_SIGNER });
   // Allow tests to inject a KMSClient via authConfig.kmsJwt.kmsClient
   // without leaking that field into the loaded-from-env public shape —
   // production env never sets it.
@@ -135,6 +142,7 @@ async function getKmsSigner(authConfig) {
     expectedRoles: authConfig.kmsJwt.expectedRoles,
     maxTtlSeconds: authConfig.kmsJwt.maxTtlSeconds,
     clockSkewSeconds: authConfig.kmsJwt.clockSkewSeconds,
+    credentialsProvider,
   });
   SIGNER_CACHE.set(authConfig.kmsJwt, signer);
   return signer;

--- a/mcp-server/src/auth/kms-jwt-signer.js
+++ b/mcp-server/src/auth/kms-jwt-signer.js
@@ -63,6 +63,7 @@ const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9
 export class KmsJwtSigner {
   #kmsClient;
   #region;
+  #credentialsProvider;
   #keyId;
   #kid;
   #kidBuf;
@@ -88,6 +89,13 @@ export class KmsJwtSigner {
    * @param {number} [opts.maxTtlSeconds]       Cap on `exp - iat`; defaults to 3600 (1h).
    * @param {number} [opts.clockSkewSeconds]    Skew tolerance for nbf/exp; defaults to 60.
    * @param {() => number} [opts.now]           Override clock (epoch seconds) for tests.
+   * @param {import("@aws-sdk/types").AwsCredentialIdentityProvider} [opts.credentialsProvider]
+   *   Optional AWS SDK credentials provider passed to the lazy-constructed
+   *   KMSClient. Used by Phase 5a (Roles Anywhere) — see
+   *   `mcp-server/src/services/aws-credentials.js`. When null/undefined,
+   *   the lazy KMSClient gets no explicit credentials and falls through to
+   *   the SDK's default credential chain (env vars, shared config, etc.) —
+   *   the pre-5a behavior, unchanged.
    */
   constructor(opts) {
     if (!opts || typeof opts !== "object") {
@@ -105,6 +113,7 @@ export class KmsJwtSigner {
       maxTtlSeconds,
       clockSkewSeconds,
       now,
+      credentialsProvider,
     } = opts;
     if (!keyId || typeof keyId !== "string") {
       throw new Error("KmsJwtSigner: keyId is required (full KMS key ARN)");
@@ -150,6 +159,7 @@ export class KmsJwtSigner {
 
     this.#kmsClient = kmsClient ?? null;
     this.#region = region ?? null;
+    this.#credentialsProvider = credentialsProvider ?? null;
     this.#keyId = keyId;
     this.#kid = kid;
     // Pre-compute the buffer for constant-time kid comparison. The kid
@@ -184,7 +194,13 @@ export class KmsJwtSigner {
   async #getClient() {
     if (this.#kmsClient) return this.#kmsClient;
     const { KMSClient } = await import("@aws-sdk/client-kms");
-    this.#kmsClient = new KMSClient({ region: this.#region });
+    // Phase 5a: pass the optional credentialsProvider through to
+    // KMSClient. When null (default chain), behavior matches pre-5a.
+    const clientOpts = { region: this.#region };
+    if (this.#credentialsProvider) {
+      clientOpts.credentials = this.#credentialsProvider;
+    }
+    this.#kmsClient = new KMSClient(clientOpts);
     return this.#kmsClient;
   }
 

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -24,6 +24,10 @@ import {
 } from "./abis.js";
 import { loadBlockchainConfig } from "./config.js";
 import { KmsSigner } from "./kms-signer.js";
+import {
+  buildKmsCredentialsProvider,
+  PROFILE_BLOCKCHAIN_SIGNER,
+} from "../services/aws-credentials.js";
 import { buildXcmRequestPayload } from "./xcm-message-builder.js";
 import { hashCanonicalContent } from "../core/canonical-content.js";
 import {
@@ -1732,10 +1736,19 @@ function createSigner(config, provider) {
     // KmsSigner lazy-constructs the KMSClient on first signing call,
     // so importing this module doesn't load the AWS SDK for local-
     // backend deploys.
+    //
+    // Phase 5a: when AWS_USE_ROLES_ANYWHERE=true, plumb an SDK
+    // credentials provider keyed to the blockchain-signer shared-config
+    // profile. Null otherwise — KmsSigner falls through to the SDK's
+    // default chain (pre-5a behavior, unchanged).
+    const credentialsProvider = buildKmsCredentialsProvider({
+      profile: PROFILE_BLOCKCHAIN_SIGNER,
+    });
     return new KmsSigner({
       region: config.awsRegion,
       keyId: config.kmsKeyId,
       provider,
+      credentialsProvider,
     });
   }
   // Default "local" path — unchanged from pre-Phase-3 behavior.

--- a/mcp-server/src/blockchain/kms-signer.js
+++ b/mcp-server/src/blockchain/kms-signer.js
@@ -57,6 +57,7 @@ import {
 export class KmsSigner extends AbstractSigner {
   #kmsClient;
   #region;
+  #credentialsProvider;
   #keyId;
   #cachedAddress = null;
   // Promise-coalescing: if two callers race for getAddress() before
@@ -78,8 +79,14 @@ export class KmsSigner extends AbstractSigner {
    * @param {object} [options.provider]   ethers Provider; required for
    *                                      sendTransaction, optional for
    *                                      pure signing.
+   * @param {import("@aws-sdk/types").AwsCredentialIdentityProvider} [options.credentialsProvider]
+   *   Optional AWS SDK credentials provider passed to the lazy KMSClient.
+   *   Wired by Phase 5a — see `mcp-server/src/services/aws-credentials.js`.
+   *   When null/undefined, the lazy KMSClient gets no explicit credentials
+   *   and falls through to the SDK's default credential chain (env vars,
+   *   shared config, etc.), preserving pre-5a behavior.
    */
-  constructor({ kmsClient, region, keyId, provider }) {
+  constructor({ kmsClient, region, keyId, provider, credentialsProvider }) {
     super(provider ?? null);
     if (!keyId || typeof keyId !== "string") {
       throw new Error("KmsSigner: keyId is required (KMS key id, ARN, or alias)");
@@ -89,6 +96,7 @@ export class KmsSigner extends AbstractSigner {
     }
     this.#kmsClient = kmsClient ?? null;
     this.#region = region ?? null;
+    this.#credentialsProvider = credentialsProvider ?? null;
     this.#keyId = keyId;
   }
 
@@ -97,7 +105,14 @@ export class KmsSigner extends AbstractSigner {
     // Lazy-import + lazy-construct KMSClient on first signing call.
     // Cached for the lifetime of the KmsSigner.
     const { KMSClient } = await import("@aws-sdk/client-kms");
-    this.#kmsClient = new KMSClient({ region: this.#region });
+    // Phase 5a: pass the optional credentialsProvider through. When
+    // null (Roles Anywhere disabled), behavior matches pre-5a — the
+    // SDK uses its default credential chain.
+    const clientOpts = { region: this.#region };
+    if (this.#credentialsProvider) {
+      clientOpts.credentials = this.#credentialsProvider;
+    }
+    this.#kmsClient = new KMSClient(clientOpts);
     return this.#kmsClient;
   }
 
@@ -144,6 +159,7 @@ export class KmsSigner extends AbstractSigner {
       region: this.#region ?? undefined,
       keyId: this.#keyId,
       provider,
+      credentialsProvider: this.#credentialsProvider ?? undefined,
     });
   }
 

--- a/mcp-server/src/services/aws-credentials.js
+++ b/mcp-server/src/services/aws-credentials.js
@@ -1,0 +1,84 @@
+// fromIni lives in @aws-sdk/credential-provider-ini (which is already
+// a transitive dep via @aws-sdk/client-kms) — avoiding a new top-level
+// dep on @aws-sdk/credential-providers (just a convenience re-export).
+import { fromIni } from "@aws-sdk/credential-provider-ini";
+
+import { ConfigError } from "../core/errors.js";
+
+/**
+ * Phase 5a (IAM Roles Anywhere) cutover helper.
+ *
+ * The backend constructs two KMSClients — one for the blockchain
+ * signer (`KmsSigner`) and one for the JWT signer (`KmsJwtSigner`).
+ * Before Phase 5a both relied on the SDK's default credential
+ * provider chain, which on the VPS reads `AWS_ACCESS_KEY_ID` /
+ * `AWS_SECRET_ACCESS_KEY` env vars (long-lived static IAM keys).
+ *
+ * Phase 5a swaps those static keys for IAM Roles Anywhere — the VPS
+ * holds X.509 client certs, and `aws_signing_helper credential-process`
+ * exchanges them for 1-hour STS sessions. The SDK reaches the helper
+ * via `~/.aws/config` `credential_process` directives, but only when
+ * the SDK is told to use a specific shared-config profile (otherwise
+ * it falls back to env vars). The single Node process needs to address
+ * two profiles — one per signer — so we can't just set `AWS_PROFILE`
+ * globally.
+ *
+ * This module returns an SDK-shaped credential provider (the result
+ * of `fromIni({ profile })`) the signer-construction sites pass to
+ * `KMSClient({ credentials })`. The provider lazy-spawns the helper
+ * on each refresh and caches the resulting session until expiry —
+ * standard AWS SDK behavior.
+ *
+ * Gated by `AWS_USE_ROLES_ANYWHERE=true`. When unset or false, returns
+ * null and the signers fall through to the default chain (preserves
+ * pre-cutover behavior). The flag is documented in
+ * `docs/PHASE_5A_IAM_ROLES_ANYWHERE_PLAN.md` §6 (Phase 5a-cutover).
+ */
+
+const FLAG_ENV_VAR = "AWS_USE_ROLES_ANYWHERE";
+
+/**
+ * AWS shared-config profile names baked into the VPS
+ * /etc/agent-stack/aws-config — created during the Phase 5a operator
+ * setup. Hard-coded because the profiles match specific Roles
+ * Anywhere trust anchors + IAM roles defined in the same setup; an
+ * env-configurable name would only invite drift between the env and
+ * the actual config file.
+ */
+export const PROFILE_BLOCKCHAIN_SIGNER = "averray-signer";
+export const PROFILE_JWT_SIGNER = "averray-jwt-signer";
+
+/**
+ * Return an AWS SDK credentials provider bound to the given shared-
+ * config profile, or `null` when Roles Anywhere isn't enabled in the
+ * current env. The signer construction sites pass the result to
+ * `new KMSClient({ credentials })` only when non-null; otherwise they
+ * let the SDK use its default credential chain (existing static-key
+ * path, unchanged).
+ *
+ * @param {object} opts
+ * @param {string} opts.profile      Shared-config profile name (use the
+ *                                   `PROFILE_*` constants above).
+ * @param {Record<string,string>} [opts.env]  Override `process.env` for tests.
+ * @returns {import("@aws-sdk/types").AwsCredentialIdentityProvider | null}
+ */
+export function buildKmsCredentialsProvider({ profile, env = process.env } = {}) {
+  const raw = env[FLAG_ENV_VAR];
+  const enabled = typeof raw === "string" && raw.trim().toLowerCase() === "true";
+  if (!enabled) {
+    return null;
+  }
+  if (!profile || typeof profile !== "string" || profile.trim().length === 0) {
+    throw new ConfigError(
+      `buildKmsCredentialsProvider: profile is required when ${FLAG_ENV_VAR}=true ` +
+        "(use PROFILE_BLOCKCHAIN_SIGNER or PROFILE_JWT_SIGNER from this module).",
+    );
+  }
+  return fromIni({ profile });
+}
+
+/**
+ * Test-only escape hatch. Exposes the flag name so tests can manipulate
+ * env without hard-coding the string in multiple places.
+ */
+export const ROLES_ANYWHERE_FLAG_ENV_VAR = FLAG_ENV_VAR;

--- a/mcp-server/src/services/aws-credentials.test.js
+++ b/mcp-server/src/services/aws-credentials.test.js
@@ -1,0 +1,120 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildKmsCredentialsProvider,
+  PROFILE_BLOCKCHAIN_SIGNER,
+  PROFILE_JWT_SIGNER,
+  ROLES_ANYWHERE_FLAG_ENV_VAR,
+} from "./aws-credentials.js";
+import { ConfigError } from "../core/errors.js";
+
+test("buildKmsCredentialsProvider: returns null when flag is unset (default chain)", () => {
+  const provider = buildKmsCredentialsProvider({
+    profile: PROFILE_BLOCKCHAIN_SIGNER,
+    env: {},
+  });
+  assert.equal(provider, null);
+});
+
+test("buildKmsCredentialsProvider: returns null when flag is explicitly 'false'", () => {
+  const provider = buildKmsCredentialsProvider({
+    profile: PROFILE_BLOCKCHAIN_SIGNER,
+    env: { [ROLES_ANYWHERE_FLAG_ENV_VAR]: "false" },
+  });
+  assert.equal(provider, null);
+});
+
+test("buildKmsCredentialsProvider: returns null on arbitrary non-true values", () => {
+  for (const value of ["0", "no", "off", "FALSE", "True   ", " true", "1", ""]) {
+    const provider = buildKmsCredentialsProvider({
+      profile: PROFILE_BLOCKCHAIN_SIGNER,
+      env: { [ROLES_ANYWHERE_FLAG_ENV_VAR]: value },
+    });
+    // Only "true" (case-insensitive, trimmed) enables. Everything else
+    // is null — fail-safe default.
+    if (value.trim().toLowerCase() === "true") {
+      assert.notEqual(provider, null, `expected non-null for value=${JSON.stringify(value)}`);
+    } else {
+      assert.equal(provider, null, `expected null for value=${JSON.stringify(value)}`);
+    }
+  }
+});
+
+test("buildKmsCredentialsProvider: returns a fromIni-shaped provider function when flag is 'true'", () => {
+  const provider = buildKmsCredentialsProvider({
+    profile: PROFILE_JWT_SIGNER,
+    env: { [ROLES_ANYWHERE_FLAG_ENV_VAR]: "true" },
+  });
+  // fromIni returns a function the SDK calls to refresh credentials.
+  // We don't invoke it here (would attempt to spawn aws_signing_helper
+  // against a real config file we don't have in tests). The presence
+  // of a function-shaped return is the contract.
+  assert.equal(typeof provider, "function");
+});
+
+test("buildKmsCredentialsProvider: 'TRUE' is also accepted (case-insensitive)", () => {
+  const provider = buildKmsCredentialsProvider({
+    profile: PROFILE_BLOCKCHAIN_SIGNER,
+    env: { [ROLES_ANYWHERE_FLAG_ENV_VAR]: "TRUE" },
+  });
+  assert.equal(typeof provider, "function");
+});
+
+test("buildKmsCredentialsProvider: ' true ' (with whitespace) is accepted", () => {
+  const provider = buildKmsCredentialsProvider({
+    profile: PROFILE_BLOCKCHAIN_SIGNER,
+    env: { [ROLES_ANYWHERE_FLAG_ENV_VAR]: "  true\n" },
+  });
+  assert.equal(typeof provider, "function");
+});
+
+test("buildKmsCredentialsProvider: throws ConfigError when profile is missing under flag=true", () => {
+  assert.throws(
+    () =>
+      buildKmsCredentialsProvider({
+        env: { [ROLES_ANYWHERE_FLAG_ENV_VAR]: "true" },
+      }),
+    (err) =>
+      err instanceof ConfigError &&
+      /profile is required/i.test(err.message) &&
+      /AWS_USE_ROLES_ANYWHERE=true/.test(err.message),
+  );
+});
+
+test("buildKmsCredentialsProvider: throws ConfigError on empty/non-string profile under flag=true", () => {
+  for (const profile of ["", "   ", 42, null, undefined, {}]) {
+    assert.throws(
+      () =>
+        buildKmsCredentialsProvider({
+          profile,
+          env: { [ROLES_ANYWHERE_FLAG_ENV_VAR]: "true" },
+        }),
+      (err) => err instanceof ConfigError && /profile is required/i.test(err.message),
+      `expected throw for profile=${JSON.stringify(profile)}`,
+    );
+  }
+});
+
+test("buildKmsCredentialsProvider: with default env arg, reads process.env", () => {
+  // Smoke-test the default-arg path. process.env.AWS_USE_ROLES_ANYWHERE
+  // is almost certainly unset in the test runner, so we expect null.
+  // (We explicitly unset to be safe.)
+  const prior = process.env[ROLES_ANYWHERE_FLAG_ENV_VAR];
+  delete process.env[ROLES_ANYWHERE_FLAG_ENV_VAR];
+  try {
+    const provider = buildKmsCredentialsProvider({ profile: PROFILE_JWT_SIGNER });
+    assert.equal(provider, null);
+  } finally {
+    if (prior !== undefined) process.env[ROLES_ANYWHERE_FLAG_ENV_VAR] = prior;
+  }
+});
+
+test("buildKmsCredentialsProvider: exported profile constants match the §5.3 aws-config", () => {
+  // These names are baked into the VPS /etc/agent-stack/aws-config
+  // produced during Phase 5a operator setup. Renaming either constant
+  // here without renaming the profile section in the aws-config would
+  // make Roles Anywhere silently fall back to default chain.
+  assert.equal(PROFILE_BLOCKCHAIN_SIGNER, "averray-signer");
+  assert.equal(PROFILE_JWT_SIGNER, "averray-jwt-signer");
+});


### PR DESCRIPTION
## Summary

Resolves the "open implementation question" in `PHASE_5A_IAM_ROLES_ANYWHERE_PLAN.md` §5.5: the backend's two KMSClients (blockchain + JWT signer) can now construct with explicit credentials keyed to specific shared-config profiles. Gated by `AWS_USE_ROLES_ANYWHERE=true` (default off) — **zero runtime change at merge**.

| File | Change |
|---|---|
| `mcp-server/src/services/aws-credentials.js` (new) | `buildKmsCredentialsProvider({ profile })` — flag-gated `fromIni` provider builder. Exports `PROFILE_BLOCKCHAIN_SIGNER` + `PROFILE_JWT_SIGNER` matching the VPS aws-config sections. |
| `mcp-server/src/services/aws-credentials.test.js` (new, 10 tests) | Flag handling (unset/false/true/whitespace/case), missing-profile errors, profile-constant pinning |
| `mcp-server/src/auth/kms-jwt-signer.js` | Accept optional `credentialsProvider`, pass through to lazy KMSClient |
| `mcp-server/src/blockchain/kms-signer.js` | Same. `connect()` propagates the provider |
| `mcp-server/src/auth/jwt.js` | `getKmsSigner` builds JWT-profile provider |
| `mcp-server/src/blockchain/gateway.js` | `createSigner` builds blockchain-profile provider |
| `mcp-server/package.json` | Add `@aws-sdk/credential-provider-ini` as explicit dep (was transitive) |
| `docs/PHASE_5A_IAM_ROLES_ANYWHERE_PLAN.md` | §5.5 rewritten; §6 migration phases refactored to 5a-cutover-code (this PR) / 5a-cutover-flip (operator) / 5a-cutover-retire-static-env (later) |

## Runtime impact at merge

**Zero.** `AWS_USE_ROLES_ANYWHERE` is unset in prod, so `buildKmsCredentialsProvider` returns `null` at every call site, KMSClients get no credentials override, and the SDK's default chain resolves the same way as today. The new code path is exercised only after the operator flips the flag.

## Activation (operator, post-merge)

On the VPS, three steps:

1. **`docker-compose.yml` volume mounts** (already documented in plan §5.5):
   ```yaml
   volumes:
     - /etc/agent-stack/aws-config:/root/.aws/config:ro
     - /etc/agent-stack/roles-anywhere:/etc/agent-stack/roles-anywhere:ro
     - /usr/local/bin/aws_signing_helper:/usr/local/bin/aws_signing_helper:ro
   environment:
     AWS_USE_ROLES_ANYWHERE: "true"
     AWS_CONFIG_FILE: /root/.aws/config
   ```
2. **Restart the backend container** with `--force-recreate`.
3. **Verify** with `sts:GetCallerIdentity` from inside the container — expected ARN: `arn:aws:sts::079209845430:assumed-role/averray-{signer,jwt-signer}-testnet-role/<session-id>`. The `assumed-role` prefix (not `user`) is the proof Roles Anywhere is live. Command in §"Phase 5a-cutover-flip" of the plan doc.

After 24h soak, a small follow-up PR comments out the four static `AWS_*_ACCESS_KEY_*` op refs from `backend.env.template`. After 30 days clean, the §5a-retire PR `aws iam delete-access-key`s the now-unused static IAM keys.

## Test plan

- [x] `node --check` on all 6 modified/new modules
- [x] 281/281 local auth+service tests pass (10 new in `aws-credentials.test.js`)
- [ ] CI green (full suite including `kms-jwt-signer.test.js` and `jwt-dispatcher.test.js` which need deps not in this worktree's node_modules)
- [ ] Post-deploy: backend boot logs show `jwt-kms-credential-check.ok` as before (this PR is invisible until the operator flips the flag)
- [ ] After operator activation: `sts:GetCallerIdentity` from inside the container returns `assumed-role/...` ARNs for both signers

🤖 Generated with [Claude Code](https://claude.com/claude-code)