### PR TITLE
test(ops): prove hosted smoke alert wrapper

### DIFF
--- a/docs/roadmap-updates/2026-05-19-codex-alert-destination.md
+++ b/docs/roadmap-updates/2026-05-19-codex-alert-destination.md
@@ -1,0 +1,42 @@
+# Roadmap Update: Alert destination
+
+- **Date:** 2026-05-19
+- **Agent:** codex/alert-wrapper-proof
+- **Roadmap section:** Open Work To RC1/Testnet Launch / P0 Launch Gates
+- **Item:** Alert destination
+- **Related PRs/issues:** pending PR for this branch
+- **Proposed status:** Ready for proof
+- **Owner:** Operator / roadmap steward after merge
+
+## Summary
+
+The hosted-stack alert wrapper already existed, and this branch adds regression
+coverage proving it sends a structured webhook payload when the hosted smoke
+check fails. This makes the P0 item implementation-ready, but not yet Proofed:
+an operator still needs to configure the real production alert destination and
+run one deliberate hosted smoke failure to prove delivery.
+
+## Evidence
+
+- `scripts/ops/check-hosted-stack-and-alert.test.mjs` covers:
+  - passing smoke exits without alerting;
+  - failing smoke without `ALERT_WEBHOOK_URL` fails closed;
+  - failing smoke with a webhook sends JSON containing service, environment,
+    timestamp, check name, summary, and captured output.
+- The wrapper now supports `CHECK_HOSTED_STACK_SCRIPT` so tests can inject a
+  deterministic smoke-check stub without touching production URLs.
+
+## Blockers Or Caveats
+
+- Production `ALERT_WEBHOOK_URL` still needs to be configured in the scheduler
+  environment that runs `scripts/ops/check-hosted-stack-and-alert.sh`.
+- A deliberate hosted smoke failure must be sent to the real operator channel
+  before the roadmap item can move from `Ready for proof` to `Proofed`.
+
+## Requested Roadmap Change
+
+After this branch merges, update the P0 launch gate row:
+
+```md
+| Alert destination | Ready for proof | Alert wrapper is tested for structured webhook delivery on smoke failure. Close after `ALERT_WEBHOOK_URL` is configured in the production scheduler environment and one deliberate hosted smoke failure reaches the operator channel. |
+```

--- a/scripts/ops/check-hosted-stack-and-alert.sh
+++ b/scripts/ops/check-hosted-stack-and-alert.sh
@@ -3,12 +3,13 @@
 set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-CHECK_SCRIPT="${SCRIPT_DIR}/check-hosted-stack.sh"
+CHECK_SCRIPT=${CHECK_HOSTED_STACK_SCRIPT:-"${SCRIPT_DIR}/check-hosted-stack.sh"}
 
 ALERT_WEBHOOK_URL=${ALERT_WEBHOOK_URL:-}
 ALERT_SERVICE_NAME=${ALERT_SERVICE_NAME:-averray-hosted-stack}
 ALERT_ENVIRONMENT=${ALERT_ENVIRONMENT:-production-like}
 TIMEOUT_SEC=${TIMEOUT_SEC:-20}
+CURL_BIN=${CURL_BIN:-curl}
 
 require_command() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -32,7 +33,7 @@ if [[ -z "$ALERT_WEBHOOK_URL" ]]; then
   exit 1
 fi
 
-require_command curl
+require_command "$CURL_BIN"
 require_command jq
 
 payload=$(
@@ -55,7 +56,7 @@ payload=$(
     }'
 )
 
-curl -fsS --max-time "$TIMEOUT_SEC" \
+"$CURL_BIN" -fsS --max-time "$TIMEOUT_SEC" \
   -H "Content-Type: application/json" \
   -d "$payload" \
   "$ALERT_WEBHOOK_URL" >/dev/null

--- a/scripts/ops/check-hosted-stack-and-alert.test.mjs
+++ b/scripts/ops/check-hosted-stack-and-alert.test.mjs
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const scriptPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "check-hosted-stack-and-alert.sh"
+);
+
+async function makeStubScript(body) {
+  const root = await mkdtemp(join(tmpdir(), "hosted-stack-alert-"));
+  const stub = join(root, "check-hosted-stack-stub.sh");
+  await writeFile(stub, `#!/usr/bin/env bash\nset -euo pipefail\n${body}\n`, "utf8");
+  await chmod(stub, 0o755);
+  return stub;
+}
+
+function shellQuote(value) {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+async function makeCurlCaptureScript() {
+  const root = await mkdtemp(join(tmpdir(), "hosted-stack-alert-curl-"));
+  const curl = join(root, "curl-capture.sh");
+  const headersPath = join(root, "headers.txt");
+  const payloadPath = join(root, "payload.json");
+  const urlPath = join(root, "url.txt");
+
+  await writeFile(
+    curl,
+    `#!/usr/bin/env bash
+set -euo pipefail
+payload=""
+url=""
+headers=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -d)
+      payload="$2"
+      shift 2
+      ;;
+    -H)
+      headers+=("$2")
+      shift 2
+      ;;
+    --max-time)
+      shift 2
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+
+printf '%s\\n' "$url" > ${shellQuote(urlPath)}
+printf '%s\\n' "$payload" > ${shellQuote(payloadPath)}
+printf '%s\\n' "\${headers[@]}" > ${shellQuote(headersPath)}
+`,
+    "utf8"
+  );
+  await chmod(curl, 0o755);
+
+  return { curl, headersPath, payloadPath, urlPath };
+}
+
+async function runScript(env = {}) {
+  try {
+    const result = await execFileAsync(scriptPath, [], {
+      env: {
+        ...process.env,
+        ...env,
+      },
+      timeout: 10_000,
+    });
+    return { code: 0, stdout: result.stdout, stderr: result.stderr };
+  } catch (error) {
+    return {
+      code: typeof error.code === "number" ? error.code : 1,
+      stdout: error.stdout ?? "",
+      stderr: error.stderr ?? "",
+    };
+  }
+}
+
+test("hosted stack alert wrapper exits cleanly when the smoke check passes", async () => {
+  const stub = await makeStubScript('echo "hosted stack ok"');
+  const result = await runScript({
+    CHECK_HOSTED_STACK_SCRIPT: stub,
+    ALERT_WEBHOOK_URL: "http://127.0.0.1:9/unused",
+  });
+
+  assert.equal(result.code, 0);
+  assert.match(result.stdout, /hosted stack ok/);
+  assert.equal(result.stderr, "");
+});
+
+test("hosted stack alert wrapper fails closed when no webhook is configured", async () => {
+  const stub = await makeStubScript('echo "smoke failed"; echo "api down" >&2; exit 7');
+  const result = await runScript({
+    CHECK_HOSTED_STACK_SCRIPT: stub,
+    ALERT_WEBHOOK_URL: "",
+  });
+
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /smoke failed/);
+  assert.match(result.stderr, /api down/);
+  assert.match(result.stderr, /ALERT_WEBHOOK_URL is not set/);
+});
+
+test("hosted stack alert wrapper sends a structured webhook payload on failure", async () => {
+  const stub = await makeStubScript('echo "smoke failed"; echo "indexer stale" >&2; exit 9');
+  const curlCapture = await makeCurlCaptureScript();
+
+  const result = await runScript({
+    CHECK_HOSTED_STACK_SCRIPT: stub,
+    ALERT_WEBHOOK_URL: "https://alerts.example.test/webhook",
+    ALERT_SERVICE_NAME: "averray-smoke-test",
+    ALERT_ENVIRONMENT: "ci",
+    CURL_BIN: curlCapture.curl,
+  });
+
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /Alert sent to configured webhook/);
+
+  const url = await readFile(curlCapture.urlPath, "utf8");
+  assert.equal(url.trim(), "https://alerts.example.test/webhook");
+
+  const headers = await readFile(curlCapture.headersPath, "utf8");
+  assert.match(headers, /Content-Type: application\/json/);
+
+  const body = await readFile(curlCapture.payloadPath, "utf8");
+  const payload = JSON.parse(body);
+  assert.equal(payload.status, "firing");
+  assert.equal(payload.service, "averray-smoke-test");
+  assert.equal(payload.environment, "ci");
+  assert.equal(payload.check, "scripts/ops/check-hosted-stack.sh");
+  assert.equal(payload.summary, "Hosted stack smoke check failed");
+  assert.match(payload.output, /smoke failed/);
+  assert.match(payload.output, /indexer stale/);
+  assert.match(payload.timestamp, /^\d{4}-\d{2}-\d{2}T/);
+  assert.doesNotMatch(body, /ALERT_WEBHOOK_URL|re_[A-Za-z0-9_-]{12,}/);
+});


### PR DESCRIPTION
## Summary
- add regression coverage for the hosted-stack alert wrapper success, fail-closed, and webhook-delivery paths
- allow the wrapper to inject a smoke-check script and curl binary for deterministic tests while keeping production defaults unchanged
- add a roadmap-update fragment for moving the P0 Alert destination gate to Ready for proof after merge

## Checks
- npm run test:ops

## Impact
- Ops scripts/tests/docs only
- No backend, frontend, indexer, Caddy, contracts, or public site runtime changes
- No required VPS/env secret changes in this PR

## Follow-up
- Configure production ALERT_WEBHOOK_URL in the scheduler environment and run one deliberate hosted smoke failure to prove delivery before marking the roadmap item Proofed