### PR TITLE
[codex] Split admin status HTTP routes

### DIFF
--- a/docs/PROJECT_ROADMAP.md
+++ b/docs/PROJECT_ROADMAP.md
@@ -170,7 +170,7 @@ externally ready.
 
 | Item | Status | Close criteria |
 | --- | --- | --- |
-| HTTP server route split (`P2.3`) | Open | Split high-risk route groups out of the monolith without changing behavior; add route-level tests. |
+| HTTP server route split (`P2.3`) | Open | First slice extracted `/admin/status` and `/admin/bootstrap-self-report/send` into `mcp-server/src/protocols/http/admin-status-routes.js` with route-level tests. Continue by splitting remaining high-risk admin mutation groups (`/admin/jobs/*`, capability grants, service tokens, and XCM admin routes) without behavior changes. |
 | Frontend auth guard (`P3.7`) | Done | `(authed)/layout.tsx` wraps the operator shell in `<AuthedGuard>`, which consumes `useAuth()` and the pure-decision module `app/lib/auth/auth-guard-decisions.js`. Unauthed visitors see a neutral placeholder and redirect to `/sign-in?next=<path>` (open-redirect-safe, `/sign-in` loops blocked); mid-session 401 cascades via the existing `AuthRefreshBridge` clearing the token store. Hydration-race guarded so neither side of the auth boundary flashes the wrong frame. Tests: `node --test app/lib/auth/auth-guard-decisions.test.mjs` (9 cases); `test:app` extended to cover `app/lib/auth/*.test.mjs`. |
 | Verifier replay hardening | Done | Verification audit fields now split `verifierPolicyVersion` from `verifierConfigVersion`; replay drift reports policy-version changes; every registered verifier handler must carry current-version replay fixtures before handler changes. |
 | Schema registration for external jobs | Open | Custom/off-platform references can register signed schemas with clear trust boundaries. |

--- a/mcp-server/src/protocols/http/admin-status-routes.js
+++ b/mcp-server/src/protocols/http/admin-status-routes.js
@@ -1,0 +1,41 @@
+export function createAdminStatusRoutes({
+  authMiddleware,
+  buildIdempotentMutationContext,
+  enforceLimit,
+  getIdempotentMutationReplay,
+  rateLimitConfig,
+  readJsonBody,
+  respond,
+  respondWithMutationReceipt,
+  service,
+}) {
+  return async function handleAdminStatusRoute({ request, response, url, pathname }) {
+    if (request.method === "GET" && pathname === "/admin/status") {
+      const auth = await authMiddleware(request, url, { requireRole: "admin" });
+      respond(response, 200, await service.getAdminStatus({ auth }));
+      return true;
+    }
+
+    if (request.method === "POST" && pathname === "/admin/bootstrap-self-report/send") {
+      const auth = await authMiddleware(request, url, { requireRole: "admin" });
+      await enforceLimit("admin_jobs", auth.wallet, rateLimitConfig.adminJobs);
+      const payload = await readJsonBody(request);
+      const idempotency = buildIdempotentMutationContext({
+        route: "/admin/bootstrap-self-report/send",
+        auth,
+        payload,
+        bucket: "bootstrap_self_report_send"
+      });
+      const replay = await getIdempotentMutationReplay(idempotency);
+      if (replay) {
+        respond(response, replay.statusCode, replay.body);
+        return true;
+      }
+      const result = await service.runBootstrapSelfReport();
+      await respondWithMutationReceipt(response, idempotency, 200, result);
+      return true;
+    }
+
+    return false;
+  };
+}

--- a/mcp-server/src/protocols/http/admin-status-routes.test.js
+++ b/mcp-server/src/protocols/http/admin-status-routes.test.js
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createAdminStatusRoutes } from "./admin-status-routes.js";
+
+const AUTH = { wallet: "0xadmin", roles: ["admin"] };
+
+function makeHarness(overrides = {}) {
+  const calls = [];
+  const response = {};
+  const payload = overrides.payload ?? { reason: "manual" };
+  const idempotency = overrides.idempotency ?? {
+    bucket: "bootstrap_self_report_send",
+    key: "0xadmin:idem-1",
+    requestHash: "hash-1"
+  };
+  const route = createAdminStatusRoutes({
+    authMiddleware: async (_request, _url, options) => {
+      calls.push(["auth", options]);
+      return overrides.auth ?? AUTH;
+    },
+    buildIdempotentMutationContext: (input) => {
+      calls.push(["idempotency", input]);
+      return idempotency;
+    },
+    enforceLimit: async (bucket, key, limits) => {
+      calls.push(["limit", { bucket, key, limits }]);
+    },
+    getIdempotentMutationReplay: async (context) => {
+      calls.push(["replay", context]);
+      return overrides.replay ?? null;
+    },
+    rateLimitConfig: { adminJobs: { windowMs: 10_000, max: 5 } },
+    readJsonBody: async () => {
+      calls.push(["body"]);
+      return payload;
+    },
+    respond: (res, statusCode, body) => {
+      calls.push(["respond", { statusCode, body }]);
+      res.statusCode = statusCode;
+      res.body = body;
+    },
+    respondWithMutationReceipt: async (res, context, statusCode, body) => {
+      calls.push(["mutationReceipt", { context, statusCode, body }]);
+      res.statusCode = statusCode;
+      res.body = body;
+    },
+    service: {
+      getAdminStatus: async ({ auth }) => {
+        calls.push(["getAdminStatus", auth]);
+        return overrides.adminStatus ?? { ok: true, auth: { wallet: auth.wallet } };
+      },
+      runBootstrapSelfReport: async () => {
+        calls.push(["runBootstrapSelfReport"]);
+        return overrides.selfReport ?? { ok: true, channel: "hermes" };
+      },
+    },
+  });
+  return { calls, response, route };
+}
+
+test("admin status routes ignore unrelated paths", async () => {
+  const { calls, response, route } = makeHarness();
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/not-admin/status"),
+    pathname: "/not-admin/status",
+  });
+
+  assert.equal(handled, false);
+  assert.deepEqual(calls, []);
+  assert.deepEqual(response, {});
+});
+
+test("GET /admin/status requires admin auth and returns service status", async () => {
+  const { calls, response, route } = makeHarness();
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/admin/status"),
+    pathname: "/admin/status",
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.body, { ok: true, auth: { wallet: AUTH.wallet } });
+  assert.deepEqual(calls, [
+    ["auth", { requireRole: "admin" }],
+    ["getAdminStatus", AUTH],
+    ["respond", { statusCode: 200, body: { ok: true, auth: { wallet: AUTH.wallet } } }],
+  ]);
+});
+
+test("POST /admin/bootstrap-self-report/send rate-limits, idempotency-checks, then emits mutation receipt", async () => {
+  const { calls, response, route } = makeHarness();
+
+  const handled = await route({
+    request: { method: "POST" },
+    response,
+    url: new URL("http://localhost/admin/bootstrap-self-report/send"),
+    pathname: "/admin/bootstrap-self-report/send",
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.body, { ok: true, channel: "hermes" });
+  assert.deepEqual(calls, [
+    ["auth", { requireRole: "admin" }],
+    ["limit", { bucket: "admin_jobs", key: AUTH.wallet, limits: { windowMs: 10_000, max: 5 } }],
+    ["body"],
+    ["idempotency", {
+      route: "/admin/bootstrap-self-report/send",
+      auth: AUTH,
+      payload: { reason: "manual" },
+      bucket: "bootstrap_self_report_send",
+    }],
+    ["replay", {
+      bucket: "bootstrap_self_report_send",
+      key: "0xadmin:idem-1",
+      requestHash: "hash-1",
+    }],
+    ["runBootstrapSelfReport"],
+    ["mutationReceipt", {
+      context: {
+        bucket: "bootstrap_self_report_send",
+        key: "0xadmin:idem-1",
+        requestHash: "hash-1",
+      },
+      statusCode: 200,
+      body: { ok: true, channel: "hermes" },
+    }],
+  ]);
+});
+
+test("POST /admin/bootstrap-self-report/send returns idempotent replay without rerunning report", async () => {
+  const replay = { statusCode: 202, body: { ok: true, replay: true } };
+  const { calls, response, route } = makeHarness({ replay });
+
+  const handled = await route({
+    request: { method: "POST" },
+    response,
+    url: new URL("http://localhost/admin/bootstrap-self-report/send"),
+    pathname: "/admin/bootstrap-self-report/send",
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 202);
+  assert.deepEqual(response.body, { ok: true, replay: true });
+  assert.ok(calls.some(([name]) => name === "replay"));
+  assert.ok(!calls.some(([name]) => name === "runBootstrapSelfReport"));
+  assert.ok(!calls.some(([name]) => name === "mutationReceipt"));
+});

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -86,6 +86,7 @@ import {
 } from "../../jobs/ingest-osv-advisories.js";
 import { ingestStandardsSpecs, parseSpecs as parseStandardsSpecs } from "../../jobs/ingest-standards-specs.js";
 import { ingestWikipediaMaintenance, parseCategories } from "../../jobs/ingest-wikipedia-maintenance.js";
+import { createAdminStatusRoutes } from "./admin-status-routes.js";
 import { buildPublicJobsResponse } from "./jobs-response.js";
 import { OPERATOR_SIGNERS, makePolicy } from "../../core/builtin-policies.js";
 
@@ -1400,6 +1401,18 @@ async function runIdempotentMutation(response, context, statusCode, operation) {
     }
   }
 }
+
+const handleAdminStatusRoute = createAdminStatusRoutes({
+  authMiddleware,
+  buildIdempotentMutationContext,
+  enforceLimit,
+  getIdempotentMutationReplay,
+  rateLimitConfig,
+  readJsonBody,
+  respond,
+  respondWithMutationReceipt,
+  service,
+});
 
 function assertIssuerCanGrantCapabilities(grant, auth) {
   const issuerCapabilities = new Set(Array.isArray(auth?.capabilities) ? auth.capabilities : []);
@@ -3973,27 +3986,8 @@ const server = createServer(async (request, response) => {
       return respond(response, 200, status);
     }
 
-    if (request.method === "GET" && pathname === "/admin/status") {
-      const auth = await authMiddleware(request, url, { requireRole: "admin" });
-      return respond(response, 200, await service.getAdminStatus({ auth }));
-    }
-
-    if (request.method === "POST" && pathname === "/admin/bootstrap-self-report/send") {
-      const auth = await authMiddleware(request, url, { requireRole: "admin" });
-      await enforceLimit("admin_jobs", auth.wallet, rateLimitConfig.adminJobs);
-      const payload = await readJsonBody(request);
-      const idempotency = buildIdempotentMutationContext({
-        route: "/admin/bootstrap-self-report/send",
-        auth,
-        payload,
-        bucket: "bootstrap_self_report_send"
-      });
-      const replay = await getIdempotentMutationReplay(idempotency);
-      if (replay) {
-        return respond(response, replay.statusCode, replay.body);
-      }
-      const result = await service.runBootstrapSelfReport();
-      return respondWithMutationReceipt(response, idempotency, 200, result);
+    if (await handleAdminStatusRoute({ request, response, url, pathname })) {
+      return;
     }
 
     /*


### PR DESCRIPTION
## What changed
- Extracted the `/admin/status` and `/admin/bootstrap-self-report/send` handlers from the monolithic HTTP server into `mcp-server/src/protocols/http/admin-status-routes.js`.
- Added direct route-level tests for unmatched paths, admin auth, bootstrap self-report rate limiting/idempotency, mutation receipt emission, and replay behavior.
- Updated `docs/PROJECT_ROADMAP.md` to record this as the first slice of the `P2.3` HTTP route split, without marking the whole item done.

## Checks
- `node --test mcp-server/src/protocols/http/admin-status-routes.test.js`
- `node --check mcp-server/src/protocols/http/server.js`
- `git diff --check`

Attempted but local env-blocked:
- `npm --workspace mcp-server test` fails before this change's route tests because the local worktree/node_modules is missing AWS/Jose deps (`@aws-sdk/client-kms`, `@aws-sdk/credential-provider-ini`, `jose`) and has an incompatible `@noble/curves` subpath export under Node v25.5.0.
- `RUN_HTTP_SMOKE=1 node --test mcp-server/src/protocols/http/server.smoke.test.js` fails for the same missing dependency before the server listens.

## Surfaces
- Backend HTTP server
- Docs/roadmap

## Env / VPS
- No env, secret, VPS, or contract changes.

## Polkadot verification
- Checked the Polkadot MCP project index. This slice makes no new chain/runtime claims; it only moves existing HTTP route code behind the same auth/idempotency behavior.
