### PR TITLE
fix(auth): boot cred-check uses Roles Anywhere provider (#455/#456 root cause)

### DIFF
--- a/mcp-server/src/auth/credential-check.js
+++ b/mcp-server/src/auth/credential-check.js
@@ -32,6 +32,20 @@ const VALIDATION_TIMEOUT_MS = 10_000;
  * @param {object} [opts]
  * @param {object} [opts.logger]   Logger with `.info`/`.warn` methods.
  * @param {boolean} [opts.skip]    Test-only escape hatch — skip the live check.
+ * @param {Function} [opts.credentialsProvider]
+ *   AWS SDK credentials-provider function (e.g. the `fromIni` result from
+ *   `buildKmsCredentialsProvider`). When provided AND no `kmsJwtConfig.kmsClient`
+ *   is injected, the constructed `KMSClient` is built with this provider so the
+ *   boot check uses the same credential resolution path as the runtime signer
+ *   (`getKmsSigner` in `jwt.js`). Without it, `new KMSClient({ region })` falls
+ *   through to the SDK default chain (env vars / shared config / IMDS) — which
+ *   does NOT pick up Roles Anywhere by default and therefore disagrees with the
+ *   runtime path when `AWS_USE_ROLES_ANYWHERE=true` is set + static keys are
+ *   not in env. That drift was the root cause of the Phase 5a Stage 2C-3 prod
+ *   outage (#455 → reverted in #456): the runtime KmsJwtSigner had Roles
+ *   Anywhere wired in, but this boot check did not — so removing the env-
+ *   rendered static keys broke the boot check (`CredentialsProviderError`)
+ *   while the runtime kept working. Production callers MUST pass this opt.
  * @returns {Promise<{ ok: true, keyId: string, keyArn: string, keyState: string }>}
  * @throws {ConfigError}            If the credential chain cannot resolve or DescribeKey fails.
  */
@@ -62,9 +76,16 @@ export async function validateJwtKmsCredentialAccess(kmsJwtConfig, opts = {}) {
 
   // Reuse the test-injected KMSClient if present (KmsJwtSigner does
   // the same), so unit tests can stub the check without configuring a
-  // real AWS account.
+  // real AWS account. When none is injected, build one with the same
+  // credentials-provider the runtime signer uses — see the
+  // opts.credentialsProvider JSDoc above for the failure mode this
+  // avoids.
   const client =
-    kmsJwtConfig.kmsClient ?? new KMSClient({ region: kmsJwtConfig.region });
+    kmsJwtConfig.kmsClient ??
+    new KMSClient({
+      region: kmsJwtConfig.region,
+      ...(opts.credentialsProvider ? { credentials: opts.credentialsProvider } : {}),
+    });
 
   const startedAt = Date.now();
   let response;

--- a/mcp-server/src/auth/credential-check.test.js
+++ b/mcp-server/src/auth/credential-check.test.js
@@ -216,6 +216,43 @@ test("validateJwtKmsCredentialAccess: rejects when key has wrong KeyUsage (likel
   );
 });
 
+test("validateJwtKmsCredentialAccess: opts.credentialsProvider is accepted (regression for #455/#456 outage)", async () => {
+  // Regression coverage for the Phase 5a Stage 2C-3 outage. Pre-fix,
+  // the function silently ignored any caller-supplied credentials
+  // provider — production constructed a KMSClient via the SDK default
+  // chain while the runtime KmsJwtSigner used Roles Anywhere. Removing
+  // env-rendered static keys (#455) made the two paths disagree and
+  // the boot check threw CredentialsProviderError even though signing
+  // would have worked fine.
+  //
+  // We don't exercise the real fromIni path here (no AWS in tests).
+  // The injected kmsClient short-circuits client construction, so the
+  // provider can't be observed via the client itself. Instead we
+  // assert the call accepts the opt without throwing and the happy
+  // path still returns ok — confirming the new opt is wired without
+  // regressing existing behavior. The structural fix (passing the
+  // provider into `new KMSClient`) is exercised end-to-end on the
+  // first prod boot after merge: a failure there would resurface the
+  // same CredentialsProviderError seen in the outage.
+  const provider = async () => {
+    throw new Error("test credentialsProvider should not be invoked when kmsClient is injected");
+  };
+  const cfg = {
+    ...VALID_CFG,
+    kmsClient: new FakeKMSClient({
+      describeKey: () => ({
+        KeyMetadata: { Arn: KEY_ARN, KeyState: "Enabled", KeyUsage: "SIGN_VERIFY" },
+      }),
+    }),
+  };
+  const result = await validateJwtKmsCredentialAccess(cfg, {
+    logger: silentLogger(),
+    credentialsProvider: provider,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.keyArn, KEY_ARN);
+});
+
 test("validateJwtKmsCredentialAccess: logs at info level on success", async () => {
   const logs = [];
   const logger = {

--- a/mcp-server/src/services/bootstrap.js
+++ b/mcp-server/src/services/bootstrap.js
@@ -11,6 +11,7 @@ import { EventBus } from "../core/event-bus.js";
 import { EventListener } from "../blockchain/event-listener.js";
 import { loadAuthConfig } from "../auth/config.js";
 import { validateJwtKmsCredentialAccess } from "../auth/credential-check.js";
+import { buildKmsCredentialsProvider, PROFILE_JWT_SIGNER } from "./aws-credentials.js";
 import { createAuthMiddleware } from "../auth/middleware.js";
 import { createRateLimiter } from "../auth/rate-limit.js";
 import { resolveCapabilities, capabilityMatrix } from "../auth/capabilities.js";
@@ -177,7 +178,14 @@ export async function createPlatformRuntime() {
   // tests / disconnected dev environments.
   if (authConfig.kmsJwt) {
     try {
-      await validateJwtKmsCredentialAccess(authConfig.kmsJwt, { logger });
+      // Build the same Roles Anywhere credentials-provider the runtime
+      // KmsJwtSigner uses (see getKmsSigner in auth/jwt.js). Without it
+      // the boot check falls through to the SDK default chain — which
+      // disagrees with the runtime path once AWS_USE_ROLES_ANYWHERE=true
+      // and static AWS_*_ACCESS_KEY_* env vars are absent (the Phase 5a
+      // Stage 2C-3 outage in #455/#456).
+      const credentialsProvider = buildKmsCredentialsProvider({ profile: PROFILE_JWT_SIGNER });
+      await validateJwtKmsCredentialAccess(authConfig.kmsJwt, { logger, credentialsProvider });
     } catch (error) {
       logger.error(
         { step: "validate-jwt-kms-credentials", err: error instanceof Error ? error : new Error(String(error)) },


### PR DESCRIPTION
## Summary

Fixes the credential-resolution drift between the runtime JWT signer and the boot-time credential check that caused the Phase 5a Stage 2C-3 prod outage (#455 → reverted in #456).

- **Runtime** (`mcp-server/src/auth/jwt.js`, `getKmsSigner`): already wires the Roles Anywhere `fromIni` provider into its `KMSClient`.
- **Boot check** (`mcp-server/src/auth/credential-check.js`, `validateJwtKmsCredentialAccess`): was constructing `new KMSClient({ region })` with no `credentials` option, falling through to the SDK default chain.

While `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` were rendered into `backend.env` (blockchain signer's static IAM keys), the default chain found them and `DescribeKey` on the JWT key succeeded — masking the drift. #455 removed those env lines and the drift surfaced as `CredentialsProviderError` at boot → `/health` 502 → deploy's auto-rollback also failed because it doesn't actually restore the prior git SHA.

## What this PR changes

| File | Change |
|---|---|
| `mcp-server/src/auth/credential-check.js` | Accept `opts.credentialsProvider`; pass through to `new KMSClient` when no `kmsClient` is injected. JSDoc names the failure mode this prevents. |
| `mcp-server/src/services/bootstrap.js` | Build the provider via `buildKmsCredentialsProvider({ profile: PROFILE_JWT_SIGNER })` — same call site `getKmsSigner` uses — and pass into `validateJwtKmsCredentialAccess`. |
| `mcp-server/src/auth/credential-check.test.js` | Regression test that asserts `opts.credentialsProvider` is accepted on the happy path. |

## How the in-container Roles Anywhere path was verified post-outage

From inside the running backend container (with the incident hotfix `JWT_KMS_CREDENTIAL_CHECK_SKIP=1` keeping `/health` 200):

```
$ aws_signing_helper credential-process --certificate ... --private-key ... \
    --trust-anchor-arn ... --profile-arn ... --role-arn ... --region eu-central-2
{"Version":1,"AccessKeyId":"ASIA...","SecretAccessKey":"<…>","SessionToken":"<…>","Expiration":"…"}
--- elapsed: 1s ---
```

So Roles Anywhere itself is healthy — the boot check just wasn't using it.

## Test plan

- [x] `mcp-server/src/auth/credential-check.test.js` — 12/12 pass (was 11; added one regression).
- [x] Full `mcp-server` test suite (`find src -name "*.test.js" | xargs node --test`) — 815/815 active pass, 51 pre-existing skipped, 0 fail.
- [x] `bootstrap.js` imports cleanly under `JWT_BACKEND=hmac` (the new top-level import is used only inside the `if (authConfig.kmsJwt)` branch).
- [ ] CI green
- [ ] Post-deploy: `/health` 200 *with* `JWT_KMS_CREDENTIAL_CHECK_SKIP` still set (proves no regression).
- [ ] Then operator removes the skip flag in `/srv/agent-stack/docker-compose.yml`, restarts backend, confirms `/health` stays 200 and boot logs show `jwt-kms-credential-check.ok` with the JWT key metadata.

## Follow-up after this lands clean

- Remove `JWT_KMS_CREDENTIAL_CHECK_SKIP: "1"` from `/srv/agent-stack/docker-compose.yml` (incident hotfix).
- Re-do Stage 2C-3 — re-remove the 4 `AWS_*_ACCESS_KEY_*` lines from `deploy/backend.env.template`. This time the boot check will use Roles Anywhere too and succeed.

## Why the auto-rollback in this outage didn't help

Independent observation worth flagging (not fixed in this PR): `scripts/ops/deploy-production.sh` claims to "roll back" by rebuilding from the prior SHA, but `git -C /srv/agent-stack/app rev-parse HEAD` after the failure showed the *new* SHA still checked out — so the rollback re-deployed the same broken combination. Worth a separate follow-up to make rollback actually roll back the working tree, or to fail-stop and not pretend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)