### PR TITLE
ops: cover native XCM capture preflight

### DIFF
--- a/docs/roadmap-updates/2026-05-28-codex-native-xcm-preflight-coverage.md
+++ b/docs/roadmap-updates/2026-05-28-codex-native-xcm-preflight-coverage.md
@@ -1,0 +1,40 @@
+# Roadmap Update: Native XCM capture preflight coverage
+
+- **Date:** 2026-05-28
+- **Agent:** Codex / `codex/native-xcm-preflight-coverage`
+- **Roadmap section:** Native XCM, vDOT, And Yield Roadmap
+- **Item:** Chopsticks Bifrost SetTopic proof / External observer validation
+- **Related PRs/issues:** current PR
+- **Proposed status:** Open
+- **Owner:** Native XCM operator / roadmap steward
+
+## Summary
+
+This slice adds focused regression coverage around the native XCM capture
+preflight. The preflight now has tests proving it accepts a capture-ready vDOT
+strategy config, fails closed without a `polkadot_vdot` strategy, surfaces
+malformed destination config, and reports missing live capture environment
+variables before operators attempt a Chopsticks/PAPI capture.
+
+## Evidence
+
+- Polkadot docs MCP check:
+  `chain-interactions/send-transactions/interoperability/debug-and-preview-xcms.md`
+  identifies Chopsticks replay/dry-run as the local XCM debugging workflow.
+- Polkadot docs MCP check:
+  `smart-contracts/precompiles/xcm.md` documents the Hub XCM precompile
+  `send`/`weighMessage` interface and SCALE-encoded XCM requirement.
+- Tests: `node --test scripts/ops/preflight-native-xcm-capture.test.mjs`
+
+## Blockers Or Caveats
+
+- This does not produce real Chopsticks/PAPI evidence.
+- Native XCM roadmap rows remain `Open` until real deposit, withdraw, and
+  failure captures are collected and validated by the evidence-pack gate.
+
+## Requested Roadmap Change
+
+Keep the Native XCM rows `Open`. After this PR merges, note that the native
+capture preflight has direct tests for strategy readiness and strict live-env
+checks, reducing the chance operators start a real capture from a stale or
+scaffolded config.

--- a/scripts/ops/preflight-native-xcm-capture.mjs
+++ b/scripts/ops/preflight-native-xcm-capture.mjs
@@ -52,7 +52,7 @@ function isMain() {
   return import.meta.url === pathToFileURL(process.argv[1] ?? "").href;
 }
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const parsed = {};
   for (let idx = 0; idx < argv.length; idx += 1) {
     const arg = argv[idx];
@@ -99,7 +99,7 @@ function nextArg(argv, idx, flag) {
   return value;
 }
 
-async function checkDeclaredTooling() {
+export async function checkDeclaredTooling() {
   const rootPackage = await readPackageJson("package.json");
   const workspacePackages = await Promise.all([
     readPackageJson("mcp-server/package.json"),
@@ -135,7 +135,7 @@ async function readPackageJson(relativePath) {
   return JSON.parse(await readFile(path.resolve(relativePath), "utf8"));
 }
 
-async function checkBuilderOutputs(options) {
+export async function checkBuilderOutputs(options) {
   const details = [];
   let ok = true;
   const strategy = await loadPreflightStrategy(options);
@@ -214,7 +214,7 @@ async function checkBuilderOutputs(options) {
   };
 }
 
-async function loadPreflightStrategy(options) {
+export async function loadPreflightStrategy(options) {
   const raw = options.strategyFile
     ? await readFile(path.resolve(options.strategyFile), "utf8")
     : process.env.STRATEGIES_JSON;
@@ -227,7 +227,7 @@ async function loadPreflightStrategy(options) {
   return strategies.find((entry) => String(entry?.kind ?? "").trim().toLowerCase() === "polkadot_vdot");
 }
 
-function checkRuntimeEnv() {
+export function checkRuntimeEnv(env = process.env) {
   const required = [
     "API_URL",
     "ADMIN_JWT",
@@ -235,7 +235,7 @@ function checkRuntimeEnv() {
     "XCM_NATIVE_HUB_WS",
     "XCM_NATIVE_BIFROST_WS"
   ];
-  const missing = required.filter((name) => !String(process.env[name] ?? "").trim());
+  const missing = required.filter((name) => !String(env[name] ?? "").trim());
   return {
     name: "live capture environment is configured",
     ok: missing.length === 0,

--- a/scripts/ops/preflight-native-xcm-capture.test.mjs
+++ b/scripts/ops/preflight-native-xcm-capture.test.mjs
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  checkBuilderOutputs,
+  checkRuntimeEnv,
+  loadPreflightStrategy,
+  parseArgs
+} from "./preflight-native-xcm-capture.mjs";
+
+function vdotStrategy(overrides = {}) {
+  return {
+    strategyId: `0x${"22".repeat(32)}`,
+    kind: "polkadot_vdot",
+    assetConfig: {
+      assetClass: "foreign",
+      foreignAssetIndex: 5,
+      symbol: "vDOT",
+      xcmLocation: "{ parents: 1, interior: X1(Parachain(2030)) }"
+    },
+    xcm: {
+      destinationParachain: 2030
+    },
+    ...overrides
+  };
+}
+
+async function writeStrategyFile(payload) {
+  const dir = await mkdtemp(join(tmpdir(), "native-xcm-preflight-"));
+  const strategyFile = join(dir, "strategies.json");
+  await writeFile(strategyFile, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  return strategyFile;
+}
+
+test("parseArgs captures strict env and strategy file options", () => {
+  assert.deepEqual(
+    parseArgs(["--strict-env", "--strategy-file", "strategies.json"]),
+    {
+      strictEnv: true,
+      strategyFile: "strategies.json"
+    }
+  );
+});
+
+test("parseArgs rejects missing strategy file value", () => {
+  assert.throws(
+    () => parseArgs(["--strategy-file"]),
+    /--strategy-file requires a value/u
+  );
+});
+
+test("loadPreflightStrategy reads a deployment-style strategies object", async () => {
+  const strategyFile = await writeStrategyFile({
+    strategies: [
+      { kind: "mock_vdot" },
+      vdotStrategy()
+    ]
+  });
+
+  const strategy = await loadPreflightStrategy({ strategyFile });
+
+  assert.equal(strategy.kind, "polkadot_vdot");
+  assert.equal(strategy.xcm.destinationParachain, 2030);
+});
+
+test("checkBuilderOutputs passes for capture-ready vDOT strategy config", async () => {
+  const strategyFile = await writeStrategyFile([vdotStrategy()]);
+
+  const check = await checkBuilderOutputs({ strategyFile });
+
+  assert.equal(check.ok, true);
+  assert.match(check.details.join("\n"), /destination parachain resolves to 2030/u);
+  assert.match(check.details.join("\n"), /deposit message ends with SetTopic\(requestId\)/u);
+  assert.match(check.details.join("\n"), /withdraw message ends with SetTopic\(requestId\)/u);
+  assert.match(check.details.join("\n"), /withdraw message does not contain the known scaffold byte sequence/u);
+  assert.match(check.details.join("\n"), /deposit and withdraw messages are distinct/u);
+});
+
+test("checkBuilderOutputs fails closed without a polkadot_vdot strategy", async () => {
+  const strategyFile = await writeStrategyFile([{ kind: "mock_vdot" }]);
+
+  const check = await checkBuilderOutputs({ strategyFile });
+
+  assert.equal(check.ok, false);
+  assert.deepEqual(check.details, [
+    "no polkadot_vdot strategy was found in --strategy-file or STRATEGIES_JSON",
+    "capture preflight requires a server-controlled vDOT XCM strategy config"
+  ]);
+});
+
+test("checkBuilderOutputs surfaces malformed strategy config", async () => {
+  const strategyFile = await writeStrategyFile([
+    vdotStrategy({
+      assetConfig: {},
+      xcm: {}
+    })
+  ]);
+
+  const check = await checkBuilderOutputs({ strategyFile });
+
+  assert.equal(check.ok, false);
+  assert.match(check.details.join("\n"), /requires a destination parachain/u);
+  assert.match(check.details.join("\n"), /fix the server-owned vDOT XCM builder config before capture/u);
+});
+
+test("checkRuntimeEnv reports missing live capture env vars", () => {
+  const check = checkRuntimeEnv({
+    API_URL: "https://api.example.test",
+    ADMIN_JWT: "admin",
+    WALLET_JWT: "wallet"
+  });
+
+  assert.equal(check.ok, false);
+  assert.deepEqual(check.details, ["missing: XCM_NATIVE_HUB_WS, XCM_NATIVE_BIFROST_WS"]);
+});
+
+test("checkRuntimeEnv accepts complete live capture env vars", () => {
+  const check = checkRuntimeEnv({
+    API_URL: "https://api.example.test",
+    ADMIN_JWT: "admin",
+    WALLET_JWT: "wallet",
+    XCM_NATIVE_HUB_WS: "ws://127.0.0.1:8000",
+    XCM_NATIVE_BIFROST_WS: "ws://127.0.0.1:8001"
+  });
+
+  assert.equal(check.ok, true);
+  assert.deepEqual(check.details, ["required live capture env vars are set"]);
+});


### PR DESCRIPTION
## Summary
- Export the native XCM capture preflight checks so they can be tested directly without changing CLI behavior.
- Add regression coverage for strategy-file parsing, capture-ready `polkadot_vdot` strategy config, missing/malformed strategy config, and strict live-capture env requirements.
- Add a roadmap-update fragment keeping the Native XCM rows open until real Chopsticks/PAPI deposit, withdraw, and failure captures exist.

## Polkadot docs verification
- Checked Polkadot docs MCP: `chain-interactions/send-transactions/interoperability/debug-and-preview-xcms.md` identifies Chopsticks replay/dry-run as the local XCM debugging workflow.
- Checked Polkadot docs MCP: `smart-contracts/precompiles/xcm.md` documents the Hub XCM precompile `send` / `weighMessage` interface and SCALE-encoded XCM requirement.

## Validation
- `node --test scripts/ops/preflight-native-xcm-capture.test.mjs`
- `node --check scripts/ops/preflight-native-xcm-capture.mjs`
- `git diff --check`
- `npm run test:ops`

## Impact
- Affects Native XCM operator tooling/tests and roadmap-update docs only.
- No backend runtime, frontend, indexer, Caddy, contracts, deploy config, or production secrets changes.
- Does not close the Native XCM roadmap rows; it only reduces the chance a real capture starts from stale or scaffolded config.