### PR TITLE
fix(deploy): redeploy-indexer rollback verifies checkout + re-renders env (mirrors #467)

### DIFF
--- a/scripts/ops/redeploy-indexer.sh
+++ b/scripts/ops/redeploy-indexer.sh
@@ -185,7 +185,57 @@ rollback() {
   fi
 
   echo "Indexer gate failed; rolling back to $PREVIOUS_SHA" >&2
-  git -C "$APP_ROOT" checkout --quiet "$PREVIOUS_SHA"
+  if ! git -C "$APP_ROOT" checkout --quiet "$PREVIOUS_SHA"; then
+    echo "Rollback: git checkout $PREVIOUS_SHA failed. Working tree may be dirty or the SHA may be unreachable." >&2
+    echo "Manual intervention required: inspect $APP_ROOT for uncommitted changes or fetch the missing commit." >&2
+    exit 1
+  fi
+
+  # Verify the checkout actually moved HEAD. Mirrors the guard added to
+  # redeploy-backend.sh::rollback in #467 after the Phase 5a Stage 2C-3
+  # outage post-mortem (2026-05-21) showed `git rev-parse HEAD` still
+  # pointing at the failed-deploy SHA after the backend rollback claimed
+  # to have run. The indexer has the same shape of rollback flow, so it
+  # gets the same shape of guard.
+  local checked_out_head
+  checked_out_head=$(git -C "$APP_ROOT" rev-parse HEAD)
+  if [[ "$checked_out_head" != "$PREVIOUS_SHA" ]]; then
+    echo "Rollback checkout did NOT move HEAD: expected $PREVIOUS_SHA, got $checked_out_head." >&2
+    echo "Manual intervention required: the working tree is still at the failed-deploy SHA." >&2
+    exit 1
+  fi
+  echo "Working tree restored to $PREVIOUS_SHA"
+
+  # Re-render /run/agent-stack/indexer.env from the rolled-back template.
+  # Without this step the rendered env on disk still reflects the FAILED
+  # deploy's template — restoring just the code while leaving the new env
+  # in place can produce mismatched runtime state (e.g. an
+  # INDEXER_DATABASE_SCHEMA that points at a fresh-mint schema the rolled-
+  # back code doesn't know about, or env vars the rolled-back code still
+  # expects). Same class of gap that bit the backend in #455/#456 and was
+  # closed for the backend in #467; this PR closes the symmetric gap for
+  # the indexer.
+  local render_script="$APP_ROOT/scripts/ops/render-vps-env.sh"
+  local template="$APP_ROOT/deploy/indexer.env.template"
+  local target="/run/agent-stack/indexer.env"
+  local token="/etc/agent-stack/op-indexer.env"
+
+  if [[ -x "$render_script" && -f "$template" && -f "$token" ]]; then
+    echo "Re-rendering $target from $template @ $PREVIOUS_SHA"
+    if ! sudo bash "$render_script" "$template" "$target" "$token"; then
+      echo "Rollback env re-render failed; indexer may boot with NEW-deploy env on OLD-deploy code." >&2
+      echo "Manual intervention required: inspect $target vs $template at $PREVIOUS_SHA." >&2
+      exit 1
+    fi
+  else
+    # On a freshly-bootstrapped VPS the render path may not be fully
+    # installed yet — log the skip but don't fail, mirroring the
+    # forward-deploy render step's skip-clean conditions in
+    # deploy-production.sh::render_runtime_envs.
+    echo "Rollback skipping env re-render: render-vps-env.sh ($render_script), template ($template), or op token ($token) not present." >&2
+    echo "  This is OK on a not-yet-bootstrapped VPS but suspicious on a deployed one." >&2
+  fi
+
   compose_up
   if wait_for_ok "$HEALTH_URL" "$HEALTH_TIMEOUT_SEC" "Health check"; then
     if [[ "$ROLLBACK_WAIT_FOR_READY" == "1" ]]; then

--- a/scripts/ops/redeploy-indexer.test.mjs
+++ b/scripts/ops/redeploy-indexer.test.mjs
@@ -1,0 +1,136 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const REDEPLOY_SCRIPT = join(REPO_ROOT, "scripts/ops/redeploy-indexer.sh");
+
+// Structural tests for the rollback() function in redeploy-indexer.sh.
+// Mirrors the test pattern in redeploy-backend.test.mjs (#467). The
+// indexer's rollback flow has the same shape as the backend's — git
+// checkout PREVIOUS_SHA then rebuild — and had the same two gaps:
+//
+//   1. No verification that `git checkout` actually moved HEAD.
+//   2. No re-render of /run/agent-stack/indexer.env from the rolled-back
+//      template — restoring just the code while leaving the new env in
+//      place can produce mismatched runtime state.
+//
+// Both gaps are closed by this PR. The tests below lock in the fixes so
+// a future refactor that drops a guard fails here rather than at the
+// next failed indexer deploy.
+
+test("redeploy-indexer rollback verifies git checkout actually moved HEAD", async () => {
+  const script = await readFile(REDEPLOY_SCRIPT, "utf8");
+
+  // Pre-fix the rollback called `git checkout PREVIOUS_SHA` and trusted
+  // the exit code alone. After #467 hardened the same gap in
+  // redeploy-backend.sh, this PR adds the symmetric guard to the
+  // indexer rollback — re-read HEAD post-checkout and bail if it
+  // doesn't equal PREVIOUS_SHA.
+  assert.match(
+    script,
+    /git -C "\$APP_ROOT" rev-parse HEAD[\s\S]*?\$checked_out_head[\s\S]*?\$PREVIOUS_SHA/u,
+    "rollback must re-read HEAD after `git checkout` and compare to PREVIOUS_SHA",
+  );
+  assert.match(
+    script,
+    /Rollback checkout did NOT move HEAD/u,
+    "rollback must emit a loud error when HEAD doesn't match PREVIOUS_SHA",
+  );
+});
+
+test("redeploy-indexer rollback re-renders /run/agent-stack/indexer.env from the rolled-back template", async () => {
+  const script = await readFile(REDEPLOY_SCRIPT, "utf8");
+
+  // Same class of bug that prevented the Phase 5a Stage 2C-3 backend
+  // rollback from restoring health (closed for the backend in #467):
+  // rollback() restored the code via `git checkout` but the wrapping
+  // deploy had already rendered the new (smaller) env from the failed-
+  // deploy's template. The old code on disk now saw an env it didn't
+  // expect — health failed. Fix: rollback() must re-run
+  // render-vps-env.sh against the rolled-back template before
+  // compose_up.
+  assert.match(
+    script,
+    /render_script="\$APP_ROOT\/scripts\/ops\/render-vps-env\.sh"/u,
+    "rollback must reference scripts/ops/render-vps-env.sh",
+  );
+  assert.match(
+    script,
+    /template="\$APP_ROOT\/deploy\/indexer\.env\.template"/u,
+    "rollback must use deploy/indexer.env.template (not backend.env.template) at the rolled-back SHA",
+  );
+  assert.match(
+    script,
+    /target="\/run\/agent-stack\/indexer\.env"/u,
+    "rollback must re-render to /run/agent-stack/indexer.env (the runtime env_file:)",
+  );
+  assert.match(
+    script,
+    /sudo bash "\$render_script" "\$template" "\$target" "\$token"/u,
+    "rollback must invoke render-vps-env.sh with (template, target, token) args",
+  );
+});
+
+test("redeploy-indexer rollback re-render runs AFTER the git checkout and BEFORE compose_up", async () => {
+  const script = await readFile(REDEPLOY_SCRIPT, "utf8");
+
+  // Ordering matters in both directions. If render runs before checkout,
+  // the env is rendered from the still-broken (failed-deploy) template;
+  // if it runs after compose_up, the container has already booted with
+  // the mismatched env. Both invariants live in rollback()'s body.
+  const fnStart = script.indexOf("\nrollback() {");
+  assert.notEqual(fnStart, -1, "rollback() function should exist");
+  const fnEnd = script.indexOf("\n}", fnStart);
+  assert.notEqual(fnEnd, -1, "rollback() should be closed by `}`");
+  const fnBody = script.slice(fnStart, fnEnd);
+
+  const checkoutIdx = fnBody.indexOf("git -C \"$APP_ROOT\" checkout --quiet \"$PREVIOUS_SHA\"");
+  const renderIdx = fnBody.indexOf("sudo bash \"$render_script\"");
+  // Use lastIndexOf so the match is the actual `compose_up` call near
+  // the end of the function, not a comment mentioning it earlier.
+  const composeUpIdx = fnBody.lastIndexOf("compose_up");
+
+  assert.ok(checkoutIdx > 0, "rollback should contain the git checkout call");
+  assert.ok(renderIdx > 0, "rollback should contain the render-vps-env.sh invocation");
+  assert.ok(composeUpIdx > 0, "rollback should contain compose_up");
+  assert.ok(
+    checkoutIdx < renderIdx,
+    "render-vps-env.sh must be invoked AFTER git checkout (so it reads the rolled-back template)",
+  );
+  assert.ok(
+    renderIdx < composeUpIdx,
+    "render-vps-env.sh must be invoked BEFORE compose_up (so the container picks up the rolled-back env)",
+  );
+});
+
+test("redeploy-indexer rollback fails loudly when env re-render fails (rather than silently continuing)", async () => {
+  const script = await readFile(REDEPLOY_SCRIPT, "utf8");
+
+  // Half-rolled-back state (code from PREVIOUS_SHA, env from failed
+  // deploy) is the failure mode this PR is preventing. If the render
+  // fails for any reason — op session expired, template syntax error,
+  // sudo refused — bail loudly rather than continuing into compose_up.
+  assert.match(
+    script,
+    /Rollback env re-render failed[\s\S]*?exit 1/u,
+    "render failure inside rollback must exit non-zero, not fall through to compose_up",
+  );
+});
+
+test("redeploy-indexer rollback documents the skip path for not-yet-bootstrapped VPS", async () => {
+  const script = await readFile(REDEPLOY_SCRIPT, "utf8");
+
+  // The forward-deploy render step in deploy-production.sh has skip-
+  // clean conditions for a not-yet-bootstrapped VPS (missing render
+  // script, missing op token, missing /run dir). The rollback's render
+  // call mirrors those conditions; the skip is logged loudly so a
+  // deployed VPS hitting it is visible to the operator.
+  assert.match(
+    script,
+    /Rollback skipping env re-render/u,
+    "rollback should log when it skips the env re-render (and why)",
+  );
+});


### PR DESCRIPTION
## Summary

Closes the symmetric gap left after **#467** fixed `redeploy-backend.sh`. The indexer's rollback flow had the exact same shape as the backend's pre-#467 (`git checkout PREVIOUS_SHA` then `compose_up`) and therefore the exact same two gaps:

1. **No verification that `git checkout` actually moved HEAD.** After the Phase 5a Stage 2C-3 backend outage on 2026-05-21, post-mortem showed `git rev-parse HEAD` still pointing at the failed-deploy SHA after the rollback claimed to have run. The indexer rollback would have the same blind spot.
2. **No re-render of `/run/agent-stack/indexer.env` from the rolled-back template.** The wrapping deploy renders the env BEFORE `redeploy-indexer.sh` runs (from the NEW SHA's template). Rollback restored the code via `git checkout` but never re-rendered the env. Same class of failure mode that prevented the backend's rollback from restoring health.

## What this PR changes

In `scripts/ops/redeploy-indexer.sh::rollback()`, between `git checkout` and `compose_up`:

1. Re-read HEAD; bail with a loud error if it doesn't equal `$PREVIOUS_SHA`.
2. Invoke `scripts/ops/render-vps-env.sh` against the rolled-back `deploy/indexer.env.template` (**indexer** template, not backend) to refresh `/run/agent-stack/indexer.env`.
3. If the render fails, exit non-zero rather than falling through to `compose_up`. Half-rolled-back state is worse than failing loud.

Skip-clean conditions for a not-yet-bootstrapped VPS mirror the forward-deploy render step in `deploy-production.sh::render_runtime_envs`.

## Tests

`scripts/ops/redeploy-indexer.test.mjs` (new) mirrors `redeploy-backend.test.mjs` from #467 — five structural assertions on the rollback function body. Combined with the existing backend rollback tests:

- redeploy-indexer.test.mjs — **5/5 pass**
- redeploy-backend.test.mjs — **5/5 pass** (existing, unchanged)
- **10/10 total for the rollback shape across both services**

Plus `bash -n scripts/ops/redeploy-indexer.sh` — syntax clean.

## Why frontend is intentionally not in scope

`redeploy-frontend.sh` is a static-export deploy — no runtime `env_file:`, no env-mismatch class to fix. The HEAD-verification guard could be added cosmetically, but it doesn't close a real failure mode there. Keeping scope tight to the actual gap.

## Runtime impact

**None at merge.** This only changes the rollback path; a successful indexer deploy doesn't touch it. The next deploy that fails health check will exercise the new logic — at which point the rollback will either succeed (the intended new behavior) or fail with a clearer error (the loud-bail behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)