### PR TITLE
Classify operational event topics

### DIFF
--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -327,6 +327,13 @@ emit into it with the same topic taxonomy.
 - the operator app exposes visible job/session timeline controls for source,
   topic, phase, severity, wallet, and correlation-id filters, and keeps the
   filtered state in the URL for refreshable evidence links
+- event topic classification now covers the known non-chain producer families:
+  policy, capability grants, service tokens, job ingestion, job lifecycle
+  sweeps, funded-job upstream status, bootstrap self-reporting, recurring
+  scheduler events, and XCM observer/watcher events
+- request-scoped XCM observer/watcher events promote `requestId` to the
+  top-level `correlationId`, so queue/observe/finalize timelines are filterable
+  by one identifier
 - local claim-lock funding, verification settlement/rejection, disputed
   verification, dispute verdict, and stake-release receipts emit canonical
   `settlement` source events with funding, settlement, and dispute phases plus
@@ -336,7 +343,10 @@ emit into it with the same topic taxonomy.
 
 ### Remaining gaps
 
-- not every producer emits a canonical topic and payload shape yet
+- future producer families can still drift if they add new topic prefixes
+  without classifier coverage and tests
+- payload schemas are still producer-owned; the next taxonomy pass should
+  standardize compact `data` shapes for newly added operational families
 
 ### Improve to
 
@@ -347,7 +357,8 @@ emit into it with the same topic taxonomy.
 
 ### Concrete next changes
 
-- standardize the remaining platform event topics and payload shapes
+- require classifier tests alongside any new `eventBus.publish` topic family
+- standardize compact payload shapes for future operational event producers
 - keep operator filter presets in step with new canonical source, phase, and
   topic names as producer coverage expands
 

--- a/docs/EVENT_PRODUCER_TAXONOMY_AUDIT.md
+++ b/docs/EVENT_PRODUCER_TAXONOMY_AUDIT.md
@@ -6,6 +6,23 @@ Inventory of every `eventBus.publish(...)` call site on `main` (HEAD
 correlationId`. Docs / report only; no code changes ship in this
 audit pass.
 
+## 2026-05-27 reconciliation
+
+The original audit findings below were accurate at `89e05e6`, but the
+runtime has since caught up:
+
+- Gap A is closed: `policy.`, `capability.`, and `service-token.` topics now
+  classify into `source: "governance"` with stable phases and revocation
+  warning severity.
+- Gap B is closed: XCM outcome relay/observe/finalize events now promote
+  their `requestId` to top-level `correlationId`.
+- Additional producer families discovered after the audit are now classified:
+  `jobs.lifecycle.*`, `funded_jobs.*`, and `bootstrap.*`.
+
+The remaining taxonomy watch item is future producer drift: new event families
+should either use an existing registered prefix or add classifier coverage and
+tests in the same PR.
+
 ## How the envelope is filled
 
 `EventBus.normalizeEvent` ([`mcp-server/src/core/event-bus.js`](../mcp-server/src/core/event-bus.js))
@@ -67,7 +84,7 @@ forward at `event-listener.js:429` (which publishes whatever each
 
 ## Findings
 
-### Gap A — three topic prefixes not in `classifyEventTopic`
+### Gap A — three topic prefixes not in `classifyEventTopic` (closed)
 
 Affected publish sites: **#10, #13–#17** (policy, capability, service-token).
 
@@ -89,19 +106,19 @@ and replayable — but the canonical phase is just the topic itself,
 which makes phase-based filtering ("show me all `governance` events")
 a non-starter for this family.
 
-Recommended fix (when scope allows): extend `classifyEventTopic` to
-recognize these prefixes. Reasonable mappings:
+Implemented fix: `classifyEventTopic` recognizes these prefixes. The current
+runtime mappings are:
 
 | Prefix | `source` | `phase` | `severity` rule |
 |---|---|---|---|
 | `policy.` | `governance` | `governance` | `info` |
-| `capability.` | `governance` | `capability` | `info` (consider `warn` on `capability.revoke`) |
-| `service-token.` | `governance` | `service_token` | `info` (consider `warn` on `service-token.revoke`) |
+| `capability.` | `governance` | `capability` | `warn` on `capability.revoke`, otherwise `info` |
+| `service-token.` | `governance` | `service_token` | `warn` on `service-token.revoke`, otherwise `info` |
 
-These are **out of scope for this audit PR.** Worth a small follow-up
-PR if the team agrees on the proposed mappings.
+Regression coverage lives in
+[`mcp-server/src/core/event-bus.test.js`](../mcp-server/src/core/event-bus.test.js).
 
-### Gap B — XCM events with `requestId` not promoted to `correlationId`
+### Gap B — XCM events with `requestId` not promoted to `correlationId` (closed)
 
 Affected publish sites: **#7, #8, #9, #18**.
 
@@ -112,16 +129,11 @@ events with `correlationId: undefined`. A consumer trying to thread
 the lifecycle `queued → observed → finalized` (or `queued → observed
 → finalize_failed`) by correlation id can't.
 
-Recommended fix: set `correlationId: normalizedRequestId` on each of
-these four calls. One line per site. Behavior change is purely
-*additive* for consumers — anyone currently relying on
-`correlationId === undefined` is not load-bearing on undefined.
-
-I considered this a **borderline "tiny obvious fix"** under the
-audit brief and chose not to ship it in this PR since it does change
-runtime envelope shape on a load-bearing settlement path. Recommend
-shipping as its own focused PR with a backend test asserting the
-correlationId values on the four call sites.
+Implemented fix: each request-scoped XCM observer/watcher event sets
+`correlationId` to the normalized `requestId`. Regression coverage lives in
+[`mcp-server/src/services/xcm-settlement-watcher.test.js`](../mcp-server/src/services/xcm-settlement-watcher.test.js)
+and
+[`mcp-server/src/services/xcm-observation-relay.test.js`](../mcp-server/src/services/xcm-observation-relay.test.js).
 
 ### Gap C — `service-token.` hyphenated topic family
 
@@ -168,11 +180,9 @@ to match the rest of the family.
 
 ## Suggested follow-up PRs (separate from this report)
 
-1. **Extend `classifyEventTopic`** for `policy.`, `capability.`,
-   `service-token.` per the table in Gap A. Single function change in
-   `event-bus.js`, add tests asserting the new branches resolve.
-2. **Promote `requestId → correlationId`** on the four XCM publish
-   sites in Gap B. One-line changes per site, backed by tests.
-3. **(Optional, larger)** Decide on `service-token` vs `service_token`
+1. **Keep the classifier in lockstep with new producer families.** New
+   `eventBus.publish` topic prefixes should add classifier tests in the same
+   PR.
+2. **(Optional, larger)** Decide on `service-token` vs `service_token`
    topic naming and migrate downstream consumers + tests if the
    underscore form wins.

--- a/mcp-server/src/core/event-bus.js
+++ b/mcp-server/src/core/event-bus.js
@@ -230,6 +230,27 @@ function classifyEventTopic(topic, data = {}) {
       severity: "info"
     };
   }
+  if (topic.startsWith("jobs.lifecycle.")) {
+    return {
+      source: "schedule",
+      phase: "job_lifecycle",
+      severity: topic.includes("failed") ? "error" : "info"
+    };
+  }
+  if (topic.startsWith("funded_jobs.")) {
+    return {
+      source: "ingestion",
+      phase: "upstream_status",
+      severity: fundedJobSeverity(data)
+    };
+  }
+  if (topic.startsWith("bootstrap.")) {
+    return {
+      source: "system",
+      phase: "bootstrap",
+      severity: bootstrapSeverity(topic, data)
+    };
+  }
   if (topic.startsWith("system.")) {
     return {
       source: "system",
@@ -308,6 +329,20 @@ function xcmSeverity(topic, data) {
 }
 
 function fundingSeverity(topic, data) {
+  const status = normalizeText(data?.status);
+  if (topic.includes("failed") || status === "failed") return "error";
+  return "info";
+}
+
+function fundedJobSeverity(data) {
+  const finalStatus = normalizeText(data?.finalStatus);
+  const upstreamStatus = normalizeText(data?.upstreamStatus);
+  if (finalStatus === "reverted" || upstreamStatus === "reverted") return "error";
+  if (["closed_unmerged", "open_stale"].includes(finalStatus)) return "warn";
+  return "info";
+}
+
+function bootstrapSeverity(topic, data) {
   const status = normalizeText(data?.status);
   if (topic.includes("failed") || status === "failed") return "error";
   return "info";

--- a/mcp-server/src/core/event-bus.test.js
+++ b/mcp-server/src/core/event-bus.test.js
@@ -180,6 +180,74 @@ test("EventBus classifies governance topics (policy, capability, service-token)"
   assert.equal(tokenRevoke.severity, "warn");
 });
 
+test("EventBus classifies operational job and bootstrap topics", () => {
+  const bus = new EventBus();
+
+  const lifecycle = bus.publish({
+    id: "lifecycle-1",
+    topic: "jobs.lifecycle.swept",
+    jobId: "job-stale",
+    timestamp: "2026-01-01T00:00:00.000Z"
+  });
+  assert.equal(lifecycle.source, "schedule");
+  assert.equal(lifecycle.phase, "job_lifecycle");
+  assert.equal(lifecycle.severity, "info");
+  assert.equal(lifecycle.correlationId, "job-stale");
+
+  const merged = bus.publish({
+    id: "funded-merged-1",
+    topic: "funded_jobs.upstream_status",
+    jobId: "job-merged",
+    sessionId: "session-merged",
+    timestamp: "2026-01-01T00:00:01.000Z",
+    data: { finalStatus: "merged", upstreamStatus: "merged" }
+  });
+  assert.equal(merged.source, "ingestion");
+  assert.equal(merged.phase, "upstream_status");
+  assert.equal(merged.severity, "info");
+  assert.equal(merged.correlationId, "session-merged");
+
+  const closedUnmerged = bus.publish({
+    id: "funded-closed-1",
+    topic: "funded_jobs.upstream_status",
+    jobId: "job-closed",
+    timestamp: "2026-01-01T00:00:02.000Z",
+    data: { finalStatus: "closed_unmerged", upstreamStatus: "closed_unmerged" }
+  });
+  assert.equal(closedUnmerged.source, "ingestion");
+  assert.equal(closedUnmerged.phase, "upstream_status");
+  assert.equal(closedUnmerged.severity, "warn");
+
+  const reverted = bus.publish({
+    id: "funded-reverted-1",
+    topic: "funded_jobs.upstream_status",
+    jobId: "job-reverted",
+    timestamp: "2026-01-01T00:00:03.000Z",
+    data: { finalStatus: "reverted", upstreamStatus: "reverted" }
+  });
+  assert.equal(reverted.severity, "error");
+
+  const selfReport = bus.publish({
+    id: "bootstrap-report-1",
+    topic: "bootstrap.self_report.sent",
+    timestamp: "2026-01-01T00:00:04.000Z",
+    data: { status: "sent" }
+  });
+  assert.equal(selfReport.source, "system");
+  assert.equal(selfReport.phase, "bootstrap");
+  assert.equal(selfReport.severity, "info");
+
+  const failedSelfReport = bus.publish({
+    id: "bootstrap-report-failed-1",
+    topic: "bootstrap.self_report.failed",
+    timestamp: "2026-01-01T00:00:05.000Z",
+    data: { status: "failed" }
+  });
+  assert.equal(failedSelfReport.source, "system");
+  assert.equal(failedSelfReport.phase, "bootstrap");
+  assert.equal(failedSelfReport.severity, "error");
+});
+
 test("EventBus persists events and replays durable filters beyond the ring buffer", async () => {
   const store = new MemoryStateStore();
   const bus = new EventBus({ bufferSize: 1, eventStore: store });


### PR DESCRIPTION
## What changed
- Classifies `jobs.lifecycle.*`, `funded_jobs.*`, and `bootstrap.*` event families into canonical source/phase/severity buckets.
- Adds event-bus regression coverage for lifecycle, funded-job upstream status, and bootstrap self-report topics.
- Updates the event taxonomy audit and roadmap to mark already-closed governance/XCM gaps accurately.

## Checks
- `node --test mcp-server/src/core/event-bus.test.js`
- `node --test mcp-server/src/services/xcm-settlement-watcher.test.js mcp-server/src/services/xcm-observation-relay.test.js`
- classifier sanity script for known topic families
- `git diff --check`
- `npm --workspace mcp-server test`

## Impact
- Backend + docs only.
- No frontend, indexer, contract, Caddy, public site, or VPS secret changes.
- Polkadot MCP docs check: BlockScout/Routescan/Subscan are explorer/history surfaces; this is app-side observability taxonomy only, not a Polkadot protocol change.