### PR TITLE
ops: harden hardware MFA proof freshness

### DIFF
--- a/docs/PHASE_4E_PLAN.md
+++ b/docs/PHASE_4E_PLAN.md
@@ -158,8 +158,13 @@ Recommended path:
 ```bash
 node scripts/ops/check-hardware-mfa-evidence.mjs \
   --file docs/evidence/hardware-mfa-YYYY-MM-DD.json \
+  --max-completed-age-hours 30 \
   --json
 ```
+
+The max-age flag is required for launch sign-off. Older artifacts can remain
+useful audit history, but they must not be reused as current proof that the
+admin trust chain is hardware-MFA protected.
 
 Minimum shape:
 

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -465,9 +465,14 @@ This checklist improves release discipline, but it does not replace:
 - a real, audited strategy adapter path instead of the mock vDOT adapter
 - explicit incident ownership and paging
 - hardware MFA across the admin trust chain. Evidence must be captured in
-  `docs/evidence/hardware-mfa-YYYY-MM-DD.json` and validated with
-  `node scripts/ops/check-hardware-mfa-evidence.mjs --file <path> --json`
-  before mainnet launch sign-off.
+  `docs/evidence/hardware-mfa-YYYY-MM-DD.json` and validated before mainnet
+  launch sign-off:
+  ```bash
+  node scripts/ops/check-hardware-mfa-evidence.mjs \
+    --file docs/evidence/hardware-mfa-YYYY-MM-DD.json \
+    --max-completed-age-hours 30 \
+    --json
+  ```
 
 Until those are done, treat the stack as production-like testnet, not
 irreversible real-funds infrastructure.

--- a/docs/roadmap-updates/2026-05-24-codex-hardware-mfa-proof-freshness.md
+++ b/docs/roadmap-updates/2026-05-24-codex-hardware-mfa-proof-freshness.md
@@ -1,0 +1,36 @@
+# Roadmap Update: Hardware MFA Proof Freshness
+
+- **Date:** 2026-05-24
+- **Agent:** codex/hardware-mfa-proof-freshness
+- **Roadmap section:** Auth, Secrets, And Capability Roadmap
+- **Item:** Hardware MFA for admin chain accounts
+- **Related PRs/issues:** [PR #512](https://github.com/averray-agent/agent/pull/512)
+- **Proposed status:** Ready for proof
+- **Owner:** Operator
+
+## Summary
+
+The hardware-MFA evidence validator now supports an explicit max-age gate for
+launch proof artifacts. This keeps older enrollment records useful as audit
+history while requiring a fresh, dated operator artifact before the admin trust
+chain can move to `Proofed`.
+
+## Evidence
+
+- Updated script: `scripts/ops/check-hardware-mfa-evidence.mjs`
+- Updated tests: `scripts/ops/check-hardware-mfa-evidence.test.mjs`
+- Updated launch/runbook command:
+  `node scripts/ops/check-hardware-mfa-evidence.mjs --file docs/evidence/hardware-mfa-YYYY-MM-DD.json --max-completed-age-hours 30 --json`
+
+## Blockers Or Caveats
+
+- The roadmap row remains `Ready for proof` until the operator captures a
+  sanitized live evidence artifact and validates it with the max-age gate.
+- The evidence file must not contain recovery codes, provider tokens, private
+  keys, JWTs, or raw recovery material.
+
+## Requested Roadmap Change
+
+Keep `Hardware MFA for admin chain accounts` as `Ready for proof`. Once live
+evidence exists, cite the artifact path, validation command, operator signature,
+and backup-key login-test coverage before moving the item to `Proofed`.

--- a/scripts/ops/check-hardware-mfa-evidence.mjs
+++ b/scripts/ops/check-hardware-mfa-evidence.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 
 const SCRIPT_NAME = basename(fileURLToPath(import.meta.url));
 export const SCHEMA_VERSION = "hardware-mfa-evidence-v1";
+const FUTURE_SKEW_MS = 5 * 60 * 1000;
 
 const REQUIRED_ACCOUNT_IDS = [
   "one_password_admin",
@@ -19,11 +20,14 @@ const REQUIRED_ACCOUNT_IDS = [
 const ALLOWED_METHODS = new Set(["provider_ui", "provider_api", "operator_attestation"]);
 
 function usage() {
-  return `Usage: node scripts/ops/${SCRIPT_NAME} --file docs/evidence/hardware-mfa-YYYY-MM-DD.json [--json]
+  return `Usage: node scripts/ops/${SCRIPT_NAME} --file docs/evidence/hardware-mfa-YYYY-MM-DD.json [--json] [--max-completed-age-hours N]
 
 Validates the operator evidence that hardware-backed MFA is enrolled across the
 admin trust chain. This check is read-only; it does not call providers or store
 recovery codes.
+
+Use --max-completed-age-hours when validating live launch evidence so stale
+historical artifacts cannot be reused as current admin-trust proof.
 `;
 }
 
@@ -31,7 +35,8 @@ function parseArgs(argv) {
   const args = {
     file: undefined,
     json: false,
-    help: false
+    help: false,
+    maxCompletedAgeHours: undefined
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -40,6 +45,13 @@ function parseArgs(argv) {
       index += 1;
     } else if (arg === "--json") {
       args.json = true;
+    } else if (arg === "--max-completed-age-hours") {
+      const value = Number(argv[index + 1]);
+      if (!Number.isFinite(value) || value <= 0) {
+        throw new Error("--max-completed-age-hours must be a positive number");
+      }
+      args.maxCompletedAgeHours = value;
+      index += 1;
     } else if (arg === "-h" || arg === "--help") {
       args.help = true;
     } else if (!args.file && !arg.startsWith("-")) {
@@ -88,6 +100,12 @@ function requireIsoDate(value, path, errors) {
   return raw;
 }
 
+function requireIsoTimestamp(value, path, errors) {
+  const raw = requireIsoDate(value, path, errors);
+  const timestamp = Date.parse(raw);
+  return Number.isFinite(timestamp) ? timestamp : undefined;
+}
+
 function requireNonEmptyArray(value, path, errors) {
   if (!Array.isArray(value) || value.length === 0) {
     errors.push(`${path} must be a non-empty array`);
@@ -129,6 +147,34 @@ function scanForSecretLikeValues(value, path, errors) {
   }
 }
 
+function assertFreshTimestamp(timestamp, path, options, errors, { completedAt = undefined } = {}) {
+  if (!Number.isFinite(timestamp)) return;
+  if (Number.isFinite(completedAt) && timestamp > completedAt + FUTURE_SKEW_MS) {
+    errors.push(`${path} must not be later than completedAt`);
+  }
+
+  const maxCompletedAgeHours = options.maxCompletedAgeHours;
+  if (maxCompletedAgeHours === undefined) return;
+  if (!Number.isFinite(maxCompletedAgeHours) || maxCompletedAgeHours <= 0) {
+    errors.push("maxCompletedAgeHours must be a positive number");
+    return;
+  }
+
+  const now = options.now instanceof Date ? options.now : new Date(options.now ?? Date.now());
+  const nowMs = now.getTime();
+  if (!Number.isFinite(nowMs)) {
+    errors.push("now must be a valid Date or timestamp");
+    return;
+  }
+  if (timestamp > nowMs + FUTURE_SKEW_MS) {
+    errors.push(`${path} must not be in the future`);
+  }
+  const maxAgeMs = maxCompletedAgeHours * 60 * 60 * 1000;
+  if (nowMs - timestamp > maxAgeMs) {
+    errors.push(`${path} must be within ${maxCompletedAgeHours} hour(s)`);
+  }
+}
+
 function validateHardwareKeys(keys, errors) {
   const items = requireNonEmptyArray(keys, "hardwareKeys", errors);
   if (items.length < 2) {
@@ -150,7 +196,7 @@ function validateHardwareKeys(keys, errors) {
   return labels;
 }
 
-function validateAccount(rawAccount, index, keyLabels, errors) {
+function validateAccount(rawAccount, index, keyLabels, errors, { completedAt, freshnessOptions }) {
   const path = `accounts[${index}]`;
   const account = assertObject(rawAccount, path, errors);
   const id = requireString(account.id, `${path}.id`, errors);
@@ -180,7 +226,8 @@ function validateAccount(rawAccount, index, keyLabels, errors) {
     errors.push(`${path}.recoveryCodesStored must be true`);
   }
   requireString(account.recoveryLocation, `${path}.recoveryLocation`, errors);
-  requireIsoDate(account.lastVerifiedAt, `${path}.lastVerifiedAt`, errors);
+  const lastVerifiedAt = requireIsoTimestamp(account.lastVerifiedAt, `${path}.lastVerifiedAt`, errors);
+  assertFreshTimestamp(lastVerifiedAt, `${path}.lastVerifiedAt`, freshnessOptions, errors, { completedAt });
 
   const evidence = assertObject(account.evidence, `${path}.evidence`, errors);
   const method = requireString(evidence.method, `${path}.evidence.method`, errors);
@@ -219,14 +266,15 @@ function validateAccount(rawAccount, index, keyLabels, errors) {
   return id;
 }
 
-export function validateEvidence(evidence) {
+export function validateEvidence(evidence, options = {}) {
   const errors = [];
   const doc = assertObject(evidence, "evidence", errors);
 
   if (doc.schemaVersion !== SCHEMA_VERSION) {
     errors.push(`schemaVersion must be ${SCHEMA_VERSION}`);
   }
-  requireIsoDate(doc.completedAt, "completedAt", errors);
+  const completedAt = requireIsoTimestamp(doc.completedAt, "completedAt", errors);
+  assertFreshTimestamp(completedAt, "completedAt", options, errors);
 
   const operator = assertObject(doc.operator, "operator", errors);
   requireString(operator.name, "operator.name", errors);
@@ -236,7 +284,10 @@ export function validateEvidence(evidence) {
   const accounts = requireNonEmptyArray(doc.accounts, "accounts", errors);
   const seenAccountIds = new Set();
   accounts.forEach((account, index) => {
-    const id = validateAccount(account, index, keyLabels, errors);
+    const id = validateAccount(account, index, keyLabels, errors, {
+      completedAt,
+      freshnessOptions: options
+    });
     if (id) {
       if (seenAccountIds.has(id)) {
         errors.push(`accounts must not contain duplicate id ${id}`);
@@ -272,7 +323,8 @@ export function validateEvidence(evidence) {
       accountCount: Array.isArray(doc.accounts) ? doc.accounts.length : 0,
       accounts: Array.isArray(doc.accounts)
         ? doc.accounts.map((account) => account?.id).filter(Boolean)
-        : []
+        : [],
+      freshnessEnforced: Number.isFinite(options.maxCompletedAgeHours)
     }
   };
 }
@@ -288,7 +340,9 @@ async function main() {
   }
   const raw = await readFile(args.file, "utf8");
   const parsed = JSON.parse(raw);
-  const result = validateEvidence(parsed);
+  const result = validateEvidence(parsed, {
+    maxCompletedAgeHours: args.maxCompletedAgeHours
+  });
   if (args.json) {
     process.stdout.write(`${JSON.stringify({
       status: result.ok ? "ok" : "not_ok",

--- a/scripts/ops/check-hardware-mfa-evidence.test.mjs
+++ b/scripts/ops/check-hardware-mfa-evidence.test.mjs
@@ -92,6 +92,19 @@ function validEvidence(overrides = {}) {
   };
 }
 
+function freshEvidence() {
+  const now = new Date();
+  const verifiedAt = new Date(now.getTime() - 10 * 60 * 1000).toISOString();
+  return validEvidence({
+    completedAt: now.toISOString(),
+    accounts: validEvidence().accounts.map((entry) => ({
+      ...entry,
+      lastVerifiedAt: verifiedAt,
+      subjects: entry.subjects?.map((subject) => ({ ...subject }))
+    }))
+  });
+}
+
 async function writeEvidenceFile(doc) {
   const dir = await mkdtemp(join(tmpdir(), "hardware-mfa-evidence-"));
   const file = join(dir, "evidence.json");
@@ -105,6 +118,17 @@ test("validateEvidence accepts complete hardware MFA evidence", () => {
   assert.deepEqual(result.errors, []);
   assert.equal(result.summary.hardwareKeyCount, 2);
   assert.equal(result.summary.accountCount, 6);
+  assert.equal(result.summary.freshnessEnforced, false);
+});
+
+test("validateEvidence accepts fresh launch proof with a max completed age", () => {
+  const result = validateEvidence(validEvidence(), {
+    now: new Date("2026-05-22T13:30:00.000Z"),
+    maxCompletedAgeHours: 2
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.summary.freshnessEnforced, true);
 });
 
 test("validateEvidence rejects missing trust-chain accounts", () => {
@@ -214,12 +238,72 @@ test("validateEvidence rejects raw secret-looking values", () => {
   assert.ok(result.errors.some((error) => error.includes("appears to contain a secret value")));
 });
 
+test("validateEvidence rejects stale or future-dated launch proof", () => {
+  const stale = validateEvidence(validEvidence(), {
+    now: new Date("2026-05-23T13:01:00.000Z"),
+    maxCompletedAgeHours: 24
+  });
+  assert.equal(stale.ok, false);
+  assert.ok(stale.errors.includes("completedAt must be within 24 hour(s)"));
+  assert.ok(stale.errors.includes("accounts[0].lastVerifiedAt must be within 24 hour(s)"));
+
+  const future = validateEvidence(validEvidence({
+    completedAt: "2026-05-22T13:10:00.000Z"
+  }), {
+    now: new Date("2026-05-22T13:00:00.000Z"),
+    maxCompletedAgeHours: 24
+  });
+  assert.equal(future.ok, false);
+  assert.ok(future.errors.includes("completedAt must not be in the future"));
+});
+
+test("validateEvidence rejects account verification after evidence completion", () => {
+  const result = validateEvidence(validEvidence({
+    accounts: [
+      account("one_password_admin", {
+        lastVerifiedAt: "2026-05-22T13:10:01.000Z"
+      }),
+      account("aws_root"),
+      account("aws_iam_admins"),
+      account("github_org_admin"),
+      account("domain_registrar"),
+      account("vps_provider")
+    ]
+  }));
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.includes("accounts[0].lastVerifiedAt must not be later than completedAt"));
+});
+
+test("validateEvidence rejects invalid freshness options", () => {
+  const result = validateEvidence(validEvidence(), {
+    now: new Date("2026-05-22T13:30:00.000Z"),
+    maxCompletedAgeHours: 0
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.includes("maxCompletedAgeHours must be a positive number"));
+});
+
 test("CLI exits zero and prints JSON for valid evidence", async () => {
   const file = await writeEvidenceFile(validEvidence());
   const { stdout } = await execFileAsync(process.execPath, [scriptPath, "--file", file, "--json"]);
   const parsed = JSON.parse(stdout);
   assert.equal(parsed.status, "ok");
   assert.equal(parsed.summary.operator, "Pascal");
+});
+
+test("CLI accepts max completed age for fresh evidence", async () => {
+  const file = await writeEvidenceFile(freshEvidence());
+  const { stdout } = await execFileAsync(process.execPath, [
+    scriptPath,
+    "--file",
+    file,
+    "--max-completed-age-hours",
+    "1",
+    "--json"
+  ]);
+  const parsed = JSON.parse(stdout);
+  assert.equal(parsed.status, "ok");
+  assert.equal(parsed.summary.freshnessEnforced, true);
 });
 
 test("CLI exits non-zero for invalid evidence", async () => {
@@ -240,6 +324,24 @@ test("CLI exits non-zero for invalid evidence", async () => {
     (error) => {
       assert.notEqual(error.code, 0);
       assert.match(error.stderr, /accounts\[0\]\.status must be hardware_key_enrolled/u);
+      return true;
+    }
+  );
+});
+
+test("CLI exits non-zero for invalid max completed age", async () => {
+  const file = await writeEvidenceFile(validEvidence());
+  await assert.rejects(
+    () => execFileAsync(process.execPath, [
+      scriptPath,
+      "--file",
+      file,
+      "--max-completed-age-hours",
+      "0"
+    ]),
+    (error) => {
+      assert.notEqual(error.code, 0);
+      assert.match(error.stderr, /--max-completed-age-hours must be a positive number/u);
       return true;
     }
   );


### PR DESCRIPTION
## Summary
- add an explicit --max-completed-age-hours gate to the hardware-MFA evidence validator
- reject future/stale completedAt values and account lastVerifiedAt timestamps that are stale or later than completedAt
- document the launch-signoff command and add a roadmap fragment for operator handoff

## Checks
- node --test scripts/ops/check-hardware-mfa-evidence.test.mjs
- npm run test:ops
- git diff --check

## Impact
- Backend: no runtime change
- Frontend: no
- Indexer: no
- Caddy: no
- Contracts: no
- Public site: no
- Ops/docs: yes, hardware-MFA proof validation only

## Env / VPS changes
None. Operators should validate live hardware-MFA evidence with --max-completed-age-hours before moving the admin-trust proof item to Proofed.