### PR TITLE
ops: harden native XCM SetTopic extraction

### DIFF
--- a/docs/NATIVE_XCM_OBSERVER.md
+++ b/docs/NATIVE_XCM_OBSERVER.md
@@ -299,6 +299,22 @@ npm run capture:native-xcm-evidence -- \
   --output artifacts/xcm/native-observer-evidence.json
 ```
 
+If the replay output is raw decoded event JSON, normalize each side first:
+
+```bash
+npm run extract:native-xcm-event -- \
+  --chain hub \
+  --events-json artifacts/xcm/hub-events.json \
+  --request-id 0x1111111111111111111111111111111111111111111111111111111111111111 \
+  --output artifacts/xcm/hub.json
+```
+
+The extractor only promotes an explicit `messageTopic`, `topic`, `setTopic`, or
+`message_id`/`messageId` field to SetTopic evidence. It deliberately does not
+infer `messageTopic` just because the request id appears somewhere else in the
+decoded event body. Use `--allow-missing-topic` only when investigating the
+`remote_ref` fallback path; do not use it for SetTopic preservation proof.
+
 Validate a captured envelope with:
 
 ```bash

--- a/docs/roadmap-updates/2026-05-28-codex-native-xcm-settopic-extractor.md
+++ b/docs/roadmap-updates/2026-05-28-codex-native-xcm-settopic-extractor.md
@@ -1,0 +1,40 @@
+# Roadmap Update: Native XCM SetTopic proof prep
+
+- **Date:** 2026-05-28
+- **Agent:** Codex / `codex/native-xcm-settopic-proof-prep`
+- **Roadmap section:** Native XCM, vDOT, And Yield Roadmap
+- **Item:** Chopsticks Bifrost SetTopic proof / External observer validation
+- **Related PRs/issues:** current PR
+- **Proposed status:** Open
+- **Owner:** Native XCM operator / roadmap steward
+
+## Summary
+
+This slice hardens the native XCM event extractor so SetTopic proof cannot be
+fabricated from arbitrary request-id text in decoded event JSON. Captured Hub or
+Bifrost evidence must now include an explicit topic-like field before the
+extractor emits `messageTopic`; missing-topic captures are only allowed for the
+`remote_ref` fallback investigation path.
+
+## Evidence
+
+- Polkadot docs MCP check:
+  `chain-interactions/send-transactions/interoperability/debug-and-preview-xcms.md`
+  documents Chopsticks replay/dry-run as the supported way to capture and debug
+  local XCM behavior.
+- Polkadot docs MCP check:
+  `smart-contracts/precompiles/xcm.md` documents the Hub XCM precompile
+  `send`/`weighMessage` flow and SCALE-encoded XCM messages.
+- Tests: `node --test scripts/ops/extract-native-xcm-event.test.mjs`
+
+## Blockers Or Caveats
+
+- This does not produce real Chopsticks/PAPI evidence.
+- The roadmap rows remain `Open` until deposit, withdraw, and failure captures
+  are collected and validated by `check-native-xcm-evidence-pack.mjs`.
+
+## Requested Roadmap Change
+
+Keep the Native XCM rows `Open`. After this PR merges, note that the SetTopic
+capture extractor now requires explicit topic/message-id fields, reducing the
+risk that a false-positive decoded event advances the native observer gate.

--- a/scripts/ops/extract-native-xcm-event.mjs
+++ b/scripts/ops/extract-native-xcm-event.mjs
@@ -74,9 +74,12 @@ export function extractEventEvidence({ input, chain, requestId, overrides = {} }
   if (!blockHash) fail("blockHash is required; pass --block-hash or include it in the decoded event JSON.");
   if (!eventIndex) fail("eventIndex is required; pass --event-index or include it in the decoded event JSON.");
 
-  const messageTopic = pickTopic(source, normalizedRequestId) || (matched ? normalizedRequestId : "");
+  const messageTopic = pickTopic(source);
   if (!messageTopic && !allowMissingTopic) {
-    fail("messageTopic is required unless --allow-missing-topic is set.");
+    fail(
+      "messageTopic is required unless --allow-missing-topic is set. " +
+      "The extractor will not infer SetTopic proof from requestId text outside an explicit topic/message-id field."
+    );
   }
 
   if (normalizedChain === "hub") {
@@ -219,7 +222,11 @@ function looksLikeEvent(value) {
 }
 
 function findMatchingEvent(events, requestId) {
-  return events.find(({ event }) => containsString(event, requestId));
+  const normalizedRequestId = String(requestId).toLowerCase();
+  return events.find(({ event }) => {
+    const topic = pickTopic(event);
+    return topic && String(topic).toLowerCase() === normalizedRequestId;
+  }) ?? events.find(({ event }) => containsString(event, requestId));
 }
 
 function containsString(value, needle) {
@@ -237,14 +244,14 @@ const BLOCK_HASH_KEYS = ["blockHash", "block_hash"];
 const EVENT_INDEX_KEYS = ["eventIndex", "event_index", "index"];
 const EXTRINSIC_HASH_KEYS = ["extrinsicHash", "extrinsic_hash", "txHash", "transactionHash"];
 const MESSAGE_HASH_KEYS = ["messageHash", "message_hash"];
-const TOPIC_KEYS = ["messageTopic", "message_topic", "topic", "setTopic", "set_topic"];
+const TOPIC_KEYS = ["messageTopic", "message_topic", "topic", "setTopic", "set_topic", "messageId", "message_id"];
 const ASSET_LOCATION_KEYS = ["assetLocation", "asset_location", "location", "asset"];
 const AMOUNT_KEYS = ["amount", "settledAssets", "settled_assets", "assets", "value"];
 
-function pickTopic(source, requestId) {
+function pickTopic(source) {
   const explicit = pickDeep(source, TOPIC_KEYS);
   if (explicit) return explicit;
-  return containsString(source, requestId) ? requestId : "";
+  return "";
 }
 
 function pickDeep(value, keys) {

--- a/scripts/ops/extract-native-xcm-event.test.mjs
+++ b/scripts/ops/extract-native-xcm-event.test.mjs
@@ -50,6 +50,99 @@ test("extracts Hub evidence from decoded event JSON", () => {
   });
 });
 
+test("extracts Hub SetTopic evidence from explicit message_id fields", () => {
+  const evidence = extractEventEvidence({
+    chain: "hub",
+    requestId: REQUEST_ID,
+    input: {
+      blockNumber: "123",
+      blockHash: BLOCK_HASH,
+      events: [
+        {
+          eventIndex: "123-7",
+          extrinsicHash: EXTRINSIC_HASH,
+          messageHash: MESSAGE_HASH,
+          event: {
+            section: "PolkadotXcm",
+            method: "Sent",
+            data: {
+              message_id: REQUEST_ID
+            }
+          }
+        }
+      ]
+    }
+  });
+
+  assert.equal(evidence.messageTopic, REQUEST_ID);
+});
+
+test("does not infer SetTopic evidence from request id text outside topic fields", () => {
+  assert.throws(
+    () => extractEventEvidence({
+      chain: "hub",
+      requestId: REQUEST_ID,
+      input: {
+        blockNumber: "123",
+        blockHash: BLOCK_HASH,
+        events: [
+          {
+            eventIndex: "123-7",
+            extrinsicHash: EXTRINSIC_HASH,
+            messageHash: MESSAGE_HASH,
+            event: {
+              section: "System",
+              method: "Remarked",
+              data: {
+                note: `request ${REQUEST_ID} was seen in a non-topic field`
+              }
+            }
+          }
+        ]
+      }
+    }),
+    /will not infer SetTopic proof/u
+  );
+});
+
+test("prefers explicit topic event over earlier non-topic request id mention", () => {
+  const evidence = extractEventEvidence({
+    chain: "hub",
+    requestId: REQUEST_ID,
+    input: {
+      blockNumber: "123",
+      blockHash: BLOCK_HASH,
+      events: [
+        {
+          eventIndex: "123-2",
+          event: {
+            section: "System",
+            method: "Remarked",
+            data: {
+              note: `request ${REQUEST_ID} was logged before the XCM event`
+            }
+          }
+        },
+        {
+          eventIndex: "123-7",
+          extrinsicHash: EXTRINSIC_HASH,
+          messageHash: MESSAGE_HASH,
+          event: {
+            section: "PolkadotXcm",
+            method: "Sent",
+            data: {
+              message_id: REQUEST_ID
+            }
+          }
+        }
+      ]
+    }
+  });
+
+  assert.equal(evidence.eventIndex, "123-7");
+  assert.equal(evidence.messageTopic, REQUEST_ID);
+});
+
 test("extracts Bifrost evidence and amount from decoded event JSON", () => {
   const evidence = extractEventEvidence({
     chain: "bifrost",


### PR DESCRIPTION
## Summary
- Harden `extract-native-xcm-event` so it only emits `messageTopic` from explicit topic/message-id fields, instead of inferring SetTopic proof from arbitrary request-id text in decoded event JSON.
- Prefer explicit topic-bearing events when a decoded block contains earlier non-topic request-id mentions.
- Document the stricter extraction flow in `docs/NATIVE_XCM_OBSERVER.md` and add a roadmap-update fragment keeping the Native XCM rows open until real Chopsticks/PAPI evidence is captured.

## Polkadot docs verification
- Checked Polkadot docs MCP: `chain-interactions/send-transactions/interoperability/debug-and-preview-xcms.md` confirms Chopsticks replay/dry-run is the supported local workflow for XCM debugging and evidence capture.
- Checked Polkadot docs MCP: `smart-contracts/precompiles/xcm.md` confirms the Hub XCM precompile `send` / `weighMessage` flow and SCALE-encoded XCM message requirement.

## Validation
- `node --test scripts/ops/extract-native-xcm-event.test.mjs`
- `node --check scripts/ops/extract-native-xcm-event.mjs`
- `git diff --check`
- `npm run test:ops`

## Impact
- Affects Native XCM operator tooling and docs only.
- No backend runtime, frontend, indexer, Caddy, contracts, deploy config, or production secrets changes.
- Does not close the Native XCM roadmap rows; real deposit, withdraw, and failure captures still need to be collected and validated by the evidence-pack gate.