### PR TITLE
[codex] Harden verifier replay versioning

### DIFF
--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -106,26 +106,28 @@ is still too loose for high-trust operation.
   endpoints
 - verification results persist `verificationInput`,
   `verificationInputHash`, `verifierConfigSnapshot`, `verifierConfigHash`,
-  `verifierConfigVersion`, and `handlerVersion`
+  `verifierPolicyVersion`, `verifierConfigVersion`, and `handlerVersion`
 - direct verification ingestion and `/verifier/run` both enrich stored verdicts
   with the same audit fields
 - `/verifier/replay` evaluates against the stored verifier config snapshot when
   one exists, so audits are not silently affected by later config edits
+- replay drift reports handler, handler-version, verifier-policy-version,
+  evidence-schema, and verifier-config-hash mismatches
+- every registered verifier handler has a current-version fixture under
+  `mcp-server/src/services/__fixtures__/verifier-replay/<handler>/vN/`
 
 ### Remaining gaps
 
 - `benchmark` and `deterministic` handlers can still operate on plain text
   evidence for legacy jobs
-- verifier policy version is not yet separate from verifier config version
 - replay still uses the current handler implementation; `handlerVersion`
   records the version that ran, but the code itself is not version-pinned
 
 ### Concrete next changes
 
 - add `evidenceSchemaRef` or `submissionSchemaRef` to jobs
-- split `policyVersion` from `verifierConfig.version` when verifier rules move
-  beyond simple config data
-- add handler-versioned replay fixtures before introducing v2 verifier handlers
+- keep adding handler-versioned replay fixtures before introducing v2 verifier
+  handlers or changing current handler semantics
 
 ### What this unlocks
 

--- a/docs/PROJECT_ROADMAP.md
+++ b/docs/PROJECT_ROADMAP.md
@@ -172,7 +172,7 @@ externally ready.
 | --- | --- | --- |
 | HTTP server route split (`P2.3`) | Open | Split high-risk route groups out of the monolith without changing behavior; add route-level tests. |
 | Frontend auth guard (`P3.7`) | Open | Authenticated app layout has a real guard/401 flow and cannot show misleading authed shells. |
-| Verifier replay hardening | Open | Split verifier policy version from config version and require handler-versioned fixtures before v2 handler changes. |
+| Verifier replay hardening | Done | Verification audit fields now split `verifierPolicyVersion` from `verifierConfigVersion`; replay drift reports policy-version changes; every registered verifier handler must carry current-version replay fixtures before handler changes. |
 | Schema registration for external jobs | Open | Custom/off-platform references can register signed schemas with clear trust boundaries. |
 | Dispute/arbitration semantics | Open | Decide release path, store arbitrator reasoning under content hash, expose dispute UI fields, and rehearse arbitrator notifications. |
 | Timeline operator UX verification | Open | Backend trace filters landed. Close criterion: confirm the operator app exposes the intended filters and either mark Done (if already wired in `app/`) or open a narrow PR to wire them. |

--- a/mcp-server/src/core/job-catalog-metadata.test.js
+++ b/mcp-server/src/core/job-catalog-metadata.test.js
@@ -226,6 +226,7 @@ test("public Wikipedia definitions include direct agent affordances", () => {
   assert.equal(job.verificationContract.version, "verification-contract-v1");
   assert.equal(job.verificationContract.verifierMode, "benchmark");
   assert.equal(job.verificationContract.handler, "benchmark");
+  assert.equal(job.verificationContract.verifierPolicyVersion, 1);
   assert.equal(job.verificationContract.verifierConfigVersion, 1);
   assert.equal(job.verificationContract.replayEndpoint, "POST /verifier/replay");
   assert.equal(typeof job.verificationContract.verifierConfigHash, "string");

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -1354,6 +1354,7 @@ function buildVerificationTimelineEntry(session, verificationOverride = undefine
       reasonCode: verification.reasonCode,
       handler: verification.handler,
       handlerVersion: verification.handlerVersion,
+      verifierPolicyVersion: verification.verifierPolicyVersion,
       verifierConfigVersion: verification.verifierConfigVersion
     })
   });

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -485,9 +485,11 @@ test("getSessionTimeline includes transitions and verification state", async () 
   const timeline = await service.getSessionTimeline(submitted.sessionId);
   assert.equal(timeline.timelineVersion, "v2");
   assert.equal(timeline.session.status, "resolved");
+  assert.equal(result.verifierPolicyVersion, 1);
   assert.equal(result.verifierConfigVersion, 1);
   assert.equal(result.verificationContract.version, "verification-contract-v1");
   assert.equal(result.verificationContract.handler, "benchmark");
+  assert.equal(result.verificationContract.verifierPolicyVersion, 1);
   assert.equal(result.verificationInput.kind, "structured");
   assert.equal(typeof result.verifierConfigHash, "string");
   assert.equal(typeof result.verificationInputHash, "string");
@@ -512,6 +514,7 @@ test("getSessionTimeline includes transitions and verification state", async () 
   assert.equal(verificationEvent.topic, "session.verification");
   assert.equal(verificationEvent.source, "verification");
   assert.equal(verificationEvent.data.handlerVersion, 1);
+  assert.equal(verificationEvent.data.verifierPolicyVersion, 1);
   assert.equal(verificationEvent.data.verifierConfigVersion, 1);
 });
 

--- a/mcp-server/src/core/verifier-contract.js
+++ b/mcp-server/src/core/verifier-contract.js
@@ -5,6 +5,12 @@ export const VERIFICATION_CONTRACT_VERSION = "verification-contract-v1";
 export function buildVerificationContract(job, { verdict = undefined, verificationInput = undefined } = {}) {
   const verifierConfig = cloneJson(job?.verifierConfig);
   const verifierConfigVersion = normalizeVersion(verifierConfig?.version);
+  const verifierPolicyVersion = normalizeVersion(firstDefined(
+    job?.verification?.policyVersion,
+    job?.verifierPolicy?.version,
+    job?.verifierPolicyVersion,
+    undefined
+  ));
   const handler = firstString(verdict?.handler, verifierConfig?.handler, job?.verifierMode, "unknown");
   const handlerVersion = normalizeOptionalVersion(verdict?.handlerVersion);
   const evidenceSchemaRef = firstString(
@@ -19,6 +25,7 @@ export function buildVerificationContract(job, { verdict = undefined, verificati
     verifierMode: firstString(job?.verifierMode, undefined),
     handler,
     handlerVersion,
+    verifierPolicyVersion,
     verifierConfigVersion,
     verifierConfigHash: hashCanonicalContent(verifierConfig ?? null),
     evidenceSchemaRef,
@@ -30,6 +37,7 @@ export function buildVerificationContract(job, { verdict = undefined, verificati
       "verificationInputHash",
       "verifierConfigSnapshot",
       "verifierConfigHash",
+      "verifierPolicyVersion",
       "verifierConfigVersion",
       "handlerVersion",
       "evidenceSchemaRef"
@@ -41,6 +49,7 @@ export function buildVerificationAuditFields(job, { verdict = {}, verificationIn
   const verifierConfigSnapshot = cloneJson(job?.verifierConfig);
   const contract = buildVerificationContract(job, { verdict, verificationInput });
   const fields = {
+    verifierPolicyVersion: contract.verifierPolicyVersion,
     verifierConfigVersion: contract.verifierConfigVersion,
     verifierConfigHash: contract.verifierConfigHash,
     verifierConfigSnapshot,
@@ -81,6 +90,10 @@ function normalizeOptionalVersion(value) {
 
 function firstString(...values) {
   return values.find((value) => typeof value === "string" && value.trim())?.trim();
+}
+
+function firstDefined(...values) {
+  return values.find((value) => value !== undefined && value !== null);
 }
 
 function cloneJson(value) {

--- a/mcp-server/src/services/__fixtures__/verifier-replay/human_fallback/v1/review-required.json
+++ b/mcp-server/src/services/__fixtures__/verifier-replay/human_fallback/v1/review-required.json
@@ -1,0 +1,25 @@
+{
+  "handler": "human_fallback",
+  "handlerVersion": 1,
+  "evidenceSchemaRef": "schema://jobs/human-review-output",
+  "job": {
+    "id": "human-review-001",
+    "verifierMode": "human_fallback",
+    "outputSchemaRef": "schema://jobs/human-review-output",
+    "verification": {
+      "policyVersion": 1
+    },
+    "verifierConfig": {
+      "version": 1,
+      "handler": "human_fallback",
+      "autoApprove": false,
+      "escalationMessage": "Manual verifier review required."
+    }
+  },
+  "verificationInput": "Manual review requested.",
+  "expected": {
+    "outcome": "disputed",
+    "reasonCode": "HUMAN_REVIEW_REQUIRED",
+    "score": 0
+  }
+}

--- a/mcp-server/src/services/verification-ingestion-service.js
+++ b/mcp-server/src/services/verification-ingestion-service.js
@@ -40,6 +40,7 @@ export class VerificationIngestionService {
         reasonCode: verdict.reasonCode,
         handler: verdict.handler,
         handlerVersion: auditFields.handlerVersion ?? verdict.handlerVersion,
+        verifierPolicyVersion: auditFields.verifierPolicyVersion,
         verifierConfigVersion: auditFields.verifierConfigVersion
       }
     }, status, {
@@ -49,6 +50,7 @@ export class VerificationIngestionService {
         reasonCode: verdict.reasonCode,
         handler: verdict.handler,
         handlerVersion: auditFields.handlerVersion ?? verdict.handlerVersion,
+        verifierPolicyVersion: auditFields.verifierPolicyVersion,
         verifierConfigVersion: auditFields.verifierConfigVersion
       }
     });
@@ -86,6 +88,7 @@ export class VerificationIngestionService {
         status,
         handler: verdict.handler,
         handlerVersion: auditFields.handlerVersion ?? verdict.handlerVersion,
+        verifierPolicyVersion: auditFields.verifierPolicyVersion,
         verifierConfigVersion: auditFields.verifierConfigVersion
       }
     });
@@ -135,6 +138,7 @@ export class VerificationIngestionService {
         reasonCode: verdict.reasonCode,
         handler: verdict.handler,
         handlerVersion: auditFields.handlerVersion ?? verdict.handlerVersion,
+        verifierPolicyVersion: auditFields.verifierPolicyVersion,
         verifierConfigVersion: auditFields.verifierConfigVersion,
         disputeId: disputed ? disputeIdForSession(session.sessionId) : undefined
       }

--- a/mcp-server/src/services/verifier-handlers.js
+++ b/mcp-server/src/services/verifier-handlers.js
@@ -23,6 +23,7 @@ function structuredEvidence(input) {
 function createBenchmarkHandler() {
   return {
     id: "benchmark",
+    version: HANDLER_VERSION,
     evaluate(job, evidence) {
       const normalized = normalizeEvidence(evidence);
       const matched = job.verifierConfig.requiredKeywords.filter((keyword) => normalized.includes(keyword.toLowerCase()));
@@ -44,6 +45,7 @@ function createBenchmarkHandler() {
 function createDeterministicHandler() {
   return {
     id: "deterministic",
+    version: HANDLER_VERSION,
     evaluate(job, evidence) {
       const normalized = normalizeEvidence(evidence);
       const expected = job.verifierConfig.expectedOutputs.map((value) => value.toLowerCase());
@@ -69,6 +71,7 @@ function createDeterministicHandler() {
 function createHumanFallbackHandler() {
   return {
     id: "human_fallback",
+    version: HANDLER_VERSION,
     evaluate(job) {
       return {
         jobId: job.id,
@@ -86,6 +89,7 @@ function createHumanFallbackHandler() {
 function createGithubPrHandler({ fetchImpl = globalThis.fetch, githubToken = process.env.GITHUB_TOKEN, githubApiBaseUrl = "https://api.github.com" } = {}) {
   return {
     id: "github_pr",
+    version: HANDLER_VERSION,
     async evaluate(job, evidence) {
       const normalized = normalizeEvidence(evidence);
       const structured = structuredEvidence(evidence);
@@ -217,6 +221,13 @@ export class VerifierRegistry {
 
   listHandlers() {
     return [...this.handlers.keys()];
+  }
+
+  listHandlerMetadata() {
+    return [...this.handlers.values()].map((handler) => ({
+      id: handler.id,
+      version: handler.version
+    }));
   }
 
   async evaluate(job, evidence) {

--- a/mcp-server/src/services/verifier-service.js
+++ b/mcp-server/src/services/verifier-service.js
@@ -88,6 +88,10 @@ export class VerifierService {
     return this.registry.listHandlers();
   }
 
+  listHandlerMetadata() {
+    return this.registry.listHandlerMetadata?.() ?? this.listHandlers().map((id) => ({ id }));
+  }
+
   resolveVerificationInput(session, overrideEvidence = undefined) {
     if (overrideEvidence !== undefined) {
       return session?.submission && typeof overrideEvidence === "string" && !overrideEvidence.length
@@ -143,6 +147,16 @@ function detectReplayDrift({ existing, verdict, auditFields }) {
     && capturedEvidenceSchemaRef !== liveEvidenceSchemaRef
   ) {
     drift.evidenceSchemaRef = { captured: capturedEvidenceSchemaRef, live: liveEvidenceSchemaRef };
+  }
+
+  const capturedPolicyVersion = existing.verifierPolicyVersion;
+  const livePolicyVersion = auditFields?.verifierPolicyVersion;
+  if (
+    capturedPolicyVersion !== undefined
+    && livePolicyVersion !== undefined
+    && capturedPolicyVersion !== livePolicyVersion
+  ) {
+    drift.verifierPolicyVersion = { captured: capturedPolicyVersion, live: livePolicyVersion };
   }
 
   // verifierConfigHash drift means the stored snapshot disagrees with the

--- a/mcp-server/src/services/verifier-service.test.js
+++ b/mcp-server/src/services/verifier-service.test.js
@@ -32,6 +32,20 @@ function loadFixturesForHandler(handlerId) {
   return fixtures;
 }
 
+function listFixtureHandlerIds() {
+  return readdirSync(FIXTURE_ROOT, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function fixtureVersionsForHandler(handlerId) {
+  const handlerDir = path.join(FIXTURE_ROOT, handlerId);
+  return readdirSync(handlerDir)
+    .filter((entry) => /^v\d+$/u.test(entry))
+    .sort();
+}
+
 const SESSION_ID = "release-readiness-check-001:0xabc";
 
 test("verifySubmission persists verification input and supports replay", async () => {
@@ -82,11 +96,13 @@ test("verifySubmission persists verification input and supports replay", async (
 
   assert.equal(result.outcome, "approved");
   assert.equal(result.handlerVersion, 1);
+  assert.equal(result.verifierPolicyVersion, 1);
   assert.equal(result.verifierConfigVersion, 1);
   assert.deepEqual(result.verifierConfigSnapshot, job.verifierConfig);
   assert.equal(result.verificationContract.version, "verification-contract-v1");
   assert.equal(result.verificationContract.handler, "deterministic");
   assert.equal(result.verificationContract.handlerVersion, 1);
+  assert.equal(result.verificationContract.verifierPolicyVersion, 1);
   assert.equal(typeof result.verifierConfigHash, "string");
   assert.equal(typeof result.verificationInputHash, "string");
   assert.equal(result.verificationInput.kind, "structured");
@@ -452,6 +468,29 @@ test("verification contract carries evidenceSchemaRef and lists it in snapshot f
   assert.ok(contract.snapshotFields.includes("evidenceSchemaRef"));
 });
 
+test("verification contract separates verifier policy version from config version", () => {
+  const job = {
+    id: "policy-versioned-job",
+    outputSchemaRef: "schema://jobs/release-readiness-output",
+    verifierMode: "deterministic",
+    verification: {
+      policyVersion: 3
+    },
+    verifierConfig: {
+      version: 7,
+      handler: "deterministic",
+      expectedOutputs: ["release_id"],
+      matchMode: "contains_all"
+    }
+  };
+
+  const contract = buildVerificationContract(job, { verdict: { handlerVersion: 1 } });
+  assert.equal(contract.verifierPolicyVersion, 3);
+  assert.equal(contract.verifierConfigVersion, 7);
+  assert.ok(contract.snapshotFields.includes("verifierPolicyVersion"));
+  assert.ok(contract.snapshotFields.includes("verifierConfigVersion"));
+});
+
 test("verification contract prefers job.verification.evidenceSchemaRef when both are set", () => {
   const job = {
     outputSchemaRef: "schema://jobs/release-readiness-output",
@@ -462,7 +501,22 @@ test("verification contract prefers job.verification.evidenceSchemaRef when both
   assert.equal(contract.evidenceSchemaRef, "schema://jobs/github-pr-evidence-output");
 });
 
-for (const handlerId of ["benchmark", "deterministic", "github_pr"]) {
+test("every registered verifier handler has replay fixtures for its current handler version", () => {
+  const registry = new VerifierRegistry({ githubToken: "" });
+  const fixtureHandlers = new Set(listFixtureHandlerIds());
+
+  for (const { id, version } of registry.listHandlerMetadata()) {
+    assert.ok(fixtureHandlers.has(id), `missing replay fixture directory for handler ${id}`);
+    const versions = fixtureVersionsForHandler(id);
+    assert.ok(versions.includes(`v${version}`), `missing replay fixtures for ${id} current handler version v${version}`);
+    assert.ok(
+      loadFixturesForHandler(id).some((entry) => entry.version === `v${version}`),
+      `no replay fixture JSON files for ${id} current handler version v${version}`
+    );
+  }
+});
+
+for (const handlerId of listFixtureHandlerIds()) {
   for (const { name, version, fixture } of loadFixturesForHandler(handlerId)) {
     test(`handler-versioned replay fixture remains stable under current handler: ${name}`, async () => {
       // Force the github_pr handler down its tokenless path so replay does not depend on a live GitHub fetch.
@@ -600,6 +654,7 @@ test("replayVerification surfaces handler version drift instead of silently re-r
     reasonCode: fixture.expected.reasonCode,
     handler: fixture.handler,
     handlerVersion: 99,
+    verifierPolicyVersion: 99,
     verifierConfigSnapshot: fixture.job.verifierConfig,
     verifierConfigHash: "stale-hash-from-prior-snapshot",
     verificationInput: normalizeSubmission(fixture.verificationInput.structured),
@@ -611,6 +666,7 @@ test("replayVerification surfaces handler version drift instead of silently re-r
 
   assert.ok(replay.replayDrift, "expected replayDrift to be set when captured handler version differs from live");
   assert.deepEqual(replay.replayDrift.handlerVersion, { captured: 99, live: 1 });
+  assert.deepEqual(replay.replayDrift.verifierPolicyVersion, { captured: 99, live: 1 });
   // Snapshot-hash drift exposes snapshot tampering; here it is forced by the stale stored hash.
   assert.equal(replay.replayDrift.verifierConfigHash.captured, "stale-hash-from-prior-snapshot");
 });


### PR DESCRIPTION
## What changed
- Split verifier policy versioning from verifier config versioning in the verification contract and persisted audit fields.
- Added verifier policy version to verification summaries, timeline events, ingestion events, and replay drift detection.
- Added handler version metadata to registered verifier handlers and a regression test requiring each registered handler to have current-version replay fixtures.
- Added a human_fallback/v1 replay fixture so all current handlers are covered.
- Updated the exact Verifier replay hardening roadmap row to Done and refreshed the narrow framework-roadmap notes for this verifier section.

## Checks
- npm --workspace mcp-server test
- node --test mcp-server/src/services/verifier-service.test.js
- node --test mcp-server/src/core/platform-service.test.js mcp-server/src/core/job-catalog-metadata.test.js
- git diff --check

## Surfaces affected
- Backend verifier contract/service/tests.
- Docs only for docs/PROJECT_ROADMAP.md and docs/CORE_FRAMEWORK_ROADMAP.md.
- No frontend, indexer, Caddy, contracts, or public site changes.

## Environment / VPS secrets
- None.

## Polkadot verification
- No Polkadot-specific implementation or claims in this PR; Polkadot docs MCP/runtime verification was not applicable.