### PR TITLE
backend: split dispute routes

### DIFF
--- a/docs/roadmap-updates/2026-05-24-codex-dispute-route-split.md
+++ b/docs/roadmap-updates/2026-05-24-codex-dispute-route-split.md
@@ -1,0 +1,28 @@
+# Roadmap Update: HTTP server route split (`P2.3`)
+
+- **Date:** 2026-05-24
+- **Agent:** codex/dispute-route-split
+- **Roadmap section:** RC1 Launch Readiness
+- **Item:** HTTP server route split (`P2.3`)
+- **Related PRs/issues:** PR pending
+- **Proposed status:** Open
+- **Owner:** Roadmap steward
+
+## Summary
+
+The next narrow route-split slice extracts the authenticated dispute endpoints from `server.js` into `mcp-server/src/protocols/http/dispute-routes.js`. The route module keeps the existing response shapes and idempotency behavior while exposing `listDisputes()` back to the activity alert feed.
+
+## Evidence
+
+- New route module: `mcp-server/src/protocols/http/dispute-routes.js`
+- Focused tests: `mcp-server/src/protocols/http/dispute-routes.test.js`
+- Local checks to be recorded in the PR body after completion.
+
+## Blockers Or Caveats
+
+- The canonical `P2.3` row remains Open because this is one slice of the larger server split, not full closure.
+- No Polkadot protocol semantics changed in this slice.
+
+## Requested Roadmap Change
+
+Append a fifteenth-slice note to the `HTTP server route split (P2.3)` row after the PR merges: dispute routes (`/disputes`, `/disputes/:id`, `/disputes/:id/verdict`, `/disputes/:id/release`) moved to `dispute-routes.js` with tests for auth, listing, idempotent replay, verdict recording, session transition, release recording, and unrelated path handling.

--- a/mcp-server/src/protocols/http/dispute-routes.js
+++ b/mcp-server/src/protocols/http/dispute-routes.js
@@ -1,0 +1,427 @@
+import { AuthorizationError, ValidationError } from "../../core/errors.js";
+import {
+  ARBITRATOR_SLA_SECONDS,
+  buildDisputeReasoningReceipt,
+  buildDisputeResolution,
+  disputeIdForSession,
+  normalizeDisputeReleaseRequestPayload,
+  normalizeDisputeVerdictRequestPayload,
+} from "../../core/dispute-resolution.js";
+import { transitionSession } from "../../core/session-state-machine.js";
+
+function compactObject(value) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined && entry !== null)
+  );
+}
+
+function addSecondsIso(value, seconds) {
+  const parsed = Date.parse(value ?? "");
+  const base = Number.isFinite(parsed) ? parsed : Date.now();
+  return new Date(base + seconds * 1000).toISOString();
+}
+
+export function createDisputeRoutes({
+  authMiddleware,
+  buildScopedIdempotentMutationContext,
+  eventBus,
+  gateway,
+  getIdempotentMutationReplay,
+  hasRole,
+  parseLimit,
+  persistContentRecord,
+  publicBaseUrl,
+  defaultVerifierAddress,
+  readJsonBody,
+  respond,
+  respondWithMutationReceipt,
+  service,
+  stateStore,
+}) {
+  async function resolveRemainingPayout(session) {
+    if (gateway?.isEnabled?.() && typeof gateway.getJob === "function") {
+      const live = await gateway.getJob(session.chainJobId ?? session.jobId);
+      return Math.max(Number(live.reward ?? 0) - Number(live.released ?? 0), 0);
+    }
+    try {
+      const job = service.getJobDefinition(session.jobId);
+      return Math.max(Number(job.rewardAmount ?? 0), 0);
+    } catch {
+      return 0;
+    }
+  }
+
+  async function buildDisputeFromSession(session) {
+    const id = disputeIdForSession(session.sessionId);
+    const [verdictReceipt, releaseReceipt] = await Promise.all([
+      stateStore.getMutationReceipt?.("dispute_verdict", id),
+      stateStore.getMutationReceipt?.("dispute_release", id)
+    ]);
+    const openedAt = session.disputedAt ?? session.updatedAt ?? new Date().toISOString();
+    const windowEndsAt = addSecondsIso(openedAt, ARBITRATOR_SLA_SECONDS);
+    const timeline = (session.statusHistory ?? []).map((entry, index) => ({
+      id: `${id}:session:${index}`,
+      at: entry.at,
+      actor: "system",
+      action: entry.reason ?? `session_${entry.to}`,
+      data: entry
+    }));
+    if (verdictReceipt) {
+      timeline.push({
+        id: `${id}:verdict`,
+        at: verdictReceipt.decidedAt,
+        actor: verdictReceipt.decidedBy,
+        action: "verdict_submitted",
+        data: verdictReceipt
+      });
+    }
+    if (releaseReceipt) {
+      timeline.push({
+        id: `${id}:release`,
+        at: releaseReceipt.releasedAt,
+        actor: releaseReceipt.releasedBy,
+        action: "stake_release_recorded",
+        data: releaseReceipt
+      });
+    }
+
+    let job;
+    try {
+      job = service.getJobDefinition(session.jobId);
+    } catch {
+      job = undefined;
+    }
+
+    return {
+      id,
+      status: releaseReceipt || verdictReceipt ? "resolved" : "open",
+      sessionId: session.sessionId,
+      chainJobId: session.chainJobId,
+      claimant: session.wallet,
+      respondent: defaultVerifierAddress ?? "0x0000000000000000000000000000000000000000",
+      openedAt,
+      windowEndsAt,
+      slaSeconds: ARBITRATOR_SLA_SECONDS,
+      evidence: {
+        before: compactObject({
+          jobId: session.jobId,
+          jobTitle: job?.title,
+          requirements: job?.verifierTerms,
+          claimStake: session.claimStake,
+          claimFee: session.claimFee,
+          totalClaimLock: session.totalClaimLock
+        }),
+        after: compactObject({
+          submission: session.submission,
+          verification: session.verification ?? session.verificationSummary
+        })
+      },
+      verdict: verdictReceipt?.verdict ?? null,
+      reasonCode: verdictReceipt?.reasonCode,
+      reasoningHash: verdictReceipt?.reasoningHash,
+      metadataURI: verdictReceipt?.metadataURI,
+      txHash: verdictReceipt?.txHash,
+      chainStatus: verdictReceipt?.chainStatus,
+      workerPayout: verdictReceipt?.workerPayout,
+      remainingPayout: verdictReceipt?.remainingPayout,
+      stakedAmount: Number(session.claimStake ?? 0),
+      claimFee: Number(session.claimFee ?? 0),
+      totalClaimLock: Number(session.totalClaimLock ?? session.claimStake ?? 0),
+      release: releaseReceipt ?? null,
+      timeline: timeline.sort((left, right) => String(left.at ?? "").localeCompare(String(right.at ?? "")))
+    };
+  }
+
+  async function listDisputes(limit = 100) {
+    const sessions = await service.listRecentSessions(limit);
+    const candidates = await Promise.all(
+      sessions.map(async (session) => {
+        if (session.status === "disputed") {
+          return session;
+        }
+        const id = disputeIdForSession(session.sessionId);
+        const [verdictReceipt, releaseReceipt] = await Promise.all([
+          stateStore.getMutationReceipt?.("dispute_verdict", id),
+          stateStore.getMutationReceipt?.("dispute_release", id)
+        ]);
+        return verdictReceipt || releaseReceipt ? session : undefined;
+      })
+    );
+    return Promise.all(candidates.filter(Boolean).map((session) => buildDisputeFromSession(session)));
+  }
+
+  async function findDispute(id, limit = 250) {
+    const disputes = await listDisputes(limit);
+    return disputes.find((dispute) => dispute.id === id);
+  }
+
+  async function handleDisputeRoute({ request, response, url, pathname }) {
+    if (request.method === "GET" && pathname === "/disputes") {
+      await authMiddleware(request, url);
+      respond(response, 200, await listDisputes(parseLimit(url, 100, 500)));
+      return true;
+    }
+
+    if (request.method === "GET" && pathname.startsWith("/disputes/")) {
+      await authMiddleware(request, url);
+      const id = decodeURIComponent(pathname.slice("/disputes/".length));
+      if (!id || id.includes("/")) {
+        throw new ValidationError("dispute id path segment is required.");
+      }
+      const dispute = await findDispute(id);
+      if (!dispute) {
+        respond(response, 404, { status: "not_found", id });
+        return true;
+      }
+      respond(response, 200, dispute);
+      return true;
+    }
+
+    if (request.method === "POST" && /^\/disputes\/[^/]+\/verdict$/u.test(pathname)) {
+      const auth = await authMiddleware(request, url);
+      if (!hasRole(auth.claims, "admin") && !hasRole(auth.claims, "verifier")) {
+        throw new AuthorizationError("Requires admin or verifier role.", "missing_role");
+      }
+      const id = decodeURIComponent(pathname.slice("/disputes/".length, -"/verdict".length));
+      const dispute = await findDispute(id);
+      if (!dispute) {
+        respond(response, 404, { status: "not_found", id });
+        return true;
+      }
+      const payload = await readJsonBody(request);
+      const idempotency = buildScopedIdempotentMutationContext({
+        route: "/disputes/:id/verdict",
+        auth,
+        scope: id,
+        payload,
+        normalizedPayload: normalizeDisputeVerdictRequestPayload(id, payload),
+        bucket: "dispute_verdict_idempotency"
+      });
+      const replay = await getIdempotentMutationReplay(idempotency);
+      if (replay) {
+        respond(response, replay.statusCode, replay.body);
+        return true;
+      }
+      if (dispute.verdict || dispute.reasonCode) {
+        await respondWithMutationReceipt(response, idempotency, 200, dispute);
+        return true;
+      }
+      const session = await service.resumeSession(dispute.sessionId);
+      const decidedAt = new Date().toISOString();
+      const remainingPayout = await resolveRemainingPayout(session);
+      const resolution = buildDisputeResolution({
+        verdict: payload?.verdict ?? payload?.outcome,
+        remainingPayout,
+        workerPayout: payload?.workerPayout ?? payload?.payoutAmount
+      });
+      const reasoning = buildDisputeReasoningReceipt({
+        id,
+        dispute,
+        payload,
+        auth,
+        verdict: resolution.verdict,
+        decidedAt,
+        publicBaseUrl
+      });
+      await persistContentRecord(reasoning.contentRecord);
+      const chainReceipt = gateway?.isEnabled?.() && typeof gateway.resolveDispute === "function"
+        ? await gateway.resolveDispute(
+            session.chainJobId ?? session.jobId,
+            resolution.workerPayout,
+            resolution.reasonCode,
+            reasoning.metadataURI
+          )
+        : {
+            txHash: undefined,
+            blockNumber: undefined,
+            status: undefined
+          };
+      const receipt = {
+        id,
+        disputeId: id,
+        sessionId: dispute.sessionId,
+        jobId: session.jobId,
+        chainJobId: session.chainJobId,
+        verdict: resolution.verdict,
+        workerPayout: resolution.workerPayout,
+        remainingPayout,
+        reasonCode: resolution.reasonCode,
+        reasoningHash: reasoning.reasoningHash,
+        metadataURI: reasoning.metadataURI,
+        rationale: reasoning.rationale || undefined,
+        releaseAction: resolution.releaseAction,
+        payoutSource: resolution.payoutSource,
+        txHash: chainReceipt.txHash,
+        blockNumber: chainReceipt.blockNumber,
+        chainStatus: gateway?.isEnabled?.()
+          ? (chainReceipt.status === 1 ? "confirmed" : "submitted")
+          : "local_only",
+        decidedBy: auth.wallet,
+        decidedAt
+      };
+      await stateStore.upsertMutationReceipt?.("dispute_verdict", id, receipt);
+      if (session.status === "disputed") {
+        const transitioned = transitionSession(session, resolution.nextSessionStatus, {
+          reason: resolution.reasonCode,
+          timestamp: decidedAt,
+          metadata: {
+            disputeId: id,
+            verdict: resolution.verdict,
+            workerPayout: resolution.workerPayout,
+            reasonCode: resolution.reasonCode,
+            txHash: receipt.txHash
+          }
+        });
+        await stateStore.upsertSession?.(transitioned);
+      }
+      eventBus?.publish({
+        id: `dispute-verdict-${id}-${Date.now()}`,
+        topic: "dispute.verdict_recorded",
+        wallet: dispute.claimant,
+        wallets: [dispute.claimant, auth.wallet],
+        jobId: session.jobId,
+        sessionId: dispute.sessionId,
+        timestamp: receipt.decidedAt,
+        correlationId: dispute.sessionId,
+        txHash: receipt.txHash,
+        blockNumber: receipt.blockNumber,
+        source: "settlement",
+        phase: "dispute",
+        severity: resolution.verdict === "dismissed" ? "info" : "warn",
+        data: {
+          disputeId: id,
+          jobId: session.jobId,
+          chainJobId: session.chainJobId,
+          openedAt: dispute.openedAt,
+          windowEndsAt: dispute.windowEndsAt,
+          slaSeconds: dispute.slaSeconds,
+          verdict: resolution.verdict,
+          workerPayout: resolution.workerPayout,
+          reasonCode: resolution.reasonCode,
+          reasoningHash: receipt.reasoningHash,
+          metadataURI: receipt.metadataURI,
+          txHash: receipt.txHash,
+          blockNumber: receipt.blockNumber,
+          chainStatus: receipt.chainStatus
+        }
+      });
+      const body = {
+        ...dispute,
+        status: "resolved",
+        verdict: resolution.verdict,
+        reasonCode: resolution.reasonCode,
+        reasoningHash: reasoning.reasoningHash,
+        metadataURI: reasoning.metadataURI,
+        txHash: receipt.txHash,
+        chainStatus: receipt.chainStatus,
+        workerPayout: resolution.workerPayout,
+        remainingPayout,
+        timeline: [
+          ...dispute.timeline,
+          {
+            id: `${id}:verdict`,
+            at: receipt.decidedAt,
+            actor: receipt.decidedBy,
+            action: "verdict_submitted",
+            data: receipt
+          }
+        ]
+      };
+      await respondWithMutationReceipt(response, idempotency, 200, body);
+      return true;
+    }
+
+    if (request.method === "POST" && /^\/disputes\/[^/]+\/release$/u.test(pathname)) {
+      const auth = await authMiddleware(request, url, { requireRole: "admin" });
+      const id = decodeURIComponent(pathname.slice("/disputes/".length, -"/release".length));
+      const dispute = await findDispute(id);
+      if (!dispute) {
+        respond(response, 404, { status: "not_found", id });
+        return true;
+      }
+      const payload = await readJsonBody(request);
+      const idempotency = buildScopedIdempotentMutationContext({
+        route: "/disputes/:id/release",
+        auth,
+        scope: id,
+        payload,
+        normalizedPayload: normalizeDisputeReleaseRequestPayload(id, dispute, payload),
+        bucket: "dispute_release_idempotency"
+      });
+      const replay = await getIdempotentMutationReplay(idempotency);
+      if (replay) {
+        respond(response, replay.statusCode, replay.body);
+        return true;
+      }
+      if (dispute.release) {
+        await respondWithMutationReceipt(response, idempotency, 200, dispute);
+        return true;
+      }
+      const session = await service.resumeSession(dispute.sessionId).catch(() => undefined);
+      const receipt = {
+        id,
+        disputeId: id,
+        sessionId: dispute.sessionId,
+        jobId: session?.jobId,
+        chainJobId: session?.chainJobId,
+        action: typeof payload?.action === "string" && payload.action.trim() ? payload.action.trim() : "release",
+        amount: Number(payload?.amount ?? dispute.stakedAmount ?? 0),
+        chainStatus: dispute.txHash ? "settled_by_verdict" : "local_only",
+        txHash: dispute.txHash,
+        releasedBy: auth.wallet,
+        releasedAt: new Date().toISOString()
+      };
+      await stateStore.upsertMutationReceipt?.("dispute_release", id, receipt);
+      eventBus?.publish({
+        id: `dispute-release-${id}-${Date.now()}`,
+        topic: "settlement.stake_release_recorded",
+        wallet: dispute.claimant,
+        wallets: [dispute.claimant, auth.wallet],
+        jobId: session?.jobId,
+        sessionId: dispute.sessionId,
+        timestamp: receipt.releasedAt,
+        correlationId: dispute.sessionId,
+        txHash: receipt.txHash,
+        source: "settlement",
+        phase: "settlement",
+        severity: "info",
+        data: {
+          disputeId: id,
+          jobId: session?.jobId,
+          chainJobId: session?.chainJobId,
+          openedAt: dispute.openedAt,
+          windowEndsAt: dispute.windowEndsAt,
+          amount: receipt.amount,
+          action: receipt.action,
+          chainStatus: receipt.chainStatus,
+          txHash: receipt.txHash
+        }
+      });
+      const body = {
+        ...dispute,
+        status: "resolved",
+        release: receipt,
+        timeline: [
+          ...dispute.timeline,
+          {
+            id: `${id}:release`,
+            at: receipt.releasedAt,
+            actor: receipt.releasedBy,
+            action: "stake_release_recorded",
+            data: receipt
+          }
+        ]
+      };
+      await respondWithMutationReceipt(response, idempotency, 200, body);
+      return true;
+    }
+
+    return false;
+  }
+
+  return {
+    findDispute,
+    handleDisputeRoute,
+    listDisputes,
+  };
+}

--- a/mcp-server/src/protocols/http/dispute-routes.test.js
+++ b/mcp-server/src/protocols/http/dispute-routes.test.js
@@ -1,0 +1,296 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { AuthorizationError, ValidationError } from "../../core/errors.js";
+import { disputeIdForSession } from "../../core/dispute-resolution.js";
+import { createDisputeRoutes } from "./dispute-routes.js";
+
+const ADMIN = "0x1111111111111111111111111111111111111111";
+const WORKER = "0x2222222222222222222222222222222222222222";
+const VERIFIER = "0x3333333333333333333333333333333333333333";
+const SESSION = {
+  sessionId: "session-dispute-1",
+  jobId: "job-1",
+  chainJobId: "chain-job-1",
+  wallet: WORKER,
+  status: "disputed",
+  disputedAt: "2026-05-01T00:00:00.000Z",
+  claimStake: 4,
+  claimFee: 0.25,
+  totalClaimLock: 4.25,
+  submission: { contentHash: "0xsub" },
+  verification: { outcome: "disputed" },
+  statusHistory: [
+    { from: "submitted", to: "disputed", at: "2026-05-01T00:00:00.000Z", reason: "verification_rejected" }
+  ]
+};
+const JOB = {
+  id: "job-1",
+  title: "Review a release",
+  verifierTerms: "Verify evidence.",
+  rewardAmount: 12,
+};
+
+function makeHarness(overrides = {}) {
+  const calls = [];
+  const response = {};
+  const receipts = new Map(Object.entries(overrides.receipts ?? {}));
+  const auth = overrides.auth ?? { wallet: ADMIN, claims: { roles: ["admin"] } };
+  const sessions = overrides.sessions ?? [SESSION];
+  const jobs = overrides.jobs ?? new Map([[JOB.id, JOB]]);
+  const payload = overrides.payload ?? {};
+  const gateway = overrides.gateway ?? { isEnabled: () => false };
+
+  const routes = createDisputeRoutes({
+    authMiddleware: async (request, url, options = {}) => {
+      calls.push(["authMiddleware", { method: request.method, pathname: url.pathname, options }]);
+      if (overrides.authError) {
+        throw overrides.authError;
+      }
+      return auth;
+    },
+    buildScopedIdempotentMutationContext: (input) => {
+      calls.push(["idempotencyContext", input]);
+      return {
+        bucket: input.bucket,
+        key: `${input.auth.wallet}:${input.scope}:${input.payload?.idempotencyKey ?? "auto"}`,
+        requestHash: `hash:${input.route}:${input.scope}`
+      };
+    },
+    eventBus: {
+      publish: (event) => calls.push(["publish", event])
+    },
+    gateway,
+    getIdempotentMutationReplay: async (context) => {
+      calls.push(["replay", context]);
+      return overrides.replay;
+    },
+    hasRole: (claims, role) => Array.isArray(claims?.roles) && claims.roles.includes(role),
+    parseLimit: (url, fallback, max) => {
+      calls.push(["parseLimit", { fallback, max, limit: url.searchParams.get("limit") }]);
+      return Number(url.searchParams.get("limit") ?? fallback);
+    },
+    persistContentRecord: async (record) => {
+      calls.push(["persistContentRecord", record]);
+      return record;
+    },
+    publicBaseUrl: "https://api.example.test",
+    defaultVerifierAddress: VERIFIER,
+    readJsonBody: async () => {
+      calls.push(["readJsonBody"]);
+      return payload;
+    },
+    respond: (res, statusCode, body, headers = {}) => {
+      calls.push(["respond", { statusCode, body, headers }]);
+      res.statusCode = statusCode;
+      res.body = body;
+      res.headers = headers;
+    },
+    respondWithMutationReceipt: async (res, context, statusCode, body) => {
+      calls.push(["respondWithMutationReceipt", { context, statusCode, body }]);
+      res.statusCode = statusCode;
+      res.body = body;
+    },
+    service: {
+      getJobDefinition: (jobId) => {
+        calls.push(["getJobDefinition", jobId]);
+        const job = jobs.get(jobId);
+        if (!job) {
+          throw new Error(`missing job ${jobId}`);
+        }
+        return job;
+      },
+      listRecentSessions: async (limit) => {
+        calls.push(["listRecentSessions", limit]);
+        return sessions;
+      },
+      resumeSession: async (sessionId) => {
+        calls.push(["resumeSession", sessionId]);
+        const session = sessions.find((candidate) => candidate.sessionId === sessionId);
+        if (!session) {
+          throw new Error(`missing session ${sessionId}`);
+        }
+        return session;
+      },
+    },
+    stateStore: {
+      getMutationReceipt: async (bucket, key) => {
+        calls.push(["getMutationReceipt", { bucket, key }]);
+        return receipts.get(`${bucket}:${key}`);
+      },
+      upsertMutationReceipt: async (bucket, key, receipt) => {
+        calls.push(["upsertMutationReceipt", { bucket, key, receipt }]);
+        receipts.set(`${bucket}:${key}`, receipt);
+      },
+      upsertSession: async (session) => {
+        calls.push(["upsertSession", session]);
+      },
+    },
+  });
+
+  return { calls, receipts, response, route: routes.handleDisputeRoute, routes };
+}
+
+function call(route, { method = "GET", path }) {
+  return route({
+    request: { method },
+    response: {},
+    url: new URL(`http://localhost${path}`),
+    pathname: path,
+  });
+}
+
+test("dispute routes ignore unrelated paths and methods", async () => {
+  const { calls, response, route } = makeHarness();
+
+  assert.equal(await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/jobs"),
+    pathname: "/jobs",
+  }), false);
+  assert.equal(await route({
+    request: { method: "POST" },
+    response,
+    url: new URL("http://localhost/disputes"),
+    pathname: "/disputes",
+  }), false);
+
+  assert.deepEqual(calls, []);
+  assert.deepEqual(response, {});
+});
+
+test("GET /disputes authenticates, parses limit, and returns open and receipt-backed disputes", async () => {
+  const resolvedSession = { ...SESSION, sessionId: "session-resolved", status: "resolved" };
+  const resolvedId = disputeIdForSession(resolvedSession.sessionId);
+  const verdictReceipt = {
+    id: resolvedId,
+    verdict: "dismissed",
+    reasonCode: "DISPUTE_OVERTURNED",
+    decidedAt: "2026-05-02T00:00:00.000Z",
+    decidedBy: ADMIN
+  };
+  const { calls, response, route } = makeHarness({
+    sessions: [SESSION, resolvedSession, { ...SESSION, sessionId: "session-quiet", status: "resolved" }],
+    receipts: {
+      [`dispute_verdict:${resolvedId}`]: verdictReceipt
+    }
+  });
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/disputes?limit=7"),
+    pathname: "/disputes",
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.body.map((dispute) => [dispute.sessionId, dispute.status]), [
+    [SESSION.sessionId, "open"],
+    [resolvedSession.sessionId, "resolved"],
+  ]);
+  assert.equal(response.body[0].respondent, VERIFIER);
+  assert.ok(calls.some(([name, detail]) => name === "parseLimit" && detail.limit === "7"));
+  assert.ok(calls.some(([name]) => name === "authMiddleware"));
+});
+
+test("GET /disputes/:id rejects nested decoded ids", async () => {
+  const { route } = makeHarness();
+
+  await assert.rejects(
+    call(route, { method: "GET", path: "/disputes/abc%2Fdef" }),
+    (error) => error instanceof ValidationError
+  );
+});
+
+test("POST /disputes/:id/verdict requires admin or verifier role before dispute lookup", async () => {
+  const { calls, route } = makeHarness({
+    auth: { wallet: WORKER, claims: { roles: [] } }
+  });
+  const id = disputeIdForSession(SESSION.sessionId);
+
+  await assert.rejects(
+    call(route, { method: "POST", path: `/disputes/${id}/verdict` }),
+    (error) => error instanceof AuthorizationError && error.code === "missing_role"
+  );
+  assert.deepEqual(calls.map(([name]) => name), ["authMiddleware"]);
+});
+
+test("POST /disputes/:id/verdict returns idempotent replay before side effects", async () => {
+  const id = disputeIdForSession(SESSION.sessionId);
+  const replay = { statusCode: 200, body: { replay: true } };
+  const { calls, response, route } = makeHarness({
+    payload: { verdict: "dismissed", idempotencyKey: "idem-1" },
+    replay
+  });
+
+  const handled = await route({
+    request: { method: "POST" },
+    response,
+    url: new URL(`http://localhost/disputes/${id}/verdict`),
+    pathname: `/disputes/${id}/verdict`,
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.body, { replay: true });
+  assert.ok(!calls.some(([name]) => name === "resumeSession"));
+  assert.ok(!calls.some(([name]) => name === "persistContentRecord"));
+  assert.ok(!calls.some(([name]) => name === "upsertMutationReceipt"));
+});
+
+test("POST /disputes/:id/verdict records a local resolution and session transition", async () => {
+  const id = disputeIdForSession(SESSION.sessionId);
+  const { calls, response, route } = makeHarness({
+    auth: { wallet: VERIFIER, claims: { roles: ["verifier"] } },
+    payload: { verdict: "dismissed", rationale: "Evidence supports the worker.", idempotencyKey: "idem-2" }
+  });
+
+  const handled = await route({
+    request: { method: "POST" },
+    response,
+    url: new URL(`http://localhost/disputes/${id}/verdict`),
+    pathname: `/disputes/${id}/verdict`,
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.status, "resolved");
+  assert.equal(response.body.verdict, "dismissed");
+  assert.equal(response.body.workerPayout, JOB.rewardAmount);
+  assert.equal(response.body.chainStatus, "local_only");
+  assert.ok(response.body.metadataURI.startsWith("https://api.example.test/content/"));
+  assert.ok(calls.some(([name]) => name === "persistContentRecord"));
+  assert.ok(calls.some(([name, detail]) => name === "upsertMutationReceipt"
+    && detail.bucket === "dispute_verdict"
+    && detail.key === id
+    && detail.receipt.reasonCode === "DISPUTE_OVERTURNED"));
+  assert.ok(calls.some(([name, session]) => name === "upsertSession" && session.status === "resolved"));
+  assert.ok(calls.some(([name, event]) => name === "publish" && event.topic === "dispute.verdict_recorded"));
+  assert.ok(calls.some(([name]) => name === "respondWithMutationReceipt"));
+});
+
+test("POST /disputes/:id/release requires admin auth and records release", async () => {
+  const id = disputeIdForSession(SESSION.sessionId);
+  const { calls, response, route } = makeHarness({
+    payload: { action: "return-stake", amount: 4, idempotencyKey: "idem-3" }
+  });
+
+  const handled = await route({
+    request: { method: "POST" },
+    response,
+    url: new URL(`http://localhost/disputes/${id}/release`),
+    pathname: `/disputes/${id}/release`,
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.status, "resolved");
+  assert.equal(response.body.release.action, "return-stake");
+  assert.equal(response.body.release.amount, 4);
+  assert.deepEqual(calls.find(([name]) => name === "authMiddleware")?.[1].options, { requireRole: "admin" });
+  assert.ok(calls.some(([name, detail]) => name === "upsertMutationReceipt"
+    && detail.bucket === "dispute_release"
+    && detail.key === id));
+  assert.ok(calls.some(([name, event]) => name === "publish" && event.topic === "settlement.stake_release_recorded"));
+});

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -42,15 +42,6 @@ import { getAddress, keccak256, toUtf8Bytes } from "ethers";
 import { buildBadgeFromSession } from "../../core/badge-metadata.js";
 import { buildDiscoveryManifest } from "../../core/discovery-manifest.js";
 import {
-  ARBITRATOR_SLA_SECONDS,
-  buildDisputeReasoningReceipt,
-  buildDisputeResolution,
-  disputeIdForSession,
-  normalizeDisputeReleaseRequestPayload,
-  normalizeDisputeVerdictRequestPayload
-} from "../../core/dispute-resolution.js";
-import { transitionSession } from "../../core/session-state-machine.js";
-import {
   getPublicBuiltinJobSchemaByName,
   listBuiltinJobSchemas,
   schemaRefToJobSchemaPath
@@ -64,6 +55,7 @@ import { createAdminXcmRoutes } from "./admin-xcm-routes.js";
 import { createActivityRoutes } from "./activity-routes.js";
 import { createBadgeRoutes } from "./badge-routes.js";
 import { createContentRoutes } from "./content-routes.js";
+import { createDisputeRoutes } from "./dispute-routes.js";
 import { createGasRoutes } from "./gas-routes.js";
 import { createJobRoutes } from "./job-routes.js";
 import { createPolicyRoutes } from "./policy-routes.js";
@@ -612,133 +604,10 @@ async function listAlerts(limit = 20) {
   return alerts.slice(0, limit);
 }
 
-function addSecondsIso(value, seconds) {
-  const parsed = Date.parse(value ?? "");
-  const base = Number.isFinite(parsed) ? parsed : Date.now();
-  return new Date(base + seconds * 1000).toISOString();
-}
-
 async function persistContentRecord(record) {
   await contentRecoveryLog?.append?.(record);
   await stateStore.upsertContent?.(record);
   return record;
-}
-
-async function resolveRemainingPayout(session) {
-  if (gateway?.isEnabled?.() && typeof gateway.getJob === "function") {
-    const live = await gateway.getJob(session.chainJobId ?? session.jobId);
-    return Math.max(Number(live.reward ?? 0) - Number(live.released ?? 0), 0);
-  }
-  try {
-    const job = service.getJobDefinition(session.jobId);
-    return Math.max(Number(job.rewardAmount ?? 0), 0);
-  } catch {
-    return 0;
-  }
-}
-
-async function buildDisputeFromSession(session) {
-  const id = disputeIdForSession(session.sessionId);
-  const [verdictReceipt, releaseReceipt] = await Promise.all([
-    stateStore.getMutationReceipt?.("dispute_verdict", id),
-    stateStore.getMutationReceipt?.("dispute_release", id)
-  ]);
-  const openedAt = session.disputedAt ?? session.updatedAt ?? new Date().toISOString();
-  const windowEndsAt = addSecondsIso(openedAt, ARBITRATOR_SLA_SECONDS);
-  const timeline = (session.statusHistory ?? []).map((entry, index) => ({
-    id: `${id}:session:${index}`,
-    at: entry.at,
-    actor: "system",
-    action: entry.reason ?? `session_${entry.to}`,
-    data: entry
-  }));
-  if (verdictReceipt) {
-    timeline.push({
-      id: `${id}:verdict`,
-      at: verdictReceipt.decidedAt,
-      actor: verdictReceipt.decidedBy,
-      action: "verdict_submitted",
-      data: verdictReceipt
-    });
-  }
-  if (releaseReceipt) {
-    timeline.push({
-      id: `${id}:release`,
-      at: releaseReceipt.releasedAt,
-      actor: releaseReceipt.releasedBy,
-      action: "stake_release_recorded",
-      data: releaseReceipt
-    });
-  }
-
-  let job;
-  try {
-    job = service.getJobDefinition(session.jobId);
-  } catch {
-    job = undefined;
-  }
-
-  return {
-    id,
-    status: releaseReceipt || verdictReceipt ? "resolved" : "open",
-    sessionId: session.sessionId,
-    chainJobId: session.chainJobId,
-    claimant: session.wallet,
-    respondent: process.env.DEFAULT_VERIFIER_ADDRESS ?? "0x0000000000000000000000000000000000000000",
-    openedAt,
-    windowEndsAt,
-    slaSeconds: ARBITRATOR_SLA_SECONDS,
-    evidence: {
-      before: compactObject({
-        jobId: session.jobId,
-        jobTitle: job?.title,
-        requirements: job?.verifierTerms,
-        claimStake: session.claimStake,
-        claimFee: session.claimFee,
-        totalClaimLock: session.totalClaimLock
-      }),
-      after: compactObject({
-        submission: session.submission,
-        verification: session.verification ?? session.verificationSummary
-      })
-    },
-    verdict: verdictReceipt?.verdict ?? null,
-    reasonCode: verdictReceipt?.reasonCode,
-    reasoningHash: verdictReceipt?.reasoningHash,
-    metadataURI: verdictReceipt?.metadataURI,
-    txHash: verdictReceipt?.txHash,
-    chainStatus: verdictReceipt?.chainStatus,
-    workerPayout: verdictReceipt?.workerPayout,
-    remainingPayout: verdictReceipt?.remainingPayout,
-    stakedAmount: Number(session.claimStake ?? 0),
-    claimFee: Number(session.claimFee ?? 0),
-    totalClaimLock: Number(session.totalClaimLock ?? session.claimStake ?? 0),
-    release: releaseReceipt ?? null,
-    timeline: timeline.sort((left, right) => String(left.at ?? "").localeCompare(String(right.at ?? "")))
-  };
-}
-
-async function listDisputes(limit = 100) {
-  const sessions = await service.listRecentSessions(limit);
-  const candidates = await Promise.all(
-    sessions.map(async (session) => {
-      if (session.status === "disputed") {
-        return session;
-      }
-      const id = disputeIdForSession(session.sessionId);
-      const [verdictReceipt, releaseReceipt] = await Promise.all([
-        stateStore.getMutationReceipt?.("dispute_verdict", id),
-        stateStore.getMutationReceipt?.("dispute_release", id)
-      ]);
-      return verdictReceipt || releaseReceipt ? session : undefined;
-    })
-  );
-  return Promise.all(candidates.filter(Boolean).map((session) => buildDisputeFromSession(session)));
-}
-
-async function findDispute(id, limit = 250) {
-  const disputes = await listDisputes(limit);
-  return disputes.find((dispute) => dispute.id === id);
 }
 
 function resolveCorsHeaders(request) {
@@ -1279,6 +1148,27 @@ const handleBadgeRoute = createBadgeRoutes({
   verifierService,
 });
 
+const {
+  handleDisputeRoute,
+  listDisputes,
+} = createDisputeRoutes({
+  authMiddleware,
+  buildScopedIdempotentMutationContext,
+  eventBus,
+  gateway,
+  getIdempotentMutationReplay,
+  hasRole,
+  parseLimit,
+  persistContentRecord,
+  publicBaseUrl: process.env.PUBLIC_BASE_URL,
+  defaultVerifierAddress: process.env.DEFAULT_VERIFIER_ADDRESS,
+  readJsonBody,
+  respond,
+  respondWithMutationReceipt,
+  service,
+  stateStore,
+});
+
 const handleActivityRoute = createActivityRoutes({
   authMiddleware,
   listAlerts,
@@ -1654,253 +1544,8 @@ const server = createServer(async (request, response) => {
       return;
     }
 
-    if (request.method === "GET" && pathname === "/disputes") {
-      await authMiddleware(request, url);
-      return respond(response, 200, await listDisputes(parseLimit(url, 100, 500)));
-    }
-
-    if (request.method === "GET" && pathname.startsWith("/disputes/")) {
-      await authMiddleware(request, url);
-      const id = decodeURIComponent(pathname.slice("/disputes/".length));
-      if (!id || id.includes("/")) {
-        throw new ValidationError("dispute id path segment is required.");
-      }
-      const dispute = await findDispute(id);
-      if (!dispute) {
-        return respond(response, 404, { status: "not_found", id });
-      }
-      return respond(response, 200, dispute);
-    }
-
-    if (request.method === "POST" && /^\/disputes\/[^/]+\/verdict$/u.test(pathname)) {
-      const auth = await authMiddleware(request, url);
-      if (!hasRole(auth.claims, "admin") && !hasRole(auth.claims, "verifier")) {
-        throw new AuthorizationError("Requires admin or verifier role.", "missing_role");
-      }
-      const id = decodeURIComponent(pathname.slice("/disputes/".length, -"/verdict".length));
-      const dispute = await findDispute(id);
-      if (!dispute) {
-        return respond(response, 404, { status: "not_found", id });
-      }
-      const payload = await readJsonBody(request);
-      const idempotency = buildScopedIdempotentMutationContext({
-        route: "/disputes/:id/verdict",
-        auth,
-        scope: id,
-        payload,
-        normalizedPayload: normalizeDisputeVerdictRequestPayload(id, payload),
-        bucket: "dispute_verdict_idempotency"
-      });
-      const replay = await getIdempotentMutationReplay(idempotency);
-      if (replay) {
-        return respond(response, replay.statusCode, replay.body);
-      }
-      if (dispute.verdict || dispute.reasonCode) {
-        return respondWithMutationReceipt(response, idempotency, 200, dispute);
-      }
-      const session = await service.resumeSession(dispute.sessionId);
-      const decidedAt = new Date().toISOString();
-      const remainingPayout = await resolveRemainingPayout(session);
-      const resolution = buildDisputeResolution({
-        verdict: payload?.verdict ?? payload?.outcome,
-        remainingPayout,
-        workerPayout: payload?.workerPayout ?? payload?.payoutAmount
-      });
-      const reasoning = buildDisputeReasoningReceipt({
-        id,
-        dispute,
-        payload,
-        auth,
-        verdict: resolution.verdict,
-        decidedAt,
-        publicBaseUrl: process.env.PUBLIC_BASE_URL
-      });
-      await persistContentRecord(reasoning.contentRecord);
-      const chainReceipt = gateway?.isEnabled?.() && typeof gateway.resolveDispute === "function"
-        ? await gateway.resolveDispute(
-            session.chainJobId ?? session.jobId,
-            resolution.workerPayout,
-            resolution.reasonCode,
-            reasoning.metadataURI
-          )
-        : {
-            txHash: undefined,
-            blockNumber: undefined,
-            status: undefined
-          };
-      const receipt = {
-        id,
-        disputeId: id,
-        sessionId: dispute.sessionId,
-        jobId: session.jobId,
-        chainJobId: session.chainJobId,
-        verdict: resolution.verdict,
-        workerPayout: resolution.workerPayout,
-        remainingPayout,
-        reasonCode: resolution.reasonCode,
-        reasoningHash: reasoning.reasoningHash,
-        metadataURI: reasoning.metadataURI,
-        rationale: reasoning.rationale || undefined,
-        releaseAction: resolution.releaseAction,
-        payoutSource: resolution.payoutSource,
-        txHash: chainReceipt.txHash,
-        blockNumber: chainReceipt.blockNumber,
-        chainStatus: gateway?.isEnabled?.()
-          ? (chainReceipt.status === 1 ? "confirmed" : "submitted")
-          : "local_only",
-        decidedBy: auth.wallet,
-        decidedAt
-      };
-      await stateStore.upsertMutationReceipt?.("dispute_verdict", id, receipt);
-      if (session.status === "disputed") {
-        const transitioned = transitionSession(session, resolution.nextSessionStatus, {
-          reason: resolution.reasonCode,
-          timestamp: decidedAt,
-          metadata: {
-            disputeId: id,
-            verdict: resolution.verdict,
-            workerPayout: resolution.workerPayout,
-            reasonCode: resolution.reasonCode,
-            txHash: receipt.txHash
-          }
-        });
-        await stateStore.upsertSession?.(transitioned);
-      }
-      eventBus?.publish({
-        id: `dispute-verdict-${id}-${Date.now()}`,
-        topic: "dispute.verdict_recorded",
-        wallet: dispute.claimant,
-        wallets: [dispute.claimant, auth.wallet],
-        jobId: session.jobId,
-        sessionId: dispute.sessionId,
-        timestamp: receipt.decidedAt,
-        correlationId: dispute.sessionId,
-        txHash: receipt.txHash,
-        blockNumber: receipt.blockNumber,
-        source: "settlement",
-        phase: "dispute",
-        severity: resolution.verdict === "dismissed" ? "info" : "warn",
-        data: {
-          disputeId: id,
-          jobId: session.jobId,
-          chainJobId: session.chainJobId,
-          openedAt: dispute.openedAt,
-          windowEndsAt: dispute.windowEndsAt,
-          slaSeconds: dispute.slaSeconds,
-          verdict: resolution.verdict,
-          workerPayout: resolution.workerPayout,
-          reasonCode: resolution.reasonCode,
-          reasoningHash: receipt.reasoningHash,
-          metadataURI: receipt.metadataURI,
-          txHash: receipt.txHash,
-          blockNumber: receipt.blockNumber,
-          chainStatus: receipt.chainStatus
-        }
-      });
-      const body = {
-        ...dispute,
-        status: "resolved",
-        verdict: resolution.verdict,
-        reasonCode: resolution.reasonCode,
-        reasoningHash: reasoning.reasoningHash,
-        metadataURI: reasoning.metadataURI,
-        txHash: receipt.txHash,
-        chainStatus: receipt.chainStatus,
-        workerPayout: resolution.workerPayout,
-        remainingPayout,
-        timeline: [
-          ...dispute.timeline,
-          {
-            id: `${id}:verdict`,
-            at: receipt.decidedAt,
-            actor: receipt.decidedBy,
-            action: "verdict_submitted",
-            data: receipt
-          }
-        ]
-      };
-      return respondWithMutationReceipt(response, idempotency, 200, body);
-    }
-
-    if (request.method === "POST" && /^\/disputes\/[^/]+\/release$/u.test(pathname)) {
-      const auth = await authMiddleware(request, url, { requireRole: "admin" });
-      const id = decodeURIComponent(pathname.slice("/disputes/".length, -"/release".length));
-      const dispute = await findDispute(id);
-      if (!dispute) {
-        return respond(response, 404, { status: "not_found", id });
-      }
-      const payload = await readJsonBody(request);
-      const idempotency = buildScopedIdempotentMutationContext({
-        route: "/disputes/:id/release",
-        auth,
-        scope: id,
-        payload,
-        normalizedPayload: normalizeDisputeReleaseRequestPayload(id, dispute, payload),
-        bucket: "dispute_release_idempotency"
-      });
-      const replay = await getIdempotentMutationReplay(idempotency);
-      if (replay) {
-        return respond(response, replay.statusCode, replay.body);
-      }
-      if (dispute.release) {
-        return respondWithMutationReceipt(response, idempotency, 200, dispute);
-      }
-      const session = await service.resumeSession(dispute.sessionId).catch(() => undefined);
-      const receipt = {
-        id,
-        disputeId: id,
-        sessionId: dispute.sessionId,
-        jobId: session?.jobId,
-        chainJobId: session?.chainJobId,
-        action: typeof payload?.action === "string" && payload.action.trim() ? payload.action.trim() : "release",
-        amount: Number(payload?.amount ?? dispute.stakedAmount ?? 0),
-        chainStatus: dispute.txHash ? "settled_by_verdict" : "local_only",
-        txHash: dispute.txHash,
-        releasedBy: auth.wallet,
-        releasedAt: new Date().toISOString()
-      };
-      await stateStore.upsertMutationReceipt?.("dispute_release", id, receipt);
-      eventBus?.publish({
-        id: `dispute-release-${id}-${Date.now()}`,
-        topic: "settlement.stake_release_recorded",
-        wallet: dispute.claimant,
-        wallets: [dispute.claimant, auth.wallet],
-        jobId: session?.jobId,
-        sessionId: dispute.sessionId,
-        timestamp: receipt.releasedAt,
-        correlationId: dispute.sessionId,
-        txHash: receipt.txHash,
-        source: "settlement",
-        phase: "settlement",
-        severity: "info",
-        data: {
-          disputeId: id,
-          jobId: session?.jobId,
-          chainJobId: session?.chainJobId,
-          openedAt: dispute.openedAt,
-          windowEndsAt: dispute.windowEndsAt,
-          amount: receipt.amount,
-          action: receipt.action,
-          chainStatus: receipt.chainStatus,
-          txHash: receipt.txHash
-        }
-      });
-      const body = {
-        ...dispute,
-        status: "resolved",
-        release: receipt,
-        timeline: [
-          ...dispute.timeline,
-          {
-            id: `${id}:release`,
-            at: receipt.releasedAt,
-            actor: receipt.releasedBy,
-            action: "stake_release_recorded",
-            data: receipt
-          }
-        ]
-      };
-      return respondWithMutationReceipt(response, idempotency, 200, body);
+    if (await handleDisputeRoute({ request, response, url, pathname })) {
+      return;
     }
 
     // ---------- auth routes ----------


### PR DESCRIPTION
## What changed

- Extracted the authenticated dispute endpoints into `mcp-server/src/protocols/http/dispute-routes.js`.
- Kept the existing `server.js` alert feed behavior by wiring the route module `listDisputes()` accessor back into `/alerts`.
- Added focused route tests for dispute listing, id validation, verdict auth, idempotent replay, verdict recording/session transition, release recording, and unrelated route handling.
- Added a roadmap fragment for the P2.3 route-split steward instead of editing the shared roadmap row directly.
- Rebased on current `origin/main` after #504 and resolved the import-only conflict in `server.js`.

## Affected areas

- Backend HTTP routing: yes
- Frontend/indexer/contracts/public site/Caddy: no
- Env/VPS secrets: none

## Checks

- Polkadot MCP docs check: `get_project_info` returned `Polkadot Developer Docs` with index status `ready`.
- `node --check mcp-server/src/protocols/http/dispute-routes.js`
- `node --check mcp-server/src/protocols/http/server.js`
- `node --test mcp-server/src/protocols/http/dispute-routes.test.js mcp-server/src/protocols/http/activity-routes.test.js mcp-server/src/protocols/http/content-routes.test.js`
- `npm --workspace mcp-server test`
- `git diff --check`
