### PR TITLE
Add KMS signing alarm foundation

### DIFF
--- a/deploy/iac/cloudwatch/README.md
+++ b/deploy/iac/cloudwatch/README.md
@@ -1,0 +1,53 @@
+# KMS Signing Alarms
+
+This directory is the first CloudWatch/CloudTrail IaC foundation for the hosted
+stack. The template is intentionally additive: it does not create or modify KMS
+keys, IAM roles, Roles Anywhere trust anchors, or key policies.
+
+## Template
+
+- `kms-signing-alarms.yaml`
+
+The stack creates:
+
+- a regional CloudTrail trail for KMS API management events
+- a 90-day S3 log bucket for CloudTrail files
+- a CloudWatch Logs group for CloudTrail delivery
+- metric filters for the blockchain signer key and JWT signer key
+- alarms for non-zero KMS signing errors, non-zero KMS access denied, KMS sign
+  call spikes, auth failure spikes, and refresh-token replay detection
+- backend log metric filters for `kms.sign.duration` events
+- a dashboard with KMS sign call/error counts, GetPublicKey counts, auth
+  failures, and p50/p95/p99 signer latency
+
+AWS KMS API calls such as `Sign`, `GetPublicKey`, and `DescribeKey` are
+CloudTrail management events. The template therefore uses an advanced
+management-event selector restricted to `kms.amazonaws.com` and deliberately
+does not set `ExcludeManagementEventSources` for KMS.
+
+## Deploy
+
+Pass the two signer key ARNs and threshold values from live baseline data. The
+spike thresholds intentionally have no defaults so operators do not accidentally
+ship guessed values.
+
+```bash
+aws cloudformation deploy \
+  --region eu-central-2 \
+  --stack-name averray-testnet-kms-signing-alarms \
+  --template-file deploy/iac/cloudwatch/kms-signing-alarms.yaml \
+  --capabilities CAPABILITY_IAM \
+  --parameter-overrides \
+    EnvironmentName=testnet \
+    BlockchainSignerKeyArn="arn:aws:kms:eu-central-2:079209845430:key/<blockchain-signer-key-id>" \
+    JwtSignerKeyArn="arn:aws:kms:eu-central-2:079209845430:key/<jwt-signer-key-id>" \
+    BlockchainSignSpikeThresholdPer5Min="<baseline-derived-threshold>" \
+    JwtSignSpikeThresholdPer5Min="<baseline-derived-threshold>" \
+    AuthFailureThresholdPer5Min="<baseline-derived-threshold>" \
+    PageTopicArn="<sns-topic-for-page-on-call>" \
+    AlertTopicArn="<sns-topic-for-slack-alert-channel>"
+```
+
+If the alert SNS topics are not ready yet, omit `PageTopicArn` and
+`AlertTopicArn`; the alarms will still be created without actions and can be
+wired later by updating the stack.

--- a/deploy/iac/cloudwatch/kms-signing-alarms.yaml
+++ b/deploy/iac/cloudwatch/kms-signing-alarms.yaml
@@ -1,0 +1,573 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Averray KMS signing observability. Captures KMS API activity in CloudTrail,
+  emits CloudWatch metrics for signer calls/errors/auth failures, and alarms on
+  non-zero signing failures or baseline-defined spikes.
+
+Parameters:
+  EnvironmentName:
+    Type: String
+    Default: testnet
+    AllowedPattern: "^[a-z0-9-]+$"
+    Description: Short environment label used in names and alarm labels.
+  MetricNamespace:
+    Type: String
+    Default: Averray/KMS
+    Description: CloudWatch namespace for KMS/auth observability metrics.
+  CloudTrailLogGroupName:
+    Type: String
+    Default: /averray/testnet/cloudtrail/kms
+    Description: Log group that receives CloudTrail KMS API activity.
+  BackendLogGroupName:
+    Type: String
+    Default: /averray/testnet/backend
+    Description: Existing backend structured-log group to filter for signer latency and auth failures.
+  BlockchainSignerKeyArn:
+    Type: String
+    AllowedPattern: "^arn:aws:kms:[a-z0-9-]+:[0-9]{12}:key/.+$"
+    Description: Full ARN for the blockchain mutation signer KMS key.
+  JwtSignerKeyArn:
+    Type: String
+    AllowedPattern: "^arn:aws:kms:[a-z0-9-]+:[0-9]{12}:key/.+$"
+    Description: Full ARN for the JWT signer KMS key.
+  BlockchainSignSpikeThresholdPer5Min:
+    Type: Number
+    MinValue: 1
+    Description: Baseline-derived blockchain kms:Sign spike threshold for a 5-minute window. Intentionally no default.
+  JwtSignSpikeThresholdPer5Min:
+    Type: Number
+    MinValue: 1
+    Description: Baseline-derived JWT kms:Sign spike threshold for a 5-minute window. Intentionally no default.
+  AuthFailureThresholdPer5Min:
+    Type: Number
+    MinValue: 1
+    Description: Baseline-derived 401/403 auth failure threshold for a 5-minute window. Intentionally no default.
+  PageTopicArn:
+    Type: String
+    Default: ""
+    Description: Optional SNS topic ARN wired to the page-on-call destination.
+  AlertTopicArn:
+    Type: String
+    Default: ""
+    Description: Optional SNS topic ARN wired to the Slack/operator alert channel.
+
+Conditions:
+  HasPageTopic: !Not [!Equals [!Ref PageTopicArn, ""]]
+  HasAlertTopic: !Not [!Equals [!Ref AlertTopicArn, ""]]
+
+Resources:
+  CloudTrailBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub averray-${EnvironmentName}-${AWS::AccountId}-${AWS::Region}-cloudtrail-kms
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      LifecycleConfiguration:
+        Rules:
+          - Id: ExpireTestnetCloudTrailAfter90Days
+            Status: Enabled
+            ExpirationInDays: 90
+
+  CloudTrailBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref CloudTrailBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AWSCloudTrailAclCheck
+            Effect: Allow
+            Principal:
+              Service: cloudtrail.amazonaws.com
+            Action: s3:GetBucketAcl
+            Resource: !GetAtt CloudTrailBucket.Arn
+            Condition:
+              StringEquals:
+                aws:SourceArn: !Sub arn:${AWS::Partition}:cloudtrail:${AWS::Region}:${AWS::AccountId}:trail/averray-${EnvironmentName}-kms-audit
+          - Sid: AWSCloudTrailWrite
+            Effect: Allow
+            Principal:
+              Service: cloudtrail.amazonaws.com
+            Action: s3:PutObject
+            Resource: !Sub ${CloudTrailBucket.Arn}/AWSLogs/${AWS::AccountId}/*
+            Condition:
+              StringEquals:
+                s3:x-amz-acl: bucket-owner-full-control
+                aws:SourceArn: !Sub arn:${AWS::Partition}:cloudtrail:${AWS::Region}:${AWS::AccountId}:trail/averray-${EnvironmentName}-kms-audit
+
+  CloudTrailKmsLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Ref CloudTrailLogGroupName
+      RetentionInDays: 90
+
+  CloudTrailLogsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: cloudtrail.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: cloudtrail-kms-log-writer
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub ${CloudTrailKmsLogGroup.Arn}:log-stream:*
+
+  KmsAuditTrail:
+    Type: AWS::CloudTrail::Trail
+    DependsOn:
+      - CloudTrailBucketPolicy
+      - CloudTrailLogsRole
+    Properties:
+      TrailName: !Sub averray-${EnvironmentName}-kms-audit
+      IsLogging: true
+      IncludeGlobalServiceEvents: false
+      IsMultiRegionTrail: false
+      EnableLogFileValidation: true
+      S3BucketName: !Ref CloudTrailBucket
+      CloudWatchLogsLogGroupArn: !GetAtt CloudTrailKmsLogGroup.Arn
+      CloudWatchLogsRoleArn: !GetAtt CloudTrailLogsRole.Arn
+      AdvancedEventSelectors:
+        - Name: KMS signer API activity
+          FieldSelectors:
+            - Field: eventCategory
+              Equals:
+                - Management
+            - Field: eventSource
+              Equals:
+                - kms.amazonaws.com
+            - Field: eventName
+              Equals:
+                - Sign
+                - GetPublicKey
+                - DescribeKey
+                - Encrypt
+                - Decrypt
+
+  BlockchainKMSSignCallCountMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref CloudTrailLogGroupName
+      FilterPattern: !Sub '{ ($.eventSource = "kms.amazonaws.com") && ($.eventName = "Sign") && ($.resources[0].ARN = "${BlockchainSignerKeyArn}") }'
+      MetricTransformations:
+        - MetricNamespace: !Ref MetricNamespace
+          MetricName: BlockchainKMSSignCallCount
+          MetricValue: "1"
+          Unit: Count
+
+  JwtKMSSignCallCountMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref CloudTrailLogGroupName
+      FilterPattern: !Sub '{ ($.eventSource = "kms.amazonaws.com") && ($.eventName = "Sign") && ($.resources[0].ARN = "${JwtSignerKeyArn}") }'
+      MetricTransformations:
+        - MetricNamespace: !Ref MetricNamespace
+          MetricName: JwtKMSSignCallCount
+          MetricValue: "1"
+          Unit: Count
+
+  BlockchainKMSSignErrorCountMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref CloudTrailLogGroupName
+      FilterPattern: !Sub '{ ($.eventSource = "kms.amazonaws.com") && ($.eventName = "Sign") && ($.resources[0].ARN = "${BlockchainSignerKeyArn}") && ($.errorCode = *) }'
+      MetricTransformations:
+        - MetricNamespace: !Ref MetricNamespace
+          MetricName: BlockchainKMSSignErrorCount
+          MetricValue: "1"
+          Unit: Count
+
+  JwtKMSSignErrorCountMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref CloudTrailLogGroupName
+      FilterPattern: !Sub '{ ($.eventSource = "kms.amazonaws.com") && ($.eventName = "Sign") && ($.resources[0].ARN = "${JwtSignerKeyArn}") && ($.errorCode = *) }'
+      MetricTransformations:
+        - MetricNamespace: !Ref MetricNamespace
+          MetricName: JwtKMSSignErrorCount
+          MetricValue: "1"
+          Unit: Count
+
+  BlockchainKMSSignErrorByCodeMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref CloudTrailLogGroupName
+      FilterPattern: !Sub '{ ($.eventSource = "kms.amazonaws.com") && ($.eventName = "Sign") && ($.resources[0].ARN = "${BlockchainSignerKeyArn}") && ($.errorCode = *) }'
+      MetricTransformations:
+        - MetricNamespace: !Ref MetricNamespace
+          MetricName: BlockchainKMSSignErrorByCodeCount
+          MetricValue: "1"
+          Unit: Count
+          Dimensions:
+            - Key: ErrorCode
+              Value: $.errorCode
+
+  JwtKMSSignErrorByCodeMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref CloudTrailLogGroupName
+      FilterPattern: !Sub '{ ($.eventSource = "kms.amazonaws.com") && ($.eventName = "Sign") && ($.resources[0].ARN = "${JwtSignerKeyArn}") && ($.errorCode = *) }'
+      MetricTransformations:
+        - MetricNamespace: !Ref MetricNamespace
+          MetricName: JwtKMSSignErrorByCodeCount
+          MetricValue: "1"
+          Unit: Count
+          Dimensions:
+            - Key: ErrorCode
+              Value: $.errorCode
+
+  BlockchainKMSGetPublicKeyCallCountMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref CloudTrailLogGroupName
+      FilterPattern: !Sub '{ ($.eventSource = "kms.amazonaws.com") && ($.eventName = "GetPublicKey") && ($.resources[0].ARN = "${BlockchainSignerKeyArn}") }'
+      MetricTransformations:
+        - MetricNamespace: !Ref MetricNamespace
+          MetricName: BlockchainKMSGetPublicKeyCallCount
+          MetricValue: "1"
+          Unit: Count
+
+  JwtKMSGetPublicKeyCallCountMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref CloudTrailLogGroupName
+      FilterPattern: !Sub '{ ($.eventSource = "kms.amazonaws.com") && ($.eventName = "GetPublicKey") && ($.resources[0].ARN = "${JwtSignerKeyArn}") }'
+      MetricTransformations:
+        - MetricNamespace: !Ref MetricNamespace
+          MetricName: JwtKMSGetPublicKeyCallCount
+          MetricValue: "1"
+          Unit: Count
+
+  BlockchainKMSAccessDeniedCountMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref CloudTrailLogGroupName
+      FilterPattern: !Sub '{ ($.eventSource = "kms.amazonaws.com") && ($.resources[0].ARN = "${BlockchainSignerKeyArn}") && (($.errorCode = "AccessDenied") || ($.errorCode = "AccessDeniedException")) }'
+      MetricTransformations:
+        - MetricNamespace: !Ref MetricNamespace
+          MetricName: BlockchainKMSAccessDeniedCount
+          MetricValue: "1"
+          Unit: Count
+
+  JwtKMSAccessDeniedCountMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref CloudTrailLogGroupName
+      FilterPattern: !Sub '{ ($.eventSource = "kms.amazonaws.com") && ($.resources[0].ARN = "${JwtSignerKeyArn}") && (($.errorCode = "AccessDenied") || ($.errorCode = "AccessDeniedException")) }'
+      MetricTransformations:
+        - MetricNamespace: !Ref MetricNamespace
+          MetricName: JwtKMSAccessDeniedCount
+          MetricValue: "1"
+          Unit: Count
+
+  BlockchainKMSSignDurationMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref BackendLogGroupName
+      FilterPattern: '{ ($.event = "kms.sign.duration") && ($.signer = "blockchain") && ($.success = true) }'
+      MetricTransformations:
+        - MetricNamespace: !Ref MetricNamespace
+          MetricName: BlockchainKMSSignDurationMs
+          MetricValue: $.durationMs
+          Unit: Milliseconds
+
+  JwtKMSSignDurationMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref BackendLogGroupName
+      FilterPattern: '{ ($.event = "kms.sign.duration") && ($.signer = "jwt") && ($.success = true) }'
+      MetricTransformations:
+        - MetricNamespace: !Ref MetricNamespace
+          MetricName: JwtKMSSignDurationMs
+          MetricValue: $.durationMs
+          Unit: Milliseconds
+
+  AuthFailureCountMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref BackendLogGroupName
+      FilterPattern: '{ ($.msg = "http.error") && (($.status = 401) || ($.status = 403)) }'
+      MetricTransformations:
+        - MetricNamespace: !Ref MetricNamespace
+          MetricName: AuthFailureCount
+          MetricValue: "1"
+          Unit: Count
+
+  AuthRefreshReplayCountMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref BackendLogGroupName
+      FilterPattern: '{ (($.msg = "http.error") && ($.code = "refresh_replay_detected")) || (($.msg = "auth_refresh.cookie_rejected") && ($.code = "refresh_replay_detected")) }'
+      MetricTransformations:
+        - MetricNamespace: !Ref MetricNamespace
+          MetricName: AuthRefreshReplayDetectedCount
+          MetricValue: "1"
+          Unit: Count
+
+  BlockchainKMSSignErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub averray-${EnvironmentName}-blockchain-kms-sign-error
+      AlarmDescription: Blockchain signer kms:Sign produced at least one CloudTrail error in 5 minutes.
+      Namespace: !Ref MetricNamespace
+      MetricName: BlockchainKMSSignErrorCount
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: !If
+        - HasPageTopic
+        - - !Ref PageTopicArn
+        - !Ref AWS::NoValue
+
+  JwtKMSSignErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub averray-${EnvironmentName}-jwt-kms-sign-error
+      AlarmDescription: JWT signer kms:Sign produced at least one CloudTrail error in 5 minutes.
+      Namespace: !Ref MetricNamespace
+      MetricName: JwtKMSSignErrorCount
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: !If
+        - HasPageTopic
+        - - !Ref PageTopicArn
+        - !Ref AWS::NoValue
+
+  BlockchainKMSAccessDeniedAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub averray-${EnvironmentName}-blockchain-kms-access-denied
+      AlarmDescription: Blockchain signer KMS access was denied; inspect IAM/Roles Anywhere/KMS policy immediately.
+      Namespace: !Ref MetricNamespace
+      MetricName: BlockchainKMSAccessDeniedCount
+      Statistic: Sum
+      Period: 60
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: !If
+        - HasPageTopic
+        - - !Ref PageTopicArn
+        - !Ref AWS::NoValue
+
+  JwtKMSAccessDeniedAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub averray-${EnvironmentName}-jwt-kms-access-denied
+      AlarmDescription: JWT signer KMS access was denied; inspect IAM/Roles Anywhere/KMS policy immediately.
+      Namespace: !Ref MetricNamespace
+      MetricName: JwtKMSAccessDeniedCount
+      Statistic: Sum
+      Period: 60
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: !If
+        - HasPageTopic
+        - - !Ref PageTopicArn
+        - !Ref AWS::NoValue
+
+  BlockchainKMSSignSpikeAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub averray-${EnvironmentName}-blockchain-kms-sign-spike
+      AlarmDescription: Blockchain signer kms:Sign calls exceeded the baseline-derived 5-minute threshold.
+      Namespace: !Ref MetricNamespace
+      MetricName: BlockchainKMSSignCallCount
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: !Ref BlockchainSignSpikeThresholdPer5Min
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: !If
+        - HasAlertTopic
+        - - !Ref AlertTopicArn
+        - !Ref AWS::NoValue
+
+  JwtKMSSignSpikeAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub averray-${EnvironmentName}-jwt-kms-sign-spike
+      AlarmDescription: JWT signer kms:Sign calls exceeded the baseline-derived 5-minute threshold.
+      Namespace: !Ref MetricNamespace
+      MetricName: JwtKMSSignCallCount
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: !Ref JwtSignSpikeThresholdPer5Min
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: !If
+        - HasAlertTopic
+        - - !Ref AlertTopicArn
+        - !Ref AWS::NoValue
+
+  AuthFailureSpikeAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub averray-${EnvironmentName}-auth-failure-spike
+      AlarmDescription: Auth 401/403 responses exceeded the baseline-derived 5-minute threshold.
+      Namespace: !Ref MetricNamespace
+      MetricName: AuthFailureCount
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: !Ref AuthFailureThresholdPer5Min
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: !If
+        - HasAlertTopic
+        - - !Ref AlertTopicArn
+        - !Ref AWS::NoValue
+
+  AuthRefreshReplayDetectedAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub averray-${EnvironmentName}-auth-refresh-replay-detected
+      AlarmDescription: Refresh-token strict replay detection fired; treat as credential theft until disproven.
+      Namespace: !Ref MetricNamespace
+      MetricName: AuthRefreshReplayDetectedCount
+      Statistic: Sum
+      Period: 60
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: !If
+        - HasPageTopic
+        - - !Ref PageTopicArn
+        - !Ref AWS::NoValue
+
+  KmsSigningDashboard:
+    Type: AWS::CloudWatch::Dashboard
+    Properties:
+      DashboardName: !Sub averray-${EnvironmentName}-kms-signing
+      DashboardBody: !Sub |
+        {
+          "widgets": [
+            {
+              "type": "metric",
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 6,
+              "properties": {
+                "title": "KMS Sign calls and errors",
+                "region": "${AWS::Region}",
+                "metrics": [
+                  [ "${MetricNamespace}", "BlockchainKMSSignCallCount", { "stat": "Sum", "label": "blockchain sign calls" } ],
+                  [ ".", "JwtKMSSignCallCount", { "stat": "Sum", "label": "jwt sign calls" } ],
+                  [ ".", "BlockchainKMSSignErrorCount", { "stat": "Sum", "label": "blockchain sign errors" } ],
+                  [ ".", "JwtKMSSignErrorCount", { "stat": "Sum", "label": "jwt sign errors" } ]
+                ],
+                "period": 300
+              }
+            },
+            {
+              "type": "metric",
+              "x": 12,
+              "y": 0,
+              "width": 12,
+              "height": 6,
+              "properties": {
+                "title": "KMS Sign duration percentiles",
+                "region": "${AWS::Region}",
+                "metrics": [
+                  [ "${MetricNamespace}", "BlockchainKMSSignDurationMs", { "stat": "p50", "label": "blockchain p50" } ],
+                  [ ".", "BlockchainKMSSignDurationMs", { "stat": "p95", "label": "blockchain p95" } ],
+                  [ ".", "BlockchainKMSSignDurationMs", { "stat": "p99", "label": "blockchain p99" } ],
+                  [ ".", "JwtKMSSignDurationMs", { "stat": "p50", "label": "jwt p50" } ],
+                  [ ".", "JwtKMSSignDurationMs", { "stat": "p95", "label": "jwt p95" } ],
+                  [ ".", "JwtKMSSignDurationMs", { "stat": "p99", "label": "jwt p99" } ]
+                ],
+                "period": 300,
+                "yAxis": { "left": { "label": "milliseconds" } }
+              }
+            },
+            {
+              "type": "metric",
+              "x": 0,
+              "y": 6,
+              "width": 12,
+              "height": 6,
+              "properties": {
+                "title": "KMS GetPublicKey and AccessDenied",
+                "region": "${AWS::Region}",
+                "metrics": [
+                  [ "${MetricNamespace}", "BlockchainKMSGetPublicKeyCallCount", { "stat": "Sum", "label": "blockchain GetPublicKey" } ],
+                  [ ".", "JwtKMSGetPublicKeyCallCount", { "stat": "Sum", "label": "jwt GetPublicKey" } ],
+                  [ ".", "BlockchainKMSAccessDeniedCount", { "stat": "Sum", "label": "blockchain AccessDenied" } ],
+                  [ ".", "JwtKMSAccessDeniedCount", { "stat": "Sum", "label": "jwt AccessDenied" } ]
+                ],
+                "period": 300
+              }
+            },
+            {
+              "type": "metric",
+              "x": 12,
+              "y": 6,
+              "width": 12,
+              "height": 6,
+              "properties": {
+                "title": "Auth failures",
+                "region": "${AWS::Region}",
+                "metrics": [
+                  [ "${MetricNamespace}", "AuthFailureCount", { "stat": "Sum", "label": "401/403 failures" } ],
+                  [ ".", "AuthRefreshReplayDetectedCount", { "stat": "Sum", "label": "refresh replay detected" } ]
+                ],
+                "period": 300
+              }
+            }
+          ]
+        }
+
+Outputs:
+  TrailName:
+    Description: CloudTrail trail that captures KMS API activity.
+    Value: !Ref KmsAuditTrail
+  TrailBucketName:
+    Description: S3 bucket holding CloudTrail logs with 90-day expiration.
+    Value: !Ref CloudTrailBucket
+  TrailLogGroupName:
+    Description: CloudWatch Logs group receiving CloudTrail KMS API activity.
+    Value: !Ref CloudTrailLogGroupName
+  MetricNamespace:
+    Description: CloudWatch namespace containing KMS/auth alarm metrics.
+    Value: !Ref MetricNamespace
+  DashboardName:
+    Description: Dashboard with KMS call, error, auth failure, and p50/p95/p99 sign-duration widgets.
+    Value: !Ref KmsSigningDashboard

--- a/docs/INCIDENT_RESPONSE.md
+++ b/docs/INCIDENT_RESPONSE.md
@@ -92,7 +92,9 @@ The minimum useful alert set is:
 1. External uptime / cron runner hitting:
    - `./scripts/ops/check-hosted-stack-and-alert.sh`
 2. Backend Sentry for 5xx exceptions
-3. Human reports from operators or counterparties
+3. CloudWatch alarms from the KMS/auth alarm stack in
+   [`deploy/iac/cloudwatch/kms-signing-alarms.yaml`](../deploy/iac/cloudwatch/kms-signing-alarms.yaml)
+4. Human reports from operators or counterparties
 
 Recommended webhook env for the smoke-alert wrapper:
 
@@ -107,7 +109,59 @@ relay that accepts JSON POSTs.
 
 ---
 
-## 4. First 15 minutes
+## 4. KMS and auth alerts
+
+The KMS/auth alarm bundle separates the blockchain mutation signer from the JWT
+signer. Treat the alarm name prefix as the first routing clue:
+
+- `blockchain-kms-*`: chain mutations, escrow, settlement, and treasury actions
+  may be unable to sign or may be signing unexpectedly often.
+- `jwt-kms-*`: SIWE, refresh, service-token issuance, and admin JWT minting may
+  be unable to issue ES256 tokens.
+- `auth-*`: the backend is seeing anomalous authentication failures or refresh
+  replay detection.
+
+### Alarm meanings
+
+| Alarm | Severity | Meaning | First move |
+|---|---|---|---|
+| `*-kms-sign-error` | P1 | `kms:Sign` returned a CloudTrail error for that signer key. | Check CloudTrail event details, backend `kms.sign.duration` failure logs, and whether the key/role/region changed. |
+| `*-kms-access-denied` | P1 | KMS rejected the caller. This usually means a broken Roles Anywhere session, revoked permission, wrong key ARN, or policy drift. | Verify the shared-config profile and role session, then compare the effective IAM/KMS policy to the last known-good deployment. |
+| `*-kms-sign-spike` | P2 unless value movement is suspicious, then P1 | Sign call volume exceeded the baseline-derived 5-minute threshold. | Compare against expected worker traffic and recent deploys; pause mutating flows if the blockchain signer spike does not match known activity. |
+| `auth-failure-spike` | P2 | 401/403 responses exceeded the baseline-derived 5-minute threshold. | Inspect `http.error` logs by `code`, especially `bad_signature`, `token_expired`, `token_revoked`, and `missing_capability`. |
+| `auth-refresh-replay-detected` | P1 | Strict refresh-token replay detection fired. Treat as credential theft until disproven. | Revoke the affected refresh chain if not already revoked, identify wallet/session, and rotate any exposed operator credential. |
+
+### First debug commands
+
+```bash
+aws cloudwatch describe-alarms \
+  --region eu-central-2 \
+  --alarm-name-prefix averray-testnet
+
+aws logs filter-log-events \
+  --region eu-central-2 \
+  --log-group-name /averray/testnet/cloudtrail/kms \
+  --filter-pattern '{ ($.eventSource = "kms.amazonaws.com") && ($.eventName = "Sign") }'
+
+aws logs filter-log-events \
+  --region eu-central-2 \
+  --log-group-name /averray/testnet/backend \
+  --filter-pattern '{ $.event = "kms.sign.duration" }'
+
+aws logs filter-log-events \
+  --region eu-central-2 \
+  --log-group-name /averray/testnet/backend \
+  --filter-pattern '{ ($.msg = "http.error") && (($.status = 401) || ($.status = 403)) }'
+```
+
+If the blockchain signer alarm coincides with unexpected value movement, pause
+first and debug second. If the JWT signer is failing, expect wallet login,
+refresh, admin minting, and service-token issuance to fail while existing valid
+tokens continue until expiry.
+
+---
+
+## 5. First 15 minutes
 
 ### If value movement looks wrong
 
@@ -140,7 +194,7 @@ relay that accepts JSON POSTs.
 
 ---
 
-## 5. Response matrix
+## 6. Response matrix
 
 | Symptom | Severity | First move | Likely owner |
 |---|---|---|---|
@@ -149,13 +203,17 @@ relay that accepts JSON POSTs.
 | `index.averray.com/ready` failing | P2 | Check indexer logs/status, roll back or widen readiness window | Primary on-call |
 | Public site/app shell failing | P2 | Check Caddy + static mounts | Primary on-call |
 | Async XCM requests stuck in `pending` | P2 | Check watcher status, inspect `/xcm/request`, and rehearse manual finalize if needed | Primary on-call |
+| Blockchain KMS signer error or access denied | P1 | Pause if value movement is suspicious; inspect CloudTrail + backend signer logs | Primary on-call + pauser |
+| JWT KMS signer error or access denied | P1 | Inspect CloudTrail + backend signer logs; expect auth issuance failures | Primary on-call |
+| KMS sign call spike | P2/P1 | Compare against expected traffic; pause mutating flows if unexplained | Primary on-call |
+| Refresh replay detected | P1 | Revoke affected chain/session, identify exposure source | Primary on-call |
 | `/content/:hash` unexpectedly 404s after Redis loss/restore | P2 | Dry-run the content recovery replay log, then apply if clean | Primary on-call |
 | Redis restore drill fails | P1 | Treat as backup failure; stop risky deploys | Primary on-call |
 | Smoke check drift only | P3 | Fix docs/config/runtime mismatch | Repo owner |
 
 ---
 
-## 6. Rollback guidance
+## 7. Rollback guidance
 
 ### Backend
 
@@ -211,7 +269,7 @@ docker compose restart caddy
 
 ---
 
-## 7. Post-incident note
+## 8. Post-incident note
 
 Every P1/P2 should leave behind a short note containing:
 
@@ -229,7 +287,7 @@ If the incident required a pause, include:
 
 ---
 
-## 8. Minimum “ready for prod” bar
+## 9. Minimum “ready for prod” bar
 
 Before calling the stack truly production-ready:
 

--- a/docs/PROJECT_ROADMAP.md
+++ b/docs/PROJECT_ROADMAP.md
@@ -222,6 +222,7 @@ HTTP route-split closeout audit after `#526`: `mcp-server/src/protocols/http/ser
 - **Worker-loop refresh-flow** — shipped in PR #529. `ADMIN_JWT`
   30-day-manual-rotation path retained for backward compatibility; retire
   after a 30-day soak period proves the refresh path stable in CI.
+- **CloudTrail/CloudWatch KMS signing alarms** — shipped in PR #532. Adds a CloudFormation alarm foundation for blockchain/JWT KMS signing, auth failure anomalies, refresh replay detection, and structured `kms.sign.duration` logs. Close after the stack is deployed with baseline-derived thresholds and an alert-channel proof reaches the operator channel.
 
 ### Remaining
 

--- a/mcp-server/src/auth/jwt.js
+++ b/mcp-server/src/auth/jwt.js
@@ -142,6 +142,7 @@ async function getKmsSigner(authConfig) {
     expectedRoles: authConfig.kmsJwt.expectedRoles,
     maxTtlSeconds: authConfig.kmsJwt.maxTtlSeconds,
     clockSkewSeconds: authConfig.kmsJwt.clockSkewSeconds,
+    logger: authConfig.kmsJwt.logger,
     credentialsProvider,
   });
   SIGNER_CACHE.set(authConfig.kmsJwt, signer);

--- a/mcp-server/src/auth/kms-jwt-signer.js
+++ b/mcp-server/src/auth/kms-jwt-signer.js
@@ -350,17 +350,6 @@ export class KmsJwtSigner {
     let derSig;
     try {
       ({ Signature: derSig } = await client.send(command));
-      emitKmsSignDuration(this.#logger, "info", {
-        event: KMS_SIGN_EVENT,
-        signer: "jwt",
-        operation: "kms:Sign",
-        keyId: this.#keyId,
-        kid: this.#kid,
-        messageType: "DIGEST",
-        signingAlgorithm: "ECDSA_SHA_256",
-        durationMs: durationMsSince(startedAt),
-        success: true,
-      });
     } catch (error) {
       emitKmsSignDuration(this.#logger, "warn", {
         event: KMS_SIGN_EVENT,
@@ -377,8 +366,32 @@ export class KmsJwtSigner {
       throw error;
     }
     if (!derSig) {
-      throw new Error("KmsJwtSigner: KMS Sign returned empty Signature");
+      const error = new Error("KmsJwtSigner: KMS Sign returned empty Signature");
+      emitKmsSignDuration(this.#logger, "warn", {
+        event: KMS_SIGN_EVENT,
+        signer: "jwt",
+        operation: "kms:Sign",
+        keyId: this.#keyId,
+        kid: this.#kid,
+        messageType: "DIGEST",
+        signingAlgorithm: "ECDSA_SHA_256",
+        durationMs: durationMsSince(startedAt),
+        success: false,
+        ...serializeKmsSignError(error),
+      });
+      throw error;
     }
+    emitKmsSignDuration(this.#logger, "info", {
+      event: KMS_SIGN_EVENT,
+      signer: "jwt",
+      operation: "kms:Sign",
+      keyId: this.#keyId,
+      kid: this.#kid,
+      messageType: "DIGEST",
+      signingAlgorithm: "ECDSA_SHA_256",
+      durationMs: durationMsSince(startedAt),
+      success: true,
+    });
     const rawSig = jwsRawFromDer(new Uint8Array(derSig));
     return `${input}.${base64UrlEncode(rawSig)}`;
   }

--- a/mcp-server/src/auth/kms-jwt-signer.js
+++ b/mcp-server/src/auth/kms-jwt-signer.js
@@ -55,10 +55,42 @@ const HEADER_ALG = "ES256";
 const DEFAULT_CLOCK_SKEW_SECONDS = 60;
 const DEFAULT_MAX_TTL_SECONDS = 3600;
 const FORBIDDEN_HEADERS = ["jku", "jwk", "x5u", "x5c", "crit"];
+const KMS_SIGN_EVENT = "kms.sign.duration";
 // Standard UUIDv4 shape. We don't enforce that other UUID versions are
 // rejected at the regex level — the version-4 nibble is checked
 // explicitly so the error message stays specific.
 const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+
+function durationMsSince(startedAt) {
+  return Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+}
+
+function serializeKmsSignError(error) {
+  return {
+    errorName: error?.name ?? "Error",
+    errorCode: error?.code ?? error?.name ?? "unknown",
+    errorMessage: error?.message ?? String(error),
+  };
+}
+
+function emitKmsSignDuration(logger, level, fields) {
+  if (!logger) {
+    return;
+  }
+  if (logger && logger !== console && typeof logger[level] === "function") {
+    logger[level](fields, KMS_SIGN_EVENT);
+    return;
+  }
+
+  const line = JSON.stringify({
+    timestamp: new Date().toISOString(),
+    level,
+    ...fields,
+    msg: KMS_SIGN_EVENT,
+  });
+  const consoleMethod = level === "warn" ? "warn" : "info";
+  console[consoleMethod](line);
+}
 
 export class KmsJwtSigner {
   #kmsClient;
@@ -75,6 +107,7 @@ export class KmsJwtSigner {
   #maxTtlSeconds;
   #clockSkewSeconds;
   #now;
+  #logger;
 
   /**
    * @param {object} opts
@@ -89,6 +122,7 @@ export class KmsJwtSigner {
    * @param {number} [opts.maxTtlSeconds]       Cap on `exp - iat`; defaults to 3600 (1h).
    * @param {number} [opts.clockSkewSeconds]    Skew tolerance for nbf/exp; defaults to 60.
    * @param {() => number} [opts.now]           Override clock (epoch seconds) for tests.
+   * @param {object} [opts.logger]              Optional pino-style logger.
    * @param {import("@aws-sdk/types").AwsCredentialIdentityProvider} [opts.credentialsProvider]
    *   Optional AWS SDK credentials provider passed to the lazy-constructed
    *   KMSClient. Used by Phase 5a (Roles Anywhere) — see
@@ -113,6 +147,7 @@ export class KmsJwtSigner {
       maxTtlSeconds,
       clockSkewSeconds,
       now,
+      logger,
       credentialsProvider,
     } = opts;
     if (!keyId || typeof keyId !== "string") {
@@ -174,6 +209,7 @@ export class KmsJwtSigner {
     this.#maxTtlSeconds = maxTtlSeconds ?? DEFAULT_MAX_TTL_SECONDS;
     this.#clockSkewSeconds = clockSkewSeconds ?? DEFAULT_CLOCK_SKEW_SECONDS;
     this.#now = typeof now === "function" ? now : null;
+    this.#logger = logger ?? null;
   }
 
   /** Configured `kid` header value. */
@@ -301,17 +337,45 @@ export class KmsJwtSigner {
     // paths that never construct a KmsJwtSigner (HMAC mode).
     const { SignCommand } = await import("@aws-sdk/client-kms");
     const client = await this.#getClient();
-    const { Signature: derSig } = await client.send(
-      new SignCommand({
-        KeyId: this.#keyId,
-        Message: digest,
-        // DIGEST: our Message is already a SHA-256 digest, do not
-        // re-hash. ECDSA_SHA_256: P-256 + SHA-256 = ES256. Both are
-        // enforced by the signer principal's IAM policy condition keys.
-        MessageType: "DIGEST",
-        SigningAlgorithm: "ECDSA_SHA_256",
-      }),
-    );
+    const command = new SignCommand({
+      KeyId: this.#keyId,
+      Message: digest,
+      // DIGEST: our Message is already a SHA-256 digest, do not
+      // re-hash. ECDSA_SHA_256: P-256 + SHA-256 = ES256. Both are
+      // enforced by the signer principal's IAM policy condition keys.
+      MessageType: "DIGEST",
+      SigningAlgorithm: "ECDSA_SHA_256",
+    });
+    const startedAt = process.hrtime.bigint();
+    let derSig;
+    try {
+      ({ Signature: derSig } = await client.send(command));
+      emitKmsSignDuration(this.#logger, "info", {
+        event: KMS_SIGN_EVENT,
+        signer: "jwt",
+        operation: "kms:Sign",
+        keyId: this.#keyId,
+        kid: this.#kid,
+        messageType: "DIGEST",
+        signingAlgorithm: "ECDSA_SHA_256",
+        durationMs: durationMsSince(startedAt),
+        success: true,
+      });
+    } catch (error) {
+      emitKmsSignDuration(this.#logger, "warn", {
+        event: KMS_SIGN_EVENT,
+        signer: "jwt",
+        operation: "kms:Sign",
+        keyId: this.#keyId,
+        kid: this.#kid,
+        messageType: "DIGEST",
+        signingAlgorithm: "ECDSA_SHA_256",
+        durationMs: durationMsSince(startedAt),
+        success: false,
+        ...serializeKmsSignError(error),
+      });
+      throw error;
+    }
     if (!derSig) {
       throw new Error("KmsJwtSigner: KMS Sign returned empty Signature");
     }

--- a/mcp-server/src/auth/kms-jwt-signer.test.js
+++ b/mcp-server/src/auth/kms-jwt-signer.test.js
@@ -132,6 +132,7 @@ function buildSigner(overrides = {}) {
     maxTtlSeconds: overrides.maxTtlSeconds ?? 3600,
     clockSkewSeconds: overrides.clockSkewSeconds ?? 60,
     now: overrides.now,
+    logger: overrides.logger,
   });
 }
 
@@ -199,6 +200,19 @@ function makeHeader(overrides = {}) {
   };
 }
 
+function collectingLogger() {
+  const records = [];
+  return {
+    records,
+    info(fields, message) {
+      records.push({ level: "info", fields, message });
+    },
+    warn(fields, message) {
+      records.push({ level: "warn", fields, message });
+    },
+  };
+}
+
 // ───────────────────────────────────────────────────────────────────
 // Tests
 // ───────────────────────────────────────────────────────────────────
@@ -218,6 +232,26 @@ test("KmsJwtSigner: sign + verify happy-path round-trip", async () => {
   assert.equal(typeof claims.exp, "number");
   assert.equal(claims.exp - claims.iat, TTL_SECONDS);
   assert.match(claims.jti, /^[0-9a-f-]{36}$/u);
+});
+
+test("KmsJwtSigner: signAsync emits a structured kms:Sign duration log", async () => {
+  const logger = collectingLogger();
+  const signer = buildSigner({ logger });
+  await signer.signAsync({}, defaultSignOpts());
+
+  const record = logger.records.find((entry) => entry.message === "kms.sign.duration");
+  assert.ok(record, "expected kms.sign.duration log record");
+  assert.equal(record.level, "info");
+  assert.equal(record.fields.event, "kms.sign.duration");
+  assert.equal(record.fields.signer, "jwt");
+  assert.equal(record.fields.operation, "kms:Sign");
+  assert.equal(record.fields.keyId, KEY_ARN);
+  assert.equal(record.fields.kid, KID);
+  assert.equal(record.fields.messageType, "DIGEST");
+  assert.equal(record.fields.signingAlgorithm, "ECDSA_SHA_256");
+  assert.equal(record.fields.success, true);
+  assert.equal(typeof record.fields.durationMs, "number");
+  assert.ok(record.fields.durationMs >= 0);
 });
 
 test("KmsJwtSigner: signAsync accepts multi-role array and emits canonical roles claim", async () => {
@@ -602,6 +636,25 @@ test("KmsJwtSigner: KMS Sign called with exactly the expected parameters", async
   assert.equal(input.MessageType, "DIGEST", "MessageType is DIGEST");
   assert.equal(input.SigningAlgorithm, "ECDSA_SHA_256", "SigningAlgorithm is ECDSA_SHA_256");
   assert.equal(input.Message.length, 32, "Message is a 32-byte SHA-256 digest");
+});
+
+test("KmsJwtSigner: failed KMS Sign emits a structured duration log", async () => {
+  const logger = collectingLogger();
+  const kms = new FakeKMSClient({ failNextSign: true });
+  const signer = buildSigner({ kmsClient: kms, logger });
+
+  await assert.rejects(
+    () => signer.signAsync({}, defaultSignOpts()),
+    /AccessDeniedException: simulated KMS Sign denied/,
+  );
+  const record = logger.records.find((entry) => entry.message === "kms.sign.duration");
+  assert.ok(record, "expected failed kms.sign.duration log record");
+  assert.equal(record.level, "warn");
+  assert.equal(record.fields.signer, "jwt");
+  assert.equal(record.fields.success, false);
+  assert.equal(record.fields.errorName, "AccessDeniedException");
+  assert.equal(record.fields.errorCode, "AccessDeniedException");
+  assert.match(record.fields.errorMessage, /simulated KMS Sign denied/);
 });
 
 test("KmsJwtSigner: FakeKMS denies wrong SigningAlgorithm (mirrors IAM policy)", async () => {

--- a/mcp-server/src/auth/kms-jwt-signer.test.js
+++ b/mcp-server/src/auth/kms-jwt-signer.test.js
@@ -67,10 +67,11 @@ const ROLES = ["admin", "verifier"];
 const TTL_SECONDS = 900; // 15 min
 
 class FakeKMSClient {
-  constructor({ failNextSign = false, signWithRawKey = KMS_RAW_PRIVATE } = {}) {
+  constructor({ failNextSign = false, signWithRawKey = KMS_RAW_PRIVATE, emptySignature = false } = {}) {
     this.calls = [];
     this.failNextSign = failNextSign;
     this.signWithRawKey = signWithRawKey;
+    this.emptySignature = emptySignature;
   }
   async send(command) {
     this.calls.push(command);
@@ -94,6 +95,9 @@ class FakeKMSClient {
         const err = new Error(`AccessDeniedException: MessageType "${command.input.MessageType}" not allowed`);
         err.name = "AccessDeniedException";
         throw err;
+      }
+      if (this.emptySignature) {
+        return {};
       }
       // Sign the digest. KMS in DIGEST mode treats `Message` as a
       // pre-computed SHA-256 digest — it does NOT re-hash. Node's
@@ -655,6 +659,25 @@ test("KmsJwtSigner: failed KMS Sign emits a structured duration log", async () =
   assert.equal(record.fields.errorName, "AccessDeniedException");
   assert.equal(record.fields.errorCode, "AccessDeniedException");
   assert.match(record.fields.errorMessage, /simulated KMS Sign denied/);
+});
+
+test("KmsJwtSigner: empty KMS Sign response emits a failed duration log", async () => {
+  const logger = collectingLogger();
+  const kms = new FakeKMSClient({ emptySignature: true });
+  const signer = buildSigner({ kmsClient: kms, logger });
+
+  await assert.rejects(
+    () => signer.signAsync({}, defaultSignOpts()),
+    /KmsJwtSigner: KMS Sign returned empty Signature/,
+  );
+  const record = logger.records.find((entry) => entry.message === "kms.sign.duration");
+  assert.ok(record, "expected failed kms.sign.duration log record");
+  assert.equal(record.level, "warn");
+  assert.equal(record.fields.signer, "jwt");
+  assert.equal(record.fields.success, false);
+  assert.equal(record.fields.errorName, "Error");
+  assert.equal(record.fields.errorCode, "Error");
+  assert.match(record.fields.errorMessage, /empty Signature/);
 });
 
 test("KmsJwtSigner: FakeKMS denies wrong SigningAlgorithm (mirrors IAM policy)", async () => {

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -94,7 +94,7 @@ function canAutoMintAsset(asset) {
 }
 
 export class BlockchainGateway {
-  constructor(config = loadBlockchainConfig()) {
+  constructor(config = loadBlockchainConfig(), { logger = undefined } = {}) {
     this.config = config;
     if (!config.enabled) {
       this.provider = undefined;
@@ -109,7 +109,7 @@ export class BlockchainGateway {
     }
 
     this.provider = new JsonRpcProvider(config.rpcUrl);
-    this.signer = createSigner(config, this.provider);
+    this.signer = createSigner(config, this.provider, { logger });
     this.accountContract = new Contract(
       config.agentAccountAddress,
       AGENT_ACCOUNT_ABI,
@@ -1746,7 +1746,7 @@ export class BlockchainGateway {
  * gateway, no signing capability) — matches the pre-Phase-3 contract where
  * an empty SIGNER_PRIVATE_KEY would also yield an undefined signer.
  */
-function createSigner(config, provider) {
+function createSigner(config, provider, { logger = undefined } = {}) {
   if (config.signerBackend === "kms") {
     if (!config.kmsKeyId || !config.awsRegion) {
       // Should be caught upstream by loadBlockchainConfig's required-field
@@ -1771,6 +1771,7 @@ function createSigner(config, provider) {
       region: config.awsRegion,
       keyId: config.kmsKeyId,
       provider,
+      logger,
       credentialsProvider,
     });
   }

--- a/mcp-server/src/blockchain/kms-signer.js
+++ b/mcp-server/src/blockchain/kms-signer.js
@@ -327,16 +327,6 @@ export class KmsSigner extends AbstractSigner {
     let derSig;
     try {
       ({ Signature: derSig } = await client.send(command));
-      emitKmsSignDuration(this.#logger, "info", {
-        event: KMS_SIGN_EVENT,
-        signer: "blockchain",
-        operation: "kms:Sign",
-        keyId: this.#keyId,
-        messageType: "DIGEST",
-        signingAlgorithm: "ECDSA_SHA_256",
-        durationMs: durationMsSince(startedAt),
-        success: true,
-      });
     } catch (error) {
       emitKmsSignDuration(this.#logger, "warn", {
         event: KMS_SIGN_EVENT,
@@ -352,8 +342,30 @@ export class KmsSigner extends AbstractSigner {
       throw error;
     }
     if (!derSig) {
-      throw new Error("KMS Sign returned empty Signature");
+      const error = new Error("KMS Sign returned empty Signature");
+      emitKmsSignDuration(this.#logger, "warn", {
+        event: KMS_SIGN_EVENT,
+        signer: "blockchain",
+        operation: "kms:Sign",
+        keyId: this.#keyId,
+        messageType: "DIGEST",
+        signingAlgorithm: "ECDSA_SHA_256",
+        durationMs: durationMsSince(startedAt),
+        success: false,
+        ...serializeKmsSignError(error),
+      });
+      throw error;
     }
+    emitKmsSignDuration(this.#logger, "info", {
+      event: KMS_SIGN_EVENT,
+      signer: "blockchain",
+      operation: "kms:Sign",
+      keyId: this.#keyId,
+      messageType: "DIGEST",
+      signingAlgorithm: "ECDSA_SHA_256",
+      durationMs: durationMsSince(startedAt),
+      success: true,
+    });
 
     const { r, s: rawS } = parseDerEcdsaSignature(new Uint8Array(derSig));
     const { s: normalizedS, flipped } = normalizeSignatureS(rawS);

--- a/mcp-server/src/blockchain/kms-signer.js
+++ b/mcp-server/src/blockchain/kms-signer.js
@@ -54,11 +54,45 @@ import {
   parseSecp256k1Spki,
 } from "./spki.js";
 
+const KMS_SIGN_EVENT = "kms.sign.duration";
+
+function durationMsSince(startedAt) {
+  return Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+}
+
+function serializeKmsSignError(error) {
+  return {
+    errorName: error?.name ?? "Error",
+    errorCode: error?.code ?? error?.name ?? "unknown",
+    errorMessage: error?.message ?? String(error),
+  };
+}
+
+function emitKmsSignDuration(logger, level, fields) {
+  if (!logger) {
+    return;
+  }
+  if (logger && logger !== console && typeof logger[level] === "function") {
+    logger[level](fields, KMS_SIGN_EVENT);
+    return;
+  }
+
+  const line = JSON.stringify({
+    timestamp: new Date().toISOString(),
+    level,
+    ...fields,
+    msg: KMS_SIGN_EVENT,
+  });
+  const consoleMethod = level === "warn" ? "warn" : "info";
+  console[consoleMethod](line);
+}
+
 export class KmsSigner extends AbstractSigner {
   #kmsClient;
   #region;
   #credentialsProvider;
   #keyId;
+  #logger;
   #cachedAddress = null;
   // Promise-coalescing: if two callers race for getAddress() before
   // the first GetPublicKey response lands, share the in-flight promise
@@ -79,6 +113,7 @@ export class KmsSigner extends AbstractSigner {
    * @param {object} [options.provider]   ethers Provider; required for
    *                                      sendTransaction, optional for
    *                                      pure signing.
+   * @param {object} [options.logger]     Optional pino-style logger.
    * @param {import("@aws-sdk/types").AwsCredentialIdentityProvider} [options.credentialsProvider]
    *   Optional AWS SDK credentials provider passed to the lazy KMSClient.
    *   Wired by Phase 5a — see `mcp-server/src/services/aws-credentials.js`.
@@ -86,7 +121,7 @@ export class KmsSigner extends AbstractSigner {
    *   and falls through to the SDK's default credential chain (env vars,
    *   shared config, etc.), preserving pre-5a behavior.
    */
-  constructor({ kmsClient, region, keyId, provider, credentialsProvider }) {
+  constructor({ kmsClient, region, keyId, provider, logger, credentialsProvider }) {
     super(provider ?? null);
     if (!keyId || typeof keyId !== "string") {
       throw new Error("KmsSigner: keyId is required (KMS key id, ARN, or alias)");
@@ -98,6 +133,7 @@ export class KmsSigner extends AbstractSigner {
     this.#region = region ?? null;
     this.#credentialsProvider = credentialsProvider ?? null;
     this.#keyId = keyId;
+    this.#logger = logger ?? null;
   }
 
   async #getClient() {
@@ -159,6 +195,7 @@ export class KmsSigner extends AbstractSigner {
       region: this.#region ?? undefined,
       keyId: this.#keyId,
       provider,
+      logger: this.#logger,
       credentialsProvider: this.#credentialsProvider ?? undefined,
     });
   }
@@ -274,20 +311,46 @@ export class KmsSigner extends AbstractSigner {
 
     const { SignCommand } = await import("@aws-sdk/client-kms");
     const client = await this.#getClient();
-    const { Signature: derSig } = await client.send(
-      new SignCommand({
-        KeyId: this.#keyId,
-        Message: digestBytes,
-        // CRITICAL: DIGEST tells KMS our Message is already a digest;
-        // ECDSA_SHA_256 specifies the signing algorithm. Both are
-        // enforced as condition keys in the IAM policy
-        // (deploy/iam-policies/averray-signer-prod-role.json) so even
-        // a compromised role credential can't ask KMS to sign a raw
-        // message under a different algorithm.
-        MessageType: "DIGEST",
-        SigningAlgorithm: "ECDSA_SHA_256",
-      }),
-    );
+    const command = new SignCommand({
+      KeyId: this.#keyId,
+      Message: digestBytes,
+      // CRITICAL: DIGEST tells KMS our Message is already a digest;
+      // ECDSA_SHA_256 specifies the signing algorithm. Both are
+      // enforced as condition keys in the IAM policy
+      // (deploy/iam-policies/averray-signer-prod-role.json) so even
+      // a compromised role credential can't ask KMS to sign a raw
+      // message under a different algorithm.
+      MessageType: "DIGEST",
+      SigningAlgorithm: "ECDSA_SHA_256",
+    });
+    const startedAt = process.hrtime.bigint();
+    let derSig;
+    try {
+      ({ Signature: derSig } = await client.send(command));
+      emitKmsSignDuration(this.#logger, "info", {
+        event: KMS_SIGN_EVENT,
+        signer: "blockchain",
+        operation: "kms:Sign",
+        keyId: this.#keyId,
+        messageType: "DIGEST",
+        signingAlgorithm: "ECDSA_SHA_256",
+        durationMs: durationMsSince(startedAt),
+        success: true,
+      });
+    } catch (error) {
+      emitKmsSignDuration(this.#logger, "warn", {
+        event: KMS_SIGN_EVENT,
+        signer: "blockchain",
+        operation: "kms:Sign",
+        keyId: this.#keyId,
+        messageType: "DIGEST",
+        signingAlgorithm: "ECDSA_SHA_256",
+        durationMs: durationMsSince(startedAt),
+        success: false,
+        ...serializeKmsSignError(error),
+      });
+      throw error;
+    }
     if (!derSig) {
       throw new Error("KMS Sign returned empty Signature");
     }

--- a/mcp-server/src/blockchain/kms-signer.test.js
+++ b/mcp-server/src/blockchain/kms-signer.test.js
@@ -118,6 +118,19 @@ class FakeKMSClient {
   }
 }
 
+function collectingLogger() {
+  const records = [];
+  return {
+    records,
+    info(fields, message) {
+      records.push({ level: "info", fields, message });
+    },
+    warn(fields, message) {
+      records.push({ level: "warn", fields, message });
+    },
+  };
+}
+
 // ───────────────────────────────────────────────────────────────────
 // Tests
 // ───────────────────────────────────────────────────────────────────
@@ -144,6 +157,26 @@ test("KmsSigner.signMessage produces a signature that recovers to the expected a
   // ethers' own verifyMessage path (EIP-191).
   const recovered = recoverAddress(getBytes(hashMessage(msg)), sigHex);
   assert.equal(recovered, EXPECTED_ADDRESS);
+});
+
+test("KmsSigner.signMessage emits a structured kms:Sign duration log", async () => {
+  const kms = new FakeKMSClient();
+  const logger = collectingLogger();
+  const signer = new KmsSigner({ kmsClient: kms, keyId: "test-key", logger });
+  await signer.signMessage("observability test");
+
+  const record = logger.records.find((entry) => entry.message === "kms.sign.duration");
+  assert.ok(record, "expected kms.sign.duration log record");
+  assert.equal(record.level, "info");
+  assert.equal(record.fields.event, "kms.sign.duration");
+  assert.equal(record.fields.signer, "blockchain");
+  assert.equal(record.fields.operation, "kms:Sign");
+  assert.equal(record.fields.keyId, "test-key");
+  assert.equal(record.fields.messageType, "DIGEST");
+  assert.equal(record.fields.signingAlgorithm, "ECDSA_SHA_256");
+  assert.equal(record.fields.success, true);
+  assert.equal(typeof record.fields.durationMs, "number");
+  assert.ok(record.fields.durationMs >= 0);
 });
 
 test("KmsSigner.signMessage normalizes high-s signatures to low form (EIP-2)", async () => {
@@ -286,13 +319,22 @@ test("KmsSigner.connect returns a new instance bound to the given provider", asy
 
 test("KmsSigner surfaces KMS Sign failures with the underlying error message", async () => {
   const kms = new FakeKMSClient({ failNextSign: true });
-  const signer = new KmsSigner({ kmsClient: kms, keyId: "test-key" });
+  const logger = collectingLogger();
+  const signer = new KmsSigner({ kmsClient: kms, keyId: "test-key", logger });
   // getAddress works (it only needs GetPublicKey, not Sign).
   await signer.getAddress();
   await assert.rejects(
     () => signer.signMessage("x"),
     /simulated KMS Sign failure/,
   );
+  const record = logger.records.find((entry) => entry.message === "kms.sign.duration");
+  assert.ok(record, "expected failed kms.sign.duration log record");
+  assert.equal(record.level, "warn");
+  assert.equal(record.fields.signer, "blockchain");
+  assert.equal(record.fields.success, false);
+  assert.equal(record.fields.errorName, "Error");
+  assert.equal(record.fields.errorCode, "Error");
+  assert.match(record.fields.errorMessage, /simulated KMS Sign failure/);
 });
 
 test("KmsSigner constructor rejects missing required options", () => {

--- a/mcp-server/src/blockchain/kms-signer.test.js
+++ b/mcp-server/src/blockchain/kms-signer.test.js
@@ -77,10 +77,11 @@ function toDerSig(r, s) {
 }
 
 class FakeKMSClient {
-  constructor({ failNextSign = false, returnHighS = false } = {}) {
+  constructor({ failNextSign = false, returnHighS = false, emptySignature = false } = {}) {
     this.calls = [];
     this.failNextSign = failNextSign;
     this.returnHighS = returnHighS;
+    this.emptySignature = emptySignature;
   }
   async send(command) {
     this.calls.push(command);
@@ -92,6 +93,9 @@ class FakeKMSClient {
       if (this.failNextSign) {
         this.failNextSign = false;
         throw new Error("simulated KMS Sign failure");
+      }
+      if (this.emptySignature) {
+        return {};
       }
       // Sign the digest with our local key. ethers SigningKey gives us
       // r, s, v (or yParity); convert to DER for KMS-shaped response.
@@ -335,6 +339,25 @@ test("KmsSigner surfaces KMS Sign failures with the underlying error message", a
   assert.equal(record.fields.errorName, "Error");
   assert.equal(record.fields.errorCode, "Error");
   assert.match(record.fields.errorMessage, /simulated KMS Sign failure/);
+});
+
+test("KmsSigner treats an empty KMS Sign response as a failed duration log", async () => {
+  const kms = new FakeKMSClient({ emptySignature: true });
+  const logger = collectingLogger();
+  const signer = new KmsSigner({ kmsClient: kms, keyId: "test-key", logger });
+  await signer.getAddress();
+  await assert.rejects(
+    () => signer.signMessage("x"),
+    /KMS Sign returned empty Signature/,
+  );
+  const record = logger.records.find((entry) => entry.message === "kms.sign.duration");
+  assert.ok(record, "expected failed kms.sign.duration log record");
+  assert.equal(record.level, "warn");
+  assert.equal(record.fields.signer, "blockchain");
+  assert.equal(record.fields.success, false);
+  assert.equal(record.fields.errorName, "Error");
+  assert.equal(record.fields.errorCode, "Error");
+  assert.match(record.fields.errorMessage, /empty Signature/);
 });
 
 test("KmsSigner constructor rejects missing required options", () => {

--- a/mcp-server/src/services/bootstrap.js
+++ b/mcp-server/src/services/bootstrap.js
@@ -167,6 +167,9 @@ export async function createPlatformRuntime() {
   // the step name before the process exits. Without this, a cryptic stack
   // trace is the only signal that a required env var was missing.
   const authConfig = initStep("load-auth-config", logger, () => loadAuthConfig());
+  if (authConfig.kmsJwt) {
+    authConfig.kmsJwt.logger = logger;
+  }
 
   // Phase 5a prep — verify the AWS credential chain can actually reach
   // the JWT KMS key before declaring the backend healthy. Without this
@@ -198,7 +201,7 @@ export async function createPlatformRuntime() {
   const mutationBackendConfig = initStep("load-mutation-backend-config", logger, () =>
     loadMutationBackendConfig(process.env)
   );
-  const gateway = initStep("init-blockchain-gateway", logger, () => new BlockchainGateway());
+  const gateway = initStep("init-blockchain-gateway", logger, () => new BlockchainGateway(undefined, { logger }));
   logger.info(
     describeMutationBackendStartup(mutationBackendConfig, gateway),
     "mutation_backend.configured"

--- a/scripts/ops/kms-cloudwatch-template.test.mjs
+++ b/scripts/ops/kms-cloudwatch-template.test.mjs
@@ -1,0 +1,115 @@
+// Unit tests for deploy/iac/cloudwatch/kms-signing-alarms.yaml.
+
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import yaml from "js-yaml";
+
+const TEMPLATE_PATH = new URL("../../deploy/iac/cloudwatch/kms-signing-alarms.yaml", import.meta.url);
+
+async function templateText() {
+  return readFile(TEMPLATE_PATH, "utf8");
+}
+
+function assertIncludesAll(text, snippets) {
+  for (const snippet of snippets) {
+    assert.ok(text.includes(snippet), `expected template to include: ${snippet}`);
+  }
+}
+
+function cloudFormationSchema() {
+  const scalar = (tag) => new yaml.Type(tag, { kind: "scalar", construct: (data) => data });
+  const sequence = (tag) => new yaml.Type(tag, { kind: "sequence", construct: (data) => data });
+  return yaml.DEFAULT_SCHEMA.extend([
+    scalar("!Ref"),
+    scalar("!Sub"),
+    scalar("!GetAtt"),
+    sequence("!If"),
+    sequence("!Not"),
+    sequence("!Equals"),
+  ]);
+}
+
+test("KMS CloudWatch template is valid YAML with CloudFormation intrinsics", async () => {
+  const text = await templateText();
+  const parsed = yaml.load(text, { schema: cloudFormationSchema() });
+  assert.equal(parsed.AWSTemplateFormatVersion, "2010-09-09");
+  assert.ok(parsed.Resources.KmsAuditTrail, "expected KmsAuditTrail resource");
+});
+
+test("KMS CloudWatch template keeps KMS management events enabled", async () => {
+  const text = await templateText();
+  assertIncludesAll(text, [
+    "Type: AWS::CloudTrail::Trail",
+    "AdvancedEventSelectors:",
+    "Field: eventCategory",
+    "- Management",
+    "Field: eventSource",
+    "- kms.amazonaws.com",
+    "- Sign",
+    "- GetPublicKey",
+    "- DescribeKey",
+    "- Encrypt",
+    "- Decrypt",
+    "EnableLogFileValidation: true",
+    "RetentionInDays: 90",
+    "ExpirationInDays: 90",
+  ]);
+  assert.equal(
+    text.includes("ExcludeManagementEventSources"),
+    false,
+    "the trail must not exclude kms.amazonaws.com management events",
+  );
+});
+
+test("KMS CloudWatch template separates blockchain and JWT signer alarms", async () => {
+  const text = await templateText();
+  assertIncludesAll(text, [
+    "BlockchainSignerKeyArn:",
+    "JwtSignerKeyArn:",
+    "BlockchainKMSSignCallCount",
+    "JwtKMSSignCallCount",
+    "BlockchainKMSSignErrorCount",
+    "JwtKMSSignErrorCount",
+    "Key: ErrorCode",
+    "Value: $.errorCode",
+    "BlockchainKMSAccessDeniedCount",
+    "JwtKMSAccessDeniedCount",
+    "BlockchainKMSGetPublicKeyCallCount",
+    "JwtKMSGetPublicKeyCallCount",
+    "averray-${EnvironmentName}-blockchain-kms-sign-error",
+    "averray-${EnvironmentName}-jwt-kms-sign-error",
+    "averray-${EnvironmentName}-blockchain-kms-access-denied",
+    "averray-${EnvironmentName}-jwt-kms-access-denied",
+  ]);
+});
+
+test("KMS CloudWatch template requires baseline-derived spike thresholds", async () => {
+  const text = await templateText();
+  for (const parameterName of [
+    "BlockchainSignSpikeThresholdPer5Min",
+    "JwtSignSpikeThresholdPer5Min",
+    "AuthFailureThresholdPer5Min",
+  ]) {
+    const parameterBlock = text.match(new RegExp(`  ${parameterName}:\\n(?<body>(?:    .+\\n)+)`))?.groups?.body ?? "";
+    assert.ok(parameterBlock.includes("Type: Number"), `${parameterName} should be a Number parameter`);
+    assert.ok(parameterBlock.includes("Intentionally no default."), `${parameterName} should document no default`);
+    assert.equal(parameterBlock.includes("Default:"), false, `${parameterName} must not guess a default threshold`);
+  }
+});
+
+test("KMS CloudWatch template captures backend signer latency and auth anomalies", async () => {
+  const text = await templateText();
+  assertIncludesAll(text, [
+    "BackendLogGroupName:",
+    "FilterPattern: '{ ($.event = \"kms.sign.duration\") && ($.signer = \"blockchain\") && ($.success = true) }'",
+    "FilterPattern: '{ ($.event = \"kms.sign.duration\") && ($.signer = \"jwt\") && ($.success = true) }'",
+    "MetricName: BlockchainKMSSignDurationMs",
+    "MetricName: JwtKMSSignDurationMs",
+    "AuthFailureCount",
+    "AuthRefreshReplayDetectedCount",
+    "\"stat\": \"p50\"",
+    "\"stat\": \"p95\"",
+    "\"stat\": \"p99\"",
+  ]);
+});


### PR DESCRIPTION
## Summary
- add a CloudFormation foundation for KMS CloudTrail delivery, CloudWatch metric filters, signer/auth alarms, and a KMS signing dashboard
- emit structured `kms.sign.duration` logs from the blockchain and JWT KMS signers so CloudWatch can track p50/p95/p99 signing latency
- document KMS/auth alert response steps and move the roadmap row into In Flight

## Implementation note
AWS records KMS API activity such as `Sign`, `GetPublicKey`, `DescribeKey`, `Encrypt`, and `Decrypt` as CloudTrail management events. The template uses an advanced management-event selector scoped to `kms.amazonaws.com` and keeps KMS management events enabled.

## Checks
- `node --test mcp-server/src/blockchain/kms-signer.test.js mcp-server/src/auth/kms-jwt-signer.test.js scripts/ops/kms-cloudwatch-template.test.mjs`
- `npm --workspace mcp-server test`
- `npm run test:ops`
- `git diff --check`
- `git diff --cached --check`

## Impact
- Affects backend structured logging, deploy/iac, and docs.
- No KMS key permissions, IAM role boundary, Roles Anywhere config, env templates, or deployments changed.
- CloudWatch spike thresholds are required stack parameters so operators must pass baseline-derived values.