### PR TITLE
fix(deploy): redeploy-backend rollback verifies checkout + re-renders env

### DIFF
--- a/scripts/ops/redeploy-backend.sh
+++ b/scripts/ops/redeploy-backend.sh
@@ -102,7 +102,61 @@ rollback() {
   fi
 
   echo "Health check failed; rolling back to $PREVIOUS_SHA" >&2
-  git -C "$APP_ROOT" checkout --quiet "$PREVIOUS_SHA"
+  if ! git -C "$APP_ROOT" checkout --quiet "$PREVIOUS_SHA"; then
+    echo "Rollback: git checkout $PREVIOUS_SHA failed. Working tree may be dirty or the SHA may be unreachable." >&2
+    echo "Manual intervention required: inspect $APP_ROOT for uncommitted changes or fetch the missing commit." >&2
+    exit 1
+  fi
+
+  # Verify the checkout actually moved HEAD. The Phase 5a Stage 2C-3
+  # rollback outage post-mortem (2026-05-21, PR #455) showed `git
+  # rev-parse HEAD` still pointing at the failed-deploy SHA after this
+  # function claimed to have rolled back — root cause never fully
+  # isolated (suspected: silent checkout no-op when working tree state
+  # interferes). This guard turns that class of failure into a loud
+  # bail before the rollback's compose_up rebuilds with the still-
+  # broken code.
+  local checked_out_head
+  checked_out_head=$(git -C "$APP_ROOT" rev-parse HEAD)
+  if [[ "$checked_out_head" != "$PREVIOUS_SHA" ]]; then
+    echo "Rollback checkout did NOT move HEAD: expected $PREVIOUS_SHA, got $checked_out_head." >&2
+    echo "Manual intervention required: the working tree is still at the failed-deploy SHA." >&2
+    exit 1
+  fi
+  echo "Working tree restored to $PREVIOUS_SHA"
+
+  # Re-render /run/agent-stack/backend.env from the rolled-back
+  # template. Without this step the rendered env on disk still
+  # reflects the FAILED deploy's template — restoring just the code
+  # while leaving the new env in place can produce mismatched runtime
+  # state (env vars the rolled-back code still expects, or vice
+  # versa). This is the gap that prevented the Phase 5a Stage 2C-3
+  # rollback from restoring health: PR #455 removed static-key env
+  # lines from backend.env.template; the wrapping deploy rendered the
+  # new (smaller) env before container-restart; rollback then restored
+  # the OLD code that read those env vars, but /run/agent-stack/
+  # backend.env no longer carried them.
+  local render_script="$APP_ROOT/scripts/ops/render-vps-env.sh"
+  local template="$APP_ROOT/deploy/backend.env.template"
+  local target="/run/agent-stack/backend.env"
+  local token="/etc/agent-stack/op-backend.env"
+
+  if [[ -x "$render_script" && -f "$template" && -f "$token" ]]; then
+    echo "Re-rendering $target from $template @ $PREVIOUS_SHA"
+    if ! sudo bash "$render_script" "$template" "$target" "$token"; then
+      echo "Rollback env re-render failed; backend may boot with NEW-deploy env on OLD-deploy code." >&2
+      echo "Manual intervention required: inspect $target vs $template at $PREVIOUS_SHA." >&2
+      exit 1
+    fi
+  else
+    # On a freshly-bootstrapped VPS the render path may not be fully
+    # installed yet — log the skip but don't fail, mirroring the
+    # forward-deploy render step's skip-clean conditions in
+    # deploy-production.sh::render_runtime_envs.
+    echo "Rollback skipping env re-render: render-vps-env.sh ($render_script), template ($template), or op token ($token) not present." >&2
+    echo "  This is OK on a not-yet-bootstrapped VPS but suspicious on a deployed one." >&2
+  fi
+
   compose_up
   if wait_for_health; then
     echo "Rollback succeeded; service is serving the previous build."

--- a/scripts/ops/redeploy-backend.test.mjs
+++ b/scripts/ops/redeploy-backend.test.mjs
@@ -1,0 +1,130 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const REDEPLOY_SCRIPT = join(REPO_ROOT, "scripts/ops/redeploy-backend.sh");
+
+// Structural tests for the rollback() function's contract. These are
+// not full integration tests (no docker / sudo / curl stubbing) — they
+// verify that the SCRIPT contains the specific safeguards that the
+// Phase 5a Stage 2C-3 outage post-mortem identified as missing. Any
+// future refactor that drops one of these lines should fail loudly
+// here rather than at the next failed deploy in production.
+
+test("redeploy-backend rollback verifies git checkout actually moved HEAD", async () => {
+  const script = await readFile(REDEPLOY_SCRIPT, "utf8");
+
+  // The pre-fix rollback called `git checkout PREVIOUS_SHA` and trusted
+  // the exit code. The 2026-05-21 outage post-mortem showed HEAD still
+  // pointing at the failed-deploy SHA after this function claimed to
+  // have rolled back. The guard reads HEAD post-checkout and bails if
+  // it doesn't equal PREVIOUS_SHA.
+  assert.match(
+    script,
+    /git -C "\$APP_ROOT" rev-parse HEAD[\s\S]*?\$checked_out_head[\s\S]*?\$PREVIOUS_SHA/u,
+    "rollback must re-read HEAD after `git checkout` and compare to PREVIOUS_SHA",
+  );
+  assert.match(
+    script,
+    /Rollback checkout did NOT move HEAD/u,
+    "rollback must emit a loud error when HEAD doesn't match PREVIOUS_SHA",
+  );
+});
+
+test("redeploy-backend rollback re-renders /run/agent-stack/backend.env from the rolled-back template", async () => {
+  const script = await readFile(REDEPLOY_SCRIPT, "utf8");
+
+  // The actual root cause of the Phase 5a Stage 2C-3 outage rollback's
+  // inability to restore health: rollback() restored the code via `git
+  // checkout` but the wrapping deploy had already rendered the new
+  // (smaller) /run/agent-stack/backend.env. The old code on disk now
+  // saw an env it didn't expect — boot failed. Fix: rollback() must
+  // re-run render-vps-env.sh against the rolled-back template before
+  // compose_up.
+  assert.match(
+    script,
+    /render_script="\$APP_ROOT\/scripts\/ops\/render-vps-env\.sh"/u,
+    "rollback must reference scripts/ops/render-vps-env.sh",
+  );
+  assert.match(
+    script,
+    /template="\$APP_ROOT\/deploy\/backend\.env\.template"/u,
+    "rollback must use deploy/backend.env.template at the rolled-back SHA",
+  );
+  assert.match(
+    script,
+    /target="\/run\/agent-stack\/backend\.env"/u,
+    "rollback must re-render to /run/agent-stack/backend.env (the runtime env_file:)",
+  );
+  assert.match(
+    script,
+    /sudo bash "\$render_script" "\$template" "\$target" "\$token"/u,
+    "rollback must invoke render-vps-env.sh with (template, target, token) args",
+  );
+});
+
+test("redeploy-backend rollback re-render runs AFTER the git checkout and BEFORE compose_up", async () => {
+  const script = await readFile(REDEPLOY_SCRIPT, "utf8");
+
+  // Ordering matters. If render runs before checkout, the env is
+  // rendered from the still-broken (failed-deploy) template; if it
+  // runs after compose_up, the container has already booted with the
+  // mismatched env. Both invariants live in rollback()'s body, so the
+  // structural test scopes to that function.
+  const fnStart = script.indexOf("\nrollback() {");
+  assert.notEqual(fnStart, -1, "rollback() function should exist");
+  const fnEnd = script.indexOf("\n}", fnStart);
+  assert.notEqual(fnEnd, -1, "rollback() should be closed by `}`");
+  const fnBody = script.slice(fnStart, fnEnd);
+
+  const checkoutIdx = fnBody.indexOf("git -C \"$APP_ROOT\" checkout --quiet \"$PREVIOUS_SHA\"");
+  const renderIdx = fnBody.indexOf("sudo bash \"$render_script\"");
+  // Use lastIndexOf so the match is the actual `compose_up` call near
+  // the end of the function, not a comment mentioning it earlier.
+  const composeUpIdx = fnBody.lastIndexOf("compose_up");
+
+  assert.ok(checkoutIdx > 0, "rollback should contain the git checkout call");
+  assert.ok(renderIdx > 0, "rollback should contain the render-vps-env.sh invocation");
+  assert.ok(composeUpIdx > 0, "rollback should contain compose_up");
+  assert.ok(
+    checkoutIdx < renderIdx,
+    "render-vps-env.sh must be invoked AFTER git checkout (so it reads the rolled-back template)",
+  );
+  assert.ok(
+    renderIdx < composeUpIdx,
+    "render-vps-env.sh must be invoked BEFORE compose_up (so the container picks up the rolled-back env)",
+  );
+});
+
+test("redeploy-backend rollback fails loudly when env re-render fails (rather than silently continuing)", async () => {
+  const script = await readFile(REDEPLOY_SCRIPT, "utf8");
+
+  // Half-rolled-back state (code from PREVIOUS_SHA, env from failed
+  // deploy) is the failure mode we're trying to avoid. If the render
+  // fails for any reason — op session expired, template syntax error,
+  // sudo refused — bail loudly rather than continuing into compose_up.
+  assert.match(
+    script,
+    /Rollback env re-render failed[\s\S]*?exit 1/u,
+    "render failure inside rollback must exit non-zero, not fall through to compose_up",
+  );
+});
+
+test("redeploy-backend rollback documents the skip path for not-yet-bootstrapped VPS", async () => {
+  const script = await readFile(REDEPLOY_SCRIPT, "utf8");
+
+  // The forward-deploy render step in deploy-production.sh has skip-
+  // clean conditions for a not-yet-bootstrapped VPS (missing
+  // render-vps-env.sh, missing op token, missing /run dir). The
+  // rollback's render call mirrors those conditions; here we just
+  // make sure the skip is logged loudly so a deployed VPS hitting it
+  // is visible to the operator.
+  assert.match(
+    script,
+    /Rollback skipping env re-render/u,
+    "rollback should log when it skips the env re-render (and why)",
+  );
+});


### PR DESCRIPTION
## Summary

Closes the rollback-doesn't-actually-roll-back gap exposed by the Phase 5a Stage 2C-3 outage on 2026-05-21.

`scripts/ops/redeploy-backend.sh::rollback()` had two missing safeguards:

1. **No verification the `git checkout` moved HEAD.** After the failed Stage 2C-3 deploy, the script logged `Health check failed; rolling back to 43fe2f81...` but `git rev-parse HEAD` on the VPS showed the new SHA `ca51338` post-rollback. The script trusted `git checkout`'s exit code only.
2. **No re-render of `/run/agent-stack/backend.env` from the rolled-back template.** The wrapping deploy renders the env BEFORE redeploy-backend.sh runs, using the NEW SHA's template. Rollback restored code via `git checkout` but the env on disk was still the new (smaller) one. The half-rolled-back container booted with **new env on old code** — exactly the failure mode that prevented #456's rollback from restoring health.

## The fix

In `rollback()`, between `git checkout` and `compose_up`:

1. Re-read HEAD; bail with a loud error if it doesn't equal `$PREVIOUS_SHA`.
2. Invoke `scripts/ops/render-vps-env.sh` against the rolled-back `deploy/backend.env.template` to refresh `/run/agent-stack/backend.env`.
3. If the render fails, exit non-zero rather than falling through to `compose_up`. Half-rolled-back state is worse than failing loud.

Skip-clean conditions for a not-yet-bootstrapped VPS (missing render script / template / op token) mirror the forward-deploy render step in `deploy-production.sh::render_runtime_envs`.

## Tests

`scripts/ops/redeploy-backend.test.mjs` (new) — structural assertions on the rollback function:

- HEAD-after-checkout verification exists
- `render-vps-env.sh` invocation exists with the right (template, target, token) args
- Render runs **after** `git checkout` and **before** `compose_up` (ordering matters in both directions)
- Render failure exits non-zero
- Skip-path logging exists

5/5 pass. Existing `scripts/ops/deploy-production.test.mjs` (the wrapper integration test) still 4/4 pass. `bash -n scripts/ops/redeploy-backend.sh` — syntax clean.

Not a full integration test (no docker / sudo / curl stubbing) — these are shape-of-script tests that future refactors will trip on if they drop a guard.

## Known same-shape gap (intentionally NOT in this PR)

`scripts/ops/redeploy-indexer.sh` has the same rollback pattern. `indexer.env` is similarly rendered at deploy time, so the same env-mismatch class applies. Worth a follow-up PR with the same shape of fix. `redeploy-frontend.sh` is static-export only — no runtime `env_file:`, no fix needed.

## Runtime impact

**None at merge.** This only changes the rollback path; a successful deploy doesn't touch it. The next deploy that fails health check will exercise the new logic — at which point the rollback will either succeed (the intended new behavior) or fail with a clearer error (the loud-bail behavior the post-mortem wanted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)