### PR TITLE
backend: split xcm request route

### DIFF
--- a/docs/roadmap-updates/2026-05-24-codex-xcm-request-route-split.md
+++ b/docs/roadmap-updates/2026-05-24-codex-xcm-request-route-split.md
@@ -1,0 +1,40 @@
+# Roadmap Update: HTTP server route split (`P2.3`) — XCM request route
+
+- **Date:** 2026-05-24
+- **Agent:** codex/xcm-request-route-split
+- **Roadmap section:** P1 Product And Platform Hardening
+- **Item:** HTTP server route split (`P2.3`)
+- **Related PRs/issues:** this PR; overlaps the route-split row currently touched by PR #513
+- **Proposed status:** Open
+- **Owner:** Roadmap steward
+
+## Summary
+
+The worker-facing `GET /xcm/request` route was extracted from
+`mcp-server/src/protocols/http/server.js` into
+`mcp-server/src/protocols/http/xcm-request-routes.js`. The route still
+authenticates the caller, requires `requestId`, loads the XCM request, enforces
+wallet/admin ownership through the existing helper, and returns the same record
+shape.
+
+## Evidence
+
+- `node --test mcp-server/src/protocols/http/xcm-request-routes.test.js`
+- `node --check mcp-server/src/protocols/http/xcm-request-routes.js`
+- `node --check mcp-server/src/protocols/http/server.js`
+- `git diff --check`
+
+## Blockers Or Caveats
+
+- `PROJECT_ROADMAP.md` is not edited directly in this PR because PR #513 is
+  already editing the `P2.3` route-split row.
+
+## Requested Roadmap Change
+
+After this PR lands, append this sentence to the `HTTP server route split
+(\`P2.3\`)` row:
+
+`Next slice extracted authenticated GET /xcm/request into
+mcp-server/src/protocols/http/xcm-request-routes.js with tests covering auth,
+missing requestId validation, ownership failure propagation, successful request
+reads, and unrelated path/method behavior.`

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -48,6 +48,7 @@ import { createProfileRoutes } from "./profile-routes.js";
 import { createSchemaRoutes } from "./schema-routes.js";
 import { createSessionRoutes } from "./session-routes.js";
 import { createVerifierRoutes } from "./verifier-routes.js";
+import { createXcmRequestRoutes } from "./xcm-request-routes.js";
 import { OPERATOR_SIGNERS, makePolicy } from "../../core/builtin-policies.js";
 
 const {
@@ -926,6 +927,13 @@ const handleAdminXcmRoute = createAdminXcmRoutes({
   storeIdempotentMutationReceipt,
 });
 
+const handleXcmRequestRoute = createXcmRequestRoutes({
+  authMiddleware,
+  ensureXcmRequestOwnership,
+  respond,
+  service,
+});
+
 const handleGasRoute = createGasRoutes({
   authMiddleware,
   pimlicoClient,
@@ -1377,15 +1385,8 @@ const server = createServer(async (request, response) => {
       return;
     }
 
-    if (request.method === "GET" && pathname === "/xcm/request") {
-      const auth = await authMiddleware(request, url);
-      const requestId = url.searchParams.get("requestId") ?? "";
-      if (!requestId) {
-        throw new ValidationError("requestId is required.");
-      }
-      const record = await service.getXcmRequest(requestId);
-      ensureXcmRequestOwnership(record, auth);
-      return respond(response, 200, record);
+    if (await handleXcmRequestRoute({ request, response, url, pathname })) {
+      return;
     }
 
     if (await handleAdminStatusRoute({ request, response, url, pathname })) {

--- a/mcp-server/src/protocols/http/xcm-request-routes.js
+++ b/mcp-server/src/protocols/http/xcm-request-routes.js
@@ -1,0 +1,24 @@
+import { ValidationError } from "../../core/errors.js";
+
+export function createXcmRequestRoutes({
+  authMiddleware,
+  ensureXcmRequestOwnership,
+  respond,
+  service,
+}) {
+  return async function handleXcmRequestRoute({ request, response, url, pathname }) {
+    if (request.method !== "GET" || pathname !== "/xcm/request") {
+      return false;
+    }
+
+    const auth = await authMiddleware(request, url);
+    const requestId = url.searchParams.get("requestId") ?? "";
+    if (!requestId) {
+      throw new ValidationError("requestId is required.");
+    }
+    const record = await service.getXcmRequest(requestId);
+    ensureXcmRequestOwnership(record, auth);
+    respond(response, 200, record);
+    return true;
+  };
+}

--- a/mcp-server/src/protocols/http/xcm-request-routes.test.js
+++ b/mcp-server/src/protocols/http/xcm-request-routes.test.js
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { AuthorizationError, ValidationError } from "../../core/errors.js";
+import { createXcmRequestRoutes } from "./xcm-request-routes.js";
+
+const AUTH = {
+  wallet: "0x1111111111111111111111111111111111111111",
+};
+const REQUEST_ID = `0x${"ab".repeat(32)}`;
+const RECORD = {
+  requestId: REQUEST_ID,
+  account: AUTH.wallet,
+  status: "pending",
+};
+
+function makeHarness(overrides = {}) {
+  const calls = [];
+  const response = {};
+  const route = createXcmRequestRoutes({
+    authMiddleware: async (_request, _url) => {
+      calls.push(["auth"]);
+      return overrides.auth ?? AUTH;
+    },
+    ensureXcmRequestOwnership: (record, auth) => {
+      calls.push(["ensureOwnership", { record, auth }]);
+      if (overrides.ownershipError) {
+        throw overrides.ownershipError;
+      }
+    },
+    respond: (res, statusCode, body, headers = {}) => {
+      calls.push(["respond", { statusCode, body, headers }]);
+      res.statusCode = statusCode;
+      res.body = body;
+      res.headers = headers;
+    },
+    service: {
+      getXcmRequest: async (requestId) => {
+        calls.push(["getXcmRequest", requestId]);
+        return overrides.record ?? RECORD;
+      },
+    },
+  });
+  return { calls, response, route };
+}
+
+test("xcm request routes ignore unrelated paths and methods", async () => {
+  const { calls, response, route } = makeHarness();
+
+  assert.equal(await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/xcm/not-request"),
+    pathname: "/xcm/not-request",
+  }), false);
+  assert.equal(await route({
+    request: { method: "POST" },
+    response,
+    url: new URL(`http://localhost/xcm/request?requestId=${REQUEST_ID}`),
+    pathname: "/xcm/request",
+  }), false);
+
+  assert.deepEqual(calls, []);
+  assert.deepEqual(response, {});
+});
+
+test("GET /xcm/request authenticates, loads the request, checks ownership, and responds", async () => {
+  const { calls, response, route } = makeHarness();
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL(`http://localhost/xcm/request?requestId=${REQUEST_ID}`),
+    pathname: "/xcm/request",
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.body, RECORD);
+  assert.deepEqual(calls, [
+    ["auth"],
+    ["getXcmRequest", REQUEST_ID],
+    ["ensureOwnership", { record: RECORD, auth: AUTH }],
+    ["respond", { statusCode: 200, body: RECORD, headers: {} }],
+  ]);
+});
+
+test("GET /xcm/request validates requestId before service reads", async () => {
+  const { calls, response, route } = makeHarness();
+
+  await assert.rejects(
+    () => route({
+      request: { method: "GET" },
+      response,
+      url: new URL("http://localhost/xcm/request"),
+      pathname: "/xcm/request",
+    }),
+    ValidationError,
+  );
+
+  assert.deepEqual(calls, [["auth"]]);
+  assert.deepEqual(response, {});
+});
+
+test("GET /xcm/request propagates ownership failures before responding", async () => {
+  const ownershipError = new AuthorizationError("not yours", "xcm_request_not_owned");
+  const { calls, response, route } = makeHarness({ ownershipError });
+
+  await assert.rejects(
+    () => route({
+      request: { method: "GET" },
+      response,
+      url: new URL(`http://localhost/xcm/request?requestId=${REQUEST_ID}`),
+      pathname: "/xcm/request",
+    }),
+    ownershipError,
+  );
+
+  assert.deepEqual(calls, [
+    ["auth"],
+    ["getXcmRequest", REQUEST_ID],
+    ["ensureOwnership", { record: RECORD, auth: AUTH }],
+  ]);
+  assert.deepEqual(response, {});
+});


### PR DESCRIPTION
## Summary
- Extract authenticated `GET /xcm/request` from `server.js` into `xcm-request-routes.js`.
- Add focused route tests covering auth, missing `requestId`, ownership failures, successful reads, and unrelated route fallthrough.
- Add a roadmap fragment instead of editing `PROJECT_ROADMAP.md` directly because PR #513 is already touching the P2.3 route-split row.

## Checks
- `node --test mcp-server/src/protocols/http/xcm-request-routes.test.js`
- `node --check mcp-server/src/protocols/http/xcm-request-routes.js`
- `node --check mcp-server/src/protocols/http/xcm-request-routes.test.js`
- `node --check mcp-server/src/protocols/http/server.js`
- `git diff --check`
- Attempted `npm --workspace mcp-server test`; blocked locally by unrelated missing infra dependencies / local runtime issues: `@aws-sdk/client-kms`, `@aws-sdk/credential-provider-ini`, and the existing local test environment failures around hosted/provider dependencies.

## Impact
- Backend route organization only.
- Roadmap fragment only; no direct roadmap row update.
- No frontend, indexer, Caddy, contracts, public site, VPS secret, or environment changes.
