### PR TITLE
ops: validate backup readiness evidence

### DIFF
--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -64,9 +64,10 @@ functions, but it does not close the live pause/unpause rehearsal box.
 - [ ] Latest Postgres backup exists and is recent. Evidence:
   `./scripts/ops/check-backup-readiness.sh --json` reports
   `components[postgres].status == "ok"` with `ageSeconds <
-  maxAgeHours * 3600`.
+  maxAgeHours * 3600`, then the saved JSON passes
+  `node scripts/ops/check-backup-readiness-evidence.mjs`.
 - [ ] Latest Redis backup exists and is recent. Same readiness check,
-  `components[redis].status == "ok"`.
+  `components[redis].status == "ok"` and the saved JSON validator passes.
 - [ ] The monthly restore drill has been run on the current stack
   shape. Evidence: a dated line in the operator log naming both
   backup file paths used, the row count from the Postgres spot-check,
@@ -88,7 +89,12 @@ backup file):
 ```bash
 ./scripts/ops/check-backup-readiness.sh
 # or for machine-readable output:
-./scripts/ops/check-backup-readiness.sh --json
+./scripts/ops/check-backup-readiness.sh --json \
+  > docs/evidence/backup-readiness-YYYY-MM-DD.json
+
+node scripts/ops/check-backup-readiness-evidence.mjs \
+  --file docs/evidence/backup-readiness-YYYY-MM-DD.json \
+  --max-checked-age-hours 30
 ```
 
 Restore procedures:

--- a/docs/roadmap-updates/2026-05-24-codex-backup-readiness-evidence.md
+++ b/docs/roadmap-updates/2026-05-24-codex-backup-readiness-evidence.md
@@ -1,0 +1,36 @@
+# Roadmap Update: Backup readiness evidence validation
+
+- **Date:** 2026-05-24
+- **Agent:** Codex / `codex/backup-readiness-evidence`
+- **Roadmap section:** P0 Launch Gates
+- **Item:** Postgres backup readiness / Redis backup readiness
+- **Related PRs/issues:** [PR #507](https://github.com/averray-agent/agent/pull/507)
+- **Proposed status:** Open
+- **Owner:** Launch operator / roadmap steward
+
+## Summary
+
+This slice adds a read-only validator for saved
+`check-backup-readiness.sh --json` output. It does not prove current production
+backups by itself; it lets operators save the readiness JSON as an artifact and
+verify that both Postgres and Redis components are `ok`, within the captured
+age threshold, and recent enough for launch evidence.
+
+## Evidence
+
+- New validator: `scripts/ops/check-backup-readiness-evidence.mjs`.
+- New focused tests: `scripts/ops/check-backup-readiness-evidence.test.mjs`.
+- Checklist wiring: `docs/PRODUCTION_CHECKLIST.md` now shows saving and
+  validating `docs/evidence/backup-readiness-YYYY-MM-DD.json`.
+
+## Blockers Or Caveats
+
+- The roadmap rows remain `Open` until the operator captures live production
+  readiness evidence and validates it with `--max-checked-age-hours`.
+- This does not replace the separate restore-drill proof.
+
+## Requested Roadmap Change
+
+Keep `Postgres backup readiness` and `Redis backup readiness` as `Open`. Once
+validated production evidence exists, update the exact rows with the evidence
+path, component file names, ages, and validator command output.

--- a/scripts/ops/check-backup-readiness-evidence.mjs
+++ b/scripts/ops/check-backup-readiness-evidence.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_NAME = basename(fileURLToPath(import.meta.url));
+const COMPONENT_RULES = {
+  postgres: {
+    suffix: ".sql.gz"
+  },
+  redis: {
+    suffix: ".rdb.gz"
+  }
+};
+
+function usage() {
+  return `Usage: node scripts/ops/${SCRIPT_NAME} --file docs/evidence/backup-readiness-YYYY-MM-DD.json [--json] [--max-checked-age-hours N]
+
+Validates the saved JSON emitted by check-backup-readiness.sh --json. This
+check is read-only; it does not inspect, restore, delete, or modify backups.
+`;
+}
+
+function parseArgs(argv) {
+  const args = {
+    file: undefined,
+    json: false,
+    maxCheckedAgeHours: undefined,
+    help: false
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--file") {
+      args.file = argv[index + 1];
+      index += 1;
+    } else if (arg === "--json") {
+      args.json = true;
+    } else if (arg === "--max-checked-age-hours") {
+      args.maxCheckedAgeHours = parsePositiveInteger(argv[index + 1], "--max-checked-age-hours");
+      index += 1;
+    } else if (arg === "-h" || arg === "--help") {
+      args.help = true;
+    } else if (!args.file && !arg.startsWith("-")) {
+      args.file = arg;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+
+  return args;
+}
+
+function parsePositiveInteger(value, flag) {
+  if (!/^[1-9][0-9]*$/u.test(String(value ?? ""))) {
+    throw new Error(`${flag} must be a positive integer`);
+  }
+  return Number(value);
+}
+
+function assertObject(value, path, errors) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    errors.push(`${path} must be an object`);
+    return {};
+  }
+  return value;
+}
+
+function requireString(value, path, errors, { pattern = undefined } = {}) {
+  if (typeof value !== "string" || !value.trim()) {
+    errors.push(`${path} must be a non-empty string`);
+    return "";
+  }
+  const trimmed = value.trim();
+  if (pattern && !pattern.test(trimmed)) {
+    errors.push(`${path} has an invalid format`);
+  }
+  return trimmed;
+}
+
+function requireNumber(value, path, errors, { integer = false, min = undefined } = {}) {
+  const ok = integer ? Number.isInteger(value) : Number.isFinite(value);
+  if (!ok) {
+    errors.push(`${path} must be ${integer ? "an integer" : "a finite number"}`);
+    return undefined;
+  }
+  if (min !== undefined && value < min) {
+    errors.push(`${path} must be >= ${min}`);
+  }
+  return value;
+}
+
+function requireIsoDate(value, path, errors) {
+  const raw = requireString(value, path, errors);
+  if (!raw) return "";
+  if (!/^\d{4}-\d{2}-\d{2}T/u.test(raw) || !Number.isFinite(Date.parse(raw))) {
+    errors.push(`${path} must be an ISO-8601 date/time`);
+  }
+  return raw;
+}
+
+function requireArray(value, path, errors) {
+  if (!Array.isArray(value)) {
+    errors.push(`${path} must be an array`);
+    return [];
+  }
+  return value;
+}
+
+function componentByName(readiness, name) {
+  const components = Array.isArray(readiness?.components) ? readiness.components : [];
+  return components.find((component) => component?.name === name);
+}
+
+function validateComponent(readiness, name, errors) {
+  const rules = COMPONENT_RULES[name];
+  const component = assertObject(componentByName(readiness, name), `components.${name}`, errors);
+
+  if (component.status !== "ok") {
+    errors.push(`components.${name}.status must be ok`);
+  }
+  const file = requireString(component.file, `components.${name}.file`, errors);
+  if (file && !file.endsWith(rules.suffix)) {
+    errors.push(`components.${name}.file must end with ${rules.suffix}`);
+  }
+  const ageSeconds = requireNumber(component.ageSeconds, `components.${name}.ageSeconds`, errors, {
+    integer: true,
+    min: 0
+  });
+  requireString(component.message, `components.${name}.message`, errors);
+
+  if (Number.isInteger(readiness.maxAgeHours) && Number.isInteger(ageSeconds)) {
+    const maxAgeSeconds = readiness.maxAgeHours * 3600;
+    if (ageSeconds > maxAgeSeconds) {
+      errors.push(`components.${name}.ageSeconds must be <= maxAgeHours * 3600`);
+    }
+  }
+
+  return { file, ageSeconds };
+}
+
+export function validateEvidence(evidence, options = {}) {
+  const errors = [];
+  const warnings = [];
+  const doc = assertObject(evidence, "evidence", errors);
+
+  const checkedAt = requireIsoDate(doc.checkedAt, "checkedAt", errors);
+  requireString(doc.backupDir, "backupDir", errors);
+  requireNumber(doc.maxAgeHours, "maxAgeHours", errors, { integer: true, min: 1 });
+  if (doc.overallStatus !== "ok") {
+    errors.push("overallStatus must be ok");
+  }
+
+  const components = requireArray(doc.components, "components", errors);
+  const seenComponents = new Set();
+  for (const [index, rawComponent] of components.entries()) {
+    const component = assertObject(rawComponent, `components[${index}]`, errors);
+    const name = requireString(component.name, `components[${index}].name`, errors);
+    if (!name) continue;
+    if (seenComponents.has(name)) {
+      errors.push(`components must not contain duplicate ${name}`);
+    }
+    seenComponents.add(name);
+  }
+
+  const postgres = validateComponent(doc, "postgres", errors);
+  const redis = validateComponent(doc, "redis", errors);
+
+  if (checkedAt && options.maxCheckedAgeHours !== undefined) {
+    const checkedAtMs = Date.parse(checkedAt);
+    const nowMs = Date.now();
+    const maxAgeMs = options.maxCheckedAgeHours * 3600 * 1000;
+    const futureSlackMs = 5 * 60 * 1000;
+    if (checkedAtMs > nowMs + futureSlackMs) {
+      errors.push("checkedAt must not be in the future");
+    } else if (nowMs - checkedAtMs > maxAgeMs) {
+      errors.push(`checkedAt must be within ${options.maxCheckedAgeHours}h`);
+    }
+  }
+
+  if (!errors.length && options.maxCheckedAgeHours === undefined) {
+    warnings.push("checkedAt freshness was not enforced; use --max-checked-age-hours for launch proof");
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    summary: {
+      checkedAt: doc.checkedAt,
+      backupDir: doc.backupDir,
+      maxAgeHours: doc.maxAgeHours,
+      postgresFile: postgres.file,
+      postgresAgeSeconds: postgres.ageSeconds,
+      redisFile: redis.file,
+      redisAgeSeconds: redis.ageSeconds
+    }
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(usage());
+    return;
+  }
+  if (!args.file) {
+    throw new Error("--file is required");
+  }
+
+  const parsed = JSON.parse(await readFile(args.file, "utf8"));
+  const result = validateEvidence(parsed, {
+    maxCheckedAgeHours: args.maxCheckedAgeHours
+  });
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify({
+      status: result.ok ? "ok" : "not_ok",
+      file: args.file,
+      summary: result.summary,
+      warnings: result.warnings,
+      errors: result.errors
+    }, null, 2)}\n`);
+  } else if (result.ok) {
+    process.stdout.write(`Backup readiness evidence ok: ${args.file}\n`);
+    for (const warning of result.warnings) {
+      process.stderr.write(`- warning: ${warning}\n`);
+    }
+  } else {
+    process.stderr.write(`Backup readiness evidence invalid: ${args.file}\n`);
+    for (const error of result.errors) {
+      process.stderr.write(`- ${error}\n`);
+    }
+  }
+
+  if (!result.ok) {
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ops/check-backup-readiness-evidence.test.mjs
+++ b/scripts/ops/check-backup-readiness-evidence.test.mjs
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { validateEvidence } from "./check-backup-readiness-evidence.mjs";
+
+const execFileAsync = promisify(execFile);
+const scriptPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "check-backup-readiness-evidence.mjs"
+);
+
+function isoHoursAgo(hours) {
+  return new Date(Date.now() - hours * 3600 * 1000).toISOString();
+}
+
+function validEvidence(overrides = {}) {
+  return {
+    checkedAt: isoHoursAgo(1),
+    backupDir: "/srv/agent-stack/backups",
+    maxAgeHours: 26,
+    overallStatus: "ok",
+    components: [
+      {
+        name: "postgres",
+        status: "ok",
+        file: "/srv/agent-stack/backups/postgres/agent-20260524-010000.sql.gz",
+        ageSeconds: 3600,
+        message: "Newest backup is 1.0h old"
+      },
+      {
+        name: "redis",
+        status: "ok",
+        file: "/srv/agent-stack/backups/redis/redis-20260524-010000.rdb.gz",
+        ageSeconds: 7200,
+        message: "Newest backup is 2.0h old"
+      }
+    ],
+    ...overrides
+  };
+}
+
+async function writeEvidenceFile(doc) {
+  const dir = await mkdtemp(join(tmpdir(), "backup-readiness-evidence-"));
+  const file = join(dir, "evidence.json");
+  await writeFile(file, `${JSON.stringify(doc, null, 2)}\n`, "utf8");
+  return file;
+}
+
+test("validateEvidence accepts complete backup readiness evidence", () => {
+  const result = validateEvidence(validEvidence(), { maxCheckedAgeHours: 6 });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.errors, []);
+  assert.deepEqual(result.warnings, []);
+  assert.equal(result.summary.postgresFile, "/srv/agent-stack/backups/postgres/agent-20260524-010000.sql.gz");
+  assert.equal(result.summary.redisAgeSeconds, 7200);
+});
+
+test("validateEvidence warns when evidence freshness is not enforced", () => {
+  const result = validateEvidence(validEvidence());
+
+  assert.equal(result.ok, true);
+  assert.match(result.warnings[0], /checkedAt freshness was not enforced/u);
+});
+
+test("validateEvidence rejects stale or failed component evidence", () => {
+  const result = validateEvidence(validEvidence({
+    overallStatus: "not_ok",
+    components: [
+      {
+        name: "postgres",
+        status: "stale",
+        file: "/srv/agent-stack/backups/postgres/agent-20260520-010000.sql.gz",
+        ageSeconds: 100000,
+        message: "stale"
+      },
+      {
+        name: "redis",
+        status: "ok",
+        file: "/srv/agent-stack/backups/redis/redis-20260524-010000.dump",
+        ageSeconds: 3600,
+        message: "ok"
+      }
+    ]
+  }));
+
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.includes("overallStatus must be ok"));
+  assert.ok(result.errors.includes("components.postgres.status must be ok"));
+  assert.ok(result.errors.includes("components.postgres.ageSeconds must be <= maxAgeHours * 3600"));
+  assert.ok(result.errors.includes("components.redis.file must end with .rdb.gz"));
+});
+
+test("validateEvidence rejects missing and duplicate components", () => {
+  const result = validateEvidence(validEvidence({
+    components: [
+      {
+        name: "postgres",
+        status: "ok",
+        file: "/srv/agent-stack/backups/postgres/agent-20260524-010000.sql.gz",
+        ageSeconds: 3600,
+        message: "ok"
+      },
+      {
+        name: "postgres",
+        status: "ok",
+        file: "/srv/agent-stack/backups/postgres/agent-20260524-020000.sql.gz",
+        ageSeconds: 1800,
+        message: "ok"
+      }
+    ]
+  }));
+
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.includes("components must not contain duplicate postgres"));
+  assert.ok(result.errors.includes("components.redis must be an object"));
+  assert.ok(result.errors.includes("components.redis.status must be ok"));
+});
+
+test("validateEvidence rejects stale saved evidence when max checked age is set", () => {
+  const result = validateEvidence(validEvidence({
+    checkedAt: isoHoursAgo(30)
+  }), { maxCheckedAgeHours: 6 });
+
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.includes("checkedAt must be within 6h"));
+});
+
+test("CLI exits zero and prints JSON for valid evidence", async () => {
+  const file = await writeEvidenceFile(validEvidence());
+  const { stdout, stderr } = await execFileAsync(process.execPath, [
+    scriptPath,
+    "--file",
+    file,
+    "--max-checked-age-hours",
+    "6",
+    "--json"
+  ]);
+
+  const parsed = JSON.parse(stdout);
+  assert.equal(stderr, "");
+  assert.equal(parsed.status, "ok");
+  assert.equal(parsed.summary.maxAgeHours, 26);
+  assert.deepEqual(parsed.errors, []);
+});
+
+test("CLI exits non-zero for invalid evidence", async () => {
+  const file = await writeEvidenceFile(validEvidence({
+    components: []
+  }));
+
+  await assert.rejects(
+    () => execFileAsync(process.execPath, [scriptPath, "--file", file]),
+    (error) => {
+      assert.notEqual(error.code, 0);
+      assert.match(error.stderr, /components\.postgres must be an object/u);
+      assert.match(error.stderr, /components\.redis must be an object/u);
+      return true;
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- add a read-only validator for saved check-backup-readiness.sh --json output
- verify Postgres and Redis components are ok, within the captured maxAgeHours, and optionally checked recently via --max-checked-age-hours
- wire the validator into the production checklist and add a roadmap-update fragment without changing canonical roadmap status

## Checks
- node --test scripts/ops/check-backup-readiness-evidence.test.mjs scripts/ops/check-backup-readiness.test.mjs
- npm run test:ops
- git diff --check

## Impact
- Backend: no
- Frontend: no
- Indexer: no
- Caddy: no
- Contracts: no
- Public site: no
- Ops/docs: yes

## Notes
- This does not prove current production backups by itself; the operator still needs to capture live readiness JSON and validate it with --max-checked-age-hours.
- This does not replace restore-drill evidence.
- No env or VPS secret changes required.