### PR TITLE
ops: harden observability proof freshness

### DIFF
--- a/docs/OBSERVABILITY_POSTURE.md
+++ b/docs/OBSERVABILITY_POSTURE.md
@@ -97,5 +97,10 @@ artifact. Validate it before using it to close the P0 observability rows:
 ```bash
 node scripts/ops/check-observability-proof.mjs \
   --file docs/evidence/observability-YYYY-MM-DD.json \
+  --max-completed-age-hours 30 \
   --json
 ```
+
+The freshness flag is intentionally explicit: it lets older artifacts remain
+auditable while preventing stale evidence from being reused as current launch
+proof.

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -296,7 +296,7 @@ deployed-config evidence that lives outside the repo. The wiring exists in
 code; only the production env vars need to be set. Record the three
 observability gates as one dated artifact and validate it with
 `node scripts/ops/check-observability-proof.mjs --file
-docs/evidence/observability-YYYY-MM-DD.json --json` before moving the
+docs/evidence/observability-YYYY-MM-DD.json --max-completed-age-hours 30 --json` before moving the
 roadmap rows to `Proofed`. Concrete verification commands per box:
 
 - **Backend metrics bearer-protected and reachable.** Production now fails

--- a/docs/roadmap-updates/2026-05-24-codex-observability-proof-freshness.md
+++ b/docs/roadmap-updates/2026-05-24-codex-observability-proof-freshness.md
@@ -1,0 +1,35 @@
+# Roadmap Update: Observability Proof Freshness
+
+- **Date:** 2026-05-24
+- **Agent:** codex/observability-proof-freshness
+- **Roadmap section:** P0 Launch Gates
+- **Item:** Metrics auth / Sentry/logging decision / Alert destination
+- **Related PRs/issues:** [PR #510](https://github.com/averray-agent/agent/pull/510)
+- **Proposed status:** Ready for proof
+- **Owner:** Operator
+
+## Summary
+
+The observability evidence validator now supports an explicit max-age gate for
+launch proof artifacts. This keeps old evidence auditable while requiring the
+operator to prove that metrics auth, alert delivery, and logging/Sentry posture
+were observed recently before the roadmap rows move to `Proofed`.
+
+## Evidence
+
+- Updated script: `scripts/ops/check-observability-proof.mjs`
+- Updated tests: `scripts/ops/check-observability-proof.test.mjs`
+- Updated runbook/checklist command:
+  `node scripts/ops/check-observability-proof.mjs --file docs/evidence/observability-YYYY-MM-DD.json --max-completed-age-hours 30 --json`
+
+## Blockers Or Caveats
+
+- The roadmap rows remain `Ready for proof` until the operator captures a live
+  production evidence artifact and validates it with the max-age gate.
+
+## Requested Roadmap Change
+
+Keep `Metrics auth`, `Sentry/logging decision`, and `Alert destination` as
+`Ready for proof`. When the live artifact exists, cite the artifact path,
+validation command, metrics HTTP statuses, alert delivery details, and logging
+decision before moving those rows to `Proofed`.

--- a/scripts/ops/check-observability-proof.mjs
+++ b/scripts/ops/check-observability-proof.mjs
@@ -6,20 +6,25 @@ import { fileURLToPath } from "node:url";
 
 const SCRIPT_NAME = basename(fileURLToPath(import.meta.url));
 const SCHEMA_VERSION = "observability-proof-v1";
+const FUTURE_SKEW_MS = 5 * 60 * 1000;
 
 function usage() {
-  return `Usage: node scripts/ops/${SCRIPT_NAME} --file docs/evidence/observability-YYYY-MM-DD.json [--json]
+  return `Usage: node scripts/ops/${SCRIPT_NAME} --file docs/evidence/observability-YYYY-MM-DD.json [--json] [--max-completed-age-hours N]
 
 Validates the operator evidence for the RC1 observability gates:
 metrics bearer auth, hosted alert delivery, and Sentry/logging posture.
 This check is read-only; it does not call the hosted stack or alert vendors.
+
+Use --max-completed-age-hours when validating live launch evidence so stale
+historical artifacts cannot be reused as current production proof.
 `;
 }
 
 function parseArgs(argv) {
   const args = {
     file: undefined,
-    json: false
+    json: false,
+    maxCompletedAgeHours: undefined
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -28,6 +33,14 @@ function parseArgs(argv) {
       index += 1;
     } else if (arg === "--json") {
       args.json = true;
+    } else if (arg === "--max-completed-age-hours") {
+      const raw = argv[index + 1];
+      const value = Number(raw);
+      if (!Number.isFinite(value) || value <= 0) {
+        throw new Error("--max-completed-age-hours must be a positive number");
+      }
+      args.maxCompletedAgeHours = value;
+      index += 1;
     } else if (arg === "-h" || arg === "--help") {
       args.help = true;
     } else if (!args.file && !arg.startsWith("-")) {
@@ -95,6 +108,12 @@ function requireDateOnly(value, path, errors) {
   return requireString(value, path, errors, { pattern: /^\d{4}-\d{2}-\d{2}$/u });
 }
 
+function requireIsoTimestamp(value, path, errors) {
+  const raw = requireIsoDate(value, path, errors);
+  const timestamp = Date.parse(raw);
+  return Number.isFinite(timestamp) ? timestamp : undefined;
+}
+
 function requireHttpUrl(value, path, errors) {
   const raw = requireString(value, path, errors);
   if (!raw) return "";
@@ -109,22 +128,63 @@ function requireHttpUrl(value, path, errors) {
   return raw;
 }
 
-function validateEvidence(evidence) {
+function assertNotAfterCompletedAt(value, path, completedAt, errors) {
+  if (!Number.isFinite(value) || !Number.isFinite(completedAt)) return;
+  if (value > completedAt + FUTURE_SKEW_MS) {
+    errors.push(`${path} must not be later than completedAt`);
+  }
+}
+
+function validateFreshness(completedAt, options, errors) {
+  const maxCompletedAgeHours = options.maxCompletedAgeHours;
+  if (maxCompletedAgeHours === undefined) return;
+  if (!Number.isFinite(maxCompletedAgeHours) || maxCompletedAgeHours <= 0) {
+    errors.push("maxCompletedAgeHours must be a positive number");
+    return;
+  }
+  if (!Number.isFinite(completedAt)) return;
+
+  const now = options.now instanceof Date ? options.now : new Date(options.now ?? Date.now());
+  const nowMs = now.getTime();
+  if (!Number.isFinite(nowMs)) {
+    errors.push("now must be a valid Date or timestamp");
+    return;
+  }
+  if (completedAt > nowMs + FUTURE_SKEW_MS) {
+    errors.push("completedAt must not be in the future");
+  }
+  const maxAgeMs = maxCompletedAgeHours * 60 * 60 * 1000;
+  if (nowMs - completedAt > maxAgeMs) {
+    errors.push(`completedAt must be within ${maxCompletedAgeHours} hour(s)`);
+  }
+}
+
+function validateEvidence(evidence, options = {}) {
   const errors = [];
   const doc = assertObject(evidence, "evidence", errors);
 
   if (doc.schemaVersion !== SCHEMA_VERSION) {
     errors.push(`schemaVersion must be ${SCHEMA_VERSION}`);
   }
-  requireDateOnly(doc.proofDate, "proofDate", errors);
-  requireIsoDate(doc.completedAt, "completedAt", errors);
+  const proofDate = requireDateOnly(doc.proofDate, "proofDate", errors);
+  const completedAt = requireIsoTimestamp(doc.completedAt, "completedAt", errors);
+  if (proofDate && Number.isFinite(completedAt)) {
+    const completedDate = new Date(completedAt).toISOString().slice(0, 10);
+    if (proofDate !== completedDate) {
+      errors.push("proofDate must match completedAt UTC date");
+    }
+  }
+  validateFreshness(completedAt, options, errors);
 
   const operator = assertObject(doc.operator, "operator", errors);
   requireString(operator.name, "operator.name", errors);
   requireString(operator.signature, "operator.signature", errors);
 
   const target = assertObject(doc.target, "target", errors);
-  requireString(target.environment, "target.environment", errors);
+  const environment = requireString(target.environment, "target.environment", errors);
+  if (environment && environment !== "production") {
+    errors.push("target.environment must be production");
+  }
   const apiBaseUrl = requireHttpUrl(target.apiBaseUrl, "target.apiBaseUrl", errors);
   if (apiBaseUrl && !/^https:\/\/api\.averray\.com\/?$/u.test(apiBaseUrl)) {
     errors.push("target.apiBaseUrl must be the hosted production API base URL");
@@ -152,7 +212,8 @@ function validateEvidence(evidence) {
   if (metrics.authenticatedStatus !== 200) {
     errors.push("metricsAuth.authenticatedStatus must be 200");
   }
-  requireIsoDate(metrics.observedAt, "metricsAuth.observedAt", errors);
+  const metricsObservedAt = requireIsoTimestamp(metrics.observedAt, "metricsAuth.observedAt", errors);
+  assertNotAfterCompletedAt(metricsObservedAt, "metricsAuth.observedAt", completedAt, errors);
 
   const alert = assertObject(doc.alertDestination, "alertDestination", errors);
   if (requireBoolean(alert.webhookConfigured, "alertDestination.webhookConfigured", errors) !== true) {
@@ -163,7 +224,8 @@ function validateEvidence(evidence) {
   }
   requireString(alert.channel, "alertDestination.channel", errors);
   requireString(alert.messageId, "alertDestination.messageId", errors);
-  requireIsoDate(alert.receivedAt, "alertDestination.receivedAt", errors);
+  const alertReceivedAt = requireIsoTimestamp(alert.receivedAt, "alertDestination.receivedAt", errors);
+  assertNotAfterCompletedAt(alertReceivedAt, "alertDestination.receivedAt", completedAt, errors);
   requireString(alert.failureMode, "alertDestination.failureMode", errors);
 
   const logging = assertObject(doc.sentryLogging, "sentryLogging", errors);
@@ -178,7 +240,8 @@ function validateEvidence(evidence) {
   requireString(logging.observedLogLine, "sentryLogging.observedLogLine", errors, {
     forbidden: /(Bearer\s+[-._~+/A-Za-z0-9]+=*|gho_[A-Za-z0-9_]+|re_[A-Za-z0-9_-]{12,}|https:\/\/[^@\s]+@sentry)/iu
   });
-  requireIsoDate(logging.observedAt, "sentryLogging.observedAt", errors);
+  const loggingObservedAt = requireIsoTimestamp(logging.observedAt, "sentryLogging.observedAt", errors);
+  assertNotAfterCompletedAt(loggingObservedAt, "sentryLogging.observedAt", completedAt, errors);
   if (decision === "sentry_enabled") {
     if (requireBoolean(logging.sentryReadyObserved, "sentryLogging.sentryReadyObserved", errors) !== true) {
       errors.push("sentryLogging.sentryReadyObserved must be true when Sentry is enabled");
@@ -225,7 +288,9 @@ async function main() {
   }
   const raw = await readFile(args.file, "utf8");
   const parsed = JSON.parse(raw);
-  const result = validateEvidence(parsed);
+  const result = validateEvidence(parsed, {
+    maxCompletedAgeHours: args.maxCompletedAgeHours
+  });
   if (args.json) {
     process.stdout.write(`${JSON.stringify({
       status: result.ok ? "ok" : "not_ok",

--- a/scripts/ops/check-observability-proof.test.mjs
+++ b/scripts/ops/check-observability-proof.test.mjs
@@ -56,6 +56,27 @@ function validEvidence(overrides = {}) {
   };
 }
 
+function freshEvidence() {
+  const now = new Date();
+  const observedAt = new Date(now.getTime() - 5 * 60 * 1000).toISOString();
+  return validEvidence({
+    proofDate: now.toISOString().slice(0, 10),
+    completedAt: now.toISOString(),
+    metricsAuth: {
+      ...validEvidence().metricsAuth,
+      observedAt
+    },
+    alertDestination: {
+      ...validEvidence().alertDestination,
+      receivedAt: observedAt
+    },
+    sentryLogging: {
+      ...validEvidence().sentryLogging,
+      observedAt
+    }
+  });
+}
+
 async function writeEvidenceFile(doc) {
   const dir = await mkdtemp(join(tmpdir(), "observability-proof-"));
   const file = join(dir, "evidence.json");
@@ -70,6 +91,15 @@ test("validateEvidence accepts log-only observability proof", () => {
   assert.equal(result.summary.metrics.unauthenticatedStatus, 401);
   assert.equal(result.summary.alertDelivered, true);
   assert.equal(result.summary.sentryLoggingDecision, "log_only_deferred");
+});
+
+test("validateEvidence accepts fresh launch proof with a max completed age", () => {
+  const result = validateEvidence(validEvidence(), {
+    now: new Date("2026-05-22T19:00:00.000Z"),
+    maxCompletedAgeHours: 2
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.errors, []);
 });
 
 test("validateEvidence accepts Sentry-enabled observability proof", () => {
@@ -92,7 +122,7 @@ test("validateEvidence accepts Sentry-enabled observability proof", () => {
 test("validateEvidence rejects incomplete or misleading proof", () => {
   const doc = validEvidence({
     target: {
-      environment: "production",
+      environment: "staging",
       apiBaseUrl: "https://api.example.test"
     },
     metricsAuth: {
@@ -113,6 +143,7 @@ test("validateEvidence rejects incomplete or misleading proof", () => {
 
   const result = validateEvidence(doc);
   assert.equal(result.ok, false);
+  assert.ok(result.errors.includes("target.environment must be production"));
   assert.ok(result.errors.includes("target.apiBaseUrl must be the hosted production API base URL"));
   assert.ok(result.errors.includes("metricsAuth.command must include CHECK_METRICS_AUTH=1"));
   assert.ok(result.errors.includes("metricsAuth.command must not include the raw metrics token"));
@@ -121,6 +152,57 @@ test("validateEvidence rejects incomplete or misleading proof", () => {
   assert.ok(result.errors.includes("alertDestination.deliberateFailureDelivered must be true"));
   assert.ok(result.errors.includes("sentryLogging.observedLogLine must not contain secret-looking material"));
   assert.ok(result.errors.includes("evidence must not include bearer tokens, provider API keys, or Sentry DSNs"));
+});
+
+test("validateEvidence rejects stale or future-dated launch proof", () => {
+  const stale = validateEvidence(validEvidence(), {
+    now: new Date("2026-05-25T18:31:00.000Z"),
+    maxCompletedAgeHours: 24
+  });
+  assert.equal(stale.ok, false);
+  assert.ok(stale.errors.includes("completedAt must be within 24 hour(s)"));
+
+  const future = validateEvidence(validEvidence({
+    proofDate: "2026-05-22",
+    completedAt: "2026-05-22T19:10:00.000Z"
+  }), {
+    now: new Date("2026-05-22T19:00:00.000Z"),
+    maxCompletedAgeHours: 24
+  });
+  assert.equal(future.ok, false);
+  assert.ok(future.errors.includes("completedAt must not be in the future"));
+});
+
+test("validateEvidence rejects mismatched or post-completion timestamps", () => {
+  const result = validateEvidence(validEvidence({
+    proofDate: "2026-05-23",
+    metricsAuth: {
+      ...validEvidence().metricsAuth,
+      observedAt: "2026-05-22T18:40:01.000Z"
+    },
+    alertDestination: {
+      ...validEvidence().alertDestination,
+      receivedAt: "2026-05-22T18:40:01.000Z"
+    },
+    sentryLogging: {
+      ...validEvidence().sentryLogging,
+      observedAt: "2026-05-22T18:40:01.000Z"
+    }
+  }));
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.includes("proofDate must match completedAt UTC date"));
+  assert.ok(result.errors.includes("metricsAuth.observedAt must not be later than completedAt"));
+  assert.ok(result.errors.includes("alertDestination.receivedAt must not be later than completedAt"));
+  assert.ok(result.errors.includes("sentryLogging.observedAt must not be later than completedAt"));
+});
+
+test("validateEvidence rejects invalid freshness options", () => {
+  const result = validateEvidence(validEvidence(), {
+    now: new Date("2026-05-22T19:00:00.000Z"),
+    maxCompletedAgeHours: 0
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.includes("maxCompletedAgeHours must be a positive number"));
 });
 
 test("validateEvidence rejects Sentry-enabled proof without ready observation", () => {
@@ -147,6 +229,20 @@ test("CLI exits zero and prints JSON for valid evidence", async () => {
   assert.equal(parsed.summary.operator, "Pascal");
 });
 
+test("CLI accepts max completed age for fresh evidence", async () => {
+  const file = await writeEvidenceFile(freshEvidence());
+  const { stdout } = await execFileAsync(process.execPath, [
+    scriptPath,
+    "--file",
+    file,
+    "--max-completed-age-hours",
+    "1",
+    "--json"
+  ]);
+  const parsed = JSON.parse(stdout);
+  assert.equal(parsed.status, "ok");
+});
+
 test("CLI exits non-zero for invalid evidence", async () => {
   const file = await writeEvidenceFile(validEvidence({
     alertDestination: {
@@ -159,6 +255,24 @@ test("CLI exits non-zero for invalid evidence", async () => {
     (error) => {
       assert.notEqual(error.code, 0);
       assert.match(error.stderr, /alertDestination\.webhookConfigured must be true/u);
+      return true;
+    }
+  );
+});
+
+test("CLI exits non-zero for invalid max completed age", async () => {
+  const file = await writeEvidenceFile(validEvidence());
+  await assert.rejects(
+    () => execFileAsync(process.execPath, [
+      scriptPath,
+      "--file",
+      file,
+      "--max-completed-age-hours",
+      "0"
+    ]),
+    (error) => {
+      assert.notEqual(error.code, 0);
+      assert.match(error.stderr, /--max-completed-age-hours must be a positive number/u);
       return true;
     }
   );


### PR DESCRIPTION
## Summary
- add an explicit --max-completed-age-hours gate to the observability proof validator
- reject future/stale completedAt values, proofDate/completedAt mismatches, non-production targets, and observations that occur after completedAt
- document the launch-proof validation command and add a roadmap fragment for steward/operator handoff

## Checks
- node --test scripts/ops/check-observability-proof.test.mjs scripts/ops/check-hosted-stack.test.mjs scripts/ops/check-hosted-stack-and-alert.test.mjs
- npm run test:ops
- git diff --check

## Impact
- Backend: no runtime change
- Frontend: no
- Indexer: no
- Caddy: no
- Contracts: no
- Public site: no
- Ops/docs: yes, observability proof validation only

## Env / VPS changes
None. Operators should use the documented --max-completed-age-hours flag when validating live observability proof artifacts before moving the P0 rows to Proofed.