### PR TITLE
fix(deploy): install ca-certificates in mcp-server image for aws_signing_helper TLS

### DIFF
--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -1,5 +1,28 @@
 FROM node:22-bookworm-slim
 
+# ca-certificates: required by the IAM Roles Anywhere `aws_signing_helper`
+# binary (mounted at /usr/local/bin/aws_signing_helper by docker-compose
+# in Phase 5a). aws_signing_helper is a Go binary that makes HTTPS calls
+# to rolesanywhere.<region>.amazonaws.com to exchange the VPS-side client
+# cert for STS session credentials. Go's net/http reads CA roots from
+# /etc/ssl/certs/ca-certificates.crt (Debian path). node:22-bookworm-slim
+# ships without ca-certificates, so without this install the TLS
+# handshake fails with `x509: certificate signed by unknown authority`
+# even though the cert chain itself is fine — Go just can't find any
+# trust anchors to validate against.
+#
+# Node's own HTTPS works regardless because Node bundles its own CA
+# store in the binary, so this install is specifically about supporting
+# external tools (currently aws_signing_helper; future: anything else
+# mounted in via docker-compose that needs to validate TLS).
+#
+# --no-install-recommends keeps the image minimal — ca-certificates'
+# recommended deps include openssl and gnupg, neither of which the
+# backend needs at runtime.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY mcp-server/package*.json ./


### PR DESCRIPTION
## Summary

Follow-up to #447. The mounted `aws_signing_helper` Go binary couldn't validate AWS's TLS cert against `rolesanywhere.eu-central-2.amazonaws.com` because `node:22-bookworm-slim` ships without `ca-certificates`. Go's `net/http` reads CA roots from `/etc/ssl/certs/ca-certificates.crt` (Debian path); empty path → `x509: certificate signed by unknown authority` on every CreateSession.

Node's own HTTPS calls (KMS `Sign`, etc.) work because Node bundles a CA store in its binary. This install is specifically about supporting mounted-in tools that link against the system CA bundle.

## Diagnosed in prod

During the §5.5 operator setup tonight, the first `fromIni({profile: 'averray-jwt-signer'})` call from inside the container returned:

```
Command failed: /usr/local/bin/aws_signing_helper credential-process ...
RolesAnywhere: CreateSession, ... tls: failed to verify certificate:
x509: certificate signed by unknown authority
```

## Stopgap currently in place

The VPS's `/srv/agent-stack/docker-compose.yml` mounts the host's `/etc/ssl/certs/ca-certificates.crt` as a read-only volume at the same path. That keeps prod working *right now* but couples the container to the host's CA bundle in a way that breaks if (a) the host's package manager moves the file, (b) the image is reused on a different OS, or (c) someone forgets the mount in a future compose edit.

## What this PR does

Installs `ca-certificates` at build time via `apt-get install -y --no-install-recommends ca-certificates` in a single RUN that also clears apt-lists for layer cleanliness. After the deploy that ships this:

- Image is self-contained for TLS validation
- Host mount becomes redundant (still works as an override; harmless)
- Future image rebuilds (mainnet redeploy, second-region setup, etc.) get TLS for free

After this deploys cleanly + Roles Anywhere is verified still working without the host mount, the operator can optionally drop the host-path CA mount from `/srv/agent-stack/docker-compose.yml`. Belt-and-suspenders is fine too.

## Test plan

- [x] Dockerfile syntax (visual review)
- [ ] CI green
- [ ] Post-deploy: backend container boots clean, `fromIni({profile: 'averray-jwt-signer'})` from inside the container returns `ASIA*` STS credentials *without* relying on the host-path CA mount (operator can temporarily remove the mount to confirm — or just trust the layer is there)

Per `docs/PHASE_5A_IAM_ROLES_ANYWHERE_PLAN.md` §5.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)