### PR TITLE
backend: split admin capability grant routes

### DIFF
--- a/docs/roadmap-updates/2026-05-22-codex-http-route-split-capability-grants.md
+++ b/docs/roadmap-updates/2026-05-22-codex-http-route-split-capability-grants.md
@@ -1,0 +1,28 @@
+# Roadmap Update: HTTP server route split (`P2.3`) capability grants slice
+
+- **Date:** 2026-05-22
+- **Agent:** codex/admin-capability-route-split
+- **Roadmap section:** P1 Product And Platform Hardening
+- **Item:** HTTP server route split (`P2.3`)
+- **Related PRs/issues:** current PR; overlaps active service-token route split PR #479
+- **Proposed status:** Open
+- **Owner:** roadmap steward
+
+## Summary
+
+This slice extracts the `/admin/capability-grants` list/create/revoke route group from the monolithic HTTP server into `mcp-server/src/protocols/http/admin-capability-grant-routes.js` without changing route behavior. The canonical roadmap row should remain `Open` until the remaining admin route groups are split and merged.
+
+## Evidence
+
+- Added focused route tests in `mcp-server/src/protocols/http/admin-capability-grant-routes.test.js`.
+- `node --test mcp-server/src/protocols/http/admin-capability-grant-routes.test.js`
+- `RUN_HTTP_SMOKE=1 node --test --test-name-pattern "capability grant" mcp-server/src/protocols/http/server.smoke.test.js`
+
+## Blockers Or Caveats
+
+- PR #479 is already editing the same roadmap row for service-token routes, so this PR intentionally avoids editing `docs/PROJECT_ROADMAP.md`.
+- Remaining route-split work still includes service tokens if #479 is not yet merged and XCM admin routes.
+
+## Requested Roadmap Change
+
+After this PR and PR #479 are both merged, update the `HTTP server route split (P2.3)` row to mention the capability-grants slice and keep the item `Open` until the remaining high-risk admin route groups are extracted.

--- a/mcp-server/src/protocols/http/admin-capability-grant-routes.js
+++ b/mcp-server/src/protocols/http/admin-capability-grant-routes.js
@@ -1,0 +1,161 @@
+import { listAllKnownCapabilities } from "../../auth/capabilities.js";
+import {
+  applyRevocation,
+  buildCapabilityGrant,
+  projectGrant
+} from "../../core/capability-grants.js";
+import { ValidationError } from "../../core/errors.js";
+
+export function createAdminCapabilityGrantRoutes({
+  assertIssuerCanGrantCapabilities,
+  authMiddleware,
+  buildMutationRequestHash,
+  enforceLimit,
+  eventBus,
+  getIdempotentMutationReplay,
+  parseIdempotencyKey,
+  parseLimit,
+  rateLimitConfig,
+  readJsonBody,
+  respond,
+  stateStore,
+  storeIdempotentMutationReceipt,
+}) {
+  async function authenticateAndLimit(request, url) {
+    const auth = await authMiddleware(request, url, { requireRole: "admin" });
+    await enforceLimit("admin_jobs", auth.wallet, rateLimitConfig.adminJobs);
+    return auth;
+  }
+
+  return async function handleAdminCapabilityGrantRoute({ request, response, url, pathname }) {
+    if (request.method === "GET" && pathname === "/admin/capability-grants") {
+      await authMiddleware(request, url, { requireRole: "admin" });
+      const subject = (url.searchParams.get("subject") ?? "").trim().toLowerCase() || undefined;
+      const status = (url.searchParams.get("status") ?? "").trim().toLowerCase() || undefined;
+      const limit = parseLimit(url, 50, 200);
+      const offset = Math.max(0, Number(url.searchParams.get("offset") ?? 0) || 0);
+      const grants = (await stateStore.listCapabilityGrants?.({ subject, status, limit, offset })) ?? [];
+      respond(response, 200, {
+        items: grants.map((grant) => projectGrant(grant)).filter(Boolean),
+        limit,
+        offset
+      });
+      return true;
+    }
+
+    if (request.method === "POST" && pathname === "/admin/capability-grants") {
+      const auth = await authenticateAndLimit(request, url);
+      const payload = await readJsonBody(request);
+      const idempotencyKey = parseIdempotencyKey(payload);
+      const mutationKey = idempotencyKey ? `${auth.wallet}:${idempotencyKey}` : undefined;
+      const requestHash = buildMutationRequestHash({
+        route: "/admin/capability-grants",
+        wallet: auth.wallet,
+        payload
+      });
+      const replay = await getIdempotentMutationReplay({
+        bucket: "capability_grant",
+        key: mutationKey,
+        requestHash
+      });
+      if (replay) {
+        respond(response, replay.statusCode, replay.body);
+        return true;
+      }
+      const knownCapabilities = listAllKnownCapabilities();
+      const grant = buildCapabilityGrant(payload ?? {}, {
+        knownCapabilities,
+        issuerWallet: auth.wallet
+      });
+      assertIssuerCanGrantCapabilities(grant, auth);
+      await stateStore.upsertCapabilityGrant?.(grant);
+      authMiddleware.invalidateCapabilityGrantCache?.(grant.subject);
+      const projection = projectGrant(grant);
+      await storeIdempotentMutationReceipt({
+        bucket: "capability_grant",
+        key: mutationKey,
+        requestHash,
+        response: projection,
+        statusCode: 201
+      });
+      eventBus?.publish({
+        id: `capability-grant-${grant.id}-${Date.now()}`,
+        topic: "capability.grant",
+        wallet: auth.wallet,
+        wallets: [auth.wallet, grant.subject],
+        timestamp: new Date().toISOString(),
+        data: {
+          grantId: grant.id,
+          subject: grant.subject,
+          capabilities: grant.capabilities,
+          scope: grant.scope ?? null
+        }
+      });
+      respond(response, 201, projection);
+      return true;
+    }
+
+    if (request.method === "POST" && pathname.startsWith("/admin/capability-grants/") && pathname.endsWith("/revoke")) {
+      const auth = await authenticateAndLimit(request, url);
+      const grantId = decodeURIComponent(pathname.slice("/admin/capability-grants/".length, -"/revoke".length));
+      if (!grantId) {
+        throw new ValidationError("grantId is required.");
+      }
+      const payload = (await readJsonBody(request).catch(() => undefined)) ?? {};
+      const idempotencyKey = parseIdempotencyKey(payload);
+      const mutationKey = idempotencyKey ? `${auth.wallet}:${grantId}:${idempotencyKey}` : undefined;
+      const requestHash = buildMutationRequestHash({
+        route: "/admin/capability-grants/:id/revoke",
+        wallet: auth.wallet,
+        payload: { grantId, ...payload }
+      });
+      const replay = await getIdempotentMutationReplay({
+        bucket: "capability_revoke",
+        key: mutationKey,
+        requestHash
+      });
+      if (replay) {
+        respond(response, replay.statusCode, replay.body);
+        return true;
+      }
+      const current = await stateStore.getCapabilityGrant?.(grantId);
+      if (!current) {
+        throw new ValidationError("Unknown grant id.", { grantId });
+      }
+      const { record, alreadyRevoked } = applyRevocation(current, {
+        revokedBy: auth.wallet,
+        revokeNote: payload?.note
+      });
+      if (!alreadyRevoked) {
+        await stateStore.upsertCapabilityGrant?.(record);
+        authMiddleware.invalidateCapabilityGrantCache?.(record.subject);
+      }
+      const projection = projectGrant(record);
+      await storeIdempotentMutationReceipt({
+        bucket: "capability_revoke",
+        key: mutationKey,
+        requestHash,
+        response: projection,
+        statusCode: 200
+      });
+      if (!alreadyRevoked) {
+        eventBus?.publish({
+          id: `capability-revoke-${record.id}-${Date.now()}`,
+          topic: "capability.revoke",
+          wallet: auth.wallet,
+          wallets: [auth.wallet, record.subject],
+          timestamp: new Date().toISOString(),
+          data: {
+            grantId: record.id,
+            subject: record.subject,
+            revokedBy: record.revokedBy ?? auth.wallet
+          }
+        });
+      }
+      respond(response, 200, projection);
+      return true;
+    }
+
+    return false;
+  };
+}

--- a/mcp-server/src/protocols/http/admin-capability-grant-routes.test.js
+++ b/mcp-server/src/protocols/http/admin-capability-grant-routes.test.js
@@ -1,0 +1,266 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { GRANT_STATUS } from "../../core/capability-grants.js";
+import { AuthorizationError, ValidationError } from "../../core/errors.js";
+import { createAdminCapabilityGrantRoutes } from "./admin-capability-grant-routes.js";
+
+const ADMIN_WALLET = "0x1111111111111111111111111111111111111111";
+const SUBJECT_WALLET = "0x2222222222222222222222222222222222222222";
+const AUTH = {
+  wallet: ADMIN_WALLET,
+  roles: ["admin"],
+  capabilities: ["jobs:claim", "jobs:submit"]
+};
+
+function activeGrant(overrides = {}) {
+  return {
+    id: "grant-existing",
+    subject: SUBJECT_WALLET,
+    capabilities: ["jobs:claim"],
+    issuedBy: ADMIN_WALLET,
+    issuedAt: "2026-05-22T00:00:00.000Z",
+    status: GRANT_STATUS.active,
+    ...overrides
+  };
+}
+
+function makeHarness(overrides = {}) {
+  const calls = [];
+  const response = {};
+  const payload = overrides.payload ?? {
+    subject: SUBJECT_WALLET,
+    capabilities: ["jobs:claim"],
+    issuedAt: "2026-05-22T00:00:00.000Z",
+    nonce: "unit-test",
+    idempotencyKey: "idem-1"
+  };
+  const storedGrants = new Map((overrides.grants ?? [activeGrant()]).map((grant) => [grant.id, grant]));
+  const route = createAdminCapabilityGrantRoutes({
+    assertIssuerCanGrantCapabilities: (grant, auth) => {
+      calls.push(["assertIssuer", { grant, auth }]);
+      const issuerCapabilities = new Set(auth.capabilities ?? []);
+      const missing = grant.capabilities.filter((capability) => !issuerCapabilities.has(capability));
+      if (missing.length) {
+        throw new AuthorizationError("Cannot grant capabilities the issuer token does not have.");
+      }
+    },
+    authMiddleware: async (_request, _url, options) => {
+      calls.push(["auth", options]);
+      return overrides.auth ?? AUTH;
+    },
+    buildMutationRequestHash: (input) => {
+      calls.push(["hash", input]);
+      return overrides.requestHash ?? "hash-1";
+    },
+    enforceLimit: async (bucket, key, limits) => {
+      calls.push(["limit", { bucket, key, limits }]);
+    },
+    eventBus: {
+      publish: (event) => calls.push(["publish", event])
+    },
+    getIdempotentMutationReplay: async (context) => {
+      calls.push(["replay", context]);
+      return overrides.replay ?? null;
+    },
+    parseIdempotencyKey: (input = {}) => {
+      calls.push(["parseIdempotencyKey", input]);
+      return typeof input?.idempotencyKey === "string" && input.idempotencyKey.trim()
+        ? input.idempotencyKey.trim()
+        : undefined;
+    },
+    parseLimit: (url, fallback, max) => {
+      calls.push(["parseLimit", { fallback, max }]);
+      return Number(url.searchParams.get("limit") ?? fallback);
+    },
+    rateLimitConfig: { adminJobs: { windowMs: 10_000, max: 5 } },
+    readJsonBody: async () => {
+      calls.push(["body"]);
+      if (overrides.bodyError) throw overrides.bodyError;
+      return payload;
+    },
+    respond: (res, statusCode, body) => {
+      calls.push(["respond", { statusCode, body }]);
+      res.statusCode = statusCode;
+      res.body = body;
+    },
+    stateStore: {
+      getCapabilityGrant: async (grantId) => {
+        calls.push(["getGrant", grantId]);
+        return storedGrants.get(grantId);
+      },
+      listCapabilityGrants: async (query) => {
+        calls.push(["listGrants", query]);
+        return [...storedGrants.values()];
+      },
+      upsertCapabilityGrant: async (grant) => {
+        calls.push(["upsertGrant", grant]);
+        storedGrants.set(grant.id, grant);
+      }
+    },
+    storeIdempotentMutationReceipt: async (receipt) => {
+      calls.push(["storeReceipt", receipt]);
+    },
+  });
+  return { calls, response, route };
+}
+
+test("admin capability grant routes ignore unrelated paths", async () => {
+  const { calls, response, route } = makeHarness();
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/admin/not-capabilities"),
+    pathname: "/admin/not-capabilities",
+  });
+
+  assert.equal(handled, false);
+  assert.deepEqual(calls, []);
+  assert.deepEqual(response, {});
+});
+
+test("GET /admin/capability-grants lists projected grants", async () => {
+  const { calls, response, route } = makeHarness();
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL(`http://localhost/admin/capability-grants?subject=${SUBJECT_WALLET.toUpperCase()}&status=ACTIVE&limit=2&offset=3`),
+    pathname: "/admin/capability-grants",
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.body, {
+    items: [activeGrant()],
+    limit: 2,
+    offset: 3
+  });
+  assert.deepEqual(calls.slice(0, 3), [
+    ["auth", { requireRole: "admin" }],
+    ["parseLimit", { fallback: 50, max: 200 }],
+    ["listGrants", {
+      subject: SUBJECT_WALLET,
+      status: "active",
+      limit: 2,
+      offset: 3
+    }]
+  ]);
+});
+
+test("POST /admin/capability-grants creates a grant with idempotency receipt and event", async () => {
+  const { calls, response, route } = makeHarness();
+
+  const handled = await route({
+    request: { method: "POST" },
+    response,
+    url: new URL("http://localhost/admin/capability-grants"),
+    pathname: "/admin/capability-grants",
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 201);
+  assert.equal(response.body.subject, SUBJECT_WALLET);
+  assert.deepEqual(response.body.capabilities, ["jobs:claim"]);
+  assert.equal(response.body.status, GRANT_STATUS.active);
+  assert.ok(response.body.id.startsWith("grant-"));
+  assert.deepEqual(calls.find(([name]) => name === "limit")?.[1], {
+    bucket: "admin_jobs",
+    key: ADMIN_WALLET,
+    limits: { windowMs: 10_000, max: 5 }
+  });
+  assert.deepEqual(calls.find(([name]) => name === "storeReceipt")?.[1], {
+    bucket: "capability_grant",
+    key: `${ADMIN_WALLET}:idem-1`,
+    requestHash: "hash-1",
+    response: response.body,
+    statusCode: 201
+  });
+  assert.equal(calls.find(([name]) => name === "publish")?.[1].topic, "capability.grant");
+});
+
+test("POST /admin/capability-grants returns idempotent replay before write side effects", async () => {
+  const replay = { statusCode: 201, body: { id: "grant-replay", replay: true } };
+  const { calls, response, route } = makeHarness({ replay });
+
+  const handled = await route({
+    request: { method: "POST" },
+    response,
+    url: new URL("http://localhost/admin/capability-grants"),
+    pathname: "/admin/capability-grants",
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 201);
+  assert.deepEqual(response.body, { id: "grant-replay", replay: true });
+  assert.ok(!calls.some(([name]) => name === "upsertGrant"));
+  assert.ok(!calls.some(([name]) => name === "publish"));
+});
+
+test("POST /admin/capability-grants/:id/revoke revokes a grant idempotently", async () => {
+  const { calls, response, route } = makeHarness({
+    payload: { note: "operator cleanup", idempotencyKey: "idem-revoke" }
+  });
+
+  const handled = await route({
+    request: { method: "POST" },
+    response,
+    url: new URL("http://localhost/admin/capability-grants/grant-existing/revoke"),
+    pathname: "/admin/capability-grants/grant-existing/revoke",
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.id, "grant-existing");
+  assert.equal(response.body.status, GRANT_STATUS.revoked);
+  assert.equal(response.body.revokedBy, ADMIN_WALLET);
+  assert.equal(response.body.revokeNote, "operator cleanup");
+  assert.deepEqual(calls.find(([name]) => name === "storeReceipt")?.[1], {
+    bucket: "capability_revoke",
+    key: `${ADMIN_WALLET}:grant-existing:idem-revoke`,
+    requestHash: "hash-1",
+    response: response.body,
+    statusCode: 200
+  });
+  assert.equal(calls.find(([name]) => name === "publish")?.[1].topic, "capability.revoke");
+});
+
+test("POST /admin/capability-grants/:id/revoke returns replay before reading grant", async () => {
+  const replay = { statusCode: 200, body: { id: "grant-existing", replay: true } };
+  const { calls, response, route } = makeHarness({
+    replay,
+    payload: { idempotencyKey: "idem-revoke" }
+  });
+
+  const handled = await route({
+    request: { method: "POST" },
+    response,
+    url: new URL("http://localhost/admin/capability-grants/grant-existing/revoke"),
+    pathname: "/admin/capability-grants/grant-existing/revoke",
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.body, { id: "grant-existing", replay: true });
+  assert.ok(!calls.some(([name]) => name === "getGrant"));
+  assert.ok(!calls.some(([name]) => name === "upsertGrant"));
+});
+
+test("POST /admin/capability-grants/:id/revoke rejects unknown grant ids", async () => {
+  const { calls, route } = makeHarness({
+    grants: [],
+    payload: { idempotencyKey: "idem-revoke" }
+  });
+
+  await assert.rejects(
+    () => route({
+      request: { method: "POST" },
+      response: {},
+      url: new URL("http://localhost/admin/capability-grants/missing/revoke"),
+      pathname: "/admin/capability-grants/missing/revoke",
+    }),
+    ValidationError
+  );
+  assert.ok(calls.some(([name]) => name === "getGrant"));
+  assert.ok(!calls.some(([name]) => name === "upsertGrant"));
+});

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -76,6 +76,7 @@ import {
   listBuiltinJobSchemas,
   schemaRefToJobSchemaPath
 } from "../../core/job-schema-registry.js";
+import { createAdminCapabilityGrantRoutes } from "./admin-capability-grant-routes.js";
 import { createAdminJobsRoutes } from "./admin-jobs-routes.js";
 import { createAdminStatusRoutes } from "./admin-status-routes.js";
 import { buildPublicJobsResponse } from "./jobs-response.js";
@@ -1420,6 +1421,22 @@ const handleAdminJobsRoute = createAdminJobsRoutes({
   respond,
   respondWithMutationReceipt,
   service,
+  storeIdempotentMutationReceipt,
+});
+
+const handleAdminCapabilityGrantRoute = createAdminCapabilityGrantRoutes({
+  assertIssuerCanGrantCapabilities,
+  authMiddleware,
+  buildMutationRequestHash,
+  enforceLimit,
+  eventBus,
+  getIdempotentMutationReplay,
+  parseIdempotencyKey,
+  parseLimit,
+  rateLimitConfig,
+  readJsonBody,
+  respond,
+  stateStore,
   storeIdempotentMutationReceipt,
 });
 
@@ -3395,77 +3412,8 @@ const server = createServer(async (request, response) => {
       return;
     }
 
-    /*
-     * Capability grants — operator-issued, scoped delegations of
-     * platform capabilities to a subject wallet (a service token,
-     * an automation bot, or a co-operator). Modelled after
-     * Polkadot's Staking Operator Proxy: a strict subset of the
-     * issuer's capabilities, no further delegation, revocable at
-     * any time. Roadmap §6.
-     */
-    if (request.method === "GET" && pathname === "/admin/capability-grants") {
-      await authMiddleware(request, url, { requireRole: "admin" });
-      const subject = (url.searchParams.get("subject") ?? "").trim().toLowerCase() || undefined;
-      const status = (url.searchParams.get("status") ?? "").trim().toLowerCase() || undefined;
-      const limit = parseLimit(url, 50, 200);
-      const offset = Math.max(0, Number(url.searchParams.get("offset") ?? 0) || 0);
-      const grants = (await stateStore.listCapabilityGrants?.({ subject, status, limit, offset })) ?? [];
-      return respond(response, 200, {
-        items: grants.map((grant) => projectGrant(grant)).filter(Boolean),
-        limit,
-        offset
-      });
-    }
-
-    if (request.method === "POST" && pathname === "/admin/capability-grants") {
-      const auth = await authMiddleware(request, url, { requireRole: "admin" });
-      await enforceLimit("admin_jobs", auth.wallet, rateLimitConfig.adminJobs);
-      const payload = await readJsonBody(request);
-      const idempotencyKey = parseIdempotencyKey(payload);
-      const mutationKey = idempotencyKey ? `${auth.wallet}:${idempotencyKey}` : undefined;
-      const requestHash = buildMutationRequestHash({
-        route: "/admin/capability-grants",
-        wallet: auth.wallet,
-        payload
-      });
-      const replay = await getIdempotentMutationReplay({
-        bucket: "capability_grant",
-        key: mutationKey,
-        requestHash
-      });
-      if (replay) {
-        return respond(response, replay.statusCode, replay.body);
-      }
-      const knownCapabilities = listAllKnownCapabilities();
-      const grant = buildCapabilityGrant(payload ?? {}, {
-        knownCapabilities,
-        issuerWallet: auth.wallet
-      });
-      assertIssuerCanGrantCapabilities(grant, auth);
-      await stateStore.upsertCapabilityGrant?.(grant);
-      authMiddleware.invalidateCapabilityGrantCache?.(grant.subject);
-      const projection = projectGrant(grant);
-      await storeIdempotentMutationReceipt({
-        bucket: "capability_grant",
-        key: mutationKey,
-        requestHash,
-        response: projection,
-        statusCode: 201
-      });
-      eventBus?.publish({
-        id: `capability-grant-${grant.id}-${Date.now()}`,
-        topic: "capability.grant",
-        wallet: auth.wallet,
-        wallets: [auth.wallet, grant.subject],
-        timestamp: new Date().toISOString(),
-        data: {
-          grantId: grant.id,
-          subject: grant.subject,
-          capabilities: grant.capabilities,
-          scope: grant.scope ?? null
-        }
-      });
-      return respond(response, 201, projection);
+    if (await handleAdminCapabilityGrantRoute({ request, response, url, pathname })) {
+      return;
     }
 
     if (request.method === "GET" && pathname === "/admin/service-tokens") {
@@ -3674,66 +3622,6 @@ const server = createServer(async (request, response) => {
         });
       }
       return respond(response, 200, body);
-    }
-
-    if (request.method === "POST" && pathname.startsWith("/admin/capability-grants/") && pathname.endsWith("/revoke")) {
-      const auth = await authMiddleware(request, url, { requireRole: "admin" });
-      await enforceLimit("admin_jobs", auth.wallet, rateLimitConfig.adminJobs);
-      const grantId = decodeURIComponent(pathname.slice("/admin/capability-grants/".length, -"/revoke".length));
-      if (!grantId) {
-        throw new ValidationError("grantId is required.");
-      }
-      const payload = (await readJsonBody(request).catch(() => undefined)) ?? {};
-      const idempotencyKey = parseIdempotencyKey(payload);
-      const mutationKey = idempotencyKey ? `${auth.wallet}:${grantId}:${idempotencyKey}` : undefined;
-      const requestHash = buildMutationRequestHash({
-        route: "/admin/capability-grants/:id/revoke",
-        wallet: auth.wallet,
-        payload: { grantId, ...payload }
-      });
-      const replay = await getIdempotentMutationReplay({
-        bucket: "capability_revoke",
-        key: mutationKey,
-        requestHash
-      });
-      if (replay) {
-        return respond(response, replay.statusCode, replay.body);
-      }
-      const current = await stateStore.getCapabilityGrant?.(grantId);
-      if (!current) {
-        throw new ValidationError("Unknown grant id.", { grantId });
-      }
-      const { record, alreadyRevoked } = applyRevocation(current, {
-        revokedBy: auth.wallet,
-        revokeNote: payload?.note
-      });
-      if (!alreadyRevoked) {
-        await stateStore.upsertCapabilityGrant?.(record);
-        authMiddleware.invalidateCapabilityGrantCache?.(record.subject);
-      }
-      const projection = projectGrant(record);
-      await storeIdempotentMutationReceipt({
-        bucket: "capability_revoke",
-        key: mutationKey,
-        requestHash,
-        response: projection,
-        statusCode: 200
-      });
-      if (!alreadyRevoked) {
-        eventBus?.publish({
-          id: `capability-revoke-${record.id}-${Date.now()}`,
-          topic: "capability.revoke",
-          wallet: auth.wallet,
-          wallets: [auth.wallet, record.subject],
-          timestamp: new Date().toISOString(),
-          data: {
-            grantId: record.id,
-            subject: record.subject,
-            revokedBy: record.revokedBy ?? auth.wallet
-          }
-        });
-      }
-      return respond(response, 200, projection);
     }
 
     if (request.method === "GET" && pathname === "/admin/github/status") {


### PR DESCRIPTION
## What changed
- Extracted the /admin/capability-grants list/create/revoke route group into mcp-server/src/protocols/http/admin-capability-grant-routes.js.
- Added focused route-level coverage for listing, creation, idempotent replay, revocation, and unknown grant handling.
- Added a roadmap-update fragment instead of editing docs/PROJECT_ROADMAP.md because PR #479 is already touching the same HTTP server route split row.

## Checks run
- node --test mcp-server/src/protocols/http/admin-capability-grant-routes.test.js
- RUN_HTTP_SMOKE=1 node --test --test-name-pattern "capability grant" mcp-server/src/protocols/http/server.smoke.test.js
- npm --workspace mcp-server test
- git diff --check

## Affected areas
- Backend: yes
- Frontend: no
- Indexer: no
- Caddy: no
- Contracts: no
- Public site: no

## Env / VPS changes
- None