### PR TITLE
Harden observability proof env loading

### DIFF
--- a/scripts/ops/collect-observability-proof.sh
+++ b/scripts/ops/collect-observability-proof.sh
@@ -46,11 +46,35 @@ require_command "$CURL_BIN"
 require_command "$JQ_BIN"
 require_command mktemp
 
+load_observability_env() {
+  local line key value first last
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line=${line%$'\r'}
+    [[ -z "$line" || "$line" == \#* || "$line" != *=* ]] && continue
+
+    key=${line%%=*}
+    value=${line#*=}
+    key=${key#export }
+
+    case "$key" in
+      METRICS_BEARER_TOKEN|ALERT_WEBHOOK_URL|SENTRY_DSN)
+        if [[ ${#value} -ge 2 ]]; then
+          first=${value:0:1}
+          last=${value: -1}
+          if [[ "$first" == "$last" && ( "$first" == '"' || "$first" == "'" ) ]]; then
+            value=${value:1:${#value}-2}
+          fi
+        fi
+        printf -v "$key" '%s' "$value"
+        export "$key"
+        ;;
+    esac
+  done < "$BACKEND_ENV_FILE"
+}
+
 if [[ -r "$BACKEND_ENV_FILE" ]]; then
-  set -a
-  # shellcheck disable=SC1090
-  . "$BACKEND_ENV_FILE"
-  set +a
+  load_observability_env
 elif [[ -z "${METRICS_BEARER_TOKEN:-}" || -z "${ALERT_WEBHOOK_URL:-}" ]]; then
   echo "Backend env file is not readable and required observability secrets were not supplied: $BACKEND_ENV_FILE" >&2
   exit 1

--- a/scripts/ops/collect-observability-proof.test.mjs
+++ b/scripts/ops/collect-observability-proof.test.mjs
@@ -32,6 +32,7 @@ test("collect-observability-proof emits sanitized hosted evidence", async () => 
     [
       "METRICS_BEARER_TOKEN=metrics-secret-token",
       "ALERT_WEBHOOK_URL=https://hooks.example.test/secret-webhook",
+      "BOOTSTRAP_SELF_REPORT_SUBJECT_PREFIX=Averray bootstrap self-report",
       "",
     ].join("\n"),
     "utf8"


### PR DESCRIPTION
## Summary
- stop sourcing the full backend runtime env in the hosted observability proof collector
- parse only METRICS_BEARER_TOKEN, ALERT_WEBHOOK_URL, and SENTRY_DSN from the env file without shell evaluation
- add a regression case for the current unquoted bootstrap subject line with spaces

## Checks
- bash -n scripts/ops/collect-observability-proof.sh
- node --test scripts/ops/collect-observability-proof.test.mjs
- git diff --check

## Impact
- Ops proof script only. No backend, frontend, indexer, contracts, Caddy, or public-site runtime changes.
- No env or VPS secret changes required.