### PR TITLE
ops(audit): flag missing serviceOperators[backend-signer] in launch-readiness audit

### DIFF
--- a/scripts/ops/audit-launch-readiness.mjs
+++ b/scripts/ops/audit-launch-readiness.mjs
@@ -6,6 +6,14 @@
  * Read-only — no signing. Hits Hub TestNet and reports:
  *   - TreasuryPolicy.paused / owner / pauser
  *   - verifiers(backendSigner)
+ *   - serviceOperators(backendSigner) — the wallet that calls
+ *     EscrowCore.claimJobFor and other onlyOperator entry points.
+ *     Distinct from the verifier role; both flip independently and a
+ *     KMS-signer rotation needs both. Missing this check let a real
+ *     prod misconfig (Phase 3 KMS cutover authorized the new signer as
+ *     verifier but not as service operator) slip past launch readiness
+ *     until the first hosted worker-loop hit a bare `require(false)`
+ *     on `claimJobFor`. The audit now flags it preemptively.
  *   - serviceOperators(EscrowCore) / serviceOperators(AgentAccountCore)
  *   - approvedAssets(USDC) (auto-generated getter on the public mapping)
  * Then prints a punch list of any setVerifier / setServiceOperator /
@@ -120,6 +128,7 @@ async function main() {
     pauser,
     paused,
     signerIsVerifier,
+    signerIsOperator,
     escrowIsOperator,
     agentAccountIsOperator,
     arbitratorIsApproved,
@@ -138,6 +147,7 @@ async function main() {
     policy.pauser(),
     policy.paused(),
     policy.verifiers(backendSigner),
+    policy.serviceOperators(backendSigner),
     policy.serviceOperators(escrowAddress),
     policy.serviceOperators(agentAccountAddress),
     policy.arbitrators(expectedArbitrator),
@@ -180,6 +190,7 @@ async function main() {
   console.log(`pauser:        ${pauser}  ${ciEqual(pauser, expectedPauser) ? "✅" : `⚠ expected ${expectedPauser}`}`);
   console.log(`paused:        ${paused}  ${paused ? "❌" : "✅"}`);
   console.log(`verifiers(${short(backendSigner)})         ${signerIsVerifier ? "✅" : "❌"}  ${signerIsVerifier}`);
+  console.log(`serviceOperators(${short(backendSigner)})  ${signerIsOperator ? "✅" : "❌"}  ${signerIsOperator}  (backend signer must be an operator to call EscrowCore.claimJobFor)`);
   console.log(`serviceOperators(escrow)         ${escrowIsOperator ? "✅" : "❌"}  ${escrowIsOperator}`);
   console.log(`serviceOperators(agentAccount)   ${agentAccountIsOperator ? "✅" : "❌"}  ${agentAccountIsOperator}  (defensive — strictly required for v1 single-payout is escrow only)`);
   console.log(`arbitrators(${short(expectedArbitrator)})  ${arbitratorIsApproved ? "✅" : "❌"}  ${arbitratorIsApproved}  (required for resolveDispute)`);
@@ -218,6 +229,18 @@ async function main() {
   }
   if (!signerIsVerifier) {
     fixes.push(buildCall("setVerifier", [backendSigner, true], policyAddress));
+  }
+  if (!signerIsOperator) {
+    // Backend signer must be a service operator to call
+    // EscrowCore.claimJobFor (the admin-operated path that brokers
+    // claim-on-behalf-of-worker, dispute resolution, etc.). Without
+    // this, the platform's user-facing job lifecycle silently
+    // reverts with bare `require(false)` on every chain mutation
+    // initiated by the backend. The signer-rotation runbook needs
+    // to flip BOTH verifiers[signer]=true AND
+    // serviceOperators[signer]=true; missing either one is a launch
+    // blocker.
+    fixes.push(buildCall("setServiceOperator", [backendSigner, true], policyAddress));
   }
   if (!escrowIsOperator) {
     fixes.push(buildCall("setServiceOperator", [escrowAddress, true], policyAddress));


### PR DESCRIPTION
## Summary

Closes a silent-misconfig class that bit us on the 2026-05-25 hosted worker-loop attempt. The Phase 3 KMS cutover authorized the new signer as **verifier** but did NOT authorize it as a **service operator**. Both flip independently on TreasuryPolicy and both are required for the platform's user-facing job lifecycle.

The audit already checked `verifiers[backendSigner]` but didn't check `serviceOperators[backendSigner]`. This PR adds the missing check.

## Why this matters

Without `serviceOperators[backendSigner] = true`:
- Every `EscrowCore.claimJobFor()` call from the backend signer reverts with bare `require(false)` (via TreasuryPolicy line 248: `if (!serviceOperators[msg.sender]) revert Unauthorized();`)
- That breaks the entire **claim-on-behalf-of-worker** path the platform uses for hosted job execution
- Also breaks: dispute resolution, release-claim-economics, any admin-operated escrow function
- Filed issue #517 for the related platform/chain liquidity-view drift bug we found alongside this

## Verified against live state

```
serviceOperators(0x31ad…ab7F)  FAIL  false  (backend signer must be
  an operator to call EscrowCore.claimJobFor)

Multisig fix list (1 call):
  1. setServiceOperator(0x31ad…ab7F, true)
     to:    0x648Cc5fdE94435992296C4e5ac642d18bB64c12B
     data:  0xeea03c28...01  (full payload in audit output)
```

That's the exact multisig payload Pascal needs to sign — and the kind of payload the audit's existing fix-list generator already auto-emits for `setVerifier`, `setServiceOperator(escrow/agentAccount)`, etc. This just extends the same pattern to the signer-as-operator case.

## What this PR changes

`scripts/ops/audit-launch-readiness.mjs`:

1. Reads `policy.serviceOperators(backendSigner)` in the live-state parallel reads (one extra `Promise.all` element).
2. Prints it next to the existing verifier check with the same pass/fail formatting + an inline explanation of why this role matters.
3. If false, appends `setServiceOperator(backendSigner, true)` to the multisig fix list with auto-generated (to, value, data) calldata via the existing `buildCall` helper.

Diff is small and additive — no existing behavior changes. The audit's existing exit code 2 on any fix-list-non-empty still applies, so CI catches future signer-rotation misconfigs preemptively.

## Test plan

- [x] Ran against live testnet — flags the missing role correctly, emits the matching multisig payload (output pasted above).
- [x] All other existing checks still pass (verifier, escrow operator, agentAccount operator, arbitrator, USDC, parameter drift).
- [ ] CI green (docs-script change; existing tests for audit-launch-readiness should keep passing).

## After this lands + Pascal signs the multisig

The hosted worker loop should clear `claimJobFor`. Re-running the audit will return all-green and exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)