### PR TITLE
Fix dispute open ABI for hosted proof

### DIFF
--- a/mcp-server/src/blockchain/abis.js
+++ b/mcp-server/src/blockchain/abis.js
@@ -48,6 +48,7 @@ export const ESCROW_CORE_ABI = [
   "function autoDisclose(bytes32 hash)",
   "function autoDisclosed(bytes32 hash) view returns (bool)",
   "function autoResolveOnTimeout(bytes32 jobId)",
+  "function openDispute(bytes32 jobId)",
   "function resolveDispute(bytes32 jobId, uint256 workerPayout, bytes32 reasonCode, string metadataURI)",
   "function previewClaimEconomics(address worker, bytes32 jobId) view returns (uint256 claimStake, uint16 claimStakeBps, uint256 claimFee, uint16 claimFeeBps, bool waived, uint256 claimNumber)",
   "function workerClaimCount(address worker) view returns (uint256)",

--- a/scripts/ops/audit-launch-readiness.test.mjs
+++ b/scripts/ops/audit-launch-readiness.test.mjs
@@ -359,6 +359,16 @@ test("end-to-end: ESCROW_CORE_ABI exposes claimJobFor — the selector the 2026-
   assert.equal(claimJobFor.selector, "0x090cf6d5");
 });
 
+test("end-to-end: ESCROW_CORE_ABI exposes openDispute for live dispute proof", () => {
+  // The hosted dispute verdict proof moves rejected chain jobs into the
+  // disputed state before the arbitrator resolves them. Keep the gateway ABI
+  // pinned to that contract surface so the live path cannot regress silently.
+  const selectors = selectorsFromAbi(ESCROW_CORE_ABI);
+  const openDispute = selectors.find((s) => s.signature === "openDispute(bytes32)");
+  assert.ok(openDispute, "ESCROW_CORE_ABI must include openDispute(bytes32)");
+  assert.equal(openDispute.selector, "0xf08ef6cb");
+});
+
 test("end-to-end: synthetic 'pre-#357' bytecode reports claimJobFor as the only missing selector", () => {
   // Reconstruct the exact failure mode: a bytecode that contains every
   // ESCROW_CORE_ABI selector except claimJobFor. This is the report the


### PR DESCRIPTION
## What changed
- Added the missing EscrowCore `openDispute(bytes32)` fragment to the backend gateway ABI.
- Added a selector regression test so the hosted dispute verdict proof cannot lose the open-dispute call surface silently.

## Checks run
- `node --test scripts/ops/audit-launch-readiness.test.mjs`
- `npm --workspace mcp-server test -- mcp-server/src/blockchain/gateway.test.js mcp-server/src/protocols/http/dispute-routes.test.js`

## Affected surfaces
- Backend blockchain gateway ABI only.
- No frontend, indexer, Caddy, contracts, public site, or VPS secret changes.

## Notes
- This unblocks the live dispute proof after #557/#561/#565. The hosted proof currently reaches `gateway.openDispute` and fails because the contract instance lacks the ABI fragment.