### PR TITLE
[codex] Add restore drill evidence validator

### DIFF
--- a/docs/BACKUP_RESTORE_DRILL.md
+++ b/docs/BACKUP_RESTORE_DRILL.md
@@ -131,9 +131,12 @@ key count within a reasonable band of the production count.
 
 Cleanup: `docker rm -f drill-redis`.
 
-### 5. Record the drill in the operator log
+### 5. Record the drill evidence
 
-A successful drill writes one line to the operator log naming:
+A successful drill records both a human-readable operator-log line and a
+machine-readable evidence file.
+
+The operator-log line names:
 
 - Date of the drill.
 - The two backup file paths used (postgres + redis).
@@ -142,9 +145,77 @@ A successful drill writes one line to the operator log naming:
 - Key count from the Redis DBSIZE check.
 - Operator name and signature (initials).
 
-This is the evidence that closes the `PRODUCTION_CHECKLIST.md` line
-"The monthly restore drill has been run at least once on the current
-stack shape."
+The evidence file should live under `docs/evidence/` with a date-stamped name,
+for example `docs/evidence/restore-drill-2026-05-22.json`, and follow this
+shape:
+
+```json
+{
+  "schemaVersion": "restore-drill-evidence-v1",
+  "drillDate": "2026-05-22",
+  "completedAt": "2026-05-22T16:30:00.000Z",
+  "operator": {
+    "name": "Pascal",
+    "signature": "PK"
+  },
+  "target": {
+    "type": "disposable_container",
+    "label": "local restore drill containers"
+  },
+  "readiness": {
+    "checkedAt": "2026-05-22T16:00:00.000Z",
+    "backupDir": "/srv/agent-stack/backups",
+    "maxAgeHours": 26,
+    "overallStatus": "ok",
+    "components": [
+      {
+        "name": "postgres",
+        "status": "ok",
+        "file": "/srv/agent-stack/backups/postgres/agent-20260522-010000.sql.gz",
+        "ageSeconds": 3600,
+        "message": "Newest backup is 1.0h old"
+      },
+      {
+        "name": "redis",
+        "status": "ok",
+        "file": "/srv/agent-stack/backups/redis/redis-20260522-010000.rdb.gz",
+        "ageSeconds": 3600,
+        "message": "Newest backup is 1.0h old"
+      }
+    ]
+  },
+  "postgres": {
+    "backupFile": "agent-20260522-010000.sql.gz",
+    "restoreTarget": "drill-postgres",
+    "restoreExitCode": 0,
+    "rowCheck": {
+      "query": "select count(*) from submissions;",
+      "rowCount": 42
+    }
+  },
+  "redis": {
+    "backupFile": "redis-20260522-010000.rdb.gz",
+    "restoreTarget": "drill-redis",
+    "restoreExitCode": 0,
+    "dbSize": 13
+  },
+  "cleanup": {
+    "postgresTargetRemoved": true,
+    "redisTargetRemoved": true
+  }
+}
+```
+
+Validate the evidence before using it to close the checklist row:
+
+```bash
+node scripts/ops/check-restore-drill-evidence.mjs \
+  --file docs/evidence/restore-drill-YYYY-MM-DD.json \
+  --json
+```
+
+This is the evidence that closes the `PRODUCTION_CHECKLIST.md` line "The
+monthly restore drill has been run at least once on the current stack shape."
 
 ## What the drill does NOT do
 

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -70,7 +70,9 @@ functions, but it does not close the live pause/unpause rehearsal box.
 - [ ] The monthly restore drill has been run on the current stack
   shape. Evidence: a dated line in the operator log naming both
   backup file paths used, the row count from the Postgres spot-check,
-  and the key count from `DBSIZE` on the restored Redis container.
+  and the key count from `DBSIZE` on the restored Redis container,
+  plus a validated `docs/evidence/restore-drill-YYYY-MM-DD.json`
+  artifact checked with `node scripts/ops/check-restore-drill-evidence.mjs`.
   Procedure: [BACKUP_RESTORE_DRILL.md](./BACKUP_RESTORE_DRILL.md).
 
 Run backups (writes new snapshots):

--- a/docs/roadmap-updates/2026-05-22-codex-backup-restore-drill-proof.md
+++ b/docs/roadmap-updates/2026-05-22-codex-backup-restore-drill-proof.md
@@ -1,0 +1,37 @@
+# Roadmap Update: Backup Restore Drill Proof
+
+- **Date:** 2026-05-22
+- **Agent:** codex/backup-restore-rc1-proof
+- **Roadmap section:** P0 Launch Gates
+- **Item:** Postgres backup readiness / Redis backup readiness / Restore drill
+- **Related PRs/issues:** pending PR from `codex/backup-restore-rc1-proof`
+- **Proposed status:** Open
+- **Owner:** Operator
+
+## Summary
+
+The existing backup-readiness check already proves recent Postgres and Redis
+backup files exist. This slice adds a machine-readable restore-drill evidence
+validator so the operator can record the monthly disposable-target restore in a
+form CI and reviewers can check before the roadmap row moves.
+
+## Evidence
+
+- New script: `scripts/ops/check-restore-drill-evidence.mjs`
+- New tests: `scripts/ops/check-restore-drill-evidence.test.mjs`
+- Updated runbook: `docs/BACKUP_RESTORE_DRILL.md`
+- Updated checklist evidence requirement: `docs/PRODUCTION_CHECKLIST.md`
+
+## Blockers Or Caveats
+
+- The roadmap rows should stay `Open` until the operator runs the drill against
+  current production backup copies, commits or otherwise records the validated
+  `docs/evidence/restore-drill-YYYY-MM-DD.json` artifact, and cites the
+  readiness JSON plus restore target/counts.
+
+## Requested Roadmap Change
+
+Do not mark `Postgres backup readiness`, `Redis backup readiness`, or
+`Restore drill` Done/Proofed from this tooling PR alone. After live operator
+evidence exists, update those exact rows with the evidence artifact path, backup
+file names, Postgres row count, Redis `DBSIZE`, and validation command output.

--- a/scripts/ops/check-restore-drill-evidence.mjs
+++ b/scripts/ops/check-restore-drill-evidence.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_NAME = basename(fileURLToPath(import.meta.url));
+const SCHEMA_VERSION = "restore-drill-evidence-v1";
+
+function usage() {
+  return `Usage: node scripts/ops/${SCRIPT_NAME} --file docs/evidence/restore-drill-YYYY-MM-DD.json [--json]
+
+Validates the machine-readable evidence produced by the monthly backup restore
+drill. This check is read-only; it does not restore, delete, or modify backups.
+`;
+}
+
+function parseArgs(argv) {
+  const args = {
+    file: undefined,
+    json: false
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--file") {
+      args.file = argv[index + 1];
+      index += 1;
+    } else if (arg === "--json") {
+      args.json = true;
+    } else if (arg === "-h" || arg === "--help") {
+      args.help = true;
+    } else if (!args.file && !arg.startsWith("-")) {
+      args.file = arg;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function assertObject(value, path, errors) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    errors.push(`${path} must be an object`);
+    return {};
+  }
+  return value;
+}
+
+function requireString(value, path, errors, { pattern = undefined } = {}) {
+  if (typeof value !== "string" || !value.trim()) {
+    errors.push(`${path} must be a non-empty string`);
+    return "";
+  }
+  const trimmed = value.trim();
+  if (pattern && !pattern.test(trimmed)) {
+    errors.push(`${path} has an invalid format`);
+  }
+  return trimmed;
+}
+
+function requireNumber(value, path, errors, { integer = false, min = undefined } = {}) {
+  const ok = integer ? Number.isInteger(value) : Number.isFinite(value);
+  if (!ok) {
+    errors.push(`${path} must be ${integer ? "an integer" : "a finite number"}`);
+    return undefined;
+  }
+  if (min !== undefined && value < min) {
+    errors.push(`${path} must be >= ${min}`);
+  }
+  return value;
+}
+
+function requireBoolean(value, path, errors) {
+  if (typeof value !== "boolean") {
+    errors.push(`${path} must be boolean`);
+    return undefined;
+  }
+  return value;
+}
+
+function requireIsoDate(value, path, errors) {
+  const raw = requireString(value, path, errors);
+  if (!raw) return "";
+  if (!/^\d{4}-\d{2}-\d{2}T/u.test(raw)) {
+    errors.push(`${path} must be an ISO-8601 date/time`);
+    return raw;
+  }
+  const parsed = Date.parse(raw);
+  if (!Number.isFinite(parsed)) {
+    errors.push(`${path} must be an ISO-8601 date/time`);
+  }
+  return raw;
+}
+
+function requireDateOnly(value, path, errors) {
+  return requireString(value, path, errors, { pattern: /^\d{4}-\d{2}-\d{2}$/u });
+}
+
+function readinessComponent(readiness, name) {
+  const components = Array.isArray(readiness?.components) ? readiness.components : [];
+  return components.find((component) => component?.name === name);
+}
+
+function validateBackupComponent(component, name, suffix, errors) {
+  const path = `readiness.components.${name}`;
+  if (!component) {
+    errors.push(`${path} is required`);
+    return "";
+  }
+  if (component.status !== "ok") {
+    errors.push(`${path}.status must be ok`);
+  }
+  const file = requireString(component.file, `${path}.file`, errors);
+  if (file && !file.endsWith(suffix)) {
+    errors.push(`${path}.file must end with ${suffix}`);
+  }
+  requireNumber(component.ageSeconds, `${path}.ageSeconds`, errors, { integer: true, min: 0 });
+  return file;
+}
+
+function sameBackupFile(left, right) {
+  return Boolean(left && right && basename(left) === basename(right));
+}
+
+function validateEvidence(evidence) {
+  const errors = [];
+  const doc = assertObject(evidence, "evidence", errors);
+
+  if (doc.schemaVersion !== SCHEMA_VERSION) {
+    errors.push(`schemaVersion must be ${SCHEMA_VERSION}`);
+  }
+  requireDateOnly(doc.drillDate, "drillDate", errors);
+  requireIsoDate(doc.completedAt, "completedAt", errors);
+
+  const operator = assertObject(doc.operator, "operator", errors);
+  requireString(operator.name, "operator.name", errors);
+  requireString(operator.signature, "operator.signature", errors);
+
+  const target = assertObject(doc.target, "target", errors);
+  const targetType = requireString(target.type, "target.type", errors);
+  if (!["disposable_container", "disposable_vm", "local_throwaway"].includes(targetType)) {
+    errors.push("target.type must be disposable_container, disposable_vm, or local_throwaway");
+  }
+  requireString(target.label, "target.label", errors);
+  if (/prod|production|live/i.test(String(target.label ?? ""))) {
+    errors.push("target.label must not describe a production/live target");
+  }
+
+  const readiness = assertObject(doc.readiness, "readiness", errors);
+  if (readiness.overallStatus !== "ok") {
+    errors.push("readiness.overallStatus must be ok");
+  }
+  requireIsoDate(readiness.checkedAt, "readiness.checkedAt", errors);
+  requireString(readiness.backupDir, "readiness.backupDir", errors);
+  requireNumber(readiness.maxAgeHours, "readiness.maxAgeHours", errors, { integer: true, min: 1 });
+  const postgresReadinessFile = validateBackupComponent(
+    readinessComponent(readiness, "postgres"),
+    "postgres",
+    ".sql.gz",
+    errors
+  );
+  const redisReadinessFile = validateBackupComponent(
+    readinessComponent(readiness, "redis"),
+    "redis",
+    ".rdb.gz",
+    errors
+  );
+
+  const postgres = assertObject(doc.postgres, "postgres", errors);
+  const postgresBackupFile = requireString(postgres.backupFile, "postgres.backupFile", errors);
+  if (postgresBackupFile && !postgresBackupFile.endsWith(".sql.gz")) {
+    errors.push("postgres.backupFile must end with .sql.gz");
+  }
+  if (postgresReadinessFile && !sameBackupFile(postgresReadinessFile, postgresBackupFile)) {
+    errors.push("postgres.backupFile must match the readiness postgres backup file");
+  }
+  requireString(postgres.restoreTarget, "postgres.restoreTarget", errors);
+  if (!/drill|throwaway|disposable/i.test(String(postgres.restoreTarget ?? ""))) {
+    errors.push("postgres.restoreTarget must clearly be a drill/throwaway target");
+  }
+  requireNumber(postgres.restoreExitCode, "postgres.restoreExitCode", errors, { integer: true, min: 0 });
+  if (postgres.restoreExitCode !== 0) {
+    errors.push("postgres.restoreExitCode must be 0");
+  }
+  const rowCheck = assertObject(postgres.rowCheck, "postgres.rowCheck", errors);
+  requireString(rowCheck.query, "postgres.rowCheck.query", errors);
+  requireNumber(rowCheck.rowCount, "postgres.rowCheck.rowCount", errors, { integer: true, min: 0 });
+
+  const redis = assertObject(doc.redis, "redis", errors);
+  const redisBackupFile = requireString(redis.backupFile, "redis.backupFile", errors);
+  if (redisBackupFile && !redisBackupFile.endsWith(".rdb.gz")) {
+    errors.push("redis.backupFile must end with .rdb.gz");
+  }
+  if (redisReadinessFile && !sameBackupFile(redisReadinessFile, redisBackupFile)) {
+    errors.push("redis.backupFile must match the readiness redis backup file");
+  }
+  requireString(redis.restoreTarget, "redis.restoreTarget", errors);
+  if (!/drill|throwaway|disposable/i.test(String(redis.restoreTarget ?? ""))) {
+    errors.push("redis.restoreTarget must clearly be a drill/throwaway target");
+  }
+  requireNumber(redis.restoreExitCode, "redis.restoreExitCode", errors, { integer: true, min: 0 });
+  if (redis.restoreExitCode !== 0) {
+    errors.push("redis.restoreExitCode must be 0");
+  }
+  requireNumber(redis.dbSize, "redis.dbSize", errors, { integer: true, min: 0 });
+
+  const cleanup = assertObject(doc.cleanup, "cleanup", errors);
+  if (requireBoolean(cleanup.postgresTargetRemoved, "cleanup.postgresTargetRemoved", errors) !== true) {
+    errors.push("cleanup.postgresTargetRemoved must be true");
+  }
+  if (requireBoolean(cleanup.redisTargetRemoved, "cleanup.redisTargetRemoved", errors) !== true) {
+    errors.push("cleanup.redisTargetRemoved must be true");
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    summary: {
+      drillDate: doc.drillDate,
+      postgresBackupFile,
+      redisBackupFile,
+      postgresRowCount: rowCheck.rowCount,
+      redisDbSize: redis.dbSize,
+      operator: operator.name
+    }
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(usage());
+    return;
+  }
+  if (!args.file) {
+    throw new Error("--file is required");
+  }
+  const raw = await readFile(args.file, "utf8");
+  const parsed = JSON.parse(raw);
+  const result = validateEvidence(parsed);
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify({
+      status: result.ok ? "ok" : "not_ok",
+      file: args.file,
+      summary: result.summary,
+      errors: result.errors
+    }, null, 2)}\n`);
+  } else if (result.ok) {
+    process.stdout.write(`Restore drill evidence ok: ${args.file}\n`);
+  } else {
+    process.stderr.write(`Restore drill evidence invalid: ${args.file}\n`);
+    for (const error of result.errors) {
+      process.stderr.write(`- ${error}\n`);
+    }
+  }
+  if (!result.ok) {
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}
+
+export {
+  SCHEMA_VERSION,
+  validateEvidence
+};

--- a/scripts/ops/check-restore-drill-evidence.test.mjs
+++ b/scripts/ops/check-restore-drill-evidence.test.mjs
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { execFile } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { SCHEMA_VERSION, validateEvidence } from "./check-restore-drill-evidence.mjs";
+
+const execFileAsync = promisify(execFile);
+const scriptPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "check-restore-drill-evidence.mjs"
+);
+
+function validEvidence(overrides = {}) {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    drillDate: "2026-05-22",
+    completedAt: "2026-05-22T16:30:00.000Z",
+    operator: {
+      name: "Pascal",
+      signature: "PK"
+    },
+    target: {
+      type: "disposable_container",
+      label: "local restore drill containers"
+    },
+    readiness: {
+      checkedAt: "2026-05-22T16:00:00.000Z",
+      backupDir: "/srv/agent-stack/backups",
+      maxAgeHours: 26,
+      overallStatus: "ok",
+      components: [
+        {
+          name: "postgres",
+          status: "ok",
+          file: "/srv/agent-stack/backups/postgres/agent-20260522-010000.sql.gz",
+          ageSeconds: 3600,
+          message: "Newest backup is 1.0h old"
+        },
+        {
+          name: "redis",
+          status: "ok",
+          file: "/srv/agent-stack/backups/redis/redis-20260522-010000.rdb.gz",
+          ageSeconds: 3600,
+          message: "Newest backup is 1.0h old"
+        }
+      ]
+    },
+    postgres: {
+      backupFile: "agent-20260522-010000.sql.gz",
+      restoreTarget: "drill-postgres",
+      restoreExitCode: 0,
+      rowCheck: {
+        query: "select count(*) from submissions;",
+        rowCount: 42
+      }
+    },
+    redis: {
+      backupFile: "redis-20260522-010000.rdb.gz",
+      restoreTarget: "drill-redis",
+      restoreExitCode: 0,
+      dbSize: 13
+    },
+    cleanup: {
+      postgresTargetRemoved: true,
+      redisTargetRemoved: true
+    },
+    ...overrides
+  };
+}
+
+async function writeEvidenceFile(doc) {
+  const dir = await mkdtemp(join(tmpdir(), "restore-drill-evidence-"));
+  const file = join(dir, "evidence.json");
+  await writeFile(file, JSON.stringify(doc, null, 2), "utf8");
+  return file;
+}
+
+test("validateEvidence accepts complete restore drill evidence", () => {
+  const result = validateEvidence(validEvidence());
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.summary.postgresRowCount, 42);
+  assert.equal(result.summary.redisDbSize, 13);
+});
+
+test("validateEvidence rejects stale readiness and production-looking targets", () => {
+  const doc = validEvidence({
+    completedAt: "2026-05-22",
+    target: {
+      type: "production",
+      label: "production postgres"
+    },
+    readiness: {
+      ...validEvidence().readiness,
+      overallStatus: "not_ok",
+      backupDir: "",
+      components: [
+        {
+          name: "postgres",
+          status: "stale",
+          file: "/srv/agent-stack/backups/postgres/agent-20260520-010000.sql.gz",
+          ageSeconds: 200000,
+          message: "stale"
+        }
+      ]
+    }
+  });
+  const result = validateEvidence(doc);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.includes("readiness.overallStatus must be ok"));
+  assert.ok(result.errors.includes("completedAt must be an ISO-8601 date/time"));
+  assert.ok(result.errors.includes("readiness.backupDir must be a non-empty string"));
+  assert.ok(result.errors.includes("target.type must be disposable_container, disposable_vm, or local_throwaway"));
+  assert.ok(result.errors.includes("target.label must not describe a production/live target"));
+  assert.ok(result.errors.includes("readiness.components.redis is required"));
+});
+
+test("validateEvidence rejects mismatched readiness and restore files", () => {
+  const doc = validEvidence({
+    postgres: {
+      ...validEvidence().postgres,
+      backupFile: "different.sql.gz"
+    }
+  });
+  const result = validateEvidence(doc);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.includes("postgres.backupFile must match the readiness postgres backup file"));
+});
+
+test("CLI exits zero and prints JSON for valid evidence", async () => {
+  const file = await writeEvidenceFile(validEvidence());
+  const { stdout } = await execFileAsync(process.execPath, [scriptPath, "--file", file, "--json"]);
+  const parsed = JSON.parse(stdout);
+  assert.equal(parsed.status, "ok");
+  assert.equal(parsed.summary.operator, "Pascal");
+});
+
+test("CLI exits non-zero for invalid evidence", async () => {
+  const file = await writeEvidenceFile(validEvidence({
+    redis: {
+      ...validEvidence().redis,
+      restoreExitCode: 1
+    }
+  }));
+  await assert.rejects(
+    () => execFileAsync(process.execPath, [scriptPath, "--file", file]),
+    (error) => {
+      assert.notEqual(error.code, 0);
+      assert.match(error.stderr, /redis\.restoreExitCode must be 0/u);
+      return true;
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- add a read-only restore-drill evidence validator for dated docs/evidence/restore-drill-YYYY-MM-DD.json artifacts
- document the machine-readable evidence shape in docs/BACKUP_RESTORE_DRILL.md
- tighten docs/PRODUCTION_CHECKLIST.md so the restore drill row requires validated evidence
- add a roadmap fragment keeping the backup/restore rows Open until a live operator drill produces evidence

## Checks
- node --test scripts/ops/check-restore-drill-evidence.test.mjs scripts/ops/check-backup-readiness.test.mjs
- npm run test:ops
- git diff --check

## Surfaces
- Ops scripts/docs only.
- No backend, frontend, indexer, Caddy, contracts, or public-site runtime changes.

## Env / VPS
- No new environment variables or VPS secrets.
- Operator still needs to run the real disposable-target restore drill against current production backup copies and record a validated evidence artifact before marking the roadmap/checklist row complete.

## Polkadot verification
- Not applicable for this PR; it does not make Polkadot runtime, chain, XCM, or multisig claims.