### PR TITLE
[codex] add worker-loop refresh auth

### DIFF
--- a/docs/OPERATOR_ONBOARDING.md
+++ b/docs/OPERATOR_ONBOARDING.md
@@ -130,12 +130,13 @@ the setup is wired.
 op item get aws-signer-testnet --vault prod-backend --fields kms-key-id
 op item get aws-jwt-signer-testnet --vault prod-backend --fields kms-key-id
 op item get admin-jwt --vault prod-smoke --fields password >/dev/null
+op item get admin-refresh-token --vault prod-smoke --fields password >/dev/null
 ```
 
 Expected: each call resolves without prompting for a vault unlock.
 The two `aws-*-signer-testnet` items resolve KMS key ARNs (non-secret
-metadata); the `prod-smoke/admin-jwt` resolve confirms you have
-prod-smoke vault scope for any future admin-JWT rotation. If you see
+metadata); the `prod-smoke/admin-jwt` and `prod-smoke/admin-refresh-token`
+resolves confirm you have prod-smoke vault scope for hosted-smoke auth. If you see
 "permission denied" or "vault not found", your service-account token
 is not scoped correctly — see [`SECRETS.md`](./SECRETS.md) §"Vault
 scopes" before continuing.
@@ -278,13 +279,59 @@ Expected: `published` or `already_current` in the job log. A failure
 here is operationally noisy but not fund-affecting; investigate but do
 not panic.
 
-### 5.4 The admin-JWT rotation ritual
+### 5.4 Hosted smoke auth
 
-The hosted product-proof smoke calls `/admin/async-xcm-status` with a
-30-day ES256 admin token stored at `op://prod-smoke/admin-jwt/password`.
-After Stage 2C-2 (`JWT_BACKEND=kms`), HS256 tokens are refused — an
-expired or stale-format admin-JWT will surface as `curl exit 22` /
-`HTTP 401` on the deploy's `Checking admin async XCM status` step.
+The hosted product-proof worker loop should use the same short-lived access
+token pattern as browser SIWE sessions. Store a refresh cookie once at
+`op://prod-smoke/admin-refresh-token/password`, then let
+`scripts/ops/get-admin-refresh-token.mjs` exchange it for a fresh access token
+via `POST /auth/refresh` at the start of each run.
+
+The refresh route has strict replay semantics and rotates the refresh cookie on
+every successful exchange. For scheduled smokes, the helper must write the
+rotated cookie back to the same 1Password item; otherwise the next run will
+reuse the old cookie and trigger `refresh_replay_detected`.
+
+To seed the new path:
+
+1. Sign in through the normal SIWE operator flow with the admin/verifier wallet.
+2. Copy the `refresh_token` cookie value scoped to `/auth/refresh`.
+3. Store it in 1Password:
+
+```bash
+op item edit admin-refresh-token --vault prod-smoke "password=$REFRESH_TOKEN"
+unset REFRESH_TOKEN
+```
+
+4. Verify the helper can exchange and rotate it:
+
+```bash
+cd /path/to/agent
+ADMIN_REFRESH_TOKEN_OP='op://prod-smoke/admin-refresh-token/password' \
+  node scripts/ops/get-admin-refresh-token.mjs >/tmp/averray-admin-access.jwt
+rm -f /tmp/averray-admin-access.jwt
+```
+
+Expected: the command exits `0`, prints one short-lived access JWT to stdout,
+and updates `op://prod-smoke/admin-refresh-token/password` with the rotated
+refresh cookie. The prod-smoke 1Password service account used by scheduled
+smokes therefore needs read/write access to that one item. `--no-write-back` is
+only for one-off diagnostics because it leaves the stored refresh cookie stale.
+
+During the soak period, the legacy direct-JWT path remains available. Set
+`ADMIN_JWT_OP` to force the old path, or leave the existing `ADMIN_JWT` env var
+in place as a rollback fallback. When both `ADMIN_REFRESH_TOKEN_OP` and
+`ADMIN_JWT` are present, the worker-loop script uses the refresh-flow path; when
+`ADMIN_JWT_OP` is present, it uses the legacy path intentionally. If you want
+the helper to use the default 1Password reference without spelling it out, set
+`ADMIN_REFRESH_FLOW=1`.
+
+The legacy path uses a 30-day ES256 admin token stored at
+`op://prod-smoke/admin-jwt/password`. After Stage 2C-2 (`JWT_BACKEND=kms`),
+HS256 tokens are refused — an expired or stale-format admin-JWT will surface as
+`curl exit 22` / `HTTP 401` on smoke steps that still depend on `ADMIN_JWT`.
+This direct-JWT path is retained for backward compatibility and should be
+deprecated after the refresh path has soaked for 30 days.
 
 To rotate (run from your laptop with `op` signed in):
 

--- a/docs/PROJECT_ROADMAP.md
+++ b/docs/PROJECT_ROADMAP.md
@@ -206,7 +206,9 @@ externally ready.
 
 ### In Flight
 
-(None — Phase 4b Stage 2C-2 (`#439`), Stage 2C-3 (`#463`), and the Phase 5a Roles Anywhere cutover all landed 2026-05-21 and moved to the Completed list above.)
+- **Worker-loop refresh-flow** — shipped in PR #529. `ADMIN_JWT`
+  30-day-manual-rotation path retained for backward compatibility; retire
+  after a 30-day soak period proves the refresh path stable in CI.
 
 ### Remaining
 
@@ -214,7 +216,6 @@ externally ready.
 - **HMAC retirement (Stage 2C-3 cleanup)** — ≥30 days after 2026-05-21: delete `op://prod-backend/auth-jwt-secrets`, drop the HMAC code branch from `mcp-server/src/auth/jwt.js`, retire `AUTH_JWT_SECRETS` from the secrets inventory + rotation calendar. Dispatcher already refuses HS256 at the verifier level since 2C-2; this is cleanup of unused config/code.
 - **Phase 5a-retire** — ≥30 days after 2026-05-21: `aws iam delete-access-key` for the static keys still in 1Password (`op://prod-backend/aws-signer-testnet`, `op://prod-backend/aws-jwt-signer-testnet`), delete the `access-key-id` + `secret-access-key` 1Password fields. Backend already runs entirely on Roles Anywhere — this removes the static-key rollback escape hatch once Roles Anywhere is proven stable.
 - Mainnet multi-region KMS from day one.
-- Worker-loop refresh-flow so hosted smokes do not depend on manually rotated 30-day admin JWTs.
 - CloudTrail/CloudWatch alarms for KMS signing and anomalous auth failures.
 
 ## Blockchain And Mainnet Roadmap

--- a/scripts/ops/deploy-production.sh
+++ b/scripts/ops/deploy-production.sh
@@ -314,6 +314,11 @@ run_node_script() {
     -w /workspace \
     -e API_BASE_URL="${API_BASE_URL:-https://api.averray.com}" \
     -e ADMIN_JWT="${ADMIN_JWT:-}" \
+    -e ADMIN_JWT_OP="${ADMIN_JWT_OP:-}" \
+    -e ADMIN_REFRESH_FLOW="${ADMIN_REFRESH_FLOW:-}" \
+    -e ADMIN_REFRESH_TOKEN="${ADMIN_REFRESH_TOKEN:-}" \
+    -e ADMIN_REFRESH_TOKEN_OP="${ADMIN_REFRESH_TOKEN_OP:-}" \
+    -e ADMIN_REFRESH_TOKEN_WRITE_BACK="${ADMIN_REFRESH_TOKEN_WRITE_BACK:-}" \
     -e AVERRAY_TOKEN="${AVERRAY_TOKEN:-}" \
     -e PRODUCT_PROOF_WORKER_TOKEN="${PRODUCT_PROOF_WORKER_TOKEN:-}" \
     -e PRODUCT_PROOF_EVIDENCE_FILE="$PRODUCT_PROOF_EVIDENCE_FILE" \
@@ -336,8 +341,19 @@ run_product_proof_worker_loop() {
       ;;
   esac
 
-  if [[ -z "${PRODUCT_PROOF_WORKER_TOKEN:-}" && -z "${AVERRAY_TOKEN:-}" && -z "${ADMIN_JWT:-}" ]]; then
-    echo "PRODUCT_PROOF_REQUIRE_WORKER_LOOP=1 requires PRODUCT_PROOF_WORKER_TOKEN, AVERRAY_TOKEN, or ADMIN_JWT." >&2
+  local has_admin_refresh_flow=0
+  case "${ADMIN_REFRESH_FLOW:-}" in
+    1|true|yes) has_admin_refresh_flow=1 ;;
+  esac
+
+  if [[ -z "${PRODUCT_PROOF_WORKER_TOKEN:-}" \
+    && -z "${AVERRAY_TOKEN:-}" \
+    && -z "${ADMIN_JWT:-}" \
+    && -z "${ADMIN_JWT_OP:-}" \
+    && -z "${ADMIN_REFRESH_TOKEN:-}" \
+    && -z "${ADMIN_REFRESH_TOKEN_OP:-}" \
+    && "$has_admin_refresh_flow" -ne 1 ]]; then
+    echo "PRODUCT_PROOF_REQUIRE_WORKER_LOOP=1 requires PRODUCT_PROOF_WORKER_TOKEN, AVERRAY_TOKEN, ADMIN_JWT, ADMIN_JWT_OP, ADMIN_REFRESH_TOKEN, ADMIN_REFRESH_TOKEN_OP, or ADMIN_REFRESH_FLOW=1." >&2
     exit 1
   fi
 

--- a/scripts/ops/get-admin-refresh-token.mjs
+++ b/scripts/ops/get-admin-refresh-token.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export const DEFAULT_API_BASE_URL = "https://api.averray.com";
+export const DEFAULT_ADMIN_REFRESH_TOKEN_OP = "op://prod-smoke/admin-refresh-token/password";
+export const REFRESH_COOKIE_NAME = "refresh_token";
+
+export async function getAdminRefreshToken({
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+  readSecretImpl = readOpSecret,
+  writeSecretImpl = writeOpSecret
+} = {}) {
+  if (typeof fetchImpl !== "function") {
+    throw new Error("fetch is not available in this Node runtime.");
+  }
+
+  const apiBaseUrl = stripTrailingSlash(env.API_BASE_URL || DEFAULT_API_BASE_URL);
+  const credential = await resolveRefreshCredential({ env, readSecretImpl });
+  const response = await fetchImpl(`${apiBaseUrl}/auth/refresh`, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      cookie: `${REFRESH_COOKIE_NAME}=${credential.refreshToken}`
+    }
+  });
+  const text = await response.text();
+  const payload = text ? safeJsonParse(text) : undefined;
+
+  if (!response.ok) {
+    throw buildRefreshHttpError({ response, payload });
+  }
+
+  const accessToken = payload?.token;
+  if (typeof accessToken !== "string" || accessToken.trim() === "") {
+    throw new Error("POST /auth/refresh succeeded but did not return a token.");
+  }
+
+  const rotatedRefreshToken = extractRefreshCookie(response.headers);
+  if (credential.writeBackRef) {
+    if (!rotatedRefreshToken) {
+      throw new Error(
+        "POST /auth/refresh succeeded but did not return a rotated refresh cookie; refusing to leave the stored admin refresh token stale."
+      );
+    }
+    if (rotatedRefreshToken !== credential.refreshToken) {
+      await writeSecretImpl(credential.writeBackRef, rotatedRefreshToken);
+    }
+  }
+
+  return {
+    accessToken,
+    expiresAt: payload?.expiresAt ?? null,
+    wallet: payload?.wallet ?? null,
+    roles: Array.isArray(payload?.roles) ? payload.roles : [],
+    credentialSource: credential.source,
+    writeBackRef: credential.writeBackRef ?? null,
+    rotatedRefreshTokenPersisted: Boolean(credential.writeBackRef && rotatedRefreshToken)
+  };
+}
+
+export async function resolveRefreshCredential({ env = process.env, readSecretImpl = readOpSecret } = {}) {
+  const rawToken = stringOrEmpty(env.ADMIN_REFRESH_TOKEN);
+  if (rawToken) {
+    return {
+      refreshToken: rawToken,
+      source: "ADMIN_REFRESH_TOKEN",
+      writeBackRef: null
+    };
+  }
+
+  const configured = stringOrEmpty(env.ADMIN_REFRESH_TOKEN_OP) || DEFAULT_ADMIN_REFRESH_TOKEN_OP;
+  if (configured.startsWith("op://")) {
+    const refreshToken = await readSecretImpl(configured);
+    if (!stringOrEmpty(refreshToken)) {
+      throw new Error(`Admin refresh token at ${configured} is empty.`);
+    }
+    return {
+      refreshToken: refreshToken.trim(),
+      source: configured,
+      writeBackRef: writeBackEnabled(env) ? configured : null
+    };
+  }
+
+  return {
+    refreshToken: configured,
+    source: "ADMIN_REFRESH_TOKEN_OP",
+    writeBackRef: null
+  };
+}
+
+export async function readOpSecret(opRef) {
+  const { stdout } = await execFileAsync("op", ["read", opRef], { maxBuffer: 1024 * 1024 });
+  return stdout.trim();
+}
+
+export async function writeOpSecret(opRef, value) {
+  const { vault, item, field } = parseOpRef(opRef);
+  await execFileAsync("op", ["item", "edit", item, "--vault", vault, `${field}=${value}`], {
+    maxBuffer: 1024 * 1024
+  });
+}
+
+export function parseOpRef(opRef) {
+  const parts = String(opRef ?? "").replace(/^op:\/\//u, "").split("/");
+  if (!String(opRef ?? "").startsWith("op://") || parts.length < 3 || parts.some((part) => part.trim() === "")) {
+    throw new Error(`Invalid 1Password reference: ${opRef}`);
+  }
+  const [vault, item, ...fieldParts] = parts;
+  return {
+    vault,
+    item,
+    field: fieldParts.join("/")
+  };
+}
+
+export function extractRefreshCookie(headers) {
+  for (const header of getSetCookieHeaders(headers)) {
+    const match = String(header).match(new RegExp(`(?:^|[,;]\\s*)${REFRESH_COOKIE_NAME}=([^;,\\s]+)`, "u"));
+    if (match?.[1]) return match[1];
+  }
+  return null;
+}
+
+function getSetCookieHeaders(headers) {
+  if (!headers) return [];
+  if (typeof headers.getSetCookie === "function") {
+    return headers.getSetCookie();
+  }
+  if (typeof headers.get === "function") {
+    const value = headers.get("set-cookie");
+    return value ? [value] : [];
+  }
+  return [];
+}
+
+function buildRefreshHttpError({ response, payload }) {
+  const code = payload?.error ?? payload?.code ?? `http_${response.status}`;
+  const message = payload?.message ?? `POST /auth/refresh failed with HTTP ${response.status}`;
+  const requestId = payload?.requestId ? `; requestId=${payload.requestId}` : "";
+  const error = new Error(
+    `Admin refresh token rejected by POST /auth/refresh: ${code} (HTTP ${response.status}): ${message}${requestId}`
+  );
+  error.name = "AdminRefreshTokenError";
+  error.status = response.status;
+  error.code = code;
+  error.payload = payload;
+  error.details = payload?.details;
+  return error;
+}
+
+function writeBackEnabled(env) {
+  return !["0", "false", "no"].includes(String(env.ADMIN_REFRESH_TOKEN_WRITE_BACK ?? "1").trim().toLowerCase());
+}
+
+function stripTrailingSlash(value) {
+  return String(value).replace(/\/+$/u, "");
+}
+
+function stringOrEmpty(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function safeJsonParse(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseArgs(argv) {
+  const env = {};
+  let help = false;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--api-base-url") {
+      env.API_BASE_URL = argv[index + 1] ?? "";
+      index += 1;
+    } else if (arg === "--refresh-token-op") {
+      env.ADMIN_REFRESH_TOKEN_OP = argv[index + 1] ?? "";
+      index += 1;
+    } else if (arg === "--refresh-token") {
+      env.ADMIN_REFRESH_TOKEN = argv[index + 1] ?? "";
+      index += 1;
+    } else if (arg === "--no-write-back") {
+      env.ADMIN_REFRESH_TOKEN_WRITE_BACK = "0";
+    } else if (arg === "-h" || arg === "--help") {
+      help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return { env, help };
+}
+
+function usage() {
+  return `Usage: node scripts/ops/get-admin-refresh-token.mjs [--api-base-url URL] [--refresh-token-op OP_REF] [--refresh-token TOKEN] [--no-write-back]
+
+Exchanges the hosted-smoke admin refresh cookie for a fresh short-lived access
+token via POST /auth/refresh. The access token is printed to stdout.
+
+Default refresh-token source: ${DEFAULT_ADMIN_REFRESH_TOKEN_OP}
+Successful refreshes write the rotated refresh cookie back to the same
+1Password item unless --no-write-back is set.
+`;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  (async () => {
+    const parsed = parseArgs(process.argv.slice(2));
+    if (parsed.help) {
+      console.log(usage());
+      return;
+    }
+    const result = await getAdminRefreshToken({
+      env: {
+        ...process.env,
+        ...parsed.env
+      }
+    });
+    console.log(result.accessToken);
+  })().catch((error) => {
+    console.error(error?.message ?? String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ops/get-admin-refresh-token.test.mjs
+++ b/scripts/ops/get-admin-refresh-token.test.mjs
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_ADMIN_REFRESH_TOKEN_OP,
+  extractRefreshCookie,
+  getAdminRefreshToken,
+  parseOpRef,
+  resolveRefreshCredential
+} from "./get-admin-refresh-token.mjs";
+
+test("getAdminRefreshToken exchanges refresh cookie and persists the rotated cookie", async () => {
+  const calls = [];
+  const result = await getAdminRefreshToken({
+    env: {
+      API_BASE_URL: "https://api.example.test",
+      ADMIN_REFRESH_TOKEN_OP: "op://prod-smoke/admin-refresh-token/password"
+    },
+    async readSecretImpl(ref) {
+      calls.push(["read", ref]);
+      return "refresh-old";
+    },
+    async writeSecretImpl(ref, value) {
+      calls.push(["write", ref, value]);
+    },
+    async fetchImpl(url, options) {
+      calls.push(["fetch", url, options.headers.cookie]);
+      assert.equal(url, "https://api.example.test/auth/refresh");
+      assert.equal(options.method, "POST");
+      assert.equal(options.headers.cookie, "refresh_token=refresh-old");
+      return jsonResponse(
+        200,
+        {
+          token: "eyJhbGciOiJFUzI1NiJ9.eyJzdWIiOiIwMTIzIn0.signature",
+          wallet: "0x1111111111111111111111111111111111111111",
+          roles: ["admin", "verifier"],
+          expiresAt: "2026-05-26T12:15:00.000Z",
+          tokenType: "Bearer"
+        },
+        { "set-cookie": "refresh_token=refresh-new; HttpOnly; Secure; SameSite=Strict; Path=/auth/refresh" }
+      );
+    }
+  });
+
+  assert.equal(result.accessToken, "eyJhbGciOiJFUzI1NiJ9.eyJzdWIiOiIwMTIzIn0.signature");
+  assert.equal(result.credentialSource, "op://prod-smoke/admin-refresh-token/password");
+  assert.equal(result.writeBackRef, "op://prod-smoke/admin-refresh-token/password");
+  assert.equal(result.rotatedRefreshTokenPersisted, true);
+  assert.deepEqual(calls, [
+    ["read", "op://prod-smoke/admin-refresh-token/password"],
+    ["fetch", "https://api.example.test/auth/refresh", "refresh_token=refresh-old"],
+    ["write", "op://prod-smoke/admin-refresh-token/password", "refresh-new"]
+  ]);
+});
+
+test("getAdminRefreshToken surfaces refresh replay detection without writing a token", async () => {
+  const writes = [];
+  await assert.rejects(
+    getAdminRefreshToken({
+      env: { ADMIN_REFRESH_TOKEN_OP: "op://prod-smoke/admin-refresh-token/password" },
+      async readSecretImpl() {
+        return "refresh-old";
+      },
+      async writeSecretImpl(...args) {
+        writes.push(args);
+      },
+      async fetchImpl() {
+        return jsonResponse(401, {
+          error: "refresh_replay_detected",
+          message: "refresh: refresh_replay_detected",
+          requestId: "request-replay"
+        });
+      }
+    }),
+    (error) => {
+      assert.equal(error.name, "AdminRefreshTokenError");
+      assert.equal(error.status, 401);
+      assert.equal(error.code, "refresh_replay_detected");
+      assert.match(error.message, /refresh_replay_detected/u);
+      assert.match(error.message, /request-replay/u);
+      return true;
+    }
+  );
+  assert.deepEqual(writes, []);
+});
+
+test("getAdminRefreshToken surfaces expired refresh tokens", async () => {
+  await assert.rejects(
+    getAdminRefreshToken({
+      env: { ADMIN_REFRESH_TOKEN: "expired-refresh-token" },
+      async fetchImpl() {
+        return jsonResponse(401, {
+          error: "refresh_expired",
+          message: "refresh: refresh_expired",
+          requestId: "request-expired"
+        });
+      }
+    }),
+    (error) => {
+      assert.equal(error.code, "refresh_expired");
+      assert.match(error.message, /refresh_expired/u);
+      assert.match(error.message, /request-expired/u);
+      return true;
+    }
+  );
+});
+
+test("getAdminRefreshToken fails closed when refresh succeeds but rotated cookie is missing", async () => {
+  await assert.rejects(
+    getAdminRefreshToken({
+      env: { ADMIN_REFRESH_TOKEN_OP: "op://prod-smoke/admin-refresh-token/password" },
+      async readSecretImpl() {
+        return "refresh-old";
+      },
+      async writeSecretImpl() {
+        throw new Error("should not write without a rotated cookie");
+      },
+      async fetchImpl() {
+        return jsonResponse(200, { token: "access-token" });
+      }
+    }),
+    /did not return a rotated refresh cookie/u
+  );
+});
+
+test("resolveRefreshCredential supports default OP source, raw token, and disabled write-back", async () => {
+  const defaultCredential = await resolveRefreshCredential({
+    env: {},
+    async readSecretImpl(ref) {
+      assert.equal(ref, DEFAULT_ADMIN_REFRESH_TOKEN_OP);
+      return "default-refresh";
+    }
+  });
+  assert.equal(defaultCredential.refreshToken, "default-refresh");
+  assert.equal(defaultCredential.source, DEFAULT_ADMIN_REFRESH_TOKEN_OP);
+  assert.equal(defaultCredential.writeBackRef, DEFAULT_ADMIN_REFRESH_TOKEN_OP);
+
+  const rawCredential = await resolveRefreshCredential({
+    env: { ADMIN_REFRESH_TOKEN: "raw-refresh" }
+  });
+  assert.equal(rawCredential.refreshToken, "raw-refresh");
+  assert.equal(rawCredential.source, "ADMIN_REFRESH_TOKEN");
+  assert.equal(rawCredential.writeBackRef, null);
+
+  const readOnlyCredential = await resolveRefreshCredential({
+    env: {
+      ADMIN_REFRESH_TOKEN_OP: "op://prod-smoke/admin-refresh-token/password",
+      ADMIN_REFRESH_TOKEN_WRITE_BACK: "0"
+    },
+    async readSecretImpl() {
+      return "readonly-refresh";
+    }
+  });
+  assert.equal(readOnlyCredential.refreshToken, "readonly-refresh");
+  assert.equal(readOnlyCredential.writeBackRef, null);
+});
+
+test("extractRefreshCookie and parseOpRef handle hosted refresh-cookie shapes", () => {
+  const headers = new Headers({
+    "set-cookie": "refresh_token=rotated-value; HttpOnly; Secure; SameSite=Strict; Path=/auth/refresh"
+  });
+  assert.equal(extractRefreshCookie(headers), "rotated-value");
+  assert.deepEqual(parseOpRef("op://prod-smoke/admin-refresh-token/password"), {
+    vault: "prod-smoke",
+    item: "admin-refresh-token",
+    field: "password"
+  });
+});
+
+function jsonResponse(status, body, headers = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json",
+      ...headers
+    }
+  });
+}

--- a/scripts/ops/run-hosted-worker-loop.mjs
+++ b/scripts/ops/run-hosted-worker-loop.mjs
@@ -4,6 +4,11 @@ import { dirname } from "node:path";
 
 import { AgentPlatformClient } from "../../sdk/agent-platform-client.js";
 import { DEFAULT_ESCROW_ASSET } from "../../mcp-server/src/core/assets.js";
+import {
+  DEFAULT_ADMIN_REFRESH_TOKEN_OP,
+  getAdminRefreshToken,
+  readOpSecret
+} from "./get-admin-refresh-token.mjs";
 
 const DEFAULT_API_BASE_URL = "https://api.averray.com";
 const PRODUCT_PROOF_OUTPUT_SCHEMA_REF = "schema://jobs/product-proof-worker-loop";
@@ -23,16 +28,27 @@ const REQUIRED_ESCROW_ASSET = {
 export async function runHostedWorkerLoop({
   env = process.env,
   client = undefined,
+  fetchImpl = globalThis.fetch,
+  readSecretImpl = readOpSecret,
+  writeSecretImpl = undefined,
   now = () => Date.now(),
   log = console.log
 } = {}) {
   const apiBaseUrl = stripTrailingSlash(env.API_BASE_URL || DEFAULT_API_BASE_URL);
-  const token = env.PRODUCT_PROOF_WORKER_TOKEN || env.AVERRAY_TOKEN || env.ADMIN_JWT;
-  if (!token) {
-    throw new Error("PRODUCT_PROOF_WORKER_TOKEN, AVERRAY_TOKEN, or ADMIN_JWT is required.");
+  const auth = client
+    ? { token: undefined, mode: "injected_client", source: "client" }
+    : await resolveHostedWorkerLoopAuth({
+        env,
+        apiBaseUrl,
+        fetchImpl,
+        readSecretImpl,
+        writeSecretImpl
+      });
+  if (!client) {
+    log(`Hosted worker-loop auth path: ${auth.mode} (${auth.source})`);
   }
 
-  const platform = client ?? new AgentPlatformClient({ baseUrl: apiBaseUrl, token });
+  const platform = client ?? new AgentPlatformClient({ baseUrl: apiBaseUrl, token: auth.token, fetchImpl });
   const timestamp = now();
   const jobId = env.PRODUCT_PROOF_JOB_ID || `product-proof-worker-loop-${timestamp}`;
   const idempotencyKey = env.PRODUCT_PROOF_IDEMPOTENCY_KEY || `product-proof:${jobId}`;
@@ -214,6 +230,87 @@ export async function runHostedWorkerLoop({
   return evidenceDoc;
 }
 
+export function selectHostedWorkerLoopAuthPath(env = process.env) {
+  const productProofToken = pick(env.PRODUCT_PROOF_WORKER_TOKEN);
+  if (productProofToken) {
+    return { mode: "direct_token", source: "PRODUCT_PROOF_WORKER_TOKEN", token: productProofToken };
+  }
+
+  const averrayToken = pick(env.AVERRAY_TOKEN);
+  if (averrayToken) {
+    return { mode: "direct_token", source: "AVERRAY_TOKEN", token: averrayToken };
+  }
+
+  const adminJwtOp = pick(env.ADMIN_JWT_OP);
+  if (adminJwtOp) {
+    return { mode: "legacy_admin_jwt", source: "ADMIN_JWT_OP", token: adminJwtOp };
+  }
+
+  const adminRefreshToken = pick(env.ADMIN_REFRESH_TOKEN);
+  if (adminRefreshToken) {
+    return { mode: "admin_refresh", source: "ADMIN_REFRESH_TOKEN" };
+  }
+
+  const adminRefreshTokenOp = pick(env.ADMIN_REFRESH_TOKEN_OP);
+  if (adminRefreshTokenOp) {
+    return { mode: "admin_refresh", source: "ADMIN_REFRESH_TOKEN_OP" };
+  }
+
+  if (enabled(env.ADMIN_REFRESH_FLOW)) {
+    return { mode: "admin_refresh", source: DEFAULT_ADMIN_REFRESH_TOKEN_OP };
+  }
+
+  const adminJwt = pick(env.ADMIN_JWT);
+  if (adminJwt) {
+    return { mode: "legacy_admin_jwt", source: "ADMIN_JWT", token: adminJwt };
+  }
+
+  return { mode: "admin_refresh", source: DEFAULT_ADMIN_REFRESH_TOKEN_OP };
+}
+
+export async function resolveHostedWorkerLoopAuth({
+  env = process.env,
+  apiBaseUrl = DEFAULT_API_BASE_URL,
+  fetchImpl = globalThis.fetch,
+  readSecretImpl = readOpSecret,
+  writeSecretImpl = undefined
+} = {}) {
+  const selection = selectHostedWorkerLoopAuthPath(env);
+
+  if (selection.mode === "admin_refresh") {
+    const result = await getAdminRefreshToken({
+      env: {
+        ...env,
+        API_BASE_URL: apiBaseUrl
+      },
+      fetchImpl,
+      readSecretImpl,
+      ...(writeSecretImpl ? { writeSecretImpl } : {})
+    });
+    return {
+      mode: "admin_refresh",
+      source: result.credentialSource,
+      token: result.accessToken
+    };
+  }
+
+  if (selection.mode === "legacy_admin_jwt") {
+    const token = selection.token.startsWith("op://")
+      ? await readSecretImpl(selection.token)
+      : selection.token;
+    if (!pick(token)) {
+      throw new Error(`${selection.source} resolved to an empty admin JWT.`);
+    }
+    return {
+      mode: selection.mode,
+      source: selection.source,
+      token: token.trim()
+    };
+  }
+
+  return selection;
+}
+
 export function formatHostedWorkerLoopError(error) {
   const message = error?.message ?? String(error);
   const parts = [message];
@@ -246,6 +343,14 @@ function redactDiagnosticValue(value) {
       ? "[redacted]"
       : redactDiagnosticValue(entry)
   ]));
+}
+
+function pick(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : "";
+}
+
+function enabled(value) {
+  return ["1", "true", "yes"].includes(String(value ?? "").trim().toLowerCase());
 }
 
 function buildProductProofSubmission({ jobId, evidence, timestamp }) {

--- a/scripts/ops/run-hosted-worker-loop.test.mjs
+++ b/scripts/ops/run-hosted-worker-loop.test.mjs
@@ -6,7 +6,9 @@ import test from "node:test";
 
 import {
   formatHostedWorkerLoopError,
-  runHostedWorkerLoop
+  resolveHostedWorkerLoopAuth,
+  runHostedWorkerLoop,
+  selectHostedWorkerLoopAuthPath
 } from "./run-hosted-worker-loop.mjs";
 
 test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidence", async () => {
@@ -156,9 +158,93 @@ test("runHostedWorkerLoop creates, claims, submits, verifies, and writes evidenc
 
 test("runHostedWorkerLoop fails closed without a token", async () => {
   await assert.rejects(
-    runHostedWorkerLoop({ env: {}, log: () => {} }),
-    /PRODUCT_PROOF_WORKER_TOKEN, AVERRAY_TOKEN, or ADMIN_JWT is required/u
+    runHostedWorkerLoop({
+      env: {},
+      log: () => {},
+      async readSecretImpl() {
+        throw new Error("op read failed for admin-refresh-token");
+      }
+    }),
+    /op read failed for admin-refresh-token/u
   );
+});
+
+test("selectHostedWorkerLoopAuthPath chooses explicit refresh and legacy branches", () => {
+  assert.deepEqual(selectHostedWorkerLoopAuthPath({ PRODUCT_PROOF_WORKER_TOKEN: "worker-token" }), {
+    mode: "direct_token",
+    source: "PRODUCT_PROOF_WORKER_TOKEN",
+    token: "worker-token"
+  });
+  assert.deepEqual(selectHostedWorkerLoopAuthPath({ AVERRAY_TOKEN: "averray-token" }), {
+    mode: "direct_token",
+    source: "AVERRAY_TOKEN",
+    token: "averray-token"
+  });
+  assert.deepEqual(selectHostedWorkerLoopAuthPath({
+    ADMIN_JWT_OP: "legacy-token",
+    ADMIN_REFRESH_TOKEN_OP: "op://prod-smoke/admin-refresh-token/password"
+  }), {
+    mode: "legacy_admin_jwt",
+    source: "ADMIN_JWT_OP",
+    token: "legacy-token"
+  });
+  assert.deepEqual(selectHostedWorkerLoopAuthPath({
+    ADMIN_JWT: "legacy-token",
+    ADMIN_REFRESH_TOKEN_OP: "op://prod-smoke/admin-refresh-token/password"
+  }), {
+    mode: "admin_refresh",
+    source: "ADMIN_REFRESH_TOKEN_OP"
+  });
+  assert.deepEqual(selectHostedWorkerLoopAuthPath({ ADMIN_JWT: "legacy-token" }), {
+    mode: "legacy_admin_jwt",
+    source: "ADMIN_JWT",
+    token: "legacy-token"
+  });
+  assert.deepEqual(selectHostedWorkerLoopAuthPath({}), {
+    mode: "admin_refresh",
+    source: "op://prod-smoke/admin-refresh-token/password"
+  });
+});
+
+test("resolveHostedWorkerLoopAuth exchanges refresh token without running the loop", async () => {
+  const calls = [];
+  const auth = await resolveHostedWorkerLoopAuth({
+    apiBaseUrl: "https://api.example.test",
+    env: { ADMIN_REFRESH_TOKEN_OP: "op://prod-smoke/admin-refresh-token/password" },
+    async readSecretImpl(ref) {
+      calls.push(["read", ref]);
+      return "refresh-old";
+    },
+    async writeSecretImpl(ref, value) {
+      calls.push(["write", ref, value]);
+    },
+    async fetchImpl(url, options) {
+      calls.push(["fetch", url, options.headers.cookie]);
+      return new Response(JSON.stringify({
+        token: "short-lived-access-token",
+        roles: ["admin", "verifier"],
+        wallet: "0x1111111111111111111111111111111111111111",
+        expiresAt: "2026-05-26T12:15:00.000Z"
+      }), {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "set-cookie": "refresh_token=refresh-new; HttpOnly; Secure; SameSite=Strict; Path=/auth/refresh"
+        }
+      });
+    }
+  });
+
+  assert.deepEqual(auth, {
+    mode: "admin_refresh",
+    source: "op://prod-smoke/admin-refresh-token/password",
+    token: "short-lived-access-token"
+  });
+  assert.deepEqual(calls, [
+    ["read", "op://prod-smoke/admin-refresh-token/password"],
+    ["fetch", "https://api.example.test/auth/refresh", "refresh_token=refresh-old"],
+    ["write", "op://prod-smoke/admin-refresh-token/password", "refresh-new"]
+  ]);
 });
 
 test("runHostedWorkerLoop fails closed before mutation when token lacks verifier capability", async () => {


### PR DESCRIPTION
## Summary
- add scripts/ops/get-admin-refresh-token.mjs to exchange the hosted-smoke admin refresh cookie via POST /auth/refresh and persist the rotated refresh cookie back to 1Password
- update run-hosted-worker-loop.mjs to support direct worker tokens, explicit legacy ADMIN_JWT/ADMIN_JWT_OP fallback, and refresh-flow auth via ADMIN_REFRESH_TOKEN_OP or ADMIN_REFRESH_FLOW=1
- document the new operator pattern, keep the 30-day direct-JWT path as backward compat, and move the exact roadmap item to In Flight for the 30-day soak

## Why
The hosted product-proof worker loop currently depends on a manually rotated 30-day admin JWT. Browser SIWE sessions already use short-lived access tokens with refresh-cookie rotation, so the smoke path should mirror that behavior and avoid slow-decay manual token hygiene.

## Checks
- bash -n scripts/ops/deploy-production.sh
- git diff --check
- node --test scripts/ops/get-admin-refresh-token.test.mjs scripts/ops/run-hosted-worker-loop.test.mjs
- npm run test:ops

## Impact
- Affects ops scripts and docs only.
- No backend route, auth signer, KMS key, HMAC retirement, frontend, indexer, Caddy, contract, generated static output, env template, or workflow changes.
- Operator follow-up: create op://prod-smoke/admin-refresh-token/password from a SIWE refresh cookie and grant the scheduled smoke service account read/write access to that item before enabling ADMIN_REFRESH_TOKEN_OP or ADMIN_REFRESH_FLOW=1.

## Soak / rollback
- ADMIN_JWT_OP forces the legacy direct-JWT path.
- Existing ADMIN_JWT remains a fallback.
- Retire the direct-JWT path only after a 30-day CI/hosted-smoke soak proves refresh stable.