### PR TITLE
Bind schema-native helpers to advertised schemas

### DIFF
--- a/docs/CORE_FRAMEWORK_ROADMAP.md
+++ b/docs/CORE_FRAMEWORK_ROADMAP.md
@@ -169,8 +169,8 @@ discipline for custom/off-platform schemas.
   validation traces plus the verifier-input and funding modes in the launch
   evidence gate
 - the generic claim-and-submit helper now uses the same schema-native readiness
-  guard before claim, so the pattern is available outside the product-proof
-  smoke loop
+  guard before claim and resolves the expected schema from definition/preflight
+  first, so advertised contract drift blocks before any claim is consumed
 
 ### Gaps today
 

--- a/docs/REFERENCE_AGENT_WORKFLOWS.md
+++ b/docs/REFERENCE_AGENT_WORKFLOWS.md
@@ -18,19 +18,22 @@ The smallest safe worker loop is implemented in
    contract.
 3. Read `/jobs/preflight?jobId=<id>` with the worker token before consuming a
    claim attempt.
-4. Build the direct structured submission object required by the job's output
+4. Resolve the expected output schema from the definition and preflight
+   surfaces; stop if they disagree.
+5. Build the direct structured submission object required by the job's output
    schema.
-5. Call `POST /jobs/validate-submission` with that exact object before any
+6. Call `POST /jobs/validate-submission` with that exact object before any
    mutation.
-6. Claim once through `POST /jobs/claim`, using a stable idempotency key for
+7. Claim once through `POST /jobs/claim`, using a stable idempotency key for
    the intended run.
-7. Submit once through `POST /jobs/submit`.
-8. Read `/session/timeline?sessionId=<id>` and record the receipt summary.
+8. Submit once through `POST /jobs/submit`.
+9. Read `/session/timeline?sessionId=<id>` and record the receipt summary.
 
 The worker must not wrap structured output under `submission.output`. The SDK
-helper `assertSchemaNativeSubmissionReady(jobId, submission)` validates the
-direct object and probes that an invalid wrapper is rejected before the claim is
-attempted.
+helpers `resolveExpectedSubmissionSchemaRef(definition, preflight)` and
+`assertSchemaNativeSubmissionReady(jobId, submission, { expectedSchemaRef })`
+bind the advertised contract to the validator, validate the direct object, and
+probe that an invalid wrapper is rejected before the claim is attempted.
 
 Dry run first:
 

--- a/examples/claim-and-submit-job/README.md
+++ b/examples/claim-and-submit-job/README.md
@@ -39,7 +39,9 @@ AVERRAY_TOKEN="$TOKEN" node examples/claim-and-submit-job/index.mjs \
 ```
 
 The example calls the SDK's `assertSchemaNativeSubmissionReady` guard before
-claiming. That makes the direct draft pass `/jobs/validate-submission`, records
-the schema ref used, and probes an intentionally invalid `submission.output`
-wrapper through the same read-only route. If the draft is missing required
-fields, it stops before consuming a claim attempt.
+claiming. It first resolves the expected schema from `/jobs/definition` and
+`/jobs/preflight`, then makes the direct draft pass `/jobs/validate-submission`,
+records the schema ref used, and probes an intentionally invalid
+`submission.output` wrapper through the same read-only route. If the advertised
+schema surfaces drift or the draft is missing required fields, it stops before
+consuming a claim attempt.

--- a/examples/claim-and-submit-job/index.mjs
+++ b/examples/claim-and-submit-job/index.mjs
@@ -4,7 +4,8 @@ import { pathToFileURL } from "node:url";
 
 import {
   AgentPlatformClient,
-  AgentPlatformValidationError
+  AgentPlatformValidationError,
+  resolveExpectedSubmissionSchemaRef
 } from "../../sdk/agent-platform-client.js";
 
 const DEFAULT_API_URL = "https://api.averray.com";
@@ -53,7 +54,14 @@ export async function runClaimAndSubmit({
     client.getJobDefinition(jobId),
     token ? client.preflightJob(jobId) : Promise.resolve(undefined)
   ]);
-  const readiness = buildReadinessSummary({ onboarding, definition, preflight, tokenPresent: Boolean(token) });
+  const expectedSchemaRef = resolveExpectedSubmissionSchemaRef(definition, preflight);
+  const readiness = buildReadinessSummary({
+    onboarding,
+    definition,
+    preflight,
+    tokenPresent: Boolean(token),
+    expectedSchemaRef
+  });
 
   if (!execute) {
     return {
@@ -82,7 +90,9 @@ export async function runClaimAndSubmit({
   const draftSubmission = submission ?? evidence;
   let validationReadiness;
   try {
-    validationReadiness = await client.assertSchemaNativeSubmissionReady(jobId, draftSubmission);
+    validationReadiness = await client.assertSchemaNativeSubmissionReady(jobId, draftSubmission, {
+      expectedSchemaRef
+    });
   } catch (error) {
     if (!(error instanceof AgentPlatformValidationError)) {
       throw error;
@@ -129,17 +139,19 @@ export async function runClaimAndSubmit({
   };
 }
 
-export function buildReadinessSummary({ onboarding, definition, preflight, tokenPresent }) {
+export function buildReadinessSummary({ onboarding, definition, preflight, tokenPresent, expectedSchemaRef = undefined }) {
   const claimStatus = definition?.claimStatus ?? {};
   const preflightClaimable = preflight?.claimable ?? preflight?.eligible ?? preflight?.allowed;
   const definitionClaimable = claimStatus.claimable ?? definition?.claimable;
   const claimable = preflightClaimable ?? definitionClaimable ?? false;
   const reason = preflight?.reason ?? claimStatus.reason ?? definition?.reason ?? null;
+  const resolvedSchemaRef = expectedSchemaRef ?? resolveExpectedSubmissionSchemaRef(definition, preflight);
   return {
     tokenPresent,
     onboardingEntrypoint: onboarding?.onboarding?.entrypoint ?? onboarding?.entrypoint ?? "/onboarding",
     jobId: definition?.id ?? definition?.jobId ?? null,
     title: definition?.title ?? null,
+    expectedSubmissionSchemaRef: resolvedSchemaRef ?? null,
     claimState: claimStatus.claimState ?? definition?.claimState ?? null,
     claimable: Boolean(claimable),
     reason,

--- a/examples/claim-and-submit-job/index.test.mjs
+++ b/examples/claim-and-submit-job/index.test.mjs
@@ -51,6 +51,7 @@ test("buildReadinessSummary treats claimStatus as the claimability source", () =
 
   assert.equal(readiness.canAttemptClaim, true);
   assert.equal(readiness.reason, "claimable");
+  assert.equal(readiness.expectedSubmissionSchemaRef, null);
 });
 
 test("runClaimAndSubmit dry-run avoids claim and submit mutations", async () => {
@@ -64,6 +65,7 @@ test("runClaimAndSubmit dry-run avoids claim and submit mutations", async () => 
 
   assert.equal(summary.mode, "dry_run");
   assert.equal(summary.readiness.canAttemptClaim, true);
+  assert.equal(summary.readiness.expectedSubmissionSchemaRef, "schema://jobs/example-output");
   assert.deepEqual(calls, [
     "https://api.example/onboarding",
     "https://api.example/jobs/definition?jobId=job-1",
@@ -87,6 +89,7 @@ test("runClaimAndSubmit executes claim, submit, and timeline reads when requeste
   assert.equal(summary.mode, "executed");
   assert.equal(summary.claim.sessionId, "session-1");
   assert.equal(summary.validation.valid, true);
+  assert.equal(summary.validation.schemaRef, "schema://jobs/example-output");
   assert.equal(summary.validationReadiness.validatedBeforeClaim, true);
   assert.equal(summary.validationReadiness.invalidWrappedOutput.valid, false);
   assert.equal(summary.submit.status, "submitted");
@@ -116,6 +119,26 @@ test("runClaimAndSubmit blocks before claim when local draft validation fails", 
   assert.ok(!calls.includes("https://api.example/jobs/claim"));
 });
 
+test("runClaimAndSubmit blocks before claim when validation schema drifts from advertised contract", async () => {
+  const calls = [];
+  const summary = await runClaimAndSubmit({
+    apiUrl: "https://api.example",
+    token: "token",
+    jobId: "job-1",
+    submission: { result: "complete" },
+    execute: true,
+    fetchImpl: fakeFetch(calls, { validationSchemaRef: "schema://jobs/other-output" })
+  });
+
+  assert.equal(summary.mode, "blocked");
+  assert.equal(summary.readiness.expectedSubmissionSchemaRef, "schema://jobs/example-output");
+  assert.equal(summary.validation.schemaRef, "schema://jobs/other-output");
+  assert.equal(summary.claim, null);
+  assert.equal(summary.submit, null);
+  assert.ok(calls.includes("https://api.example/jobs/validate-submission"));
+  assert.ok(!calls.includes("https://api.example/jobs/claim"));
+});
+
 test("summarizeTimeline returns compact timeline metadata", () => {
   assert.deepEqual(summarizeTimeline({
     timelineVersion: "v2",
@@ -129,7 +152,12 @@ test("summarizeTimeline returns compact timeline metadata", () => {
   });
 });
 
-function fakeFetch(calls, { validationValid = true } = {}) {
+function fakeFetch(calls, {
+  definitionSchemaRef = "schema://jobs/example-output",
+  preflightSchemaRef = "schema://jobs/example-output",
+  validationSchemaRef = "schema://jobs/example-output",
+  validationValid = true
+} = {}) {
   return async (url, options = {}) => {
     calls.push(String(url));
     if (String(url).endsWith("/onboarding")) {
@@ -138,11 +166,17 @@ function fakeFetch(calls, { validationValid = true } = {}) {
     if (String(url).includes("/jobs/definition")) {
       return jsonResponse({
         id: "job-1",
+        outputSchemaRef: definitionSchemaRef,
+        submissionContract: {
+          outputSchemaRef: definitionSchemaRef,
+          schemaValidates: "payload.submission",
+          doNotWrapInOutput: true
+        },
         claimStatus: { claimState: "open", claimable: true, reason: "claimable" }
       });
     }
     if (String(url).includes("/jobs/preflight")) {
-      return jsonResponse({ claimable: true, reason: "claimable" });
+      return jsonResponse({ claimable: true, reason: "claimable", requiredOutputSchema: preflightSchemaRef });
     }
     if (String(url).endsWith("/jobs/validate-submission")) {
       assert.equal(options.method, "POST");
@@ -152,7 +186,7 @@ function fakeFetch(calls, { validationValid = true } = {}) {
         return jsonResponse({
           valid: false,
           submitSafe: false,
-          schemaRef: "schema://jobs/example-output",
+          schemaRef: validationSchemaRef,
           schemaValidates: "payload.submission",
           message: "Send the structured proposal object directly as submission, not under submission.output.",
           path: "payload.submission.output",
@@ -166,11 +200,11 @@ function fakeFetch(calls, { validationValid = true } = {}) {
         ? {
             valid: true,
             submitSafe: true,
-            schemaRef: "schema://jobs/example-output",
+            schemaRef: validationSchemaRef,
             schemaValidates: "payload.submission",
             submissionKind: "structured"
           }
-        : { valid: false, schemaRef: "schema://jobs/example-output", message: "submission.result is required" });
+        : { valid: false, schemaRef: validationSchemaRef, message: "submission.result is required" });
     }
     if (String(url).endsWith("/jobs/claim")) {
       assert.equal(options.method, "POST");

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -32,6 +32,9 @@ seeing where claim and submit happen. For helper workflows that need a hard
 schema-native guard, `assertSchemaNativeSubmissionReady(jobId, draft)` validates
 the exact direct schema object and records a read-only rejected
 `submission.output` wrapper probe before any claim is consumed.
+`resolveExpectedSubmissionSchemaRef(definition, preflight)` reads the advertised
+schema from `/jobs/definition` and `/jobs/preflight`, fails closed when those
+surfaces disagree, and gives the expected ref to pass into the readiness guard.
 `claimJobAfterValidation(jobId, draft, key)` validates the exact draft before
 consuming a claim attempt, and `submitValidatedWork(jobId, sessionId, draft)`
 validates again before the submit mutation. These helpers throw

--- a/sdk/agent-platform-client.d.ts
+++ b/sdk/agent-platform-client.d.ts
@@ -25,6 +25,12 @@ export const DEFAULT_ESCROW_ASSET_SYMBOL: "USDC";
  */
 export function createIdempotencyKey(prefix?: string): IdempotencyKey;
 
+/**
+ * Resolve the output schema ref advertised by job definition/preflight records.
+ * Throws AgentPlatformValidationError when the records disagree.
+ */
+export function resolveExpectedSubmissionSchemaRef(...records: unknown[]): BuiltinJobSchemaRef | string | undefined;
+
 export interface AgentPlatformClientOptions {
   baseUrl: string;
   token?: string;

--- a/sdk/agent-platform-client.js
+++ b/sdk/agent-platform-client.js
@@ -30,6 +30,31 @@ export function createIdempotencyKey(prefix = "run") {
   return `${safePrefix}-${timestamp}-${suffix}`;
 }
 
+/**
+ * Resolve the output schema a worker should expect from job definition and
+ * preflight surfaces. Returns undefined for legacy/plain-evidence jobs.
+ */
+export function resolveExpectedSubmissionSchemaRef(...records) {
+  const refs = [];
+  for (const record of records) {
+    collectSubmissionSchemaRefs(record, refs);
+  }
+  const uniqueRefs = [...new Set(refs)];
+  if (uniqueRefs.length > 1) {
+    throw new AgentPlatformValidationError({
+      message: `Conflicting submission schema refs: ${uniqueRefs.join(", ")}.`,
+      validation: {
+        valid: false,
+        submitSafe: false,
+        code: "submission_schema_ref_conflict",
+        schemaRefs: uniqueRefs,
+        message: "Job definition and preflight returned conflicting submission schema refs."
+      }
+    });
+  }
+  return uniqueRefs[0];
+}
+
 function generateRandomSuffix() {
   const cryptoImpl = globalThis.crypto;
   if (cryptoImpl?.randomUUID) {
@@ -633,6 +658,22 @@ export class AgentPlatformValidationError extends Error {
 
 function isSubmitSafeValidation(validation) {
   return validation?.valid === true && validation?.submitSafe !== false;
+}
+
+function collectSubmissionSchemaRefs(record, refs) {
+  if (!isStructuredObject(record)) return;
+  pushSchemaRef(refs, record.submissionContract?.outputSchemaRef);
+  pushSchemaRef(refs, record.submissionContract?.schemaRef);
+  pushSchemaRef(refs, record.requiredOutputSchema);
+  pushSchemaRef(refs, record.outputSchemaRef);
+  pushSchemaRef(refs, record.source?.outputSchemaRef);
+  pushSchemaRef(refs, record.verification?.evidenceSchemaRef);
+}
+
+function pushSchemaRef(refs, value) {
+  if (typeof value !== "string") return;
+  const trimmed = value.trim();
+  if (trimmed) refs.push(trimmed);
 }
 
 function isStructuredObject(value) {

--- a/sdk/agent-platform-client.test.mjs
+++ b/sdk/agent-platform-client.test.mjs
@@ -5,7 +5,8 @@ import {
   AgentPlatformApiError,
   AgentPlatformClient,
   AgentPlatformValidationError,
-  createIdempotencyKey
+  createIdempotencyKey,
+  resolveExpectedSubmissionSchemaRef
 } from "./agent-platform-client.js";
 
 test("builder read helpers call the expected public endpoints", async () => {
@@ -340,6 +341,38 @@ test("schema-native readiness validates direct output and rejected wrapper befor
     "https://api.example.test/jobs/validate-submission",
     "https://api.example.test/jobs/validate-submission"
   ]);
+});
+
+test("resolveExpectedSubmissionSchemaRef reads definition and preflight schema refs", () => {
+  assert.equal(resolveExpectedSubmissionSchemaRef(
+    {
+      outputSchemaRef: "schema://jobs/pr-review-findings-output",
+      submissionContract: {
+        outputSchemaRef: "schema://jobs/pr-review-findings-output"
+      }
+    },
+    {
+      requiredOutputSchema: "schema://jobs/pr-review-findings-output"
+    }
+  ), "schema://jobs/pr-review-findings-output");
+
+  assert.equal(resolveExpectedSubmissionSchemaRef({ claimStatus: { claimable: true } }), undefined);
+
+  assert.throws(
+    () => resolveExpectedSubmissionSchemaRef(
+      { outputSchemaRef: "schema://jobs/pr-review-findings-output" },
+      { requiredOutputSchema: "schema://jobs/release-readiness-output" }
+    ),
+    (error) => {
+      assert.ok(error instanceof AgentPlatformValidationError);
+      assert.equal(error.code, "submission_schema_ref_conflict");
+      assert.deepEqual(error.validation.schemaRefs, [
+        "schema://jobs/pr-review-findings-output",
+        "schema://jobs/release-readiness-output"
+      ]);
+      return true;
+    }
+  );
 });
 
 test("operator surface helpers call policy, audit, and alert endpoints", async () => {

--- a/sdk/api-surface-model.mjs
+++ b/sdk/api-surface-model.mjs
@@ -16,6 +16,12 @@ export const DEFAULT_ESCROW_ASSET_SYMBOL: "USDC";
  */
 export function createIdempotencyKey(prefix?: string): IdempotencyKey;
 
+/**
+ * Resolve the output schema ref advertised by job definition/preflight records.
+ * Throws AgentPlatformValidationError when the records disagree.
+ */
+export function resolveExpectedSubmissionSchemaRef(...records: unknown[]): BuiltinJobSchemaRef | string | undefined;
+
 export interface AgentPlatformClientOptions {
   baseUrl: string;
   token?: string;


### PR DESCRIPTION
## What changed
- Add SDK helper to resolve the expected submission schema from job definition/preflight records and fail closed on conflicts.
- Wire the generic claim-and-submit example to pass that schema into the schema-native readiness guard before any claim.
- Update SDK/example docs and roadmap notes; regenerate SDK declarations.

## Polkadot MCP double-check
- Checked Polkadot Hub Asset Hub/ERC20 precompile docs earlier in this slice. The change stays in SDK/helper schema validation and does not add runtime ERC20 metadata calls; static schema/assets metadata remains the source of truth.

## Checks
- npm run generate:sdk-types
- node --test sdk/agent-platform-client.test.mjs examples/claim-and-submit-job/index.test.mjs
- npm run test:sdk
- npm run test:examples
- git diff --check

## Surfaces
- SDK, examples, docs only. No backend, frontend, indexer, contracts, Caddy, public site, environment, or VPS secret changes.