### PR TITLE
Expose funded job instrumentation evidence

### DIFF
--- a/docs/AVERRAY_WORKING_SPEC.md
+++ b/docs/AVERRAY_WORKING_SPEC.md
@@ -848,8 +848,18 @@ Short, linkable, defensible. Drop into docs root and README:
 Before public v1.0.0-rc1 launch:
 
 **Instrumentation (week 1 prerequisite):**
-- [ ] `funded_jobs` table live and populating
+- [x] `funded_jobs` table live and populating
+  - Records are written on claim, enriched on submit/verify, and persisted
+    through the durable state store. `/admin/status.upstreamStatus.fundedJobs`
+    now exposes bounded table evidence (`totalRecords`, open/final/pollable
+    counts, source/status buckets, latest timestamps) so the operator can prove
+    the table survived restart and is receiving records.
 - [ ] Daily upstream-status poller running against GitHub + MediaWiki APIs
+  - Poller, CLI, and report generation are implemented. The remaining launch
+    proof is production configuration/evidence: set
+    `UPSTREAM_STATUS_POLLER_ENABLED=true`, then verify
+    `/admin/status.upstreamStatus.running`, `lastSuccessfulAt`, and
+    `fundedJobs.pollableRecords`/status buckets after a hosted run.
 - [x] Hermes/operator self-report proof scheduled and visible
   - Scheduled/manual GitHub workflow exists for `ops_health` and
     `daily_operator_brief`; first production artifacts were recorded in

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -297,8 +297,9 @@ RUN_SUBSCAN_XCM_VALIDATION=1 ./scripts/ops/check-release-readiness.sh testnet
       production `ADMIN_JWT` from 1Password, ran with
       `smoke_check_bootstrap_instrumentation=1`, reached `Checking bootstrap
       instrumentation`, and ended with `Hosted stack smoke check passed.`
-  - The smoke gate verifies `upstreamStatus` is enabled/running and that the
-    optional `.bootstrapSelfReport` status is well-formed and sanitized.
+  - The smoke gate verifies `upstreamStatus` is enabled/running, exposes a
+    durable evidence note plus bounded `fundedJobs` table counters, and that
+    the optional `.bootstrapSelfReport` status is well-formed and sanitized.
   - `/admin/status.bootstrapSelfReport` does not contain API-key-shaped
     tokens such as `Bearer ...` or `re_...`; only the boolean
     `providerConfigured` may reveal that the provider is configured.

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -382,7 +382,25 @@ export class PlatformService {
         running: false,
         intervalMs: 0,
         batchSize: 0,
-        lastRun: undefined
+        lastRun: undefined,
+        lastAttemptedAt: undefined,
+        lastFinishedAt: undefined,
+        lastSuccessfulAt: undefined,
+        lastFailureReason: undefined,
+        evidencePersistenceNote: "poller not initialised",
+        fundedJobs: {
+          totalRecords: 0,
+          openRecords: 0,
+          finalRecords: 0,
+          pollableRecords: 0,
+          awaitingSubmissionRecords: 0,
+          recordsWithUpstreamEvidence: 0,
+          byFinalStatus: {},
+          bySourceType: {},
+          lastFundedAt: undefined,
+          lastUpdatedAt: undefined,
+          recordLimit: 0
+        }
       },
       this.bootstrapSelfReportScheduler?.getStatus?.() ?? {
         enabled: false,

--- a/mcp-server/src/services/upstream-status-poller.js
+++ b/mcp-server/src/services/upstream-status-poller.js
@@ -5,11 +5,16 @@ import {
   summarizeFundedJobs
 } from "../core/funded-jobs.js";
 
+const DEFAULT_STATUS_RECORD_LIMIT = 10_000;
+const UPSTREAM_STATUS_STATE_SCOPE = "upstream-status-poller";
+
 export class UpstreamStatusPollerService {
   constructor(stateStore, eventBus = undefined, {
     enabled = false,
     intervalMs = 24 * 60 * 60 * 1000,
     batchSize = 50,
+    statusRecordLimit = DEFAULT_STATUS_RECORD_LIMIT,
+    stateScope = UPSTREAM_STATUS_STATE_SCOPE,
     githubToken = undefined,
     githubApiBaseUrl = "https://api.github.com",
     fetchImpl = fetch,
@@ -20,6 +25,8 @@ export class UpstreamStatusPollerService {
     this.enabled = enabled;
     this.intervalMs = intervalMs;
     this.batchSize = batchSize;
+    this.statusRecordLimit = statusRecordLimit;
+    this.stateScope = stateScope;
     this.githubToken = githubToken;
     this.githubApiBaseUrl = githubApiBaseUrl;
     this.fetchImpl = fetchImpl;
@@ -44,12 +51,42 @@ export class UpstreamStatusPollerService {
   }
 
   async getStatus() {
+    const persisted = await this.stateStore.getServiceState?.(this.stateScope) ?? {};
+    const fundedJobs = await this.getFundedJobStatusSnapshot(new Date());
     return {
       enabled: this.enabled,
       running: this.running,
       intervalMs: this.intervalMs,
       batchSize: this.batchSize,
-      lastRun: this.lastRun
+      lastRun: this.lastRun ?? persisted.lastRun,
+      lastAttemptedAt: persisted.lastAttemptedAt,
+      lastFinishedAt: persisted.lastFinishedAt,
+      lastSuccessfulAt: persisted.lastSuccessfulAt,
+      lastFailureReason: persisted.lastFailureReason,
+      evidencePersistenceNote: typeof this.stateStore.upsertServiceState === "function"
+        ? "durable_service_state"
+        : "in_process_only",
+      fundedJobs
+    };
+  }
+
+  async getFundedJobStatusSnapshot(now = new Date()) {
+    const records = await this.stateStore.listFundedJobs?.({ limit: this.statusRecordLimit }) ?? [];
+    const finalRecords = records.filter(isFinalFundedJob);
+    const pollableRecords = records.filter((record) => !isFinalFundedJob(record) && isPollableFundedJobRecord(record, now));
+    const recordsWithUpstreamEvidence = records.filter(hasPollableUpstreamEvidence);
+    return {
+      totalRecords: records.length,
+      openRecords: records.length - finalRecords.length,
+      finalRecords: finalRecords.length,
+      pollableRecords: pollableRecords.length,
+      awaitingSubmissionRecords: records.filter((record) => !isFinalFundedJob(record) && record?.upstreamStatus === "not_submitted").length,
+      recordsWithUpstreamEvidence: recordsWithUpstreamEvidence.length,
+      byFinalStatus: countBy(records, (record) => record?.finalStatus ?? FUNDED_JOB_STATUSES.OPEN),
+      bySourceType: countBy(records, (record) => record?.sourceType ?? "unknown"),
+      lastFundedAt: maxIso(records.map((record) => record?.fundedAt)),
+      lastUpdatedAt: maxIso(records.map((record) => record?.updatedAt)),
+      recordLimit: this.statusRecordLimit
     };
   }
 
@@ -120,9 +157,21 @@ export class UpstreamStatusPollerService {
     }, this.intervalMs);
   }
 
-  finishRun(summary) {
+  async finishRun(summary) {
     summary.finishedAt = new Date().toISOString();
     this.lastRun = summary;
+    const previous = await this.stateStore.getServiceState?.(this.stateScope) ?? {};
+    await this.stateStore.upsertServiceState?.(this.stateScope, {
+      lastAttemptedAt: summary.startedAt,
+      lastFinishedAt: summary.finishedAt,
+      lastSuccessfulAt: summary.errors.length === 0
+        ? summary.finishedAt
+        : previous.lastSuccessfulAt,
+      lastFailureReason: summary.errors.length === 0
+        ? null
+        : `${summary.errors.length} upstream status poll error${summary.errors.length === 1 ? "" : "s"}`,
+      lastRun: summary
+    });
     return summary;
   }
 
@@ -356,6 +405,36 @@ export function loadUpstreamStatusPollerConfig(env = process.env) {
 function isPastDeadline(record, now) {
   const deadline = Date.parse(record?.deadlineAt ?? "");
   return Number.isFinite(deadline) && now.getTime() > deadline;
+}
+
+function hasPollableUpstreamEvidence(record) {
+  const upstream = record?.upstream;
+  if (upstream?.kind === "github_pull_request") {
+    return Boolean(upstream.owner && upstream.name && upstream.pullNumber);
+  }
+  if (upstream?.kind === "mediawiki_revision") {
+    return Boolean(!upstream.proposalOnly && upstream.editRevisionId && upstream.language);
+  }
+  return false;
+}
+
+function isPollableFundedJobRecord(record, now) {
+  return hasPollableUpstreamEvidence(record) || isPastDeadline(record, now);
+}
+
+function countBy(records, selector) {
+  return records.reduce((accumulator, record) => {
+    const key = selector(record);
+    accumulator[key] = (accumulator[key] ?? 0) + 1;
+    return accumulator;
+  }, {});
+}
+
+function maxIso(values) {
+  return values
+    .filter((value) => typeof value === "string" && Number.isFinite(Date.parse(value)))
+    .sort()
+    .at(-1);
 }
 
 function parseBooleanEnv(raw) {

--- a/mcp-server/src/services/upstream-status-poller.test.js
+++ b/mcp-server/src/services/upstream-status-poller.test.js
@@ -196,3 +196,53 @@ test("UpstreamStatusPollerService updates records and generates report", async (
   assert.equal(report.mergeRate, 1);
   assert.equal(report.confirmedPayout, 5);
 });
+
+test("UpstreamStatusPollerService status exposes durable funded-job evidence", async () => {
+  const stateStore = new MemoryStateStore();
+  await stateStore.upsertFundedJob({
+    ...githubRecord,
+    upstreamStatus: "submitted"
+  });
+  await stateStore.upsertFundedJob({
+    jobId: "wiki-proposal-only",
+    sourceType: "wikipedia_article",
+    rewardAmount: 2,
+    fundedAt: "2026-01-02T00:00:00.000Z",
+    deadlineAt: "2027-01-16T00:00:00.000Z",
+    finalStatus: "open",
+    upstreamStatus: "not_submitted",
+    upstream: {
+      kind: "mediawiki_revision",
+      language: "en",
+      proposalOnly: true,
+      reviewRevisionId: "123"
+    }
+  });
+  const poller = new UpstreamStatusPollerService(stateStore, undefined, {
+    enabled: true,
+    fetchImpl: async () => jsonResponse({ state: "closed", merged: true, merged_at: "2026-01-03T00:00:00Z" })
+  });
+
+  const beforeRun = await poller.getStatus();
+  assert.equal(beforeRun.evidencePersistenceNote, "durable_service_state");
+  assert.equal(beforeRun.fundedJobs.totalRecords, 2);
+  assert.equal(beforeRun.fundedJobs.openRecords, 2);
+  assert.equal(beforeRun.fundedJobs.pollableRecords, 1);
+  assert.equal(beforeRun.fundedJobs.awaitingSubmissionRecords, 1);
+  assert.equal(beforeRun.fundedJobs.recordsWithUpstreamEvidence, 1);
+  assert.deepEqual(beforeRun.fundedJobs.bySourceType, {
+    github_issue: 1,
+    wikipedia_article: 1
+  });
+
+  await poller.runOnce(new Date("2026-01-04T00:00:00.000Z"));
+  const resumed = new UpstreamStatusPollerService(stateStore, undefined, { enabled: true });
+  const afterRestart = await resumed.getStatus();
+  assert.equal(afterRestart.lastRun.checked, 1);
+  assert.equal(afterRestart.lastRun.updated, 1);
+  assert.equal(afterRestart.lastAttemptedAt, "2026-01-04T00:00:00.000Z");
+  assert.ok(afterRestart.lastSuccessfulAt);
+  assert.equal(afterRestart.lastFailureReason, null);
+  assert.equal(afterRestart.fundedJobs.finalRecords, 1);
+  assert.equal(afterRestart.fundedJobs.byFinalStatus.merged, 1);
+});

--- a/scripts/ops/check-hosted-stack.sh
+++ b/scripts/ops/check-hosted-stack.sh
@@ -311,7 +311,18 @@ if enabled "$CHECK_BOOTSTRAP_INSTRUMENTATION"; then
     (.upstreamStatus.intervalMs | type) == "number" and
     .upstreamStatus.intervalMs <= 86400000 and
     (.upstreamStatus.batchSize | type) == "number" and
-    .upstreamStatus.batchSize > 0
+    .upstreamStatus.batchSize > 0 and
+    (.upstreamStatus.evidencePersistenceNote | type) == "string" and
+    (.upstreamStatus.lastRun == null or (.upstreamStatus.lastRun | type) == "object") and
+    (.upstreamStatus.fundedJobs | type) == "object" and
+    (.upstreamStatus.fundedJobs.totalRecords | type) == "number" and
+    (.upstreamStatus.fundedJobs.openRecords | type) == "number" and
+    (.upstreamStatus.fundedJobs.finalRecords | type) == "number" and
+    (.upstreamStatus.fundedJobs.pollableRecords | type) == "number" and
+    (.upstreamStatus.fundedJobs.awaitingSubmissionRecords | type) == "number" and
+    (.upstreamStatus.fundedJobs.recordsWithUpstreamEvidence | type) == "number" and
+    (.upstreamStatus.fundedJobs.byFinalStatus | type) == "object" and
+    (.upstreamStatus.fundedJobs.bySourceType | type) == "object"
   ' >/dev/null <<<"$admin_status_json"
   jq -e '
     (.bootstrapSelfReport | type) == "object" and

--- a/scripts/ops/check-hosted-stack.test.mjs
+++ b/scripts/ops/check-hosted-stack.test.mjs
@@ -62,6 +62,16 @@ test("operator reporting gate keeps email optional and guards secrets", async ()
   );
   assert.match(
     script,
+    /\.upstreamStatus\.fundedJobs\.totalRecords \| type\) == "number"/u,
+    "operator reporting instrumentation should expose bounded funded-job table counters"
+  );
+  assert.match(
+    script,
+    /\.upstreamStatus\.evidencePersistenceNote \| type\) == "string"/u,
+    "upstream status evidence should say whether service state is durable"
+  );
+  assert.match(
+    script,
     /\.bootstrapSelfReport\.to \| type\) == "array"/u,
     "operator reporting instrumentation should expose a concrete recipient list"
   );


### PR DESCRIPTION
## What changed
- Exposes durable upstream-status poller evidence on /admin/status, including last run timestamps and persistence notes.
- Adds bounded fundedJobs counters/status buckets so the hosted smoke can prove funded job rows exist and survive restart.
- Extends the hosted smoke gate and docs/checklist with the remaining production proof step.

## Checks run
- node --test mcp-server/src/services/upstream-status-poller.test.js
- node --test scripts/ops/check-hosted-stack.test.mjs
- git diff --check
- npm run test:ops
- npm --workspace mcp-server test

## Affected surfaces
- Backend/admin status
- Ops smoke script
- Docs/checklist

## Env / deploy notes
- No new secrets required.
- Daily upstream-status poller launch proof still requires production UPSTREAM_STATUS_POLLER_ENABLED=true and a hosted status run showing running + lastSuccessfulAt.