### PR TITLE
Reconcile launch checklist with roadmap proof state

### DIFF
--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -170,8 +170,12 @@ Restore procedures:
 - [x] Indexer freshness is within the accepted lag budget.
 - [x] Latest `Deploy Production` workflow on `main` is green after the
   1Password SSH/basic-auth/admin-JWT cutovers.
-- [ ] When an admin JWT is available, `/admin/status` reports the async XCM
-  watcher lane cleanly.
+- [x] When an admin JWT is available, `/admin/status` reports the async XCM
+  watcher lane cleanly. Evidence: Deploy Production run `26256776666` on
+  2026-05-21 reached `Checking admin async XCM status` against live
+  `/admin/status` with the rotated ES256 `ADMIN_JWT` and passed all watcher,
+  relay, and freshness assertions. Deploy Production run `26273097236`
+  reproduced the green assertion bundle on 2026-05-22.
 - [x] Hosted scoped service-token proof passes with sanitized evidence:
   issue a least-privilege token, prove allowed and denied routes, revoke it,
   and confirm `listServiceTokens` does not expose raw token material.
@@ -479,8 +483,19 @@ roadmap rows to `Proofed`. Concrete verification commands per box:
   pre-existing open dispute. It never creates disputes and never iterates
   the queue. Regression covered by
   `node --test scripts/ops/run-dispute-verdict-proof.test.mjs`.
-- [ ] Public discovery, schema, and trust pages reflect the current deployed behavior.
-- [ ] Canonical public discovery manifest matches the API mirror.
+- [x] Public discovery, schema, and trust pages reflect the current deployed behavior.
+  Evidence: Deploy Production run `26256248052` on 2026-05-21 reached
+  `Checking product-proof gate` and passed public discovery manifest, API
+  mirror, onboarding/discovery agreement, public trust and schema pages,
+  identity schemas, and job schema index/sample schema checks before printing
+  `Product-proof gate passed.` Runs `26256776666` and `26273097236` reproduced
+  the green gate.
+- [x] Canonical public discovery manifest matches the API mirror. Evidence:
+  the same product-proof gate deep-equals
+  `https://averray.com/.well-known/agent-tools.json` against
+  `https://api.averray.com/agent-tools.json`; run `26256248052` passed that
+  assertion via `Checking public discovery manifest` then
+  `Checking API discovery mirror`.
 
 If any of these drift, external agents will learn the wrong contract.
 

--- a/docs/PROJECT_ROADMAP.md
+++ b/docs/PROJECT_ROADMAP.md
@@ -1,7 +1,7 @@
 # Averray Unified Project Roadmap
 
-- **Status date:** 2026-05-27
-- **Baseline reviewed:** `origin/main` at `38702bf`
+- **Status date:** 2026-05-28
+- **Baseline reviewed:** `origin/main` at `39ab1b8`
 - **Latest docs audit:** [`DOCS_AUDIT_2026-05-19.md`](./DOCS_AUDIT_2026-05-19.md)
 - **Purpose:** one status and roadmap page for the specs, audits, launch
   checklists, security plans, and product-proof work.
@@ -309,32 +309,27 @@ Metrics:
 
 ## Current Open PRs And Issues
 
-As of 2026-05-19:
+As of 2026-05-28:
 
 - Open issues in `averray-agent/agent`: none.
-- Open PRs:
-  - `#439` draft: Stage 2C-2 KMS-only JWT backend flip. Blocked on soak and
-    verification criteria above.
+- Open PRs in `averray-agent/agent`: none.
 
 ## Immediate Work Queue
 
-1. Keep `#439` draft until `#438` has soaked and the service-token/auth checks
-   pass under `JWT_BACKEND=both`. Then mark ready → auto-merge picks it up and
-   the Stage 2C-2 deploy refuses HS256.
-2. Track the Stage 2C-3 HMAC retirement window: ≥30 days after `#439` lands,
-   delete `op://prod-backend/auth-jwt-secrets`, drop the HMAC code branch
-   from `mcp-server/src/auth/jwt.js`, and retire `AUTH_JWT_SECRETS` from the
-   secrets inventory + calendar.
-3. Close the remaining `PRODUCTION_CHECKLIST.md` P0 launch gates:
-   pauser/rehearsal, backups, restore drill, `/admin/status` hosted check,
-   metrics/logging/alerts, self-report evidence, dispute verdict proof, and
-   public discovery/schema/trust proof.
-4. Open or assign a narrow PR for `P2.3` route split if no existing agent
-   owns it. (`P3.7` frontend auth guard closed; row marked Done above.)
-5. Operator: act on `PHASE_4E_PLAN.md` § 7 decision points (one vs two
+1. Configure production `METRICS_BEARER_TOKEN` and `ALERT_WEBHOOK_URL`, then
+   run the `Hosted Observability Proof` workflow and move Metrics auth,
+   Sentry/logging, and Alert destination from `Ready for proof` to `Proofed`
+   only after the sanitized artifact validates.
+2. Run the hosted dispute verdict proof against a specific open dispute and
+   record the evidence artifact plus chain dispatch status.
+3. Track the Stage 2C-3 HMAC retirement window: ≥30 days after the 2026-05-21
+   KMS-only JWT cutover, delete `op://prod-backend/auth-jwt-secrets`, drop the
+   HMAC code branch from `mcp-server/src/auth/jwt.js`, and retire
+   `AUTH_JWT_SECRETS` from the secrets inventory + calendar.
+4. Operator: act on `PHASE_4E_PLAN.md` § 7 decision points (one vs two
    operators, registrar identity + FIDO2 support, GitHub org-2FA member
    audit before flipping enforcement) before procuring YubiKeys.
-6. Keep native XCM/vDOT work behind the staging evidence gate and week-12
+5. Keep native XCM/vDOT work behind the staging evidence gate and week-12
    product gate.
 
 ## Completion Definition


### PR DESCRIPTION
## Summary
- mark hosted /admin/status async XCM and public discovery/schema/trust checklist rows with the existing roadmap proof evidence
- refresh roadmap status date, baseline commit, open PR/issue snapshot, and immediate queue
- remove stale #439/P2.3 follow-up items now that they are represented as done/live in the roadmap

## Checks
- git diff --check

## Scope
- Docs only; no backend, frontend, indexer, Caddy, contracts, or public-site behavior changes.

## Env/VPS changes
- None.