### PR TITLE
Resolve orphaned old EscrowCore balances

### DIFF
--- a/docs/AUDIT_REMEDIATION.md
+++ b/docs/AUDIT_REMEDIATION.md
@@ -745,17 +745,39 @@ This section captures operator-side security events that are out-of-scope for th
 | 5    | In-process atomic swap of `SIGNER_PRIVATE_KEY` value in `mcp-server/.env.local` from the leaked key to the new admin key (read-derive-verify-write-readback pattern).        | n/a (off-chain)      |
 | 6    | `deployments/testnet.json` updated: `deployer` / `pauser` / `arbitrator` → new admin. Verified by `scripts/ops/audit-launch-readiness.mjs --profile testnet` (all checks green). | n/a (file change)    |
 
-**Retired address.** `0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519` — no longer pauser, no longer approved arbitrator, AAC.positions.liquid drained to 0, EOA PAS balance reduced to dust (~6 PAS). Note: `0.200001` USDC remains in `AAC.positions.reserved` against an in-flight obligation. When that obligation resolves and the reserved unlocks back to `liquid`, the leaked key's `withdraw` capability is moot because the operator backend now signs as the new admin (see Step 5 — `.env.local` was rotated immediately after roles moved, so the legitimate process holds the active key; any race with the leaked key would resolve to the new admin reading first on each ops cycle).
+**Retired address.** `0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519` — no longer pauser, no longer approved arbitrator, AAC.positions.liquid drained to 0, EOA PAS balance reduced to dust (~6 PAS). Verified on 2026-05-26: `AAC.positions(oldAdmin, USDC)` still has `reserved=200001` and `jobStakeLocked=60000`. These amounts no longer have a normal release path because the old EscrowCore `0x7BB8fea44bDeE9870cF27c1dB616E7017BC38b0a` was revoked from `TreasuryPolicy.serviceOperators` during PR #525, and the relevant old EscrowCore settlement/timeout paths call `AgentAccountCore` mutation functions that are `onlyOperator` gated.
 
 **New address.** `0x6778F050eAc8313e4dbB176d7BAB44510E833ac8` — now pauser, approved arbitrator, holds 9.339999 USDC in AAC.positions.liquid and ~9970 PAS native.
 
 **Tooling.** All admin-side scripts under `scripts/ops/rotate-admin-*.mjs` follow a single safety pattern: keys are loaded with `fs.readFileSync` into `ethers.Wallet`, and the `Wallet` object is the only thing that touches the bytes. Address-only output. The `--dry-run` default + `--commit` opt-in mirrors the existing `scripts/ops/admin-topup-kms-signer.mjs` (commit `07ca5a4` on `claude/kms-signer-topup`). For the multisig role rotations the operator signs via browser extension (Talisman / SubWallet / polkadot{.js}) through polkadot-js-apps — the sub-agent never touches Substrate keys.
 
-**Evidence.** `docs/evidence/admin-eoa-rotation-2026-05-25.drain.json` (drain tx hashes + block numbers + state deltas) and `docs/evidence/admin-eoa-rotation-2026-05-25.audit-launch.txt` (post-rotation audit-launch-readiness output). All **role + parameter** checks are green for this rotation. The same audit-launch output also surfaces one **unrelated** finding from PR #521's newly-added deployed-bytecode-selector check — `EscrowCore` is missing `claimJobFor(bytes32,address)` [0x090cf6d5]. That finding is not caused by this rotation (which never touches EscrowCore) and is tracked as a separate redeploy task — see the structured `unrelatedFindings` array in `docs/evidence/admin-eoa-rotation-2026-05-25.json`.
+**Evidence.** `docs/evidence/admin-eoa-rotation-2026-05-25.drain.json` (drain tx hashes + block numbers + state deltas), `docs/evidence/admin-eoa-rotation-2026-05-25.audit-launch.txt` (post-rotation audit-launch-readiness output), and [`docs/evidence/orphaned-balances-2026-05-26.json`](./evidence/orphaned-balances-2026-05-26.json) (fresh read-only chain verification of the orphaned balances). All **role + parameter** checks are green for this rotation. The same audit-launch output also surfaces one **unrelated** finding from PR #521's newly-added deployed-bytecode-selector check — `EscrowCore` is missing `claimJobFor(bytes32,address)` [0x090cf6d5]. That finding is not caused by this rotation (which never touches EscrowCore) and was resolved by the PR #525 EscrowCore redeploy.
+
+**Orphaned balance verification — 2026-05-26.** Read-only chain evidence at [`docs/evidence/orphaned-balances-2026-05-26.json`](./evidence/orphaned-balances-2026-05-26.json) recorded:
+
+- `TreasuryPolicy.serviceOperators(0x7BB8fea44bDeE9870cF27c1dB616E7017BC38b0a) == false`.
+- Old admin `AAC.positions(oldAdmin, USDC)`: `liquid=0`, `reserved=200001`, `jobStakeLocked=60000`, `debtOutstanding=0`.
+- KMS signer `AAC.positions(kmsSigner, USDC)`: `liquid=200000`, `reserved=200000`, `jobStakeLocked=0`, `debtOutstanding=0`.
+- Four unsettled jobs remain on the old EscrowCore:
+  - `0xde082633770170fbab249604d031ac90d8ee966d9e245ce133ea0ab11947429f` — old admin poster/worker, `Submitted`, `claimExpiry=1778682156`, `reward=100000`, `claimStake=0`, `claimFee=0`.
+  - `0x4024b69fed02a193e009a4ca9c6433ad962e1c5de5a7f3683795ded07b9638fa` — old admin poster/worker, `Submitted`, `claimExpiry=1778878728`, `reward=100000`, `claimStake=10000`, `claimFee=50000`.
+  - `0x0ef0e5bb5bb6eedb0c607e052aa11222a1f2a51a3f8e7a4b569b013f54789bf9` — KMS signer poster, no worker, `Open`, `claimExpiry=0`, `reward=100000`.
+  - `0x98e3c985a26d50a744c82d0cd4d8368da455cc20a5ab71ea1e3cd9ae0dae196a` — KMS signer poster, no worker, `Open`, `claimExpiry=0`, `reward=100000`.
+- Total orphaned position tail at verification time: `460001` USDC base units (`0.460001` USDC). The two old-admin submitted jobs account for `200000` base units of reserved USDC; one extra reserved base unit is dust from the prior cutover/debugging sequence.
+
+**Recovery feasibility.** Normal old-escrow release is blocked in practice. [`contracts/EscrowCore.sol`](../contracts/EscrowCore.sol) can only move the old job balances by calling `AgentAccountCore.settleReservedTo`, `refundReserved`, `releaseJobStake`, `slashJobStake`, or `slashClaimFee`. Those functions are all `onlyOperator` in [`contracts/AgentAccountCore.sol`](../contracts/AgentAccountCore.sol), and the old EscrowCore is no longer a service operator in [`contracts/TreasuryPolicy.sol`](../contracts/TreasuryPolicy.sol). There is no dedicated `EscrowCore.recover` or `cancelOpenJob` function in the current contract surface. A recovery attempt would require a deliberate owner/multisig session, for example:
+
+1. Multisig owner temporarily calls `TreasuryPolicy.setServiceOperator(oldEscrowCore, true)`.
+2. Operator executes state-specific old EscrowCore flows (`resolveSinglePayout` / timeout / dispute paths for submitted jobs; claim + submit + resolve for open jobs), or an explicitly reviewed direct-AAC recovery plan that temporarily grants a recovery caller operator status and calls `AgentAccountCore.refundReserved` / `releaseJobStake` directly. The latter bypasses old escrow state and should be treated as a separate recovery runbook, not routine cleanup.
+3. Multisig owner calls `TreasuryPolicy.setServiceOperator(oldEscrowCore, false)` again and verifies both old/new service-operator statuses.
+
+For the old-admin balances, any normal settlement/refund would land liquid value back on the retired/leaked old-admin AAC position, so an additional compromised-key drain or bespoke recovery action would still be needed to move it elsewhere. This increases operational risk for a sub-dollar testnet amount.
+
+**Recommendation.** Accept loss for testnet. Do not attempt recovery for `0.460001` USDC. The recovery procedure would require at least two owner/multisig role changes, one or more state-machine/recovery transactions, and a careful post-check for a value smaller than operator time and risk. Record this as accepted testnet loss and keep the evidence for mainnet launch discipline.
 
 **Follow-ups.**
 
-- [ ] Sweep the `200_001` USDC reserved-then-released amount from the retired admin's AAC position once the in-flight obligation resolves. Owner: Pascal. Verification: `policy.positions(0xFd2EAE…6519, USDC).liquid == 0` after the obligation completes.
+- [x] Verify and write off the `460001` USDC-base-unit orphaned balance tail (`0.460001` USDC) left behind old EscrowCore. Owner: Pascal/Codex. Verification: [`docs/evidence/orphaned-balances-2026-05-26.json`](./evidence/orphaned-balances-2026-05-26.json); recommendation is accepted testnet loss, not recovery.
 - [ ] Delete the `op://prod-backend/signer-private-key/password` 1Password item after the 30-day rollback soak (originally targeted ~2026-06-15 per the Phase 3 cutover; now also covers the 2026-05-25 transcript-leak vector).
 - [ ] Review the operator workflow that placed `SIGNER_PRIVATE_KEY` (deriving to the admin address) into `mcp-server/.env.local` in the first place — see whether `loadKeyFromEnvFile` should be replaced by `op read` invocations for admin-side scripts, so the local file disappears entirely.
 
@@ -822,11 +844,13 @@ redaction commands.
 
 ### Follow-ups that remain open
 
-- The `200_001` USDC reserved tail on the retired
-  `0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519` admin address remains open.
-  After PR #525 redeployed EscrowCore, that tail is tied to the old retired
-  contract path and is effectively orphaned until the original in-flight
-  obligation can be resolved or conclusively written off.
+- The old EscrowCore balance tail is now verified and written off as accepted
+  testnet loss. Evidence:
+  [`docs/evidence/orphaned-balances-2026-05-26.json`](./evidence/orphaned-balances-2026-05-26.json).
+  Total at risk was `0.460001` USDC: old admin `reserved=200001` +
+  `jobStakeLocked=60000`, KMS signer `reserved=200000`. The remediation lesson
+  is to settle or finalize in-flight obligations through reviewed state-machine
+  paths before revoking a contract from `TreasuryPolicy.serviceOperators`.
 - Delete `op://prod-backend/signer-private-key/password` after the 30-day soak
   period ends. That item was already backend-retired by the KMS cutover and is
   now also incident-related.

--- a/docs/OPERATOR_ONBOARDING.md
+++ b/docs/OPERATOR_ONBOARDING.md
@@ -295,6 +295,45 @@ Please run 'eval $(op signin)' first
 Do not print the 1Password error verbatim if it might include item names or
 partial secret context. Print the instruction above, then exit non-zero.
 
+## EscrowCore redeploy orphan-balance check
+
+Before retiring an EscrowCore from `TreasuryPolicy.serviceOperators`, the
+operator must prove the old contract has no unsettled job entries that still
+touch `AgentAccountCore.positions(...).reserved` or `jobStakeLocked`.
+
+`scripts/ops/redeploy-escrowcore.mjs` runs this pre-Phase-2 check during
+`--phase all` and `--phase deploy`:
+
+```bash
+node scripts/ops/redeploy-escrowcore.mjs --phase all
+```
+
+If the check reports unsettled old jobs, stop and settle or finalize them
+through a reviewed state-machine path before wiring the new contract, or
+explicitly accept that the balances may be orphaned after the old contract is
+revoked.
+
+The escape hatch is intentionally loud:
+
+```bash
+node scripts/ops/redeploy-escrowcore.mjs --phase all \
+  --acknowledge-orphaned-balances
+```
+
+`--acknowledge-orphaned-balances` means the operator has reviewed the listed
+jobs, understands that the old EscrowCore may lose the `AgentAccountCore`
+`onlyOperator` capability after Phase 2, and accepts the resulting orphaned
+balance risk. Do not use it as routine cleanup. For mainnet, the expected path
+is to clear all obligations first and run without the flag.
+
+For older contracts deployed before the current manifest window, operators may
+bound the log scan explicitly:
+
+```bash
+node scripts/ops/redeploy-escrowcore.mjs --phase all \
+  --orphan-scan-from-block <old-escrow-deploy-block>
+```
+
 ## 5. Day-to-day duties
 
 ### 5.1 The deploy ritual

--- a/docs/evidence/orphaned-balances-2026-05-26.json
+++ b/docs/evidence/orphaned-balances-2026-05-26.json
@@ -1,0 +1,211 @@
+{
+  "schemaVersion": 1,
+  "kind": "averray.orphanedBalancesEvidence",
+  "profile": "testnet",
+  "generatedAt": "2026-05-26T19:51:20.671Z",
+  "mode": "read_only_chain_verification",
+  "chain": {
+    "name": "Paseo Asset Hub TestNet",
+    "chainId": "420420417",
+    "ethRpc": "https://eth-rpc-testnet.polkadot.io/",
+    "observedBlockNumber": 9329023
+  },
+  "contracts": {
+    "oldEscrowCore": "0x7BB8fea44bDeE9870cF27c1dB616E7017BC38b0a",
+    "newEscrowCore": "0xb8fd8A932F69bD5E39700b7cf6D2920aF84d1B27",
+    "agentAccountCore": "0x71B111d8c9DF84Be26cb9067D27dAd7A2d5E7e08",
+    "treasuryPolicy": "0x648Cc5fdE94435992296C4e5ac642d18bB64c12B",
+    "usdc": "0x0000053900000000000000000000000001200000"
+  },
+  "targets": {
+    "oldAdmin": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+    "kmsSigner": "0x31ad432dFe083B998c69B6dB88A984ec5207ab7F"
+  },
+  "treasuryPolicyReads": {
+    "owner": "0x1f8C4da4AAAC79916350f1fabF1221309591B6F9",
+    "paused": false,
+    "oldEscrowServiceOperator": false,
+    "newEscrowServiceOperator": true
+  },
+  "positions": {
+    "oldAdmin": {
+      "account": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+      "asset": "USDC",
+      "assetAddress": "0x0000053900000000000000000000000001200000",
+      "raw": {
+        "liquid": "0",
+        "reserved": "200001",
+        "strategyAllocated": "0",
+        "collateralLocked": "0",
+        "jobStakeLocked": "60000",
+        "debtOutstanding": "0"
+      },
+      "formatted": {
+        "liquid": "0.0",
+        "reserved": "0.200001",
+        "jobStakeLocked": "0.06",
+        "debtOutstanding": "0.0"
+      }
+    },
+    "kmsSigner": {
+      "account": "0x31ad432dFe083B998c69B6dB88A984ec5207ab7F",
+      "asset": "USDC",
+      "assetAddress": "0x0000053900000000000000000000000001200000",
+      "raw": {
+        "liquid": "200000",
+        "reserved": "200000",
+        "strategyAllocated": "0",
+        "collateralLocked": "0",
+        "jobStakeLocked": "0",
+        "debtOutstanding": "0"
+      },
+      "formatted": {
+        "liquid": "0.2",
+        "reserved": "0.2",
+        "jobStakeLocked": "0.0",
+        "debtOutstanding": "0.0"
+      }
+    }
+  },
+  "oldEscrowLogScan": {
+    "fromBlock": 8700000,
+    "toBlock": 9329023,
+    "chunkSize": 25000,
+    "oldEscrowLogCount": 64,
+    "matchedJobCount": 10,
+    "unsettledMatchedJobCount": 4
+  },
+  "unsettledJobEscrows": [
+    {
+      "jobId": "0xde082633770170fbab249604d031ac90d8ee966d9e245ce133ea0ab11947429f",
+      "poster": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+      "worker": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+      "state": "Submitted",
+      "claimExpiry": "1778682156",
+      "reward": "100000",
+      "claimStake": "0",
+      "claimFee": "0",
+      "released": "0",
+      "firstEvent": {
+        "name": "JobCreated",
+        "blockNumber": 8798331,
+        "transactionHash": "0x341bbcfd87aca515570ac9cb8ce603603eee9e1f52953594c6094fbd967159e8"
+      },
+      "lastObservedEvent": {
+        "name": "Submitted",
+        "blockNumber": 8798335,
+        "transactionHash": "0xa1133398fad6aef3b373030816244e76223d04934f782312a72b0710de6625b2"
+      }
+    },
+    {
+      "jobId": "0x4024b69fed02a193e009a4ca9c6433ad962e1c5de5a7f3683795ded07b9638fa",
+      "poster": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+      "worker": "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+      "state": "Submitted",
+      "claimExpiry": "1778878728",
+      "reward": "100000",
+      "claimStake": "10000",
+      "claimFee": "50000",
+      "released": "0",
+      "firstEvent": {
+        "name": "JobCreated",
+        "blockNumber": 8890635,
+        "transactionHash": "0x867683b820202c5ee95a8f79e644388af18dfd84ca4007a148232087473c74e4"
+      },
+      "lastObservedEvent": {
+        "name": "Submitted",
+        "blockNumber": 8890640,
+        "transactionHash": "0xdf0a065a70da70c4b908010cdb685fed455645d49c885f64b875b71c6b57b7cb"
+      }
+    },
+    {
+      "jobId": "0x0ef0e5bb5bb6eedb0c607e052aa11222a1f2a51a3f8e7a4b569b013f54789bf9",
+      "poster": "0x31ad432dFe083B998c69B6dB88A984ec5207ab7F",
+      "worker": "0x0000000000000000000000000000000000000000",
+      "state": "Open",
+      "claimExpiry": "0",
+      "reward": "100000",
+      "claimStake": "0",
+      "claimFee": "0",
+      "released": "0",
+      "firstEvent": {
+        "name": "JobCreated",
+        "blockNumber": 9254892,
+        "transactionHash": "0x7a23830c95205790017dc92120fc352173489995f095b57837e28824370125e5"
+      },
+      "lastObservedEvent": {
+        "name": "JobFunded",
+        "blockNumber": 9254892,
+        "transactionHash": "0x7a23830c95205790017dc92120fc352173489995f095b57837e28824370125e5"
+      }
+    },
+    {
+      "jobId": "0x98e3c985a26d50a744c82d0cd4d8368da455cc20a5ab71ea1e3cd9ae0dae196a",
+      "poster": "0x31ad432dFe083B998c69B6dB88A984ec5207ab7F",
+      "worker": "0x0000000000000000000000000000000000000000",
+      "state": "Open",
+      "claimExpiry": "0",
+      "reward": "100000",
+      "claimStake": "0",
+      "claimFee": "0",
+      "released": "0",
+      "firstEvent": {
+        "name": "JobCreated",
+        "blockNumber": 9280145,
+        "transactionHash": "0x8152cb87dd6e77aba27bbad6aacd10b71c6e9b0c0b0ca0457776070adb630f0f"
+      },
+      "lastObservedEvent": {
+        "name": "JobFunded",
+        "blockNumber": 9280145,
+        "transactionHash": "0x8152cb87dd6e77aba27bbad6aacd10b71c6e9b0c0b0ca0457776070adb630f0f"
+      }
+    }
+  ],
+  "accountingSummary": {
+    "oldAdminReservedRaw": "200001",
+    "oldAdminJobStakeLockedRaw": "60000",
+    "kmsSignerReservedRaw": "200000",
+    "totalAtRiskRaw": "460001",
+    "totalAtRiskUsdc": "0.460001",
+    "notes": [
+      "The two old-admin Submitted jobs account for 200000 base units of reserved USDC; the observed position has one additional reserved base unit of dust.",
+      "The second old-admin Submitted job accounts for 10000 base units of claim stake plus 50000 base units of claim fee locked as jobStakeLocked.",
+      "The two KMS-signer Open jobs account for 200000 base units of reserved USDC."
+    ]
+  },
+  "contractCodePaths": [
+    {
+      "file": "contracts/EscrowCore.sol",
+      "paths": [
+        "resolveSinglePayout -> AgentAccountCore.settleReservedTo/refundReserved/releaseJobStake",
+        "resolveMilestone -> AgentAccountCore.settleReservedTo/refundReserved/releaseJobStake",
+        "handleClaimTimeout -> AgentAccountCore.slashJobStake/slashClaimFee",
+        "finalizeRejectedJob -> _refundPosterBalances/_slashRejectedWorker",
+        "resolveDispute/autoResolveOnTimeout -> _resolveDispute"
+      ]
+    },
+    {
+      "file": "contracts/AgentAccountCore.sol",
+      "paths": [
+        "refundReserved is onlyOperator",
+        "settleReservedTo is onlyOperator",
+        "releaseJobStake is onlyOperator",
+        "slashJobStake is onlyOperator",
+        "slashClaimFee is onlyOperator"
+      ]
+    },
+    {
+      "file": "contracts/TreasuryPolicy.sol",
+      "paths": [
+        "setServiceOperator is onlyOwner",
+        "serviceOperators(oldEscrowCore) currently reads false"
+      ]
+    }
+  ],
+  "conclusion": {
+    "normalOldEscrowReleaseBlocked": true,
+    "reason": "The old EscrowCore still owns the only normal state-machine paths for these jobs, but TreasuryPolicy.serviceOperators(oldEscrowCore) is false. EscrowCore callbacks into AgentAccountCore value-mutation functions therefore revert at AgentAccountCore.onlyOperator.",
+    "recommendedRemediation": "accept_loss_testnet",
+    "recoveryNotAttempted": true
+  }
+}

--- a/docs/roadmap-updates/2026-05-26-codex-orphaned-balances-audit.md
+++ b/docs/roadmap-updates/2026-05-26-codex-orphaned-balances-audit.md
@@ -1,0 +1,44 @@
+# Roadmap Update: Orphaned old EscrowCore balance audit
+
+- **Date:** 2026-05-26
+- **Agent:** Codex / `codex/orphaned-balances-audit-and-runbook-hardening`
+- **Roadmap section:** P0 Launch Gates / Audit remediation follow-ups
+- **Item:** 2026-05-25 old EscrowCore orphaned USDC balances
+- **Related PRs/issues:** current PR
+- **Proposed status:** Done
+- **Owner:** Roadmap steward
+
+## Summary
+
+This slice verifies the old EscrowCore tail state left by the 2026-05-25
+cutover, documents that normal old-escrow release is blocked after the old
+contract was revoked from `TreasuryPolicy.serviceOperators`, and recommends
+accepting the sub-dollar testnet loss rather than running a multisig recovery.
+It also adds a pre-retirement orphan-balance guard to the EscrowCore redeploy
+runbook so future retirements fail loudly when unsettled old jobs still touch
+`AgentAccountCore` reserved or locked-stake balances.
+
+## Evidence
+
+- Read-only chain evidence:
+  `docs/evidence/orphaned-balances-2026-05-26.json`.
+- Audit trail update:
+  `docs/AUDIT_REMEDIATION.md`.
+- Operator runbook guard:
+  `scripts/ops/redeploy-escrowcore.mjs`.
+- Focused test coverage:
+  `node --test scripts/ops/redeploy-escrowcore.test.mjs`.
+
+## Blockers Or Caveats
+
+- No funds were moved and no recovery was attempted. The documented
+  recommendation is accepted testnet loss for `0.460001` USDC.
+- The guard prevents silent future retirements, but operators can still bypass
+  with `--acknowledge-orphaned-balances` after explicit review.
+
+## Requested Roadmap Change
+
+Mark the 2026-05-25 `AUDIT_REMEDIATION` follow-up for old EscrowCore orphaned
+balances as closed after this PR merges. Keep the evidence link in the
+canonical roadmap or launch-gate notes if the steward wants this visible during
+mainnet readiness review.

--- a/scripts/ops/redeploy-escrowcore.mjs
+++ b/scripts/ops/redeploy-escrowcore.mjs
@@ -70,7 +70,16 @@
  *     --multisig-exec-tx 0xEXEC_TX --commit
  */
 
-import { JsonRpcProvider, Wallet, Contract, ContractFactory, Interface, formatEther, getCreateAddress } from "ethers";
+import {
+  JsonRpcProvider,
+  Wallet,
+  Contract,
+  ContractFactory,
+  Interface,
+  ZeroAddress,
+  formatUnits,
+  getCreateAddress
+} from "ethers";
 import { readFile, writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
@@ -85,8 +94,33 @@ const TREASURY_POLICY_ABI = [
   "function setServiceOperator(address account, bool allowed)"
 ];
 
+const AGENT_ACCOUNT_READ_ABI = [
+  "function positions(address account, address asset) view returns (uint256 liquid,uint256 reserved,uint256 strategyAllocated,uint256 collateralLocked,uint256 jobStakeLocked,uint256 debtOutstanding)"
+];
+
+const ESCROW_TAIL_SCAN_ABI = [
+  "function jobs(bytes32 jobId) view returns (address poster,address worker,address asset,bytes32 verifierMode,bytes32 category,bytes32 specHash,uint256 reward,uint256 opsReserve,uint256 contingencyReserve,uint256 released,uint256 claimExpiry,uint256 claimStake,uint16 claimStakeBps,uint256 claimFee,uint16 claimFeeBps,bool claimEconomicsWaived,address rejectingVerifier,uint256 rejectedAt,uint256 disputedAt,uint8 payoutMode,uint8 state)",
+  "event JobCreated(bytes32 indexed jobId,address indexed poster,bytes32 indexed specHash,address asset,uint256 totalReserved,uint8 payoutMode)",
+  "event JobFunded(bytes32 indexed jobId,address indexed poster,address indexed asset,uint256 totalReserved,uint8 payoutMode)",
+  "event RecurringJobFundedFromTemplate(bytes32 indexed jobId,bytes32 indexed templateId,address indexed poster,address asset,uint256 totalReserved)",
+  "event JobClaimed(bytes32 indexed jobId,address indexed worker,uint256 claimExpiry,uint256 claimStake)",
+  "event ClaimEconomicsLocked(bytes32 indexed jobId,address indexed worker,uint256 claimStake,uint256 claimFee,bool waived,uint256 claimNumber)",
+  "event WorkSubmitted(bytes32 indexed jobId,address indexed worker,bytes32 evidenceHash)",
+  "event Submitted(bytes32 indexed jobId,address indexed worker,bytes32 indexed payloadHash)",
+  "event JobReopened(bytes32 indexed jobId)",
+  "event JobRejected(bytes32 indexed jobId,bytes32 reasonCode)",
+  "event Verified(bytes32 indexed jobId,address indexed verifier,bool approved,bytes32 reasonCode,bytes32 reasoningHash)",
+  "event DisputeOpened(bytes32 indexed jobId,address indexed opener,uint256 disputedAt)",
+  "event DisputeResolved(bytes32 indexed jobId,address indexed arbitrator,uint256 workerPayout,bytes32 reasonCode,string metadataURI)",
+  "event AutoResolvedOnTimeout(bytes32 indexed jobId,address indexed caller,uint256 workerPayout,bytes32 reasonCode)",
+  "event JobClosed(bytes32 indexed jobId,address indexed worker,uint256 releasedAmount)"
+];
+
 const PHASES = new Set(["deploy", "finalize", "all"]);
 const PRIVATE_KEY_RE = /^0x[a-fA-F0-9]{64}$/u;
+const DEFAULT_ORPHAN_SCAN_CHUNK_SIZE = 25_000;
+const JOB_STATE_NAMES = ["None", "Open", "Claimed", "Submitted", "Rejected", "Disputed", "Closed"];
+const PAYOUT_MODE_NAMES = ["Single", "Milestone"];
 
 /**
  * Spawn `op read <ref>` and capture stdout. The secret is consumed via
@@ -146,7 +180,10 @@ export function parseArgs(argv) {
     signerSecretRef: undefined,
     skipRevoke: false,
     skipManifestUpdate: false,
-    skipAuditRerun: false
+    skipAuditRerun: false,
+    acknowledgeOrphanedBalances: false,
+    orphanScanFromBlock: 0,
+    orphanScanChunkSize: DEFAULT_ORPHAN_SCAN_CHUNK_SIZE
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
@@ -161,6 +198,9 @@ export function parseArgs(argv) {
     else if (arg === "--skip-revoke") args.skipRevoke = true;
     else if (arg === "--skip-manifest-update") args.skipManifestUpdate = true;
     else if (arg === "--skip-audit-rerun") args.skipAuditRerun = true;
+    else if (arg === "--acknowledge-orphaned-balances") args.acknowledgeOrphanedBalances = true;
+    else if (arg === "--orphan-scan-from-block") args.orphanScanFromBlock = Number(argv[++i]);
+    else if (arg === "--orphan-scan-chunk-size") args.orphanScanChunkSize = Number(argv[++i]);
     else if (arg === "--help" || arg === "-h") args.help = true;
   }
   return args;
@@ -179,6 +219,19 @@ function printUsage() {
       "Modes:",
       "  --dry-run                 (default) Print plan, no side effects.",
       "  --commit                  Send/write side effects for the chosen phase.",
+      "",
+      "Pre-Phase-2 safety check:",
+      "  --acknowledge-orphaned-balances",
+      "                            Allow the deploy/all plan to proceed even if the",
+      "                            old EscrowCore still has unsettled jobs tied to",
+      "                            AAC reserved/jobStakeLocked balances. This means",
+      "                            those balances may become orphaned after Phase 2",
+      "                            revokes the old EscrowCore service-operator role.",
+      "  --orphan-scan-from-block <n>",
+      "                            First block to scan for old EscrowCore job events",
+      "                            (default: 0).",
+      "  --orphan-scan-chunk-size <n>",
+      `                            getLogs chunk size (default: ${DEFAULT_ORPHAN_SCAN_CHUNK_SIZE}).`,
       "",
       "Phase 1 (deploy) options:",
       "  --signer-secret-ref <ref> 1Password secret reference, e.g.",
@@ -279,6 +332,229 @@ async function readWiringState({ provider, manifest }) {
     treasury.serviceOperators(manifest.contracts.escrowCore)
   ]);
   return { owner, oldIsOperator };
+}
+
+function assertPositiveInteger(label, value) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative safe integer. Got: ${value}`);
+  }
+}
+
+function normalizePosition(position) {
+  return {
+    liquid: BigInt(position.liquid),
+    reserved: BigInt(position.reserved),
+    strategyAllocated: BigInt(position.strategyAllocated),
+    collateralLocked: BigInt(position.collateralLocked),
+    jobStakeLocked: BigInt(position.jobStakeLocked),
+    debtOutstanding: BigInt(position.debtOutstanding)
+  };
+}
+
+function serializePosition(position, decimals = 6) {
+  const normalized = normalizePosition(position);
+  return {
+    liquid: normalized.liquid.toString(),
+    reserved: normalized.reserved.toString(),
+    strategyAllocated: normalized.strategyAllocated.toString(),
+    collateralLocked: normalized.collateralLocked.toString(),
+    jobStakeLocked: normalized.jobStakeLocked.toString(),
+    debtOutstanding: normalized.debtOutstanding.toString(),
+    formatted: {
+      liquid: formatUnits(normalized.liquid, decimals),
+      reserved: formatUnits(normalized.reserved, decimals),
+      jobStakeLocked: formatUnits(normalized.jobStakeLocked, decimals),
+      debtOutstanding: formatUnits(normalized.debtOutstanding, decimals)
+    }
+  };
+}
+
+function hasReservedOrLockedStake(position) {
+  const normalized = normalizePosition(position);
+  return normalized.reserved > 0n || normalized.jobStakeLocked > 0n;
+}
+
+function serializeJobEscrow(jobId, job) {
+  return {
+    jobId,
+    poster: job.poster,
+    worker: job.worker,
+    asset: job.asset,
+    reward: job.reward.toString(),
+    opsReserve: job.opsReserve.toString(),
+    contingencyReserve: job.contingencyReserve.toString(),
+    released: job.released.toString(),
+    claimExpiry: job.claimExpiry.toString(),
+    claimStake: job.claimStake.toString(),
+    claimFee: job.claimFee.toString(),
+    rejectedAt: job.rejectedAt.toString(),
+    disputedAt: job.disputedAt.toString(),
+    payoutMode: PAYOUT_MODE_NAMES[Number(job.payoutMode)] ?? String(job.payoutMode),
+    state: JOB_STATE_NAMES[Number(job.state)] ?? String(job.state),
+    stateIndex: Number(job.state)
+  };
+}
+
+function getNamedArg(args, name) {
+  try {
+    const value = args[name];
+    return value === undefined ? undefined : value;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function collectOldEscrowJobIds({ provider, escrowAddress, fromBlock = 0, toBlock, chunkSize = DEFAULT_ORPHAN_SCAN_CHUNK_SIZE }) {
+  assertPositiveInteger("fromBlock", fromBlock);
+  assertPositiveInteger("chunkSize", chunkSize);
+  if (chunkSize === 0) throw new Error("chunkSize must be greater than 0.");
+  const latest = toBlock ?? await provider.getBlockNumber();
+  assertPositiveInteger("toBlock", latest);
+
+  const iface = new Interface(ESCROW_TAIL_SCAN_ABI);
+  const jobIds = new Set();
+  let scannedLogCount = 0;
+
+  for (let from = fromBlock; from <= latest; from += chunkSize) {
+    const to = Math.min(latest, from + chunkSize - 1);
+    const logs = await provider.getLogs({ address: escrowAddress, fromBlock: from, toBlock: to });
+    scannedLogCount += logs.length;
+    for (const log of logs) {
+      let parsed;
+      try {
+        parsed = iface.parseLog(log);
+      } catch {
+        continue;
+      }
+      const jobId = getNamedArg(parsed.args, "jobId");
+      if (jobId) jobIds.add(jobId);
+    }
+  }
+
+  return {
+    fromBlock,
+    toBlock: latest,
+    chunkSize,
+    scannedLogCount,
+    jobIds: [...jobIds].sort()
+  };
+}
+
+export async function findUnsettledOldEscrowBalances({ provider, manifest, fromBlock = 0, chunkSize = DEFAULT_ORPHAN_SCAN_CHUNK_SIZE }) {
+  const oldEscrow = manifest.contracts.escrowCore;
+  const accountCore = manifest.contracts.agentAccountCore;
+  assertAddress("contracts.escrowCore", oldEscrow);
+  assertAddress("contracts.agentAccountCore", accountCore);
+
+  const scan = await collectOldEscrowJobIds({ provider, escrowAddress: oldEscrow, fromBlock, chunkSize });
+  const escrow = new Contract(oldEscrow, ESCROW_TAIL_SCAN_ABI, provider);
+  const accounts = new Contract(accountCore, AGENT_ACCOUNT_READ_ABI, provider);
+  const findings = [];
+
+  for (const jobId of scan.jobIds) {
+    const job = await escrow.jobs(jobId);
+    const jobJson = serializeJobEscrow(jobId, job);
+    if (jobJson.state === "None" || jobJson.state === "Closed") {
+      continue;
+    }
+
+    const [posterPositionRaw, workerPositionRaw] = await Promise.all([
+      accounts.positions(job.poster, job.asset),
+      job.worker === ZeroAddress
+        ? Promise.resolve(null)
+        : accounts.positions(job.worker, job.asset)
+    ]);
+
+    const posterHasTail = hasReservedOrLockedStake(posterPositionRaw);
+    const workerHasTail = workerPositionRaw ? hasReservedOrLockedStake(workerPositionRaw) : false;
+    if (!posterHasTail && !workerHasTail) {
+      continue;
+    }
+
+    findings.push({
+      ...jobJson,
+      posterPosition: serializePosition(posterPositionRaw),
+      workerPosition: workerPositionRaw ? serializePosition(workerPositionRaw) : null,
+      nonZeroTails: {
+        poster: posterHasTail,
+        worker: workerHasTail
+      }
+    });
+  }
+
+  return {
+    oldEscrow,
+    agentAccountCore: accountCore,
+    scan: {
+      fromBlock: scan.fromBlock,
+      toBlock: scan.toBlock,
+      chunkSize: scan.chunkSize,
+      scannedLogCount: scan.scannedLogCount,
+      scannedJobCount: scan.jobIds.length
+    },
+    findings
+  };
+}
+
+function formatOrphanedBalanceFinding(finding) {
+  const worker = finding.worker === ZeroAddress ? "(none)" : finding.worker;
+  const posterTail = `${finding.posterPosition.formatted.reserved} reserved / ${finding.posterPosition.formatted.jobStakeLocked} stake`;
+  const workerTail = finding.workerPosition
+    ? `${finding.workerPosition.formatted.reserved} reserved / ${finding.workerPosition.formatted.jobStakeLocked} stake`
+    : "n/a";
+  return [
+    `- ${finding.jobId}`,
+    `  state=${finding.state} claimExpiry=${finding.claimExpiry}`,
+    `  poster=${finding.poster} (${posterTail})`,
+    `  worker=${worker} (${workerTail})`,
+    `  reward=${formatUnits(finding.reward, 6)} USDC claimStake=${formatUnits(finding.claimStake, 6)} claimFee=${formatUnits(finding.claimFee, 6)}`
+  ].join("\n");
+}
+
+export function evaluateOrphanedBalancePreflight(report, { acknowledge = false } = {}) {
+  if (!report.findings.length) {
+    return {
+      ok: true,
+      acknowledged: false,
+      message: `No unsettled old EscrowCore jobs with non-zero AAC reserved/jobStakeLocked tails found across ${report.scan.scannedJobCount} scanned job(s).`
+    };
+  }
+
+  const body = report.findings.map(formatOrphanedBalanceFinding).join("\n");
+  const message = [
+    `${report.findings.length} unsettled old EscrowCore job(s) still touch AAC reserved/jobStakeLocked balances.`,
+    `Retiring ${report.oldEscrow} from TreasuryPolicy.serviceOperators can orphan those balances because normal escrow release paths call AgentAccountCore onlyOperator mutation functions.`,
+    "",
+    body
+  ].join("\n");
+
+  if (acknowledge) {
+    return {
+      ok: true,
+      acknowledged: true,
+      message: `${message}\n\nAcknowledged via --acknowledge-orphaned-balances; continuing.`
+    };
+  }
+
+  throw new Error(
+    `${message}\n\nAbort: settle or finalize these jobs first, or pass --acknowledge-orphaned-balances to record that the operator accepts the orphaning risk.`
+  );
+}
+
+async function runOrphanedBalancePreflight({ args, provider, manifest }) {
+  const report = await findUnsettledOldEscrowBalances({
+    provider,
+    manifest,
+    fromBlock: args.orphanScanFromBlock,
+    chunkSize: args.orphanScanChunkSize
+  });
+  const decision = evaluateOrphanedBalancePreflight(report, {
+    acknowledge: args.acknowledgeOrphanedBalances
+  });
+  const log = decision.acknowledged ? console.warn : console.log;
+  log(`\n## Pre-Phase-2 orphaned balance check`);
+  log(decision.message);
+  return { report, decision };
 }
 
 function runAudit(profile) {
@@ -549,6 +825,8 @@ async function main() {
     await runFinalize({ args, deploymentsPath, manifest, provider, wiringState });
     return;
   }
+
+  await runOrphanedBalancePreflight({ args, provider, manifest });
 
   // --phase deploy: print plan; with --commit, send EVM CREATE.
   if (args.phase === "deploy") {

--- a/scripts/ops/redeploy-escrowcore.test.mjs
+++ b/scripts/ops/redeploy-escrowcore.test.mjs
@@ -1,7 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { Interface } from "ethers";
-import { parseArgs, loadKeyFromOp, rewriteEscrowAddressInTemplate } from "./redeploy-escrowcore.mjs";
+import {
+  parseArgs,
+  loadKeyFromOp,
+  rewriteEscrowAddressInTemplate,
+  evaluateOrphanedBalancePreflight
+} from "./redeploy-escrowcore.mjs";
 
 test("parseArgs defaults to dry-run + phase=all + profile=testnet", () => {
   const args = parseArgs([]);
@@ -50,6 +55,18 @@ test("parseArgs collects --skip-* flags", () => {
   ]);
   assert.equal(args.skipManifestUpdate, true);
   assert.equal(args.skipAuditRerun, true);
+});
+
+test("parseArgs collects orphaned balance acknowledgement flags", () => {
+  const args = parseArgs([
+    "--phase", "deploy",
+    "--acknowledge-orphaned-balances",
+    "--orphan-scan-from-block", "8800000",
+    "--orphan-scan-chunk-size", "5000"
+  ]);
+  assert.equal(args.acknowledgeOrphanedBalances, true);
+  assert.equal(args.orphanScanFromBlock, 8_800_000);
+  assert.equal(args.orphanScanChunkSize, 5_000);
 });
 
 test("loadKeyFromOp rejects refs that aren't op://", () => {
@@ -108,4 +125,95 @@ test("rewriteEscrowAddressInTemplate reports missing ESCROW_CORE_ADDRESS line", 
   const result = rewriteEscrowAddressInTemplate("FOO=bar\n", "0xb8fd8A932F69bD5E39700b7cf6D2920aF84d1B27");
   assert.equal(result.changed, false);
   assert.equal(result.reason, "no ESCROW_CORE_ADDRESS line");
+});
+
+function syntheticPreflightReport(findings) {
+  return {
+    oldEscrow: "0x7BB8fea44bDeE9870cF27c1dB616E7017BC38b0a",
+    agentAccountCore: "0x71B111d8c9DF84Be26cb9067D27dAd7A2d5E7e08",
+    scan: {
+      fromBlock: 8_800_000,
+      toBlock: 9_300_000,
+      chunkSize: 25_000,
+      scannedLogCount: 58,
+      scannedJobCount: 9
+    },
+    findings
+  };
+}
+
+function syntheticFinding(overrides = {}) {
+  const emptyPosition = {
+    liquid: "0",
+    reserved: "0",
+    strategyAllocated: "0",
+    collateralLocked: "0",
+    jobStakeLocked: "0",
+    debtOutstanding: "0",
+    formatted: {
+      liquid: "0.0",
+      reserved: "0.0",
+      jobStakeLocked: "0.0",
+      debtOutstanding: "0.0"
+    }
+  };
+  return {
+    jobId: "0x" + "42".repeat(32),
+    poster: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+    worker: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519",
+    asset: "0x0000053900000000000000000000000001200000",
+    reward: "100000",
+    opsReserve: "0",
+    contingencyReserve: "0",
+    released: "0",
+    claimExpiry: "1778878728",
+    claimStake: "10000",
+    claimFee: "50000",
+    rejectedAt: "0",
+    disputedAt: "0",
+    payoutMode: "Single",
+    state: "Submitted",
+    stateIndex: 3,
+    posterPosition: {
+      ...emptyPosition,
+      reserved: "200001",
+      jobStakeLocked: "60000",
+      formatted: {
+        ...emptyPosition.formatted,
+        reserved: "0.200001",
+        jobStakeLocked: "0.06"
+      }
+    },
+    workerPosition: emptyPosition,
+    nonZeroTails: {
+      poster: true,
+      worker: false
+    },
+    ...overrides
+  };
+}
+
+test("evaluateOrphanedBalancePreflight passes clean synthetic escrow state", () => {
+  const decision = evaluateOrphanedBalancePreflight(syntheticPreflightReport([]));
+  assert.equal(decision.ok, true);
+  assert.equal(decision.acknowledged, false);
+  assert.match(decision.message, /No unsettled old EscrowCore jobs/u);
+});
+
+test("evaluateOrphanedBalancePreflight aborts on synthetic stuck balances", () => {
+  assert.throws(
+    () => evaluateOrphanedBalancePreflight(syntheticPreflightReport([syntheticFinding()])),
+    /Abort: settle or finalize these jobs first/u
+  );
+});
+
+test("evaluateOrphanedBalancePreflight bypasses stuck balances with explicit acknowledgement", () => {
+  const decision = evaluateOrphanedBalancePreflight(
+    syntheticPreflightReport([syntheticFinding()]),
+    { acknowledge: true }
+  );
+  assert.equal(decision.ok, true);
+  assert.equal(decision.acknowledged, true);
+  assert.match(decision.message, /Acknowledged via --acknowledge-orphaned-balances/u);
+  assert.match(decision.message, /state=Submitted claimExpiry=1778878728/u);
 });


### PR DESCRIPTION
## Summary
- add read-only evidence for the old EscrowCore orphaned USDC tails and document the accept-loss testnet recommendation
- update AUDIT_REMEDIATION and operator onboarding with the verified recovery analysis and runbook guidance
- harden redeploy-escrowcore with an orphaned-balance preflight plus explicit acknowledgement flag
- add roadmap fragment for steward consolidation

## Checks
- node --test scripts/ops/redeploy-escrowcore.test.mjs
- npm run test:ops
- node --test scripts/ops/check-ai-instruction-integrity.test.mjs
- git diff --check / git diff --cached --check
- evidence JSON parse check

## Scope
Affects docs and scripts/ops only. No deployments, address manifests, contract changes, or chain mutations. Read-only chain evidence was captured in docs/evidence/orphaned-balances-2026-05-26.json.