### PR TITLE
ops: fix external-schema-proof jobId case + archived lookup

### DIFF
--- a/mcp-server/src/core/job-catalog-metadata.test.js
+++ b/mcp-server/src/core/job-catalog-metadata.test.js
@@ -160,6 +160,9 @@ test("job lifecycle supports archival and claimability guardrails", () => {
     () => service.getPublicJobDefinition("archive-lifecycle-001"),
     /Unknown job: archive-lifecycle-001/
   );
+  const archivedDefinition = service.getPublicJobDefinition("archive-lifecycle-001", { includeArchived: true });
+  assert.equal(archivedDefinition.id, "archive-lifecycle-001");
+  assert.equal(archivedDefinition.lifecycle.state, "archived");
   assert.throws(
     () => service.getClaimableJobDefinition("archive-lifecycle-001"),
     /not claimable/

--- a/mcp-server/src/core/job-catalog-service.js
+++ b/mcp-server/src/core/job-catalog-service.js
@@ -412,12 +412,13 @@ export class JobCatalogService {
     return this.withLifecycle(this.requireJob(jobId));
   }
 
-  getPublicJobDefinition(jobId) {
+  getPublicJobDefinition(jobId, visibility = {}) {
     const job = this.requireJob(jobId);
-    if (!this.isVisibleJob(job)) {
+    const { now = new Date(), ...visibilityOptions } = visibility;
+    if (!this.isVisibleJob(job, { ...visibilityOptions, now })) {
       throw new NotFoundError(`Unknown job: ${jobId}`, "job_not_found");
     }
-    return this.withLifecycle(job);
+    return this.withLifecycle(job, now);
   }
 
   getClaimableJobDefinition(jobId) {

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -593,9 +593,21 @@ export class PlatformService {
   }
 
   async getPublicJobDefinition(jobId, options = {}) {
-    const { wallet, currentWallet, now = new Date() } = options;
+    const {
+      wallet,
+      currentWallet,
+      now = new Date(),
+      includeArchived = false,
+      includePaused = false,
+      includeStale = false
+    } = options;
     return this.attachClaimState(
-      this.jobCatalogService.getPublicJobDefinition(jobId),
+      this.jobCatalogService.getPublicJobDefinition(jobId, {
+        includeArchived,
+        includePaused,
+        includeStale,
+        now
+      }),
       { wallet: currentWallet ?? wallet, now }
     );
   }

--- a/mcp-server/src/protocols/http/job-routes.js
+++ b/mcp-server/src/protocols/http/job-routes.js
@@ -33,8 +33,13 @@ export function createJobRoutes({
     }
 
     if (request.method === "GET" && pathname === "/jobs/definition") {
+      const includeArchived = isTruthyFlag(url.searchParams.get("includeArchived"));
+      const auth = includeArchived
+        ? await authMiddleware(request, url, { requireRole: "admin" })
+        : undefined;
       respond(response, 200, await service.getPublicJobDefinition(url.searchParams.get("jobId") ?? "", {
-        wallet: url.searchParams.get("wallet") ?? undefined
+        wallet: url.searchParams.get("wallet") ?? undefined,
+        ...(includeArchived ? { includeArchived: true, currentWallet: auth.wallet } : {})
       }));
       return true;
     }
@@ -165,4 +170,8 @@ export function createJobRoutes({
 
     return false;
   };
+}
+
+function isTruthyFlag(value) {
+  return ["1", "true", "yes"].includes(String(value ?? "").trim().toLowerCase());
 }

--- a/mcp-server/src/protocols/http/job-routes.test.js
+++ b/mcp-server/src/protocols/http/job-routes.test.js
@@ -59,8 +59,8 @@ function makeHarness(overrides = {}) {
     ...overrides.service,
   };
   const route = createJobRoutes({
-    authMiddleware: async (_request, _url) => {
-      calls.push(["authMiddleware"]);
+    authMiddleware: async (_request, _url, options) => {
+      calls.push(options === undefined ? ["authMiddleware"] : ["authMiddleware", options]);
       return auth;
     },
     enforceLimit: async (bucket, key, limits) => {
@@ -149,6 +149,25 @@ test("GET /jobs/definition forwards job and optional wallet", async () => {
   assert.deepEqual(calls.slice(0, 2), [
     ["getPublicJobDefinition", { jobId: "job-1", options: { wallet: "0xabc" } }],
     ["respond", { statusCode: 200, body: { id: "job-1", wallet: "0xabc" }, headers: {} }],
+  ]);
+});
+
+test("GET /jobs/definition requires admin auth to include archived jobs", async () => {
+  const { calls, response, route } = makeHarness();
+
+  assert.equal(await invoke(route, { path: "/jobs/definition?jobId=archive-1&includeArchived=true", response }), true);
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(calls.slice(0, 3), [
+    ["authMiddleware", { requireRole: "admin" }],
+    ["getPublicJobDefinition", {
+      jobId: "archive-1",
+      options: {
+        wallet: undefined,
+        includeArchived: true,
+        currentWallet: WALLET
+      }
+    }],
+    ["respond", { statusCode: 200, body: { id: "archive-1", wallet: undefined }, headers: {} }],
   ]);
 });
 

--- a/scripts/ops/check-external-schema-registration-proof.mjs
+++ b/scripts/ops/check-external-schema-registration-proof.mjs
@@ -48,7 +48,10 @@ export async function checkExternalSchemaRegistrationProof({
 
   const apiBaseUrl = stripTrailingSlash(env.API_BASE_URL || DEFAULT_API_BASE_URL);
   const runStamp = `${now().toISOString().replace(/[:.]/gu, "-")}-${randomUUID().slice(0, 8)}`;
-  const jobId = string(env.EXTERNAL_SCHEMA_PROOF_JOB_ID) || `external-schema-proof-${runStamp}`;
+  const jobId = normalizeJobId(string(env.EXTERNAL_SCHEMA_PROOF_JOB_ID) || `external-schema-proof-${runStamp}`);
+  if (!jobId) {
+    throw new Error("External schema proof jobId is empty after normalization.");
+  }
   const idempotencyKey = string(env.EXTERNAL_SCHEMA_PROOF_IDEMPOTENCY_KEY) || `external-schema-proof:${jobId}`;
   const evidenceFile = string(env.EXTERNAL_SCHEMA_PROOF_EVIDENCE_FILE);
 
@@ -91,8 +94,12 @@ export async function checkExternalSchemaRegistrationProof({
     lifecycleStatus: created.lifecycle?.status
   };
 
-  log("Checking public job definition exposes registered schema trust metadata");
-  const definition = await fetchJson(fetchImpl, `${apiBaseUrl}/jobs/definition?jobId=${encodeURIComponent(jobId)}`);
+  log("Checking authenticated archived job definition exposes registered schema trust metadata");
+  const definition = await fetchJson(
+    fetchImpl,
+    `${apiBaseUrl}/jobs/definition?jobId=${encodeURIComponent(jobId)}&includeArchived=true`,
+    { headers: bearer(adminToken) }
+  );
   assert.equal(definition.id, jobId);
   assert.equal(definition.submissionContract?.registeredSchema, true);
   assert.equal(definition.submissionContract?.outputSchemaRef, DEFAULT_SCHEMA_REF);
@@ -262,6 +269,13 @@ function stripTrailingSlash(value) {
 
 function string(value) {
   return String(value ?? "").trim();
+}
+
+function normalizeJobId(value) {
+  return string(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 }
 
 function truncate(value, max = 400) {

--- a/scripts/ops/check-external-schema-registration-proof.test.mjs
+++ b/scripts/ops/check-external-schema-registration-proof.test.mjs
@@ -10,6 +10,7 @@ import { checkExternalSchemaRegistrationProof } from "./check-external-schema-re
 const API_BASE_URL = "https://api.example.test";
 const ADMIN_TOKEN = "admin-token";
 const JOB_ID = "external-schema-proof-test";
+const NORMALIZED_UPPERCASE_JOB_ID = "external-schema-proof-2026-05-27t12-00-00-000z";
 const SCHEMA_REF = "schema://jobs/external-proof-output";
 const SCHEMA_URL = "https://schemas.example.com/jobs/external-proof-output.json";
 const ISSUER = "0xF4Bc6F29F319dE2e6A9197F3f214a3C4B6138BAB";
@@ -55,6 +56,10 @@ test("checkExternalSchemaRegistrationProof creates an archived job and proves re
   assert.equal(normalizedRegistrations[0].signatureVerified, true);
   assert.equal(normalizedRegistrations[0].trusted, true);
 
+  const definitionCall = calls.find((call) => call.method === "GET" && call.url.startsWith(`${API_BASE_URL}/jobs/definition?`));
+  assert.equal(definitionCall.authorization, `Bearer ${ADMIN_TOKEN}`);
+  assert.equal(definitionCall.url, `${API_BASE_URL}/jobs/definition?jobId=${encodeURIComponent(JOB_ID)}&includeArchived=true`);
+
   const validationCalls = calls.filter((call) => call.method === "POST" && call.url === `${API_BASE_URL}/jobs/validate-submission`);
   assert.equal(validationCalls.length, 2);
   assert.deepEqual(validationCalls[0].body, {
@@ -68,6 +73,27 @@ test("checkExternalSchemaRegistrationProof creates an archived job and proves re
   const evidenceText = await readFile(evidenceFile, "utf8");
   assert.doesNotMatch(evidenceText, new RegExp(ADMIN_TOKEN, "u"));
   assert.equal(JSON.parse(evidenceText).schemaRef, SCHEMA_REF);
+});
+
+test("checkExternalSchemaRegistrationProof normalizes jobId before create and lookup", async () => {
+  const { fetch, calls } = fakeExternalSchemaFetch({ expectedJobId: NORMALIZED_UPPERCASE_JOB_ID });
+
+  const evidence = await checkExternalSchemaRegistrationProof({
+    env: {
+      ADMIN_JWT: ADMIN_TOKEN,
+      API_BASE_URL,
+      EXTERNAL_SCHEMA_PROOF_JOB_ID: "External Schema Proof 2026-05-27T12:00:00.000Z"
+    },
+    fetchImpl: fetch,
+    log: () => {},
+    now: () => new Date("2026-05-26T12:00:00.000Z")
+  });
+
+  assert.equal(evidence.jobId, NORMALIZED_UPPERCASE_JOB_ID);
+  const createCall = calls.find((call) => call.method === "POST" && call.url === `${API_BASE_URL}/admin/jobs`);
+  assert.equal(createCall.body.id, NORMALIZED_UPPERCASE_JOB_ID);
+  const definitionCall = calls.find((call) => call.method === "GET" && call.url.startsWith(`${API_BASE_URL}/jobs/definition?`));
+  assert.equal(definitionCall.url, `${API_BASE_URL}/jobs/definition?jobId=${encodeURIComponent(NORMALIZED_UPPERCASE_JOB_ID)}&includeArchived=true`);
 });
 
 test("checkExternalSchemaRegistrationProof fails closed before network calls without ADMIN_JWT", async () => {
@@ -123,6 +149,7 @@ test("checkExternalSchemaRegistrationProof rejects definitions missing trust met
 
 function fakeExternalSchemaFetch({
   adminSession = defaultAdminSession(),
+  expectedJobId = JOB_ID,
   omitTrustMetadata = false
 } = {}) {
   const calls = [];
@@ -143,16 +170,16 @@ function fakeExternalSchemaFetch({
 
     if (call.url === `${API_BASE_URL}/admin/jobs` && method === "POST") {
       return json({
-        id: call.body.id,
+        id: normalizeJobIdForTest(call.body.id),
         outputSchemaRef: call.body.outputSchemaRef,
         schemaRegistrations: call.body.schemaRegistrations,
         lifecycle: call.body.lifecycle
       }, 201);
     }
 
-    if (call.url === `${API_BASE_URL}/jobs/definition?jobId=${encodeURIComponent(JOB_ID)}`) {
+    if (call.url === `${API_BASE_URL}/jobs/definition?jobId=${encodeURIComponent(expectedJobId)}&includeArchived=true`) {
       return json({
-        id: JOB_ID,
+        id: expectedJobId,
         submissionContract: {
           registeredSchema: true,
           outputSchemaRef: SCHEMA_REF,
@@ -228,4 +255,12 @@ function text(body, status = 200) {
     status,
     text: async () => body
   };
+}
+
+function normalizeJobIdForTest(value) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 }


### PR DESCRIPTION
## Summary
- normalize the external-schema proof job id before create/lookup so it matches catalog storage
- keep proof jobs archived, but allow admin-authenticated direct /jobs/definition lookup with includeArchived=true
- update proof, route, and catalog tests for archived lookup and server-style id normalization

## Checks
- node --test scripts/ops/check-external-schema-registration-proof.test.mjs
- node --test mcp-server/src/protocols/http/job-routes.test.js mcp-server/src/core/job-catalog-metadata.test.js
- npm run test:ops
- npm --workspace mcp-server test

## Impact
- Backend: adds admin-gated includeArchived direct job definition lookup
- Ops: fixes CHECK_EXTERNAL_SCHEMA_PROOF=1 proof script behavior
- Frontend/indexer/contracts/Caddy/public site: no changes
- Env/VPS secrets: no changes

Note: I did not mark the roadmap row Proofed; hosted operator evidence capture remains the follow-up after this fix lands.