### PR TITLE
[codex] Add pauser rehearsal proof

### DIFF
--- a/docs/MULTISIG_SETUP.md
+++ b/docs/MULTISIG_SETUP.md
@@ -191,19 +191,44 @@ Every line must print `[ok]`. If anything says `[FAIL]` do **not** proceed.
 
 ### 5c. Rehearse pause from the hot key
 
-The pauser is a single EOA, so you can use `cast`:
+The pauser is a single EOA, but do the read-only proof first so you know the
+live transaction will exercise the right address and the right contract
+capability:
 
 ```bash
-cast send "$TREASURY_POLICY" "setPaused(bool)" true \
-  --rpc-url "$RPC_URL" --private-key "$PAUSER_KEY"
-
-# Confirm it stuck
-cast call "$TREASURY_POLICY" "paused()(bool)" --rpc-url "$RPC_URL"
-
-# Unpause
-cast send "$TREASURY_POLICY" "setPaused(bool)" false \
-  --rpc-url "$RPC_URL" --private-key "$PAUSER_KEY"
+node scripts/ops/run-pauser-rehearsal.mjs \
+  --profile testnet \
+  --out artifacts/pauser-rehearsal-readonly.json
 ```
+
+That proof checks:
+
+- live `owner`, `pauser`, and `paused` values against `deployments/testnet.json`
+- `pauser != owner` and `pauser != address(0)`
+- `eth_call` from the pauser can call `setPaused(bool)`
+- `eth_call` from the pauser cannot call owner-only functions such as
+  `setPauser`, `setVerifier`, `setServiceOperator`, or `transferOwnership`
+- whether the pauser address overlaps verifier/arbitrator/deployer roles
+
+For mainnet or any real-funds rehearsal, add `--require-dedicated-pauser` so
+the proof fails if the pauser overlaps deployer, verifier, arbitrator, or
+owner. The current testnet manifest deliberately carries a bounded overlap
+while we finish launch rehearsal; do not copy that shape to mainnet.
+
+Then run the live rehearsal from the pauser key:
+
+```bash
+PAUSER_PRIVATE_KEY=0x<pauser-testnet-key> \
+node scripts/ops/run-pauser-rehearsal.mjs \
+  --profile testnet \
+  --live \
+  --out docs/evidence/pauser-rehearsal-testnet-YYYY-MM-DD.json
+```
+
+The live mode sends `setPaused(true)`, confirms `paused() == true`, sends
+`setPaused(false)`, confirms `paused() == false`, and writes a sanitized JSON
+evidence file containing only public addresses, checks, and transaction hashes.
+Do not commit private keys or shell history containing them.
 
 ### 5d. Rehearse an admin op from the multisig
 

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -24,11 +24,40 @@ If this checklist is not green, the answer is "not ready yet".
 - [x] `TreasuryPolicy.owner` is the intended multisig address.
 - [x] `deployments/testnet-multisig-owner.json` is `status: "verified"` and matches the deployment manifest owner.
 - [ ] `TreasuryPolicy.pauser` is a hot key that only holds pause power.
-- [x] `./scripts/verify_deployment.sh testnet` passes cleanly.
+- [ ] `./scripts/verify_deployment.sh testnet` passes cleanly. Last checked on
+  2026-05-21 with `--require-owner-record-final`: owner, pauser, and owner
+  record passed, but `verifiers(0xFd2E...6519)` was false while
+  `deployments/testnet.json` still expected it to be true. Resolve the
+  manifest/on-chain verifier mismatch before launch.
 - [ ] Pause and unpause were rehearsed from the pauser key.
 - [x] At least one owner-only admin operation was rehearsed from the multisig.
 
 See [MULTISIG_SETUP.md](./MULTISIG_SETUP.md) for the exact rehearsal flow.
+Use the dedicated pauser proof before closing the two remaining boxes:
+
+```bash
+# Read-only capability proof: no mutation, no private key.
+node scripts/ops/run-pauser-rehearsal.mjs \
+  --profile testnet \
+  --out artifacts/pauser-rehearsal-readonly.json
+
+# Live launch evidence: pauses and unpauses the deployed TreasuryPolicy.
+PAUSER_PRIVATE_KEY=0x<pauser-testnet-key> \
+node scripts/ops/run-pauser-rehearsal.mjs \
+  --profile testnet \
+  --live \
+  --out docs/evidence/pauser-rehearsal-testnet-YYYY-MM-DD.json
+```
+
+For mainnet or any real-funds rehearsal, add `--require-dedicated-pauser`.
+The current testnet pauser address overlaps other testnet roles in
+`deployments/testnet.json`; that is acceptable only as a bounded testnet
+shortcut and must not be carried into mainnet.
+
+Read-only evidence captured on 2026-05-21:
+[`docs/evidence/pauser-rehearsal-readonly-2026-05-21.json`](evidence/pauser-rehearsal-readonly-2026-05-21.json).
+It proves the live pauser can call `setPaused(bool)` and cannot call owner-only
+functions, but it does not close the live pause/unpause rehearsal box.
 
 ---
 

--- a/docs/PROJECT_ROADMAP.md
+++ b/docs/PROJECT_ROADMAP.md
@@ -152,8 +152,8 @@ externally ready.
 
 | Item | Status | Close criteria |
 | --- | --- | --- |
-| Control-plane pauser | Open | `TreasuryPolicy.pauser` is a hot key with only pause power, recorded in deploy docs. |
-| Pause/unpause rehearsal | Open | Rehearse pause and unpause from pauser key and record tx hashes in `PRODUCTION_CHECKLIST.md`. |
+| Control-plane pauser | Ready for proof | `TreasuryPolicy` already scopes `pauser` to `setPaused(bool)`. `scripts/ops/run-pauser-rehearsal.mjs` now proves the live pauser can pause, cannot call owner-only functions, and reports role overlap. Read-only proof captured in `docs/evidence/pauser-rehearsal-readonly-2026-05-21.json`. Close after the live testnet evidence is recorded; mainnet must run with `--require-dedicated-pauser`. |
+| Pause/unpause rehearsal | Ready for proof | Run `PAUSER_PRIVATE_KEY=... node scripts/ops/run-pauser-rehearsal.mjs --profile testnet --live --out docs/evidence/pauser-rehearsal-testnet-YYYY-MM-DD.json`, then record the pause and unpause tx hashes in `PRODUCTION_CHECKLIST.md`. |
 | Postgres backup readiness | Open | `check-backup-readiness.sh --json` reports recent Postgres backup. |
 | Redis backup readiness | Open | `check-backup-readiness.sh --json` reports recent Redis backup if Redis contains non-rebuildable state. |
 | Restore drill | Open | Restore drill performed and documented with date, source backup, and target. |

--- a/docs/evidence/pauser-rehearsal-readonly-2026-05-21.json
+++ b/docs/evidence/pauser-rehearsal-readonly-2026-05-21.json
@@ -1,0 +1,191 @@
+{
+  "schemaVersion": 1,
+  "kind": "averray.pauserRehearsalEvidence",
+  "profile": "testnet",
+  "generatedAt": "2026-05-21T18:44:13.061Z",
+  "mode": "read_only_capability_proof",
+  "manifestPath": "deployments/testnet.json",
+  "rpcUrl": "https://eth-rpc-testnet.polkadot.io/",
+  "contracts": {
+    "treasuryPolicy": "0x648Cc5fdE94435992296C4e5ac642d18bB64c12B"
+  },
+  "manifest": {
+    "owner": "0x1f8C4da4AAAC79916350f1fabF1221309591B6F9",
+    "pauser": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+    "verifier": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+    "arbitrator": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+    "deployer": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519"
+  },
+  "live": {
+    "owner": "0x1f8C4da4AAAC79916350f1fabF1221309591B6F9",
+    "pauser": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+    "paused": false
+  },
+  "roleOverlap": {
+    "dedicated": false,
+    "overlaps": [
+      "deployer",
+      "verifier",
+      "arbitrator"
+    ],
+    "severity": "warning"
+  },
+  "roleReads": {
+    "serviceOperator": false,
+    "verifier": false,
+    "arbitrator": true
+  },
+  "simulation": [
+    {
+      "name": "pauser_can_call_setPaused_true",
+      "expected": "success",
+      "actual": "success"
+    },
+    {
+      "name": "pauser_cannot_call_setPauser",
+      "expected": "revert",
+      "actual": "revert"
+    },
+    {
+      "name": "pauser_cannot_call_setVerifier",
+      "expected": "revert",
+      "actual": "revert"
+    },
+    {
+      "name": "pauser_cannot_call_setServiceOperator",
+      "expected": "revert",
+      "actual": "revert"
+    },
+    {
+      "name": "pauser_cannot_call_transferOwnership",
+      "expected": "revert",
+      "actual": "revert"
+    }
+  ],
+  "transactions": {},
+  "checks": [
+    {
+      "name": "owner_matches_manifest",
+      "ok": true,
+      "details": {
+        "expected": "0x1f8C4da4AAAC79916350f1fabF1221309591B6F9",
+        "actual": "0x1f8C4da4AAAC79916350f1fabF1221309591B6F9"
+      }
+    },
+    {
+      "name": "pauser_matches_manifest",
+      "ok": true,
+      "details": {
+        "expected": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+        "actual": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519"
+      }
+    },
+    {
+      "name": "pauser_is_nonzero",
+      "ok": true,
+      "details": {
+        "pauser": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519"
+      }
+    },
+    {
+      "name": "pauser_not_owner",
+      "ok": true,
+      "details": {
+        "owner": "0x1f8C4da4AAAC79916350f1fabF1221309591B6F9",
+        "pauser": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519"
+      }
+    },
+    {
+      "name": "pauser_not_service_operator",
+      "ok": true,
+      "details": {
+        "serviceOperator": false,
+        "verifier": false,
+        "arbitrator": true
+      }
+    },
+    {
+      "name": "pauser_not_owner_admin_if_owner_distinct",
+      "ok": true,
+      "details": {
+        "owner": "0x1f8C4da4AAAC79916350f1fabF1221309591B6F9",
+        "pauser": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519"
+      }
+    },
+    {
+      "name": "pauser_can_call_setPaused_true",
+      "ok": true,
+      "details": {
+        "expected": "success",
+        "actual": "success"
+      }
+    },
+    {
+      "name": "pauser_cannot_call_setPauser",
+      "ok": true,
+      "details": {
+        "expected": "revert",
+        "actual": "revert",
+        "error": "execution reverted (unknown custom error)"
+      }
+    },
+    {
+      "name": "pauser_cannot_call_setVerifier",
+      "ok": true,
+      "details": {
+        "expected": "revert",
+        "actual": "revert",
+        "error": "execution reverted (unknown custom error)"
+      }
+    },
+    {
+      "name": "pauser_cannot_call_setServiceOperator",
+      "ok": true,
+      "details": {
+        "expected": "revert",
+        "actual": "revert",
+        "error": "execution reverted (unknown custom error)"
+      }
+    },
+    {
+      "name": "pauser_cannot_call_transferOwnership",
+      "ok": true,
+      "details": {
+        "expected": "revert",
+        "actual": "revert",
+        "error": "execution reverted (unknown custom error)"
+      }
+    }
+  ],
+  "warnings": [
+    {
+      "code": "pauser_role_overlap",
+      "severity": "warning",
+      "message": "Current pauser address overlaps other manifest roles. This is acceptable only for bounded testnet rehearsal; mainnet must use a dedicated pauser.",
+      "overlaps": [
+        "deployer",
+        "verifier",
+        "arbitrator"
+      ]
+    },
+    {
+      "code": "pauser_onchain_role_overlap",
+      "severity": "warning",
+      "message": "Current pauser address also has other on-chain TreasuryPolicy roles. This is acceptable only for bounded testnet rehearsal; mainnet must use a dedicated pauser.",
+      "overlaps": [
+        "arbitrator"
+      ]
+    },
+    {
+      "code": "live_rehearsal_not_run",
+      "severity": "warning",
+      "message": "Read-only capability proof passed, but the launch checklist still needs a live pause/unpause tx pair."
+    }
+  ],
+  "ok": true,
+  "launchGate": {
+    "controlPlanePauserReady": true,
+    "pauseUnpauseRehearsed": false,
+    "requiresLiveRehearsal": true
+  }
+}

--- a/scripts/ops/query-treasury-policy.mjs
+++ b/scripts/ops/query-treasury-policy.mjs
@@ -2,7 +2,7 @@
 // Quick read-only probe of TreasuryPolicy state. Cutover support script.
 import { JsonRpcProvider, Contract } from "ethers";
 
-const RPC = process.env.RPC_URL || "https://testnet-passet-hub-eth-rpc.polkadot.io";
+const RPC = process.env.RPC_URL || "https://eth-rpc-testnet.polkadot.io/";
 const POLICY = "0x648Cc5fdE94435992296C4e5ac642d18bB64c12B";
 const ABI = [
   "function owner() view returns (address)",

--- a/scripts/ops/run-pauser-rehearsal.mjs
+++ b/scripts/ops/run-pauser-rehearsal.mjs
@@ -1,0 +1,407 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { Contract, Interface, JsonRpcProvider, Wallet, getAddress, isAddress } from "ethers";
+
+const TREASURY_POLICY_ABI = [
+  "function owner() view returns (address)",
+  "function pauser() view returns (address)",
+  "function paused() view returns (bool)",
+  "function setPaused(bool)",
+  "function setPauser(address)",
+  "function setVerifier(address,bool)",
+  "function setServiceOperator(address,bool)",
+  "function transferOwnership(address)",
+  "function verifiers(address) view returns (bool)",
+  "function arbitrators(address) view returns (bool)",
+  "function serviceOperators(address) view returns (bool)"
+];
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+export function parseArgs(argv = process.argv.slice(2)) {
+  const options = {
+    profile: process.env.PROFILE || "testnet",
+    manifest: process.env.DEPLOYMENT_MANIFEST || "",
+    out: process.env.PAUSER_REHEARSAL_EVIDENCE_FILE || "",
+    live: parseBoolean(process.env.PAUSER_REHEARSAL_LIVE),
+    requireDedicatedPauser: parseBoolean(process.env.REQUIRE_DEDICATED_PAUSER),
+    allowStartPaused: parseBoolean(process.env.ALLOW_START_PAUSED)
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--profile":
+        options.profile = requireValue(argv, ++i, arg);
+        break;
+      case "--manifest":
+        options.manifest = requireValue(argv, ++i, arg);
+        break;
+      case "--out":
+        options.out = requireValue(argv, ++i, arg);
+        break;
+      case "--live":
+        options.live = true;
+        break;
+      case "--require-dedicated-pauser":
+        options.requireDedicatedPauser = true;
+        break;
+      case "--allow-start-paused":
+        options.allowStartPaused = true;
+        break;
+      case "--help":
+      case "-h":
+        options.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+export function evaluateDedicatedPauser({ pauser, owner, deployer, verifier, arbitrator }) {
+  const overlaps = [];
+  const pauserAddress = normalizeAddress(pauser);
+  const candidates = [
+    ["owner", owner],
+    ["deployer", deployer],
+    ["verifier", verifier],
+    ["arbitrator", arbitrator]
+  ];
+
+  for (const [role, address] of candidates) {
+    if (address && sameAddress(pauserAddress, address)) overlaps.push(role);
+  }
+
+  return {
+    dedicated: overlaps.length === 0,
+    overlaps,
+    severity: overlaps.length === 0 ? "ok" : overlaps.includes("owner") ? "error" : "warning"
+  };
+}
+
+export async function runPauserRehearsal(options, env = process.env) {
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+  const manifestPath = options.manifest
+    ? path.resolve(options.manifest)
+    : path.join(repoRoot, "deployments", `${options.profile}.json`);
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  const rpcUrl = env.RPC_URL || manifest.rpcUrl;
+  const treasuryPolicy = normalizeAddress(manifest.contracts?.treasuryPolicy);
+  const expectedOwner = normalizeAddress(manifest.owner);
+  const expectedPauser = normalizeAddress(manifest.pauser);
+  const expectedVerifier = normalizeAddress(manifest.verifier);
+  const expectedArbitrator = normalizeAddress(manifest.arbitrator);
+  const deployer = manifest.deployer ? normalizeAddress(manifest.deployer) : "";
+
+  if (!rpcUrl) throw new Error("RPC_URL is required, either in env or deployment manifest.");
+  if (!treasuryPolicy) throw new Error("deployment manifest is missing contracts.treasuryPolicy.");
+  if (!expectedOwner) throw new Error("deployment manifest is missing owner.");
+  if (!expectedPauser) throw new Error("deployment manifest is missing pauser.");
+
+  const provider = new JsonRpcProvider(rpcUrl);
+  const policy = new Contract(treasuryPolicy, TREASURY_POLICY_ABI, provider);
+  const iface = new Interface(TREASURY_POLICY_ABI);
+
+  const [liveOwner, livePauser, initialPaused] = await Promise.all([
+    policy.owner(),
+    policy.pauser(),
+    policy.paused()
+  ]);
+
+  const live = {
+    owner: normalizeAddress(liveOwner),
+    pauser: normalizeAddress(livePauser),
+    paused: Boolean(initialPaused)
+  };
+
+  const checks = [];
+  const warnings = [];
+  const transactions = {};
+
+  addCheck(checks, "owner_matches_manifest", sameAddress(live.owner, expectedOwner), {
+    expected: expectedOwner,
+    actual: live.owner
+  });
+  addCheck(checks, "pauser_matches_manifest", sameAddress(live.pauser, expectedPauser), {
+    expected: expectedPauser,
+    actual: live.pauser
+  });
+  addCheck(checks, "pauser_is_nonzero", !sameAddress(live.pauser, ZERO_ADDRESS), {
+    pauser: live.pauser
+  });
+  addCheck(checks, "pauser_not_owner", !sameAddress(live.pauser, live.owner), {
+    owner: live.owner,
+    pauser: live.pauser
+  });
+
+  const roleOverlap = evaluateDedicatedPauser({
+    pauser: live.pauser,
+    owner: live.owner,
+    deployer,
+    verifier: expectedVerifier,
+    arbitrator: expectedArbitrator
+  });
+  if (!roleOverlap.dedicated) {
+    warnings.push({
+      code: "pauser_role_overlap",
+      severity: roleOverlap.severity,
+      message:
+        "Current pauser address overlaps other manifest roles. This is acceptable only for bounded testnet rehearsal; mainnet must use a dedicated pauser.",
+      overlaps: roleOverlap.overlaps
+    });
+  }
+  if (options.requireDedicatedPauser) {
+    addCheck(checks, "pauser_is_dedicated_role", roleOverlap.dedicated, roleOverlap);
+  }
+
+  const roleReads = await readPauserRoleFlags(policy, live.pauser);
+  const onChainRoleOverlaps = Object.entries(roleReads)
+    .filter(([, enabled]) => enabled === true)
+    .map(([role]) => role);
+  if (onChainRoleOverlaps.length > 0) {
+    warnings.push({
+      code: "pauser_onchain_role_overlap",
+      severity: "warning",
+      message:
+        "Current pauser address also has other on-chain TreasuryPolicy roles. This is acceptable only for bounded testnet rehearsal; mainnet must use a dedicated pauser.",
+      overlaps: onChainRoleOverlaps
+    });
+  }
+  addCheck(checks, "pauser_not_service_operator", roleReads.serviceOperator === false, roleReads);
+  addCheck(checks, "pauser_not_owner_admin_if_owner_distinct", !sameAddress(live.pauser, live.owner), {
+    owner: live.owner,
+    pauser: live.pauser
+  });
+  if (options.requireDedicatedPauser) {
+    addCheck(checks, "pauser_not_verifier", roleReads.verifier === false, roleReads);
+    addCheck(checks, "pauser_not_arbitrator", roleReads.arbitrator === false, roleReads);
+  }
+
+  const simulation = await simulatePauserCapabilities({ provider, iface, treasuryPolicy, from: live.pauser });
+  checks.push(...simulation.checks);
+
+  if (options.live) {
+    if (live.paused && !options.allowStartPaused) {
+      throw new Error("Refusing live rehearsal because policy is already paused. Use --allow-start-paused only during a named incident.");
+    }
+    const pauserPrivateKey = env.PAUSER_PRIVATE_KEY || "";
+    if (!pauserPrivateKey) {
+      throw new Error("PAUSER_PRIVATE_KEY is required for --live.");
+    }
+    const wallet = new Wallet(pauserPrivateKey, provider);
+    if (!sameAddress(wallet.address, live.pauser)) {
+      throw new Error(`PAUSER_PRIVATE_KEY address ${wallet.address} does not match TreasuryPolicy.pauser ${live.pauser}.`);
+    }
+
+    const livePolicy = new Contract(treasuryPolicy, TREASURY_POLICY_ABI, wallet);
+    const pauseTx = await livePolicy.setPaused(true);
+    const pauseReceipt = await pauseTx.wait();
+    transactions.pause = txEvidence(pauseReceipt, pauseTx.hash);
+
+    const afterPause = await policy.paused();
+    addCheck(checks, "live_pause_state_confirmed", Boolean(afterPause) === true, {
+      paused: Boolean(afterPause)
+    });
+
+    let unpauseReceipt;
+    let unpauseHash;
+    let unpauseError = "";
+    try {
+      const unpauseTx = await livePolicy.setPaused(false);
+      unpauseHash = unpauseTx.hash;
+      unpauseReceipt = await unpauseTx.wait();
+    } catch (caught) {
+      unpauseError = caught?.shortMessage || caught?.message || String(caught);
+    } finally {
+      transactions.unpause = unpauseReceipt
+        ? txEvidence(unpauseReceipt, unpauseHash)
+        : { hash: unpauseHash || null, status: "not_confirmed", error: unpauseError };
+    }
+
+    const afterUnpause = await policy.paused();
+    addCheck(checks, "live_unpause_state_confirmed", Boolean(afterUnpause) === false, {
+      paused: Boolean(afterUnpause),
+      ...(unpauseError ? { error: unpauseError } : {})
+    });
+  } else {
+    warnings.push({
+      code: "live_rehearsal_not_run",
+      severity: "warning",
+      message: "Read-only capability proof passed, but the launch checklist still needs a live pause/unpause tx pair."
+    });
+  }
+
+  const failures = checks.filter((check) => !check.ok);
+  const evidence = {
+    schemaVersion: 1,
+    kind: "averray.pauserRehearsalEvidence",
+    profile: options.profile,
+    generatedAt: new Date().toISOString(),
+    mode: options.live ? "live_pause_unpause" : "read_only_capability_proof",
+    manifestPath: path.relative(repoRoot, manifestPath),
+    rpcUrl,
+    contracts: { treasuryPolicy },
+    manifest: {
+      owner: expectedOwner,
+      pauser: expectedPauser,
+      verifier: expectedVerifier,
+      arbitrator: expectedArbitrator,
+      deployer
+    },
+    live,
+    roleOverlap,
+    roleReads,
+    simulation: simulation.summary,
+    transactions,
+    checks,
+    warnings,
+    ok: failures.length === 0,
+    launchGate: {
+      controlPlanePauserReady: failures.length === 0,
+      pauseUnpauseRehearsed: Boolean(options.live && transactions.pause?.status === 1 && transactions.unpause?.status === 1),
+      requiresLiveRehearsal: !options.live
+    }
+  };
+
+  if (options.out) {
+    const outPath = path.resolve(options.out);
+    fs.mkdirSync(path.dirname(outPath), { recursive: true });
+    fs.writeFileSync(outPath, `${JSON.stringify(evidence, null, 2)}\n`);
+  }
+
+  return evidence;
+}
+
+function parseBoolean(value) {
+  return value === "1" || value === "true" || value === "yes";
+}
+
+function requireValue(argv, index, flag) {
+  const value = argv[index];
+  if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value.`);
+  return value;
+}
+
+function normalizeAddress(value) {
+  if (!value || !isAddress(value)) return "";
+  return getAddress(value);
+}
+
+function sameAddress(left, right) {
+  return normalizeAddress(left).toLowerCase() === normalizeAddress(right).toLowerCase();
+}
+
+function addCheck(checks, name, ok, details = {}) {
+  checks.push({ name, ok: Boolean(ok), details });
+}
+
+async function readPauserRoleFlags(policy, pauser) {
+  const [serviceOperator, verifier, arbitrator] = await Promise.all([
+    policy.serviceOperators(pauser),
+    policy.verifiers(pauser),
+    policy.arbitrators(pauser)
+  ]);
+  return {
+    serviceOperator: Boolean(serviceOperator),
+    verifier: Boolean(verifier),
+    arbitrator: Boolean(arbitrator)
+  };
+}
+
+async function simulatePauserCapabilities({ provider, iface, treasuryPolicy, from }) {
+  const checks = [];
+  const calls = [
+    {
+      name: "pauser_can_call_setPaused_true",
+      expectSuccess: true,
+      data: iface.encodeFunctionData("setPaused", [true])
+    },
+    {
+      name: "pauser_cannot_call_setPauser",
+      expectSuccess: false,
+      data: iface.encodeFunctionData("setPauser", [from])
+    },
+    {
+      name: "pauser_cannot_call_setVerifier",
+      expectSuccess: false,
+      data: iface.encodeFunctionData("setVerifier", [from, true])
+    },
+    {
+      name: "pauser_cannot_call_setServiceOperator",
+      expectSuccess: false,
+      data: iface.encodeFunctionData("setServiceOperator", [from, true])
+    },
+    {
+      name: "pauser_cannot_call_transferOwnership",
+      expectSuccess: false,
+      data: iface.encodeFunctionData("transferOwnership", [from])
+    }
+  ];
+
+  const summary = [];
+  for (const call of calls) {
+    let success = false;
+    let error = "";
+    try {
+      await provider.call({ from, to: treasuryPolicy, data: call.data });
+      success = true;
+    } catch (caught) {
+      error = caught?.shortMessage || caught?.message || String(caught);
+    }
+    addCheck(checks, call.name, success === call.expectSuccess, {
+      expected: call.expectSuccess ? "success" : "revert",
+      actual: success ? "success" : "revert",
+      ...(error ? { error } : {})
+    });
+    summary.push({
+      name: call.name,
+      expected: call.expectSuccess ? "success" : "revert",
+      actual: success ? "success" : "revert"
+    });
+  }
+  return { checks, summary };
+}
+
+function txEvidence(receipt, hash) {
+  return {
+    hash,
+    blockNumber: Number(receipt.blockNumber),
+    status: Number(receipt.status)
+  };
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/ops/run-pauser-rehearsal.mjs [--profile testnet] [--out path]
+  PAUSER_PRIVATE_KEY=0x... node scripts/ops/run-pauser-rehearsal.mjs --live --profile testnet --out docs/evidence/pauser-rehearsal-testnet-YYYY-MM-DD.json
+
+Options:
+  --profile <name>                  Deployment manifest profile. Default: testnet.
+  --manifest <path>                 Explicit deployment manifest path.
+  --out <path>                      Write sanitized JSON evidence to a file.
+  --live                            Send setPaused(true), confirm, then setPaused(false).
+  --require-dedicated-pauser        Fail if pauser overlaps deployer/verifier/arbitrator/owner.
+  --allow-start-paused              Allow live mode when the policy is already paused.
+`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const options = parseArgs();
+    if (options.help) {
+      printHelp();
+    } else {
+      const evidence = await runPauserRehearsal(options);
+      console.log(JSON.stringify(evidence, null, 2));
+      if (!evidence.ok) process.exitCode = 1;
+    }
+  } catch (error) {
+    console.error(error?.message || String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ops/run-pauser-rehearsal.test.mjs
+++ b/scripts/ops/run-pauser-rehearsal.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { evaluateDedicatedPauser, parseArgs } from "./run-pauser-rehearsal.mjs";
+
+test("parseArgs supports live evidence options", () => {
+  const options = parseArgs([
+    "--profile",
+    "testnet",
+    "--out",
+    "docs/evidence/pauser.json",
+    "--live",
+    "--require-dedicated-pauser"
+  ]);
+
+  assert.equal(options.profile, "testnet");
+  assert.equal(options.out, "docs/evidence/pauser.json");
+  assert.equal(options.live, true);
+  assert.equal(options.requireDedicatedPauser, true);
+});
+
+test("dedicated pauser evaluator reports overlapping roles", () => {
+  const result = evaluateDedicatedPauser({
+    pauser: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+    owner: "0x1f8c4da4aaac79916350f1fabf1221309591b6f9",
+    deployer: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+    verifier: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+    arbitrator: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519"
+  });
+
+  assert.equal(result.dedicated, false);
+  assert.equal(result.severity, "warning");
+  assert.deepEqual(result.overlaps, ["deployer", "verifier", "arbitrator"]);
+});
+
+test("dedicated pauser evaluator treats owner overlap as an error", () => {
+  const result = evaluateDedicatedPauser({
+    pauser: "0x1111111111111111111111111111111111111111",
+    owner: "0x1111111111111111111111111111111111111111"
+  });
+
+  assert.equal(result.dedicated, false);
+  assert.equal(result.severity, "error");
+  assert.deepEqual(result.overlaps, ["owner"]);
+});


### PR DESCRIPTION
## Summary
- add a pauser rehearsal script with read-only capability proof and guarded live pause/unpause mode
- archive the 2026-05-21 read-only Hub TestNet pauser evidence
- update the production checklist, multisig runbook, and roadmap so the control-plane pauser items are Ready for proof rather than incorrectly marked complete
- update the TreasuryPolicy probe default RPC to the current Hub TestNet endpoint

## Validation
- node --check scripts/ops/run-pauser-rehearsal.mjs
- node --test scripts/ops/run-pauser-rehearsal.test.mjs
- git diff --check
- node scripts/ops/run-pauser-rehearsal.mjs --profile testnet --out docs/evidence/pauser-rehearsal-readonly-2026-05-21.json
- node scripts/ops/query-treasury-policy.mjs
- ./scripts/verify_deployment.sh testnet --require-owner-record-final still fails on the known verifier manifest mismatch: owner, pauser, owner record, and service operators pass, but deployments/testnet.json still expects verifiers(0xFd2E...6519)=true while live verifier has moved to the KMS address.
- npm run test:ops could not complete in this isolated worktree because node_modules is not installed here; it fails importing @polkadot/util-crypto even though package.json/package-lock include it. The new pauser test file passes directly.

## Impact
- Backend/scripts and docs only.
- No frontend, indexer, Caddy, contract bytecode, public site, or secret changes.
- No live pause/unpause mutation was performed; that still requires the pauser key and should write docs/evidence/pauser-rehearsal-testnet-YYYY-MM-DD.json.

## Polkadot Docs Check
- Rechecked Asset Hub smart-contract account guidance: native accounts need pallet_revive.map_account() before Ethereum-compatible contract interactions.
- Rechecked Asset Hub smart-contract transaction model around pallet_revive and EVM compatibility.
