### PR TITLE
ops: load observability proof env safely

### DIFF
--- a/scripts/ops/collect-observability-proof.sh
+++ b/scripts/ops/collect-observability-proof.sh
@@ -38,6 +38,42 @@ sanitize_output() {
     -e 's#https://[^@[:space:]]+@sentry#https://[redacted]@sentry#g'
 }
 
+read_env_value() {
+  local name=$1
+  local file=$2
+  local line value
+
+  line="$(grep -E "^${name}=" "$file" | tail -n 1 || true)"
+  if [[ -z "$line" ]]; then
+    return 1
+  fi
+
+  value="${line#*=}"
+  value="${value%$'\r'}"
+
+  if [[ "$value" == \"*\" && "$value" == *\" ]]; then
+    value="${value:1:${#value}-2}"
+  elif [[ "$value" == \'*\' && "$value" == *\' ]]; then
+    value="${value:1:${#value}-2}"
+  fi
+
+  printf '%s' "$value"
+}
+
+load_backend_env_value() {
+  local name=$1
+  local value
+
+  if [[ -n "${!name:-}" || ! -r "$BACKEND_ENV_FILE" ]]; then
+    return 0
+  fi
+
+  if value="$(read_env_value "$name" "$BACKEND_ENV_FILE")"; then
+    printf -v "$name" '%s' "$value"
+    export "$name"
+  fi
+}
+
 iso_now() {
   date -u +"%Y-%m-%dT%H:%M:%SZ"
 }
@@ -47,10 +83,9 @@ require_command "$JQ_BIN"
 require_command mktemp
 
 if [[ -r "$BACKEND_ENV_FILE" ]]; then
-  set -a
-  # shellcheck disable=SC1090
-  . "$BACKEND_ENV_FILE"
-  set +a
+  load_backend_env_value METRICS_BEARER_TOKEN
+  load_backend_env_value ALERT_WEBHOOK_URL
+  load_backend_env_value SENTRY_DSN
 elif [[ -z "${METRICS_BEARER_TOKEN:-}" || -z "${ALERT_WEBHOOK_URL:-}" ]]; then
   echo "Backend env file is not readable and required observability secrets were not supplied: $BACKEND_ENV_FILE" >&2
   exit 1

--- a/scripts/ops/collect-observability-proof.test.mjs
+++ b/scripts/ops/collect-observability-proof.test.mjs
@@ -31,6 +31,7 @@ test("collect-observability-proof emits sanitized hosted evidence", async () => 
     envFile,
     [
       "METRICS_BEARER_TOKEN=metrics-secret-token",
+      "BOOTSTRAP_SELF_REPORT_SUBJECT_PREFIX=Averray bootstrap self-report",
       "ALERT_WEBHOOK_URL=https://hooks.example.test/secret-webhook",
       "",
     ].join("\n"),


### PR DESCRIPTION
## What changed
- Fix `scripts/ops/collect-observability-proof.sh` so it reads only the observability keys it needs from `/run/agent-stack/backend.env` instead of sourcing the whole Docker env file as shell.
- Add regression coverage with the exact unquoted space-bearing env line that caused the hosted proof failure.

## Why
Hosted Observability Proof run `26588905880` failed in `Collect hosted observability proof` before any sub-proof ran:

```
/run/agent-stack/backend.env: line 242: bootstrap: command not found
```

That line is `BOOTSTRAP_SELF_REPORT_SUBJECT_PREFIX=Averray bootstrap self-report`, which is valid Docker env-file syntax but not safe to `source` in bash.

## Checks run
- `node --test scripts/ops/collect-observability-proof.test.mjs`
- `node scripts/ops/check-env-template-structure.mjs`
- `git diff --check`

## Impact
- Ops/proof runner only.
- No roadmap rows flipped here.
- After this lands and deploys, rerun Hosted Observability Proof to collect the combined evidence for Metrics auth, Sentry/logging decision, and Alert destination.