### PR TITLE
Make hosted alert payload webhook friendly

### DIFF
--- a/scripts/ops/check-hosted-stack-and-alert.sh
+++ b/scripts/ops/check-hosted-stack-and-alert.sh
@@ -37,17 +37,25 @@ fi
 require_command "$CURL_BIN"
 require_command jq
 
+alert_text="$ALERT_SERVICE_NAME smoke check failed in $ALERT_ENVIRONMENT"
+if [[ -n "$ALERT_CORRELATION_ID" ]]; then
+  alert_text="$alert_text (correlation: $ALERT_CORRELATION_ID)"
+fi
+
 payload=$(
   jq -n \
     --arg service "$ALERT_SERVICE_NAME" \
     --arg environment "$ALERT_ENVIRONMENT" \
     --arg correlationId "$ALERT_CORRELATION_ID" \
+    --arg text "$alert_text" \
     --arg hostname "$(hostname)" \
     --arg check "scripts/ops/check-hosted-stack.sh" \
     --arg output "$output" \
     --arg timestamp "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
     '{
       status: "firing",
+      text: $text,
+      content: $text,
       service: $service,
       environment: $environment,
       hostname: $hostname,

--- a/scripts/ops/check-hosted-stack-and-alert.test.mjs
+++ b/scripts/ops/check-hosted-stack-and-alert.test.mjs
@@ -142,6 +142,11 @@ test("hosted stack alert wrapper sends a structured webhook payload on failure",
   const body = await readFile(curlCapture.payloadPath, "utf8");
   const payload = JSON.parse(body);
   assert.equal(payload.status, "firing");
+  assert.equal(
+    payload.text,
+    "averray-smoke-test smoke check failed in ci (correlation: github-observability-alert-123)"
+  );
+  assert.equal(payload.content, payload.text);
   assert.equal(payload.service, "averray-smoke-test");
   assert.equal(payload.environment, "ci");
   assert.equal(payload.correlationId, "github-observability-alert-123");


### PR DESCRIPTION
## What changed
- Add top-level `text` and `content` fields to the hosted smoke alert webhook payload while preserving the structured fields.
- Cover the Slack/Discord-friendly summary in the alert wrapper test.

## Why
The hosted observability proof now gets past env loading, but the production alert webhook returns HTTP 400 during the deliberate failure check. Incoming webhook providers commonly require a top-level human-readable body even when structured metadata is present.

## Checks run
- `bash -n scripts/ops/check-hosted-stack-and-alert.sh`
- `node --test scripts/ops/check-hosted-stack-and-alert.test.mjs scripts/ops/collect-observability-proof.test.mjs`
- `git diff --check`

## Impact
- Ops proof/alert wrapper only.
- No backend runtime, frontend, indexer, contracts, or VPS secret changes.