### PR TITLE
[codex] harden pauser proof freshness

### DIFF
--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -48,15 +48,19 @@ node scripts/ops/run-pauser-rehearsal.mjs \
 
 # Validate the captured evidence before ticking checklist boxes.
 node scripts/ops/check-pauser-rehearsal-evidence.mjs \
-  --file docs/evidence/pauser-rehearsal-readonly-YYYY-MM-DD.json
+  --file docs/evidence/pauser-rehearsal-readonly-YYYY-MM-DD.json \
+  --max-generated-age-hours 30
 
 node scripts/ops/check-pauser-rehearsal-evidence.mjs \
   --file docs/evidence/pauser-rehearsal-testnet-YYYY-MM-DD.json \
-  --require-live
+  --require-live \
+  --max-generated-age-hours 30
 ```
 
 For mainnet or any real-funds rehearsal, add `--require-dedicated-pauser`
 to both the rehearsal and evidence validation commands.
+The max-age flag keeps older proof files useful for audit history without
+letting stale evidence close current launch boxes.
 The current testnet pauser address overlaps other testnet roles in
 `deployments/testnet.json`; that is acceptable only as a bounded testnet
 shortcut and must not be carried into mainnet.

--- a/docs/roadmap-updates/2026-05-24-codex-pauser-proof-freshness.md
+++ b/docs/roadmap-updates/2026-05-24-codex-pauser-proof-freshness.md
@@ -1,0 +1,36 @@
+# Roadmap Update: Pauser Proof Freshness
+
+- **Date:** 2026-05-24
+- **Agent:** codex/pauser-proof-freshness
+- **Roadmap section:** P0 Launch Gates
+- **Item:** Control-plane pauser / Pause-unpause rehearsal
+- **Related PRs/issues:** [PR #514](https://github.com/averray-agent/agent/pull/514)
+- **Proposed status:** Ready for proof
+- **Owner:** Operator
+
+## Summary
+
+The pauser rehearsal evidence validator now supports an explicit max-age gate
+for launch proof artifacts. This keeps older read-only and live rehearsal files
+available as audit history while requiring fresh evidence before the
+control-plane pauser and pause/unpause checklist boxes are closed.
+
+## Evidence
+
+- Updated script: `scripts/ops/check-pauser-rehearsal-evidence.mjs`
+- Updated tests: `scripts/ops/check-pauser-rehearsal-evidence.test.mjs`
+- Updated checklist command:
+  `node scripts/ops/check-pauser-rehearsal-evidence.mjs --file docs/evidence/pauser-rehearsal-testnet-YYYY-MM-DD.json --require-live --max-generated-age-hours 30`
+
+## Blockers Or Caveats
+
+- The roadmap rows remain `Ready for proof` until the operator captures a live
+  testnet pause/unpause artifact and validates it with the max-age gate.
+- Mainnet or real-funds proof must also use `--require-dedicated-pauser`.
+
+## Requested Roadmap Change
+
+Keep `Control-plane pauser` and `Pause/unpause rehearsal` as `Ready for proof`.
+After live evidence exists, cite the artifact path, validation command, pause
+tx hash, unpause tx hash, and dedicated-pauser result before moving either row
+to `Proofed`.

--- a/scripts/ops/check-pauser-rehearsal-evidence.mjs
+++ b/scripts/ops/check-pauser-rehearsal-evidence.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 const SCRIPT_NAME = basename(fileURLToPath(import.meta.url));
 export const SCHEMA_VERSION = 1;
 export const EVIDENCE_KIND = "averray.pauserRehearsalEvidence";
+const FUTURE_SKEW_MS = 5 * 60 * 1000;
 
 const READ_ONLY_REQUIRED_CHECKS = [
   "owner_matches_manifest",
@@ -37,11 +38,14 @@ const ADDRESS_PATTERN = /^0x[a-fA-F0-9]{40}$/u;
 const TX_HASH_PATTERN = /^0x[a-fA-F0-9]{64}$/u;
 
 function usage() {
-  return `Usage: node scripts/ops/${SCRIPT_NAME} --file docs/evidence/pauser-rehearsal-YYYY-MM-DD.json [--json] [--require-live] [--require-dedicated-pauser]
+  return `Usage: node scripts/ops/${SCRIPT_NAME} --file docs/evidence/pauser-rehearsal-YYYY-MM-DD.json [--json] [--require-live] [--require-dedicated-pauser] [--max-generated-age-hours N]
 
 Validates the machine-readable evidence produced by run-pauser-rehearsal.mjs.
 This check is read-only; it does not call RPC, sign transactions, pause, or
 unpause contracts.
+
+Use --max-generated-age-hours when validating live launch evidence so stale
+historical artifacts cannot be reused as current pauser proof.
 `;
 }
 
@@ -51,6 +55,7 @@ function parseArgs(argv) {
     json: false,
     requireLive: false,
     requireDedicatedPauser: false,
+    maxGeneratedAgeHours: undefined,
     help: false
   };
 
@@ -65,6 +70,13 @@ function parseArgs(argv) {
       args.requireLive = true;
     } else if (arg === "--require-dedicated-pauser") {
       args.requireDedicatedPauser = true;
+    } else if (arg === "--max-generated-age-hours") {
+      const value = Number(argv[index + 1]);
+      if (!Number.isFinite(value) || value <= 0) {
+        throw new Error("--max-generated-age-hours must be a positive number");
+      }
+      args.maxGeneratedAgeHours = value;
+      index += 1;
     } else if (arg === "-h" || arg === "--help") {
       args.help = true;
     } else if (!args.file && !arg.startsWith("-")) {
@@ -124,6 +136,12 @@ function requireIsoDate(value, path, errors) {
     errors.push(`${path} must be an ISO-8601 date/time`);
   }
   return raw;
+}
+
+function requireIsoTimestamp(value, path, errors) {
+  const raw = requireIsoDate(value, path, errors);
+  const timestamp = Date.parse(raw);
+  return Number.isFinite(timestamp) ? timestamp : undefined;
 }
 
 function requireArray(value, path, errors) {
@@ -186,6 +204,30 @@ function validateTx(tx, path, errors) {
   }
 }
 
+function validateGeneratedFreshness(generatedAt, options, errors) {
+  const maxGeneratedAgeHours = options.maxGeneratedAgeHours;
+  if (maxGeneratedAgeHours === undefined) return;
+  if (!Number.isFinite(maxGeneratedAgeHours) || maxGeneratedAgeHours <= 0) {
+    errors.push("maxGeneratedAgeHours must be a positive number");
+    return;
+  }
+  if (!Number.isFinite(generatedAt)) return;
+
+  const now = options.now instanceof Date ? options.now : new Date(options.now ?? Date.now());
+  const nowMs = now.getTime();
+  if (!Number.isFinite(nowMs)) {
+    errors.push("now must be a valid Date or timestamp");
+    return;
+  }
+  if (generatedAt > nowMs + FUTURE_SKEW_MS) {
+    errors.push("generatedAt must not be in the future");
+  }
+  const maxAgeMs = maxGeneratedAgeHours * 60 * 60 * 1000;
+  if (nowMs - generatedAt > maxAgeMs) {
+    errors.push(`generatedAt must be within ${maxGeneratedAgeHours} hour(s)`);
+  }
+}
+
 export function validateEvidence(evidence, options = {}) {
   const errors = [];
   const warnings = [];
@@ -198,7 +240,8 @@ export function validateEvidence(evidence, options = {}) {
     errors.push(`kind must be ${EVIDENCE_KIND}`);
   }
   requireString(doc.profile, "profile", errors);
-  requireIsoDate(doc.generatedAt, "generatedAt", errors);
+  const generatedAt = requireIsoTimestamp(doc.generatedAt, "generatedAt", errors);
+  validateGeneratedFreshness(generatedAt, options, errors);
   const mode = requireString(doc.mode, "mode", errors);
   if (!["read_only_capability_proof", "live_pause_unpause"].includes(mode)) {
     errors.push("mode must be read_only_capability_proof or live_pause_unpause");
@@ -298,7 +341,8 @@ export function validateEvidence(evidence, options = {}) {
       pauser: live.pauser,
       controlPlanePauserReady: launchGate.controlPlanePauserReady,
       pauseUnpauseRehearsed: launchGate.pauseUnpauseRehearsed,
-      dedicatedPauser: roleOverlap.dedicated
+      dedicatedPauser: roleOverlap.dedicated,
+      freshnessEnforced: Number.isFinite(options.maxGeneratedAgeHours)
     }
   };
 }
@@ -317,7 +361,8 @@ async function main() {
   const parsed = JSON.parse(raw);
   const result = validateEvidence(parsed, {
     requireLive: args.requireLive,
-    requireDedicatedPauser: args.requireDedicatedPauser
+    requireDedicatedPauser: args.requireDedicatedPauser,
+    maxGeneratedAgeHours: args.maxGeneratedAgeHours
   });
 
   if (args.json) {

--- a/scripts/ops/check-pauser-rehearsal-evidence.test.mjs
+++ b/scripts/ops/check-pauser-rehearsal-evidence.test.mjs
@@ -135,6 +135,13 @@ function liveEvidence(overrides = {}) {
   });
 }
 
+function freshLiveEvidence(overrides = {}) {
+  return liveEvidence({
+    generatedAt: new Date().toISOString(),
+    ...overrides
+  });
+}
+
 async function writeEvidenceFile(doc) {
   const dir = await mkdtemp(join(tmpdir(), "pauser-rehearsal-evidence-"));
   const file = join(dir, "evidence.json");
@@ -157,6 +164,19 @@ test("validateEvidence accepts live pause and unpause proof", () => {
   assert.deepEqual(result.warnings, []);
   assert.equal(result.summary.pauseUnpauseRehearsed, true);
   assert.equal(result.summary.dedicatedPauser, true);
+  assert.equal(result.summary.freshnessEnforced, false);
+});
+
+test("validateEvidence accepts fresh live proof with a max generated age", () => {
+  const result = validateEvidence(liveEvidence(), {
+    requireLive: true,
+    requireDedicatedPauser: true,
+    now: new Date("2026-05-24T11:00:00.000Z"),
+    maxGeneratedAgeHours: 2
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.summary.freshnessEnforced, true);
 });
 
 test("validateEvidence rejects read-only evidence when live proof is required", () => {
@@ -213,6 +233,36 @@ test("validateEvidence rejects role overlap when dedicated pauser proof is requi
   assert.ok(result.errors.includes("checks must include pauser_is_dedicated_role"));
 });
 
+test("validateEvidence rejects stale or future-dated generatedAt for launch proof", () => {
+  const stale = validateEvidence(liveEvidence(), {
+    requireLive: true,
+    now: new Date("2026-05-25T10:01:00.000Z"),
+    maxGeneratedAgeHours: 24
+  });
+  assert.equal(stale.ok, false);
+  assert.ok(stale.errors.includes("generatedAt must be within 24 hour(s)"));
+
+  const future = validateEvidence(liveEvidence({
+    generatedAt: "2026-05-24T11:10:00.000Z"
+  }), {
+    requireLive: true,
+    now: new Date("2026-05-24T11:00:00.000Z"),
+    maxGeneratedAgeHours: 24
+  });
+  assert.equal(future.ok, false);
+  assert.ok(future.errors.includes("generatedAt must not be in the future"));
+});
+
+test("validateEvidence rejects invalid freshness options", () => {
+  const result = validateEvidence(liveEvidence(), {
+    requireLive: true,
+    now: new Date("2026-05-24T11:00:00.000Z"),
+    maxGeneratedAgeHours: 0
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.includes("maxGeneratedAgeHours must be a positive number"));
+});
+
 test("CLI exits zero and prints JSON for valid read-only evidence", async () => {
   const file = await writeEvidenceFile(validEvidence());
   const { stdout, stderr } = await execFileAsync(process.execPath, [scriptPath, "--file", file, "--json"]);
@@ -221,6 +271,23 @@ test("CLI exits zero and prints JSON for valid read-only evidence", async () => 
   assert.equal(parsed.status, "ok");
   assert.equal(parsed.summary.pauser, PAUSER);
   assert.equal(parsed.warnings.length, 1);
+});
+
+test("CLI accepts max generated age for fresh live evidence", async () => {
+  const file = await writeEvidenceFile(freshLiveEvidence());
+  const { stdout } = await execFileAsync(process.execPath, [
+    scriptPath,
+    "--file",
+    file,
+    "--require-live",
+    "--require-dedicated-pauser",
+    "--max-generated-age-hours",
+    "1",
+    "--json"
+  ]);
+  const parsed = JSON.parse(stdout);
+  assert.equal(parsed.status, "ok");
+  assert.equal(parsed.summary.freshnessEnforced, true);
 });
 
 test("CLI exits non-zero for evidence that does not satisfy live proof", async () => {
@@ -232,6 +299,25 @@ test("CLI exits non-zero for evidence that does not satisfy live proof", async (
       assert.notEqual(error.code, 0);
       assert.match(error.stderr, /mode must be live_pause_unpause/u);
       assert.match(error.stderr, /transactions\.pause must be an object/u);
+      return true;
+    }
+  );
+});
+
+test("CLI exits non-zero for invalid max generated age", async () => {
+  const file = await writeEvidenceFile(liveEvidence());
+
+  await assert.rejects(
+    () => execFileAsync(process.execPath, [
+      scriptPath,
+      "--file",
+      file,
+      "--max-generated-age-hours",
+      "0"
+    ]),
+    (error) => {
+      assert.notEqual(error.code, 0);
+      assert.match(error.stderr, /--max-generated-age-hours must be a positive number/u);
       return true;
     }
   );


### PR DESCRIPTION
## Summary
- add an explicit --max-generated-age-hours gate to pauser rehearsal evidence validation
- reject stale or future-dated generatedAt values when freshness enforcement is requested
- document the fresh-evidence launch checklist path and add a roadmap update fragment

## Checks
- git diff --check
- node --test scripts/ops/check-pauser-rehearsal-evidence.test.mjs
- npm run test:ops

## Impact
- Affects ops scripts and docs only.
- No backend, frontend, indexer, Caddy, contract, public site, environment, or VPS secret changes.