### PR TITLE
backend: split account routes

### DIFF
--- a/docs/roadmap-updates/2026-05-24-codex-account-route-split.md
+++ b/docs/roadmap-updates/2026-05-24-codex-account-route-split.md
@@ -1,0 +1,38 @@
+# Roadmap Update: HTTP server route split (`P2.3`)
+
+## Slice
+
+- **Date:** 2026-05-24
+- **Agent:** Codex
+- **Item:** HTTP server route split (`P2.3`)
+- **Status:** Partial progress; canonical item remains Open.
+
+## What changed
+
+- Extracted public `/strategies` plus protected `/account`, `/account/borrow-capacity`, `/account/fund`, `/account/allocate`, `/account/deallocate`, `/account/strategies`, `/account/borrow`, and `/account/repay` into `mcp-server/src/protocols/http/account-routes.js`.
+- Moved account/treasury-specific strategy math, live adapter overlays, async-XCM treasury option parsing, and timeline normalization into the account route module.
+- Kept shared idempotent mutation helpers in `server.js` while threading them into the route module.
+- Added low-cardinality metric labels and root endpoint entries for the account route family.
+- Added `mcp-server/src/protocols/http/account-routes.test.js` for:
+  - unrelated route fall-through;
+  - public strategy metadata;
+  - wallet account summary reads;
+  - live strategy allocation overlays;
+  - borrow-capacity reads;
+  - sync fund/allocate/repay mutation idempotency;
+  - async-XCM allocation receipt storage;
+  - async-XCM server-assembled field rejection;
+  - strategy portfolio summary/timeline output.
+
+## Evidence
+
+- Polkadot MCP docs check: `get_project_info` returned `Polkadot Developer Docs` with index status `ready`.
+- `node --check mcp-server/src/protocols/http/account-routes.js`
+- `node --check mcp-server/src/protocols/http/server.js`
+- `node --test mcp-server/src/protocols/http/account-routes.test.js`
+- `npm --workspace mcp-server test` (819 passing)
+
+## Follow-up
+
+- Append this slice to the canonical `HTTP server route split (P2.3)` row after merge.
+- Remaining inline route groups in `server.js` include event streaming, XCM request read, payments, root health/status/provider/metrics/onboarding, and any residual system/status surfaces.

--- a/mcp-server/src/protocols/http/account-routes.js
+++ b/mcp-server/src/protocols/http/account-routes.js
@@ -1,0 +1,627 @@
+import { keccak256, toUtf8Bytes } from "ethers";
+
+import { ValidationError } from "../../core/errors.js";
+
+function sumNumericValues(record = {}) {
+  return Object.values(record).reduce((sum, value) => sum + (Number(value) || 0), 0);
+}
+
+function ratioToBps(numerator, denominator) {
+  if (!Number.isFinite(numerator) || !Number.isFinite(denominator) || denominator <= 0) {
+    return 0;
+  }
+  return Math.round((numerator / denominator) * 10_000);
+}
+
+function normalizeRawIntegerString(value) {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+  if (typeof value === "bigint") {
+    return value >= 0n ? value.toString() : undefined;
+  }
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value >= 0 ? String(value) : undefined;
+  }
+  const normalized = String(value).trim();
+  if (!/^\d+$/u.test(normalized)) {
+    return undefined;
+  }
+  return BigInt(normalized).toString();
+}
+
+function calculateRoutedAmountRaw(sharesRaw, telemetry = {}) {
+  const normalizedSharesRaw = normalizeRawIntegerString(sharesRaw);
+  const totalAssetsRaw = normalizeRawIntegerString(telemetry.totalAssetsRaw);
+  const totalSharesRaw = normalizeRawIntegerString(telemetry.totalSharesRaw);
+  if (normalizedSharesRaw === undefined || totalAssetsRaw === undefined || totalSharesRaw === undefined) {
+    return undefined;
+  }
+  const denominator = BigInt(totalSharesRaw);
+  if (denominator <= 0n) {
+    return undefined;
+  }
+  return ((BigInt(normalizedSharesRaw) * BigInt(totalAssetsRaw)) / denominator).toString();
+}
+
+function resolveAssetSymbol(gateway, assetAddress) {
+  if (!assetAddress) return "DOT";
+  const supportedAssets = gateway?.config?.supportedAssets ?? [];
+  const match = supportedAssets.find((asset) => asset.address?.toLowerCase() === assetAddress.toLowerCase());
+  return match?.symbol ?? "DOT";
+}
+
+function resolveStrategyAssetSymbol(gateway, strategy) {
+  return strategy?.assetConfig?.symbol ?? resolveAssetSymbol(gateway, strategy?.asset);
+}
+
+function findStrategyConfig({ gateway, strategies, strategyId }) {
+  if (!strategyId) return undefined;
+  const normalized = gateway?.normalizeStrategyId?.(strategyId) ?? strategyId;
+  return strategies.find((entry) => entry.strategyId === strategyId || entry.strategyId === normalized);
+}
+
+function normalizeAsyncWeight(input = undefined) {
+  return {
+    refTime: input?.refTime ?? input?.ref_time ?? 0,
+    proofSize: input?.proofSize ?? input?.proof_size ?? 0
+  };
+}
+
+function deriveAsyncNonce(seed) {
+  const hash = keccak256(toUtf8Bytes(seed));
+  return Number.parseInt(hash.slice(2, 14), 16);
+}
+
+function rejectCallerSuppliedAsyncXcmField(payload, url, field) {
+  if (payload && Object.prototype.hasOwnProperty.call(payload, field)) {
+    throw new ValidationError(`Async XCM ${field} is assembled by the server and cannot be supplied by the caller.`);
+  }
+  if (url.searchParams.has(field)) {
+    throw new ValidationError(`Async XCM ${field} is assembled by the server and cannot be supplied by the caller.`);
+  }
+}
+
+function parseAsyncTreasuryOptions(payload = {}, url, { defaultRecipient = undefined } = {}) {
+  rejectCallerSuppliedAsyncXcmField(payload, url, "destination");
+  rejectCallerSuppliedAsyncXcmField(payload, url, "message");
+  rejectCallerSuppliedAsyncXcmField(payload, url, "nonce");
+
+  const queryWeight = {
+    refTime: url.searchParams.get("maxWeightRefTime"),
+    proofSize: url.searchParams.get("maxWeightProofSize")
+  };
+  const maxWeight = normalizeAsyncWeight(
+    payload?.maxWeight && typeof payload.maxWeight === "object"
+      ? payload.maxWeight
+      : queryWeight
+  );
+  const idempotencyKey = typeof payload?.idempotencyKey === "string" && payload.idempotencyKey.trim()
+    ? payload.idempotencyKey.trim()
+    : undefined;
+  const recipient = typeof payload?.recipient === "string" && payload.recipient.trim()
+    ? payload.recipient.trim()
+    : (url.searchParams.get("recipient")?.trim() || defaultRecipient);
+  const requestedSharesRaw = payload?.requestedShares ?? payload?.shares ?? url.searchParams.get("shares");
+  const requestedShares = Number.isFinite(Number(requestedSharesRaw)) && Number(requestedSharesRaw) > 0
+    ? Number(requestedSharesRaw)
+    : undefined;
+  return {
+    maxWeight,
+    idempotencyKey,
+    recipient,
+    requestedShares
+  };
+}
+
+function buildLaneAttention({ shares, isMock, debtTotal, borrowCapacity, deploymentShareBps }) {
+  if (!(shares > 0)) {
+    return undefined;
+  }
+  if (isMock) {
+    return {
+      code: "simulated_yield",
+      tone: "tier-warn",
+      message: "This lane is using the mock vDOT adapter, so yield is simulated rather than market-backed."
+    };
+  }
+  if (debtTotal > 0 && !(borrowCapacity > 0)) {
+    return {
+      code: "credit_constrained",
+      tone: "tier-warn",
+      message: "This wallet has debt outstanding and no additional live borrow headroom."
+    };
+  }
+  if (deploymentShareBps >= 7000) {
+    return {
+      code: "lane_concentration",
+      tone: "status-pending",
+      message: "Most deployed capital is concentrated in this lane right now."
+    };
+  }
+  return undefined;
+}
+
+function formatAdapterYieldLabel({ telemetry, isMock, shares }) {
+  if (!telemetry?.reported) {
+    return isMock
+      ? "Mock adapter is registered, but no simulated yield data is reported yet."
+      : "Adapter is registered, but it is not reporting a live yield/performance read yet.";
+  }
+  const sharePrice = Number(telemetry.sharePrice);
+  const performanceBps = Number(telemetry.performanceBps);
+  const sharePriceLabel = Number.isFinite(sharePrice) ? `${sharePrice.toFixed(4)}x share price` : "share price unavailable";
+  const driftLabel = Number.isFinite(performanceBps)
+    ? `${performanceBps >= 0 ? "+" : ""}${performanceBps} bps`
+    : "drift unavailable";
+  if (shares > 0) {
+    return `${sharePriceLabel} \u00b7 ${driftLabel} on the adapter for currently routed wallet capital.`;
+  }
+  return `${sharePriceLabel} \u00b7 ${driftLabel} on deployed adapter capital.`;
+}
+
+function normalizeTimelineEntry(entry = {}) {
+  const amount = Number(entry.amount ?? 0);
+  const yieldDelta = Number(entry.yieldDelta ?? entry.realizedYieldDelta ?? 0);
+  return {
+    id: entry.id,
+    type: entry.type ?? "treasury_event",
+    strategyId: entry.strategyId,
+    asset: entry.asset ?? "DOT",
+    amount,
+    ...(entry.amountRaw !== undefined ? { amountRaw: normalizeRawIntegerString(entry.amountRaw) ?? String(entry.amountRaw) } : {}),
+    yieldDelta,
+    ...(entry.yieldDeltaRaw !== undefined ? { yieldDeltaRaw: String(entry.yieldDeltaRaw) } : {}),
+    ...(entry.realizedYieldDeltaRaw !== undefined ? { realizedYieldDeltaRaw: String(entry.realizedYieldDeltaRaw) } : {}),
+    ...(entry.principalAfterRaw !== undefined ? { principalAfterRaw: String(entry.principalAfterRaw) } : {}),
+    ...(entry.markValueAfterRaw !== undefined ? { markValueAfterRaw: String(entry.markValueAfterRaw) } : {}),
+    ...(entry.requestedSharesRaw !== undefined ? { requestedSharesRaw: String(entry.requestedSharesRaw) } : {}),
+    at: entry.at
+  };
+}
+
+function readAsset(payload, url) {
+  return typeof payload?.asset === "string" && payload.asset.trim()
+    ? payload.asset.trim()
+    : (url.searchParams.get("asset")?.trim() || "DOT");
+}
+
+function readAmount(payload, url) {
+  return Number(payload?.amount ?? url.searchParams.get("amount") ?? "0");
+}
+
+function readStrategyId(payload, url) {
+  return typeof payload?.strategyId === "string" && payload.strategyId.trim()
+    ? payload.strategyId.trim()
+    : (url.searchParams.get("strategyId")?.trim() || "default-low-risk");
+}
+
+export function createAccountRoutes({
+  authMiddleware,
+  buildIdempotentMutationContext,
+  buildMutationRequestHash,
+  ensureAsyncXcmTreasuryAdmin,
+  gateway,
+  getIdempotentMutationReplay,
+  readJsonBody,
+  requireChainBackedMutation,
+  respond,
+  runIdempotentMutation,
+  service,
+  storeIdempotentMutationReceipt,
+  strategies,
+  stripIdempotencyKey,
+}) {
+  async function handleSyncAccountMutation({ request, response, url, route, bucket, operation }) {
+    const auth = await authMiddleware(request, url);
+    const payload = await readJsonBody(request);
+    const asset = readAsset(payload, url);
+    const amount = readAmount(payload, url);
+    const idempotency = buildIdempotentMutationContext({
+      route,
+      auth,
+      payload,
+      normalizedPayload: {
+        ...stripIdempotencyKey(payload),
+        asset,
+        amount
+      },
+      bucket
+    });
+    await runIdempotentMutation(response, idempotency, 200, async () => {
+      await requireChainBackedMutation(route);
+      return operation({ wallet: auth.wallet, asset, amount });
+    });
+    return true;
+  }
+
+  return async function handleAccountRoute({ request, response, url, pathname }) {
+    if (request.method === "GET" && pathname === "/strategies") {
+      respond(
+        response,
+        200,
+        {
+          strategies,
+          docs: "https://github.com/depre-dev/agent/blob/main/docs/strategies/vdot.md"
+        },
+        { "cache-control": "public, max-age=300" }
+      );
+      return true;
+    }
+
+    if (request.method === "GET" && pathname === "/account") {
+      const auth = await authMiddleware(request, url);
+      const account = await service.getAccountSummary(auth.wallet);
+      if (!gateway?.isEnabled?.() || !strategies.length) {
+        respond(response, 200, account);
+        return true;
+      }
+
+      const [strategyPositions, strategyTelemetry] = await Promise.all([
+        gateway.getStrategyPositions(auth.wallet, strategies).catch(() => []),
+        gateway.getStrategyTelemetry(strategies).catch(() => [])
+      ]);
+      const sharesByStrategy = Object.fromEntries(strategyPositions.map((entry) => [entry.strategyId, Number(entry.shares ?? 0)]));
+      const telemetryByStrategy = Object.fromEntries(strategyTelemetry.map((entry) => [entry.strategyId, entry]));
+      const liveAllocatedByAsset = {};
+      for (const strategy of strategies) {
+        const shares = Number(sharesByStrategy[strategy.strategyId] ?? 0);
+        if (!(shares > 0)) continue;
+        const telemetry = telemetryByStrategy[strategy.strategyId];
+        const liveValue = telemetry?.reported && Number.isFinite(Number(telemetry.sharePrice))
+          ? shares * Number(telemetry.sharePrice)
+          : shares;
+        const symbol = resolveAssetSymbol(gateway, strategy.asset);
+        liveAllocatedByAsset[symbol] = (liveAllocatedByAsset[symbol] ?? 0) + liveValue;
+      }
+
+      respond(response, 200, {
+        ...account,
+        strategyAllocated: {
+          ...account.strategyAllocated,
+          ...liveAllocatedByAsset
+        }
+      });
+      return true;
+    }
+
+    if (request.method === "GET" && pathname === "/account/borrow-capacity") {
+      const auth = await authMiddleware(request, url);
+      const asset = url.searchParams.get("asset")?.trim() || "DOT";
+      respond(response, 200, {
+        wallet: auth.wallet,
+        asset,
+        borrowCapacity: await service.getBorrowCapacity(auth.wallet, asset)
+      });
+      return true;
+    }
+
+    if (request.method === "POST" && pathname === "/account/fund") {
+      return handleSyncAccountMutation({
+        request,
+        response,
+        url,
+        route: "/account/fund",
+        bucket: "account_fund",
+        operation: ({ wallet, asset, amount }) => service.fundAccount(wallet, asset, amount)
+      });
+    }
+
+    if (request.method === "POST" && pathname === "/account/allocate") {
+      const auth = await authMiddleware(request, url);
+      const payload = await readJsonBody(request);
+      const asset = readAsset(payload, url);
+      const strategyId = readStrategyId(payload, url);
+      const amount = readAmount(payload, url);
+      const strategy = findStrategyConfig({ gateway, strategies, strategyId });
+      if (strategy?.executionMode === "async_xcm") {
+        await requireChainBackedMutation("/account/allocate");
+        ensureAsyncXcmTreasuryAdmin(auth);
+        const strategyAsset = resolveStrategyAssetSymbol(gateway, strategy);
+        const options = parseAsyncTreasuryOptions(payload, url);
+        const mutationKey = options.idempotencyKey
+          ? `${auth.wallet}:${strategyId}:${options.idempotencyKey}`
+          : undefined;
+        const requestHash = buildMutationRequestHash({
+          route: "/account/allocate",
+          wallet: auth.wallet,
+          payload: {
+            ...payload,
+            asset,
+            amount,
+            strategyId,
+            strategyAsset,
+            asyncXcm: stripIdempotencyKey(options)
+          }
+        });
+        const replay = await getIdempotentMutationReplay({
+          bucket: "account_allocate_async",
+          key: mutationKey,
+          requestHash
+        });
+        if (replay) {
+          respond(response, replay.statusCode, replay.body);
+          return true;
+        }
+        const nonce = options.nonce ?? (mutationKey ? deriveAsyncNonce(mutationKey) : Date.now());
+        const result = await service.allocateIdleFunds(
+          auth.wallet,
+          strategyAsset,
+          amount,
+          strategyId,
+          strategy,
+          { ...options, nonce }
+        );
+        await storeIdempotentMutationReceipt({
+          bucket: "account_allocate_async",
+          key: mutationKey,
+          requestHash,
+          response: result,
+          statusCode: 200
+        });
+        respond(response, 200, result);
+        return true;
+      }
+      const idempotency = buildIdempotentMutationContext({
+        route: "/account/allocate",
+        auth,
+        payload,
+        normalizedPayload: {
+          ...stripIdempotencyKey(payload),
+          asset,
+          amount,
+          strategyId
+        },
+        bucket: "account_allocate_sync"
+      });
+      await runIdempotentMutation(response, idempotency, 200, async () => {
+        await requireChainBackedMutation("/account/allocate");
+        return service.allocateIdleFunds(auth.wallet, asset, amount, strategyId, strategy);
+      });
+      return true;
+    }
+
+    if (request.method === "POST" && pathname === "/account/deallocate") {
+      const auth = await authMiddleware(request, url);
+      const payload = await readJsonBody(request);
+      const asset = readAsset(payload, url);
+      const strategyId = readStrategyId(payload, url);
+      const amount = readAmount(payload, url);
+      const strategy = findStrategyConfig({ gateway, strategies, strategyId });
+      if (strategy?.executionMode === "async_xcm") {
+        await requireChainBackedMutation("/account/deallocate");
+        ensureAsyncXcmTreasuryAdmin(auth);
+        const strategyAsset = resolveStrategyAssetSymbol(gateway, strategy);
+        const options = parseAsyncTreasuryOptions(payload, url, {
+          defaultRecipient: gateway?.config?.agentAccountAddress
+        });
+        const mutationKey = options.idempotencyKey
+          ? `${auth.wallet}:${strategyId}:${options.idempotencyKey}`
+          : undefined;
+        const requestHash = buildMutationRequestHash({
+          route: "/account/deallocate",
+          wallet: auth.wallet,
+          payload: {
+            ...payload,
+            asset,
+            amount,
+            strategyId,
+            strategyAsset,
+            asyncXcm: stripIdempotencyKey(options)
+          }
+        });
+        const replay = await getIdempotentMutationReplay({
+          bucket: "account_deallocate_async",
+          key: mutationKey,
+          requestHash
+        });
+        if (replay) {
+          respond(response, replay.statusCode, replay.body);
+          return true;
+        }
+        const nonce = options.nonce ?? (mutationKey ? deriveAsyncNonce(mutationKey) : Date.now());
+        const result = await service.deallocateIdleFunds(
+          auth.wallet,
+          strategyAsset,
+          amount,
+          strategyId,
+          strategy,
+          { ...options, nonce }
+        );
+        await storeIdempotentMutationReceipt({
+          bucket: "account_deallocate_async",
+          key: mutationKey,
+          requestHash,
+          response: result,
+          statusCode: 200
+        });
+        respond(response, 200, result);
+        return true;
+      }
+      const idempotency = buildIdempotentMutationContext({
+        route: "/account/deallocate",
+        auth,
+        payload,
+        normalizedPayload: {
+          ...stripIdempotencyKey(payload),
+          asset,
+          amount,
+          strategyId
+        },
+        bucket: "account_deallocate_sync"
+      });
+      await runIdempotentMutation(response, idempotency, 200, async () => {
+        await requireChainBackedMutation("/account/deallocate");
+        return service.deallocateIdleFunds(auth.wallet, asset, amount, strategyId, strategy);
+      });
+      return true;
+    }
+
+    if (request.method === "GET" && pathname === "/account/strategies") {
+      const auth = await authMiddleware(request, url);
+      const account = await service.getAccountSummary(auth.wallet);
+      const borrowCapacity = await service.getBorrowCapacity(auth.wallet, "DOT").catch(() => undefined);
+      const adapterTelemetryByStrategy = gateway?.isEnabled?.()
+        ? Object.fromEntries((await gateway.getStrategyTelemetry(strategies)).map((entry) => [entry.strategyId, entry]))
+        : {};
+      const strategyPositions = gateway?.isEnabled?.()
+        ? await gateway.getStrategyPositions(auth.wallet, strategies)
+        : [];
+      const sharesByStrategy = gateway?.isEnabled?.()
+        ? Object.fromEntries(strategyPositions.map((entry) => [entry.strategyId, entry.shares]))
+        : (account.strategyShares ?? {});
+      const pendingByStrategy = gateway?.isEnabled?.()
+        ? Object.fromEntries(strategyPositions.map((entry) => [entry.strategyId, entry]))
+        : (account.strategyPending ?? {});
+      const totalLiquid = sumNumericValues(account.liquid);
+      const debtTotal = sumNumericValues(account.debtOutstanding);
+      const strategyActivity = account.strategyActivity ?? {};
+      const strategyAccounting = account.strategyAccounting ?? {};
+      const positions = strategies.map((strategy) => {
+        const shares = Number(sharesByStrategy[strategy.strategyId] ?? 0);
+        const pendingPosition = pendingByStrategy[strategy.strategyId] ?? {};
+        const sharesRaw = normalizeRawIntegerString(pendingPosition.sharesRaw);
+        const pendingDepositAssets = Number(pendingPosition.pendingDepositAssets ?? 0);
+        const pendingDepositAssetsRaw = normalizeRawIntegerString(pendingPosition.pendingDepositAssetsRaw);
+        const pendingWithdrawalShares = Number(pendingPosition.pendingWithdrawalShares ?? 0);
+        const pendingWithdrawalSharesRaw = normalizeRawIntegerString(pendingPosition.pendingWithdrawalSharesRaw);
+        const lastMovement = strategyActivity[strategy.strategyId];
+        const accounting = strategyAccounting[strategy.strategyId] ?? {};
+        const isMock = String(strategy.kind ?? "").includes("mock");
+        const telemetry = adapterTelemetryByStrategy[strategy.strategyId];
+        const routedAmount = telemetry?.reported && Number.isFinite(Number(telemetry.sharePrice))
+          ? shares * Number(telemetry.sharePrice)
+          : shares;
+        const routedAmountRaw = calculateRoutedAmountRaw(sharesRaw, telemetry);
+        const principalValue = Number(accounting.principal ?? shares);
+        const realizedYield = Number(accounting.realizedYield ?? 0);
+        const unrealizedYield = routedAmount - principalValue;
+        return {
+          strategyId: strategy.strategyId,
+          asset: strategy.asset,
+          assetConfig: strategy.assetConfig,
+          assetSymbol: resolveStrategyAssetSymbol(gateway, strategy),
+          executionMode: strategy.executionMode ?? "sync",
+          shares,
+          ...(sharesRaw !== undefined ? { sharesRaw } : {}),
+          shareCount: shares,
+          pendingDepositAssets,
+          ...(pendingDepositAssetsRaw !== undefined ? { pendingDepositAssetsRaw } : {}),
+          pendingWithdrawalShares,
+          ...(pendingWithdrawalSharesRaw !== undefined ? { pendingWithdrawalSharesRaw } : {}),
+          routedAmount,
+          ...(routedAmountRaw !== undefined ? { routedAmountRaw } : {}),
+          principalValue,
+          ...(accounting.principalRaw !== undefined ? { principalValueRaw: String(accounting.principalRaw) } : {}),
+          ...(accounting.markValueRaw !== undefined ? { markValueRaw: String(accounting.markValueRaw) } : {}),
+          unrealizedYield,
+          realizedYield,
+          ...(accounting.realizedYieldRaw !== undefined ? { realizedYieldRaw: String(accounting.realizedYieldRaw) } : {}),
+          totalYield: realizedYield + unrealizedYield,
+          statusLabel: pendingDepositAssets > 0
+            ? "Pending deposit"
+            : pendingWithdrawalShares > 0
+              ? "Pending withdraw"
+              : shares > 0
+                ? "Routed"
+                : "Idle",
+          yieldReported: Boolean(telemetry?.reported),
+          yieldStatus: telemetry?.reported ? (isMock ? "simulated" : "live") : (isMock ? "simulated_unreported" : "unreported"),
+          yieldLabel: formatAdapterYieldLabel({ telemetry, isMock, shares }),
+          sharePrice: telemetry?.sharePrice,
+          performanceBps: telemetry?.performanceBps,
+          adapterTotalAssets: telemetry?.totalAssets,
+          ...(telemetry?.totalAssetsRaw !== undefined ? { adapterTotalAssetsRaw: String(telemetry.totalAssetsRaw) } : {}),
+          adapterTotalShares: telemetry?.totalShares,
+          ...(telemetry?.totalSharesRaw !== undefined ? { adapterTotalSharesRaw: String(telemetry.totalSharesRaw) } : {}),
+          adapterLinked: true,
+          adapterLinkStatus: shares > 0
+            ? "Wallet capital is now settled into the adapter and priced from live adapter reads."
+            : "Adapter performance is live even when this wallet has no routed capital in the lane.",
+          riskLabel: telemetry?.riskLabel || strategy.riskLabel || "",
+          lastAction: lastMovement?.action,
+          lastMovementAt: lastMovement?.at,
+          attention: buildLaneAttention({
+            shares,
+            isMock,
+            debtTotal,
+            borrowCapacity: Number(borrowCapacity),
+            deploymentShareBps: 0
+          })
+        };
+      });
+      const totalAllocated = positions.reduce((sum, entry) => sum + (Number(entry.routedAmount) || 0), 0);
+      const totalPrincipal = positions.reduce((sum, entry) => sum + (Number(entry.principalValue) || 0), 0);
+      const totalUnrealizedYield = positions.reduce((sum, entry) => sum + (Number(entry.unrealizedYield) || 0), 0);
+      const totalRealizedYield = positions.reduce((sum, entry) => sum + (Number(entry.realizedYield) || 0), 0);
+      const treasuryBase = totalLiquid + totalAllocated;
+      const normalizedPositions = positions.map((entry) => ({
+        ...entry,
+        deploymentShareBps: ratioToBps(Number(entry.routedAmount), totalAllocated),
+        treasuryShareBps: ratioToBps(Number(entry.routedAmount), treasuryBase),
+        attention: buildLaneAttention({
+          shares: Number(entry.routedAmount),
+          isMock: entry.yieldStatus === "simulated" || entry.yieldStatus === "simulated_unreported",
+          debtTotal,
+          borrowCapacity: Number(borrowCapacity),
+          deploymentShareBps: ratioToBps(Number(entry.routedAmount), totalAllocated)
+        })
+      }));
+      const treasuryTimeline = await service.recordStrategySnapshots(
+        auth.wallet,
+        normalizedPositions.map((entry) => ({
+          strategyId: entry.strategyId,
+          asset: entry.asset,
+          assetSymbol: entry.assetSymbol,
+          shares: entry.shares,
+          currentValue: entry.routedAmount,
+          currentValueRaw: entry.routedAmountRaw,
+          sharePrice: entry.sharePrice
+        }))
+      );
+      respond(response, 200, {
+        wallet: auth.wallet,
+        summary: {
+          treasuryBase,
+          liquid: totalLiquid,
+          allocated: totalAllocated,
+          principal: totalPrincipal,
+          unrealizedYield: totalUnrealizedYield,
+          realizedYield: totalRealizedYield,
+          totalYield: totalRealizedYield + totalUnrealizedYield,
+          debt: debtTotal,
+          borrowCapacity: Number.isFinite(Number(borrowCapacity)) ? Number(borrowCapacity) : undefined,
+          deployedLanes: normalizedPositions.filter((entry) => entry.routedAmount > 0).length,
+          attentionCount: normalizedPositions.filter((entry) => entry.attention).length
+        },
+        positions: normalizedPositions,
+        timeline: (treasuryTimeline ?? []).map(normalizeTimelineEntry)
+      });
+      return true;
+    }
+
+    if (request.method === "POST" && pathname === "/account/borrow") {
+      return handleSyncAccountMutation({
+        request,
+        response,
+        url,
+        route: "/account/borrow",
+        bucket: "account_borrow",
+        operation: ({ wallet, asset, amount }) => service.borrow(wallet, asset, amount)
+      });
+    }
+
+    if (request.method === "POST" && pathname === "/account/repay") {
+      return handleSyncAccountMutation({
+        request,
+        response,
+        url,
+        route: "/account/repay",
+        bucket: "account_repay",
+        operation: ({ wallet, asset, amount }) => service.repay(wallet, asset, amount)
+      });
+    }
+
+    return false;
+  };
+}

--- a/mcp-server/src/protocols/http/account-routes.test.js
+++ b/mcp-server/src/protocols/http/account-routes.test.js
@@ -1,0 +1,385 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ValidationError } from "../../core/errors.js";
+import { createAccountRoutes } from "./account-routes.js";
+
+const AUTH = {
+  wallet: "0x1111111111111111111111111111111111111111",
+  claims: { roles: ["admin"] }
+};
+
+const DEFAULT_STRATEGIES = [
+  {
+    strategyId: "default-low-risk",
+    asset: "0x0000000000000000000000000000000000000abc",
+    assetConfig: { symbol: "USDC" },
+    riskLabel: "low"
+  }
+];
+
+function stripIdempotencyKey(payload = {}) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return payload;
+  }
+  const { idempotencyKey, ...rest } = payload;
+  return rest;
+}
+
+function makeHarness(overrides = {}) {
+  const calls = [];
+  const response = {};
+  const payload = overrides.payload ?? {};
+  const strategies = overrides.strategies ?? DEFAULT_STRATEGIES;
+  const account = overrides.account ?? {
+    liquid: { DOT: 10 },
+    debtOutstanding: { DOT: 0 },
+    strategyAllocated: { DOT: 1 },
+    strategyShares: {},
+    strategyPending: {},
+    strategyActivity: {},
+    strategyAccounting: {}
+  };
+  const gateway = overrides.gateway ?? {
+    isEnabled: () => false,
+    config: {
+      agentAccountAddress: "0x2222222222222222222222222222222222222222",
+      supportedAssets: [{ address: "0x0000000000000000000000000000000000000abc", symbol: "USDC" }]
+    },
+    getStrategyPositions: async () => {
+      calls.push(["getStrategyPositions"]);
+      return [];
+    },
+    getStrategyTelemetry: async () => {
+      calls.push(["getStrategyTelemetry"]);
+      return [];
+    }
+  };
+  const service = overrides.service ?? {
+    getAccountSummary: async (wallet) => {
+      calls.push(["getAccountSummary", wallet]);
+      return account;
+    },
+    getBorrowCapacity: async (wallet, asset) => {
+      calls.push(["getBorrowCapacity", { wallet, asset }]);
+      return overrides.borrowCapacity ?? 5;
+    },
+    fundAccount: async (wallet, asset, amount) => {
+      calls.push(["fundAccount", { wallet, asset, amount }]);
+      return { status: "funded", wallet, asset, amount };
+    },
+    allocateIdleFunds: async (wallet, asset, amount, strategyId, strategy, options) => {
+      calls.push(["allocateIdleFunds", { wallet, asset, amount, strategyId, strategy, options }]);
+      return { status: "allocated", wallet, asset, amount, strategyId, options };
+    },
+    deallocateIdleFunds: async (wallet, asset, amount, strategyId, strategy, options) => {
+      calls.push(["deallocateIdleFunds", { wallet, asset, amount, strategyId, strategy, options }]);
+      return { status: "deallocated", wallet, asset, amount, strategyId, options };
+    },
+    recordStrategySnapshots: async (wallet, snapshots) => {
+      calls.push(["recordStrategySnapshots", { wallet, snapshots }]);
+      return overrides.timeline ?? [{ id: "t1", amount: 2, at: "2026-01-01T00:00:00.000Z" }];
+    },
+    borrow: async (wallet, asset, amount) => {
+      calls.push(["borrow", { wallet, asset, amount }]);
+      return { status: "borrowed", wallet, asset, amount };
+    },
+    repay: async (wallet, asset, amount) => {
+      calls.push(["repay", { wallet, asset, amount }]);
+      return { status: "repaid", wallet, asset, amount };
+    }
+  };
+
+  const route = createAccountRoutes({
+    authMiddleware: async (_request, _url) => {
+      calls.push(["auth"]);
+      return overrides.auth ?? AUTH;
+    },
+    buildIdempotentMutationContext: (input) => {
+      calls.push(["buildContext", input]);
+      return overrides.context ?? { bucket: input.bucket, key: `key:${input.bucket}`, requestHash: `hash:${input.bucket}` };
+    },
+    buildMutationRequestHash: (input) => {
+      calls.push(["buildMutationRequestHash", input]);
+      return overrides.requestHash ?? `hash:${input.route}:${input.payload.strategyId}`;
+    },
+    ensureAsyncXcmTreasuryAdmin: (auth) => {
+      calls.push(["ensureAsyncXcmTreasuryAdmin", auth.wallet]);
+    },
+    gateway,
+    getIdempotentMutationReplay: async (context) => {
+      calls.push(["getReplay", context]);
+      return overrides.replay;
+    },
+    readJsonBody: async () => {
+      calls.push(["body"]);
+      return payload;
+    },
+    requireChainBackedMutation: async (routeName) => {
+      calls.push(["requireChainBackedMutation", routeName]);
+    },
+    respond: (res, statusCode, body, headers = {}) => {
+      calls.push(["respond", { statusCode, body, headers }]);
+      res.statusCode = statusCode;
+      res.body = body;
+      res.headers = headers;
+    },
+    runIdempotentMutation: async (res, context, statusCode, operation) => {
+      calls.push(["runIdempotentMutation", { context, statusCode }]);
+      const body = await operation();
+      res.statusCode = statusCode;
+      res.body = body;
+      calls.push(["respond", { statusCode, body, headers: {} }]);
+    },
+    service,
+    storeIdempotentMutationReceipt: async (receipt) => {
+      calls.push(["storeReceipt", receipt]);
+    },
+    strategies,
+    stripIdempotencyKey,
+  });
+
+  return { calls, response, route };
+}
+
+test("account routes ignore unrelated paths", async () => {
+  const { calls, response, route } = makeHarness();
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/not-account"),
+    pathname: "/not-account",
+  });
+
+  assert.equal(handled, false);
+  assert.deepEqual(calls, []);
+  assert.deepEqual(response, {});
+});
+
+test("GET /strategies returns public strategy metadata with cache headers", async () => {
+  const { response, route } = makeHarness();
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/strategies"),
+    pathname: "/strategies",
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.body.strategies, DEFAULT_STRATEGIES);
+  assert.deepEqual(response.headers, { "cache-control": "public, max-age=300" });
+});
+
+test("GET /account returns stored summary when live strategies are disabled", async () => {
+  const { calls, response, route } = makeHarness();
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/account"),
+    pathname: "/account",
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.body.strategyAllocated, { DOT: 1 });
+  assert.deepEqual(calls.slice(0, 3), [
+    ["auth"],
+    ["getAccountSummary", AUTH.wallet],
+    ["respond", { statusCode: 200, body: response.body, headers: {} }],
+  ]);
+});
+
+test("GET /account overlays live strategy allocation by asset symbol", async () => {
+  const gateway = {
+    isEnabled: () => true,
+    config: {
+      supportedAssets: [{ address: "0x0000000000000000000000000000000000000abc", symbol: "USDC" }]
+    },
+    getStrategyPositions: async () => [{ strategyId: "default-low-risk", shares: 5 }],
+    getStrategyTelemetry: async () => [{ strategyId: "default-low-risk", reported: true, sharePrice: 2 }]
+  };
+  const { response, route } = makeHarness({ gateway });
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/account"),
+    pathname: "/account",
+  });
+
+  assert.equal(handled, true);
+  assert.deepEqual(response.body.strategyAllocated, { DOT: 1, USDC: 10 });
+});
+
+test("GET /account/borrow-capacity returns wallet-scoped capacity", async () => {
+  const { response, route } = makeHarness({ borrowCapacity: 12 });
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/account/borrow-capacity?asset=USDC"),
+    pathname: "/account/borrow-capacity",
+  });
+
+  assert.equal(handled, true);
+  assert.deepEqual(response.body, {
+    wallet: AUTH.wallet,
+    asset: "USDC",
+    borrowCapacity: 12
+  });
+});
+
+test("POST /account/fund keeps mutation idempotency and normalized payload", async () => {
+  const { calls, response, route } = makeHarness({
+    payload: { amount: 7, idempotencyKey: "idem-1" }
+  });
+
+  const handled = await route({
+    request: { method: "POST" },
+    response,
+    url: new URL("http://localhost/account/fund?asset=USDC"),
+    pathname: "/account/fund",
+  });
+
+  const contextCall = calls.find(([name]) => name === "buildContext");
+  assert.equal(handled, true);
+  assert.deepEqual(contextCall[1].normalizedPayload, { amount: 7, asset: "USDC" });
+  assert.deepEqual(calls.map(([name]) => name).filter((name) => name === "requireChainBackedMutation"), [
+    "requireChainBackedMutation"
+  ]);
+  assert.deepEqual(response.body, { status: "funded", wallet: AUTH.wallet, asset: "USDC", amount: 7 });
+});
+
+test("POST /account/allocate sync path preserves strategy selection", async () => {
+  const { calls, response, route } = makeHarness({
+    payload: { amount: 3, strategyId: "default-low-risk" }
+  });
+
+  const handled = await route({
+    request: { method: "POST" },
+    response,
+    url: new URL("http://localhost/account/allocate"),
+    pathname: "/account/allocate",
+  });
+
+  assert.equal(handled, true);
+  const allocateCall = calls.find(([name]) => name === "allocateIdleFunds");
+  assert.equal(allocateCall[1].asset, "DOT");
+  assert.equal(allocateCall[1].amount, 3);
+  assert.equal(allocateCall[1].strategyId, "default-low-risk");
+  assert.equal(response.body.status, "allocated");
+});
+
+test("POST /account/allocate async path stores idempotent receipt", async () => {
+  const strategies = [
+    {
+      strategyId: "async-lane",
+      executionMode: "async_xcm",
+      asset: "0x0000000000000000000000000000000000000abc",
+      assetConfig: { symbol: "USDC" }
+    }
+  ];
+  const { calls, response, route } = makeHarness({
+    strategies,
+    payload: {
+      amount: 4,
+      strategyId: "async-lane",
+      idempotencyKey: "idem-async",
+      maxWeight: { refTime: 11, proofSize: 22 },
+      shares: "9"
+    }
+  });
+
+  const handled = await route({
+    request: { method: "POST" },
+    response,
+    url: new URL("http://localhost/account/allocate"),
+    pathname: "/account/allocate",
+  });
+
+  const allocateCall = calls.find(([name]) => name === "allocateIdleFunds");
+  const storeCall = calls.find(([name]) => name === "storeReceipt");
+  assert.equal(handled, true);
+  assert.equal(allocateCall[1].asset, "USDC");
+  assert.equal(allocateCall[1].options.maxWeight.refTime, 11);
+  assert.equal(allocateCall[1].options.requestedShares, 9);
+  assert.equal(typeof allocateCall[1].options.nonce, "number");
+  assert.equal(storeCall[1].bucket, "account_allocate_async");
+  assert.equal(response.body.status, "allocated");
+});
+
+test("POST /account/deallocate async path rejects caller-assembled XCM fields", async () => {
+  const strategies = [
+    {
+      strategyId: "async-lane",
+      executionMode: "async_xcm",
+      assetConfig: { symbol: "USDC" }
+    }
+  ];
+  const { route } = makeHarness({
+    strategies,
+    payload: { amount: 1, strategyId: "async-lane", destination: { parents: 1 } }
+  });
+
+  await assert.rejects(
+    () => route({
+      request: { method: "POST" },
+      response: {},
+      url: new URL("http://localhost/account/deallocate"),
+      pathname: "/account/deallocate",
+    }),
+    ValidationError
+  );
+});
+
+test("GET /account/strategies builds treasury positions and timeline", async () => {
+  const { response, route } = makeHarness({
+    account: {
+      liquid: { DOT: 10 },
+      debtOutstanding: { DOT: 2 },
+      strategyAllocated: {},
+      strategyShares: { "default-low-risk": 3 },
+      strategyPending: {},
+      strategyActivity: { "default-low-risk": { action: "allocated", at: "2026-01-01T00:00:00.000Z" } },
+      strategyAccounting: { "default-low-risk": { principal: 2, realizedYield: 1 } }
+    },
+    borrowCapacity: 0
+  });
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/account/strategies"),
+    pathname: "/account/strategies",
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.body.summary.liquid, 10);
+  assert.equal(response.body.summary.allocated, 3);
+  assert.equal(response.body.summary.deployedLanes, 1);
+  assert.equal(response.body.positions[0].attention.code, "credit_constrained");
+  assert.equal(response.body.timeline[0].id, "t1");
+  assert.equal(response.body.timeline[0].type, "treasury_event");
+  assert.equal(response.body.timeline[0].asset, "DOT");
+  assert.equal(response.body.timeline[0].amount, 2);
+});
+
+test("POST /account/repay uses the shared sync mutation path", async () => {
+  const { response, route } = makeHarness({
+    payload: { asset: "USDC", amount: 2 }
+  });
+
+  const handled = await route({
+    request: { method: "POST" },
+    response,
+    url: new URL("http://localhost/account/repay"),
+    pathname: "/account/repay",
+  });
+
+  assert.equal(handled, true);
+  assert.deepEqual(response.body, { status: "repaid", wallet: AUTH.wallet, asset: "USDC", amount: 2 });
+});

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -35,6 +35,7 @@ import { createAdminSessionsRoutes } from "./admin-sessions-routes.js";
 import { createAdminStatusRoutes } from "./admin-status-routes.js";
 import { createAdminXcmRoutes } from "./admin-xcm-routes.js";
 import { createActivityRoutes } from "./activity-routes.js";
+import { createAccountRoutes } from "./account-routes.js";
 import { createAuthRoutes } from "./auth-routes.js";
 import { createBadgeRoutes } from "./badge-routes.js";
 import { createContentRoutes } from "./content-routes.js";
@@ -643,7 +644,13 @@ function metricPathLabel(pathname) {
     "/admin/xcm/observe",
     "/admin/xcm/finalize",
     "/account",
+    "/account/allocate",
+    "/account/borrow",
+    "/account/borrow-capacity",
+    "/account/deallocate",
     "/account/fund",
+    "/account/repay",
+    "/account/strategies",
     "/auth/session",
     "/payments/send",
     "/reputation",
@@ -683,118 +690,6 @@ function metricPathLabel(pathname) {
   if (pathname.startsWith("/badges/")) return "/badges/:sessionId";
   if (pathname.startsWith("/agents/")) return "/agents/:wallet";
   return "other";
-}
-
-function sumNumericValues(record = {}) {
-  return Object.values(record).reduce((sum, value) => sum + (Number(value) || 0), 0);
-}
-
-function ratioToBps(numerator, denominator) {
-  if (!Number.isFinite(numerator) || !Number.isFinite(denominator) || denominator <= 0) {
-    return 0;
-  }
-  return Math.round((numerator / denominator) * 10_000);
-}
-
-function normalizeRawIntegerString(value) {
-  if (value === undefined || value === null || value === "") {
-    return undefined;
-  }
-  if (typeof value === "bigint") {
-    return value >= 0n ? value.toString() : undefined;
-  }
-  if (typeof value === "number") {
-    return Number.isSafeInteger(value) && value >= 0 ? String(value) : undefined;
-  }
-  const normalized = String(value).trim();
-  if (!/^\d+$/u.test(normalized)) {
-    return undefined;
-  }
-  return BigInt(normalized).toString();
-}
-
-function calculateRoutedAmountRaw(sharesRaw, telemetry = {}) {
-  const normalizedSharesRaw = normalizeRawIntegerString(sharesRaw);
-  const totalAssetsRaw = normalizeRawIntegerString(telemetry.totalAssetsRaw);
-  const totalSharesRaw = normalizeRawIntegerString(telemetry.totalSharesRaw);
-  if (normalizedSharesRaw === undefined || totalAssetsRaw === undefined || totalSharesRaw === undefined) {
-    return undefined;
-  }
-  const denominator = BigInt(totalSharesRaw);
-  if (denominator <= 0n) {
-    return undefined;
-  }
-  return ((BigInt(normalizedSharesRaw) * BigInt(totalAssetsRaw)) / denominator).toString();
-}
-
-function resolveAssetSymbol(assetAddress) {
-  if (!assetAddress) return "DOT";
-  const supportedAssets = gateway?.config?.supportedAssets ?? [];
-  const match = supportedAssets.find((asset) => asset.address?.toLowerCase() === assetAddress.toLowerCase());
-  return match?.symbol ?? "DOT";
-}
-
-function resolveStrategyAssetSymbol(strategy) {
-  return strategy?.assetConfig?.symbol ?? resolveAssetSymbol(strategy?.asset);
-}
-
-function findStrategyConfig(strategyId) {
-  if (!strategyId) return undefined;
-  const normalized = gateway?.normalizeStrategyId?.(strategyId) ?? strategyId;
-  return strategies.find((entry) => entry.strategyId === strategyId || entry.strategyId === normalized);
-}
-
-function normalizeAsyncWeight(input = undefined) {
-  return {
-    refTime: input?.refTime ?? input?.ref_time ?? 0,
-    proofSize: input?.proofSize ?? input?.proof_size ?? 0
-  };
-}
-
-function deriveAsyncNonce(seed) {
-  const hash = keccak256(toUtf8Bytes(seed));
-  return Number.parseInt(hash.slice(2, 14), 16);
-}
-
-function rejectCallerSuppliedAsyncXcmField(payload, url, field) {
-  if (payload && Object.prototype.hasOwnProperty.call(payload, field)) {
-    throw new ValidationError(`Async XCM ${field} is assembled by the server and cannot be supplied by the caller.`);
-  }
-  if (url.searchParams.has(field)) {
-    throw new ValidationError(`Async XCM ${field} is assembled by the server and cannot be supplied by the caller.`);
-  }
-}
-
-function parseAsyncTreasuryOptions(payload = {}, url, { defaultRecipient = undefined } = {}) {
-  rejectCallerSuppliedAsyncXcmField(payload, url, "destination");
-  rejectCallerSuppliedAsyncXcmField(payload, url, "message");
-  rejectCallerSuppliedAsyncXcmField(payload, url, "nonce");
-
-  const queryWeight = {
-    refTime: url.searchParams.get("maxWeightRefTime"),
-    proofSize: url.searchParams.get("maxWeightProofSize")
-  };
-  const maxWeight = normalizeAsyncWeight(
-    payload?.maxWeight && typeof payload.maxWeight === "object"
-      ? payload.maxWeight
-      : queryWeight
-  );
-  const idempotencyKey = typeof payload?.idempotencyKey === "string" && payload.idempotencyKey.trim()
-    ? payload.idempotencyKey.trim()
-    : undefined;
-  const recipient = typeof payload?.recipient === "string" && payload.recipient.trim()
-    ? payload.recipient.trim()
-    : (url.searchParams.get("recipient")?.trim() || defaultRecipient);
-  const requestedSharesRaw = payload?.requestedShares ?? payload?.shares ?? url.searchParams.get("shares");
-  const requestedShares = Number.isFinite(Number(requestedSharesRaw)) && Number(requestedSharesRaw) > 0
-    ? Number(requestedSharesRaw)
-    : undefined;
-  return {
-    maxWeight,
-    idempotencyKey,
-    recipient,
-    requestedShares
-  };
 }
 
 function parseIdempotencyKey(payload = {}) {
@@ -1169,71 +1064,22 @@ const handleAuthRoute = createAuthRoutes({
   stateStore,
 });
 
-function buildLaneAttention({ shares, isMock, debtTotal, borrowCapacity, deploymentShareBps }) {
-  if (!(shares > 0)) {
-    return undefined;
-  }
-  if (isMock) {
-    return {
-      code: "simulated_yield",
-      tone: "tier-warn",
-      message: "This lane is using the mock vDOT adapter, so yield is simulated rather than market-backed."
-    };
-  }
-  if (debtTotal > 0 && !(borrowCapacity > 0)) {
-    return {
-      code: "credit_constrained",
-      tone: "tier-warn",
-      message: "This wallet has debt outstanding and no additional live borrow headroom."
-    };
-  }
-  if (deploymentShareBps >= 7000) {
-    return {
-      code: "lane_concentration",
-      tone: "status-pending",
-      message: "Most deployed capital is concentrated in this lane right now."
-    };
-  }
-  return undefined;
-}
-
-function formatAdapterYieldLabel({ telemetry, isMock, shares }) {
-  if (!telemetry?.reported) {
-    return isMock
-      ? "Mock adapter is registered, but no simulated yield data is reported yet."
-      : "Adapter is registered, but it is not reporting a live yield/performance read yet.";
-  }
-  const sharePrice = Number(telemetry.sharePrice);
-  const performanceBps = Number(telemetry.performanceBps);
-  const sharePriceLabel = Number.isFinite(sharePrice) ? `${sharePrice.toFixed(4)}x share price` : "share price unavailable";
-  const driftLabel = Number.isFinite(performanceBps)
-    ? `${performanceBps >= 0 ? "+" : ""}${performanceBps} bps`
-    : "drift unavailable";
-  if (shares > 0) {
-    return `${sharePriceLabel} · ${driftLabel} on the adapter for currently routed wallet capital.`;
-  }
-  return `${sharePriceLabel} · ${driftLabel} on deployed adapter capital.`;
-}
-
-function normalizeTimelineEntry(entry = {}) {
-  const amount = Number(entry.amount ?? 0);
-  const yieldDelta = Number(entry.yieldDelta ?? entry.realizedYieldDelta ?? 0);
-  return {
-    id: entry.id,
-    type: entry.type ?? "treasury_event",
-    strategyId: entry.strategyId,
-    asset: entry.asset ?? "DOT",
-    amount,
-    ...(entry.amountRaw !== undefined ? { amountRaw: normalizeRawIntegerString(entry.amountRaw) ?? String(entry.amountRaw) } : {}),
-    yieldDelta,
-    ...(entry.yieldDeltaRaw !== undefined ? { yieldDeltaRaw: String(entry.yieldDeltaRaw) } : {}),
-    ...(entry.realizedYieldDeltaRaw !== undefined ? { realizedYieldDeltaRaw: String(entry.realizedYieldDeltaRaw) } : {}),
-    ...(entry.principalAfterRaw !== undefined ? { principalAfterRaw: String(entry.principalAfterRaw) } : {}),
-    ...(entry.markValueAfterRaw !== undefined ? { markValueAfterRaw: String(entry.markValueAfterRaw) } : {}),
-    ...(entry.requestedSharesRaw !== undefined ? { requestedSharesRaw: String(entry.requestedSharesRaw) } : {}),
-    at: entry.at
-  };
-}
+const handleAccountRoute = createAccountRoutes({
+  authMiddleware,
+  buildIdempotentMutationContext,
+  buildMutationRequestHash,
+  ensureAsyncXcmTreasuryAdmin,
+  gateway,
+  getIdempotentMutationReplay,
+  readJsonBody,
+  requireChainBackedMutation,
+  respond,
+  runIdempotentMutation,
+  service,
+  storeIdempotentMutationReceipt,
+  strategies,
+  stripIdempotencyKey,
+});
 
 const server = createServer(async (request, response) => {
   const url = new URL(request.url ?? "/", "http://localhost");
@@ -1297,7 +1143,13 @@ const server = createServer(async (request, response) => {
           "/auth/session",
           "/events",
           "/account",
+          "/account/allocate",
+          "/account/borrow",
+          "/account/borrow-capacity",
+          "/account/deallocate",
           "/account/fund",
+          "/account/repay",
+          "/account/strategies",
           "/xcm/request",
           "/payments/send",
           "/reputation",
@@ -1471,20 +1323,8 @@ const server = createServer(async (request, response) => {
       return;
     }
 
-    if (request.method === "GET" && pathname === "/strategies") {
-      // Public read: which yield/strategy adapters are registered for
-      // this deployment. Populated from STRATEGIES_JSON env (copied from
-      // the deployment manifest). Returns an empty list when no strategy
-      // adapter is registered — that's the expected state on dev/Anvil.
-      return respond(
-        response,
-        200,
-        {
-          strategies,
-          docs: "https://github.com/depre-dev/agent/blob/main/docs/strategies/vdot.md"
-        },
-        { "cache-control": "public, max-age=300" }
-      );
+    if (await handleAccountRoute({ request, response, url, pathname })) {
+      return;
     }
 
     if (await handleSessionRoute({ request, response, url, pathname })) {
@@ -1535,416 +1375,6 @@ const server = createServer(async (request, response) => {
 
     if (await handleEventRoute({ request, response, url, pathname })) {
       return;
-    }
-
-    if (request.method === "GET" && pathname === "/account") {
-      const auth = await authMiddleware(request, url);
-      const account = await service.getAccountSummary(auth.wallet);
-      if (!gateway?.isEnabled?.() || !strategies.length) {
-        return respond(response, 200, account);
-      }
-
-      const [strategyPositions, strategyTelemetry] = await Promise.all([
-        gateway.getStrategyPositions(auth.wallet, strategies).catch(() => []),
-        gateway.getStrategyTelemetry(strategies).catch(() => [])
-      ]);
-      const sharesByStrategy = Object.fromEntries(strategyPositions.map((entry) => [entry.strategyId, Number(entry.shares ?? 0)]));
-      const telemetryByStrategy = Object.fromEntries(strategyTelemetry.map((entry) => [entry.strategyId, entry]));
-      const liveAllocatedByAsset = {};
-      for (const strategy of strategies) {
-        const shares = Number(sharesByStrategy[strategy.strategyId] ?? 0);
-        if (!(shares > 0)) continue;
-        const telemetry = telemetryByStrategy[strategy.strategyId];
-        const liveValue = telemetry?.reported && Number.isFinite(Number(telemetry.sharePrice))
-          ? shares * Number(telemetry.sharePrice)
-          : shares;
-        const symbol = resolveAssetSymbol(strategy.asset);
-        liveAllocatedByAsset[symbol] = (liveAllocatedByAsset[symbol] ?? 0) + liveValue;
-      }
-
-      return respond(response, 200, {
-        ...account,
-        strategyAllocated: {
-          ...account.strategyAllocated,
-          ...liveAllocatedByAsset
-        }
-      });
-    }
-
-    if (request.method === "GET" && pathname === "/account/borrow-capacity") {
-      const auth = await authMiddleware(request, url);
-      const asset = url.searchParams.get("asset")?.trim() || "DOT";
-      return respond(response, 200, {
-        wallet: auth.wallet,
-        asset,
-        borrowCapacity: await service.getBorrowCapacity(auth.wallet, asset)
-      });
-    }
-
-    if (request.method === "POST" && pathname === "/account/fund") {
-      const auth = await authMiddleware(request, url);
-      const payload = await readJsonBody(request);
-      const asset = typeof payload?.asset === "string" && payload.asset.trim()
-        ? payload.asset.trim()
-        : (url.searchParams.get("asset")?.trim() || "DOT");
-      const amount = Number(payload?.amount ?? url.searchParams.get("amount") ?? "0");
-      const idempotency = buildIdempotentMutationContext({
-        route: "/account/fund",
-        auth,
-        payload,
-        normalizedPayload: {
-          ...stripIdempotencyKey(payload),
-          asset,
-          amount
-        },
-        bucket: "account_fund"
-      });
-      return await runIdempotentMutation(response, idempotency, 200, async () => {
-        await requireChainBackedMutation("/account/fund");
-        return service.fundAccount(auth.wallet, asset, amount);
-      });
-    }
-
-    if (request.method === "POST" && pathname === "/account/allocate") {
-      const auth = await authMiddleware(request, url);
-      const payload = await readJsonBody(request);
-      const asset = typeof payload?.asset === "string" && payload.asset.trim()
-        ? payload.asset.trim()
-        : (url.searchParams.get("asset")?.trim() || "DOT");
-      const strategyId = typeof payload?.strategyId === "string" && payload.strategyId.trim()
-        ? payload.strategyId.trim()
-        : (url.searchParams.get("strategyId")?.trim() || "default-low-risk");
-      const amount = Number(payload?.amount ?? url.searchParams.get("amount") ?? "0");
-      const strategy = findStrategyConfig(strategyId);
-      if (strategy?.executionMode === "async_xcm") {
-        await requireChainBackedMutation("/account/allocate");
-        ensureAsyncXcmTreasuryAdmin(auth);
-        const strategyAsset = resolveStrategyAssetSymbol(strategy);
-        const options = parseAsyncTreasuryOptions(payload, url);
-        const mutationKey = options.idempotencyKey
-          ? `${auth.wallet}:${strategyId}:${options.idempotencyKey}`
-          : undefined;
-        const requestHash = buildMutationRequestHash({
-          route: "/account/allocate",
-          wallet: auth.wallet,
-          payload: {
-            ...payload,
-            asset,
-            amount,
-            strategyId,
-            strategyAsset,
-            asyncXcm: stripIdempotencyKey(options)
-          }
-        });
-        const replay = await getIdempotentMutationReplay({
-          bucket: "account_allocate_async",
-          key: mutationKey,
-          requestHash
-        });
-        if (replay) {
-          return respond(response, replay.statusCode, replay.body);
-        }
-        const nonce = options.nonce ?? (mutationKey ? deriveAsyncNonce(mutationKey) : Date.now());
-        const result = await service.allocateIdleFunds(
-          auth.wallet,
-          strategyAsset,
-          amount,
-          strategyId,
-          strategy,
-          { ...options, nonce }
-        );
-        await storeIdempotentMutationReceipt({
-          bucket: "account_allocate_async",
-          key: mutationKey,
-          requestHash,
-          response: result,
-          statusCode: 200
-        });
-        return respond(response, 200, result);
-      }
-      const idempotency = buildIdempotentMutationContext({
-        route: "/account/allocate",
-        auth,
-        payload,
-        normalizedPayload: {
-          ...stripIdempotencyKey(payload),
-          asset,
-          amount,
-          strategyId
-        },
-        bucket: "account_allocate_sync"
-      });
-      return await runIdempotentMutation(response, idempotency, 200, async () => {
-        await requireChainBackedMutation("/account/allocate");
-        return service.allocateIdleFunds(auth.wallet, asset, amount, strategyId, strategy);
-      });
-    }
-
-    if (request.method === "POST" && pathname === "/account/deallocate") {
-      const auth = await authMiddleware(request, url);
-      const payload = await readJsonBody(request);
-      const asset = typeof payload?.asset === "string" && payload.asset.trim()
-        ? payload.asset.trim()
-        : (url.searchParams.get("asset")?.trim() || "DOT");
-      const strategyId = typeof payload?.strategyId === "string" && payload.strategyId.trim()
-        ? payload.strategyId.trim()
-        : (url.searchParams.get("strategyId")?.trim() || "default-low-risk");
-      const amount = Number(payload?.amount ?? url.searchParams.get("amount") ?? "0");
-      const strategy = findStrategyConfig(strategyId);
-      if (strategy?.executionMode === "async_xcm") {
-        await requireChainBackedMutation("/account/deallocate");
-        ensureAsyncXcmTreasuryAdmin(auth);
-        const strategyAsset = resolveStrategyAssetSymbol(strategy);
-        const options = parseAsyncTreasuryOptions(payload, url, {
-          defaultRecipient: gateway?.config?.agentAccountAddress
-        });
-        const mutationKey = options.idempotencyKey
-          ? `${auth.wallet}:${strategyId}:${options.idempotencyKey}`
-          : undefined;
-        const requestHash = buildMutationRequestHash({
-          route: "/account/deallocate",
-          wallet: auth.wallet,
-          payload: {
-            ...payload,
-            asset,
-            amount,
-            strategyId,
-            strategyAsset,
-            asyncXcm: stripIdempotencyKey(options)
-          }
-        });
-        const replay = await getIdempotentMutationReplay({
-          bucket: "account_deallocate_async",
-          key: mutationKey,
-          requestHash
-        });
-        if (replay) {
-          return respond(response, replay.statusCode, replay.body);
-        }
-        const nonce = options.nonce ?? (mutationKey ? deriveAsyncNonce(mutationKey) : Date.now());
-        const result = await service.deallocateIdleFunds(
-          auth.wallet,
-          strategyAsset,
-          amount,
-          strategyId,
-          strategy,
-          { ...options, nonce }
-        );
-        await storeIdempotentMutationReceipt({
-          bucket: "account_deallocate_async",
-          key: mutationKey,
-          requestHash,
-          response: result,
-          statusCode: 200
-        });
-        return respond(response, 200, result);
-      }
-      const idempotency = buildIdempotentMutationContext({
-        route: "/account/deallocate",
-        auth,
-        payload,
-        normalizedPayload: {
-          ...stripIdempotencyKey(payload),
-          asset,
-          amount,
-          strategyId
-        },
-        bucket: "account_deallocate_sync"
-      });
-      return await runIdempotentMutation(response, idempotency, 200, async () => {
-        await requireChainBackedMutation("/account/deallocate");
-        return service.deallocateIdleFunds(auth.wallet, asset, amount, strategyId, strategy);
-      });
-    }
-
-    if (request.method === "GET" && pathname === "/account/strategies") {
-      const auth = await authMiddleware(request, url);
-      const account = await service.getAccountSummary(auth.wallet);
-      const borrowCapacity = await service.getBorrowCapacity(auth.wallet, "DOT").catch(() => undefined);
-      const adapterTelemetryByStrategy = gateway?.isEnabled?.()
-        ? Object.fromEntries((await gateway.getStrategyTelemetry(strategies)).map((entry) => [entry.strategyId, entry]))
-        : {};
-      const strategyPositions = gateway?.isEnabled?.()
-        ? await gateway.getStrategyPositions(auth.wallet, strategies)
-        : [];
-      const sharesByStrategy = gateway?.isEnabled?.()
-        ? Object.fromEntries(strategyPositions.map((entry) => [entry.strategyId, entry.shares]))
-        : (account.strategyShares ?? {});
-      const pendingByStrategy = gateway?.isEnabled?.()
-        ? Object.fromEntries(strategyPositions.map((entry) => [entry.strategyId, entry]))
-        : (account.strategyPending ?? {});
-      const totalLiquid = sumNumericValues(account.liquid);
-      const debtTotal = sumNumericValues(account.debtOutstanding);
-      const strategyActivity = account.strategyActivity ?? {};
-      const strategyAccounting = account.strategyAccounting ?? {};
-      const positions = strategies.map((strategy) => {
-        const shares = Number(sharesByStrategy[strategy.strategyId] ?? 0);
-        const pendingPosition = pendingByStrategy[strategy.strategyId] ?? {};
-        const sharesRaw = normalizeRawIntegerString(pendingPosition.sharesRaw);
-        const pendingDepositAssets = Number(pendingPosition.pendingDepositAssets ?? 0);
-        const pendingDepositAssetsRaw = normalizeRawIntegerString(pendingPosition.pendingDepositAssetsRaw);
-        const pendingWithdrawalShares = Number(pendingPosition.pendingWithdrawalShares ?? 0);
-        const pendingWithdrawalSharesRaw = normalizeRawIntegerString(pendingPosition.pendingWithdrawalSharesRaw);
-        const lastMovement = strategyActivity[strategy.strategyId];
-        const accounting = strategyAccounting[strategy.strategyId] ?? {};
-        const isMock = String(strategy.kind ?? "").includes("mock");
-        const telemetry = adapterTelemetryByStrategy[strategy.strategyId];
-        const routedAmount = telemetry?.reported && Number.isFinite(Number(telemetry.sharePrice))
-          ? shares * Number(telemetry.sharePrice)
-          : shares;
-        const routedAmountRaw = calculateRoutedAmountRaw(sharesRaw, telemetry);
-        const principalValue = Number(accounting.principal ?? shares);
-        const realizedYield = Number(accounting.realizedYield ?? 0);
-        const unrealizedYield = routedAmount - principalValue;
-        return {
-          strategyId: strategy.strategyId,
-          asset: strategy.asset,
-          assetConfig: strategy.assetConfig,
-          assetSymbol: resolveStrategyAssetSymbol(strategy),
-          executionMode: strategy.executionMode ?? "sync",
-          shares,
-          ...(sharesRaw !== undefined ? { sharesRaw } : {}),
-          shareCount: shares,
-          pendingDepositAssets,
-          ...(pendingDepositAssetsRaw !== undefined ? { pendingDepositAssetsRaw } : {}),
-          pendingWithdrawalShares,
-          ...(pendingWithdrawalSharesRaw !== undefined ? { pendingWithdrawalSharesRaw } : {}),
-          routedAmount,
-          ...(routedAmountRaw !== undefined ? { routedAmountRaw } : {}),
-          principalValue,
-          ...(accounting.principalRaw !== undefined ? { principalValueRaw: String(accounting.principalRaw) } : {}),
-          ...(accounting.markValueRaw !== undefined ? { markValueRaw: String(accounting.markValueRaw) } : {}),
-          unrealizedYield,
-          realizedYield,
-          ...(accounting.realizedYieldRaw !== undefined ? { realizedYieldRaw: String(accounting.realizedYieldRaw) } : {}),
-          totalYield: realizedYield + unrealizedYield,
-          statusLabel: pendingDepositAssets > 0
-            ? "Pending deposit"
-            : pendingWithdrawalShares > 0
-              ? "Pending withdraw"
-              : shares > 0
-                ? "Routed"
-                : "Idle",
-          yieldReported: Boolean(telemetry?.reported),
-          yieldStatus: telemetry?.reported ? (isMock ? "simulated" : "live") : (isMock ? "simulated_unreported" : "unreported"),
-          yieldLabel: formatAdapterYieldLabel({ telemetry, isMock, shares }),
-          sharePrice: telemetry?.sharePrice,
-          performanceBps: telemetry?.performanceBps,
-          adapterTotalAssets: telemetry?.totalAssets,
-          ...(telemetry?.totalAssetsRaw !== undefined ? { adapterTotalAssetsRaw: String(telemetry.totalAssetsRaw) } : {}),
-          adapterTotalShares: telemetry?.totalShares,
-          ...(telemetry?.totalSharesRaw !== undefined ? { adapterTotalSharesRaw: String(telemetry.totalSharesRaw) } : {}),
-          adapterLinked: true,
-          adapterLinkStatus: shares > 0
-            ? "Wallet capital is now settled into the adapter and priced from live adapter reads."
-            : "Adapter performance is live even when this wallet has no routed capital in the lane.",
-          riskLabel: telemetry?.riskLabel || strategy.riskLabel || "",
-          lastAction: lastMovement?.action,
-          lastMovementAt: lastMovement?.at,
-          attention: buildLaneAttention({
-            shares,
-            isMock,
-            debtTotal,
-            borrowCapacity: Number(borrowCapacity),
-            deploymentShareBps: 0
-          })
-        };
-      });
-      const totalAllocated = positions.reduce((sum, entry) => sum + (Number(entry.routedAmount) || 0), 0);
-      const totalPrincipal = positions.reduce((sum, entry) => sum + (Number(entry.principalValue) || 0), 0);
-      const totalUnrealizedYield = positions.reduce((sum, entry) => sum + (Number(entry.unrealizedYield) || 0), 0);
-      const totalRealizedYield = positions.reduce((sum, entry) => sum + (Number(entry.realizedYield) || 0), 0);
-      const treasuryBase = totalLiquid + totalAllocated;
-      const normalizedPositions = positions.map((entry) => ({
-        ...entry,
-        deploymentShareBps: ratioToBps(Number(entry.routedAmount), totalAllocated),
-        treasuryShareBps: ratioToBps(Number(entry.routedAmount), treasuryBase),
-        attention: buildLaneAttention({
-          shares: Number(entry.routedAmount),
-          isMock: entry.yieldStatus === "simulated" || entry.yieldStatus === "simulated_unreported",
-          debtTotal,
-          borrowCapacity: Number(borrowCapacity),
-          deploymentShareBps: ratioToBps(Number(entry.routedAmount), totalAllocated)
-        })
-      }));
-      const treasuryTimeline = await service.recordStrategySnapshots(
-        auth.wallet,
-        normalizedPositions.map((entry) => ({
-          strategyId: entry.strategyId,
-          asset: entry.asset,
-          assetSymbol: entry.assetSymbol,
-          shares: entry.shares,
-          currentValue: entry.routedAmount,
-          currentValueRaw: entry.routedAmountRaw,
-          sharePrice: entry.sharePrice
-        }))
-      );
-      return respond(response, 200, {
-        wallet: auth.wallet,
-        summary: {
-          treasuryBase,
-          liquid: totalLiquid,
-          allocated: totalAllocated,
-          principal: totalPrincipal,
-          unrealizedYield: totalUnrealizedYield,
-          realizedYield: totalRealizedYield,
-          totalYield: totalRealizedYield + totalUnrealizedYield,
-          debt: debtTotal,
-          borrowCapacity: Number.isFinite(Number(borrowCapacity)) ? Number(borrowCapacity) : undefined,
-          deployedLanes: normalizedPositions.filter((entry) => entry.routedAmount > 0).length,
-          attentionCount: normalizedPositions.filter((entry) => entry.attention).length
-        },
-        positions: normalizedPositions,
-        timeline: (treasuryTimeline ?? []).map(normalizeTimelineEntry)
-      });
-    }
-
-    if (request.method === "POST" && pathname === "/account/borrow") {
-      const auth = await authMiddleware(request, url);
-      const payload = await readJsonBody(request);
-      const asset = typeof payload?.asset === "string" && payload.asset.trim()
-        ? payload.asset.trim()
-        : (url.searchParams.get("asset")?.trim() || "DOT");
-      const amount = Number(payload?.amount ?? url.searchParams.get("amount") ?? "0");
-      const idempotency = buildIdempotentMutationContext({
-        route: "/account/borrow",
-        auth,
-        payload,
-        normalizedPayload: {
-          ...stripIdempotencyKey(payload),
-          asset,
-          amount
-        },
-        bucket: "account_borrow"
-      });
-      return await runIdempotentMutation(response, idempotency, 200, async () => {
-        await requireChainBackedMutation("/account/borrow");
-        return service.borrow(auth.wallet, asset, amount);
-      });
-    }
-
-    if (request.method === "POST" && pathname === "/account/repay") {
-      const auth = await authMiddleware(request, url);
-      const payload = await readJsonBody(request);
-      const asset = typeof payload?.asset === "string" && payload.asset.trim()
-        ? payload.asset.trim()
-        : (url.searchParams.get("asset")?.trim() || "DOT");
-      const amount = Number(payload?.amount ?? url.searchParams.get("amount") ?? "0");
-      const idempotency = buildIdempotentMutationContext({
-        route: "/account/repay",
-        auth,
-        payload,
-        normalizedPayload: {
-          ...stripIdempotencyKey(payload),
-          asset,
-          amount
-        },
-        bucket: "account_repay"
-      });
-      return await runIdempotentMutation(response, idempotency, 200, async () => {
-        await requireChainBackedMutation("/account/repay");
-        return service.repay(auth.wallet, asset, amount);
-      });
     }
 
     if (request.method === "GET" && pathname === "/xcm/request") {


### PR DESCRIPTION
## What changed
- Extracted public /strategies and protected /account route family into mcp-server/src/protocols/http/account-routes.js.
- Moved account/treasury strategy math, async-XCM account mutation handling, and strategy timeline normalization behind the route module.
- Added account route tests covering fallthrough, account reads, borrow capacity, sync idempotent mutations, async-XCM receipt/replay behavior, and strategy portfolio output.
- Added a roadmap fragment for the P2.3 HTTP route split progress.

## Checks
- Polkadot MCP docs check: get_project_info returned Polkadot Developer Docs with index status ready.
- node --check mcp-server/src/protocols/http/account-routes.js
- node --check mcp-server/src/protocols/http/server.js
- node --test mcp-server/src/protocols/http/account-routes.test.js
- npm --workspace mcp-server test (819 passing)
- git diff --check

## Surface
- Backend: yes
- Docs/roadmap: yes
- Frontend/indexer/contracts/public site/Caddy: no

## Env / VPS
- No environment or VPS secret changes required.