### PR TITLE
docs: mark metrics auth ready for proof

### DIFF
--- a/docs/PROJECT_ROADMAP.md
+++ b/docs/PROJECT_ROADMAP.md
@@ -158,7 +158,7 @@ externally ready.
 | Redis backup readiness | Open | `check-backup-readiness.sh --json` reports recent Redis backup if Redis contains non-rebuildable state. |
 | Restore drill | Open | Restore drill performed and documented with date, source backup, and target. |
 | Hosted `/admin/status` async XCM smoke | Open | Run hosted check with live admin JWT and verify async XCM watcher lane. |
-| Metrics auth | Open | Backend metrics endpoint fails closed when unconfigured in production and `CHECK_METRICS_AUTH=1` proves unauthenticated `401` plus scraper-token `200` against the hosted stack. |
+| Metrics auth | Ready for proof | Code deployed in `#445`; hosted `/metrics` now fails closed with `503 metrics_auth_unconfigured` when no scraper token is configured. Close after production `METRICS_BEARER_TOKEN` is set and `CHECK_METRICS_AUTH=1` proves unauthenticated `401` plus scraper-token `200` against the hosted stack. |
 | Sentry/logging decision | Open | Backend Sentry configured or explicitly deferred; frontend decision recorded; structured logs visible. |
 | Alert destination | Open | At least one deploy/health failure path reaches the operator. |
 | Operator self-report evidence | Open | Hermes/operator report proof replaces optional Resend email proof. Evidence should include correlation ID and durable destination. |


### PR DESCRIPTION
## What changed
- Move the `Metrics auth` roadmap item from `Open` to `Ready for proof`.
- Record the deployed evidence from `#445`: hosted `/metrics` now fails closed with `503 metrics_auth_unconfigured` when no scraper token is configured.
- Keep the close criterion explicit: configure production `METRICS_BEARER_TOKEN`, then run `CHECK_METRICS_AUTH=1` to prove unauthenticated `401` and bearer `200`.

## Checks
- `git diff --check`

## Impact
- Docs/status only.
- No backend, frontend, indexer, contracts, Caddy, public-site runtime, env, or VPS secret changes.