### PR TITLE
backend: split admin github status route

### DIFF
--- a/docs/roadmap-updates/2026-05-22-codex-http-route-split-github-status.md
+++ b/docs/roadmap-updates/2026-05-22-codex-http-route-split-github-status.md
@@ -1,0 +1,28 @@
+# Roadmap Update: HTTP server route split (`P2.3`) GitHub status slice
+
+- **Date:** 2026-05-22
+- **Agent:** codex/admin-github-status-route-split
+- **Roadmap section:** P1 Product And Platform Hardening
+- **Item:** HTTP server route split (`P2.3`)
+- **Related PRs/issues:** current PR; overlaps active route-split PR #485
+- **Proposed status:** Open
+- **Owner:** roadmap steward
+
+## Summary
+
+This slice extracts the read-only `/admin/github/status` route from the monolithic HTTP server into `mcp-server/src/protocols/http/admin-github-routes.js` without changing admin auth, query parsing, or the service call shape. The canonical roadmap row should remain `Open` until the active route-split PRs merge and the steward consolidates the row.
+
+## Evidence
+
+- Added focused route tests in `mcp-server/src/protocols/http/admin-github-routes.test.js`.
+- `node --test mcp-server/src/protocols/http/admin-github-routes.test.js`
+- `npm --workspace mcp-server test`
+
+## Blockers Or Caveats
+
+- PR #485 is already touching the same roadmap row, so this PR intentionally avoids editing `docs/PROJECT_ROADMAP.md`.
+- This PR does not make new chain-readiness or Polkadot runtime claims; it only preserves and relocates existing HTTP route behavior.
+
+## Requested Roadmap Change
+
+After this PR and the overlapping route-split PRs are merged, update the `HTTP server route split (P2.3)` row to mention the GitHub operator status route slice and keep the item `Open` only if additional monolithic route groups remain.

--- a/mcp-server/src/protocols/http/admin-github-routes.js
+++ b/mcp-server/src/protocols/http/admin-github-routes.js
@@ -1,0 +1,20 @@
+export function createAdminGithubRoutes({
+  authMiddleware,
+  parseLimit,
+  respond,
+  service,
+}) {
+  return async function handleAdminGithubRoute({ request, response, url, pathname }) {
+    if (request.method === "GET" && pathname === "/admin/github/status") {
+      await authMiddleware(request, url, { requireRole: "admin" });
+      respond(response, 200, await service.getGithubOperatorStatus({
+        repos: url.searchParams.has("repos") ? url.searchParams.get("repos") : undefined,
+        limit: parseLimit(url, 5, 20),
+        view: url.searchParams.get("view") ?? undefined
+      }));
+      return true;
+    }
+
+    return false;
+  };
+}

--- a/mcp-server/src/protocols/http/admin-github-routes.test.js
+++ b/mcp-server/src/protocols/http/admin-github-routes.test.js
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createAdminGithubRoutes } from "./admin-github-routes.js";
+
+const AUTH = { wallet: "0xadmin", roles: ["admin"] };
+
+function makeHarness(overrides = {}) {
+  const calls = [];
+  const response = {};
+  const route = createAdminGithubRoutes({
+    authMiddleware: async (_request, _url, options) => {
+      calls.push(["auth", options]);
+      return overrides.auth ?? AUTH;
+    },
+    parseLimit: (url, fallback, max) => {
+      calls.push(["parseLimit", { fallback, max }]);
+      return Number(url.searchParams.get("limit") ?? fallback);
+    },
+    respond: (res, statusCode, body) => {
+      calls.push(["respond", { statusCode, body }]);
+      res.statusCode = statusCode;
+      res.body = body;
+    },
+    service: {
+      getGithubOperatorStatus: async (options) => {
+        calls.push(["getGithubOperatorStatus", options]);
+        return overrides.githubStatus ?? { ok: true, options };
+      },
+    },
+  });
+  return { calls, response, route };
+}
+
+test("admin GitHub routes ignore unrelated paths", async () => {
+  const { calls, response, route } = makeHarness();
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/admin/not-github/status"),
+    pathname: "/admin/not-github/status",
+  });
+
+  assert.equal(handled, false);
+  assert.deepEqual(calls, []);
+  assert.deepEqual(response, {});
+});
+
+test("GET /admin/github/status requires admin auth and returns helper status", async () => {
+  const { calls, response, route } = makeHarness();
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/admin/github/status"),
+    pathname: "/admin/github/status",
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.body, {
+    ok: true,
+    options: {
+      repos: undefined,
+      limit: 5,
+      view: undefined,
+    },
+  });
+  assert.deepEqual(calls, [
+    ["auth", { requireRole: "admin" }],
+    ["parseLimit", { fallback: 5, max: 20 }],
+    ["getGithubOperatorStatus", {
+      repos: undefined,
+      limit: 5,
+      view: undefined,
+    }],
+    ["respond", {
+      statusCode: 200,
+      body: {
+        ok: true,
+        options: {
+          repos: undefined,
+          limit: 5,
+          view: undefined,
+        },
+      },
+    }],
+  ]);
+});
+
+test("GET /admin/github/status preserves repos, limit, and view query handling", async () => {
+  const { calls, response, route } = makeHarness();
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/admin/github/status?repos=org/a,org/b&limit=17&view=prs"),
+    pathname: "/admin/github/status",
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(calls.slice(1, 3), [
+    ["parseLimit", { fallback: 5, max: 20 }],
+    ["getGithubOperatorStatus", {
+      repos: "org/a,org/b",
+      limit: 17,
+      view: "prs",
+    }],
+  ]);
+});
+
+test("GET /admin/github/status preserves explicitly empty query values", async () => {
+  const { calls, response, route } = makeHarness();
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/admin/github/status?repos=&view="),
+    pathname: "/admin/github/status",
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(calls.find(([name]) => name === "getGithubOperatorStatus"), [
+    "getGithubOperatorStatus",
+    {
+      repos: "",
+      limit: 5,
+      view: "",
+    },
+  ]);
+});

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -70,6 +70,7 @@ import {
   schemaRefToJobSchemaPath
 } from "../../core/job-schema-registry.js";
 import { createAdminCapabilityRoutes } from "./admin-capability-routes.js";
+import { createAdminGithubRoutes } from "./admin-github-routes.js";
 import { createAdminJobsRoutes } from "./admin-jobs-routes.js";
 import { createAdminStatusRoutes } from "./admin-status-routes.js";
 import { buildPublicJobsResponse } from "./jobs-response.js";
@@ -1430,6 +1431,13 @@ const handleAdminCapabilityRoute = createAdminCapabilityRoutes({
   respond,
   stateStore,
   storeIdempotentMutationReceipt,
+});
+
+const handleAdminGithubRoute = createAdminGithubRoutes({
+  authMiddleware,
+  parseLimit,
+  respond,
+  service,
 });
 
 function buildLaneAttention({ shares, isMock, debtTotal, borrowCapacity, deploymentShareBps }) {
@@ -3290,13 +3298,8 @@ const server = createServer(async (request, response) => {
       return;
     }
 
-    if (request.method === "GET" && pathname === "/admin/github/status") {
-      await authMiddleware(request, url, { requireRole: "admin" });
-      return respond(response, 200, await service.getGithubOperatorStatus({
-        repos: url.searchParams.has("repos") ? url.searchParams.get("repos") : undefined,
-        limit: parseLimit(url, 5, 20),
-        view: url.searchParams.get("view") ?? undefined
-      }));
+    if (await handleAdminGithubRoute({ request, response, url, pathname })) {
+      return;
     }
 
     if (request.method === "POST" && pathname === "/admin/xcm/observe") {


### PR DESCRIPTION
## Summary
- extract GET /admin/github/status into mcp-server/src/protocols/http/admin-github-routes.js
- preserve admin auth, repos/limit/view query handling, and getGithubOperatorStatus call shape
- add focused route-level coverage and a roadmap-update fragment for P2.3 coordination

## Checks
- node --test mcp-server/src/protocols/http/admin-github-routes.test.js
- npm --workspace mcp-server test
- git diff --check

## Impact
- Backend: yes, route organization only
- Frontend: no
- Indexer: no
- Caddy: no
- Contracts: no
- Public site: no

## Env / VPS
- No env or VPS secret changes required.