### PR TITLE
Fix hosted dispute verdict chain signer

### DIFF
--- a/docs/DISPUTE_VERDICT_LIVE_PROOF.md
+++ b/docs/DISPUTE_VERDICT_LIVE_PROOF.md
@@ -89,8 +89,10 @@ Required env on the backend for live dispatch:
 
 - `AVERRAY_RPC_URL` — Polkadot Hub EVM RPC.
 - `ESCROW_CORE_ADDRESS` — deployed `EscrowCore` contract address.
-- Arbitrator signer key — the wallet behind this key is what
-  `EscrowCore.resolveDispute(...)` is called with.
+- Arbitrator signer key — set `ARBITRATOR_SIGNER_PRIVATE_KEY` when the
+  verifier/backend signer is intentionally different from the phase-0
+  arbitrator. If unset, the backend `SIGNER_PRIVATE_KEY` / KMS signer is
+  also used for `EscrowCore.resolveDispute(...)`.
 
 Required on-chain config:
 
@@ -103,12 +105,14 @@ Required on-chain config:
 
 Required on the deployed `EscrowCore` for the specific dispute id:
 
-- The job state must be in `Disputed`. The verdict route trusts the
-  off-chain dispute record's `status: "open"`; the on-chain side
-  enforces its own invariant. If the chain says the job is already
-  `Resolved` (or never reached `Disputed`), the `resolveDispute` call
-  will revert, the response throws, and the harness fails closed
-  with a 5xx — no receipt is persisted in that case.
+- The job state must be `Rejected` or `Disputed`. If the chain is still
+  `Rejected`, the verdict route first calls `EscrowCore.openDispute(...)`
+  with the normal backend participant signer and records
+  `chainDisputeTxHash` before calling `resolveDispute(...)` with the
+  arbitrator signer. If the chain says the job is already `Resolved`
+  (or never reached a rejectable/disputed state), the response throws
+  and the harness fails closed with a 5xx — no receipt is persisted in
+  that case.
 
 ## Proof sequence
 

--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -4,6 +4,10 @@
 # POLKADOT_RPC_URL=https://your-polkadot-rpc
 RPC_URL=https://your-asset-hub-rpc
 SIGNER_PRIVATE_KEY=0xyourprivatekey
+# Optional separate phase-0 arbitrator signer for /disputes/:id/verdict.
+# If unset, dispute verdicts use SIGNER_PRIVATE_KEY / KMS signer and that
+# wallet must be approved in TreasuryPolicy.arbitrators.
+# ARBITRATOR_SIGNER_PRIVATE_KEY=0xyourarbitratorprivatekey
 TREASURY_POLICY_ADDRESS=0xYourTreasuryPolicy
 AGENT_ACCOUNT_ADDRESS=0xYourAgentAccountCore
 ESCROW_CORE_ADDRESS=0xYourEscrowCore

--- a/mcp-server/src/blockchain/abis.js
+++ b/mcp-server/src/blockchain/abis.js
@@ -107,6 +107,7 @@ export const TREASURY_POLICY_ABI = [
   "function trustedSchemaIssuers(address issuer) view returns (bool)",
   "function setTrustedSchemaIssuer(address issuer, bool approved)",
   "function verifiers(address verifier) view returns (bool)",
+  "function arbitrators(address arbitrator) view returns (bool)",
   "function authorizedSince(address verifier) view returns (uint64)",
   "function authorizedUntil(address verifier) view returns (uint64)",
   "function wasAuthorizedAt(address verifier, uint64 timestamp) view returns (bool)",

--- a/mcp-server/src/blockchain/config.js
+++ b/mcp-server/src/blockchain/config.js
@@ -245,6 +245,7 @@ export function loadBlockchainConfig(env = process.env) {
     rpcUrl,
     signerBackend,
     signerPrivateKey: env.SIGNER_PRIVATE_KEY ?? "",
+    arbitratorSignerPrivateKey: env.ARBITRATOR_SIGNER_PRIVATE_KEY ?? "",
     kmsKeyId: env.KMS_KEY_ID ?? "",
     awsRegion: env.AWS_REGION ?? "",
     treasuryPolicyAddress: env.TREASURY_POLICY_ADDRESS ?? "",

--- a/mcp-server/src/blockchain/config.test.js
+++ b/mcp-server/src/blockchain/config.test.js
@@ -188,8 +188,20 @@ test("loadBlockchainConfig defaults SIGNER_BACKEND to 'local'", () => {
   });
   assert.equal(config.signerBackend, "local");
   assert.equal(config.signerPrivateKey, "0xabc");
+  assert.equal(config.arbitratorSignerPrivateKey, "");
   assert.equal(config.kmsKeyId, "");
   assert.equal(config.awsRegion, "");
+});
+
+test("loadBlockchainConfig accepts a separate dispute arbitrator signer", () => {
+  const config = loadBlockchainConfig({
+    ...baseEnv,
+    RPC_URL: "https://legacy.example",
+    ARBITRATOR_SIGNER_PRIVATE_KEY: "0xdef"
+  });
+
+  assert.equal(config.signerPrivateKey, "0xabc");
+  assert.equal(config.arbitratorSignerPrivateKey, "0xdef");
 });
 
 test("loadBlockchainConfig accepts SIGNER_BACKEND=kms with KMS_KEY_ID + AWS_REGION", () => {

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -119,6 +119,9 @@ export class BlockchainGateway {
 
     this.provider = new JsonRpcProvider(config.rpcUrl);
     this.signer = createSigner(config, this.provider, { logger });
+    this.arbitratorSigner = config.arbitratorSignerPrivateKey
+      ? new Wallet(config.arbitratorSignerPrivateKey, this.provider)
+      : this.signer;
     this.accountContract = new Contract(
       config.agentAccountAddress,
       AGENT_ACCOUNT_ABI,
@@ -133,6 +136,11 @@ export class BlockchainGateway {
       config.escrowCoreAddress,
       ESCROW_CORE_ABI,
       this.signer ?? this.provider
+    );
+    this.arbitratorEscrowContract = new Contract(
+      config.escrowCoreAddress,
+      ESCROW_CORE_ABI,
+      this.arbitratorSigner ?? this.provider
     );
     this.legacyEscrowContract = new Contract(
       config.escrowCoreAddress,
@@ -175,6 +183,7 @@ export class BlockchainGateway {
         enabled: true,
         blockNumber,
         signerConfigured: Boolean(this.signer),
+        arbitratorSignerConfigured: Boolean(this.arbitratorSigner),
         xcmWrapperConfigured: this.hasXcmWrapper()
       };
     } catch (error) {
@@ -183,6 +192,7 @@ export class BlockchainGateway {
         backend: "blockchain",
         enabled: true,
         signerConfigured: Boolean(this.signer),
+        arbitratorSignerConfigured: Boolean(this.arbitratorSigner),
         xcmWrapperConfigured: this.hasXcmWrapper(),
         error: this.wrapGatewayError("healthCheck", error).message
       };
@@ -393,7 +403,9 @@ export class BlockchainGateway {
           },
           roles: {
             signerAddress: undefined,
+            arbitratorSignerAddress: undefined,
             signerIsVerifier: false,
+            arbitratorSignerIsArbitrator: false,
             escrowIsServiceOperator: false,
             agentAccountIsServiceOperator: false
           },
@@ -402,7 +414,10 @@ export class BlockchainGateway {
         };
       }
 
-      const signerAddress = await this.signer?.getAddress?.();
+      const [signerAddress, arbitratorSignerAddress] = await Promise.all([
+        this.signer?.getAddress?.(),
+        this.arbitratorSigner?.getAddress?.()
+      ]);
       const readErrors = [];
       const optionalRead = async (field, promise, fallback) => {
         try {
@@ -423,6 +438,7 @@ export class BlockchainGateway {
         pauser,
         paused,
         signerIsVerifier,
+        arbitratorSignerIsArbitrator,
         escrowIsServiceOperator,
         agentAccountIsServiceOperator,
         dailyOutflowCap,
@@ -441,6 +457,9 @@ export class BlockchainGateway {
         optionalRead("pauser", this.policyContract.pauser(), undefined),
         optionalRead("paused", this.policyContract.paused(), undefined),
         signerAddress ? optionalBool("verifiers(signer)", this.policyContract.verifiers(signerAddress)) : false,
+        arbitratorSignerAddress && typeof this.policyContract.arbitrators === "function"
+          ? optionalBool("arbitrators(arbitratorSigner)", this.policyContract.arbitrators(arbitratorSignerAddress))
+          : false,
         this.config.escrowCoreAddress
           ? optionalBool("serviceOperators(escrowCore)", this.policyContract.serviceOperators(this.config.escrowCoreAddress))
           : false,
@@ -517,7 +536,9 @@ export class BlockchainGateway {
         },
         roles: {
           signerAddress,
+          arbitratorSignerAddress,
           signerIsVerifier,
+          arbitratorSignerIsArbitrator,
           escrowIsServiceOperator,
           agentAccountIsServiceOperator
         },
@@ -939,10 +960,23 @@ export class BlockchainGateway {
     });
   }
 
+  async openDispute(jobId) {
+    return this.withGatewayError("openDispute", async () => {
+      this.requireSigner("openDispute");
+      const tx = await this.escrowContract.openDispute(this.toJobId(jobId));
+      const receipt = await tx.wait();
+      return {
+        txHash: tx.hash,
+        blockNumber: receipt?.blockNumber,
+        status: Number(receipt?.status ?? 0)
+      };
+    });
+  }
+
   async resolveDispute(jobId, workerPayout, reasonCode, metadataURI = "") {
     return this.withGatewayError("resolveDispute", async () => {
-      this.requireSigner("resolveDispute");
-      const tx = await this.escrowContract.resolveDispute(
+      this.requireArbitratorSigner("resolveDispute");
+      const tx = await this.arbitratorEscrowContract.resolveDispute(
         this.toJobId(jobId),
         workerPayout,
         this.toDisputeReasonCode(reasonCode),
@@ -1510,6 +1544,12 @@ export class BlockchainGateway {
   requireSigner(operation) {
     if (!this.signer) {
       throw new ConfigError(`${operation} requires SIGNER_PRIVATE_KEY`);
+    }
+  }
+
+  requireArbitratorSigner(operation) {
+    if (!this.arbitratorSigner) {
+      throw new ConfigError(`${operation} requires ARBITRATOR_SIGNER_PRIVATE_KEY or SIGNER_PRIVATE_KEY`);
     }
   }
 

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -99,6 +99,65 @@ test("autoDiscloseContent skips when the contract already recorded the hash", as
   );
 });
 
+test("openDispute uses the primary service signer participant path", async () => {
+  const gateway = new BlockchainGateway({ enabled: false });
+  const calls = [];
+  gateway.signer = {};
+  gateway.escrowContract = {
+    async openDispute(...args) {
+      calls.push(args);
+      return {
+        hash: "0xopen",
+        async wait() {
+          return { blockNumber: 7, status: 1 };
+        }
+      };
+    }
+  };
+
+  const receipt = await gateway.openDispute("wiki-job");
+
+  assert.deepEqual(calls, [[gateway.toJobId("wiki-job")]]);
+  assert.deepEqual(receipt, { txHash: "0xopen", blockNumber: 7, status: 1 });
+});
+
+test("resolveDispute uses the arbitrator signer contract when configured", async () => {
+  const gateway = new BlockchainGateway({ enabled: false });
+  const calls = [];
+  gateway.signer = {
+    marker: "service"
+  };
+  gateway.escrowContract = {
+    async resolveDispute() {
+      throw new Error("service signer must not resolve disputes when an arbitrator signer exists");
+    }
+  };
+  gateway.arbitratorSigner = {
+    marker: "arbitrator"
+  };
+  gateway.arbitratorEscrowContract = {
+    async resolveDispute(...args) {
+      calls.push(args);
+      return {
+        hash: "0xresolve",
+        async wait() {
+          return { blockNumber: 8, status: 1 };
+        }
+      };
+    }
+  };
+
+  const receipt = await gateway.resolveDispute("wiki-job", 0, "DISPUTE_LOST", "https://api.example.test/content/0xabc");
+
+  assert.deepEqual(calls, [[
+    gateway.toJobId("wiki-job"),
+    0,
+    gateway.toDisputeReasonCode("DISPUTE_LOST"),
+    "https://api.example.test/content/0xabc"
+  ]]);
+  assert.deepEqual(receipt, { txHash: "0xresolve", blockNumber: 8, status: 1 });
+});
+
 test("handleClaimTimeout reopens the canonical chain job id", async () => {
   const gateway = new BlockchainGateway({ enabled: false });
   const calls = [];

--- a/mcp-server/src/protocols/http/dispute-routes.js
+++ b/mcp-server/src/protocols/http/dispute-routes.js
@@ -47,6 +47,18 @@ export function createDisputeRoutes({
     }
   }
 
+  async function ensureChainDisputeOpen(session) {
+    if (!gateway?.isEnabled?.() || typeof gateway.getJob !== "function" || typeof gateway.openDispute !== "function") {
+      return undefined;
+    }
+    const chainJobId = session.chainJobId ?? session.jobId;
+    const live = await gateway.getJob(chainJobId);
+    if (Number(live?.state) !== 4) {
+      return undefined;
+    }
+    return gateway.openDispute(chainJobId);
+  }
+
   async function buildDisputeFromSession(session) {
     const id = disputeIdForSession(session.sessionId);
     const [verdictReceipt, releaseReceipt] = await Promise.all([
@@ -116,6 +128,8 @@ export function createDisputeRoutes({
       reasonCode: verdictReceipt?.reasonCode,
       reasoningHash: verdictReceipt?.reasoningHash,
       metadataURI: verdictReceipt?.metadataURI,
+      chainDisputeTxHash: verdictReceipt?.chainDisputeTxHash,
+      chainDisputeBlockNumber: verdictReceipt?.chainDisputeBlockNumber,
       txHash: verdictReceipt?.txHash,
       chainStatus: verdictReceipt?.chainStatus,
       workerPayout: verdictReceipt?.workerPayout,
@@ -227,6 +241,7 @@ export function createDisputeRoutes({
         publicBaseUrl
       });
       await persistContentRecord(reasoning.contentRecord);
+      const chainDisputeReceipt = await ensureChainDisputeOpen(session);
       const chainReceipt = gateway?.isEnabled?.() && typeof gateway.resolveDispute === "function"
         ? await gateway.resolveDispute(
             session.chainJobId ?? session.jobId,
@@ -254,6 +269,8 @@ export function createDisputeRoutes({
         rationale: reasoning.rationale || undefined,
         releaseAction: resolution.releaseAction,
         payoutSource: resolution.payoutSource,
+        chainDisputeTxHash: chainDisputeReceipt?.txHash,
+        chainDisputeBlockNumber: chainDisputeReceipt?.blockNumber,
         txHash: chainReceipt.txHash,
         blockNumber: chainReceipt.blockNumber,
         chainStatus: gateway?.isEnabled?.()
@@ -303,6 +320,8 @@ export function createDisputeRoutes({
           reasonCode: resolution.reasonCode,
           reasoningHash: receipt.reasoningHash,
           metadataURI: receipt.metadataURI,
+          chainDisputeTxHash: receipt.chainDisputeTxHash,
+          chainDisputeBlockNumber: receipt.chainDisputeBlockNumber,
           txHash: receipt.txHash,
           blockNumber: receipt.blockNumber,
           chainStatus: receipt.chainStatus
@@ -315,6 +334,8 @@ export function createDisputeRoutes({
         reasonCode: resolution.reasonCode,
         reasoningHash: reasoning.reasoningHash,
         metadataURI: reasoning.metadataURI,
+        chainDisputeTxHash: receipt.chainDisputeTxHash,
+        chainDisputeBlockNumber: receipt.chainDisputeBlockNumber,
         txHash: receipt.txHash,
         chainStatus: receipt.chainStatus,
         workerPayout: resolution.workerPayout,

--- a/mcp-server/src/protocols/http/dispute-routes.test.js
+++ b/mcp-server/src/protocols/http/dispute-routes.test.js
@@ -276,6 +276,47 @@ test("POST /disputes/:id/verdict records a local resolution and session transiti
   assert.ok(calls.some(([name]) => name === "respondWithMutationReceipt"));
 });
 
+test("POST /disputes/:id/verdict opens the chain dispute before arbitrator resolution", async () => {
+  const id = disputeIdForSession(SESSION.sessionId);
+  const gatewayCalls = [];
+  const { calls, response, route } = makeHarness({
+    auth: { wallet: ADMIN, claims: { roles: ["admin"] } },
+    payload: { verdict: "upheld", rationale: "Verifier rejection stands.", idempotencyKey: "idem-chain-1" },
+    gateway: {
+      isEnabled: () => true,
+      async getJob(jobId) {
+        gatewayCalls.push(["getJob", jobId]);
+        return { reward: JOB.rewardAmount, released: 0, state: 4 };
+      },
+      async openDispute(jobId) {
+        gatewayCalls.push(["openDispute", jobId]);
+        return { txHash: "0xopen", blockNumber: 41, status: 1 };
+      },
+      async resolveDispute(jobId, workerPayout, reasonCode, metadataURI) {
+        gatewayCalls.push(["resolveDispute", { jobId, workerPayout, reasonCode, metadataURI }]);
+        return { txHash: "0xresolve", blockNumber: 42, status: 1 };
+      }
+    }
+  });
+
+  const handled = await route({
+    request: { method: "POST" },
+    response,
+    url: new URL(`http://localhost/disputes/${id}/verdict`),
+    pathname: `/disputes/${id}/verdict`,
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.chainStatus, "confirmed");
+  assert.equal(response.body.chainDisputeTxHash, "0xopen");
+  assert.equal(response.body.txHash, "0xresolve");
+  assert.deepEqual(gatewayCalls.map(([name]) => name), ["getJob", "getJob", "openDispute", "resolveDispute"]);
+  assert.ok(calls.some(([name, detail]) => name === "upsertMutationReceipt"
+    && detail.receipt.chainDisputeTxHash === "0xopen"
+    && detail.receipt.txHash === "0xresolve"));
+});
+
 test("POST /disputes/:id/release requires a verdict before recording release", async () => {
   const id = disputeIdForSession(SESSION.sessionId);
   const { calls, route } = makeHarness({


### PR DESCRIPTION
## What changed
- Adds optional ARBITRATOR_SIGNER_PRIVATE_KEY config so dispute verdict transactions can be signed by the approved phase-0 arbitrator instead of the verifier/backend signer.
- Opens the on-chain dispute from Rejected -> Disputed before resolving when the hosted dispute is locally open but chain state is still rejected.
- Records chainDisputeTxHash/chainDisputeBlockNumber in the verdict receipt and documents the live proof preconditions.

## Why
The synthetic dispute proof exposed a real hosted wiring gap: the backend/KMS signer can reject work and is the job participant, but EscrowCore.resolveDispute requires an approved TreasuryPolicy arbitrator. Without a separate arbitrator signer, the hosted proof fails closed with a contract revert.

## Checks
- npm --workspace mcp-server test -- --test-reporter=spec mcp-server/src/blockchain/config.test.js mcp-server/src/blockchain/gateway.test.js mcp-server/src/protocols/http/dispute-routes.test.js scripts/ops/run-dispute-verdict-proof.test.mjs

## Surface
Backend + docs/env example only. No contracts, indexer, Caddy, public site, or generated frontend output.

## Follow-up after merge/deploy
Render ARBITRATOR_SIGNER_PRIVATE_KEY from the testnet arbitrator key on the VPS, then rerun the live dispute proof against dispute-e03d8e28d9d6 (or a fresh synthetic dispute if it has drifted) and capture the roadmap evidence JSON.