### PR TITLE
feat: register trusted external job schemas

### DIFF
--- a/contracts/EscrowCore.sol
+++ b/contracts/EscrowCore.sol
@@ -61,6 +61,13 @@ contract EscrowCore is ReentrancyGuard {
         JobState state;
     }
 
+    struct ExternalSchemaRegistration {
+        bytes32 schemaHash;
+        string schemaUrl;
+        address schemaIssuer;
+        bytes schemaSignature;
+    }
+
     struct RecurringSinglePayoutJob {
         bytes32 jobId;
         bytes32 templateId;
@@ -73,9 +80,14 @@ contract EscrowCore is ReentrancyGuard {
         bytes32 verifierMode;
         bytes32 category;
         bytes32 specHash;
+        bytes32 schemaHash;
+        string schemaUrl;
+        address schemaIssuer;
+        bytes schemaSignature;
     }
 
     mapping(bytes32 => JobEscrow) internal _jobs;
+    mapping(bytes32 => ExternalSchemaRegistration) public jobExternalSchemas;
     mapping(address => uint256) public workerClaimCount;
     mapping(bytes32 => uint256[]) public milestoneAmounts;
     mapping(bytes32 => mapping(uint256 => bool)) public milestoneReleased;
@@ -98,6 +110,9 @@ contract EscrowCore is ReentrancyGuard {
         address asset,
         uint256 totalReserved,
         PayoutMode payoutMode
+    );
+    event ExternalSchemaRegistered(
+        bytes32 indexed jobId, bytes32 indexed schemaHash, address indexed schemaIssuer, string schemaUrl
     );
     event RecurringJobFundedFromTemplate(
         bytes32 indexed jobId, bytes32 indexed templateId, address indexed poster, address asset, uint256 totalReserved
@@ -135,6 +150,8 @@ contract EscrowCore is ReentrancyGuard {
     error ProtocolPaused();
     error MilestoneLimitExceeded();
     error AlreadyAutoDisclosed();
+    error InvalidSchemaSignature();
+    error UnauthorizedSchemaIssuer(address issuer);
 
     constructor(TreasuryPolicy policy_, AgentAccountCore accounts_, ReputationSBT reputation_) {
         policy = policy_;
@@ -143,30 +160,27 @@ contract EscrowCore is ReentrancyGuard {
     }
 
     modifier onlyVerifier() {
-        if (!policy.verifiers(msg.sender)) revert Unauthorized();
+        _onlyVerifier();
         _;
     }
 
     modifier onlyDisclosurePublisher() {
-        if (msg.sender != policy.owner() && !policy.serviceOperators(msg.sender) && !policy.verifiers(msg.sender)) {
-            revert Unauthorized();
-        }
+        _onlyDisclosurePublisher();
         _;
     }
 
     modifier onlyArbitrator() {
-        if (!policy.arbitrators(msg.sender)) revert Unauthorized();
+        _onlyArbitrator();
         _;
     }
 
     modifier onlyOperator() {
-        if (!policy.serviceOperators(msg.sender)) revert Unauthorized();
+        _onlyOperator();
         _;
     }
 
     modifier onlyParticipant(bytes32 jobId) {
-        JobEscrow memory job = _jobs[jobId];
-        if (msg.sender != job.poster && msg.sender != job.worker) revert Unauthorized();
+        _onlyParticipant(jobId);
         _;
     }
 
@@ -177,8 +191,35 @@ contract EscrowCore is ReentrancyGuard {
     ///      the escrow state machine fail fast with a clearer error instead
     ///      of bubbling an opaque ProtocolPaused from a nested call.
     modifier whenNotPaused() {
-        if (policy.paused()) revert ProtocolPaused();
+        _whenNotPaused();
         _;
+    }
+
+    function _onlyVerifier() internal view {
+        if (!policy.verifiers(msg.sender)) revert Unauthorized();
+    }
+
+    function _onlyDisclosurePublisher() internal view {
+        if (msg.sender != policy.owner() && !policy.serviceOperators(msg.sender) && !policy.verifiers(msg.sender)) {
+            revert Unauthorized();
+        }
+    }
+
+    function _onlyArbitrator() internal view {
+        if (!policy.arbitrators(msg.sender)) revert Unauthorized();
+    }
+
+    function _onlyOperator() internal view {
+        if (!policy.serviceOperators(msg.sender)) revert Unauthorized();
+    }
+
+    function _onlyParticipant(bytes32 jobId) internal view {
+        JobEscrow memory job = _jobs[jobId];
+        if (msg.sender != job.poster && msg.sender != job.worker) revert Unauthorized();
+    }
+
+    function _whenNotPaused() internal view {
+        if (policy.paused()) revert ProtocolPaused();
     }
 
     function jobs(bytes32 jobId) external view returns (JobEscrow memory) {
@@ -213,7 +254,61 @@ contract EscrowCore is ReentrancyGuard {
         bytes32 category,
         bytes32 specHash
     ) external whenNotPaused nonReentrant {
+        ExternalSchemaRegistration memory emptySchema;
+        _createSinglePayoutJob(
+            jobId,
+            asset,
+            reward,
+            opsReserve,
+            contingencyReserve,
+            claimTtl,
+            verifierMode,
+            category,
+            specHash,
+            emptySchema
+        );
+    }
+
+    function createSinglePayoutJob(
+        bytes32 jobId,
+        address asset,
+        uint256 reward,
+        uint256 opsReserve,
+        uint256 contingencyReserve,
+        uint256 claimTtl,
+        bytes32 verifierMode,
+        bytes32 category,
+        bytes32 specHash,
+        ExternalSchemaRegistration calldata externalSchema
+    ) external whenNotPaused nonReentrant {
+        _createSinglePayoutJob(
+            jobId,
+            asset,
+            reward,
+            opsReserve,
+            contingencyReserve,
+            claimTtl,
+            verifierMode,
+            category,
+            specHash,
+            externalSchema
+        );
+    }
+
+    function _createSinglePayoutJob(
+        bytes32 jobId,
+        address asset,
+        uint256 reward,
+        uint256 opsReserve,
+        uint256 contingencyReserve,
+        uint256 claimTtl,
+        bytes32 verifierMode,
+        bytes32 category,
+        bytes32 specHash,
+        ExternalSchemaRegistration memory externalSchema
+    ) internal {
         if (_jobs[jobId].state != JobState.None) revert InvalidState();
+        _validateAndStoreExternalSchema(jobId, externalSchema);
         _jobs[jobId] = JobEscrow({
             poster: msg.sender,
             worker: address(0),
@@ -253,6 +348,7 @@ contract EscrowCore is ReentrancyGuard {
     {
         if (_jobs[params.jobId].state != JobState.None) revert InvalidState();
         if (params.poster == address(0)) revert Unauthorized();
+        _validateAndStoreExternalSchema(params.jobId, _externalSchemaFromRecurring(params));
         JobEscrow storage job = _jobs[params.jobId];
         job.poster = params.poster;
         job.worker = address(0);
@@ -585,6 +681,80 @@ contract EscrowCore is ReentrancyGuard {
         if (workerPayout > 0) {
             reputation.mintBadge(job.worker, job.category, 1, metadataURI);
         }
+    }
+
+    function _externalSchemaFromRecurring(RecurringSinglePayoutJob calldata params)
+        internal
+        pure
+        returns (ExternalSchemaRegistration memory)
+    {
+        return ExternalSchemaRegistration({
+            schemaHash: params.schemaHash,
+            schemaUrl: params.schemaUrl,
+            schemaIssuer: params.schemaIssuer,
+            schemaSignature: params.schemaSignature
+        });
+    }
+
+    function _validateAndStoreExternalSchema(bytes32 jobId, ExternalSchemaRegistration memory externalSchema) internal {
+        bool hasHash = externalSchema.schemaHash != bytes32(0);
+        bool hasUrl = bytes(externalSchema.schemaUrl).length > 0;
+        bool hasIssuer = externalSchema.schemaIssuer != address(0);
+        bool hasSignature = externalSchema.schemaSignature.length > 0;
+        if (!hasHash && !hasUrl && !hasIssuer && !hasSignature) {
+            return;
+        }
+        if (!hasHash || !hasUrl || !hasIssuer || !hasSignature) {
+            revert InvalidSchemaSignature();
+        }
+
+        address recovered = _recoverExternalSchemaSigner(
+            _externalSchemaSigningHash(externalSchema.schemaHash, externalSchema.schemaUrl, jobId),
+            externalSchema.schemaSignature
+        );
+        if (recovered != externalSchema.schemaIssuer) revert InvalidSchemaSignature();
+        if (!policy.trustedSchemaIssuers(externalSchema.schemaIssuer)) {
+            revert UnauthorizedSchemaIssuer(externalSchema.schemaIssuer);
+        }
+
+        jobExternalSchemas[jobId] = externalSchema;
+        emit ExternalSchemaRegistered(
+            jobId, externalSchema.schemaHash, externalSchema.schemaIssuer, externalSchema.schemaUrl
+        );
+    }
+
+    function _externalSchemaSigningHash(bytes32 schemaHash, string memory schemaUrl, bytes32 jobId)
+        internal
+        pure
+        returns (bytes32)
+    {
+        bytes32 digest = keccak256(abi.encode(schemaHash, schemaUrl, jobId));
+        return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", digest));
+    }
+
+    function _recoverExternalSchemaSigner(bytes32 ethSignedHash, bytes memory signature)
+        internal
+        pure
+        returns (address)
+    {
+        if (signature.length != 65) revert InvalidSchemaSignature();
+
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        assembly {
+            r := mload(add(signature, 32))
+            s := mload(add(signature, 64))
+            v := byte(0, mload(add(signature, 96)))
+        }
+        if (v < 27) {
+            v += 27;
+        }
+        if (v != 27 && v != 28) revert InvalidSchemaSignature();
+
+        address signer = ecrecover(ethSignedHash, v, r, s);
+        if (signer == address(0)) revert InvalidSchemaSignature();
+        return signer;
     }
 
     function _computeClaimEconomics(address worker, JobEscrow storage job)

--- a/contracts/TreasuryPolicy.sol
+++ b/contracts/TreasuryPolicy.sol
@@ -30,6 +30,7 @@ contract TreasuryPolicy {
     mapping(address => bool) public approvedAssets;
     mapping(address => bool) public approvedStrategies;
     mapping(address => bool) public serviceOperators;
+    mapping(address => bool) public trustedSchemaIssuers;
     mapping(address => bool) public verifiers;
     mapping(address => uint64) public authorizedSince;
     mapping(address => uint64) public authorizedUntil;
@@ -46,6 +47,7 @@ contract TreasuryPolicy {
     event AssetApprovalUpdated(address indexed asset, bool approved);
     event StrategyApprovalUpdated(address indexed strategy, bool approved);
     event ServiceOperatorUpdated(address indexed operator, bool approved);
+    event TrustedSchemaIssuerSet(address indexed issuer, bool approved);
     event VerifierUpdated(address indexed verifier, bool approved);
     event ArbitratorUpdated(address indexed arbitrator, bool approved);
     event DailyOutflowCapUpdated(uint256 newCap);
@@ -128,6 +130,11 @@ contract TreasuryPolicy {
     function setServiceOperator(address operator, bool approved) external onlyOwner {
         serviceOperators[operator] = approved;
         emit ServiceOperatorUpdated(operator, approved);
+    }
+
+    function setTrustedSchemaIssuer(address issuer, bool approved) external onlyOwner {
+        trustedSchemaIssuers[issuer] = approved;
+        emit TrustedSchemaIssuerSet(issuer, approved);
     }
 
     function setVerifier(address verifier, bool approved) external onlyOwner {

--- a/docs/AVERRAY_WORKING_SPEC.md
+++ b/docs/AVERRAY_WORKING_SPEC.md
@@ -563,6 +563,39 @@ contract DiscoveryRegistry {
 | `EscrowCore` | New `autoResolveOnTimeout(bytes32 jobId)` — permissionless, callable after `ARBITRATOR_SLA = 14 days` from `disputedAt`. Forces full-payout-to-worker resolution with `REASON_ARBITRATOR_TIMEOUT`. | Stake never locks indefinitely. Agent-favorable default — system unavailability is the platform's failure, not the agent's. Anyone can call (typically the agent themselves, to free their stake). |
 | `EscrowCore` | Add `disputedAt` timestamp to job state and `Disputed` event (confirm if exists). | Required for SLA enforcement above. |
 
+### External output schema registration
+
+External posters can bring their own output schema only through an explicitly
+trusted registration path. Built-in job schemas remain server-side defaults.
+External schemas add four fields to the job contract metadata:
+
+- `schemaHash`: `keccak256` of the canonical JSON Schema document.
+- `schemaUrl`: HTTPS fetch hint for the schema document.
+- `schemaIssuer`: EVM address that endorsed the schema.
+- `schemaSignature`: EIP-191 signature by `schemaIssuer` over
+  `keccak256(abi.encode(schemaHash, schemaUrl, jobId))`.
+
+`TreasuryPolicy.trustedSchemaIssuers(address)` is the trust boundary. The
+owner multisig approves issuers through `setTrustedSchemaIssuer(issuer, true)`;
+`EscrowCore` rejects external schema jobs when the issuer is unset, the
+signature does not recover to `schemaIssuer`, or the issuer is not trusted.
+Built-in schemas omit all four fields and keep the existing path.
+
+The backend mirrors the same validation before broadcasting a job transaction:
+`POST /admin/jobs` accepts optional `externalSchema`, verifies the EIP-191
+signature, checks the trusted-issuer policy, fetches the schema URL, verifies
+the content hash, and stores the registration on the job definition. Runtime
+submission validation selects the registered external schema for that job and
+falls back to built-in validation only when no external schema registration is
+present. This keeps the public receipt trail honest: the schema used to judge a
+submission is the one the trusted issuer signed and the contract committed to.
+
+First-slice close criteria remain operational, not just code-level: redeploy
+the changed contracts, approve at least one schema issuer through multisig,
+post an off-platform-schema job through the hosted admin API, submit work
+against that schema, and capture hosted proof before marking the roadmap row
+Done or Proofed.
+
 ### Reason-code registry (off-chain convention)
 
 `EscrowCore.resolveDispute` accepts freeform `bytes32 reasonCode` — the contract doesn't restrict values. The platform conventions are documented and indexer-recognized:
@@ -1084,6 +1117,18 @@ Stripe Link's launch and Stripe Sessions 2026 announcements positioned agents as
 
 For traceability.
 
+### v2.13 (external schema registration first slice)
+
+1. **§8** Added the external output schema registration flow. External schemas
+   are optional job metadata, signed by an EVM issuer over
+   `keccak256(abi.encode(schemaHash, schemaUrl, jobId))`, approved through
+   `TreasuryPolicy.trustedSchemaIssuers`, stored with the job contract
+   metadata, and re-used by runtime submission validation.
+2. **Operator gate preserved:** the spec now states that the code slice is not
+   enough to mark the roadmap row Done or Proofed. Contract redeploy, multisig
+   `setTrustedSchemaIssuer`, hosted admin-job creation, hosted submission
+   validation, and proof capture are still required.
+
 ### v2.12 (spec-consolidation pass)
 
 1. **v2.5 Phase 1 storage discipline restored into the consolidated spec:** the uploaded v2.5 working spec carried an important three-layer content-storage model that was not present in the current consolidated `AVERRAY_WORKING_SPEC.md`. This pass ports the durable parts into §8 while preserving the newer v2.10 blockchain audit corrections and v2.11 documentation-governance authority.
@@ -1329,4 +1374,4 @@ External verification work resolved every ⏳ item in `AVERRAY_VERIFICATION_LEDG
 
 ---
 
-*Last updated: 2026-05-24*
+*Last updated: 2026-05-26*

--- a/docs/OPERATOR_ONBOARDING.md
+++ b/docs/OPERATOR_ONBOARDING.md
@@ -488,6 +488,48 @@ Both docs cite `<pkuriger@averray.com>` (primary) and `<ops@averray.com>`
 ownership, confirm those addresses route to you and update if they do
 not.
 
+### 5.6 Adding a trusted schema issuer
+
+External job schemas are not trusted just because a poster supplies a URL.
+The contract path requires an EVM issuer signature and an owner-approved
+issuer entry in `TreasuryPolicy.trustedSchemaIssuers`. Treat issuer approval
+like `setServiceOperator`: it is an owner-multisig operation, not a backend
+admin shortcut.
+
+Before proposing the multisig call:
+
+1. Confirm the issuer address is an EVM address controlled by the schema
+   publisher and that the issuer can sign an EIP-191 message.
+2. Confirm the schema document is canonical JSON Schema served at the expected
+   HTTPS URL and that its `keccak256` hash matches the registration request.
+3. Dry-run one representative registration through the backend or local
+   `schema-registry` validation path so bad URLs, bad hashes, or bad
+   signatures fail before signers touch wallets.
+
+The owner-gated call is:
+
+```solidity
+TreasuryPolicy.setTrustedSchemaIssuer(address issuer, bool approved)
+```
+
+Run it with the same two-leg `multisig.asMulti` flow documented in
+[`MULTISIG_SETUP.md`](./MULTISIG_SETUP.md). For batching, it can share a
+`utility.batchAll` with adjacent owner-gated policy changes, but do not bundle
+it with an unrelated emergency rotation unless the incident runbook says so.
+
+After the second leg lands:
+
+1. Read `TreasuryPolicy.trustedSchemaIssuers(issuer)` from chain and confirm it
+   returns `true`.
+2. Run the launch-readiness audit script and confirm the trusted-schema-issuer
+   section is green for any configured external-schema jobs.
+3. Only then post the external-schema job through `/admin/jobs`. The job must
+   carry `externalSchema.schemaHash`, `externalSchema.schemaUrl`,
+   `externalSchema.schemaIssuer`, and `externalSchema.signature`.
+4. Capture hosted proof that the off-platform schema was registered, fetched,
+   hash-checked, and used for submission validation before marking the roadmap
+   item Done or Proofed.
+
 ## 6. Recovery playbooks
 
 These exist as separate documents; this section is just the routing

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,4 +4,4 @@ test = "test"
 solc = "0.8.24"
 optimizer = true
 optimizer_runs = 200
-
+via_ir = true

--- a/mcp-server/src/blockchain/abis.js
+++ b/mcp-server/src/blockchain/abis.js
@@ -34,7 +34,9 @@ export const AGENT_ACCOUNT_ABI = [
 
 export const ESCROW_CORE_ABI = [
   "function createSinglePayoutJob(bytes32 jobId, address asset, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 claimTtl, bytes32 verifierMode, bytes32 category, bytes32 specHash)",
-  "function createSinglePayoutJobFromRecurringReserve((bytes32 jobId, bytes32 templateId, address poster, address asset, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 claimTtl, bytes32 verifierMode, bytes32 category, bytes32 specHash) params)",
+  "function createSinglePayoutJob(bytes32 jobId, address asset, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 claimTtl, bytes32 verifierMode, bytes32 category, bytes32 specHash, (bytes32 schemaHash, string schemaUrl, address schemaIssuer, bytes schemaSignature) externalSchema)",
+  "function createSinglePayoutJobFromRecurringReserve((bytes32 jobId, bytes32 templateId, address poster, address asset, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 claimTtl, bytes32 verifierMode, bytes32 category, bytes32 specHash, bytes32 schemaHash, string schemaUrl, address schemaIssuer, bytes schemaSignature) params)",
+  "function jobExternalSchemas(bytes32 jobId) view returns (bytes32 schemaHash, string schemaUrl, address schemaIssuer, bytes schemaSignature)",
   "function claimJob(bytes32 jobId)",
   "function claimJobFor(bytes32 jobId, address worker)",
   "function handleClaimTimeout(bytes32 jobId)",
@@ -52,6 +54,7 @@ export const ESCROW_CORE_ABI = [
   "function jobs(bytes32 jobId) view returns ((address poster, address worker, address asset, bytes32 verifierMode, bytes32 category, bytes32 specHash, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 released, uint256 claimExpiry, uint256 claimStake, uint16 claimStakeBps, uint256 claimFee, uint16 claimFeeBps, bool claimEconomicsWaived, address rejectingVerifier, uint256 rejectedAt, uint256 disputedAt, uint8 payoutMode, uint8 state))",
   "event JobFunded(bytes32 indexed jobId, address indexed poster, address indexed asset, uint256 totalReserved, uint8 payoutMode)",
   "event JobCreated(bytes32 indexed jobId, address indexed poster, bytes32 indexed specHash, address asset, uint256 totalReserved, uint8 payoutMode)",
+  "event ExternalSchemaRegistered(bytes32 indexed jobId, bytes32 indexed schemaHash, address indexed schemaIssuer, string schemaUrl)",
   "event RecurringJobFundedFromTemplate(bytes32 indexed jobId, bytes32 indexed templateId, address indexed poster, address asset, uint256 totalReserved)",
   "event JobClaimed(bytes32 indexed jobId, address indexed worker, uint256 claimExpiry, uint256 claimStake)",
   "event ClaimEconomicsLocked(bytes32 indexed jobId, address indexed worker, uint256 claimStake, uint256 claimFee, bool waived, uint256 claimNumber)",
@@ -101,11 +104,14 @@ export const TREASURY_POLICY_ABI = [
   "function disputeLossSkillPenalty() view returns (uint256)",
   "function disputeLossReliabilityPenalty() view returns (uint256)",
   "function serviceOperators(address operator) view returns (bool)",
+  "function trustedSchemaIssuers(address issuer) view returns (bool)",
+  "function setTrustedSchemaIssuer(address issuer, bool approved)",
   "function verifiers(address verifier) view returns (bool)",
   "function authorizedSince(address verifier) view returns (uint64)",
   "function authorizedUntil(address verifier) view returns (uint64)",
   "function wasAuthorizedAt(address verifier, uint64 timestamp) view returns (bool)",
-  "event VerifierUpdated(address indexed verifier, bool approved)"
+  "event VerifierUpdated(address indexed verifier, bool approved)",
+  "event TrustedSchemaIssuerSet(address indexed issuer, bool approved)"
 ];
 
 export const ERC20_MOCK_ABI = [

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -30,6 +30,7 @@ import {
 } from "../services/aws-credentials.js";
 import { buildXcmRequestPayload } from "./xcm-message-builder.js";
 import { hashCanonicalContent } from "../core/canonical-content.js";
+import { getRegisteredJobSchemaRegistration } from "../core/job-schema-registry.js";
 import {
   BlockchainRevertError,
   ConfigError,
@@ -46,6 +47,14 @@ const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const MAX_SAFE_INTEGER_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
 const UINT64_MAX = (1n << 64n) - 1n;
 const UINT256_MAX = (1n << 256n) - 1n;
+const EMPTY_EXTERNAL_SCHEMA = {
+  schemaHash: ZERO_BYTES32,
+  schemaUrl: "",
+  schemaIssuer: ZERO_ADDRESS,
+  schemaSignature: "0x"
+};
+const CREATE_SINGLE_PAYOUT_WITH_SCHEMA =
+  "createSinglePayoutJob(bytes32,address,uint256,uint256,uint256,uint256,bytes32,bytes32,bytes32,(bytes32,string,address,bytes))";
 
 function summarizeSupportedAssets(assets = []) {
   return assets.map(summarizeSupportedAsset);
@@ -948,6 +957,15 @@ export class BlockchainGateway {
     });
   }
 
+  async isTrustedSchemaIssuer(issuer) {
+    return this.withGatewayError("isTrustedSchemaIssuer", async () => {
+      if (!this.policyContract?.trustedSchemaIssuers) {
+        return false;
+      }
+      return Boolean(await this.policyContract.trustedSchemaIssuers(issuer));
+    });
+  }
+
   async discloseContent(hash, byWallet = undefined) {
     return this.withGatewayError("discloseContent", async () => {
       this.requireSigner("discloseContent");
@@ -1036,7 +1054,8 @@ export class BlockchainGateway {
     claimTtl,
     verifierMode,
     category,
-    specHash
+    specHash,
+    externalSchema = EMPTY_EXTERNAL_SCHEMA
   ) {
     if (contractLayout === "legacy") {
       return this.legacyEscrowContract.createSinglePayoutJob(
@@ -1048,6 +1067,20 @@ export class BlockchainGateway {
         claimTtl,
         verifierMode,
         category
+      );
+    }
+    if (this.hasExternalSchemaMetadata(externalSchema)) {
+      return this.escrowContract[CREATE_SINGLE_PAYOUT_WITH_SCHEMA](
+        jobId,
+        assetAddress,
+        reward,
+        opsReserve,
+        contingencyReserve,
+        claimTtl,
+        verifierMode,
+        category,
+        specHash,
+        externalSchema
       );
     }
     return this.escrowContract.createSinglePayoutJob(
@@ -1077,6 +1110,7 @@ export class BlockchainGateway {
     specHash
   ) {
     const funding = job?.funding;
+    const externalSchema = this.externalSchemaMetadataForJob(job);
     if (
       contractLayout !== "legacy"
       && funding?.source === "recurring_template_reserve"
@@ -1094,7 +1128,8 @@ export class BlockchainGateway {
         claimTtl,
         verifierMode,
         category,
-        specHash
+        specHash,
+        ...externalSchema
       });
     }
     return this.createSinglePayoutJobForLayout(
@@ -1107,7 +1142,34 @@ export class BlockchainGateway {
       claimTtl,
       verifierMode,
       category,
-      specHash
+      specHash,
+      externalSchema
+    );
+  }
+
+  externalSchemaMetadataForJob(job) {
+    const registration = getRegisteredJobSchemaRegistration(job?.outputSchemaRef, job?.schemaRegistrations);
+    if (registration?.registrationVersion !== "external-job-schema-eip191-v1") {
+      return EMPTY_EXTERNAL_SCHEMA;
+    }
+    return {
+      schemaHash: registration.schemaHash,
+      schemaUrl: registration.schemaUrl,
+      schemaIssuer: registration.schemaIssuer ?? registration.issuer,
+      schemaSignature: registration.signature
+    };
+  }
+
+  hasExternalSchemaMetadata(externalSchema) {
+    return Boolean(
+      externalSchema
+        && externalSchema.schemaHash
+        && externalSchema.schemaHash !== ZERO_BYTES32
+        && externalSchema.schemaUrl
+        && externalSchema.schemaIssuer
+        && externalSchema.schemaIssuer !== ZERO_ADDRESS
+        && externalSchema.schemaSignature
+        && externalSchema.schemaSignature !== "0x"
     );
   }
 

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -18,6 +18,8 @@ const USDC_TRUST_ASSET = {
   decimals: 6,
   minBalanceRaw: "70000"
 };
+const CREATE_SINGLE_PAYOUT_WITH_SCHEMA =
+  "createSinglePayoutJob(bytes32,address,uint256,uint256,uint256,uint256,bytes32,bytes32,bytes32,(bytes32,string,address,bytes))";
 
 function gatewayWithDot() {
   return new BlockchainGateway({ enabled: false, supportedAssets: [DOT_ASSET] });
@@ -1374,8 +1376,61 @@ test("createSinglePayoutJobForJob consumes recurring template reserve when fundi
     claimTtl: 3600,
     verifierMode: encodeBytes32String("BENCH"),
     category: encodeBytes32String("WIKI"),
-    specHash: `0x${"1".repeat(64)}`
+    specHash: `0x${"1".repeat(64)}`,
+    schemaHash: `0x${"0".repeat(64)}`,
+    schemaUrl: "",
+    schemaIssuer: "0x0000000000000000000000000000000000000000",
+    schemaSignature: "0x"
   }]);
+});
+
+test("createSinglePayoutJobForJob forwards registered external schema metadata", async () => {
+  const gateway = gatewayWithDot();
+  const calls = [];
+  gateway.escrowContract = {
+    async createSinglePayoutJob() {
+      throw new Error("plain rc1 signature should not be used");
+    },
+    [CREATE_SINGLE_PAYOUT_WITH_SCHEMA]: async (...args) => {
+      calls.push(args);
+      return { async wait() {} };
+    }
+  };
+  const schemaHash = `0x${"2".repeat(64)}`;
+  const schemaIssuer = "0x4444444444444444444444444444444444444444";
+  const schemaSignature = "0x1234";
+
+  await gateway.createSinglePayoutJobForJob(
+    {
+      outputSchemaRef: "schema://jobs/external-output",
+      schemaRegistrations: [{
+        schemaRef: "schema://jobs/external-output",
+        registrationVersion: "external-job-schema-eip191-v1",
+        schemaHash,
+        schemaUrl: "https://schemas.example.com/external-output.json",
+        schemaIssuer,
+        signature: schemaSignature
+      }]
+    },
+    "rc1",
+    gateway.toJobId("external-output-job"),
+    DOT_ASSET.address,
+    5_000_000_000_000_000_000n,
+    0,
+    0,
+    3600,
+    encodeBytes32String("BENCH"),
+    encodeBytes32String("EXT"),
+    `0x${"1".repeat(64)}`
+  );
+
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0][9], {
+    schemaHash,
+    schemaUrl: "https://schemas.example.com/external-output.json",
+    schemaIssuer,
+    schemaSignature
+  });
 });
 
 test("createSinglePayoutJobForLayout uses the legacy signature for legacy escrow deployments", async () => {

--- a/mcp-server/src/core/job-execution-service.js
+++ b/mcp-server/src/core/job-execution-service.js
@@ -15,10 +15,12 @@ import { hashSubmission, isStructuredSubmission, normalizeSubmission } from "./s
 import {
   getBuiltinJobSchema,
   getJobSchema,
+  getRegisteredJobSchemaRegistration,
   isRegisteredJobSchemaRef,
   validateAgainstSchema,
   validateStructuredSubmission
 } from "./job-schema-registry.js";
+import { validateSubmissionAgainstRegisteredSchema } from "../services/schema-registry.js";
 import {
   buildFundedJobFromClaim,
   parseGithubPullRequestUrl,
@@ -251,10 +253,10 @@ export class JobExecutionService {
     const submission = normalizeSubmission(normalizeSubmitPayloadShape(job.outputSchemaRef, submissionInput, {
       registrations: job.schemaRegistrations
     }));
-    validateSubmissionContract(job.outputSchemaRef, submission, { registrations: job.schemaRegistrations });
+    await validateJobSubmissionAgainstSchema(job, submission);
     await this.enforceMaintainerOpenPrCap(job, submission);
     const guardedSubmission = this.applyMaintainerSubmissionGuards(job, refreshed, submission);
-    validateSubmissionContract(job.outputSchemaRef, guardedSubmission, { registrations: job.schemaRegistrations });
+    await validateJobSubmissionAgainstSchema(job, guardedSubmission);
     if (this.blockchainGateway?.isEnabled()) {
       await this.blockchainGateway.submitWork(session.chainJobId ?? session.jobId, hashSubmission(guardedSubmission));
     }
@@ -606,6 +608,18 @@ export function validateSubmissionContract(schemaRef, submission, { path = "subm
 
   validateStructuredSubmission(schemaRef, submission.structured, { path, registrations });
   return submission;
+}
+
+async function validateJobSubmissionAgainstSchema(job, submission) {
+  const registration = getRegisteredJobSchemaRegistration(job?.outputSchemaRef, job?.schemaRegistrations);
+  if (registration?.registrationVersion === "external-job-schema-eip191-v1") {
+    await validateSubmissionAgainstRegisteredSchema(submission, job.id, {
+      schemaRef: job.outputSchemaRef,
+      registrations: job.schemaRegistrations
+    });
+    return;
+  }
+  validateSubmissionContract(job.outputSchemaRef, submission, { registrations: job.schemaRegistrations });
 }
 
 function tryValidateAgainstSchema(value, schema, path) {

--- a/mcp-server/src/core/job-schema-registry.js
+++ b/mcp-server/src/core/job-schema-registry.js
@@ -1,9 +1,11 @@
-import { getAddress, isAddress, verifyMessage } from "ethers";
+import { AbiCoder, getAddress, getBytes, id, isAddress, keccak256, toUtf8Bytes, verifyMessage } from "ethers";
 
 import { canonicalizeContent, hashCanonicalContent } from "./canonical-content.js";
 import { ValidationError } from "./errors.js";
 
 export const EXTERNAL_SCHEMA_TRUST_BOUNDARY = "external_signed_schema";
+export const EXTERNAL_SCHEMA_EIP191_VERSION = "external-job-schema-eip191-v1";
+const abiCoder = AbiCoder.defaultAbiCoder();
 
 const BUILTIN_JOB_SCHEMAS = new Map([
   ["schema://jobs/coding-input", objectSchema({
@@ -591,9 +593,13 @@ export function normalizeExternalSchemaRegistration(raw, { index = 0 } = {}) {
     throw new ValidationError(`schemaRegistrations[${index}] must be an object.`);
   }
   const prefix = `schemaRegistrations[${index}]`;
+  const schema = cloneSchema(requirePlainObject(raw.schema, `${prefix}.schema`));
+  if (raw.schemaHash !== undefined || raw.schemaIssuer !== undefined || raw.jobId !== undefined) {
+    return normalizeExternalSchemaRegistrationV1(raw, { index, schema });
+  }
+
   const schemaRef = requireJobSchemaRef(raw.schemaRef, `${prefix}.schemaRef`);
   const schemaUrl = requireNonEmptyString(raw.schemaUrl, `${prefix}.schemaUrl`);
-  const schema = cloneSchema(requirePlainObject(raw.schema, `${prefix}.schema`));
   if (schema.$id !== schemaRef) {
     throw new ValidationError(`${prefix}.schema.$id must match ${schemaRef}.`);
   }
@@ -633,6 +639,75 @@ export function normalizeExternalSchemaRegistration(raw, { index = 0 } = {}) {
     signatureVerified: true,
     registrationMessageHash: hashCanonicalContent(signingMessage)
   };
+}
+
+function normalizeExternalSchemaRegistrationV1(raw, { index, schema }) {
+  const prefix = `schemaRegistrations[${index}]`;
+  const schemaRef = requireJobSchemaRef(raw.schemaRef ?? schema.$id, `${prefix}.schemaRef`);
+  const schemaUrl = requireNonEmptyString(raw.schemaUrl, `${prefix}.schemaUrl`);
+  if (schema.$id !== schemaRef) {
+    throw new ValidationError(`${prefix}.schema.$id must match ${schemaRef}.`);
+  }
+  assertSupportedExternalSchema(schema, `${prefix}.schema`);
+
+  const schemaHash = normalizeBytes32(raw.schemaHash ?? hashExternalSchemaContent(schema), `${prefix}.schemaHash`);
+  const computedHash = hashExternalSchemaContent(schema);
+  if (schemaHash.toLowerCase() !== computedHash.toLowerCase()) {
+    throw new ValidationError(`${prefix}.schemaHash does not match fetched schema content.`);
+  }
+  const issuer = normalizeIssuerAddress(raw.schemaIssuer ?? raw.issuer, `${prefix}.schemaIssuer`);
+  const jobId = requireNonEmptyString(raw.jobId, `${prefix}.jobId`);
+  const chainJobId = normalizeBytes32(raw.chainJobId ?? id(jobId), `${prefix}.chainJobId`);
+  const signature = requireNonEmptyString(raw.schemaSignature ?? raw.signature, `${prefix}.signature`);
+  const recovered = recoverExternalSchemaRegistrationSignerV1({
+    schemaHash,
+    schemaUrl,
+    jobId: chainJobId,
+    signature
+  });
+  if (recovered !== issuer) {
+    throw new ValidationError(`${prefix}.signature does not match schemaIssuer.`);
+  }
+
+  return {
+    schemaRef,
+    schemaUrl,
+    schema,
+    schemaHash,
+    issuer,
+    schemaIssuer: issuer,
+    jobId,
+    chainJobId,
+    signature,
+    registrationVersion: EXTERNAL_SCHEMA_EIP191_VERSION,
+    trustBoundary: EXTERNAL_SCHEMA_TRUST_BOUNDARY,
+    signatureVerified: true,
+    registrationMessageHash: buildExternalSchemaRegistrationDigest({ schemaHash, schemaUrl, jobId: chainJobId })
+  };
+}
+
+export function hashExternalSchemaContent(schema) {
+  return keccak256(toUtf8Bytes(canonicalizeContent(requirePlainObject(schema, "schema"))));
+}
+
+export function buildExternalSchemaRegistrationDigest({ schemaHash, schemaUrl, jobId }) {
+  return keccak256(abiCoder.encode(
+    ["bytes32", "string", "bytes32"],
+    [
+      normalizeBytes32(schemaHash, "schemaHash"),
+      requireNonEmptyString(schemaUrl, "schemaUrl"),
+      normalizeBytes32(jobId, "jobId")
+    ]
+  ));
+}
+
+export function recoverExternalSchemaRegistrationSignerV1({ schemaHash, schemaUrl, jobId, signature }) {
+  const digest = buildExternalSchemaRegistrationDigest({ schemaHash, schemaUrl, jobId });
+  try {
+    return getAddress(verifyMessage(getBytes(digest), requireNonEmptyString(signature, "signature")));
+  } catch (error) {
+    throw new ValidationError(`External schema signature verification failed: ${error?.message ?? "invalid signature"}`);
+  }
 }
 
 export function buildExternalSchemaRegistrationMessage(registration) {
@@ -788,6 +863,14 @@ function normalizeIssuerAddress(value, field) {
     throw new ValidationError(`${field} must be an EVM address.`);
   }
   return getAddress(text);
+}
+
+function normalizeBytes32(value, field) {
+  const text = requireNonEmptyString(value, field);
+  if (!/^0x[a-fA-F0-9]{64}$/u.test(text)) {
+    throw new ValidationError(`${field} must be a bytes32 hex string.`);
+  }
+  return text;
 }
 
 function assertSupportedExternalSchema(schema, path) {

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -10,7 +10,7 @@ import { VerificationIngestionService } from "../services/verification-ingestion
 import { ConflictError, InsufficientLiquidityError, ValidationError } from "./errors.js";
 import { normalizeSubmission } from "./submission.js";
 import { buildPlatformCapabilities } from "./discovery-manifest.js";
-import { getBuiltinJobSchema, getJobSchema } from "./job-schema-registry.js";
+import { getBuiltinJobSchema, getJobSchema, getRegisteredJobSchemaRegistration } from "./job-schema-registry.js";
 import {
   buildSessionLifecycle,
   describeSessionStatus,
@@ -22,6 +22,7 @@ import { capabilityMatrix } from "../auth/capabilities.js";
 import { knownAssetMinBalanceRaw, normalizeAssetSymbol } from "./assets.js";
 import { collectGithubOperatorStatus } from "./github-operator-helper.js";
 import { collectHostDiagnostics } from "./host-diagnostics.js";
+import { registerExternalSchema, validateSubmissionAgainstRegisteredSchema } from "../services/schema-registry.js";
 
 const TIMELINE_VERSION = "v2";
 
@@ -195,7 +196,8 @@ export class PlatformService {
   }
 
   async createAdminJob(input, { posterWallet = undefined } = {}) {
-    const created = this.createJob(input);
+    const jobInput = await this.withRegisteredExternalSchema(input);
+    const created = this.createJob(jobInput);
     try {
       await this.reserveRecurringTemplateFunding(created, posterWallet);
       return created;
@@ -203,6 +205,45 @@ export class PlatformService {
       this.jobCatalogService.removeJob(created.id);
       throw error;
     }
+  }
+
+  async withRegisteredExternalSchema(input = {}) {
+    if (!input?.externalSchema) {
+      return input;
+    }
+    const outputSchemaRef = String(input.outputSchemaRef ?? `schema://jobs/${input.category}-output`).trim();
+    const existingTrustPolicy = input.schemaTrustPolicy && typeof input.schemaTrustPolicy === "object"
+      ? input.schemaTrustPolicy
+      : {};
+    const trustedIssuers = Array.isArray(existingTrustPolicy.trustedIssuers)
+      ? existingTrustPolicy.trustedIssuers
+      : [];
+    const external = input.externalSchema;
+    const registration = await registerExternalSchema({
+      schemaHash: external.schemaHash,
+      schemaUrl: external.schemaUrl,
+      schemaIssuer: external.schemaIssuer,
+      signature: external.signature ?? external.schemaSignature,
+      jobId: input.id,
+      schemaRef: outputSchemaRef,
+      trustedIssuers,
+      isTrustedIssuer: this.blockchainGateway?.isEnabled?.() && this.blockchainGateway?.isTrustedSchemaIssuer
+        ? (issuer) => this.blockchainGateway.isTrustedSchemaIssuer(issuer)
+        : undefined
+    });
+
+    return {
+      ...input,
+      outputSchemaRef,
+      schemaTrustPolicy: {
+        ...existingTrustPolicy,
+        trustedIssuers: [...new Set([...trustedIssuers, registration.schemaIssuer])]
+      },
+      schemaRegistrations: [
+        ...(Array.isArray(input.schemaRegistrations) ? input.schemaRegistrations : []),
+        registration
+      ]
+    };
   }
 
   updateJobLifecycle(jobId, patch = {}) {
@@ -541,14 +582,22 @@ export class PlatformService {
     );
   }
 
-  validateJobSubmission(jobId, submissionInput) {
+  async validateJobSubmission(jobId, submissionInput) {
     const job = this.getJobDefinition(jobId);
     const contract = buildSubmissionValidationContract(job);
     try {
       const normalized = normalizeSubmission(normalizeSubmitPayloadShape(job.outputSchemaRef, submissionInput, {
         registrations: job.schemaRegistrations
       }));
-      validateSubmissionContract(job.outputSchemaRef, normalized, { registrations: job.schemaRegistrations });
+      const registration = getRegisteredJobSchemaRegistration(job.outputSchemaRef, job.schemaRegistrations);
+      if (registration?.registrationVersion === "external-job-schema-eip191-v1") {
+        await validateSubmissionAgainstRegisteredSchema(normalized, job.id, {
+          schemaRef: job.outputSchemaRef,
+          registrations: job.schemaRegistrations
+        });
+      } else {
+        validateSubmissionContract(job.outputSchemaRef, normalized, { registrations: job.schemaRegistrations });
+      }
       return {
         jobId,
         valid: true,

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -1,9 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { Wallet, getBytes, id } from "ethers";
 
 import { PlatformService } from "./platform-service.js";
 import { EventBus } from "./event-bus.js";
 import { MemoryStateStore } from "./state-store.js";
+import {
+  buildExternalSchemaRegistrationDigest,
+  hashExternalSchemaContent
+} from "./job-schema-registry.js";
 
 const WALLET = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const CANONICAL_USDC_ASSET = {
@@ -13,6 +18,19 @@ const CANONICAL_USDC_ASSET = {
   decimals: 6,
   address: "0x0000053900000000000000000000000001200000",
   minBalanceRaw: "70000"
+};
+const EXTERNAL_SCHEMA_SIGNER = new Wallet("0x8b3a350cf5c34c9194ca3a545d0ec67d61f328d6e5d11dd95b9af16e70ec4c63");
+const EXTERNAL_SCHEMA_REF = "schema://jobs/off-platform-output";
+const EXTERNAL_SCHEMA_URL = "https://schemas.example.com/jobs/off-platform-output.json";
+const EXTERNAL_SCHEMA = {
+  $id: EXTERNAL_SCHEMA_REF,
+  type: "object",
+  additionalProperties: false,
+  required: ["summary", "result"],
+  properties: {
+    summary: { type: "string", minLength: 1 },
+    result: { type: "string", enum: ["pass", "fail"] }
+  }
 };
 
 function makePlatformService(blockchainGateway = undefined, eventBus = undefined, stateStore = undefined) {
@@ -128,6 +146,83 @@ test("createAdminJob reserves finite recurring template funding from the poster 
   assert.equal(derivative.funding.source, "recurring_template_reserve");
   assert.equal(derivative.funding.wallet, WALLET);
   assert.equal(derivative.funding.amount, 5);
+});
+
+test("external-schema admin job posts, claims, and validates against off-platform schema", async () => {
+  const schemaHash = hashExternalSchemaContent(EXTERNAL_SCHEMA);
+  const jobId = "off-platform-schema-job-001";
+  const signature = await EXTERNAL_SCHEMA_SIGNER.signMessage(getBytes(buildExternalSchemaRegistrationDigest({
+    schemaHash,
+    schemaUrl: EXTERNAL_SCHEMA_URL,
+    jobId: id(jobId)
+  })));
+  const calls = [];
+  let liveState = 0;
+  const gateway = {
+    isEnabled: () => true,
+    toJobId: (value) => id(value),
+    getDefaultClaimStakeBps: async () => 500,
+    getClaimEconomicsConfig: async () => ({}),
+    isTrustedSchemaIssuer: async (issuer) => issuer === EXTERNAL_SCHEMA_SIGNER.address,
+    getJob: async () => ({ state: liveState }),
+    ensureJob: async (job, instanceJobId) => {
+      calls.push(["ensureJob", { job, instanceJobId }]);
+    },
+    ensureClaimStakeLiquidity: async () => {},
+    claimJob: async () => {
+      liveState = 1;
+      calls.push(["claimJob"]);
+    },
+    submitWork: async (_jobId, evidenceHash) => {
+      calls.push(["submitWork", evidenceHash]);
+    }
+  };
+  const service = makePlatformService(gateway, undefined, new MemoryStateStore());
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({
+    ok: true,
+    status: 200,
+    async json() {
+      return EXTERNAL_SCHEMA;
+    }
+  });
+  try {
+    const job = await service.createAdminJob({
+      id: jobId,
+      category: "off-platform",
+      tier: "starter",
+      rewardAmount: 1,
+      rewardAsset: "DOT",
+      verifierMode: "benchmark",
+      verifierTerms: ["summary"],
+      verifierMinimumMatches: 1,
+      inputSchemaRef: "schema://jobs/coding-input",
+      outputSchemaRef: EXTERNAL_SCHEMA_REF,
+      claimTtlSeconds: 3600,
+      retryLimit: 1,
+      externalSchema: {
+        schemaHash,
+        schemaUrl: EXTERNAL_SCHEMA_URL,
+        schemaIssuer: EXTERNAL_SCHEMA_SIGNER.address,
+        signature
+      }
+    }, { posterWallet: WALLET });
+
+    assert.equal(job.schemaRegistrations[0].schemaIssuer, EXTERNAL_SCHEMA_SIGNER.address);
+    assert.equal(job.schemaRegistrations[0].schemaHash, schemaHash);
+    const claimed = await service.claimJob(WALLET, jobId, "http", "external-schema-claim");
+    const submitted = await service.submitWork(claimed.sessionId, "http", {
+      summary: "External schema was honored.",
+      result: "pass"
+    });
+
+    assert.equal(submitted.outputSchemaRegistered, true);
+    assert.equal(submitted.submission.structured.result, "pass");
+    assert.equal(calls.find(([name]) => name === "ensureJob")?.[1].job.schemaRegistrations[0].schemaHash, schemaHash);
+    assert.ok(calls.some(([name]) => name === "submitWork"));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 test("createJob allows USDC rewards at or above asset minBalance", () => {
@@ -446,10 +541,10 @@ test("getAccountPosition delegates to blockchain gateway for chain-authoritative
   assert.equal(position.source.contract, "AgentAccountCore");
 });
 
-test("validateJobSubmission gives a non-mutating schema-native verdict", () => {
+test("validateJobSubmission gives a non-mutating schema-native verdict", async () => {
   const service = makePlatformService();
 
-  const valid = service.validateJobSubmission("parent-job-001", {
+  const valid = await service.validateJobSubmission("parent-job-001", {
     summary: "Parser fixed.",
     output: "Added regression coverage.",
     status: "complete"
@@ -462,7 +557,7 @@ test("validateJobSubmission gives a non-mutating schema-native verdict", () => {
   assert.deepEqual(valid.requiredTopLevelKeys, ["summary", "output", "status"]);
   assert.equal(valid.submissionKind, "structured");
 
-  const invalid = service.validateJobSubmission("parent-job-001", "complete");
+  const invalid = await service.validateJobSubmission("parent-job-001", "complete");
   assert.equal(invalid.valid, false);
   assert.equal(invalid.submitSafe, false);
   assert.equal(invalid.schemaRef, "schema://jobs/coding-output");

--- a/mcp-server/src/protocols/http/admin-jobs-routes.test.js
+++ b/mcp-server/src/protocols/http/admin-jobs-routes.test.js
@@ -197,6 +197,29 @@ test("POST /admin/jobs creates an admin job and stores idempotent receipt", asyn
   });
 });
 
+test("POST /admin/jobs forwards external schema registration metadata", async () => {
+  const externalSchema = {
+    schemaHash: "0x8d9f6cc5431d6f2f8ddf397c7f6c96941a9df9f733c12b94be2f6a72e1f2f3d2",
+    schemaUrl: "https://schemas.example.com/agent-output.json",
+    schemaIssuer: "0x1111111111111111111111111111111111111111",
+    signature: "0xabcdef"
+  };
+  const { calls, response, route } = makeHarness({
+    payload: { id: "job-1", title: "External schema job", externalSchema, idempotencyKey: "idem-1" }
+  });
+
+  const handled = await route({
+    request: { method: "POST" },
+    response,
+    url: new URL("http://localhost/admin/jobs"),
+    pathname: "/admin/jobs",
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 201);
+  assert.deepEqual(calls.find(([name]) => name === "createAdminJob")?.[1].body.externalSchema, externalSchema);
+});
+
 test("POST /admin/jobs returns idempotent replay without creating another job", async () => {
   const replay = { statusCode: 200, body: { id: "job-1", replay: true } };
   const { calls, response, route } = makeHarness({ replay });

--- a/mcp-server/src/protocols/http/job-routes.js
+++ b/mcp-server/src/protocols/http/job-routes.js
@@ -137,7 +137,7 @@ export function createJobRoutes({
       if (submission === undefined) {
         throw new ValidationError("submission is required.");
       }
-      respond(response, 200, service.validateJobSubmission(jobId, submission));
+      respond(response, 200, await service.validateJobSubmission(jobId, submission));
       return true;
     }
 

--- a/mcp-server/src/services/schema-registry.js
+++ b/mcp-server/src/services/schema-registry.js
@@ -1,0 +1,167 @@
+import {
+  EXTERNAL_SCHEMA_EIP191_VERSION,
+  getRegisteredJobSchemaRegistration,
+  hashExternalSchemaContent,
+  normalizeExternalSchemaRegistrations,
+  recoverExternalSchemaRegistrationSignerV1,
+  validateAgainstSchema
+} from "../core/job-schema-registry.js";
+import { ExternalServiceError, ValidationError } from "../core/errors.js";
+import { normalizeSubmission } from "../core/submission.js";
+import { id } from "ethers";
+
+export async function registerExternalSchema({
+  schemaHash,
+  schemaUrl,
+  schemaIssuer,
+  signature,
+  jobId,
+  schemaRef = undefined,
+  trustedIssuers = [],
+  isTrustedIssuer = undefined,
+  fetchImpl = globalThis.fetch
+} = {}) {
+  const schema = await fetchSchemaDocument(schemaUrl, { fetchImpl });
+  const computedHash = hashExternalSchemaContent(schema);
+  if (String(computedHash).toLowerCase() !== String(schemaHash ?? "").toLowerCase()) {
+    throw new ValidationError("externalSchema.schemaHash does not match schemaUrl content.", {
+      expected: schemaHash,
+      actual: computedHash,
+      schemaUrl
+    });
+  }
+
+  const chainJobId = id(requireNonEmptyString(jobId, "externalSchema.jobId"));
+  const recovered = recoverExternalSchemaRegistrationSignerV1({
+    schemaHash: computedHash,
+    schemaUrl,
+    jobId: chainJobId,
+    signature
+  });
+  if (recovered.toLowerCase() !== String(schemaIssuer ?? "").toLowerCase()) {
+    throw new ValidationError("externalSchema.signature does not match schemaIssuer.", {
+      expected: schemaIssuer,
+      actual: recovered
+    });
+  }
+
+  const trusted = typeof isTrustedIssuer === "function"
+    ? await isTrustedIssuer(recovered)
+    : trustedIssuers.some((issuer) => String(issuer).toLowerCase() === recovered.toLowerCase());
+  if (!trusted) {
+    throw new ValidationError("externalSchema.schemaIssuer is not trusted.", {
+      schemaIssuer: recovered
+    });
+  }
+
+  const [registration] = normalizeExternalSchemaRegistrations([
+    {
+      schemaRef: schemaRef ?? schema.$id,
+      schemaUrl,
+      schema,
+      schemaHash: computedHash,
+      schemaIssuer: recovered,
+      signature,
+      jobId,
+      chainJobId,
+      registrationVersion: EXTERNAL_SCHEMA_EIP191_VERSION
+    }
+  ], {
+    allowedSchemaRefs: [schemaRef ?? schema.$id].filter(Boolean),
+    trustedIssuers: [recovered]
+  });
+  return registration;
+}
+
+export async function validateSubmissionAgainstRegisteredSchema(
+  submission,
+  jobId,
+  {
+    schemaRef = undefined,
+    registrations = [],
+    fetchImpl = globalThis.fetch
+  } = {}
+) {
+  const registration = selectRegistrationForJob({ jobId, schemaRef, registrations });
+  if (!registration) {
+    throw new ValidationError(`No registered external schema is available for job ${jobId}.`);
+  }
+  const schema = await fetchSchemaDocument(registration.schemaUrl, { fetchImpl });
+  const computedHash = hashExternalSchemaContent(schema);
+  if (computedHash.toLowerCase() !== String(registration.schemaHash).toLowerCase()) {
+    throw new ValidationError("Registered external schema content hash mismatch.", {
+      schemaUrl: registration.schemaUrl,
+      expected: registration.schemaHash,
+      actual: computedHash
+    });
+  }
+
+  const normalized = submission?.kind === "structured" || submission?.kind === "text"
+    ? submission
+    : normalizeSubmission(submission);
+  if (normalized.kind !== "structured") {
+    throw new ValidationError("Registered external schema submissions must be structured JSON.");
+  }
+  validateAgainstSchema(normalized.structured, schema, "submission");
+  return normalized;
+}
+
+async function fetchSchemaDocument(schemaUrl, { fetchImpl } = {}) {
+  const url = requireHttpUrl(schemaUrl, "externalSchema.schemaUrl");
+  if (typeof fetchImpl !== "function") {
+    throw new ExternalServiceError("No fetch implementation available for external schema registration.");
+  }
+  let response;
+  try {
+    response = await fetchImpl(url, { headers: { accept: "application/schema+json, application/json" } });
+  } catch (error) {
+    throw new ExternalServiceError(`Failed to fetch external schema: ${error?.message ?? "fetch failed"}`);
+  }
+  if (!response?.ok) {
+    throw new ExternalServiceError(`External schema fetch failed with HTTP ${response?.status ?? "unknown"}.`);
+  }
+  let schema;
+  try {
+    schema = await response.json();
+  } catch (error) {
+    throw new ValidationError(`External schema response is not JSON: ${error?.message ?? "invalid JSON"}`);
+  }
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    throw new ValidationError("External schema response must be a JSON object.");
+  }
+  return schema;
+}
+
+function selectRegistrationForJob({ jobId, schemaRef, registrations }) {
+  if (schemaRef) {
+    const byRef = getRegisteredJobSchemaRegistration(schemaRef, registrations);
+    if (byRef) return byRef;
+  }
+  const normalizedChainJobId = jobId ? id(String(jobId)) : undefined;
+  return registrations.find((entry) =>
+    entry?.registrationVersion === EXTERNAL_SCHEMA_EIP191_VERSION
+      && (!normalizedChainJobId || entry.chainJobId === normalizedChainJobId || entry.jobId === jobId)
+  );
+}
+
+function requireHttpUrl(value, field) {
+  const text = requireNonEmptyString(value, field);
+  let parsed;
+  try {
+    parsed = new URL(text);
+  } catch {
+    throw new ValidationError(`${field} must be an http(s) URL.`);
+  }
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new ValidationError(`${field} must be an http(s) URL.`);
+  }
+  return parsed.toString();
+}
+
+function requireNonEmptyString(value, field) {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) {
+    throw new ValidationError(`${field} is required.`);
+  }
+  return text;
+}

--- a/mcp-server/src/services/schema-registry.test.js
+++ b/mcp-server/src/services/schema-registry.test.js
@@ -1,0 +1,154 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Wallet, getBytes, id } from "ethers";
+
+import {
+  buildExternalSchemaRegistrationDigest,
+  hashExternalSchemaContent
+} from "../core/job-schema-registry.js";
+import {
+  registerExternalSchema,
+  validateSubmissionAgainstRegisteredSchema
+} from "./schema-registry.js";
+
+const ISSUER = new Wallet("0x59c6995e998f97a5a004497e5da795437b4466ad5c2af1c6a6d1dcb1b1ce36b9");
+const OTHER = new Wallet("0x8b3a350cf5c34c9194ca3a545d0ec67d61f328d6e5d11dd95b9af16e70ec4c63");
+const JOB_ID = "external-schema-job-001";
+const SCHEMA_URL = "https://schemas.example.com/jobs/external-audit-output.json";
+const SCHEMA_REF = "schema://jobs/external-audit-output";
+const SCHEMA = {
+  $id: SCHEMA_REF,
+  type: "object",
+  additionalProperties: false,
+  required: ["summary", "result"],
+  properties: {
+    summary: { type: "string", minLength: 1 },
+    result: { type: "string", enum: ["pass", "fail"] }
+  }
+};
+
+async function signSchema({ signer = ISSUER, schema = SCHEMA, schemaUrl = SCHEMA_URL, jobId = JOB_ID } = {}) {
+  const schemaHash = hashExternalSchemaContent(schema);
+  const digest = buildExternalSchemaRegistrationDigest({
+    schemaHash,
+    schemaUrl,
+    jobId: id(jobId)
+  });
+  return {
+    schemaHash,
+    signature: await signer.signMessage(getBytes(digest))
+  };
+}
+
+function fetchSchema(schema = SCHEMA) {
+  return async () => ({
+    ok: true,
+    status: 200,
+    async json() {
+      return schema;
+    }
+  });
+}
+
+test("registerExternalSchema verifies signer, trust, URL fetch, and content hash", async () => {
+  const signed = await signSchema();
+
+  const registration = await registerExternalSchema({
+    schemaHash: signed.schemaHash,
+    schemaUrl: SCHEMA_URL,
+    schemaIssuer: ISSUER.address,
+    signature: signed.signature,
+    jobId: JOB_ID,
+    schemaRef: SCHEMA_REF,
+    isTrustedIssuer: async (issuer) => issuer === ISSUER.address,
+    fetchImpl: fetchSchema()
+  });
+
+  assert.equal(registration.registrationVersion, "external-job-schema-eip191-v1");
+  assert.equal(registration.schemaHash, signed.schemaHash);
+  assert.equal(registration.schemaIssuer, ISSUER.address);
+  assert.equal(registration.chainJobId, id(JOB_ID));
+  assert.equal(registration.signatureVerified, true);
+  assert.equal(registration.trusted, true);
+});
+
+test("registerExternalSchema rejects invalid signatures and untrusted issuers", async () => {
+  const signedByOther = await signSchema({ signer: OTHER });
+
+  await assert.rejects(
+    () => registerExternalSchema({
+      schemaHash: signedByOther.schemaHash,
+      schemaUrl: SCHEMA_URL,
+      schemaIssuer: ISSUER.address,
+      signature: signedByOther.signature,
+      jobId: JOB_ID,
+      schemaRef: SCHEMA_REF,
+      isTrustedIssuer: async () => true,
+      fetchImpl: fetchSchema()
+    }),
+    /signature does not match schemaIssuer/u
+  );
+
+  const signed = await signSchema();
+  await assert.rejects(
+    () => registerExternalSchema({
+      schemaHash: signed.schemaHash,
+      schemaUrl: SCHEMA_URL,
+      schemaIssuer: ISSUER.address,
+      signature: signed.signature,
+      jobId: JOB_ID,
+      schemaRef: SCHEMA_REF,
+      isTrustedIssuer: async () => false,
+      fetchImpl: fetchSchema()
+    }),
+    /schemaIssuer is not trusted/u
+  );
+});
+
+test("validateSubmissionAgainstRegisteredSchema fetches schema and catches hash mismatch", async () => {
+  const signed = await signSchema();
+  const registration = await registerExternalSchema({
+    schemaHash: signed.schemaHash,
+    schemaUrl: SCHEMA_URL,
+    schemaIssuer: ISSUER.address,
+    signature: signed.signature,
+    jobId: JOB_ID,
+    schemaRef: SCHEMA_REF,
+    trustedIssuers: [ISSUER.address],
+    fetchImpl: fetchSchema()
+  });
+
+  const normalized = await validateSubmissionAgainstRegisteredSchema({
+    summary: "External schema output is valid.",
+    result: "pass"
+  }, JOB_ID, {
+    schemaRef: SCHEMA_REF,
+    registrations: [registration],
+    fetchImpl: fetchSchema()
+  });
+  assert.equal(normalized.kind, "structured");
+
+  await assert.rejects(
+    () => validateSubmissionAgainstRegisteredSchema({
+      summary: "External schema output is invalid.",
+      result: "maybe"
+    }, JOB_ID, {
+      schemaRef: SCHEMA_REF,
+      registrations: [registration],
+      fetchImpl: fetchSchema()
+    }),
+    /submission.result must be one of pass, fail/u
+  );
+
+  await assert.rejects(
+    () => validateSubmissionAgainstRegisteredSchema({
+      summary: "Hash mismatch should fail before validation.",
+      result: "pass"
+    }, JOB_ID, {
+      schemaRef: SCHEMA_REF,
+      registrations: [registration],
+      fetchImpl: fetchSchema({ ...SCHEMA, description: "changed content" })
+    }),
+    /content hash mismatch/u
+  );
+});

--- a/scripts/ops/audit-launch-readiness.mjs
+++ b/scripts/ops/audit-launch-readiness.mjs
@@ -77,6 +77,7 @@ const READ_ABI = [
   "function paused() view returns (bool)",
   "function verifiers(address) view returns (bool)",
   "function serviceOperators(address) view returns (bool)",
+  "function trustedSchemaIssuers(address) view returns (bool)",
   "function arbitrators(address) view returns (bool)",
   "function approvedAssets(address) view returns (bool)",
   "function dailyOutflowCap() view returns (uint256)",
@@ -91,6 +92,7 @@ const READ_ABI = [
 const WRITE_ABI = [
   "function setVerifier(address verifier, bool approved)",
   "function setServiceOperator(address operator, bool approved)",
+  "function setTrustedSchemaIssuer(address issuer, bool approved)",
   "function setArbitrator(address arbitrator, bool approved)",
   "function setApprovedAsset(address asset, bool approved)",
   "function setMinClaimFee(address asset, uint256 amount)",
@@ -345,6 +347,12 @@ async function main() {
   const expectedOwner = deployments.owner;
   const expectedPauser = deployments.pauser;
   const expectedParameters = deployments.parameters ?? {};
+  const configuredSchemaIssuers = Array.isArray(deployments.trustedSchemaIssuers)
+    ? deployments.trustedSchemaIssuers
+    : [];
+  const externalSchemaJobs = Array.isArray(deployments.externalSchemaJobs)
+    ? deployments.externalSchemaJobs
+    : [];
 
   console.log(`# Launch readiness audit`);
   console.log(`Profile: ${deployments.profile}`);
@@ -392,7 +400,7 @@ async function main() {
     signerUsdcBalance,
     blockNumber,
     chainId,
-    ...selectorBytecodes
+    ...rest
   ] = await Promise.all([
     policy.owner(),
     policy.pauser(),
@@ -416,8 +424,14 @@ async function main() {
     provider.getNetwork().then((n) => Number(n.chainId)),
     ...selectorTargets.map((target) =>
       target.address ? provider.getCode(target.address) : Promise.resolve("0x")
-    )
+    ),
+    ...configuredSchemaIssuers.map((issuer) => policy.trustedSchemaIssuers(issuer))
   ]);
+  const selectorBytecodes = rest.slice(0, selectorTargets.length);
+  const schemaIssuerStatuses = configuredSchemaIssuers.map((issuer, index) => ({
+    issuer,
+    trusted: Boolean(rest[selectorTargets.length + index])
+  }));
 
   // The auto-generated getter on `mapping(address => mapping(address =>
   // AssetPosition))` returns the struct's fields in declaration order. We
@@ -482,6 +496,13 @@ async function main() {
   console.log(`serviceOperators(agentAccount)   ${agentAccountIsOperator ? "✅" : "❌"}  ${agentAccountIsOperator}  (defensive — strictly required for v1 single-payout is escrow only)`);
   console.log(`arbitrators(${short(expectedArbitrator)})  ${arbitratorIsApproved ? "✅" : "❌"}  ${arbitratorIsApproved}  (required for resolveDispute)`);
   console.log(`approvedAssets(USDC)             ${usdcIsApproved ? "✅" : "❌"}  ${usdcIsApproved}`);
+  if (schemaIssuerStatuses.length > 0) {
+    for (const entry of schemaIssuerStatuses) {
+      console.log(`trustedSchemaIssuers(${short(entry.issuer)}) ${entry.trusted ? "✅" : "❌"}  ${entry.trusted}`);
+    }
+  } else {
+    console.log("trustedSchemaIssuers             ℹ  no configured issuer list in deployment profile");
+  }
 
   // Suffix classification — only thing we can introspect about the
   // ERC20-precompile address itself, since name/symbol/decimals are
@@ -586,6 +607,23 @@ async function main() {
   }
   if (!usdcIsApproved) {
     fixes.push(buildCall("setApprovedAsset", [usdcAddress, true], policyAddress));
+  }
+  for (const entry of schemaIssuerStatuses) {
+    if (!entry.trusted) {
+      fixes.push(buildCall("setTrustedSchemaIssuer", [entry.issuer, true], policyAddress));
+    }
+  }
+  for (const job of externalSchemaJobs) {
+    const issuer = job?.schemaIssuer;
+    if (!issuer) continue;
+    const known = schemaIssuerStatuses.find((entry) => ciEqual(entry.issuer, issuer));
+    if (!known?.trusted) {
+      fixes.push({
+        label: `external schema job ${job.jobId ?? "(unknown)"} uses untrusted issuer ${issuer}`,
+        reasonCode: "external_schema_issuer_untrusted",
+        runbook: `add ${issuer} to deployments/${deployments.profile}.json#trustedSchemaIssuers, rerun this audit, then prepare setTrustedSchemaIssuer(${issuer}, true)`
+      });
+    }
   }
   if (!usdcSuffixOk) {
     fixes.push({

--- a/test/AgentPlatform.t.sol
+++ b/test/AgentPlatform.t.sol
@@ -154,7 +154,11 @@ contract AgentPlatformTest is Test {
                 claimTtl: 1 days,
                 verifierMode: bytes32("AUTO"),
                 category: bytes32("CODING"),
-                specHash: SPEC_HASH
+                specHash: SPEC_HASH,
+                schemaHash: bytes32(0),
+                schemaUrl: "",
+                schemaIssuer: address(0),
+                schemaSignature: hex""
             })
         );
 

--- a/test/ExternalSchemaRegistration.t.sol
+++ b/test/ExternalSchemaRegistration.t.sol
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import {MockERC20} from "../contracts/mocks/MockERC20.sol";
+import {TreasuryPolicy} from "../contracts/TreasuryPolicy.sol";
+import {StrategyAdapterRegistry} from "../contracts/StrategyAdapterRegistry.sol";
+import {AgentAccountCore} from "../contracts/AgentAccountCore.sol";
+import {EscrowCore} from "../contracts/EscrowCore.sol";
+import {ReputationSBT} from "../contracts/ReputationSBT.sol";
+
+interface VmEvent {
+    function expectEmit(bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData, address emitter) external;
+}
+
+contract ExternalSchemaRegistrationTest is Test {
+    VmEvent internal constant vmEvent = VmEvent(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    TreasuryPolicy internal policy;
+    StrategyAdapterRegistry internal registry;
+    AgentAccountCore internal accounts;
+    ReputationSBT internal reputation;
+    EscrowCore internal escrow;
+    MockERC20 internal dot;
+
+    address internal poster = address(0xA11CE);
+    address internal issuer = 0xCc8940b1c72567cf04c9Ccc96242Ee7A4444534C;
+    address internal otherIssuer = 0xFf1914A904ed524aec571244c5aEb2140C234304;
+
+    bytes32 internal constant SPEC_HASH = bytes32("SPEC_HASH");
+    bytes32 internal constant SCHEMA_HASH = keccak256("external schema");
+    string internal constant SCHEMA_URL = "https://schemas.example.com/jobs/external-output.json";
+    bytes internal constant VALID_SIGNATURE =
+        hex"876a9ed85c63b0773c3d2d5a7eac09204aa00c7da465bfe2648f063336d5efba33eda920e896a1f5d977e15bc55c29813382e9d0fcac3679a96bc1d760c576e01b";
+    bytes internal constant BAD_SIGNATURE =
+        hex"a1d1c6d2e40953c768d6b12351c9029ab3d0a7d0b238444fca2163ff8934b79e56eceb48f9440700cdf90bbf372e4d7e0d06cf2162df0d5961aaa72400104aed1c";
+    bytes internal constant UNTRUSTED_SIGNATURE =
+        hex"1aa6b1387ef692d01bccd36f02a8e05f202500db457f28f1c558e0b3bf43c9fc1c5525a8c931d1928b10aa1083e19e649ef91691d24dc94f003f5ba338689b811b";
+    bytes internal constant RECURRING_SIGNATURE =
+        hex"64e2697330e5627eb177c3c9f7e5849f8a9ee101f0b04263a5bb3c824fd6cea15b243561da102b39c329e036650435b9562f5ca11e68e06f0ad36ba03c849f031b";
+
+    event TrustedSchemaIssuerSet(address indexed issuer, bool approved);
+    event ExternalSchemaRegistered(
+        bytes32 indexed jobId, bytes32 indexed schemaHash, address indexed schemaIssuer, string schemaUrl
+    );
+
+    function setUp() public {
+        policy = new TreasuryPolicy();
+        registry = new StrategyAdapterRegistry(policy);
+        accounts = new AgentAccountCore(policy, registry);
+        reputation = new ReputationSBT(policy);
+        escrow = new EscrowCore(policy, accounts, reputation);
+        dot = new MockERC20("Mock DOT", "mDOT");
+        policy.setApprovedAsset(address(dot), true);
+        policy.setServiceOperator(address(escrow), true);
+        policy.setServiceOperator(address(accounts), true);
+        policy.setServiceOperator(address(this), true);
+
+        dot.mint(poster, 1_000 ether);
+        vm.startPrank(poster);
+        dot.approve(address(accounts), type(uint256).max);
+        accounts.deposit(address(dot), 500 ether);
+        vm.stopPrank();
+    }
+
+    function testOwnerGatesTrustedSchemaIssuerAndEmits() public {
+        vmEvent.expectEmit(true, false, false, true, address(policy));
+        emit TrustedSchemaIssuerSet(issuer, true);
+        policy.setTrustedSchemaIssuer(issuer, true);
+        require(policy.trustedSchemaIssuers(issuer), "EXPECTED_TRUSTED_ISSUER");
+
+        vm.prank(address(0xBEEF));
+        (bool ok,) = address(policy).call(abi.encodeCall(policy.setTrustedSchemaIssuer, (otherIssuer, true)));
+        require(!ok, "EXPECTED_OWNER_GATE_REVERT");
+    }
+
+    function testValidExternalSchemaAccepted() public {
+        policy.setTrustedSchemaIssuer(issuer, true);
+        bytes32 jobId = keccak256("job/external-schema/valid");
+        bytes memory signature = VALID_SIGNATURE;
+
+        vmEvent.expectEmit(true, true, true, true, address(escrow));
+        emit ExternalSchemaRegistered(jobId, SCHEMA_HASH, issuer, SCHEMA_URL);
+
+        vm.prank(poster);
+        escrow.createSinglePayoutJob(
+            jobId,
+            address(dot),
+            10 ether,
+            0,
+            0,
+            1 days,
+            bytes32("AUTO"),
+            bytes32("CODING"),
+            SPEC_HASH,
+            EscrowCore.ExternalSchemaRegistration({
+                schemaHash: SCHEMA_HASH, schemaUrl: SCHEMA_URL, schemaIssuer: issuer, schemaSignature: signature
+            })
+        );
+
+        (bytes32 schemaHash, string memory schemaUrl, address schemaIssuer, bytes memory schemaSignature) =
+            escrow.jobExternalSchemas(jobId);
+        require(schemaHash == SCHEMA_HASH, "EXPECTED_SCHEMA_HASH");
+        require(keccak256(bytes(schemaUrl)) == keccak256(bytes(SCHEMA_URL)), "EXPECTED_SCHEMA_URL");
+        require(schemaIssuer == issuer, "EXPECTED_SCHEMA_ISSUER");
+        require(keccak256(schemaSignature) == keccak256(signature), "EXPECTED_SCHEMA_SIGNATURE");
+    }
+
+    function testInvalidSignatureRejected() public {
+        policy.setTrustedSchemaIssuer(issuer, true);
+        bytes32 jobId = keccak256("job/external-schema/bad-signature");
+        bytes memory signature = BAD_SIGNATURE;
+
+        vm.prank(poster);
+        (bool ok,) = address(escrow).call(createExternalSchemaJobCalldata(jobId, issuer, signature));
+        require(!ok, "EXPECTED_BAD_SIGNATURE_REVERT");
+    }
+
+    function testUntrustedIssuerRejected() public {
+        bytes32 jobId = keccak256("job/external-schema/untrusted");
+        bytes memory signature = UNTRUSTED_SIGNATURE;
+
+        vm.prank(poster);
+        (bool ok,) = address(escrow).call(createExternalSchemaJobCalldata(jobId, issuer, signature));
+        require(!ok, "EXPECTED_UNTRUSTED_ISSUER_REVERT");
+    }
+
+    function testRecurringReserveAcceptsExternalSchemaMetadata() public {
+        policy.setTrustedSchemaIssuer(issuer, true);
+        bytes32 templateId = keccak256("template/external-schema");
+        bytes32 jobId = keccak256("template/external-schema/run/1");
+        bytes memory signature = RECURRING_SIGNATURE;
+
+        vm.prank(poster);
+        accounts.reserveForRecurringTemplate(poster, address(dot), templateId, 10 ether);
+
+        escrow.createSinglePayoutJobFromRecurringReserve(
+            EscrowCore.RecurringSinglePayoutJob({
+                jobId: jobId,
+                templateId: templateId,
+                poster: poster,
+                asset: address(dot),
+                reward: 5 ether,
+                opsReserve: 0,
+                contingencyReserve: 0,
+                claimTtl: 1 days,
+                verifierMode: bytes32("AUTO"),
+                category: bytes32("CODING"),
+                specHash: SPEC_HASH,
+                schemaHash: SCHEMA_HASH,
+                schemaUrl: SCHEMA_URL,
+                schemaIssuer: issuer,
+                schemaSignature: signature
+            })
+        );
+
+        (bytes32 schemaHash,, address schemaIssuer,) = escrow.jobExternalSchemas(jobId);
+        require(schemaHash == SCHEMA_HASH, "EXPECTED_SCHEMA_HASH");
+        require(schemaIssuer == issuer, "EXPECTED_SCHEMA_ISSUER");
+    }
+
+    function createExternalSchemaJobCalldata(bytes32 jobId, address schemaIssuer, bytes memory signature)
+        internal
+        view
+        returns (bytes memory)
+    {
+        return abi.encodeWithSelector(
+            bytes4(
+                keccak256(
+                    "createSinglePayoutJob(bytes32,address,uint256,uint256,uint256,uint256,bytes32,bytes32,bytes32,(bytes32,string,address,bytes))"
+                )
+            ),
+            jobId,
+            address(dot),
+            10 ether,
+            0,
+            0,
+            1 days,
+            bytes32("AUTO"),
+            bytes32("CODING"),
+            SPEC_HASH,
+            EscrowCore.ExternalSchemaRegistration({
+                schemaHash: SCHEMA_HASH, schemaUrl: SCHEMA_URL, schemaIssuer: schemaIssuer, schemaSignature: signature
+            })
+        );
+    }
+}

--- a/test/Hardening.t.sol
+++ b/test/Hardening.t.sol
@@ -58,19 +58,17 @@ contract HardeningTest is Test {
 
         vm.prank(poster);
         (bool ok,) = address(escrow).call(
-            abi.encodeCall(
-                escrow.createSinglePayoutJob,
-                (
-                    keccak256("paused-job"),
-                    address(dot),
-                    10 ether,
-                    1 ether,
-                    1 ether,
-                    1 days,
-                    bytes32("AUTO"),
-                    bytes32("CODING"),
-                    SPEC_HASH
-                )
+            abi.encodeWithSelector(
+                bytes4(0x0b452fa4),
+                keccak256("paused-job"),
+                address(dot),
+                10 ether,
+                1 ether,
+                1 ether,
+                1 days,
+                bytes32("AUTO"),
+                bytes32("CODING"),
+                SPEC_HASH
             )
         );
         require(!ok, "EXPECTED_PAUSED_REVERT");


### PR DESCRIPTION
## Summary
- Adds first-slice external schema registration support across `TreasuryPolicy` and `EscrowCore`: trusted schema issuers, EIP-191 signature recovery, schema URL/hash/issuer/signature metadata, recurring-template support, and external schema registration events.
- Wires backend preflight and runtime validation through a new schema registry service: `/admin/jobs` accepts optional `externalSchema`, verifies URL content hash plus signer plus trusted issuer policy, stores the registration on the job definition, and validates submissions against the registered off-platform JSON Schema.
- Extends gateway ABIs/calls, launch-readiness audit checks, tests, and operator/spec/roadmap docs. The roadmap row is moved only to `In progress`; hosted proof remains the close gate.

## Validation
- `forge test`
- `npm --workspace mcp-server test`
- `node --test scripts/ops/audit-launch-readiness.test.mjs`
- `git diff --check`
- Polkadot docs MCP check: `reference/polkadot-hub/smart-contracts.md` confirms Polkadot Hub supports Solidity contracts through REVM with familiar Ethereum tooling such as Foundry.

## Impact
- Affects contracts, backend, ops audit script, and docs.
- No deploy performed. No `deployments/testnet.json` or address manifest changes.
- Contract changes require redeploy plus owner-multisig approval via `TreasuryPolicy.setTrustedSchemaIssuer(issuer, true)` before hosted external-schema proof can be captured.
- No VPS secret or environment changes required by this PR.