### PR TITLE
[codex] Add observability proof validator

### DIFF
--- a/docs/OBSERVABILITY_POSTURE.md
+++ b/docs/OBSERVABILITY_POSTURE.md
@@ -45,3 +45,57 @@ Look for JSON log lines with `level`, `name`, and `msg`. If Sentry is enabled,
 also verify `observability.sentry_ready` appears after backend startup. If
 Sentry remains deferred, record that the log-only posture is intentional for
 v1 and link this document from the launch notes.
+
+For RC1, record the observability proof as a machine-readable artifact under
+`docs/evidence/`, for example `docs/evidence/observability-2026-05-22.json`.
+The artifact should cover metrics auth, alert delivery, and Sentry/logging
+posture in one place:
+
+```json
+{
+  "schemaVersion": "observability-proof-v1",
+  "proofDate": "2026-05-22",
+  "completedAt": "2026-05-22T18:30:00.000Z",
+  "operator": {
+    "name": "Pascal",
+    "signature": "PK"
+  },
+  "target": {
+    "environment": "production",
+    "apiBaseUrl": "https://api.averray.com"
+  },
+  "metricsAuth": {
+    "checkHostedStackRan": true,
+    "command": "METRICS_BEARER_TOKEN=$METRICS_BEARER_TOKEN CHECK_METRICS_AUTH=1 ./scripts/ops/check-hosted-stack.sh",
+    "unauthenticatedStatus": 401,
+    "authenticatedStatus": 200,
+    "observedAt": "2026-05-22T18:00:00.000Z"
+  },
+  "alertDestination": {
+    "webhookConfigured": true,
+    "deliberateFailureDelivered": true,
+    "channel": "ops-alerts",
+    "messageId": "1747936800.123456",
+    "receivedAt": "2026-05-22T18:05:00.000Z",
+    "failureMode": "API_HEALTH_URL pointed at a disposable non-existent host"
+  },
+  "sentryLogging": {
+    "decision": "log_only_deferred",
+    "structuredLogsVisible": true,
+    "logSurface": "docker logs agent-backend --tail 50",
+    "observedLogLine": "{\"level\":30,\"name\":\"averray-mcp\",\"msg\":\"server.started\"}",
+    "observedAt": "2026-05-22T18:10:00.000Z",
+    "sentryReadyObserved": false,
+    "deferredReason": "Backend Sentry intentionally deferred for v1; structured logs are the active launch surface."
+  }
+}
+```
+
+Do not paste bearer tokens, webhook URLs, API keys, or Sentry DSNs into this
+artifact. Validate it before using it to close the P0 observability rows:
+
+```bash
+node scripts/ops/check-observability-proof.mjs \
+  --file docs/evidence/observability-YYYY-MM-DD.json \
+  --json
+```

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -291,8 +291,11 @@ RUN_SUBSCAN_XCM_VALIDATION=1 ./scripts/ops/check-release-readiness.sh testnet
 
 The first five boxes are intentionally not auto-flipped — they need
 deployed-config evidence that lives outside the repo. The wiring exists in
-code; only the production env vars need to be set. Concrete verification
-commands per box:
+code; only the production env vars need to be set. Record the three
+observability gates as one dated artifact and validate it with
+`node scripts/ops/check-observability-proof.mjs --file
+docs/evidence/observability-YYYY-MM-DD.json --json` before moving the
+roadmap rows to `Proofed`. Concrete verification commands per box:
 
 - **Backend metrics bearer-protected and reachable.** Production now fails
   closed when metrics auth is required but no token is configured. Flip this

--- a/docs/roadmap-updates/2026-05-22-codex-observability-proof.md
+++ b/docs/roadmap-updates/2026-05-22-codex-observability-proof.md
@@ -1,0 +1,39 @@
+# Roadmap Update: Observability Proof Artifact
+
+- **Date:** 2026-05-22
+- **Agent:** codex/observability-rc1-proof
+- **Roadmap section:** P0 Launch Gates
+- **Item:** Metrics auth / Sentry/logging decision / Alert destination
+- **Related PRs/issues:** pending PR from `codex/observability-rc1-proof`
+- **Proposed status:** Ready for proof
+- **Owner:** Operator
+
+## Summary
+
+The implementation gates for metrics auth, Sentry/logging posture, and hosted
+alert delivery already exist. This slice adds the missing machine-readable
+evidence envelope so the operator can record one dated proof artifact before
+the three observability rows move to `Proofed`.
+
+## Evidence
+
+- New script: `scripts/ops/check-observability-proof.mjs`
+- New tests: `scripts/ops/check-observability-proof.test.mjs`
+- Updated runbook: `docs/OBSERVABILITY_POSTURE.md`
+- Updated checklist note: `docs/PRODUCTION_CHECKLIST.md`
+
+## Blockers Or Caveats
+
+- The roadmap rows should remain `Ready for proof` until the operator configures
+  production `METRICS_BEARER_TOKEN` and `ALERT_WEBHOOK_URL`, runs the hosted
+  metrics-auth gate, confirms one deliberate alert delivery, verifies the
+  active Sentry/logging posture, and records a validated
+  `docs/evidence/observability-YYYY-MM-DD.json` artifact.
+
+## Requested Roadmap Change
+
+Do not mark `Metrics auth`, `Sentry/logging decision`, or `Alert destination`
+`Proofed` from this tooling PR alone. After live operator evidence exists,
+update those exact rows with the evidence artifact path, metrics HTTP statuses,
+alert message id/channel, Sentry/logging decision, and validation command
+output.

--- a/scripts/ops/check-observability-proof.mjs
+++ b/scripts/ops/check-observability-proof.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_NAME = basename(fileURLToPath(import.meta.url));
+const SCHEMA_VERSION = "observability-proof-v1";
+
+function usage() {
+  return `Usage: node scripts/ops/${SCRIPT_NAME} --file docs/evidence/observability-YYYY-MM-DD.json [--json]
+
+Validates the operator evidence for the RC1 observability gates:
+metrics bearer auth, hosted alert delivery, and Sentry/logging posture.
+This check is read-only; it does not call the hosted stack or alert vendors.
+`;
+}
+
+function parseArgs(argv) {
+  const args = {
+    file: undefined,
+    json: false
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--file") {
+      args.file = argv[index + 1];
+      index += 1;
+    } else if (arg === "--json") {
+      args.json = true;
+    } else if (arg === "-h" || arg === "--help") {
+      args.help = true;
+    } else if (!args.file && !arg.startsWith("-")) {
+      args.file = arg;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function assertObject(value, path, errors) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    errors.push(`${path} must be an object`);
+    return {};
+  }
+  return value;
+}
+
+function requireString(value, path, errors, { pattern = undefined, forbidden = undefined } = {}) {
+  if (typeof value !== "string" || !value.trim()) {
+    errors.push(`${path} must be a non-empty string`);
+    return "";
+  }
+  const trimmed = value.trim();
+  if (pattern && !pattern.test(trimmed)) {
+    errors.push(`${path} has an invalid format`);
+  }
+  if (forbidden && forbidden.test(trimmed)) {
+    errors.push(`${path} must not contain secret-looking material`);
+  }
+  return trimmed;
+}
+
+function requireBoolean(value, path, errors) {
+  if (typeof value !== "boolean") {
+    errors.push(`${path} must be boolean`);
+    return undefined;
+  }
+  return value;
+}
+
+function requireNumber(value, path, errors, { integer = false, min = undefined } = {}) {
+  const ok = integer ? Number.isInteger(value) : Number.isFinite(value);
+  if (!ok) {
+    errors.push(`${path} must be ${integer ? "an integer" : "a finite number"}`);
+    return undefined;
+  }
+  if (min !== undefined && value < min) {
+    errors.push(`${path} must be >= ${min}`);
+  }
+  return value;
+}
+
+function requireIsoDate(value, path, errors) {
+  const raw = requireString(value, path, errors);
+  if (!raw) return "";
+  if (!/^\d{4}-\d{2}-\d{2}T/u.test(raw) || !Number.isFinite(Date.parse(raw))) {
+    errors.push(`${path} must be an ISO-8601 date/time`);
+  }
+  return raw;
+}
+
+function requireDateOnly(value, path, errors) {
+  return requireString(value, path, errors, { pattern: /^\d{4}-\d{2}-\d{2}$/u });
+}
+
+function requireHttpUrl(value, path, errors) {
+  const raw = requireString(value, path, errors);
+  if (!raw) return "";
+  try {
+    const parsed = new URL(raw);
+    if (!["http:", "https:"].includes(parsed.protocol)) {
+      errors.push(`${path} must be an http(s) URL`);
+    }
+  } catch {
+    errors.push(`${path} must be an http(s) URL`);
+  }
+  return raw;
+}
+
+function validateEvidence(evidence) {
+  const errors = [];
+  const doc = assertObject(evidence, "evidence", errors);
+
+  if (doc.schemaVersion !== SCHEMA_VERSION) {
+    errors.push(`schemaVersion must be ${SCHEMA_VERSION}`);
+  }
+  requireDateOnly(doc.proofDate, "proofDate", errors);
+  requireIsoDate(doc.completedAt, "completedAt", errors);
+
+  const operator = assertObject(doc.operator, "operator", errors);
+  requireString(operator.name, "operator.name", errors);
+  requireString(operator.signature, "operator.signature", errors);
+
+  const target = assertObject(doc.target, "target", errors);
+  requireString(target.environment, "target.environment", errors);
+  const apiBaseUrl = requireHttpUrl(target.apiBaseUrl, "target.apiBaseUrl", errors);
+  if (apiBaseUrl && !/^https:\/\/api\.averray\.com\/?$/u.test(apiBaseUrl)) {
+    errors.push("target.apiBaseUrl must be the hosted production API base URL");
+  }
+
+  const metrics = assertObject(doc.metricsAuth, "metricsAuth", errors);
+  if (requireBoolean(metrics.checkHostedStackRan, "metricsAuth.checkHostedStackRan", errors) !== true) {
+    errors.push("metricsAuth.checkHostedStackRan must be true");
+  }
+  const metricsCommand = requireString(metrics.command, "metricsAuth.command", errors);
+  if (!metricsCommand.includes("CHECK_METRICS_AUTH=1")) {
+    errors.push("metricsAuth.command must include CHECK_METRICS_AUTH=1");
+  }
+  if (!metricsCommand.includes("METRICS_BEARER_TOKEN")) {
+    errors.push("metricsAuth.command must reference METRICS_BEARER_TOKEN without including the token value");
+  }
+  if (/METRICS_BEARER_TOKEN=(?!\$|'<|"<|<)[^\s]+/u.test(metricsCommand)) {
+    errors.push("metricsAuth.command must not include the raw metrics token");
+  }
+  requireNumber(metrics.unauthenticatedStatus, "metricsAuth.unauthenticatedStatus", errors, { integer: true });
+  if (metrics.unauthenticatedStatus !== 401) {
+    errors.push("metricsAuth.unauthenticatedStatus must be 401");
+  }
+  requireNumber(metrics.authenticatedStatus, "metricsAuth.authenticatedStatus", errors, { integer: true });
+  if (metrics.authenticatedStatus !== 200) {
+    errors.push("metricsAuth.authenticatedStatus must be 200");
+  }
+  requireIsoDate(metrics.observedAt, "metricsAuth.observedAt", errors);
+
+  const alert = assertObject(doc.alertDestination, "alertDestination", errors);
+  if (requireBoolean(alert.webhookConfigured, "alertDestination.webhookConfigured", errors) !== true) {
+    errors.push("alertDestination.webhookConfigured must be true");
+  }
+  if (requireBoolean(alert.deliberateFailureDelivered, "alertDestination.deliberateFailureDelivered", errors) !== true) {
+    errors.push("alertDestination.deliberateFailureDelivered must be true");
+  }
+  requireString(alert.channel, "alertDestination.channel", errors);
+  requireString(alert.messageId, "alertDestination.messageId", errors);
+  requireIsoDate(alert.receivedAt, "alertDestination.receivedAt", errors);
+  requireString(alert.failureMode, "alertDestination.failureMode", errors);
+
+  const logging = assertObject(doc.sentryLogging, "sentryLogging", errors);
+  const decision = requireString(logging.decision, "sentryLogging.decision", errors);
+  if (!["sentry_enabled", "log_only_deferred"].includes(decision)) {
+    errors.push("sentryLogging.decision must be sentry_enabled or log_only_deferred");
+  }
+  if (requireBoolean(logging.structuredLogsVisible, "sentryLogging.structuredLogsVisible", errors) !== true) {
+    errors.push("sentryLogging.structuredLogsVisible must be true");
+  }
+  requireString(logging.logSurface, "sentryLogging.logSurface", errors);
+  requireString(logging.observedLogLine, "sentryLogging.observedLogLine", errors, {
+    forbidden: /(Bearer\s+[-._~+/A-Za-z0-9]+=*|gho_[A-Za-z0-9_]+|re_[A-Za-z0-9_-]{12,}|https:\/\/[^@\s]+@sentry)/iu
+  });
+  requireIsoDate(logging.observedAt, "sentryLogging.observedAt", errors);
+  if (decision === "sentry_enabled") {
+    if (requireBoolean(logging.sentryReadyObserved, "sentryLogging.sentryReadyObserved", errors) !== true) {
+      errors.push("sentryLogging.sentryReadyObserved must be true when Sentry is enabled");
+    }
+    requireString(logging.sentryProject, "sentryLogging.sentryProject", errors);
+  }
+  if (decision === "log_only_deferred") {
+    if (logging.sentryReadyObserved === true) {
+      errors.push("sentryLogging.sentryReadyObserved must not be true when Sentry is deferred");
+    }
+    requireString(logging.deferredReason, "sentryLogging.deferredReason", errors);
+  }
+
+  const secretScanInput = JSON.stringify(doc);
+  if (/(Bearer\s+[-._~+/A-Za-z0-9]+=*|gho_[A-Za-z0-9_]+|re_[A-Za-z0-9_-]{12,}|https:\/\/[^@\s]+@sentry)/iu.test(secretScanInput)) {
+    errors.push("evidence must not include bearer tokens, provider API keys, or Sentry DSNs");
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    summary: {
+      proofDate: doc.proofDate,
+      environment: target.environment,
+      metrics: {
+        unauthenticatedStatus: metrics.unauthenticatedStatus,
+        authenticatedStatus: metrics.authenticatedStatus
+      },
+      alertDelivered: alert.deliberateFailureDelivered === true,
+      sentryLoggingDecision: logging.decision,
+      operator: operator.name
+    }
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(usage());
+    return;
+  }
+  if (!args.file) {
+    throw new Error("--file is required");
+  }
+  const raw = await readFile(args.file, "utf8");
+  const parsed = JSON.parse(raw);
+  const result = validateEvidence(parsed);
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify({
+      status: result.ok ? "ok" : "not_ok",
+      file: args.file,
+      summary: result.summary,
+      errors: result.errors
+    }, null, 2)}\n`);
+  } else if (result.ok) {
+    process.stdout.write(`Observability proof evidence ok: ${args.file}\n`);
+  } else {
+    process.stderr.write(`Observability proof evidence invalid: ${args.file}\n`);
+    for (const error of result.errors) {
+      process.stderr.write(`- ${error}\n`);
+    }
+  }
+  if (!result.ok) {
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}
+
+export {
+  SCHEMA_VERSION,
+  validateEvidence
+};

--- a/scripts/ops/check-observability-proof.test.mjs
+++ b/scripts/ops/check-observability-proof.test.mjs
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { SCHEMA_VERSION, validateEvidence } from "./check-observability-proof.mjs";
+
+const execFileAsync = promisify(execFile);
+const scriptPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "check-observability-proof.mjs"
+);
+
+function validEvidence(overrides = {}) {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    proofDate: "2026-05-22",
+    completedAt: "2026-05-22T18:30:00.000Z",
+    operator: {
+      name: "Pascal",
+      signature: "PK"
+    },
+    target: {
+      environment: "production",
+      apiBaseUrl: "https://api.averray.com"
+    },
+    metricsAuth: {
+      checkHostedStackRan: true,
+      command: "METRICS_BEARER_TOKEN=$METRICS_BEARER_TOKEN CHECK_METRICS_AUTH=1 ./scripts/ops/check-hosted-stack.sh",
+      unauthenticatedStatus: 401,
+      authenticatedStatus: 200,
+      observedAt: "2026-05-22T18:00:00.000Z"
+    },
+    alertDestination: {
+      webhookConfigured: true,
+      deliberateFailureDelivered: true,
+      channel: "ops-alerts",
+      messageId: "1747936800.123456",
+      receivedAt: "2026-05-22T18:05:00.000Z",
+      failureMode: "API_HEALTH_URL pointed at a disposable non-existent host"
+    },
+    sentryLogging: {
+      decision: "log_only_deferred",
+      structuredLogsVisible: true,
+      logSurface: "docker logs agent-backend --tail 50",
+      observedLogLine: "{\"level\":30,\"name\":\"averray-mcp\",\"msg\":\"server.started\"}",
+      observedAt: "2026-05-22T18:10:00.000Z",
+      sentryReadyObserved: false,
+      deferredReason: "Backend Sentry intentionally deferred for v1; structured logs are the active launch surface."
+    },
+    ...overrides
+  };
+}
+
+async function writeEvidenceFile(doc) {
+  const dir = await mkdtemp(join(tmpdir(), "observability-proof-"));
+  const file = join(dir, "evidence.json");
+  await writeFile(file, JSON.stringify(doc, null, 2), "utf8");
+  return file;
+}
+
+test("validateEvidence accepts log-only observability proof", () => {
+  const result = validateEvidence(validEvidence());
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.summary.metrics.unauthenticatedStatus, 401);
+  assert.equal(result.summary.alertDelivered, true);
+  assert.equal(result.summary.sentryLoggingDecision, "log_only_deferred");
+});
+
+test("validateEvidence accepts Sentry-enabled observability proof", () => {
+  const result = validateEvidence(validEvidence({
+    sentryLogging: {
+      decision: "sentry_enabled",
+      structuredLogsVisible: true,
+      logSurface: "docker logs agent-backend --tail 50",
+      observedLogLine: "{\"level\":30,\"name\":\"averray-mcp\",\"msg\":\"observability.sentry_ready\"}",
+      observedAt: "2026-05-22T18:10:00.000Z",
+      sentryReadyObserved: true,
+      sentryProject: "averray-backend-prod"
+    }
+  }));
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.summary.sentryLoggingDecision, "sentry_enabled");
+});
+
+test("validateEvidence rejects incomplete or misleading proof", () => {
+  const doc = validEvidence({
+    target: {
+      environment: "production",
+      apiBaseUrl: "https://api.example.test"
+    },
+    metricsAuth: {
+      ...validEvidence().metricsAuth,
+      command: "METRICS_BEARER_TOKEN=raw-token-123456 CHECK_METRICS_AUTH=0 ./scripts/ops/check-hosted-stack.sh",
+      unauthenticatedStatus: 200,
+      authenticatedStatus: 503
+    },
+    alertDestination: {
+      ...validEvidence().alertDestination,
+      deliberateFailureDelivered: false
+    },
+    sentryLogging: {
+      ...validEvidence().sentryLogging,
+      observedLogLine: "Bearer very-secret-token"
+    }
+  });
+
+  const result = validateEvidence(doc);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.includes("target.apiBaseUrl must be the hosted production API base URL"));
+  assert.ok(result.errors.includes("metricsAuth.command must include CHECK_METRICS_AUTH=1"));
+  assert.ok(result.errors.includes("metricsAuth.command must not include the raw metrics token"));
+  assert.ok(result.errors.includes("metricsAuth.unauthenticatedStatus must be 401"));
+  assert.ok(result.errors.includes("metricsAuth.authenticatedStatus must be 200"));
+  assert.ok(result.errors.includes("alertDestination.deliberateFailureDelivered must be true"));
+  assert.ok(result.errors.includes("sentryLogging.observedLogLine must not contain secret-looking material"));
+  assert.ok(result.errors.includes("evidence must not include bearer tokens, provider API keys, or Sentry DSNs"));
+});
+
+test("validateEvidence rejects Sentry-enabled proof without ready observation", () => {
+  const result = validateEvidence(validEvidence({
+    sentryLogging: {
+      decision: "sentry_enabled",
+      structuredLogsVisible: true,
+      logSurface: "docker logs agent-backend --tail 50",
+      observedLogLine: "{\"level\":30,\"name\":\"averray-mcp\",\"msg\":\"server.started\"}",
+      observedAt: "2026-05-22T18:10:00.000Z",
+      sentryReadyObserved: false,
+      sentryProject: "averray-backend-prod"
+    }
+  }));
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.includes("sentryLogging.sentryReadyObserved must be true when Sentry is enabled"));
+});
+
+test("CLI exits zero and prints JSON for valid evidence", async () => {
+  const file = await writeEvidenceFile(validEvidence());
+  const { stdout } = await execFileAsync(process.execPath, [scriptPath, "--file", file, "--json"]);
+  const parsed = JSON.parse(stdout);
+  assert.equal(parsed.status, "ok");
+  assert.equal(parsed.summary.operator, "Pascal");
+});
+
+test("CLI exits non-zero for invalid evidence", async () => {
+  const file = await writeEvidenceFile(validEvidence({
+    alertDestination: {
+      ...validEvidence().alertDestination,
+      webhookConfigured: false
+    }
+  }));
+  await assert.rejects(
+    () => execFileAsync(process.execPath, [scriptPath, "--file", file]),
+    (error) => {
+      assert.notEqual(error.code, 0);
+      assert.match(error.stderr, /alertDestination\.webhookConfigured must be true/u);
+      return true;
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- add a read-only observability proof validator for dated docs/evidence/observability-YYYY-MM-DD.json artifacts
- cover the three RC1 observability gates in one receipt: metrics bearer auth, alert delivery, and Sentry/logging posture
- document the evidence shape in docs/OBSERVABILITY_POSTURE.md and point docs/PRODUCTION_CHECKLIST.md at the validator
- add a roadmap fragment keeping Metrics auth, Sentry/logging decision, and Alert destination at Ready for proof until live operator evidence exists

## Checks
- node --test scripts/ops/check-observability-proof.test.mjs scripts/ops/check-hosted-stack-and-alert.test.mjs scripts/ops/check-hosted-stack.test.mjs mcp-server/src/core/observability.test.js
- npm run test:ops
- git diff --check

## Surfaces
- Ops scripts/docs only.
- No backend, frontend, indexer, Caddy, contracts, or public-site runtime changes.

## Env / VPS
- No new environment variables or VPS secrets.
- Operator still needs to configure production METRICS_BEARER_TOKEN and ALERT_WEBHOOK_URL, run the hosted metrics-auth gate, confirm one deliberate alert delivery, verify the active Sentry/logging posture, and record a validated evidence artifact before marking the rows Proofed.

## Polkadot verification
- Not applicable for this PR; it does not make Polkadot runtime, chain, XCM, or multisig claims.