### PR TITLE
app: align dispute split verdict UI

### DIFF
--- a/app/components/disputes/DecisionPanel.tsx
+++ b/app/components/disputes/DecisionPanel.tsx
@@ -39,10 +39,10 @@ const DECISIONS: {
     tone: "neutral",
   },
   {
-    id: "request-more",
-    label: "Request more evidence",
-    subtitle: "pause and ping opener",
-    blurb: "Window paused. Opener notified to add payload or cite policy clause.",
+    id: "split",
+    label: "Split payout",
+    subtitle: "resolve with partial payout",
+    blurb: "Backend settles a split verdict with the default partial worker payout.",
     tone: "warn",
   },
 ];
@@ -61,8 +61,7 @@ export function DecisionPanel({
   error,
 }: DecisionPanelProps) {
   const rationaleOk = rationale.trim().length >= 20;
-  const destinationOk =
-    decision === "request-more" || destination !== null;
+  const destinationOk = destination !== null;
   const committable =
     !disabled && !busy && decision !== null && rationaleOk && roleConfirmed && destinationOk;
 
@@ -111,7 +110,7 @@ export function DecisionPanel({
           style={{ letterSpacing: 0 }}
         >
           <span>{rationale.trim().length} / 20 min</span>
-          <span>sha-256 hash of this text joins the signed receipt</span>
+          <span>canonical reasoning hash joins the signed receipt</span>
         </div>
       </label>
 

--- a/app/components/disputes/DisputeDrawerBody.tsx
+++ b/app/components/disputes/DisputeDrawerBody.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { mutate } from "swr";
 import { DrawerSection } from "@/components/shell/DetailDrawer";
 import { decisionToVerdict } from "@/lib/api/dispute-adapters";
+import { releaseAmountForDecision } from "@/lib/api/dispute-verdicts";
 import { swrFetcher } from "@/lib/api/client";
 import { DisputeStatePill, OriginPill } from "./pills";
 import { PartyChip } from "./PartyChip";
@@ -50,18 +51,14 @@ export function DisputeDrawerBody({
   }, [dispute.id, dispute.resolution, dispute.state]);
 
   // If the decision changes, reset the destination to stay consistent
-  // (uphold/reject pick different valid destinations; request-more has none).
+  // with the backend verdict settlement path.
   const handleDecision = (d: DecisionKind) => {
     setDecision(d);
-    if (d === "request-more") setDestination(null);
-    else {
-      // auto-pick a default that matches the decision.
-      if (d === "uphold" && destination !== "slash-to-treasury" && destination !== "pay-verifier") {
-        setDestination("slash-to-treasury");
-      }
-      if (d === "reject" && destination !== "return-to-depositor") {
-        setDestination("return-to-depositor");
-      }
+    if (d === "uphold" && destination !== "slash-to-treasury" && destination !== "pay-verifier") {
+      setDestination("slash-to-treasury");
+    }
+    if ((d === "reject" || d === "split") && destination !== "return-to-depositor") {
+      setDestination("return-to-depositor");
     }
   };
 
@@ -90,7 +87,7 @@ export function DisputeDrawerBody({
       ]);
       verdictCommitted = true;
 
-      if (destination && decision !== "request-more") {
+      if (destination) {
         await swrFetcher([
           `${detailKey}/release`,
           {
@@ -99,7 +96,11 @@ export function DisputeDrawerBody({
             body: JSON.stringify({
               action: destination,
               destination,
-              amount: dispute.stakeFrozen,
+              amount: releaseAmountForDecision({
+                decision,
+                remainingPayout: dispute.remainingPayout,
+                stakeFrozen: dispute.stakeFrozen,
+              }),
             }),
           },
         ]);
@@ -378,7 +379,7 @@ function ResolvedCard({ dispute }: { dispute: Dispute }) {
       ? "Upheld"
       : decision === "reject"
         ? "Rejected"
-        : "Requested more evidence";
+        : "Split payout";
   const destinationLabel =
     destination === "return-to-depositor"
       ? "Returned to depositor"

--- a/app/components/disputes/StakeHoldPanel.tsx
+++ b/app/components/disputes/StakeHoldPanel.tsx
@@ -34,9 +34,13 @@ export function StakeHoldPanel({
   const allowedFor: Record<DecisionKind, ReleaseDestination[]> = {
     uphold: ["slash-to-treasury", "pay-verifier"],
     reject: ["return-to-depositor"],
-    "request-more": [],
+    split: ["return-to-depositor"],
   };
   const allowed = decision ? allowedFor[decision] : [];
+  const returnDestinationMeta =
+    decision === "split"
+      ? "Partial worker payout recorded by the split verdict."
+      : "Full unlock to the worker wallet. Run resumes.";
 
   return (
     <div className="flex flex-col gap-3 rounded-[10px] border border-[color:rgba(167,97,34,0.28)] bg-[color:rgba(244,227,207,0.28)] p-4">
@@ -114,7 +118,7 @@ export function StakeHoldPanel({
           <DestinationRadio
             id="return-to-depositor"
             label="Return to depositor"
-            meta="Full unlock to the worker wallet. Run resumes."
+            meta={returnDestinationMeta}
             checked={destination === "return-to-depositor"}
             enabled={!disabled && allowed.includes("return-to-depositor")}
             onChange={() => onDestinationChange("return-to-depositor")}

--- a/app/components/disputes/types.ts
+++ b/app/components/disputes/types.ts
@@ -31,7 +31,7 @@ export type ReleaseDestination =
   | "pay-verifier"
   | "slash-to-treasury";
 
-export type DecisionKind = "uphold" | "reject" | "request-more";
+export type DecisionKind = "uphold" | "reject" | "split";
 
 export interface DisputeParty {
   handle: string;

--- a/app/lib/api/dispute-adapters.ts
+++ b/app/lib/api/dispute-adapters.ts
@@ -8,6 +8,10 @@ import type {
   EvidenceRow,
   ReleaseDestination,
 } from "@/components/disputes/types";
+import {
+  decisionToVerdict as mapDecisionToVerdict,
+  verdictToDecision as mapVerdictToDecision,
+} from "./dispute-verdicts";
 
 const DEFAULT_REVIEWER = "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519";
 
@@ -239,16 +243,11 @@ function stakeBreakdown(total: number): Dispute["stakeBreakdown"] {
 }
 
 export function decisionToVerdict(decision: DecisionKind): "upheld" | "dismissed" | "split" {
-  if (decision === "uphold") return "upheld";
-  if (decision === "reject") return "dismissed";
-  return "split";
+  return mapDecisionToVerdict(decision) as "upheld" | "dismissed" | "split";
 }
 
 function verdictToDecision(value: unknown): DecisionKind | null {
-  if (value === "upheld" || value === "uphold") return "uphold";
-  if (value === "dismissed" || value === "reject" || value === "rejected") return "reject";
-  if (value === "split" || value === "request-more") return "request-more";
-  return null;
+  return mapVerdictToDecision(value) as DecisionKind | null;
 }
 
 function releaseToDestination(value: Record<string, unknown> | null, decision: DecisionKind | null): ReleaseDestination {

--- a/app/lib/api/dispute-verdicts.js
+++ b/app/lib/api/dispute-verdicts.js
@@ -1,0 +1,33 @@
+export function decisionToVerdict(decision) {
+  if (decision === "uphold") return "upheld";
+  if (decision === "reject") return "dismissed";
+  if (decision === "split") return "split";
+  throw new TypeError(`Unknown dispute decision: ${String(decision)}`);
+}
+
+export function verdictToDecision(value) {
+  const verdict = String(value ?? "").trim().toLowerCase();
+  if (verdict === "upheld" || verdict === "uphold") return "uphold";
+  if (verdict === "dismissed" || verdict === "reject" || verdict === "rejected") {
+    return "reject";
+  }
+  if (verdict === "split" || verdict === "partial" || verdict === "request-more") {
+    return "split";
+  }
+  return null;
+}
+
+export function releaseAmountForDecision({
+  decision,
+  remainingPayout,
+  stakeFrozen,
+}) {
+  const remaining = Number.isFinite(remainingPayout) ? remainingPayout : stakeFrozen;
+  if (decision === "split") {
+    return remaining <= 1 ? remaining : Math.floor(remaining / 2);
+  }
+  if (decision === "reject") {
+    return remaining;
+  }
+  return stakeFrozen;
+}

--- a/app/lib/api/dispute-verdicts.test.mjs
+++ b/app/lib/api/dispute-verdicts.test.mjs
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  decisionToVerdict,
+  releaseAmountForDecision,
+  verdictToDecision,
+} from "./dispute-verdicts.js";
+
+test("decisionToVerdict maps operator decisions to backend verdict tokens", () => {
+  assert.equal(decisionToVerdict("uphold"), "upheld");
+  assert.equal(decisionToVerdict("reject"), "dismissed");
+  assert.equal(decisionToVerdict("split"), "split");
+});
+
+test("decisionToVerdict rejects unknown decision tokens instead of silently settling", () => {
+  assert.throws(
+    () => decisionToVerdict("request-more"),
+    /Unknown dispute decision/u
+  );
+});
+
+test("verdictToDecision keeps backend split verdicts explicit in the operator UI", () => {
+  assert.equal(verdictToDecision("split"), "split");
+  assert.equal(verdictToDecision("partial"), "split");
+  assert.equal(verdictToDecision("request-more"), "split");
+});
+
+test("verdictToDecision maps resolved verdict aliases and ignores unknown tokens", () => {
+  assert.equal(verdictToDecision("upheld"), "uphold");
+  assert.equal(verdictToDecision("uphold"), "uphold");
+  assert.equal(verdictToDecision("dismissed"), "reject");
+  assert.equal(verdictToDecision("rejected"), "reject");
+  assert.equal(verdictToDecision("needs-human"), null);
+});
+
+test("releaseAmountForDecision mirrors backend default split payout semantics", () => {
+  assert.equal(
+    releaseAmountForDecision({ decision: "split", remainingPayout: 7, stakeFrozen: 9 }),
+    3
+  );
+  assert.equal(
+    releaseAmountForDecision({ decision: "split", remainingPayout: 1, stakeFrozen: 9 }),
+    1
+  );
+  assert.equal(
+    releaseAmountForDecision({ decision: "reject", remainingPayout: 7, stakeFrozen: 9 }),
+    7
+  );
+  assert.equal(
+    releaseAmountForDecision({ decision: "uphold", remainingPayout: 7, stakeFrozen: 9 }),
+    9
+  );
+});

--- a/docs/roadmap-updates/2026-05-24-codex-dispute-arbitration-fields.md
+++ b/docs/roadmap-updates/2026-05-24-codex-dispute-arbitration-fields.md
@@ -1,0 +1,28 @@
+# Roadmap Update: Dispute/arbitration semantics
+
+- **Date:** 2026-05-24
+- **Agent:** codex/dispute-arbitration-fields
+- **Roadmap section:** P1 Product And Platform Hardening
+- **Item:** Dispute/arbitration semantics
+- **Related PRs/issues:** pending PR from `codex/dispute-arbitration-fields`
+- **Proposed status:** Open
+- **Owner:** roadmap steward
+
+## Summary
+
+This slice removes an operator-facing dispute semantics mismatch: the UI previously labeled the third verdict path as "Request more evidence", but submitted it as the backend `split` verdict, which resolves the dispute with a partial payout instead of pausing the window. The operator UI now presents that path as "Split payout", maps backend split/partial aliases back to the explicit split decision, and uses release amounts that mirror backend default split-payout semantics.
+
+## Evidence
+
+- Added `app/lib/api/dispute-verdicts.js` as a tested pure mapping layer for operator decisions, backend verdict tokens, and default release amount projection.
+- Added `app/lib/api/dispute-verdicts.test.mjs` covering decision-to-verdict mapping, rejection of the old `request-more` decision token, legacy backend alias projection, and default split-payout amount behavior.
+- Updated dispute drawer, decision panel, and stake hold UI copy so the displayed action matches the backend settlement behavior.
+
+## Blockers Or Caveats
+
+- This does not close the full dispute/arbitration semantics row. Remaining work includes hosted dispute verdict proof, explicit final `/release` semantics, arbitrator notification rehearsal, and any future true "request more evidence" backend state if the product still wants that action.
+- Canonical roadmap was not edited because active route-split PRs are already touching the same roadmap section.
+
+## Requested Roadmap Change
+
+Append a short note to the `Dispute/arbitration semantics` row after this PR merges: "First UI-contract slice made the operator split-verdict path explicit and added mapping tests so the UI no longer labels backend `split` settlement as a request-more-evidence action."


### PR DESCRIPTION
## Summary
- replace the dispute drawer’s misleading “Request more evidence” action with an explicit “Split payout” verdict path
- add a tested dispute verdict mapping helper so `split` stays distinct and the old `request-more` token cannot silently settle from the UI path
- align local release amount projection with backend default split-payout semantics
- add a roadmap update fragment instead of editing `PROJECT_ROADMAP.md`, because active route-split PRs are already touching the same roadmap section

## Checks
- `npm run test:app`
- `npm run typecheck:app`
- `npm run build:frontend`
- `git diff --check`

## Impact
- Frontend/operator app: yes, dispute verdict UI contract and copy
- Backend/indexer/Caddy/contracts/public site: no
- Generated `frontend/`: build verified locally, generated output intentionally not committed
- Env/VPS secrets: none
- Roadmap: fragment added at `docs/roadmap-updates/2026-05-24-codex-dispute-arbitration-fields.md`