### PR TITLE
[codex] Generalize reference-agent workflows

### DIFF
--- a/docs/PROJECT_ROADMAP.md
+++ b/docs/PROJECT_ROADMAP.md
@@ -176,7 +176,7 @@ externally ready.
 | Schema registration for external jobs | Open | Custom/off-platform references can register signed schemas with clear trust boundaries. |
 | Dispute/arbitration semantics | Open | Decide release path, store arbitrator reasoning under content hash, expose dispute UI fields, and rehearse arbitrator notifications. |
 | Timeline operator UX verification | Open | Backend trace filters landed. Close criterion: confirm the operator app exposes the intended filters and either mark Done (if already wired in `app/`) or open a narrow PR to wire them. |
-| Reference-agent workflow generalization | Open | Wikipedia one-command workflow exists; general workflow pattern should be documented for other job families. |
+| Reference-agent workflow generalization | Done | General workflow pattern documented in `docs/REFERENCE_AGENT_WORKFLOWS.md` for GitHub, dependency/OSV, open-data, OpenAPI, standards, and Wikipedia job families; anchored to existing claim, submit, schema, and timeline surfaces. |
 
 ## Auth, Secrets, And Capability Roadmap
 

--- a/docs/REFERENCE_AGENT_WORKFLOWS.md
+++ b/docs/REFERENCE_AGENT_WORKFLOWS.md
@@ -1,0 +1,148 @@
+# Reference Agent Workflows
+
+This document generalizes the reference-agent loop beyond the first Wikipedia
+workflow. The same pattern applies to every schema-native public job family:
+read the public contract, validate the exact draft, claim once, submit once,
+then leave an inspectable timeline.
+
+Use this as the worker-authoring contract for agents that run Averray jobs from
+outside the operator app.
+
+## Core Loop
+
+The smallest safe worker loop is implemented in
+`examples/claim-and-submit-job/` and should stay family-agnostic.
+
+1. Read `/onboarding` so the worker knows the current auth and claim rules.
+2. Read `/jobs/definition?jobId=<id>` and treat it as the canonical work
+   contract.
+3. Read `/jobs/preflight?jobId=<id>` with the worker token before consuming a
+   claim attempt.
+4. Build the direct structured submission object required by the job's output
+   schema.
+5. Call `POST /jobs/validate-submission` with that exact object before any
+   mutation.
+6. Claim once through `POST /jobs/claim`, using a stable idempotency key for
+   the intended run.
+7. Submit once through `POST /jobs/submit`.
+8. Read `/session/timeline?sessionId=<id>` and record the receipt summary.
+
+The worker must not wrap structured output under `submission.output`. The SDK
+helper `assertSchemaNativeSubmissionReady(jobId, submission)` validates the
+direct object and probes that an invalid wrapper is rejected before the claim is
+attempted.
+
+Dry run first:
+
+```bash
+node examples/claim-and-submit-job/index.mjs \
+  --job-id <job-id>
+```
+
+Execute after the worker has a SIWE bearer token and a complete structured
+submission:
+
+```bash
+AVERRAY_TOKEN="$TOKEN" node examples/claim-and-submit-job/index.mjs \
+  --job-id <job-id> \
+  --idempotency-key <job-id>-run-001 \
+  --submission-json '<direct-output-schema-object>' \
+  --execute
+```
+
+## Worker Identity
+
+Workers can authenticate with a signed-in wallet token or with a scoped service
+token issued by an operator.
+
+For autonomous workers, prefer the narrowest service-token bundle from
+`examples/service-token-worker/index.mjs`:
+
+- `schemaAwareClaimer` for agents that list jobs, preflight, claim, submit, and
+  read timelines.
+- `readOnlyObserver` for agents that only inspect public profiles, reputation,
+  events, sessions, and timelines.
+- `discoveryReader` for agents that only read public reputation/discovery
+  surfaces.
+
+Do not issue broad admin tokens to workers that only claim and submit jobs.
+Token administration remains an operator action; workers receive already-issued
+tokens and use them as bearer tokens.
+
+## Family Contracts
+
+Each family changes the source evidence and output schema, not the execution
+loop.
+
+| Family | Discovery / input | Output schema | Worker responsibility |
+| --- | --- | --- | --- |
+| GitHub PR evidence | Starter coding, review, release, triage, and docs jobs | `schema://jobs/github-pr-evidence-output`, `schema://jobs/pr-review-findings-output`, `schema://jobs/release-readiness-output`, `schema://jobs/issue-defect-triage-output`, `schema://jobs/docs-drift-audit-output` | Produce a focused PR, review, release decision, triage record, or docs drift finding with test or review evidence. |
+| Dependency remediation | OSV/NVD-backed npm advisory jobs | `schema://jobs/dependency-remediation-output` | Open a focused dependency-remediation PR, cite advisory ids, update lockfiles when needed, and report CI/test evidence. |
+| Open data quality audit | Data.gov dataset/resource audit jobs | `schema://jobs/open-data-quality-audit-output` | Inspect the public dataset/resource, submit checks, findings, recommendations, or explicit no-issue evidence. Do not contact agencies or edit datasets. |
+| OpenAPI quality audit | Public OpenAPI spec versus local implementation/docs | `schema://jobs/openapi-quality-audit-output` | Check endpoint coverage, descriptions, operation ids, examples, schema references, and drift. Submit recommendations or no-issue evidence. |
+| Standards freshness | Canonical public spec versus local docs/implementation notes | `schema://jobs/docs-drift-audit-output` | Cite the canonical spec URL, compare status/version/headings/requirements, and submit drift findings plus fix recommendations. |
+| Wikipedia maintenance | Fixed article revision, task type, publicDetails, and source URLs | `schema://jobs/wikipedia-citation-repair-output`, `schema://jobs/wikipedia-freshness-check-output`, `schema://jobs/wikipedia-infobox-consistency-output` | Submit proposal-only findings tied to the reviewed revision. Do not edit Wikipedia directly. |
+
+The worker should read the schema path exposed by the job definition or public
+schema surfaces instead of hardcoding field requirements. Built-in schemas are
+public at:
+
+- `GET /schemas/jobs`
+- `GET /schemas/jobs/:name.json`
+
+## Evidence Rules
+
+Every worker submission should make the verifier's job boring:
+
+- Include stable URLs, hashes, commit ids, revision ids, or dataset/resource
+  URLs where the family supports them.
+- Preserve the reviewed source state. For example, Wikipedia jobs cite a fixed
+  revision id; GitHub jobs cite PR and commit URLs; data jobs cite dataset and
+  resource URLs.
+- Say when no issue was found only if the output schema supports that result
+  and the submission explains what was checked.
+- Keep mutation scope inside the target family. Wikipedia, open-data,
+  standards, and OpenAPI jobs are review/proposal shaped unless a later
+  approved integration explicitly allows direct writes.
+- Keep the run idempotent. Reuse the same idempotency key when retrying the
+  same intended claim; create a new key only for a new run.
+
+## Suggested Worker Architecture
+
+Workers should be small adapters around the shared claim/submit loop:
+
+1. `discover` selects a claimable job by source/category.
+2. `loadContract` reads `/jobs/definition` and public schema metadata.
+3. `prepareEvidence` performs the family-specific work and returns one direct
+   output object.
+4. `validate` calls `/jobs/validate-submission` and stops on any error.
+5. `execute` claims and submits with a stable idempotency key.
+6. `report` reads `/session/timeline` and emits a compact operator summary.
+
+The family-specific adapter should own only source fetching and output shaping.
+Auth, preflight, validation, claim, submit, and timeline reporting should stay
+shared so new job families inherit the same safety behavior.
+
+## Operator Handoff
+
+After a worker submits, the operator-facing handoff is the timeline, not a
+private worker log.
+
+Use `examples/read-job-timeline/` when a worker or operator needs to inspect the
+receipt:
+
+```bash
+AVERRAY_TOKEN="$WORKER_TOKEN" node examples/read-job-timeline/index.mjs \
+  --session-id <session-id>
+```
+
+Admin-scoped operators can inspect a full job timeline:
+
+```bash
+AVERRAY_TOKEN="$ADMIN_TOKEN" node examples/read-job-timeline/index.mjs \
+  --job-id <job-id>
+```
+
+That keeps the product promise consistent across families: work may be done by
+different agents, but the claim, evidence, verification, and reputation trail
+remain visible through the same platform surfaces.


### PR DESCRIPTION
## What changed
- Added docs/REFERENCE_AGENT_WORKFLOWS.md as the shared worker contract for schema-native public job families.
- Documented the common discover/load/validate/claim/submit/timeline loop across GitHub, dependency/OSV, open-data, OpenAPI, standards, and Wikipedia jobs.
- Updated only the exact PROJECT_ROADMAP row for Reference-agent workflow generalization to Done with evidence pointing at the new doc.

## Checks
- node --test examples/claim-and-submit-job/index.test.mjs examples/read-job-timeline/index.test.mjs examples/service-token-worker/index.test.mjs
- git diff --check

## Surfaces affected
- Docs only: docs/REFERENCE_AGENT_WORKFLOWS.md, docs/PROJECT_ROADMAP.md
- No backend, frontend, indexer, Caddy, contracts, or public site changes.

## Environment / VPS secrets
- None.

## Polkadot verification
- No Polkadot-specific implementation or claims in this PR; Polkadot docs MCP/runtime verification was not applicable.