### PR TITLE
Accept current backend log shape in observability proof

### DIFF
--- a/docs/OBSERVABILITY_POSTURE.md
+++ b/docs/OBSERVABILITY_POSTURE.md
@@ -98,7 +98,7 @@ includes the same `correlationId` so an operator can find the delivered message.
     "decision": "log_only_deferred",
     "structuredLogsVisible": true,
     "logSurface": "docker logs agent-backend --tail 50",
-    "observedLogLine": "{\"level\":30,\"name\":\"averray-mcp\",\"msg\":\"server.started\"}",
+    "observedLogLine": "{\"level\":\"info\",\"name\":\"averray-mcp\",\"msg\":\"http.listening\"}",
     "observedAt": "2026-05-22T18:10:00.000Z",
     "sentryReadyObserved": false,
     "deferredReason": "Backend Sentry intentionally deferred for v1; structured logs are the active launch surface."

--- a/scripts/ops/check-observability-proof.test.mjs
+++ b/scripts/ops/check-observability-proof.test.mjs
@@ -47,7 +47,7 @@ function validEvidence(overrides = {}) {
       decision: "log_only_deferred",
       structuredLogsVisible: true,
       logSurface: "docker logs agent-backend --tail 50",
-      observedLogLine: "{\"level\":30,\"name\":\"averray-mcp\",\"msg\":\"server.started\"}",
+      observedLogLine: "{\"level\":\"info\",\"name\":\"averray-mcp\",\"msg\":\"http.listening\"}",
       observedAt: "2026-05-22T18:10:00.000Z",
       sentryReadyObserved: false,
       deferredReason: "Backend Sentry intentionally deferred for v1; structured logs are the active launch surface."
@@ -108,7 +108,7 @@ test("validateEvidence accepts Sentry-enabled observability proof", () => {
       decision: "sentry_enabled",
       structuredLogsVisible: true,
       logSurface: "docker logs agent-backend --tail 50",
-      observedLogLine: "{\"level\":30,\"name\":\"averray-mcp\",\"msg\":\"observability.sentry_ready\"}",
+      observedLogLine: "{\"level\":\"info\",\"name\":\"averray-mcp\",\"msg\":\"observability.sentry_ready\"}",
       observedAt: "2026-05-22T18:10:00.000Z",
       sentryReadyObserved: true,
       sentryProject: "averray-backend-prod"
@@ -211,7 +211,7 @@ test("validateEvidence rejects Sentry-enabled proof without ready observation", 
       decision: "sentry_enabled",
       structuredLogsVisible: true,
       logSurface: "docker logs agent-backend --tail 50",
-      observedLogLine: "{\"level\":30,\"name\":\"averray-mcp\",\"msg\":\"server.started\"}",
+      observedLogLine: "{\"level\":\"info\",\"name\":\"averray-mcp\",\"msg\":\"http.listening\"}",
       observedAt: "2026-05-22T18:10:00.000Z",
       sentryReadyObserved: false,
       sentryProject: "averray-backend-prod"

--- a/scripts/ops/collect-observability-proof.sh
+++ b/scripts/ops/collect-observability-proof.sh
@@ -152,7 +152,7 @@ logging_observed_at="$(iso_now)"
 raw_logs="$("$DOCKER_BIN" logs "$BACKEND_CONTAINER" --tail 200 2>&1 || true)"
 structured_log_line="$(
   printf '%s\n' "$raw_logs" \
-    | grep -E '\{.*"level":[0-9]+.*"msg":' \
+    | grep -E '\{.*"level":("[a-z]+"|[0-9]+).*"msg":' \
     | tail -1 \
     | sanitize_output \
     | cut -c 1-1000 || true

--- a/scripts/ops/collect-observability-proof.test.mjs
+++ b/scripts/ops/collect-observability-proof.test.mjs
@@ -88,7 +88,7 @@ if [[ "$1" != "logs" ]]; then
   echo "unexpected docker command" >&2
   exit 1
 fi
-echo '{"level":30,"name":"averray-mcp","msg":"server.started","requestId":"req_123"}'
+echo '{"ts":"2026-05-28T17:54:00.000Z","level":"info","name":"averray-mcp","msg":"http.listening","requestId":"req_123"}'
 `);
 
   const { stdout } = await execFileAsync("bash", [scriptPath], {
@@ -115,7 +115,7 @@ echo '{"level":30,"name":"averray-mcp","msg":"server.started","requestId":"req_1
   assert.equal(evidence.metricsAuth.authenticatedStatus, 200);
   assert.equal(evidence.alertDestination.messageId, "github-observability-alert-123");
   assert.equal(evidence.sentryLogging.decision, "log_only_deferred");
-  assert.match(evidence.sentryLogging.observedLogLine, /server\.started/u);
+  assert.match(evidence.sentryLogging.observedLogLine, /http\.listening/u);
 
   assert.doesNotMatch(stdout, /metrics-secret-token/u);
   assert.doesNotMatch(stdout, /secret-webhook/u);
@@ -168,7 +168,7 @@ while [[ $# -gt 0 ]]; do
 done
 printf '%s' "$status"
 `);
-  const docker = await writeExecutable(root, "docker.sh", 'echo \'{"level":30,"name":"averray-mcp","msg":"server.started"}\'');
+  const docker = await writeExecutable(root, "docker.sh", 'echo \'{"level":"info","name":"averray-mcp","msg":"http.listening"}\'');
 
   await assert.rejects(
     () => execFileAsync("bash", [scriptPath], {


### PR DESCRIPTION
## What changed
- Let `collect-observability-proof.sh` recognize structured backend logs with string log levels like `"level":"info"`, while still accepting numeric pino-style levels.
- Update observability proof tests and docs examples to match the current backend logger contract: `http.listening` with string levels.

## Why
After #581 and #583, Hosted Observability Proof reached the log sampling phase but failed with:

`No structured backend log line found in docker logs agent-backend --tail 200.`

The active backend logger emits string levels, not numeric levels, so the proof grep was too narrow.

## Checks run
- `bash -n scripts/ops/collect-observability-proof.sh`
- `node --test scripts/ops/collect-observability-proof.test.mjs scripts/ops/check-observability-proof.test.mjs`
- `git diff --check`

## Impact
- Ops proof script and docs/tests only.
- No backend runtime, frontend, indexer, contracts, or VPS secret changes.