### PR TITLE
Fix hosted restore drill Redis cleanup

### DIFF
--- a/scripts/ops/run-restore-drill-from-backups.mjs
+++ b/scripts/ops/run-restore-drill-from-backups.mjs
@@ -302,6 +302,7 @@ async function restoreRedis(backupFile, suffix) {
   const container = `drill-redis-${suffix}`;
   const redisDataDir = await mkdtemp(join(tmpdir(), "averray-restore-drill-redis-"));
   let removed = false;
+  let dataDirRemoved = false;
   try {
     await pipeline(
       createReadStream(backupFile),
@@ -331,9 +332,40 @@ async function restoreRedis(backupFile, suffix) {
     } catch {
       removed = false;
     }
-    await rm(redisDataDir, { recursive: true, force: true });
+    try {
+      await rm(redisDataDir, { recursive: true, force: true });
+      dataDirRemoved = true;
+    } catch {
+      await makeDockerBindMountWritable(redisDataDir);
+      await rm(redisDataDir, { recursive: true, force: true });
+      dataDirRemoved = true;
+    }
     restoreRedis.lastRemoved = removed;
+    restoreRedis.lastDataDirRemoved = dataDirRemoved;
   }
+}
+
+async function makeDockerBindMountWritable(path) {
+  if (typeof process.getuid !== "function" || typeof process.getgid !== "function") {
+    return;
+  }
+
+  await run("docker", dockerBindMountWritableArgs(path, process.getuid(), process.getgid()));
+}
+
+function dockerBindMountWritableArgs(path, uid, gid) {
+  return [
+    "run",
+    "--rm",
+    "--user",
+    "0:0",
+    "-v",
+    `${path}:/data`,
+    REDIS_IMAGE,
+    "sh",
+    "-c",
+    `chown -R ${uid}:${gid} /data && chmod -R u+rwX /data`
+  ];
 }
 
 function buildEvidence({ readiness, selected, postgres, redis, operatorName, operatorSignature, completedAt }) {
@@ -360,7 +392,10 @@ function buildEvidence({ readiness, selected, postgres, redis, operatorName, ope
     },
     cleanup: {
       postgresTargetRemoved: restorePostgres.lastRemoved === true,
-      redisTargetRemoved: restoreRedis.lastRemoved === true
+      redisTargetRemoved: restoreRedis.lastRemoved === true,
+      ...(typeof restoreRedis.lastDataDirRemoved === "boolean"
+        ? { redisDataDirRemoved: restoreRedis.lastDataDirRemoved === true }
+        : {})
     }
   };
 }
@@ -406,6 +441,8 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 
 export {
   buildEvidence,
+  dockerBindMountWritableArgs,
+  makeDockerBindMountWritable,
   parseArgs,
   parseIntegerStdout,
   selectBackupCopies

--- a/scripts/ops/run-restore-drill-from-backups.test.mjs
+++ b/scripts/ops/run-restore-drill-from-backups.test.mjs
@@ -7,6 +7,7 @@ import { join } from "node:path";
 
 import {
   buildEvidence,
+  dockerBindMountWritableArgs,
   parseArgs,
   parseIntegerStdout,
   selectBackupCopies
@@ -83,6 +84,24 @@ test("selectBackupCopies rejects non-ok readiness before any restore", async () 
 test("parseIntegerStdout accepts non-negative integer command output", () => {
   assert.equal(parseIntegerStdout("42\n", "rows"), 42);
   assert.throws(() => parseIntegerStdout("nope", "rows"), /rows did not return/u);
+});
+
+test("dockerBindMountWritableArgs regains access to Redis-owned bind mount", () => {
+  const args = dockerBindMountWritableArgs("/tmp/redis-owned", 501, 20);
+  const redisImage = process.env.RESTORE_DRILL_REDIS_IMAGE || "redis:7";
+
+  assert.deepEqual(args.slice(0, 7), [
+    "run",
+    "--rm",
+    "--user",
+    "0:0",
+    "-v",
+    "/tmp/redis-owned:/data",
+    redisImage
+  ]);
+  assert.equal(args.at(-2), "-c");
+  assert.match(args.at(-1), /chown -R 501:20 \/data/u);
+  assert.match(args.at(-1), /chmod -R u\+rwX \/data/u);
 });
 
 test("buildEvidence preserves readiness and selected backup filenames", () => {


### PR DESCRIPTION
## What changed
- Reclaims ownership of the Redis restore drill bind-mounted temp directory before deleting it.
- Records Redis temp-dir cleanup in generated evidence when the restore path runs.
- Adds a focused unit test for the root cleanup container args.

## Why
The first hosted restore drill run copied fresh backups successfully, restored Postgres successfully, then failed during Redis cleanup with `EACCES: permission denied, scandir '/tmp/averray-restore-drill-redis-*'`. Redis changes ownership/permissions inside the bind mount; the runner needs to chown/chmod it before Node can remove it.

## Checks
- `node --test scripts/ops/run-restore-drill-from-backups.test.mjs scripts/ops/check-restore-drill-evidence.test.mjs`
- `npm run test:ops`
- `git diff --check`
- `git diff --cached --check`

## Surface
Ops workflow/script only. No backend, frontend, indexer, contracts, Caddy, or public-site changes. No env or VPS secret changes.