### PR TITLE
ops: add hardware MFA evidence validator

### DIFF
--- a/docs/PHASE_4E_PLAN.md
+++ b/docs/PHASE_4E_PLAN.md
@@ -146,6 +146,79 @@ out of each account, sign back in using the BACKUP key, confirm it
 works, sign out, sign back in with PRIMARY. If backup doesn't work,
 the enrollment is broken — fix before storing the keys.
 
+### Evidence artifact
+
+After enrollment, capture a sanitized evidence file and validate it
+before moving the roadmap item. The evidence file must say where the
+recovery material lives, but it must not contain recovery codes,
+private keys, JWTs, access keys, or provider tokens.
+
+Recommended path:
+
+```bash
+node scripts/ops/check-hardware-mfa-evidence.mjs \
+  --file docs/evidence/hardware-mfa-YYYY-MM-DD.json \
+  --json
+```
+
+Minimum shape:
+
+```json
+{
+  "schemaVersion": "hardware-mfa-evidence-v1",
+  "completedAt": "YYYY-MM-DDTHH:mm:ss.sssZ",
+  "operator": {
+    "name": "Pascal",
+    "signature": "PK"
+  },
+  "hardwareKeys": [
+    {
+      "label": "YK1-primary",
+      "serialFingerprint": "yk-primary-last4-or-hash",
+      "physicalCustodyConfirmed": true
+    },
+    {
+      "label": "YK2-backup-safe",
+      "serialFingerprint": "yk-backup-last4-or-hash",
+      "physicalCustodyConfirmed": true
+    }
+  ],
+  "accounts": [
+    {
+      "id": "one_password_admin",
+      "provider": "1Password",
+      "accountLabel": "Averray admin",
+      "status": "hardware_key_enrolled",
+      "primaryKeyLabel": "YK1-primary",
+      "backupKeyLabel": "YK2-backup-safe",
+      "backupKeyLoginTested": true,
+      "recoveryPathDocumented": true,
+      "recoveryCodesStored": true,
+      "recoveryLocation": "op://prod-critical/yubikey-recovery-runbook/notes",
+      "lastVerifiedAt": "YYYY-MM-DDTHH:mm:ss.sssZ",
+      "evidence": {
+        "method": "provider_ui",
+        "reference": "security settings inspected by operator"
+      }
+    }
+  ],
+  "recoveryRunbook": {
+    "location": "op://prod-critical/yubikey-recovery-runbook/notes",
+    "backupKeyTestedAcrossAllAccounts": true,
+    "noRawRecoveryCodesInEvidence": true
+  }
+}
+```
+
+The validator requires entries for `one_password_admin`, `aws_root`,
+`aws_iam_admins`, `github_org_admin`, `domain_registrar`, and
+`vps_provider`. For `aws_iam_admins`, include a `subjects` array with
+each human admin username and backup-key login test result. For
+GitHub it also requires member audit completion and org-wide 2FA
+enforcement. For the registrar it requires FIDO2 support; if the
+registrar cannot support FIDO2, migrate before mainnet instead of
+marking the evidence valid.
+
 ## 5. Adjacent mainnet-prep work
 
 Two items are mentioned in Phase 5 pre-flight that show up together

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -449,6 +449,10 @@ This checklist improves release discipline, but it does not replace:
 - the explicit mainnet launch profile in [MAINNET_PARAMETERS.md](./MAINNET_PARAMETERS.md)
 - a real, audited strategy adapter path instead of the mock vDOT adapter
 - explicit incident ownership and paging
+- hardware MFA across the admin trust chain. Evidence must be captured in
+  `docs/evidence/hardware-mfa-YYYY-MM-DD.json` and validated with
+  `node scripts/ops/check-hardware-mfa-evidence.mjs --file <path> --json`
+  before mainnet launch sign-off.
 
 Until those are done, treat the stack as production-like testnet, not
 irreversible real-funds infrastructure.

--- a/docs/roadmap-updates/2026-05-22-codex-hardware-mfa-proof.md
+++ b/docs/roadmap-updates/2026-05-22-codex-hardware-mfa-proof.md
@@ -1,0 +1,45 @@
+# Roadmap Update: Hardware MFA Admin Trust Chain
+
+- **Date:** 2026-05-22
+- **Agent:** codex/hardware-mfa-rc1-proof
+- **Roadmap section:** Auth, Secrets, And Capability Roadmap
+- **Item:** Hardware MFA for admin chain accounts
+- **Related PRs/issues:** current PR
+- **Proposed status:** Ready for proof
+- **Owner:** Pascal / roadmap steward
+
+## Summary
+
+This slice adds a machine-readable evidence validator for the Phase 4e hardware
+MFA gate. It does not claim the operator accounts are already enrolled. It makes
+the proof step explicit: every admin trust-chain account must have two hardware
+keys enrolled, backup-key login tested, recovery material stored elsewhere, and
+sanitized evidence committed before the item can move beyond Ready for proof.
+
+## Evidence
+
+- `scripts/ops/check-hardware-mfa-evidence.mjs` validates
+  `hardware-mfa-evidence-v1` JSON artifacts.
+- `scripts/ops/check-hardware-mfa-evidence.test.mjs` covers valid evidence,
+  missing trust-chain accounts, single-key evidence, GitHub org-2FA gaps,
+  registrar FIDO2 gaps, and secret-looking values accidentally pasted into the
+  evidence file.
+- `docs/PHASE_4E_PLAN.md` now names the evidence command and minimum JSON
+  shape.
+- `docs/PRODUCTION_CHECKLIST.md` now links hardware-MFA evidence validation as
+  a mainnet sign-off blocker.
+
+## Blockers Or Caveats
+
+- Operator enrollment still has to happen outside the repo.
+- Do not mark Proofed until a real `docs/evidence/hardware-mfa-YYYY-MM-DD.json`
+  artifact validates and the operator confirms recovery paths without storing
+  raw recovery codes in Git.
+
+## Requested Roadmap Change
+
+Move the hardware MFA bullet under `Auth, Secrets, And Capability Roadmap` from
+generic remaining work to `Ready for proof`, or add a P0/mainnet sign-off row
+with this close criterion:
+
+`node scripts/ops/check-hardware-mfa-evidence.mjs --file docs/evidence/hardware-mfa-YYYY-MM-DD.json --json` returns `status: ok` for a sanitized operator evidence artifact covering 1Password admin, AWS root, AWS IAM admins, GitHub org admin, domain registrar, and OVH/VPS provider.

--- a/scripts/ops/check-hardware-mfa-evidence.mjs
+++ b/scripts/ops/check-hardware-mfa-evidence.mjs
@@ -1,0 +1,317 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_NAME = basename(fileURLToPath(import.meta.url));
+export const SCHEMA_VERSION = "hardware-mfa-evidence-v1";
+
+const REQUIRED_ACCOUNT_IDS = [
+  "one_password_admin",
+  "aws_root",
+  "aws_iam_admins",
+  "github_org_admin",
+  "domain_registrar",
+  "vps_provider"
+];
+
+const ALLOWED_METHODS = new Set(["provider_ui", "provider_api", "operator_attestation"]);
+
+function usage() {
+  return `Usage: node scripts/ops/${SCRIPT_NAME} --file docs/evidence/hardware-mfa-YYYY-MM-DD.json [--json]
+
+Validates the operator evidence that hardware-backed MFA is enrolled across the
+admin trust chain. This check is read-only; it does not call providers or store
+recovery codes.
+`;
+}
+
+function parseArgs(argv) {
+  const args = {
+    file: undefined,
+    json: false,
+    help: false
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--file") {
+      args.file = argv[index + 1];
+      index += 1;
+    } else if (arg === "--json") {
+      args.json = true;
+    } else if (arg === "-h" || arg === "--help") {
+      args.help = true;
+    } else if (!args.file && !arg.startsWith("-")) {
+      args.file = arg;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function assertObject(value, path, errors) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    errors.push(`${path} must be an object`);
+    return {};
+  }
+  return value;
+}
+
+function requireString(value, path, errors, { pattern = undefined } = {}) {
+  if (typeof value !== "string" || !value.trim()) {
+    errors.push(`${path} must be a non-empty string`);
+    return "";
+  }
+  const trimmed = value.trim();
+  if (pattern && !pattern.test(trimmed)) {
+    errors.push(`${path} has an invalid format`);
+  }
+  return trimmed;
+}
+
+function requireBoolean(value, path, errors) {
+  if (typeof value !== "boolean") {
+    errors.push(`${path} must be boolean`);
+    return undefined;
+  }
+  return value;
+}
+
+function requireIsoDate(value, path, errors) {
+  const raw = requireString(value, path, errors);
+  if (!raw) return "";
+  if (!/^\d{4}-\d{2}-\d{2}T/u.test(raw) || !Number.isFinite(Date.parse(raw))) {
+    errors.push(`${path} must be an ISO-8601 date/time`);
+  }
+  return raw;
+}
+
+function requireNonEmptyArray(value, path, errors) {
+  if (!Array.isArray(value) || value.length === 0) {
+    errors.push(`${path} must be a non-empty array`);
+    return [];
+  }
+  return value;
+}
+
+function containsSecretLikeValue(value) {
+  if (typeof value !== "string") {
+    return false;
+  }
+  const trimmed = value.trim();
+  const patterns = [
+    /-----BEGIN [A-Z ]*PRIVATE KEY-----/u,
+    /\bAKIA[0-9A-Z]{16}\b/u,
+    /\bASIA[0-9A-Z]{16}\b/u,
+    /\beyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\b/u,
+    /\b0x[a-fA-F0-9]{64}\b/u,
+    /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/u,
+    /\bxox[baprs]-[A-Za-z0-9-]{20,}\b/u
+  ];
+  return patterns.some((pattern) => pattern.test(trimmed));
+}
+
+function scanForSecretLikeValues(value, path, errors) {
+  if (containsSecretLikeValue(value)) {
+    errors.push(`${path} appears to contain a secret value; store recovery material outside this evidence file`);
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => scanForSecretLikeValues(entry, `${path}[${index}]`, errors));
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const [key, entry] of Object.entries(value)) {
+      scanForSecretLikeValues(entry, `${path}.${key}`, errors);
+    }
+  }
+}
+
+function validateHardwareKeys(keys, errors) {
+  const items = requireNonEmptyArray(keys, "hardwareKeys", errors);
+  if (items.length < 2) {
+    errors.push("hardwareKeys must include at least two keys");
+  }
+  const labels = new Set();
+  for (const [index, rawKey] of items.entries()) {
+    const path = `hardwareKeys[${index}]`;
+    const key = assertObject(rawKey, path, errors);
+    const label = requireString(key.label, `${path}.label`, errors);
+    if (label) labels.add(label);
+    requireString(key.serialFingerprint, `${path}.serialFingerprint`, errors, {
+      pattern: /^[A-Za-z0-9._:-]{4,80}$/u
+    });
+    if (requireBoolean(key.physicalCustodyConfirmed, `${path}.physicalCustodyConfirmed`, errors) !== true) {
+      errors.push(`${path}.physicalCustodyConfirmed must be true`);
+    }
+  }
+  return labels;
+}
+
+function validateAccount(rawAccount, index, keyLabels, errors) {
+  const path = `accounts[${index}]`;
+  const account = assertObject(rawAccount, path, errors);
+  const id = requireString(account.id, `${path}.id`, errors);
+  requireString(account.provider, `${path}.provider`, errors);
+  requireString(account.accountLabel, `${path}.accountLabel`, errors);
+  if (account.status !== "hardware_key_enrolled") {
+    errors.push(`${path}.status must be hardware_key_enrolled`);
+  }
+  const primary = requireString(account.primaryKeyLabel, `${path}.primaryKeyLabel`, errors);
+  const backup = requireString(account.backupKeyLabel, `${path}.backupKeyLabel`, errors);
+  if (primary && !keyLabels.has(primary)) {
+    errors.push(`${path}.primaryKeyLabel must match a hardwareKeys[].label`);
+  }
+  if (backup && !keyLabels.has(backup)) {
+    errors.push(`${path}.backupKeyLabel must match a hardwareKeys[].label`);
+  }
+  if (primary && backup && primary === backup) {
+    errors.push(`${path}.primaryKeyLabel and ${path}.backupKeyLabel must be different`);
+  }
+  if (requireBoolean(account.backupKeyLoginTested, `${path}.backupKeyLoginTested`, errors) !== true) {
+    errors.push(`${path}.backupKeyLoginTested must be true`);
+  }
+  if (requireBoolean(account.recoveryPathDocumented, `${path}.recoveryPathDocumented`, errors) !== true) {
+    errors.push(`${path}.recoveryPathDocumented must be true`);
+  }
+  if (requireBoolean(account.recoveryCodesStored, `${path}.recoveryCodesStored`, errors) !== true) {
+    errors.push(`${path}.recoveryCodesStored must be true`);
+  }
+  requireString(account.recoveryLocation, `${path}.recoveryLocation`, errors);
+  requireIsoDate(account.lastVerifiedAt, `${path}.lastVerifiedAt`, errors);
+
+  const evidence = assertObject(account.evidence, `${path}.evidence`, errors);
+  const method = requireString(evidence.method, `${path}.evidence.method`, errors);
+  if (method && !ALLOWED_METHODS.has(method)) {
+    errors.push(`${path}.evidence.method must be provider_ui, provider_api, or operator_attestation`);
+  }
+  requireString(evidence.reference, `${path}.evidence.reference`, errors);
+
+  if (id === "domain_registrar") {
+    if (requireBoolean(account.fido2Supported, `${path}.fido2Supported`, errors) !== true) {
+      errors.push(`${path}.fido2Supported must be true; migrate registrar before mainnet if unavailable`);
+    }
+  }
+  if (id === "github_org_admin") {
+    if (requireBoolean(account.memberAuditCompleted, `${path}.memberAuditCompleted`, errors) !== true) {
+      errors.push(`${path}.memberAuditCompleted must be true before org-wide 2FA enforcement`);
+    }
+    if (requireBoolean(account.orgTwoFactorRequirementEnabled, `${path}.orgTwoFactorRequirementEnabled`, errors) !== true) {
+      errors.push(`${path}.orgTwoFactorRequirementEnabled must be true`);
+    }
+  }
+  if (id === "aws_iam_admins") {
+    const subjects = requireNonEmptyArray(account.subjects, `${path}.subjects`, errors);
+    for (const [subjectIndex, rawSubject] of subjects.entries()) {
+      const subjectPath = `${path}.subjects[${subjectIndex}]`;
+      const subject = assertObject(rawSubject, subjectPath, errors);
+      requireString(subject.username, `${subjectPath}.username`, errors);
+      if (requireBoolean(subject.hardwareKeyEnrolled, `${subjectPath}.hardwareKeyEnrolled`, errors) !== true) {
+        errors.push(`${subjectPath}.hardwareKeyEnrolled must be true`);
+      }
+      if (requireBoolean(subject.backupKeyLoginTested, `${subjectPath}.backupKeyLoginTested`, errors) !== true) {
+        errors.push(`${subjectPath}.backupKeyLoginTested must be true`);
+      }
+    }
+  }
+  return id;
+}
+
+export function validateEvidence(evidence) {
+  const errors = [];
+  const doc = assertObject(evidence, "evidence", errors);
+
+  if (doc.schemaVersion !== SCHEMA_VERSION) {
+    errors.push(`schemaVersion must be ${SCHEMA_VERSION}`);
+  }
+  requireIsoDate(doc.completedAt, "completedAt", errors);
+
+  const operator = assertObject(doc.operator, "operator", errors);
+  requireString(operator.name, "operator.name", errors);
+  requireString(operator.signature, "operator.signature", errors);
+
+  const keyLabels = validateHardwareKeys(doc.hardwareKeys, errors);
+  const accounts = requireNonEmptyArray(doc.accounts, "accounts", errors);
+  const seenAccountIds = new Set();
+  accounts.forEach((account, index) => {
+    const id = validateAccount(account, index, keyLabels, errors);
+    if (id) {
+      if (seenAccountIds.has(id)) {
+        errors.push(`accounts must not contain duplicate id ${id}`);
+      }
+      seenAccountIds.add(id);
+    }
+  });
+
+  for (const accountId of REQUIRED_ACCOUNT_IDS) {
+    if (!seenAccountIds.has(accountId)) {
+      errors.push(`accounts must include ${accountId}`);
+    }
+  }
+
+  const recovery = assertObject(doc.recoveryRunbook, "recoveryRunbook", errors);
+  requireString(recovery.location, "recoveryRunbook.location", errors);
+  if (requireBoolean(recovery.backupKeyTestedAcrossAllAccounts, "recoveryRunbook.backupKeyTestedAcrossAllAccounts", errors) !== true) {
+    errors.push("recoveryRunbook.backupKeyTestedAcrossAllAccounts must be true");
+  }
+  if (requireBoolean(recovery.noRawRecoveryCodesInEvidence, "recoveryRunbook.noRawRecoveryCodesInEvidence", errors) !== true) {
+    errors.push("recoveryRunbook.noRawRecoveryCodesInEvidence must be true");
+  }
+
+  scanForSecretLikeValues(doc, "evidence", errors);
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    summary: {
+      completedAt: doc.completedAt,
+      operator: operator.name,
+      hardwareKeyCount: Array.isArray(doc.hardwareKeys) ? doc.hardwareKeys.length : 0,
+      accountCount: Array.isArray(doc.accounts) ? doc.accounts.length : 0,
+      accounts: Array.isArray(doc.accounts)
+        ? doc.accounts.map((account) => account?.id).filter(Boolean)
+        : []
+    }
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(usage());
+    return;
+  }
+  if (!args.file) {
+    throw new Error("--file is required");
+  }
+  const raw = await readFile(args.file, "utf8");
+  const parsed = JSON.parse(raw);
+  const result = validateEvidence(parsed);
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify({
+      status: result.ok ? "ok" : "not_ok",
+      file: args.file,
+      summary: result.summary,
+      errors: result.errors
+    }, null, 2)}\n`);
+  } else if (result.ok) {
+    process.stdout.write(`Hardware MFA evidence ok: ${args.file}\n`);
+  } else {
+    process.stderr.write(`Hardware MFA evidence invalid: ${args.file}\n`);
+    for (const error of result.errors) {
+      process.stderr.write(`- ${error}\n`);
+    }
+  }
+  if (!result.ok) {
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ops/check-hardware-mfa-evidence.test.mjs
+++ b/scripts/ops/check-hardware-mfa-evidence.test.mjs
@@ -1,0 +1,246 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { execFile } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { SCHEMA_VERSION, validateEvidence } from "./check-hardware-mfa-evidence.mjs";
+
+const execFileAsync = promisify(execFile);
+const scriptPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "check-hardware-mfa-evidence.mjs"
+);
+
+function account(id, overrides = {}) {
+  const base = {
+    id,
+    provider: id.replaceAll("_", " "),
+    accountLabel: `${id} admin`,
+    status: "hardware_key_enrolled",
+    primaryKeyLabel: "YK1-primary",
+    backupKeyLabel: "YK2-backup-safe",
+    backupKeyLoginTested: true,
+    recoveryPathDocumented: true,
+    recoveryCodesStored: true,
+    recoveryLocation: "op://prod-critical/yubikey-recovery-runbook/notes",
+    lastVerifiedAt: "2026-05-22T12:30:00.000Z",
+    evidence: {
+      method: "operator_attestation",
+      reference: `${id} security settings inspected by operator`
+    }
+  };
+  if (id === "domain_registrar") {
+    base.fido2Supported = true;
+  }
+  if (id === "github_org_admin") {
+    base.memberAuditCompleted = true;
+    base.orgTwoFactorRequirementEnabled = true;
+  }
+  if (id === "aws_iam_admins") {
+    base.subjects = [
+      {
+        username: "pkuriger",
+        hardwareKeyEnrolled: true,
+        backupKeyLoginTested: true
+      }
+    ];
+  }
+  return {
+    ...base,
+    ...overrides
+  };
+}
+
+function validEvidence(overrides = {}) {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    completedAt: "2026-05-22T13:00:00.000Z",
+    operator: {
+      name: "Pascal",
+      signature: "PK"
+    },
+    hardwareKeys: [
+      {
+        label: "YK1-primary",
+        serialFingerprint: "yk-primary-1234",
+        physicalCustodyConfirmed: true
+      },
+      {
+        label: "YK2-backup-safe",
+        serialFingerprint: "yk-backup-5678",
+        physicalCustodyConfirmed: true
+      }
+    ],
+    accounts: [
+      account("one_password_admin"),
+      account("aws_root"),
+      account("aws_iam_admins"),
+      account("github_org_admin"),
+      account("domain_registrar"),
+      account("vps_provider")
+    ],
+    recoveryRunbook: {
+      location: "op://prod-critical/yubikey-recovery-runbook/notes",
+      backupKeyTestedAcrossAllAccounts: true,
+      noRawRecoveryCodesInEvidence: true
+    },
+    ...overrides
+  };
+}
+
+async function writeEvidenceFile(doc) {
+  const dir = await mkdtemp(join(tmpdir(), "hardware-mfa-evidence-"));
+  const file = join(dir, "evidence.json");
+  await writeFile(file, JSON.stringify(doc, null, 2), "utf8");
+  return file;
+}
+
+test("validateEvidence accepts complete hardware MFA evidence", () => {
+  const result = validateEvidence(validEvidence());
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.summary.hardwareKeyCount, 2);
+  assert.equal(result.summary.accountCount, 6);
+});
+
+test("validateEvidence rejects missing trust-chain accounts", () => {
+  const doc = validEvidence({
+    accounts: validEvidence().accounts.filter((entry) => entry.id !== "domain_registrar")
+  });
+  const result = validateEvidence(doc);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.includes("accounts must include domain_registrar"));
+});
+
+test("validateEvidence rejects duplicate trust-chain accounts", () => {
+  const doc = validEvidence({
+    accounts: [
+      account("one_password_admin"),
+      account("one_password_admin"),
+      account("aws_root"),
+      account("aws_iam_admins"),
+      account("github_org_admin"),
+      account("domain_registrar"),
+      account("vps_provider")
+    ]
+  });
+  const result = validateEvidence(doc);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.includes("accounts must not contain duplicate id one_password_admin"));
+});
+
+test("validateEvidence rejects single-key or untested backup-key evidence", () => {
+  const doc = validEvidence({
+    hardwareKeys: [validEvidence().hardwareKeys[0]],
+    accounts: [
+      account("one_password_admin", {
+        backupKeyLabel: "YK1-primary",
+        backupKeyLoginTested: false
+      }),
+      account("aws_root"),
+      account("aws_iam_admins"),
+      account("github_org_admin"),
+      account("domain_registrar"),
+      account("vps_provider")
+    ]
+  });
+  const result = validateEvidence(doc);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.includes("hardwareKeys must include at least two keys"));
+  assert.ok(result.errors.includes("accounts[0].primaryKeyLabel and accounts[0].backupKeyLabel must be different"));
+  assert.ok(result.errors.includes("accounts[0].backupKeyLoginTested must be true"));
+});
+
+test("validateEvidence rejects GitHub and registrar safety gaps", () => {
+  const doc = validEvidence({
+    accounts: [
+      account("one_password_admin"),
+      account("aws_root"),
+      account("aws_iam_admins"),
+      account("github_org_admin", {
+        memberAuditCompleted: false,
+        orgTwoFactorRequirementEnabled: false
+      }),
+      account("domain_registrar", {
+        fido2Supported: false
+      }),
+      account("vps_provider")
+    ]
+  });
+  const result = validateEvidence(doc);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.includes("accounts[3].memberAuditCompleted must be true before org-wide 2FA enforcement"));
+  assert.ok(result.errors.includes("accounts[3].orgTwoFactorRequirementEnabled must be true"));
+  assert.ok(result.errors.includes("accounts[4].fido2Supported must be true; migrate registrar before mainnet if unavailable"));
+});
+
+test("validateEvidence rejects IAM admin users without tested backup-key login", () => {
+  const doc = validEvidence({
+    accounts: [
+      account("one_password_admin"),
+      account("aws_root"),
+      account("aws_iam_admins", {
+        subjects: [
+          {
+            username: "pkuriger",
+            hardwareKeyEnrolled: true,
+            backupKeyLoginTested: false
+          }
+        ]
+      }),
+      account("github_org_admin"),
+      account("domain_registrar"),
+      account("vps_provider")
+    ]
+  });
+  const result = validateEvidence(doc);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.includes("accounts[2].subjects[0].backupKeyLoginTested must be true"));
+});
+
+test("validateEvidence rejects raw secret-looking values", () => {
+  const doc = validEvidence({
+    recoveryRunbook: {
+      ...validEvidence().recoveryRunbook,
+      accidentalSecret: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  });
+  const result = validateEvidence(doc);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((error) => error.includes("appears to contain a secret value")));
+});
+
+test("CLI exits zero and prints JSON for valid evidence", async () => {
+  const file = await writeEvidenceFile(validEvidence());
+  const { stdout } = await execFileAsync(process.execPath, [scriptPath, "--file", file, "--json"]);
+  const parsed = JSON.parse(stdout);
+  assert.equal(parsed.status, "ok");
+  assert.equal(parsed.summary.operator, "Pascal");
+});
+
+test("CLI exits non-zero for invalid evidence", async () => {
+  const file = await writeEvidenceFile(validEvidence({
+    accounts: [
+      account("one_password_admin", {
+        status: "totp_only"
+      }),
+      account("aws_root"),
+      account("aws_iam_admins"),
+      account("github_org_admin"),
+      account("domain_registrar"),
+      account("vps_provider")
+    ]
+  }));
+  await assert.rejects(
+    () => execFileAsync(process.execPath, [scriptPath, "--file", file]),
+    (error) => {
+      assert.notEqual(error.code, 0);
+      assert.match(error.stderr, /accounts\[0\]\.status must be hardware_key_enrolled/u);
+      return true;
+    }
+  );
+});


### PR DESCRIPTION
## What changed
- Added `scripts/ops/check-hardware-mfa-evidence.mjs` to validate sanitized `hardware-mfa-evidence-v1` operator artifacts.
- Added focused ops tests for complete evidence, missing/duplicate trust-chain accounts, single-key evidence, GitHub org-2FA gaps, registrar FIDO2 gaps, IAM admin backup-key testing, and secret-looking values.
- Updated `docs/PHASE_4E_PLAN.md` and `docs/PRODUCTION_CHECKLIST.md` with the validation command and mainnet sign-off hook.
- Added a roadmap-update fragment instead of editing the canonical roadmap directly.

## Checks run
- `node --test scripts/ops/check-hardware-mfa-evidence.test.mjs`
- `npm run test:ops`
- `git diff --check HEAD~1..HEAD`

## Impact
- Backend: no runtime API impact
- Frontend: no
- Indexer: no
- Caddy: no
- Contracts: no
- Public site: no
- Ops/docs: yes

## Env / VPS changes
- None.

## Roadmap
- Adds `docs/roadmap-updates/2026-05-22-codex-hardware-mfa-proof.md` for the `Hardware MFA for admin chain accounts` item.
- Does not mark the item Proofed; operator enrollment and a real `docs/evidence/hardware-mfa-YYYY-MM-DD.json` artifact are still required.
