### PR TITLE
[codex] Align testnet verifier manifest

### DIFF
--- a/deploy/backend.env.template
+++ b/deploy/backend.env.template
@@ -49,11 +49,10 @@
 #
 # The on-chain trust update was applied via multisig
 # TreasuryPolicy.setVerifier(0x31ad432dFe083B998c69B6dB88A984ec5207ab7F, true)
-# in block 8922707 (Paseo Asset Hub). Both the old verifier
-# (0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519) and the new KMS-derived
-# address are currently approved, so this flip has zero rejection
-# window. The OLD verifier approval will be revoked after ~24-48h of
-# confidence with the KMS path.
+# in block 8922707 (Paseo Asset Hub). The old verifier
+# (0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519) was later revoked after the
+# KMS path soaked; deployment verification now expects only the KMS-derived
+# address in deployments/testnet.json.
 SIGNER_BACKEND=kms
 
 # AWS KMS-signer references. Region + key ARN are non-confidential and

--- a/deployments/testnet.json
+++ b/deployments/testnet.json
@@ -5,7 +5,7 @@
   "deployer": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
   "owner": "0x1f8c4da4aaac79916350f1fabf1221309591b6f9",
   "pauser": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
-  "verifier": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+  "verifier": "0x31ad432dFe083B998c69B6dB88A984ec5207ab7F",
   "arbitrator": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
   "contracts": {
     "treasuryPolicy": "0x648Cc5fdE94435992296C4e5ac642d18bB64c12B",

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -24,11 +24,9 @@ If this checklist is not green, the answer is "not ready yet".
 - [x] `TreasuryPolicy.owner` is the intended multisig address.
 - [x] `deployments/testnet-multisig-owner.json` is `status: "verified"` and matches the deployment manifest owner.
 - [ ] `TreasuryPolicy.pauser` is a hot key that only holds pause power.
-- [ ] `./scripts/verify_deployment.sh testnet` passes cleanly. Last checked on
-  2026-05-21 with `--require-owner-record-final`: owner, pauser, and owner
-  record passed, but `verifiers(0xFd2E...6519)` was false while
-  `deployments/testnet.json` still expected it to be true. Resolve the
-  manifest/on-chain verifier mismatch before launch.
+- [x] `./scripts/verify_deployment.sh testnet --require-owner-record-final`
+  passes cleanly after `deployments/testnet.json` was updated to the live
+  KMS verifier address (`0x31ad...7ab7F`).
 - [ ] Pause and unpause were rehearsed from the pauser key.
 - [x] At least one owner-only admin operation was rehearsed from the multisig.
 

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -217,9 +217,9 @@ live in D.
 | Deployer | `0xFd2EAE…6519` | Local one-shot env | Only used during `deploy_contracts.sh`; transferred to multisig at end |
 | Owner (mainnet) | TBD multisig | Three signer set in D | 2-of-3 threshold per `MULTISIG_SETUP.md` |
 | Owner (testnet) | `0x1f8C…b6F9` | Same multisig signer set | |
-| Pauser | `0xFd2EAE…6519` | Local env / hot key (testnet); **multisig-controlled on mainnet** | EOA on testnet, rotated via `rotate_pauser.sh`. **Mainnet**: the pauser must be a separate multisig (or at minimum a separate hardware-protected EOA that is NOT the verifier/arbitrator key). Reusing the verifier key for pause defeats the purpose — a leaked verifier signing capability would otherwise also be able to pause/un-pause arbitrarily. |
-| Verifier | `0xFd2EAE…6519` | `SIGNER_PRIVATE_KEY` (current) → AWS KMS (target) | The hottest key |
-| Arbitrator | `0xFd2EAE…6519` | `SIGNER_PRIVATE_KEY` (current) → AWS KMS (target) | **Currently the SAME key as verifier — this is an accepted risk on testnet, NOT acceptable for mainnet.** Mainnet must split verifier and arbitrator into two distinct KMS keys (different IAM roles, different alarm thresholds, different on-chain addresses). A compromised verifier key should not also be able to resolve disputes. Track the split as a Phase 5 prerequisite. |
+| Pauser | `0xFd2EAE…6519` | Local env / hot key (testnet); **multisig-controlled on mainnet** | EOA on testnet, rotated via `rotate_pauser.sh`. **Mainnet**: the pauser must be a separate multisig (or at minimum a separate hardware-protected EOA that is NOT the verifier/arbitrator key). Reusing any verifier or arbitrator key for pause defeats the purpose — a leaked signing capability would otherwise also be able to pause/un-pause arbitrarily. |
+| Verifier | `0x31ad…7ab7F` | AWS KMS | Sole on-chain verifier after the Phase 3 cutover and old raw-key verifier revocation. |
+| Arbitrator | `0xFd2EAE…6519` | Local env / hot key (testnet); AWS KMS target | No longer the same address as the KMS verifier, but still overlaps the pauser/deployer testnet hot key. This is an accepted testnet risk only; mainnet must split verifier, arbitrator, and pauser into distinct controlled authorities. |
 
 ### F. External service tokens (vendor portals)
 

--- a/docs/evidence/pauser-rehearsal-readonly-2026-05-21.json
+++ b/docs/evidence/pauser-rehearsal-readonly-2026-05-21.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "kind": "averray.pauserRehearsalEvidence",
   "profile": "testnet",
-  "generatedAt": "2026-05-21T18:44:13.061Z",
+  "generatedAt": "2026-05-21T20:05:59.470Z",
   "mode": "read_only_capability_proof",
   "manifestPath": "deployments/testnet.json",
   "rpcUrl": "https://eth-rpc-testnet.polkadot.io/",
@@ -12,7 +12,7 @@
   "manifest": {
     "owner": "0x1f8C4da4AAAC79916350f1fabF1221309591B6F9",
     "pauser": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
-    "verifier": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+    "verifier": "0x31ad432dFe083B998c69B6dB88A984ec5207ab7F",
     "arbitrator": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
     "deployer": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519"
   },
@@ -25,7 +25,6 @@
     "dedicated": false,
     "overlaps": [
       "deployer",
-      "verifier",
       "arbitrator"
     ],
     "severity": "warning"
@@ -164,7 +163,6 @@
       "message": "Current pauser address overlaps other manifest roles. This is acceptable only for bounded testnet rehearsal; mainnet must use a dedicated pauser.",
       "overlaps": [
         "deployer",
-        "verifier",
         "arbitrator"
       ]
     },


### PR DESCRIPTION
## Summary
- update deployments/testnet.json to the live KMS verifier address
- refresh pauser read-only evidence so role overlap no longer lists the retired verifier
- update the production checklist and secrets/runbook notes to reflect the old verifier revocation

## Validation
- Polkadot docs checked via MCP: Hub smart contracts use pallet_revive for EVM compatibility, and native accounts require map_account() before Ethereum-tooling contract interaction.
- ./scripts/verify_deployment.sh testnet --require-owner-record-final
- node scripts/ops/run-pauser-rehearsal.mjs --profile testnet --out docs/evidence/pauser-rehearsal-readonly-2026-05-21.json
- node --test scripts/ops/run-pauser-rehearsal.test.mjs
- JSON parse check for deployments/testnet.json and pauser evidence
- git diff --check

## Impact
- Deployment metadata, docs, and evidence only.
- No contract bytecode, backend runtime behavior, frontend, indexer, Caddy, or secret changes.
- This closes the verifier-manifest mismatch gate; live pause/unpause still remains and requires the pauser key.
