### PR TITLE
backend: split profile routes

### DIFF
--- a/docs/roadmap-updates/2026-05-23-codex-profile-route-split.md
+++ b/docs/roadmap-updates/2026-05-23-codex-profile-route-split.md
@@ -1,0 +1,31 @@
+# Roadmap Update: HTTP server route split (`P2.3`)
+
+- **Date:** 2026-05-23
+- **Agent:** Codex / `codex/profile-route-split`
+- **Roadmap section:** P1 Product And Platform Hardening
+- **Item:** HTTP server route split (`P2.3`)
+- **Related PRs/issues:** pending PR for `codex/profile-route-split`
+- **Proposed status:** Open
+- **Owner:** Roadmap steward
+
+## Summary
+
+This implementing slice extracts the profile, agent-directory, and reputation read routes from `mcp-server/src/protocols/http/server.js` into `mcp-server/src/protocols/http/profile-routes.js`. Badge routes stay with the dedicated `badge-routes.js` slice that landed first.
+
+## Evidence
+
+- Focused tests added in `mcp-server/src/protocols/http/profile-routes.test.js`.
+- Route coverage includes `/agents`, `/agents/:wallet`, and `/reputation`, plus a guard that badge paths are left to the badge route module.
+- Canonical roadmap row was not edited because PR `#493` was already editing the same `P2.3` row when this slice started, and draft PR `#494` is editing the same roadmap section.
+
+## Blockers Or Caveats
+
+- `P2.3` remains Open; this is one narrow route-split slice, not the full `server.js` refactor.
+
+## Requested Roadmap Change
+
+After this PR lands, append this evidence to the `HTTP server route split (P2.3)` row:
+
+```text
+Tenth slice extracted `/agents`, `/agents/:wallet`, and `/reputation` into `mcp-server/src/protocols/http/profile-routes.js` with tests covering public cache headers, wallet validation, request-logger profile context, authenticated reputation reads, and routing separation from the dedicated badge module.
+```

--- a/mcp-server/src/protocols/http/profile-routes.js
+++ b/mcp-server/src/protocols/http/profile-routes.js
@@ -1,0 +1,235 @@
+import { getAddress } from "ethers";
+
+import { buildAgentProfile } from "../../core/agent-profile.js";
+import { disputeIdForSession } from "../../core/dispute-resolution.js";
+import { ValidationError } from "../../core/errors.js";
+
+const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/u;
+
+function safeChecksum(raw) {
+  try {
+    return getAddress(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function profileTierToOperatorTier(reputation = {}) {
+  const skill = Number(reputation.skill ?? 0);
+  if (skill >= 300) return "master";
+  if (reputation.tier === "elite" || skill >= 200) return "expert";
+  if (reputation.tier === "pro" || skill >= 100) return "journeyman";
+  return "apprentice";
+}
+
+function handleForWallet(wallet) {
+  const normalized = String(wallet ?? "").toLowerCase();
+  return `agent-${normalized.slice(2, 6)}-${normalized.slice(-4)}`;
+}
+
+function buildAgentDirectoryRow(profile) {
+  const reputation = profile.reputation ?? {};
+  const approvedCount = Number(profile.stats?.approvedCount ?? 0);
+  const rejectedCount = Number(profile.stats?.rejectedCount ?? 0);
+  const totalJobs = approvedCount + rejectedCount;
+  const slashEvents = (profile.disputes ?? [])
+    .filter((dispute) => dispute.verdict === "upheld")
+    .map((dispute) => ({
+      disputeId: dispute.id ?? null,
+      jobId: dispute.jobId,
+      sessionId: dispute.sessionId,
+      reasonCode: dispute.reasonCode ?? null,
+      txHash: dispute.txHash ?? null,
+      at: dispute.openedAt,
+    }));
+  return {
+    wallet: profile.wallet,
+    handle: handleForWallet(profile.wallet),
+    tier: profileTierToOperatorTier(reputation),
+    reputationScore:
+      Number(reputation.skill ?? 0) +
+      Number(reputation.reliability ?? 0) +
+      Number(reputation.economic ?? 0),
+    successRate: profile.stats?.completionRate ?? null,
+    totalJobs,
+    currentActivity: profile.currentActivity ?? null,
+    activeStake: 0,
+    badges: profile.badges ?? [],
+    slashEvents,
+  };
+}
+
+export function createProfileRoutes({
+  authMiddleware,
+  env = process.env,
+  logger,
+  parseLimit,
+  respond,
+  service,
+  stateStore,
+}) {
+  async function preloadDisputeReceipts(sessions) {
+    if (!Array.isArray(sessions) || sessions.length === 0) {
+      return () => undefined;
+    }
+    const candidates = sessions.filter((session) => {
+      if (!session || typeof session !== "object") return false;
+      const status = String(session.status ?? "").toLowerCase();
+      return status === "disputed" || Boolean(session.disputedAt);
+    });
+    if (candidates.length === 0) return () => undefined;
+    const receiptsBySession = new Map();
+    await Promise.all(
+      candidates.map(async (session) => {
+        const id = disputeIdForSession(session.sessionId);
+        const [verdict, release] = await Promise.all([
+          stateStore.getMutationReceipt?.("dispute_verdict", id),
+          stateStore.getMutationReceipt?.("dispute_release", id),
+        ]);
+        if (verdict || release) {
+          receiptsBySession.set(session.sessionId, {
+            ...(verdict ? { verdict } : {}),
+            ...(release ? { release } : {}),
+          });
+        } else {
+          receiptsBySession.set(session.sessionId, {});
+        }
+      })
+    );
+    return (sessionId) => receiptsBySession.get(sessionId);
+  }
+
+  function preloadLineage(sessions) {
+    if (!Array.isArray(sessions) || sessions.length === 0) {
+      return () => undefined;
+    }
+    const lookup = new Map();
+    for (const session of sessions) {
+      if (!session || typeof session !== "object") continue;
+      const sessionId = String(session.sessionId ?? "");
+      if (!sessionId) continue;
+
+      const entry = {};
+      let job;
+      try {
+        job = service.getJobDefinition(session.jobId);
+      } catch {
+        job = undefined;
+      }
+      if (job?.parentSessionId) {
+        const parent = {
+          sessionId: String(job.parentSessionId),
+          ...(job.lineage?.parentJobId ? { jobId: String(job.lineage.parentJobId) } : {}),
+          ...(typeof job.lineage?.parentWallet === "string"
+            ? { wallet: job.lineage.parentWallet }
+            : {})
+        };
+        if (Object.keys(parent).length > 0) entry.parent = parent;
+      }
+      let childJobs;
+      try {
+        childJobs = service.listChildJobsByParentSession?.(sessionId) ?? [];
+      } catch {
+        childJobs = [];
+      }
+      if (childJobs.length > 0) {
+        entry.children = childJobs.map((childJob) => ({
+          jobId: String(childJob.id ?? ""),
+          ...(typeof childJob.lineage?.parentWallet === "string"
+            ? { parentWallet: childJob.lineage.parentWallet }
+            : {})
+        })).filter((child) => child.jobId);
+      }
+
+      if (entry.parent || (entry.children && entry.children.length > 0)) {
+        lookup.set(sessionId, entry);
+      }
+    }
+    if (lookup.size === 0) return () => undefined;
+    return (sessionId) => lookup.get(sessionId);
+  }
+
+  async function buildAgentDirectory(limit = 50) {
+    const sessions = await service.listRecentSessions(limit);
+    const wallets = [...new Set(sessions.map((session) => session.wallet).filter(Boolean))];
+    const rows = await Promise.all(wallets.map(async (wallet) => {
+      const checksummed = safeChecksum(wallet);
+      const [reputation, history] = await Promise.all([
+        service.getReputation(checksummed),
+        service.collectSessionHistory(checksummed, { logger })
+      ]);
+      const getDisputeReceipts = await preloadDisputeReceipts(history);
+      const getLineage = preloadLineage(history);
+      const profile = buildAgentProfile({
+        wallet: wallet.toLowerCase(),
+        reputation,
+        sessions: history,
+        getJobDefinition: (jobId) => {
+          try {
+            return service.getJobDefinition(jobId);
+          } catch {
+            return undefined;
+          }
+        },
+        publicBaseUrl: env.PUBLIC_BASE_URL,
+        getDisputeReceipts,
+        getLineage,
+      });
+      return buildAgentDirectoryRow(profile);
+    }));
+    return rows.sort((left, right) => {
+      if (right.reputationScore !== left.reputationScore) {
+        return right.reputationScore - left.reputationScore;
+      }
+      return String(left.wallet).localeCompare(String(right.wallet));
+    });
+  }
+
+  return async function handleProfileRoute({ request, response, url, pathname, requestLogger }) {
+    if (request.method === "GET" && pathname === "/agents") {
+      respond(response, 200, await buildAgentDirectory(parseLimit(url, 50, 250)), {
+        "cache-control": "public, max-age=30"
+      });
+      return true;
+    }
+
+    if (request.method === "GET" && pathname.startsWith("/agents/")) {
+      const rawWallet = decodeURIComponent(pathname.slice("/agents/".length));
+      if (!ADDRESS_RE.test(rawWallet)) {
+        throw new ValidationError("wallet path segment must be a 0x-prefixed 20-byte hex address.");
+      }
+      const checksummed = safeChecksum(rawWallet);
+      const [reputation, sessions] = await Promise.all([
+        service.getReputation(checksummed),
+        service.collectSessionHistory(checksummed, { logger: requestLogger })
+      ]);
+      const getDisputeReceipts = await preloadDisputeReceipts(sessions);
+      const getLineage = preloadLineage(sessions);
+      const profile = buildAgentProfile({
+        wallet: rawWallet.toLowerCase(),
+        reputation,
+        sessions,
+        getJobDefinition: (jobId) => {
+          try {
+            return service.getJobDefinition(jobId);
+          } catch {
+            return undefined;
+          }
+        },
+        publicBaseUrl: env.PUBLIC_BASE_URL,
+        getDisputeReceipts,
+        getLineage,
+      });
+      respond(response, 200, profile, { "cache-control": "public, max-age=30" });
+      return true;
+    }
+
+    if (request.method === "GET" && pathname === "/reputation") {
+      const auth = await authMiddleware(request, url);
+      respond(response, 200, await service.getReputation(auth.wallet));
+      return true;
+    }
+
+    return false;
+  };
+}

--- a/mcp-server/src/protocols/http/profile-routes.test.js
+++ b/mcp-server/src/protocols/http/profile-routes.test.js
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ValidationError } from "../../core/errors.js";
+import { createProfileRoutes } from "./profile-routes.js";
+
+const WALLET = "0x1234567890123456789012345678901234567890";
+const OTHER_WALLET = "0x2222222222222222222222222222222222222222";
+const ROOT_LOGGER = { name: "root" };
+const REQUEST_LOGGER = { name: "request" };
+
+function sessionFixture(overrides = {}) {
+  return {
+    sessionId: "session-1",
+    wallet: WALLET,
+    jobId: "starter-coding-001",
+    chainJobId: "0xa57b4a1f00000000000000000000000000000000000000000000000000000000",
+    claimStake: 0.25,
+    claimStakeBps: 500,
+    status: "resolved",
+    verification: { outcome: "approved", reasonCode: "OK" },
+    protocolHistory: ["http"],
+    updatedAt: "2026-04-16T14:30:00.000Z",
+    ...overrides
+  };
+}
+
+function jobFixture(overrides = {}) {
+  return {
+    id: "starter-coding-001",
+    category: "coding",
+    tier: "starter",
+    rewardAsset: "DOT",
+    rewardAmount: 5,
+    verifierMode: "benchmark",
+    ...overrides
+  };
+}
+
+function makeHarness(overrides = {}) {
+  const calls = [];
+  const response = {};
+  const sessions = overrides.sessions ?? [sessionFixture()];
+  const history = overrides.history ?? sessions;
+  const job = overrides.job ?? jobFixture();
+  const route = createProfileRoutes({
+    authMiddleware: async (_request, _url) => {
+      calls.push(["auth"]);
+      return overrides.auth ?? { wallet: WALLET, roles: ["agent"] };
+    },
+    env: {
+      PUBLIC_BASE_URL: "https://api.averray.test",
+      ...overrides.env
+    },
+    logger: ROOT_LOGGER,
+    parseLimit: (url, fallback, max) => {
+      const raw = Number(url.searchParams.get("limit") ?? fallback);
+      const limit = !Number.isFinite(raw) || raw <= 0 ? fallback : Math.min(Math.trunc(raw), max);
+      calls.push(["parseLimit", { fallback, max, limit }]);
+      return limit;
+    },
+    respond: (res, statusCode, body, headers = {}) => {
+      calls.push(["respond", { statusCode, body, headers }]);
+      res.statusCode = statusCode;
+      res.body = body;
+      res.headers = headers;
+    },
+    service: {
+      listRecentSessions: async (limit) => {
+        calls.push(["listRecentSessions", limit]);
+        return sessions;
+      },
+      getReputation: async (wallet) => {
+        calls.push(["getReputation", wallet]);
+        return overrides.reputation ?? { skill: 220, reliability: 30, economic: 10, tier: "pro" };
+      },
+      collectSessionHistory: async (wallet, options = {}) => {
+        calls.push(["collectSessionHistory", { wallet, logger: options.logger }]);
+        return history;
+      },
+      getJobDefinition: (jobId) => {
+        calls.push(["getJobDefinition", jobId]);
+        if (overrides.jobError) {
+          throw overrides.jobError;
+        }
+        return job;
+      },
+      listChildJobsByParentSession: (sessionId) => {
+        calls.push(["listChildJobsByParentSession", sessionId]);
+        return overrides.childJobs ?? [];
+      },
+    },
+    stateStore: {
+      getMutationReceipt: async (bucket, id) => {
+        calls.push(["getMutationReceipt", { bucket, id }]);
+        return undefined;
+      }
+    },
+  });
+  return { calls, response, route };
+}
+
+test("profile routes ignore unrelated paths", async () => {
+  const { calls, response, route } = makeHarness();
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/not-profile"),
+    pathname: "/not-profile",
+  });
+
+  assert.equal(handled, false);
+  assert.deepEqual(calls, []);
+  assert.deepEqual(response, {});
+});
+
+test("profile routes leave badge paths to the badge route module", async () => {
+  const { calls, response, route } = makeHarness();
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/badges/session-1"),
+    pathname: "/badges/session-1",
+  });
+
+  assert.equal(handled, false);
+  assert.deepEqual(calls, []);
+  assert.deepEqual(response, {});
+});
+
+test("GET /reputation authenticates and returns wallet reputation", async () => {
+  const { calls, response, route } = makeHarness();
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/reputation"),
+    pathname: "/reputation",
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.body, { skill: 220, reliability: 30, economic: 10, tier: "pro" });
+  assert.deepEqual(calls.slice(0, 2), [
+    ["auth"],
+    ["getReputation", WALLET]
+  ]);
+});
+
+test("GET /agents returns a cached public directory", async () => {
+  const { response, route } = makeHarness({
+    sessions: [sessionFixture({ wallet: WALLET }), sessionFixture({ wallet: WALLET, sessionId: "session-2" })],
+  });
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/agents?limit=5"),
+    pathname: "/agents",
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.headers, { "cache-control": "public, max-age=30" });
+  assert.equal(response.body.length, 1);
+  assert.equal(response.body[0].wallet, WALLET);
+  assert.equal(response.body[0].handle, "agent-1234-7890");
+  assert.equal(response.body[0].tier, "expert");
+});
+
+test("GET /agents/:wallet validates wallet path", async () => {
+  const { route } = makeHarness();
+
+  await assert.rejects(
+    route({
+      request: { method: "GET" },
+      response: {},
+      url: new URL("http://localhost/agents/not-a-wallet"),
+      pathname: "/agents/not-a-wallet",
+    }),
+    (error) => error instanceof ValidationError && /wallet path segment/.test(error.message)
+  );
+});
+
+test("GET /agents/:wallet builds a public profile with request logger context", async () => {
+  const { calls, response, route } = makeHarness({
+    history: [sessionFixture({ wallet: OTHER_WALLET, sessionId: "session-2" })],
+  });
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL(`http://localhost/agents/${OTHER_WALLET}`),
+    pathname: `/agents/${OTHER_WALLET}`,
+    requestLogger: REQUEST_LOGGER,
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.wallet, OTHER_WALLET);
+  assert.deepEqual(response.headers, { "cache-control": "public, max-age=30" });
+  assert(calls.some((call) => (
+    call[0] === "collectSessionHistory" &&
+    call[1].wallet === OTHER_WALLET &&
+    call[1].logger === REQUEST_LOGGER
+  )));
+});

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -40,7 +40,6 @@ import { hasRole } from "../../auth/config.js";
 import { resolveRequestId } from "../../core/logger.js";
 import { getAddress, keccak256, toUtf8Bytes } from "ethers";
 import { buildBadgeFromSession } from "../../core/badge-metadata.js";
-import { buildAgentProfile } from "../../core/agent-profile.js";
 import { buildDiscoveryManifest } from "../../core/discovery-manifest.js";
 import {
   ARBITRATOR_SLA_SECONDS,
@@ -80,6 +79,7 @@ import { createBadgeRoutes } from "./badge-routes.js";
 import { buildPublicJobsResponse } from "./jobs-response.js";
 import { createGasRoutes } from "./gas-routes.js";
 import { createPolicyRoutes } from "./policy-routes.js";
+import { createProfileRoutes } from "./profile-routes.js";
 import { createSchemaRoutes } from "./schema-routes.js";
 import { createSessionRoutes } from "./session-routes.js";
 import { createVerifierRoutes } from "./verifier-routes.js";
@@ -303,202 +303,6 @@ function parsePositiveInteger(value, fallback, max = Number.MAX_SAFE_INTEGER) {
   return Math.min(Math.trunc(raw), max);
 }
 
-function profileTierToOperatorTier(reputation = {}) {
-  const skill = Number(reputation.skill ?? 0);
-  if (skill >= 300) return "master";
-  if (reputation.tier === "elite" || skill >= 200) return "expert";
-  if (reputation.tier === "pro" || skill >= 100) return "journeyman";
-  return "apprentice";
-}
-
-function handleForWallet(wallet) {
-  const normalized = String(wallet ?? "").toLowerCase();
-  return `agent-${normalized.slice(2, 6)}-${normalized.slice(-4)}`;
-}
-
-function buildAgentDirectoryRow(profile) {
-  const reputation = profile.reputation ?? {};
-  const approvedCount = Number(profile.stats?.approvedCount ?? 0);
-  const rejectedCount = Number(profile.stats?.rejectedCount ?? 0);
-  const totalJobs = approvedCount + rejectedCount;
-  // Slash events are upheld disputes — the verdict went against the
-  // worker. Map straight off the profile's dispute history so the
-  // agents directory exposes the same slashed-state the operator
-  // app rail already gates on.
-  const slashEvents = (profile.disputes ?? [])
-    .filter((dispute) => dispute.verdict === "upheld")
-    .map((dispute) => ({
-      disputeId: dispute.id ?? null,
-      jobId: dispute.jobId,
-      sessionId: dispute.sessionId,
-      reasonCode: dispute.reasonCode ?? null,
-      txHash: dispute.txHash ?? null,
-      at: dispute.openedAt,
-    }));
-  return {
-    wallet: profile.wallet,
-    handle: handleForWallet(profile.wallet),
-    tier: profileTierToOperatorTier(reputation),
-    reputationScore:
-      Number(reputation.skill ?? 0) +
-      Number(reputation.reliability ?? 0) +
-      Number(reputation.economic ?? 0),
-    successRate: profile.stats?.completionRate ?? null,
-    totalJobs,
-    currentActivity: profile.currentActivity ?? null,
-    activeStake: 0,
-    badges: profile.badges ?? [],
-    slashEvents,
-  };
-}
-
-/**
- * For each session in the history, fetch any dispute receipts the
- * state store carries against it. Builds the sync lookup
- * `buildAgentProfile` expects via its `getDisputeReceipts` arg so
- * the profile can emit dispute history without reaching into the
- * store itself. Skips sessions that aren't dispute candidates
- * (status !== "disputed" and no disputedAt) so the average wallet
- * with no contested submissions pays no extra fetches.
- */
-async function preloadDisputeReceipts(sessions) {
-  if (!Array.isArray(sessions) || sessions.length === 0) {
-    return () => undefined;
-  }
-  const candidates = sessions.filter((session) => {
-    if (!session || typeof session !== "object") return false;
-    const status = String(session.status ?? "").toLowerCase();
-    return status === "disputed" || Boolean(session.disputedAt);
-  });
-  if (candidates.length === 0) return () => undefined;
-  const receiptsBySession = new Map();
-  await Promise.all(
-    candidates.map(async (session) => {
-      const id = disputeIdForSession(session.sessionId);
-      const [verdict, release] = await Promise.all([
-        stateStore.getMutationReceipt?.("dispute_verdict", id),
-        stateStore.getMutationReceipt?.("dispute_release", id),
-      ]);
-      if (verdict || release) {
-        receiptsBySession.set(session.sessionId, {
-          ...(verdict ? { verdict } : {}),
-          ...(release ? { release } : {}),
-        });
-      } else {
-        // Session is in the disputed state but no receipt landed
-        // yet. Still register it so buildAgentProfile picks it up
-        // as an "open" dispute.
-        receiptsBySession.set(session.sessionId, {});
-      }
-    })
-  );
-  return (sessionId) => receiptsBySession.get(sessionId);
-}
-
-/**
- * Walk the wallet's session history and pre-build the slim
- * sub-contracting lookup `buildAgentProfile` consumes via its
- * `getLineage` arg. For each session we record:
- *   - `parent`  if the job this session is on was itself a child of
- *               another session (`job.parentSessionId` set; the
- *               parent wallet lives on `job.lineage.parentWallet`).
- *   - `children` if any sub-jobs were posted from this session
- *               (`listChildJobsByParentSession`).
- * Sessions with neither role are skipped so a wallet that's never
- * sub-contracted pays no extra cost. Roadmap §8.
- */
-function preloadLineage(sessions) {
-  if (!Array.isArray(sessions) || sessions.length === 0) {
-    return () => undefined;
-  }
-  const lookup = new Map();
-  for (const session of sessions) {
-    if (!session || typeof session !== "object") continue;
-    const sessionId = String(session.sessionId ?? "");
-    if (!sessionId) continue;
-
-    const entry = {};
-    let job;
-    try {
-      job = service.getJobDefinition(session.jobId);
-    } catch {
-      job = undefined;
-    }
-    if (job?.parentSessionId) {
-      const parent = {
-        sessionId: String(job.parentSessionId),
-        ...(job.lineage?.parentJobId ? { jobId: String(job.lineage.parentJobId) } : {}),
-        ...(typeof job.lineage?.parentWallet === "string"
-          ? { wallet: job.lineage.parentWallet }
-          : {})
-      };
-      if (Object.keys(parent).length > 0) entry.parent = parent;
-    }
-    let childJobs;
-    try {
-      childJobs = service.listChildJobsByParentSession?.(sessionId) ?? [];
-    } catch {
-      childJobs = [];
-    }
-    if (childJobs.length > 0) {
-      entry.children = childJobs.map((childJob) => ({
-        jobId: String(childJob.id ?? ""),
-        ...(typeof childJob.lineage?.parentWallet === "string"
-          ? { parentWallet: childJob.lineage.parentWallet }
-          : {})
-      })).filter((child) => child.jobId);
-    }
-
-    if (entry.parent || (entry.children && entry.children.length > 0)) {
-      lookup.set(sessionId, entry);
-    }
-  }
-  if (lookup.size === 0) return () => undefined;
-  return (sessionId) => lookup.get(sessionId);
-}
-
-async function buildAgentDirectory(limit = 50) {
-  const sessions = await service.listRecentSessions(limit);
-  const wallets = [...new Set(sessions.map((session) => session.wallet).filter(Boolean))];
-  const rows = await Promise.all(wallets.map(async (wallet) => {
-    const checksummed = safeChecksum(wallet);
-    const [reputation, history] = await Promise.all([
-      service.getReputation(checksummed),
-      service.collectSessionHistory(checksummed, { logger })
-    ]);
-    // Pre-fetch dispute receipts so directory rows correctly mark
-    // slashed (upheld-verdict) wallets. Skips wallets with no
-    // disputed sessions, so this is free in the common case.
-    const getDisputeReceipts = await preloadDisputeReceipts(history);
-    // Walk job lineage so directory rows can surface a "delegated"
-    // / "subcontracted" counter alongside the rest. Free for wallets
-    // that haven't sub-contracted.
-    const getLineage = preloadLineage(history);
-    const profile = buildAgentProfile({
-      wallet: wallet.toLowerCase(),
-      reputation,
-      sessions: history,
-      getJobDefinition: (jobId) => {
-        try {
-          return service.getJobDefinition(jobId);
-        } catch {
-          return undefined;
-        }
-      },
-      publicBaseUrl: process.env.PUBLIC_BASE_URL,
-      getDisputeReceipts,
-      getLineage,
-    });
-    return buildAgentDirectoryRow(profile);
-  }));
-  return rows.sort((left, right) => {
-    if (right.reputationScore !== left.reputationScore) {
-      return right.reputationScore - left.reputationScore;
-    }
-    return String(left.wallet).localeCompare(String(right.wallet));
-  });
-}
-
 function buildBadgeReceipt(badge) {
   const averray = badge.averray ?? {};
   return {
@@ -517,14 +321,6 @@ function buildBadgeReceipt(badge) {
   };
 }
 
-/**
- * Derive the badge `lineage` block at fetch time from the session +
- * job pair. Mirrors what `preloadLineage` does for the agent
- * profile but for a single badge: parent (if the job was a sub-job)
- * and children (if the session itself spawned sub-jobs). Returns
- * `undefined` when there's nothing to surface so the badge stays
- * clean. Roadmap §8.
- */
 function deriveBadgeLineage(session, job) {
   if (!session || !job) return undefined;
   const lineage = {};
@@ -1484,6 +1280,15 @@ const handleVerifierRoute = createVerifierRoutes({
   verifierService,
 });
 
+const handleProfileRoute = createProfileRoutes({
+  authMiddleware,
+  logger,
+  parseLimit,
+  respond,
+  service,
+  stateStore,
+});
+
 const handleSessionRoute = createSessionRoutes({
   authMiddleware,
   ensureSessionOwnership,
@@ -1894,63 +1699,8 @@ const server = createServer(async (request, response) => {
       return;
     }
 
-    // Public agent directory for the new operator app. It is derived from
-    // the same recent session + reputation source as the per-wallet profile.
-    if (request.method === "GET" && pathname === "/agents") {
-      return respond(response, 200, await buildAgentDirectory(parseLimit(url, 50, 250)), {
-        "cache-control": "public, max-age=30"
-      });
-    }
-
-    // Public agent profile — the aggregate "LinkedIn for agents" resume.
-    // Returns reputation + per-category levels + lifetime stats + ordered
-    // badges. Public (no auth) so other agents/humans can verify. See
-    // docs/schemas/agent-profile-v1.md for the full format.
-    if (request.method === "GET" && pathname.startsWith("/agents/")) {
-      const rawWallet = decodeURIComponent(pathname.slice("/agents/".length));
-      if (!/^0x[a-fA-F0-9]{40}$/u.test(rawWallet)) {
-        throw new ValidationError("wallet path segment must be a 0x-prefixed 20-byte hex address.");
-      }
-      // Sessions are keyed by the checksummed form (authMiddleware calls
-      // getAddress before persisting). We accept lowercase or checksummed
-      // in the URL, normalise for lookup, and return lowercase in the body
-      // so consumers have a single canonical form to compare against.
-      const checksummed = safeChecksum(rawWallet);
-      // Lifetime aggregates need every session, not a truncated page.
-      // collectSessionHistory walks the state store page-by-page up to a
-      // safety cap (10_000 by default) — see
-      // src/core/job-execution-service.js#collectSessionHistory.
-      const [reputation, sessions] = await Promise.all([
-        service.getReputation(checksummed),
-        service.collectSessionHistory(checksummed, { logger: requestLogger })
-      ]);
-      // Pre-fetch dispute receipts so the public profile carries
-      // dispute history (status, verdict, reasonCode) without the
-      // frontend needing a separate /disputes call. Free for wallets
-      // with no contested sessions — `preloadDisputeReceipts` short-
-      // circuits when there's nothing to fetch.
-      const getDisputeReceipts = await preloadDisputeReceipts(sessions);
-      // Pre-walk sub-contracting lineage so the profile carries a
-      // delegated / subcontracted history block + counters without
-      // a separate /jobs/sub or /admin/jobs/timeline call. Free for
-      // wallets that haven't sub-contracted. Roadmap §8.
-      const getLineage = preloadLineage(sessions);
-      const profile = buildAgentProfile({
-        wallet: rawWallet.toLowerCase(),
-        reputation,
-        sessions,
-        getJobDefinition: (jobId) => {
-          try {
-            return service.getJobDefinition(jobId);
-          } catch {
-            return undefined;
-          }
-        },
-        publicBaseUrl: process.env.PUBLIC_BASE_URL,
-        getDisputeReceipts,
-        getLineage,
-      });
-      return respond(response, 200, profile, { "cache-control": "public, max-age=30" });
+    if (await handleProfileRoute({ request, response, url, pathname, requestLogger })) {
+      return;
     }
 
     if (await handleBadgeRoute({ request, response, url, pathname })) {
@@ -3105,11 +2855,6 @@ const server = createServer(async (request, response) => {
         await requireChainBackedMutation("/account/repay");
         return service.repay(auth.wallet, asset, amount);
       });
-    }
-
-    if (request.method === "GET" && pathname === "/reputation") {
-      const auth = await authMiddleware(request, url);
-      return respond(response, 200, await service.getReputation(auth.wallet));
     }
 
     if (request.method === "GET" && pathname === "/xcm/request") {


### PR DESCRIPTION
## What changed
- Extracted public profile surfaces into `mcp-server/src/protocols/http/profile-routes.js`: `/agents`, `/agents/:wallet`, and authenticated `/reputation`.
- Added focused route tests for cache headers, wallet validation, request-logger profile context, authenticated reputation reads, and the separation from the dedicated badge route module.
- Preserved the already-merged `badge-routes.js` helper wiring in `server.js` after rebasing across the sibling badge split.
- Added a roadmap update fragment instead of editing `docs/PROJECT_ROADMAP.md` because active roadmap-section PRs were already in flight.

## Checks
- `node --test mcp-server/src/protocols/http/profile-routes.test.js`
- `node --test mcp-server/src/protocols/http/badge-routes.test.js`
- `RUN_HTTP_SMOKE=1 node --test --test-timeout=60000 src/protocols/http/server.smoke.test.js` from `mcp-server/` with localhost binding enabled
- `npm --workspace mcp-server test`

## Affected areas
- Backend: yes
- Docs: yes, roadmap update fragment only
- Frontend: no
- Indexer: no
- Caddy: no
- Contracts: no
- Public site: no

## Environment / VPS changes
None.

## Polkadot verification
No Polkadot protocol semantics changed in this slice; this is an HTTP route split only.