### PR TITLE
backend: split auth routes

### DIFF
--- a/docs/roadmap-updates/2026-05-24-codex-auth-route-split.md
+++ b/docs/roadmap-updates/2026-05-24-codex-auth-route-split.md
@@ -1,0 +1,34 @@
+# Roadmap Update: HTTP server route split (`P2.3`)
+
+## Slice
+
+- **Date:** 2026-05-24
+- **Agent:** Codex
+- **Item:** HTTP server route split (`P2.3`)
+- **Status:** Partial progress; canonical item remains Open.
+
+## What changed
+
+- Extracted `/auth/nonce`, `/auth/verify`, `/auth/session`, `/auth/logout`, and `/auth/refresh` into `mcp-server/src/protocols/http/auth-routes.js`.
+- Kept SIWE nonce issuance, SIWE verification, refresh-cookie issuance, logout revocation, opaque refresh-cookie rotation, and legacy bearer-token refresh semantics behavior-preserving.
+- Added `mcp-server/src/protocols/http/auth-routes.test.js` for:
+  - unrelated route fall-through;
+  - nonce validation and storage;
+  - SIWE verify nonce consumption and refresh-cookie issuance;
+  - session projection;
+  - logout JWT/refresh-chain revocation;
+  - opaque refresh-cookie rotation;
+  - legacy bearer refresh rotation;
+  - service-token refresh rejection.
+
+## Evidence
+
+- Polkadot MCP docs check: `get_project_info` returned `Polkadot Developer Docs` with index status `ready`.
+- `node --check mcp-server/src/protocols/http/auth-routes.js`
+- `node --check mcp-server/src/protocols/http/server.js`
+- `node --test mcp-server/src/protocols/http/auth-routes.test.js`
+
+## Follow-up
+
+- Append this slice to the canonical `HTTP server route split (P2.3)` row after merge.
+- Remaining inline route groups in `server.js` include account/treasury surfaces, event streaming, XCM request read, payments, root health/status/provider/metrics/onboarding, and strategy reads.

--- a/mcp-server/src/protocols/http/auth-routes.js
+++ b/mcp-server/src/protocols/http/auth-routes.js
@@ -1,0 +1,367 @@
+import { randomBytes } from "node:crypto";
+
+import { AuthenticationError, ValidationError } from "../../core/errors.js";
+import { buildSiweMessage, verifySiweMessage } from "../../auth/siwe.js";
+import { signTokenFromConfig } from "../../auth/jwt.js";
+import {
+  REFRESH_COOKIE_NAME,
+  RefreshError,
+  consumeRefreshToken,
+  hashRefreshToken,
+  issueRefreshToken,
+  revokeChain,
+  rotateRefreshToken,
+} from "../../auth/refresh.js";
+import {
+  buildClearCookieHeader,
+  buildSetCookieHeader,
+  makeRefreshStoreAdapter,
+  parseCookie,
+} from "../../auth/refresh-cookie.js";
+
+const SIWE_STATEMENT = "Sign in to the Agent Platform.";
+const WALLET_RE = /^0x[a-fA-F0-9]{40}$/u;
+const SIGNATURE_RE = /^(0x)?[0-9a-fA-F]{130,132}$/u;
+
+function generateNonce(randomBytesImpl) {
+  return randomBytesImpl(16).toString("hex");
+}
+
+function walletsMatch(a, b) {
+  if (!a || !b) {
+    return false;
+  }
+  return String(a).toLowerCase() === String(b).toLowerCase();
+}
+
+function supportsRefreshStore(stateStore) {
+  return Boolean(
+    stateStore
+    && typeof stateStore.getRefreshRecord === "function"
+    && typeof stateStore.upsertRefreshRecord === "function"
+  );
+}
+
+function buildTokenResponse({ token, claims, wallet, roles, authCapabilities, extra = {} }) {
+  return {
+    token,
+    wallet,
+    roles,
+    capabilities: authCapabilities.resolveCapabilities({ roles }),
+    expiresAt: new Date(claims.exp * 1000).toISOString(),
+    tokenType: "Bearer",
+    ...extra,
+  };
+}
+
+export function createAuthRoutes({
+  authCapabilities,
+  authConfig,
+  authMiddleware,
+  buildClearCookieHeaderImpl = buildClearCookieHeader,
+  buildSetCookieHeaderImpl = buildSetCookieHeader,
+  buildSiweMessageImpl = buildSiweMessage,
+  clientIp,
+  consumeRefreshTokenImpl = consumeRefreshToken,
+  enforceLimit,
+  hashRefreshTokenImpl = hashRefreshToken,
+  issueRefreshTokenImpl = issueRefreshToken,
+  logger,
+  makeRefreshStoreAdapterImpl = makeRefreshStoreAdapter,
+  parseCookieImpl = parseCookie,
+  randomBytesImpl = randomBytes,
+  rateLimitConfig,
+  readJsonBody,
+  respond,
+  revokeChainImpl = revokeChain,
+  rotateRefreshTokenImpl = rotateRefreshToken,
+  signTokenFromConfigImpl = signTokenFromConfig,
+  stateStore,
+  verifySiweMessageImpl = verifySiweMessage,
+}) {
+  function respondHandled(response, statusCode, body, headers = {}) {
+    respond(response, statusCode, body, headers);
+    return true;
+  }
+
+  return async function handleAuthRoute({ request, response, url, pathname }) {
+    if (request.method === "POST" && pathname === "/auth/nonce") {
+      await enforceLimit("auth_nonce", clientIp(request), rateLimitConfig.authNonce);
+      const payload = await readJsonBody(request);
+      const wallet = String(payload?.wallet ?? "").trim();
+      if (!WALLET_RE.test(wallet)) {
+        throw new ValidationError("wallet must be a 0x-prefixed 20-byte hex address.");
+      }
+      const nonce = generateNonce(randomBytesImpl);
+      const stored = await stateStore.storeNonce?.(nonce, wallet.toLowerCase(), authConfig.nonceTtlSeconds);
+      if (stored === false) {
+        throw new ValidationError("Nonce collision — retry.");
+      }
+      const issuedAt = new Date().toISOString();
+      const expiresAt = new Date(Date.now() + authConfig.nonceTtlSeconds * 1000).toISOString();
+      return respondHandled(response, 200, {
+        wallet,
+        nonce,
+        domain: authConfig.domain,
+        chainId: authConfig.chainId,
+        statement: SIWE_STATEMENT,
+        issuedAt,
+        expiresAt,
+        message: buildSiweMessageImpl({
+          domain: authConfig.domain,
+          address: wallet,
+          statement: SIWE_STATEMENT,
+          uri: `https://${authConfig.domain}`,
+          chainId: authConfig.chainId,
+          nonce,
+          issuedAt,
+          expirationTime: expiresAt
+        })
+      });
+    }
+
+    if (request.method === "POST" && pathname === "/auth/verify") {
+      await enforceLimit("auth_verify", clientIp(request), rateLimitConfig.authVerify);
+      const payload = await readJsonBody(request);
+      const message = typeof payload?.message === "string" ? payload.message : "";
+      const signature = typeof payload?.signature === "string" ? payload.signature : "";
+      if (!message || !signature) {
+        throw new ValidationError("message and signature are required.");
+      }
+      if (message.length > 4096) {
+        throw new ValidationError("SIWE message exceeds 4096 characters.");
+      }
+      if (!SIGNATURE_RE.test(signature)) {
+        throw new ValidationError("signature must be a 65-byte hex string.");
+      }
+      if (!authConfig.signingSecret) {
+        throw new AuthenticationError(
+          "Auth not configured — set AUTH_JWT_SECRETS to issue tokens.",
+          "auth_not_configured"
+        );
+      }
+
+      const verified = verifySiweMessageImpl(message, signature, {
+        expectedDomain: authConfig.domain,
+        expectedChainId: authConfig.chainId
+      });
+
+      const consumedWallet = await stateStore.consumeNonce?.(verified.nonce);
+      if (!consumedWallet) {
+        throw new AuthenticationError("Nonce missing or already consumed.", "invalid_nonce");
+      }
+      if (!walletsMatch(consumedWallet, verified.recoveredAddress)) {
+        throw new AuthenticationError("Nonce was issued for a different wallet.", "nonce_wallet_mismatch");
+      }
+
+      const roles = authConfig.resolveRoles?.(verified.recoveredAddress) ?? [];
+      const { token, claims } = await signTokenFromConfigImpl(
+        { sub: verified.recoveredAddress, roles },
+        { expiresInSeconds: authConfig.tokenTtlSeconds },
+        authConfig,
+      );
+
+      let setCookieHeader = null;
+      try {
+        if (supportsRefreshStore(stateStore)) {
+          const refreshAdapter = makeRefreshStoreAdapterImpl(stateStore);
+          const refreshIssue = await issueRefreshTokenImpl({
+            wallet: verified.recoveredAddress,
+            role: roles[0] ?? "user",
+            store: refreshAdapter,
+          });
+          setCookieHeader = buildSetCookieHeaderImpl(refreshIssue.rawToken);
+        }
+      } catch (err) {
+        logger?.warn?.(
+          { err, wallet: verified.recoveredAddress },
+          "auth_verify.refresh_issue_failed"
+        );
+      }
+
+      return respondHandled(
+        response,
+        200,
+        buildTokenResponse({
+          token,
+          claims,
+          wallet: verified.recoveredAddress,
+          roles,
+          authCapabilities,
+        }),
+        setCookieHeader ? { "Set-Cookie": setCookieHeader } : {}
+      );
+    }
+
+    if (request.method === "GET" && pathname === "/auth/session") {
+      const auth = await authMiddleware(request, url);
+      return respondHandled(response, 200, {
+        wallet: auth.wallet,
+        roles: auth.claims?.roles ?? [],
+        tokenKind: auth.claims?.tokenKind ?? (auth.claims?.serviceToken === true ? "service" : "wallet"),
+        serviceToken: auth.claims?.serviceToken === true,
+        ...(auth.claims?.capabilityGrantId ? { capabilityGrantId: auth.claims.capabilityGrantId } : {}),
+        capabilities: auth.capabilities ?? [],
+        capabilityMatrix: authCapabilities.capabilityMatrix()
+      });
+    }
+
+    if (request.method === "POST" && pathname === "/auth/logout") {
+      const auth = await authMiddleware(request, url);
+      const jti = auth.claims?.jti;
+      const exp = auth.claims?.exp;
+      if (jti && Number.isFinite(exp)) {
+        const ttlSeconds = Math.max(1, exp - Math.floor(Date.now() / 1000));
+        await stateStore.revokeToken?.(jti, ttlSeconds);
+      }
+
+      const refreshCookie = parseCookieImpl(request.headers?.cookie ?? null, REFRESH_COOKIE_NAME);
+      if (refreshCookie && supportsRefreshStore(stateStore)) {
+        try {
+          const refreshAdapter = makeRefreshStoreAdapterImpl(stateStore);
+          const hash = hashRefreshTokenImpl(refreshCookie);
+          await revokeChainImpl({
+            hash,
+            store: refreshAdapter,
+            reason: "logout",
+          });
+        } catch (err) {
+          logger?.warn?.({ err, wallet: auth.wallet }, "auth_logout.refresh_chain_revoke_failed");
+        }
+      }
+
+      return respondHandled(
+        response,
+        200,
+        {
+          status: "logged_out",
+          wallet: auth.wallet,
+          jti
+        },
+        { "Set-Cookie": buildClearCookieHeaderImpl() }
+      );
+    }
+
+    if (request.method === "POST" && pathname === "/auth/refresh") {
+      const refreshCookie = parseCookieImpl(request.headers?.cookie ?? null, REFRESH_COOKIE_NAME);
+
+      if (refreshCookie && supportsRefreshStore(stateStore)) {
+        await enforceLimit("auth_refresh", clientIp(request), rateLimitConfig.authRefresh);
+        if (!authConfig.signingSecret) {
+          throw new AuthenticationError(
+            "Auth not configured — set AUTH_JWT_SECRETS to issue tokens.",
+            "auth_not_configured"
+          );
+        }
+
+        const refreshAdapter = makeRefreshStoreAdapterImpl(stateStore);
+
+        let consumed;
+        try {
+          consumed = await consumeRefreshTokenImpl({ rawToken: refreshCookie, store: refreshAdapter });
+        } catch (err) {
+          response.setHeader?.("Set-Cookie", buildClearCookieHeaderImpl());
+          if (err instanceof RefreshError) {
+            const code = err.code === "refresh_replay_detected"
+              ? "refresh_replay_detected"
+              : err.code === "refresh_expired"
+                ? "refresh_expired"
+                : err.code === "refresh_revoked"
+                  ? "refresh_revoked"
+                  : "invalid_refresh_token";
+            logger?.warn?.(
+              { code, hashPrefix: err.details?.hashPrefix },
+              "auth_refresh.cookie_rejected"
+            );
+            throw new AuthenticationError(err.message, code);
+          }
+          throw err;
+        }
+
+        const roles = authConfig.resolveRoles?.(consumed.record.wallet) ?? [];
+        if (roles.length === 0) {
+          await revokeChainImpl({
+            hash: consumed.hash,
+            store: refreshAdapter,
+            reason: "no_roles_at_refresh",
+          });
+          response.setHeader?.("Set-Cookie", buildClearCookieHeaderImpl());
+          logger?.warn?.(
+            { wallet: consumed.record.wallet },
+            "auth_refresh.no_roles_chain_revoked"
+          );
+          throw new AuthenticationError(
+            "Wallet has no roles at refresh time.",
+            "no_roles_at_refresh"
+          );
+        }
+
+        const primaryRole = roles[0];
+        const rotated = await rotateRefreshTokenImpl({
+          oldRecord: { ...consumed.record, role: primaryRole },
+          oldHash: consumed.hash,
+          store: refreshAdapter,
+        });
+
+        const { token, claims } = await signTokenFromConfigImpl(
+          { sub: consumed.record.wallet, roles },
+          { expiresInSeconds: authConfig.tokenTtlSeconds },
+          authConfig,
+        );
+
+        return respondHandled(
+          response,
+          200,
+          buildTokenResponse({
+            token,
+            claims,
+            wallet: consumed.record.wallet,
+            roles,
+            authCapabilities,
+          }),
+          { "Set-Cookie": buildSetCookieHeaderImpl(rotated.rawToken) }
+        );
+      }
+
+      const auth = await authMiddleware(request, url);
+      if (auth.claims?.serviceToken === true || auth.claims?.tokenKind === "service") {
+        throw new AuthenticationError(
+          "Service tokens cannot be refreshed via /auth/refresh; rotate them via /admin/service-tokens/:id/rotate.",
+          "service_token_refresh_unsupported"
+        );
+      }
+      await enforceLimit("auth_refresh", auth.wallet, rateLimitConfig.authRefresh);
+      if (!authConfig.signingSecret) {
+        throw new AuthenticationError(
+          "Auth not configured — set AUTH_JWT_SECRETS to issue tokens.",
+          "auth_not_configured"
+        );
+      }
+
+      const oldJti = auth.claims?.jti;
+      const oldExp = auth.claims?.exp;
+      if (oldJti && Number.isFinite(oldExp)) {
+        const ttlSeconds = Math.max(1, oldExp - Math.floor(Date.now() / 1000));
+        await stateStore.revokeToken?.(oldJti, ttlSeconds);
+      }
+
+      const roles = authConfig.resolveRoles?.(auth.wallet) ?? auth.claims?.roles ?? [];
+      const { token, claims } = await signTokenFromConfigImpl(
+        { sub: auth.wallet, roles },
+        { expiresInSeconds: authConfig.tokenTtlSeconds },
+        authConfig,
+      );
+
+      return respondHandled(response, 200, buildTokenResponse({
+        token,
+        claims,
+        wallet: auth.wallet,
+        roles,
+        authCapabilities,
+        extra: { rotatedFromJti: oldJti }
+      }));
+    }
+
+    return false;
+  };
+}

--- a/mcp-server/src/protocols/http/auth-routes.test.js
+++ b/mcp-server/src/protocols/http/auth-routes.test.js
@@ -1,0 +1,340 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { AuthenticationError, ValidationError } from "../../core/errors.js";
+import { createAuthRoutes } from "./auth-routes.js";
+
+const WALLET = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const OTHER_WALLET = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const VALID_SIGNATURE = `0x${"1".repeat(130)}`;
+
+function makeHarness(overrides = {}) {
+  const calls = [];
+  const response = {
+    headers: {},
+    setHeader(name, value) {
+      calls.push(["setHeader", { name, value }]);
+      this.headers[name] = value;
+    }
+  };
+  const authConfig = {
+    domain: "app.example.test",
+    chainId: 420420,
+    nonceTtlSeconds: 60,
+    tokenTtlSeconds: 900,
+    signingSecret: "test-secret",
+    resolveRoles: (wallet) => {
+      calls.push(["resolveRoles", wallet]);
+      return overrides.roles ?? ["admin"];
+    },
+    ...(overrides.authConfig ?? {})
+  };
+  const stateStore = {
+    storeNonce: async (nonce, wallet, ttlSeconds) => {
+      calls.push(["storeNonce", { nonce, wallet, ttlSeconds }]);
+      return overrides.storeNonceResult ?? true;
+    },
+    consumeNonce: async (nonce) => {
+      calls.push(["consumeNonce", nonce]);
+      return overrides.consumedWallet ?? WALLET;
+    },
+    revokeToken: async (jti, ttlSeconds) => {
+      calls.push(["revokeToken", { jti, ttlSeconds }]);
+    },
+    ...(overrides.refreshStore
+      ? {
+          getRefreshRecord: async () => undefined,
+          upsertRefreshRecord: async () => undefined,
+        }
+      : {}),
+    ...(overrides.stateStore ?? {})
+  };
+
+  const route = createAuthRoutes({
+    authCapabilities: {
+      capabilityMatrix: () => ({ jobs: { list: ["jobs:list"] } }),
+      resolveCapabilities: ({ roles }) => roles.includes("admin") ? ["*"] : ["jobs:list"],
+    },
+    authConfig,
+    authMiddleware: async (_request, _url) => {
+      calls.push(["authMiddleware"]);
+      return overrides.auth ?? {
+        wallet: WALLET,
+        claims: { roles: ["admin"], jti: "old-jti", exp: Math.floor(Date.now() / 1000) + 120 },
+        capabilities: ["*"],
+      };
+    },
+    buildClearCookieHeaderImpl: () => {
+      calls.push(["clearCookie"]);
+      return "refresh_token=; Max-Age=0";
+    },
+    buildSetCookieHeaderImpl: (rawToken) => {
+      calls.push(["setCookie", rawToken]);
+      return `refresh_token=${rawToken}`;
+    },
+    buildSiweMessageImpl: (input) => {
+      calls.push(["buildSiweMessage", input]);
+      return "siwe-message";
+    },
+    clientIp: (request) => {
+      calls.push(["clientIp", request.ip ?? "ip-key"]);
+      return request.ip ?? "ip-key";
+    },
+    consumeRefreshTokenImpl: async ({ rawToken, store }) => {
+      calls.push(["consumeRefreshToken", { rawToken, store }]);
+      if (overrides.consumeRefreshError) throw overrides.consumeRefreshError;
+      return overrides.consumedRefresh ?? {
+        hash: "refresh-hash",
+        record: { wallet: WALLET, role: "admin" }
+      };
+    },
+    enforceLimit: async (bucket, key, limits) => {
+      calls.push(["limit", { bucket, key, limits }]);
+    },
+    hashRefreshTokenImpl: (rawToken) => {
+      calls.push(["hashRefreshToken", rawToken]);
+      return "hashed-refresh";
+    },
+    issueRefreshTokenImpl: async ({ wallet, role, store }) => {
+      calls.push(["issueRefreshToken", { wallet, role, store }]);
+      return { rawToken: "issued-refresh" };
+    },
+    logger: {
+      warn: (...args) => calls.push(["logger.warn", args])
+    },
+    makeRefreshStoreAdapterImpl: (store) => {
+      calls.push(["makeRefreshStoreAdapter", Boolean(store)]);
+      return "refresh-store";
+    },
+    parseCookieImpl: () => {
+      calls.push(["parseCookie"]);
+      return overrides.refreshCookie ?? null;
+    },
+    randomBytesImpl: (size) => {
+      calls.push(["randomBytes", size]);
+      return Buffer.from("0123456789abcdef");
+    },
+    rateLimitConfig: {
+      authNonce: { max: 2 },
+      authVerify: { max: 3 },
+      authRefresh: { max: 4 },
+    },
+    readJsonBody: async () => {
+      calls.push(["readJsonBody"]);
+      return overrides.payload ?? {};
+    },
+    respond: (res, statusCode, body, headers = {}) => {
+      calls.push(["respond", { statusCode, body, headers }]);
+      res.statusCode = statusCode;
+      res.body = body;
+      res.headers = { ...(res.headers ?? {}), ...headers };
+    },
+    revokeChainImpl: async (input) => {
+      calls.push(["revokeChain", input]);
+    },
+    rotateRefreshTokenImpl: async (input) => {
+      calls.push(["rotateRefreshToken", input]);
+      return { rawToken: "rotated-refresh" };
+    },
+    signTokenFromConfigImpl: async (claims, options, config) => {
+      calls.push(["signToken", { claims, options, config }]);
+      return {
+        token: overrides.token ?? "signed-token",
+        claims: { ...claims, exp: 1_800_000_000 }
+      };
+    },
+    stateStore,
+    verifySiweMessageImpl: (message, signature, options) => {
+      calls.push(["verifySiwe", { message, signature, options }]);
+      return overrides.verified ?? { nonce: "nonce-1", recoveredAddress: WALLET };
+    },
+  });
+
+  return { calls, response, route, stateStore };
+}
+
+async function callRoute(route, response, method, path, request = {}) {
+  return await route({
+    request: { method, headers: {}, ...request },
+    response,
+    url: new URL(`http://localhost${path}`),
+    pathname: path.split("?")[0],
+  });
+}
+
+test("auth routes ignore unrelated paths and methods", async () => {
+  const { calls, response, route } = makeHarness();
+
+  assert.equal(await callRoute(route, response, "GET", "/auth/nonce"), false);
+  assert.equal(await callRoute(route, response, "POST", "/not-auth"), false);
+  assert.deepEqual(calls, []);
+  assert.deepEqual(response.body, undefined);
+});
+
+test("POST /auth/nonce stores a wallet nonce and returns a SIWE message", async () => {
+  const displayWallet = `0x${"A".repeat(40)}`;
+  const { calls, response, route } = makeHarness({
+    payload: { wallet: displayWallet }
+  });
+
+  assert.equal(await callRoute(route, response, "POST", "/auth/nonce"), true);
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.wallet, displayWallet);
+  assert.equal(response.body.domain, "app.example.test");
+  assert.equal(response.body.chainId, 420420);
+  assert.equal(response.body.message, "siwe-message");
+  assert.deepEqual(calls.slice(0, 5).map(([name]) => name), [
+    "clientIp",
+    "limit",
+    "readJsonBody",
+    "randomBytes",
+    "storeNonce",
+  ]);
+  assert.equal(calls.find(([name]) => name === "storeNonce")?.[1].wallet, WALLET);
+});
+
+test("POST /auth/nonce rejects malformed wallet before storing", async () => {
+  const { calls, response, route } = makeHarness({ payload: { wallet: "not-wallet" } });
+
+  await assert.rejects(
+    callRoute(route, response, "POST", "/auth/nonce"),
+    (error) => error instanceof ValidationError && error.message.includes("wallet must")
+  );
+  assert.ok(!calls.some(([name]) => name === "storeNonce"));
+});
+
+test("POST /auth/verify consumes nonce, signs token, and issues refresh cookie when supported", async () => {
+  const { calls, response, route } = makeHarness({
+    payload: { message: "siwe", signature: VALID_SIGNATURE },
+    refreshStore: true,
+    roles: ["admin", "verifier"],
+  });
+
+  assert.equal(await callRoute(route, response, "POST", "/auth/verify"), true);
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.token, "signed-token");
+  assert.deepEqual(response.body.roles, ["admin", "verifier"]);
+  assert.deepEqual(response.body.capabilities, ["*"]);
+  assert.equal(response.headers["Set-Cookie"], "refresh_token=issued-refresh");
+  assert.deepEqual(calls.map(([name]) => name).slice(0, 8), [
+    "clientIp",
+    "limit",
+    "readJsonBody",
+    "verifySiwe",
+    "consumeNonce",
+    "resolveRoles",
+    "signToken",
+    "makeRefreshStoreAdapter",
+  ]);
+  assert.equal(calls.find(([name]) => name === "signToken")?.[1].claims.sub, WALLET);
+});
+
+test("POST /auth/verify rejects nonce wallet mismatch", async () => {
+  const { calls, response, route } = makeHarness({
+    payload: { message: "siwe", signature: VALID_SIGNATURE },
+    consumedWallet: OTHER_WALLET,
+  });
+
+  await assert.rejects(
+    callRoute(route, response, "POST", "/auth/verify"),
+    (error) => error instanceof AuthenticationError && error.code === "nonce_wallet_mismatch"
+  );
+  assert.ok(!calls.some(([name]) => name === "signToken"));
+});
+
+test("GET /auth/session returns wallet, token kind, grants, and capability matrix", async () => {
+  const { response, route } = makeHarness({
+    auth: {
+      wallet: WALLET,
+      claims: {
+        roles: ["agent"],
+        tokenKind: "service",
+        serviceToken: true,
+        capabilityGrantId: "grant-1",
+      },
+      capabilities: ["jobs:list"],
+    }
+  });
+
+  assert.equal(await callRoute(route, response, "GET", "/auth/session"), true);
+
+  assert.deepEqual(response.body, {
+    wallet: WALLET,
+    roles: ["agent"],
+    tokenKind: "service",
+    serviceToken: true,
+    capabilityGrantId: "grant-1",
+    capabilities: ["jobs:list"],
+    capabilityMatrix: { jobs: { list: ["jobs:list"] } }
+  });
+});
+
+test("POST /auth/logout revokes JWT and refresh chain then clears cookie", async () => {
+  const { calls, response, route } = makeHarness({
+    refreshCookie: "refresh-cookie",
+    refreshStore: true,
+  });
+
+  assert.equal(await callRoute(route, response, "POST", "/auth/logout"), true);
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.status, "logged_out");
+  assert.equal(response.body.jti, "old-jti");
+  assert.equal(response.headers["Set-Cookie"], "refresh_token=; Max-Age=0");
+  assert.ok(calls.some(([name]) => name === "revokeToken"));
+  assert.deepEqual(calls.find(([name]) => name === "revokeChain")?.[1], {
+    hash: "hashed-refresh",
+    store: "refresh-store",
+    reason: "logout"
+  });
+});
+
+test("POST /auth/refresh rotates opaque refresh cookies without bearer auth", async () => {
+  const { calls, response, route } = makeHarness({
+    refreshCookie: "refresh-cookie",
+    refreshStore: true,
+    roles: ["admin"],
+  });
+
+  assert.equal(await callRoute(route, response, "POST", "/auth/refresh"), true);
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.wallet, WALLET);
+  assert.equal(response.headers["Set-Cookie"], "refresh_token=rotated-refresh");
+  assert.ok(!calls.some(([name]) => name === "authMiddleware"));
+  assert.deepEqual(calls.find(([name]) => name === "rotateRefreshToken")?.[1], {
+    oldRecord: { wallet: WALLET, role: "admin" },
+    oldHash: "refresh-hash",
+    store: "refresh-store"
+  });
+});
+
+test("POST /auth/refresh legacy flow revokes old jti and returns rotatedFromJti", async () => {
+  const { calls, response, route } = makeHarness({ roles: ["verifier"] });
+
+  assert.equal(await callRoute(route, response, "POST", "/auth/refresh"), true);
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.rotatedFromJti, "old-jti");
+  assert.deepEqual(response.body.roles, ["verifier"]);
+  assert.ok(calls.some(([name]) => name === "authMiddleware"));
+  assert.ok(calls.some(([name]) => name === "revokeToken"));
+});
+
+test("POST /auth/refresh rejects service-token callers before signing", async () => {
+  const { calls, response, route } = makeHarness({
+    auth: {
+      wallet: WALLET,
+      claims: { tokenKind: "service", serviceToken: true },
+      capabilities: ["jobs:list"],
+    }
+  });
+
+  await assert.rejects(
+    callRoute(route, response, "POST", "/auth/refresh"),
+    (error) => error instanceof AuthenticationError && error.code === "service_token_refresh_unsupported"
+  );
+  assert.ok(!calls.some(([name]) => name === "signToken"));
+});

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -1,5 +1,5 @@
 import { createServer } from "node:http";
-import { randomBytes, timingSafeEqual } from "node:crypto";
+import { timingSafeEqual } from "node:crypto";
 import { createPlatformRuntime } from "../../services/bootstrap.js";
 import {
   assertMutationBackendAvailable,
@@ -11,30 +11,12 @@ import {
   resolveServiceHealth
 } from "../../core/health-capability.js";
 import {
-  AuthenticationError,
   AuthorizationError,
   ConflictError,
   normalizeError,
   ValidationError
 } from "../../core/errors.js";
 import { hashCanonicalContent } from "../../core/canonical-content.js";
-import { buildSiweMessage, verifySiweMessage } from "../../auth/siwe.js";
-import { signToken, signTokenFromConfig } from "../../auth/jwt.js";
-import {
-  REFRESH_COOKIE_NAME,
-  RefreshError,
-  consumeRefreshToken,
-  hashRefreshToken,
-  issueRefreshToken,
-  revokeChain,
-  rotateRefreshToken,
-} from "../../auth/refresh.js";
-import {
-  buildClearCookieHeader,
-  buildSetCookieHeader,
-  makeRefreshStoreAdapter,
-  parseCookie,
-} from "../../auth/refresh-cookie.js";
 import { extractClientKey } from "../../auth/rate-limit.js";
 import { hasRole } from "../../auth/config.js";
 import { resolveRequestId } from "../../core/logger.js";
@@ -53,6 +35,7 @@ import { createAdminSessionsRoutes } from "./admin-sessions-routes.js";
 import { createAdminStatusRoutes } from "./admin-status-routes.js";
 import { createAdminXcmRoutes } from "./admin-xcm-routes.js";
 import { createActivityRoutes } from "./activity-routes.js";
+import { createAuthRoutes } from "./auth-routes.js";
 import { createBadgeRoutes } from "./badge-routes.js";
 import { createContentRoutes } from "./content-routes.js";
 import { createDisputeRoutes } from "./dispute-routes.js";
@@ -102,7 +85,6 @@ const METRICS_AUTH_REQUIRED = parseRequiredFlag(
 );
 const port = Number(process.env.PORT ?? 8787);
 
-const SIWE_STATEMENT = "Sign in to the Agent Platform.";
 const inFlightIdempotentMutations = new Map();
 
 function respond(response, statusCode, payload, extraHeaders = {}) {
@@ -179,10 +161,6 @@ function parseEventFilters(url, { includeWallet = false } = {}) {
     filters.eventWallet = url.searchParams.get("eventWallet")?.trim() || url.searchParams.get("wallet")?.trim() || undefined;
   }
   return filters;
-}
-
-function generateNonce() {
-  return randomBytes(16).toString("hex");
 }
 
 function walletsMatch(a, b) {
@@ -1178,6 +1156,19 @@ const handleContentRoute = createContentRoutes({
   walletsMatch,
 });
 
+const handleAuthRoute = createAuthRoutes({
+  authCapabilities,
+  authConfig,
+  authMiddleware,
+  clientIp,
+  enforceLimit,
+  logger,
+  rateLimitConfig,
+  readJsonBody,
+  respond,
+  stateStore,
+});
+
 function buildLaneAttention({ shares, isMock, debtTotal, borrowCapacity, deploymentShareBps }) {
   if (!(shares > 0)) {
     return undefined;
@@ -1536,368 +1527,8 @@ const server = createServer(async (request, response) => {
       return;
     }
 
-    // ---------- auth routes ----------
-
-    if (request.method === "POST" && pathname === "/auth/nonce") {
-      await enforceLimit("auth_nonce", clientIp(request), rateLimitConfig.authNonce);
-      const payload = await readJsonBody(request);
-      const wallet = String(payload?.wallet ?? "").trim();
-      if (!/^0x[a-fA-F0-9]{40}$/u.test(wallet)) {
-        throw new ValidationError("wallet must be a 0x-prefixed 20-byte hex address.");
-      }
-      const nonce = generateNonce();
-      const stored = await stateStore.storeNonce?.(nonce, wallet.toLowerCase(), authConfig.nonceTtlSeconds);
-      if (stored === false) {
-        throw new ValidationError("Nonce collision — retry.");
-      }
-      const issuedAt = new Date().toISOString();
-      const expiresAt = new Date(Date.now() + authConfig.nonceTtlSeconds * 1000).toISOString();
-      return respond(response, 200, {
-        wallet,
-        nonce,
-        domain: authConfig.domain,
-        chainId: authConfig.chainId,
-        statement: SIWE_STATEMENT,
-        issuedAt,
-        expiresAt,
-        message: buildSiweMessage({
-          domain: authConfig.domain,
-          address: wallet,
-          statement: SIWE_STATEMENT,
-          uri: `https://${authConfig.domain}`,
-          chainId: authConfig.chainId,
-          nonce,
-          issuedAt,
-          expirationTime: expiresAt
-        })
-      });
-    }
-
-    if (request.method === "POST" && pathname === "/auth/verify") {
-      await enforceLimit("auth_verify", clientIp(request), rateLimitConfig.authVerify);
-      const payload = await readJsonBody(request);
-      const message = typeof payload?.message === "string" ? payload.message : "";
-      const signature = typeof payload?.signature === "string" ? payload.signature : "";
-      if (!message || !signature) {
-        throw new ValidationError("message and signature are required.");
-      }
-      if (message.length > 4096) {
-        throw new ValidationError("SIWE message exceeds 4096 characters.");
-      }
-      // EIP-191 personal_sign signatures are 65 bytes -> 132 chars incl. 0x.
-      // Some wallets return r/s/v concatenated without 0x; accept both but cap
-      // the length to discourage callers from submitting unrelated payloads.
-      if (!/^(0x)?[0-9a-fA-F]{130,132}$/u.test(signature)) {
-        throw new ValidationError("signature must be a 65-byte hex string.");
-      }
-      if (!authConfig.signingSecret) {
-        throw new AuthenticationError(
-          "Auth not configured — set AUTH_JWT_SECRETS to issue tokens.",
-          "auth_not_configured"
-        );
-      }
-
-      const verified = verifySiweMessage(message, signature, {
-        expectedDomain: authConfig.domain,
-        expectedChainId: authConfig.chainId
-      });
-
-      const consumedWallet = await stateStore.consumeNonce?.(verified.nonce);
-      if (!consumedWallet) {
-        throw new AuthenticationError("Nonce missing or already consumed.", "invalid_nonce");
-      }
-      if (!walletsMatch(consumedWallet, verified.recoveredAddress)) {
-        throw new AuthenticationError("Nonce was issued for a different wallet.", "nonce_wallet_mismatch");
-      }
-
-      const roles = authConfig.resolveRoles?.(verified.recoveredAddress) ?? [];
-      // Phase 4b.6 Stage 2A — route SIWE mint through the dispatcher so
-      // JWT_PRIMARY_ALG controls the emitted algorithm (default still
-      // hmac under JWT_BACKEND=both). Functionally byte-for-byte
-      // identical to the prior `signToken` call when primary_alg=hmac;
-      // flipping primary_alg=kms in a follow-up makes SIWE start
-      // minting ES256 tokens without further code change.
-      const { token, claims } = await signTokenFromConfig(
-        { sub: verified.recoveredAddress, roles },
-        { expiresInSeconds: authConfig.tokenTtlSeconds },
-        authConfig,
-      );
-
-      // Phase 4b.5b — also mint an opaque refresh token and return it
-      // as an HttpOnly cookie. The state-store exposes refresh-record
-      // CRUD via `makeRefreshStoreAdapter`. If the store backend doesn't
-      // implement the refresh methods (e.g. an older test harness), we
-      // skip cookie issuance silently and fall back to access-token-only
-      // behavior so the SIWE path itself doesn't fail.
-      let setCookieHeader = null;
-      try {
-        if (typeof stateStore?.getRefreshRecord === "function" &&
-            typeof stateStore?.upsertRefreshRecord === "function") {
-          const refreshAdapter = makeRefreshStoreAdapter(stateStore);
-          const refreshIssue = await issueRefreshToken({
-            wallet: verified.recoveredAddress,
-            role: roles[0] ?? "user",
-            store: refreshAdapter,
-          });
-          setCookieHeader = buildSetCookieHeader(refreshIssue.rawToken);
-        }
-      } catch (err) {
-        // Refresh-cookie issuance is best-effort here — if it fails for
-        // any reason, log and continue. The client just won't get a
-        // refresh cookie and will have to re-SIWE when the access token
-        // expires (the legacy behavior, fully backward compatible).
-        logger?.warn?.(
-          { err, wallet: verified.recoveredAddress },
-          "auth_verify.refresh_issue_failed"
-        );
-      }
-
-      return respond(
-        response,
-        200,
-        {
-          token,
-          wallet: verified.recoveredAddress,
-          roles,
-          capabilities: authCapabilities.resolveCapabilities({ roles }),
-          expiresAt: new Date(claims.exp * 1000).toISOString(),
-          tokenType: "Bearer"
-        },
-        setCookieHeader ? { "Set-Cookie": setCookieHeader } : {}
-      );
-    }
-
-    if (request.method === "GET" && pathname === "/auth/session") {
-      const auth = await authMiddleware(request, url);
-      return respond(response, 200, {
-        wallet: auth.wallet,
-        roles: auth.claims?.roles ?? [],
-        tokenKind: auth.claims?.tokenKind ?? (auth.claims?.serviceToken === true ? "service" : "wallet"),
-        serviceToken: auth.claims?.serviceToken === true,
-        ...(auth.claims?.capabilityGrantId ? { capabilityGrantId: auth.claims.capabilityGrantId } : {}),
-        capabilities: auth.capabilities ?? [],
-        capabilityMatrix: authCapabilities.capabilityMatrix()
-      });
-    }
-
-    if (request.method === "POST" && pathname === "/auth/logout") {
-      // Revoke the current JWT by its `jti`. Requires authentication so a
-      // random caller can't revoke someone else's token.
-      const auth = await authMiddleware(request, url);
-      const jti = auth.claims?.jti;
-      const exp = auth.claims?.exp;
-      if (jti && Number.isFinite(exp)) {
-        const ttlSeconds = Math.max(1, exp - Math.floor(Date.now() / 1000));
-        await stateStore.revokeToken?.(jti, ttlSeconds);
-      }
-
-      // Phase 4b.5b — best-effort: if the caller also carries a refresh
-      // cookie, revoke the entire refresh chain and clear the cookie. We
-      // never fail logout because of a refresh-token error; the access-
-      // token revocation above is the source of truth for "logged out".
-      const refreshCookie = parseCookie(request.headers?.cookie ?? null, REFRESH_COOKIE_NAME);
-      if (refreshCookie &&
-          typeof stateStore?.getRefreshRecord === "function" &&
-          typeof stateStore?.upsertRefreshRecord === "function") {
-        try {
-          const refreshAdapter = makeRefreshStoreAdapter(stateStore);
-          // We can't use consumeRefreshToken here because it throws on
-          // already-revoked / expired records. We hash-and-revoke directly.
-          const hash = hashRefreshToken(refreshCookie);
-          await revokeChain({
-            hash,
-            store: refreshAdapter,
-            reason: "logout",
-          });
-        } catch (err) {
-          logger?.warn?.({ err, wallet: auth.wallet }, "auth_logout.refresh_chain_revoke_failed");
-        }
-      }
-
-      return respond(
-        response,
-        200,
-        {
-          status: "logged_out",
-          wallet: auth.wallet,
-          jti
-        },
-        // Always clear the refresh cookie on logout, even if the caller
-        // didn't send one — defense-in-depth for stale browser state.
-        { "Set-Cookie": buildClearCookieHeader() }
-      );
-    }
-
-    if (request.method === "POST" && pathname === "/auth/refresh") {
-      // Phase 4b.5b — dual-mode dispatcher.
-      //
-      // NEW FLOW (preferred): an HttpOnly `refresh_token` cookie carries
-      // an opaque token. We consume it, re-resolve roles, rotate the
-      // refresh record, mint a fresh short-lived access token, and emit
-      // a new Set-Cookie. Replay of a previously-rotated cookie revokes
-      // the entire chain (see auth/refresh.js strict-replay semantics).
-      //
-      // LEGACY FLOW (fallback): an Authorization Bearer header carries
-      // a still-valid wallet JWT. We revoke its jti and mint a fresh
-      // one with the same sub. Maintained for backward compat with the
-      // operator app prior to the cookie cutover.
-      const refreshCookie = parseCookie(request.headers?.cookie ?? null, REFRESH_COOKIE_NAME);
-
-      if (refreshCookie &&
-          typeof stateStore?.getRefreshRecord === "function" &&
-          typeof stateStore?.upsertRefreshRecord === "function") {
-        // ── NEW FLOW: opaque refresh cookie ─────────────────────────
-        await enforceLimit("auth_refresh", clientIp(request), rateLimitConfig.authRefresh);
-        if (!authConfig.signingSecret) {
-          throw new AuthenticationError(
-            "Auth not configured — set AUTH_JWT_SECRETS to issue tokens.",
-            "auth_not_configured"
-          );
-        }
-
-        const refreshAdapter = makeRefreshStoreAdapter(stateStore);
-
-        let consumed;
-        try {
-          consumed = await consumeRefreshToken({ rawToken: refreshCookie, store: refreshAdapter });
-        } catch (err) {
-          // On any refresh-token failure, clear the cookie so the client
-          // doesn't keep retrying with a known-bad token. Map the refresh
-          // error to an AuthenticationError with a stable error code.
-          response.setHeader?.("Set-Cookie", buildClearCookieHeader());
-          if (err instanceof RefreshError) {
-            const code = err.code === "refresh_replay_detected"
-              ? "refresh_replay_detected"
-              : err.code === "refresh_expired"
-                ? "refresh_expired"
-                : err.code === "refresh_revoked"
-                  ? "refresh_revoked"
-                  : "invalid_refresh_token";
-            logger?.warn?.(
-              { code, hashPrefix: err.details?.hashPrefix },
-              "auth_refresh.cookie_rejected"
-            );
-            throw new AuthenticationError(err.message, code);
-          }
-          throw err;
-        }
-
-        // Role-recheck hook: re-resolve roles at refresh time so a wallet
-        // that lost its admin/verifier role since issue-time cannot keep
-        // refreshing into a privileged session.
-        const roles = authConfig.resolveRoles?.(consumed.record.wallet) ?? [];
-        if (roles.length === 0) {
-          // Wallet lost all roles since issue — revoke the chain and
-          // reject. The client will be forced back to SIWE.
-          await revokeChain({
-            hash: consumed.hash,
-            store: refreshAdapter,
-            reason: "no_roles_at_refresh",
-          });
-          response.setHeader?.("Set-Cookie", buildClearCookieHeader());
-          logger?.warn?.(
-            { wallet: consumed.record.wallet },
-            "auth_refresh.no_roles_chain_revoked"
-          );
-          throw new AuthenticationError(
-            "Wallet has no roles at refresh time.",
-            "no_roles_at_refresh"
-          );
-        }
-
-        const primaryRole = roles[0];
-        const rotated = await rotateRefreshToken({
-          oldRecord: { ...consumed.record, role: primaryRole },
-          oldHash: consumed.hash,
-          store: refreshAdapter,
-        });
-
-        // Phase 4b.6 Stage 2A — dispatcher-routed mint. See /auth/verify
-        // for the rationale; this is the cookie-refresh sibling.
-        const { token, claims } = await signTokenFromConfig(
-          { sub: consumed.record.wallet, roles },
-          { expiresInSeconds: authConfig.tokenTtlSeconds },
-          authConfig,
-        );
-
-        return respond(
-          response,
-          200,
-          {
-            token,
-            wallet: consumed.record.wallet,
-            roles,
-            capabilities: authCapabilities.resolveCapabilities({ roles }),
-            expiresAt: new Date(claims.exp * 1000).toISOString(),
-            tokenType: "Bearer"
-          },
-          { "Set-Cookie": buildSetCookieHeader(rotated.rawToken) }
-        );
-      }
-
-      // ── LEGACY FLOW: access-token rotation via Authorization header ─
-      // Rotate the caller's wallet JWT: revoke the old `jti`, mint a new one
-      // with the same `sub` + `roles`, fresh `iat` / `exp`. The operator app
-      // avoids re-SIWE every AUTH_TOKEN_TTL_SECONDS by calling this when it
-      // notices its token is approaching expiry.
-      //
-      // Hard guardrails:
-      //  - Service tokens are NOT refreshable here. They have their own
-      //    lifecycle via /admin/service-tokens/:id/rotate, signed by an
-      //    admin, and their claims (`capabilities`, `capabilityGrantId`,
-      //    `scope`) are not safe to re-mint from a stale token. Service
-      //    tokens that need a longer life rotate via the admin surface.
-      //  - The old token must currently verify (authMiddleware enforces
-      //    signature + exp + revocation), so a leaked-and-revoked token
-      //    cannot be used to bootstrap a fresh one.
-      //  - We revoke the old jti BEFORE issuing the new one, so there is
-      //    no window where two tokens for the same wallet are both valid
-      //    from a single refresh.
-      const auth = await authMiddleware(request, url);
-      if (auth.claims?.serviceToken === true || auth.claims?.tokenKind === "service") {
-        throw new AuthenticationError(
-          "Service tokens cannot be refreshed via /auth/refresh; rotate them via /admin/service-tokens/:id/rotate.",
-          "service_token_refresh_unsupported"
-        );
-      }
-      await enforceLimit("auth_refresh", auth.wallet, rateLimitConfig.authRefresh);
-      if (!authConfig.signingSecret) {
-        throw new AuthenticationError(
-          "Auth not configured — set AUTH_JWT_SECRETS to issue tokens.",
-          "auth_not_configured"
-        );
-      }
-
-      const oldJti = auth.claims?.jti;
-      const oldExp = auth.claims?.exp;
-      if (oldJti && Number.isFinite(oldExp)) {
-        // Revoke the old jti for whatever remains of its TTL so it can't
-        // be replayed if it leaked between sign and revoke.
-        const ttlSeconds = Math.max(1, oldExp - Math.floor(Date.now() / 1000));
-        await stateStore.revokeToken?.(oldJti, ttlSeconds);
-      }
-
-      // Re-resolve roles at refresh time (an operator may have been added
-      // or removed since the original sign-in).
-      const roles = authConfig.resolveRoles?.(auth.wallet) ?? auth.claims?.roles ?? [];
-      // Phase 4b.6 Stage 2A — dispatcher-routed mint for the legacy
-      // bearer-token rotation flow. Same byte-for-byte semantics under
-      // JWT_PRIMARY_ALG=hmac.
-      const { token, claims } = await signTokenFromConfig(
-        { sub: auth.wallet, roles },
-        { expiresInSeconds: authConfig.tokenTtlSeconds },
-        authConfig,
-      );
-
-      return respond(response, 200, {
-        token,
-        wallet: auth.wallet,
-        roles,
-        capabilities: authCapabilities.resolveCapabilities({ roles }),
-        expiresAt: new Date(claims.exp * 1000).toISOString(),
-        tokenType: "Bearer",
-        rotatedFromJti: oldJti
-      });
+    if (await handleAuthRoute({ request, response, url, pathname })) {
+      return;
     }
 
     // ---------- protected routes ----------


### PR DESCRIPTION
## What changed

- Extracted `/auth/nonce`, `/auth/verify`, `/auth/session`, `/auth/logout`, and `/auth/refresh` into `mcp-server/src/protocols/http/auth-routes.js`.
- Preserved SIWE nonce issuance/verification, session projection, logout revocation, opaque refresh-cookie rotation, and legacy bearer-token refresh behavior.
- Added focused route tests for fall-through, nonce storage, verify/sign/cookie issue, session projection, logout, both refresh paths, and service-token refresh rejection.
- Added a roadmap fragment for the P2.3 route-split steward instead of editing the shared roadmap row directly.

## Affected areas

- Backend HTTP routing: yes
- Frontend/indexer/contracts/public site/Caddy: no
- Env/VPS secrets: none

## Checks

- Polkadot MCP docs check: `get_project_info` returned `Polkadot Developer Docs` with index status `ready`.
- `node --check mcp-server/src/protocols/http/auth-routes.js`
- `node --check mcp-server/src/protocols/http/server.js`
- `node --test mcp-server/src/protocols/http/auth-routes.test.js`
- `node --test mcp-server/src/protocols/http/auth-routes.test.js mcp-server/src/protocols/http/session-routes.test.js mcp-server/src/protocols/http/server.smoke.test.js`
- `npm --workspace mcp-server test`
- `git diff --cached --check`
