### PR TITLE
Document observability posture

### DIFF
--- a/docs/OBSERVABILITY_POSTURE.md
+++ b/docs/OBSERVABILITY_POSTURE.md
@@ -1,0 +1,47 @@
+# Observability Posture
+
+This document records the current v1 launch posture for the P0
+`Sentry/logging decision` gate.
+
+## Current Decision
+
+- Backend Sentry is **optional and deferred** for v1 launch unless an operator
+  configures a project DSN before RC1.
+- Backend 5xx errors are always captured through the structured JSON logger,
+  even when Sentry is not configured or `@sentry/node` is not installed.
+- Frontend Sentry is **deferred for v1**. The operator app should rely on
+  visible API errors, request IDs, and backend logs for launch operations.
+- `LOG_LEVEL=info` remains the production default in
+  [`deploy/backend.env.template`](../deploy/backend.env.template).
+
+## Backend Behavior
+
+The backend creates a pino-style JSON logger through
+[`mcp-server/src/core/logger.js`](../mcp-server/src/core/logger.js). Each log
+line includes `ts`, `level`, `name`, `msg`, and any contextual fields such as
+`requestId`.
+
+[`mcp-server/src/core/observability.js`](../mcp-server/src/core/observability.js)
+wraps optional Sentry capture:
+
+- If `SENTRY_DSN` is unset, `captureException` and `captureMessage` write to
+  structured logs.
+- If `SENTRY_DSN` is set but `@sentry/node` is unavailable, the backend logs
+  `observability.sentry_unavailable` and keeps serving.
+- If Sentry is enabled successfully, 5xx errors are sent to Sentry and still
+  logged locally as `observability.captured_exception`.
+
+## Proof Required Before Marking Proofed
+
+To close the roadmap gate as `Proofed`, an operator must verify the active
+deploy target exposes the structured logs:
+
+```bash
+# On the VPS or current production log surface:
+sudo docker logs agent-backend --tail 50
+```
+
+Look for JSON log lines with `level`, `name`, and `msg`. If Sentry is enabled,
+also verify `observability.sentry_ready` appears after backend startup. If
+Sentry remains deferred, record that the log-only posture is intentional for
+v1 and link this document from the launch notes.

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -255,20 +255,20 @@ commands per box:
   ```
   The gate requires unauthenticated `/metrics` to return `401` and the same
   request with `Authorization: Bearer <token>` to return `200`.
-- **Backend Sentry configured for the active environment.** Set
-  `SENTRY_DSN` (and optionally `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`,
-  `SENTRY_TRACES_SAMPLE_RATE`) in `deploy/backend.env.template`, then
-  `npm install @sentry/node` in `mcp-server`. The backend log line
-  `observability.sentry_ready` confirms init. Flip when that log line is
-  present in the current deploy.
-- **Frontend Sentry runtime config.** Conditional. v1 has no frontend
-  Sentry scaffolding. Two valid postures: (a) flip with the inline note
-  *"N/A — frontend error reporting not required for v1"* if that is the
-  decision, or (b) leave unchecked until frontend Sentry is scaffolded.
+- **Sentry/logging posture recorded for the active environment.** The current
+  v1 posture is recorded in
+  [`OBSERVABILITY_POSTURE.md`](./OBSERVABILITY_POSTURE.md): backend Sentry is
+  optional/deferred unless a `SENTRY_DSN` is configured, backend 5xx capture
+  always falls back to structured logs, and frontend Sentry is deferred for v1.
+  If Sentry is enabled, set `SENTRY_DSN` (and optionally
+  `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`, `SENTRY_TRACES_SAMPLE_RATE`) and
+  verify `observability.sentry_ready` appears after backend startup.
 - **Structured logs visible from the current deploy target.**
   `LOG_LEVEL=info` is set; the backend writes structured JSON via the
-  default logger. Verify the operator can read backend logs (via
-  `journalctl`, `docker logs`, or the platform's log surface), then flip.
+  default logger and records 5xx captures as
+  `observability.captured_exception`. Verify the operator can read backend
+  logs (via `journalctl`, `docker logs`, or the platform's log surface), then
+  flip.
 - **Alert destination for hosted smoke-check failures.** Set
   `ALERT_WEBHOOK_URL` (and optionally `ALERT_SERVICE_NAME`,
   `ALERT_ENVIRONMENT`) in the environment that runs

--- a/docs/PROJECT_ROADMAP.md
+++ b/docs/PROJECT_ROADMAP.md
@@ -159,7 +159,7 @@ externally ready.
 | Restore drill | Open | Restore drill performed and documented with date, source backup, and target. |
 | Hosted `/admin/status` async XCM smoke | Open | Run hosted check with live admin JWT and verify async XCM watcher lane. |
 | Metrics auth | Ready for proof | Code deployed in `#445`; hosted `/metrics` now fails closed with `503 metrics_auth_unconfigured` when no scraper token is configured. Close after production `METRICS_BEARER_TOKEN` is set and `CHECK_METRICS_AUTH=1` proves unauthenticated `401` plus scraper-token `200` against the hosted stack. |
-| Sentry/logging decision | Open | Backend Sentry configured or explicitly deferred; frontend decision recorded; structured logs visible. |
+| Sentry/logging decision | Ready for proof | Backend/frontend Sentry posture is recorded in `OBSERVABILITY_POSTURE.md`; backend 5xx capture falls back to structured JSON logs and optional Sentry has regression coverage. Close after an operator verifies structured logs are visible from the active deploy target, and `observability.sentry_ready` is observed if Sentry is enabled. |
 | Alert destination | Ready for proof | Alert wrapper is tested for structured webhook delivery on smoke failure in `#449`. Close after `ALERT_WEBHOOK_URL` is configured in the production scheduler environment and one deliberate hosted smoke failure reaches the operator channel. |
 | Operator self-report evidence | Open | Hermes/operator report proof replaces optional Resend email proof. Evidence should include correlation ID and durable destination. |
 | Dispute verdict hosted proof | Open | Hosted smoke creates a dispute verdict receipt or documented equivalent. |

--- a/mcp-server/src/core/observability.js
+++ b/mcp-server/src/core/observability.js
@@ -14,15 +14,15 @@
  *   2. Set SENTRY_DSN (and optionally SENTRY_ENVIRONMENT / SENTRY_RELEASE)
  */
 
-export async function createObservability({ logger }) {
-  const dsn = process.env.SENTRY_DSN?.trim();
+export async function createObservability({ logger, env = process.env, sentryLoader = loadSentry } = {}) {
+  const dsn = env.SENTRY_DSN?.trim();
   if (!dsn) {
     return logOnly(logger);
   }
 
   let sentry;
   try {
-    sentry = await loadSentry(dsn, logger);
+    sentry = await sentryLoader(dsn, logger, env);
   } catch (error) {
     logger.warn?.(
       { err: error instanceof Error ? error : new Error(String(error)) },
@@ -55,7 +55,7 @@ export async function createObservability({ logger }) {
   };
 }
 
-async function loadSentry(dsn, logger) {
+async function loadSentry(dsn, logger, env = process.env) {
   let mod;
   try {
     mod = await import("@sentry/node");
@@ -67,12 +67,12 @@ async function loadSentry(dsn, logger) {
   }
   mod.init({
     dsn,
-    environment: process.env.SENTRY_ENVIRONMENT ?? process.env.NODE_ENV ?? "production",
-    release: process.env.SENTRY_RELEASE,
-    tracesSampleRate: parseRate(process.env.SENTRY_TRACES_SAMPLE_RATE, 0)
+    environment: env.SENTRY_ENVIRONMENT ?? env.NODE_ENV ?? "production",
+    release: env.SENTRY_RELEASE,
+    tracesSampleRate: parseRate(env.SENTRY_TRACES_SAMPLE_RATE, 0)
   });
   logger.info?.(
-    { environment: process.env.SENTRY_ENVIRONMENT ?? process.env.NODE_ENV ?? "production" },
+    { environment: env.SENTRY_ENVIRONMENT ?? env.NODE_ENV ?? "production" },
     "observability.sentry_ready"
   );
   return mod;

--- a/mcp-server/src/core/observability.test.js
+++ b/mcp-server/src/core/observability.test.js
@@ -1,0 +1,106 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createObservability } from "./observability.js";
+
+function collectingLogger() {
+  const records = [];
+  const logger = {};
+  for (const level of ["debug", "info", "warn", "error"]) {
+    logger[level] = (fieldsOrMessage, message) => {
+      records.push({ level, fieldsOrMessage, message });
+    };
+  }
+  return { logger, records };
+}
+
+test("observability uses structured-log fallback when Sentry is not configured", async () => {
+  const { logger, records } = collectingLogger();
+  const observability = await createObservability({ logger, env: {} });
+
+  assert.equal(observability.isEnabled, false);
+  observability.captureException(new Error("boom"), { requestId: "req-1" });
+  observability.captureMessage("operator.note", { level: "warn", source: "test" });
+
+  assert.equal(records.length, 2);
+  assert.equal(records[0].level, "error");
+  assert.equal(records[0].message, "observability.captured_exception");
+  assert.equal(records[0].fieldsOrMessage.requestId, "req-1");
+  assert.equal(records[0].fieldsOrMessage.err.message, "boom");
+  assert.equal(records[1].level, "warn");
+  assert.equal(records[1].message, "operator.note");
+  assert.equal(records[1].fieldsOrMessage.source, "test");
+  assert.equal(await observability.flush(), true);
+});
+
+test("observability captures to Sentry and still logs locally when configured", async () => {
+  const { logger, records } = collectingLogger();
+  const sentryCalls = [];
+  const observability = await createObservability({
+    logger,
+    env: {
+      SENTRY_DSN: "https://example@sentry.test/1",
+      SENTRY_ENVIRONMENT: "testnet"
+    },
+    sentryLoader: async (dsn, _logger, env) => {
+      assert.equal(dsn, "https://example@sentry.test/1");
+      assert.equal(env.SENTRY_ENVIRONMENT, "testnet");
+      return {
+        captureException(error, options) {
+          sentryCalls.push({ type: "exception", error, options });
+        },
+        captureMessage(message, options) {
+          sentryCalls.push({ type: "message", message, options });
+        },
+        flush(timeoutMs) {
+          sentryCalls.push({ type: "flush", timeoutMs });
+          return Promise.resolve(true);
+        }
+      };
+    }
+  });
+
+  assert.equal(observability.isEnabled, true);
+
+  const error = new Error("chain reverted");
+  observability.captureException(error, { requestId: "req-2" });
+  observability.captureMessage("ops.ready", { level: "info", lane: "deploy" });
+
+  assert.equal(await observability.flush(123), true);
+  assert.equal(sentryCalls.length, 3);
+  assert.equal(sentryCalls[0].type, "exception");
+  assert.equal(sentryCalls[0].error, error);
+  assert.deepEqual(sentryCalls[0].options.extra, { requestId: "req-2" });
+  assert.equal(sentryCalls[1].type, "message");
+  assert.equal(sentryCalls[1].message, "ops.ready");
+  assert.deepEqual(sentryCalls[1].options.extra, { lane: "deploy" });
+  assert.equal(sentryCalls[2].timeoutMs, 123);
+
+  assert.equal(records.length, 2);
+  assert.equal(records[0].level, "error");
+  assert.equal(records[0].message, "observability.captured_exception");
+  assert.equal(records[1].level, "info");
+  assert.equal(records[1].message, "ops.ready");
+});
+
+test("observability falls back to logs when Sentry loading fails", async () => {
+  const { logger, records } = collectingLogger();
+  const observability = await createObservability({
+    logger,
+    env: { SENTRY_DSN: "https://example@sentry.test/1" },
+    sentryLoader: async () => {
+      throw new Error("missing package");
+    }
+  });
+
+  assert.equal(observability.isEnabled, false);
+  assert.equal(records.length, 1);
+  assert.equal(records[0].level, "warn");
+  assert.equal(records[0].message, "observability.sentry_unavailable");
+  assert.equal(records[0].fieldsOrMessage.err.message, "missing package");
+
+  observability.captureException(new Error("still logged"), { requestId: "req-3" });
+  assert.equal(records[1].level, "error");
+  assert.equal(records[1].message, "observability.captured_exception");
+  assert.equal(records[1].fieldsOrMessage.requestId, "req-3");
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -429,6 +429,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@aws-sdk/client-kms": "^3.700.0",
+        "@aws-sdk/credential-provider-ini": "^3.700.0",
         "@paraspell/sdk-core": "^13.4.0",
         "ethers": "^6.16.0",
         "redis": "^5.11.0"


### PR DESCRIPTION
## What changed
- Added docs/OBSERVABILITY_POSTURE.md as the v1 source of truth for the Sentry/logging launch decision.
- Added deterministic tests for the backend observability seam: log-only fallback, optional Sentry capture, and Sentry loader failure fallback.
- Updated the production checklist and roadmap so the Sentry/logging gate is Ready for proof, not an open unknown.
- Synced the existing mcp-server package dependency entry into package-lock.json so clean installs include the AWS credential provider dependency already declared by the workspace.

## Checks
- npm --workspace mcp-server test
- npm run check:generated-output
- git diff --check HEAD~1..HEAD

## Impact
- Backend core test coverage and docs only. Runtime behavior is unchanged unless SENTRY_DSN is configured.
- No frontend, indexer, Caddy, contracts, or public-site changes.
- No secret changes required. Operators can optionally configure SENTRY_DSN later; otherwise structured JSON logs remain the v1 posture.

## Follow-up
- Close the roadmap proof gate after an operator verifies structured backend logs from the active deploy target. If Sentry is enabled, also verify observability.sentry_ready after backend startup.