### PR TITLE
docs: Hermes multi-agent orchestration plan + Phase 0 integration map

### DIFF
--- a/docs/HERMES_INTEGRATION_MAP.md
+++ b/docs/HERMES_INTEGRATION_MAP.md
@@ -1,0 +1,137 @@
+# Hermes Orchestration — Confirmed Integration Map (Phase 0)
+
+- **Status:** Phase 0 discovery output for [`docs/HERMES_MULTI_AGENT_ORCHESTRATION_PLAN.md`](./HERMES_MULTI_AGENT_ORCHESTRATION_PLAN.md). **Confirmed from source**, not assumed.
+- **Date:** 2026-05-29
+- **Source read:** `depre-dev/averray-reference-agent` @ `main` (public; shallow-cloned and read directly). All `path:line` citations below are in **that** repo unless prefixed `[this repo]`.
+- **Confirms or corrects** the six `[assumed]` items in §6 of the plan. Where reality differs from the plan's assumption, it's flagged **⚠ REFINEMENT**.
+
+> Note: paths like `monitor-memory-aware-narration/packages/...` that appeared in an earlier draft do **not** exist. The real layout is `packages/` + `services/` + `ops/` + `hermes/`. Use the paths in this doc.
+
+---
+
+## Repo shape (reference-agent)
+
+```
+packages/
+  averray-mcp/      ← the main MCP server Hermes calls (tools + invoke_agent_task + operator commands)
+  policy-mcp/  receipt-mcp/  trace-mcp/  wallet-mcp/   ← the other 4 MCP servers
+  monitor-ui/       ← the redesigned board SPA (MonitorPage.tsx, card-types, lane-rules)
+  mcp-common/  schemas/
+services/
+  slack-operator/   ← serves the live /monitor board, the Codex task queue + runner, testbed mission runner
+  skills-observer/  ← sidecar ingesting Hermes skill files
+ops/                ← Docker compose stack (base, prod, command-center, cloudflare-access)
+hermes/             ← Hermes config (hermes.yaml, policy.yaml) + trace plugin
+```
+
+---
+
+## Q1 — How is `agentType` set today? Why is every card `ext`? ✅ CONFIRMED
+
+`agentType` is derived by `inferAgentType()` in `services/slack-operator/src/monitor-v2.ts:208` from the classifier's **`owner` string**, not from the PR branch:
+
+```ts
+export function inferAgentType(item, type): AgentType {
+  const owner = (item.owner ?? "").toLowerCase();
+  if (type === "mission") return "hermes";
+  if (owner.includes("codex"))  return "codex";
+  if (owner.includes("hermes")) return "hermes";
+  if (owner.includes("claude")) return "claude";
+  return "ext";                          // ← default
+}
+```
+
+The board's `owner` field is set to things like `operator`, `PR author`, `merge steward`, `history` (see `mapOwnerToWaitingOn`, `monitor-v2.ts:222`) — **never `codex`/`claude`** for ordinary external PRs. So they all fall through to `ext`. The `AgentType` union is `"claude" | "codex" | "hermes" | "ext"` (`packages/monitor-ui/src/lib/monitor/card-types.ts:24`).
+
+**⚠ REFINEMENT to plan P1.** The plan assumed "map branch prefix → agentType." But `monitor-v2.ts:321` explicitly notes **the slim board model does not carry the head branch** (`// branch not in slim model`). The raw GitHub snapshot *does* have it — `operator-github.ts:1432` attaches `headBranch` from `pull.head.ref` — but it's dropped before `toBoardCard`. So **P1 is two small steps, not one**:
+1. Thread `headBranch` through the slim classified card into `toBoardCard`.
+2. In `inferAgentType`, prefer the branch prefix (`codex/*`→codex, `claude/*`→claude) and fall back to the owner-string logic.
+
+---
+
+## Q2 — Codex task queue + runner: schema, storage, lifecycle, executor ✅ CONFIRMED
+
+**Queue** — `services/slack-operator/src/codex-task-queue.ts`. JSON-file backed (`readFile`/`writeFile`), path from `AVERRAY_CODEX_TASKS_PATH` (fallback `/tmp/averray-reference-agent/codex-tasks.json`, `:435`).
+
+- `CodexTask` shape (`:37`): `{ schemaVersion:1, kind:"codex_task", id, repo, pullRequestNumber, correlationId?, title?, prompt, reason?, requester?, status, createdAt, updatedAt, approvedAt?/By?, cancelledAt?/By?, startedAt?, runnerId?, attemptCount?, completedAt?, completionSummary?, failedAt?, failureReason?, exitCode?, stdoutTail?, stderrTail?, progressMessage?, progressAt?, events?[] }`.
+- **State machine** (`:4`): `proposed → approved → running → completed | failed | cancelled`.
+- **Heartbeat** `CodexRunnerHeartbeat` (`:63`): `{ runnerId, status: idle|running|completed|failed|disabled|misconfigured|error, message, updatedAt, activeTaskId? }`.
+
+**Enqueue path** — via the **slack-operator HTTP API**, not an MCP tool: `POST /monitor/codex-tasks` (`services/slack-operator/src/index.ts:389`) → `proposeCodexTask` (`:1107`); approval → `approveCodexTask(id, { approvedBy: "operator" })` (`:1132`). This is the board's `CREATE / APPROVE TASK` lane.
+
+**Runner** — `services/slack-operator/src/codex-task-runner.ts`. `runCodexTaskRunnerForever` polls (`CODEX_TASK_RUNNER_POLL_INTERVAL_MS`, default **10s**) → `claimNextApprovedCodexTask` → run executor → `completeCodexTask`/`failCodexTask` + heartbeat. Timeout `CODEX_TASK_RUNNER_TIMEOUT_MS` default **30 min** (SIGTERM→SIGKILL). Output is **secret-sanitized** before storage (`:316` — strips private keys, JWTs, GitHub tokens, `sk-` keys).
+
+**⚠ KEY FINDING — the runner is command-agnostic.** `executeCodexTaskCommand` (`:159`) just `spawn`s `CODEX_TASK_RUNNER_COMMAND` with templated args (`{prompt}`, `{repo}`, `{pr}`, …) and passes `CODEX_TASK_*` env (incl. `CODEX_TASK_PROMPT`). It is "Codex" only by env config. The actual Codex behavior lives in `codex-branch-worker.ts`, which: defaults its CLI to `codex` (`:95`), **refuses protected branches** (`:123`), and **checks out the PR's existing head branch** to work on it (`:192`).
+
+**⚠ REFINEMENT to plan P2.** Two consequences:
+- The current model is **PR-centric**: a task is bound to an existing `pullRequestNumber` and the worker iterates on that PR's branch. It is *not* a greenfield "build feature X from scratch → open new PR" flow. A Claude worker either (a) follows the same iterate-on-PR model, or (b) the schema/worker are extended to support originating a branch+PR.
+- A Claude runner can reuse the **same queue + runner harness**; the cleanest path is to (1) generalize the queue from `codex_task` to an agent-tagged task (add an `agent: "codex" | "claude"` field), and (2) add a `claude-branch-worker` mirroring `codex-branch-worker` with `claude -p`/Agent-SDK as the command. The poll/claim/heartbeat/timeout/sanitize machinery is already done.
+
+---
+
+## Q3 — Is `claude` wired beyond the card-type union? ✅ CONFIRMED (recognized, not executed)
+
+- **Recognized:** `AgentType` union (`card-types.ts:24`); `inferAgentType` maps owner `claude`→claude (`monitor-v2.ts:213`); `AGENT_TYPES` allowlist incl. claude (`monitor-v2-debug.ts:42`); debug endpoint defaults to `claude` (`:96`); fixtures use `claude` cards (`monitor-ui/.../fixtures.ts`).
+- **NOT executed:** there is **no Claude runner or worker**. Only `codex-task-runner.ts` + `codex-branch-worker.ts` exist. Collaboration authors are `codex | hermes | operator | system` only (`monitor-ui/.../collaboration.ts:10`) — **claude is not a collaboration author**, so Hermes↔Claude board chatter has no type yet.
+
+This matches the plan: Claude is modeled but is the missing worker. **Confirmed: P2 (Claude runner) is the real net-new build.**
+
+---
+
+## Q4 — Policy / mutation guardrails: what governs what? ✅ CONFIRMED (and they do NOT cover dispatch)
+
+Two existing guardrail layers, **both about job/mission execution, neither about code dispatch**:
+
+1. **Marketplace claim/submit policy** — `packages/averray-mcp/src/mutation-policy.ts`. Governs the Wikipedia citation-repair *job* mutations (`averray_claim`/`averray_submit`): requires a `runId`, caps attempts (`maxClaimAttempts`/`maxSubmitAttempts`, default 1), enforces job/session allowlists, optional fail-open, backed by a Postgres `submissions` table. Pure economic/idempotency safety for marketplace work.
+2. **Agent budget policy** — `hermes/config/policy.yaml`: `claim.allowed_task_types: [citation_repair, freshness_check]`, `submit.require_approval_if_confidence_lt: 0.7`, `budget.per_run_usd_max: 0.5`, `per_day_usd_max: 1.0`, `max_browser_steps: 80`.
+3. **Global kill switch** — `HALT_FILE` env + `assertNoKillSwitch()` (`averray-mcp/src/index.ts:409`) blocks mutating tools when a halt file exists.
+
+**⚠ KEY FINDING for plan §7 (authority).** There is **no policy layer over code dispatch**. Proposing/approving a Codex task is gated only by (a) the slack-operator HTTP endpoint's auth and (b) `approveCodexTask` requiring `approvedBy: "operator"`. So a future *Hermes-driven* dispatch capability (Rung B/C) **cannot reuse `mutation-policy.ts`** — it needs a **new guardrail** (e.g. an allowlist of repos/intents Hermes may enqueue, a per-day task budget, and keeping the human `approved` gate). This is the security boundary to design before P4.
+
+---
+
+## Q5 — Full MCP tool surface + `invoke_agent_task` intents ✅ CONFIRMED
+
+`averray_*` tools registered in `packages/averray-mcp/src/index.ts` (selected): `list_jobs`, `get_definition`, `operator_status`, `daily_operator_brief`, `find_safe_work`, `agent_usefulness_plan`, `project_memory`, `project_runbook`, `admin_readiness`, `admin_action_proposal`, `ops_health`, `github_status`, `github_brief`, `approve_github_merge_steward_candidate`, `testbed_agent_mission`, `testbed_e2e_suite`, `run_testbed_e2e_read_only`, `handoff_monitor`, **`invoke_agent_task`** (`:328`), **`handle_operator_command`** (`:358`), `run_wikipedia_citation_repair`, `claim`, `save_draft_submission`, …
+
+`AgentInvocationIntent` (`packages/averray-mcp/src/agent-invocation.ts:24`):
+```
+operator_command | testbed_e2e_read_only | testbed_suite | testbed_case
+| pr_code_review | pr_handoff | post_deploy_verification
+```
+
+**⚠ KEY FINDING.** There is **no dispatch/enqueue intent** — `invoke_agent_task` only reviews and tests. Today Hermes literally **cannot enqueue a worker task through MCP**; tasks enter only via the monitor HTTP endpoint (Q2). So Rung B/C requires either a **new intent** (e.g. `enqueue_agent_task`) or a Hermes path to the `POST /monitor/codex-tasks` endpoint — gated by the new guardrail from Q4.
+
+---
+
+## Q6 — Monitor deployment: standalone or in the operator app? ✅ CONFIRMED
+
+The **Averray Handoff Monitor board** (the screenshot) is served by the **`slack-operator` service** at `/monitor/*` (`services/slack-operator/src/monitor.ts`, `monitor-spa.ts`, `monitor-v2.ts`), rendering the `packages/monitor-ui` SPA. Public exposure is via Cloudflare Access (`ops/compose.cloudflare-access.yml`). The Direction-A redesign is implemented **in this same `packages/monitor-ui`** per `docs/HERMES_MONITOR_REDESIGN_SPEC.md` (which also lives in this repo's `docs/`).
+
+Separately there is an **optional "command center" overlay** (`ops/compose.command-center.yml`, `--profile command-center`, runbook `docs/COMMAND_CENTER.md`) that adds:
+- **`hermes-gateway`** — a Hermes process exposing an **HTTP API on `:8642`** (`API_SERVER_ENABLED`, `API_SERVER_KEY`).
+- **`hermes-workspace`** — the Hermes Workspace UI on `:3000` (`ghcr.io/outsourc-e/hermes-workspace`).
+- The built-in **Hermes dashboard on `:9119`**.
+
+**⚠ KEY FINDING for orchestration entry points.** There are **two ways to drive Hermes**, not one:
+1. The **SSH + `hermes chat -q "<prompt>"`** path used by `[this repo]`'s GitHub workflows (one-shot, prompt-driven).
+2. The **Hermes gateway HTTP API on `:8642`** (command-center overlay) — a programmatic, session-capable entry point better suited to an orchestration loop than shelling `hermes chat`.
+
+---
+
+## Net effect on the plan (what Phase 0 changes)
+
+| Plan item | Confirmed reality | Action |
+|---|---|---|
+| **P1 attribution** | Branch is dropped before the board model; agentType comes from `owner` string. | Thread `headBranch` into the slim card, then prefer branch-prefix in `inferAgentType`. Slightly bigger than "one mapping," still small. |
+| **P2 Claude runner** | Runner harness is command-agnostic and reusable; only `codex-branch-worker` is Codex-specific; tasks are PR-centric. | Generalize queue (`agent` field) + add `claude-branch-worker`. Decide PR-centric vs greenfield. |
+| **P3 dispatch** | Enqueue is an HTTP endpoint (`POST /monitor/codex-tasks`), human-approved; no MCP enqueue intent. | Add Claude path to the endpoint + a co-pilot verb; keep human `approved` gate. |
+| **P4 routing** | Hermes has no enqueue capability and no dispatch policy. | Add `enqueue_agent_task` intent (or gateway call) **plus** a new dispatch guardrail (Q4). |
+| **§7 authority** | `mutation-policy.ts` covers marketplace/missions only. | Design a **separate** dispatch guardrail; do not reuse the marketplace policy. |
+| **Entry point** | Gateway API on `:8642` exists. | Prefer the gateway API over SSH `hermes chat` for the Rung-C loop. |
+
+**Bottom line:** the plan holds. The cheapest first PR (P1 attribution) is confirmed small. The Claude runner (P2) is real but rides on existing, command-agnostic plumbing. The one genuinely new design surface for autonomy is a **dispatch guardrail + an enqueue capability for Hermes** — neither exists today, and that is the security-relevant decision to make before Rung C.
+
+---
+
+*End of integration map. Confirmed from `depre-dev/averray-reference-agent` @ main on 2026-05-29.*

--- a/docs/HERMES_MULTI_AGENT_ORCHESTRATION_PLAN.md
+++ b/docs/HERMES_MULTI_AGENT_ORCHESTRATION_PLAN.md
@@ -1,0 +1,185 @@
+# Hermes Multi-Agent Orchestration — Feasibility Plan & Handoff
+
+- **Status:** Feasibility / planning only. **Nothing here is approved implementation.** No code in this plan has been written or merged. It exists to be handed off to another agent for refinement and execution planning.
+- **Date:** 2026-05-29
+- **Author:** Claude (feasibility study session)
+- **Scope of evidence:** Sections marked **[verified]** were read directly from this repo (`averray-agent/agent`). Sections marked **[assumed]** come from the public README overview of `depre-dev/averray-reference-agent` and `nousresearch/hermes-agent`, or from the live monitor screenshot, and **must be confirmed in Phase 0 before they are built against.**
+
+---
+
+## 0. One-paragraph summary
+
+We already run a multi-agent system without calling it one: **Codex** and **Claude** build code in their own git worktrees and open PRs; **Hermes** (an operator-side agent on the VPS) reviews PRs and reports; a **human operator** approves merges and deploys; and a live **kanban monitor** ("Hermes Handoff Monitor") makes it all legible. The goal is to evolve this from *Hermes-reviews-after-the-fact* into *Hermes-orchestrates*: an intelligent, partly self-managing workflow where Hermes decides what work is needed, routes each task to the best worker agent (Codex or Claude), tracks it, reviews it, and escalates to the human only at the merge/deploy gate — all visible and controllable from the monitor board.
+
+---
+
+## 1. What we want to achieve (goals)
+
+### North star
+An **intelligent, self-managing multi-agent workflow** with:
+- **Hermes as orchestrator** — plans/triages work, routes tasks to agents, narrates decisions, learns which agent is good at what.
+- **Codex and Claude Code as worker agents** — headless builders that take a task, work in an isolated worktree, and open a PR.
+- **The monitor board as the control plane** — every task and PR visible by agent, with the operator able to create/approve/redirect work and Hermes narrating live.
+- **The human in the loop only where it matters** — merge and deploy stay human-gated; everything up to the gate can run autonomously.
+
+### Three rungs (the path, not three separate products)
+| Rung | What Hermes does | State |
+|---|---|---|
+| **A — Reviewer/Reporter** | Reviews PRs post-CI, verifies deploys, files scheduled reports. Recommendation-only. | **This is today.** |
+| **B — Dispatcher** | Work is enqueued (by operator or Hermes); Codex/Claude runners claim and execute it; PRs flow back through review. | **Primary near-term target.** |
+| **C — Self-managing planner** | Hermes reads the board + roadmap, decides what's needed, routes each task to the best agent, tracks heartbeats, narrates, escalates only at gates. Improves routing over time via skills + memory. | **End state.** |
+
+---
+
+## 2. Current state (verified topology)
+
+```
+        CODE AGENTS                  OPERATOR AGENT              HUMAN
+   ┌──────────────────┐           ┌─────────────────┐      ┌──────────┐
+   │ Codex   (codex/*) │  opens   │     Hermes      │      │ Operator │
+   │ Claude  (claude/*)│  ──PR──▶  │  (on the VPS)   │      │  (you)   │
+   └──────────────────┘           └─────────────────┘      └──────────┘
+        build code                  reviews + reports        approves
+     in git worktrees              (recommendation-only)    merge/deploy
+            │                              ▲                      ▲
+            └──── CI is the merge gate ────┘                      │
+                          │                                       │
+                  Hermes Monitor (kanban board) ──── you watch & command ───┘
+```
+
+**[verified] — read in this repo:**
+- **Two code agents are first-class.** [`scripts/ops/start-agent-worktree.sh`](../scripts/ops/start-agent-worktree.sh) routes `codex/<task>` → `.codex/worktrees/` and `claude/<task>` → `.claude/worktrees/`. [`AGENTS.md`](../AGENTS.md) treats them as peers: one branch per task, narrow PRs, never push to `main`, CI is the merge gate.
+- **Hermes lives in a separate repo/deployment.** [`docs/HERMES_OPERATOR_REPORTS.md`](./HERMES_OPERATOR_REPORTS.md) states Hermes runs in the **`averray-reference-agent`** deployment on the production VPS, *not* in this repo. This repo only holds the workflows that reach into it over SSH.
+- **Hermes is invoked exactly one way:** `ssh … docker compose … exec -T hermes hermes chat --provider ollama-cloud -m deepseek-v4-pro:cloud -q "$PROMPT"`. The prompt always says *"Use Averray MCP tools only."* See [`.github/workflows/hermes-pr-handoff.yml`](../.github/workflows/hermes-pr-handoff.yml).
+- **Three Hermes routines, all recommendation/evidence-only (Hermes never merges or mutates GitHub):**
+  1. **PR handoff** (post-CI) → `averray_invoke_agent_task(intent='pr_handoff', TBE2E-004)`.
+  2. **Post-deploy verification** → `intent='testbed_suite'` (in [`.github/workflows/deploy-production.yml`](../.github/workflows/deploy-production.yml)).
+  3. **Scheduled operator self-reports** → daily 07:17 UTC → `averray_handle_operator_command('ops health' | 'daily operator brief')` ([`.github/workflows/hermes-operator-report.yml`](../.github/workflows/hermes-operator-report.yml)).
+- **The integration bus is MCP.** Two tool families seen in the workflows: `averray_invoke_agent_task` (intents: `pr_handoff`, `pr_code_review`, `post_deploy_verification`, `testbed_*`) and `averray_handle_operator_command`.
+
+**[verified from the live monitor screenshot]:**
+- The monitor is **live and running** (not just a spec). 8-lane pipeline: `needs-attention → drafts → codex-needed → hermes-checking → operator-review → release-queue → deploying → done`. KPI strip, LIVE clock, calm/empty "Board Now" state, a persistent **Hermes co-pilot rail** with `/mission <url>` and `/mute 1h` slash commands.
+- **Today, work enters at "Operator review"** (Hermes already ran its check; cards show `WAITING ON → OPERATOR`, 9/9 checks) and exits via **Deploying → Done**. The left half of the pipeline (drafts, codex-needed, hermes-checking) is **empty**.
+- **Every card is `agentType: ext`** — generic external PR. The data model supports `claude | codex | hermes | ext`, but in production no card is attributed to a specific agent.
+- The **Codex-needed lane** exists with the subtitle `CREATE / APPROVE TASK` but is **dormant** (no orchestrator enqueues work). The co-pilot exposes `/mission` and `/mute`, but no dispatch verb, and narrates nothing yet ("No board chatter yet").
+
+### The two gaps that separate "today" from the goal
+1. **Attribution gap** — the board can't see *which* agent did what; everything is `ext`.
+2. **Dispatch gap** — the lanes/UI for assigning work to agents exist but nothing drives them.
+
+---
+
+## 3. What the Hermes framework already gives us (no build needed)
+
+**[assumed — from `nousresearch/hermes-agent` README]** — confirm versions/availability in Phase 0:
+- **Agent loop + tool calling** (already wired to Averray MCP).
+- **Subagent spawning** — Hermes can fan out its own isolated subagents.
+- **Cron scheduler** — already used for the daily reports.
+- **Skills framework** (agentskills.io) — Hermes can create/improve reusable procedures. This is the hook for a learnable routing playbook.
+- **Memory layer** (SQLite FTS5 + summarization + user profile) — persistent routing decisions and per-agent performance history.
+- **MCP client + multiple terminal backends** (local, Docker, SSH, Modal, Daytona) — the mechanism by which Hermes could launch worker runs.
+- **Messaging gateways** (Slack, Telegram, …) — operator approvals from anywhere.
+
+**Implication:** Hermes already has the *capability* to orchestrate. The work is wiring behaviors, not adding engine features.
+
+---
+
+## 4. Target architecture (Rung C)
+
+```
+   ┌──────────────────────────── Hermes (orchestrator) ───────────────────────────┐
+   │  reads: board state + roadmap + memory                                        │
+   │  decides: what work is needed                                                 │
+   │  routes:  task → best agent (taxonomy + learned performance)                  │
+   │  narrates: decision in the co-pilot rail                                      │
+   └───────────────┬───────────────────────────────────────────┬──────────────────┘
+                   │ enqueue task (policy-gated)                 │ review verdict
+                   ▼                                             ▲
+            ┌──────────────┐        claim & run        ┌──────────────────┐
+            │  Task queue  │ ───────────────────────▶  │  PR handoff      │
+            └──────────────┘                           │  (existing)      │
+              │          │                             └──────────────────┘
+     ┌────────▼───┐  ┌───▼─────────┐                            ▲
+     │codex-runner│  │claude-runner│  headless build in worktree │
+     │ codex/*    │  │ claude/*    │ ───────── opens PR ─────────┘
+     └────────────┘  └─────────────┘
+                   │
+                   ▼
+        Monitor board (control plane) — operator creates/approves/redirects;
+        every card attributed to its agent; human owns merge/deploy gate.
+```
+
+---
+
+## 5. Workstreams / phases
+
+> **Repo legend:** `[ref-agent]` = work lands in `depre-dev/averray-reference-agent` (the VPS deployment). `[platform]` = work lands in this repo (`averray-agent/agent`). Most of this lives in the reference-agent; this repo changes only if new MCP intents/tools or workflow hooks are added.
+
+| Phase | Goal | Repo | Depends on | Rough effort | Acceptance |
+|---|---|---|---|---|---|
+| **P0 — Discovery** | Confirm the [assumed] internals so later phases are exact, not approximate. | both (read-only) | — | 0.5–1 day | A confirmed integration map (see §6 questions answered). |
+| **P1 — Agent attribution** | Board derives `agentType` from PR head-branch prefix (`codex/*`→codex, `claude/*`→claude, else ext/human). Board stops showing everything as `ext`. | `[ref-agent]` | P0 | ~0.5 day | Live board shows correct per-agent attribution on existing PRs. |
+| **P2 — Claude Code worker runner** | A `claude-task-runner` mirroring the Codex runner: claim task → `start-agent-worktree.sh claude/<slug>` → run `claude -p "<prompt>"` (or Agent SDK) headless → open PR → heartbeat. | `[ref-agent]` | P0 | 2–4 days | A queued Claude task produces a PR that flows into Operator review via existing handoff, unchanged. |
+| **P3 — Board-driven dispatch** | Light up the `codex-needed` lane (`CREATE / APPROVE TASK`) bidirectionally + add the Claude path + a co-pilot `/task` verb. Operator (and later Hermes) enqueues; runners claim. | `[ref-agent]` (+ maybe a `[platform]` MCP intent) | P1, P2 | 2–3 days | Operator creates a task from the board → it appears in `codex-needed` → runner picks it up → PR appears attributed to the agent. |
+| **P4 — Hermes as router (Rung C core)** | A Hermes skill that reads board + roadmap, decides what's needed, routes by task taxonomy (Codex owns chain/settlement; Claude takes UI/docs), enqueues (policy-gated), and **narrates the decision** in the rail. | `[ref-agent]` / Hermes skills | P3 | 3–6 days | Given a backlog, Hermes proposes + routes ≥1 task end-to-end and narrates why; operator can veto from the board. |
+| **P5 — Self-management hardening** | Heartbeats, stale-task detection, retries, escalation rules, mutation budgets/policy guardrails on dispatch, per-agent performance memory, observability. | `[ref-agent]` | P4 | ongoing | Stuck/failed tasks surface in `needs-attention`; dispatch respects policy budgets; routing improves with logged performance. |
+
+### Sequencing rationale
+- **P1 first** because it's the smallest change, the highest signal, and a prerequisite for any routing intelligence (you can't route by agent if you can't attribute by agent).
+- **P2 before P3** because dispatch needs at least one new runner to dispatch *to*; the Codex runner reportedly already exists, so Claude is the missing worker.
+- **P4/P5 are mostly prompt/skill/policy work**, not plumbing — they sit on top of P1–P3.
+
+---
+
+## 6. Open questions to answer in Phase 0 (the [assumed] list)
+
+These are the load-bearing unknowns. **Do not build P1–P3 until these are confirmed by reading `averray-reference-agent`.**
+
+1. **Board aggregator — agentType logic.** How does the board set `agentType` today? Does it already look at branch prefix, PR author, or labels? (All cards currently render `ext` — why?)
+2. **Codex task queue + runner.** What is the exact task schema (fields, states), where is the queue stored (file? Postgres?), how does the runner poll/claim/heartbeat, and what command does it execute? (P2 mirrors this.)
+3. **Claude agentType handling.** Is `claude` recognized anywhere beyond the card-type union? Any dead-ends or assumptions baked toward Codex only?
+4. **Policy / mutation guardrails.** The reference-agent overview mentions a `policy` MCP server and "mutation budgets." What can Hermes mutate today, and what gate would a *dispatch* (enqueue) capability have to pass? (This is the security boundary for Rung B/C.)
+5. **MCP tool surface.** Full list of `averray_*` MCP tools and the intents of `averray_invoke_agent_task` (workflows reveal `pr_handoff`, `pr_code_review`, `post_deploy_verification`, `testbed_*` — is there a dispatch/enqueue intent already?).
+6. **Monitor deployment.** Is the live board the separate `monitor.averray.com` deployment, or still inside the operator app? (The redesign spec said it was moving to its own deployment.)
+
+---
+
+## 7. Constraints & invariants (must not break)
+
+- **Human owns the merge/deploy gate.** [`AGENTS.md`](../AGENTS.md): no direct pushes to `main`, deploys serialized, CI is the merge gate. "Self-managing" means *self-managing up to the gate* — **no auto-merge**, at least until explicitly revisited.
+- **Authority change is the real risk.** Today Hermes is recommendation-only and never mutates GitHub. Giving it a *dispatch* (enqueue) capability must go through the policy MCP / mutation budgets — never free-form prompt authority.
+- **Two-repo split.** Worker/runner/monitor/orchestration work lands in `averray-reference-agent`. This repo changes only for new MCP intents/tools or workflow hooks.
+- **Codex owns chain/settlement.** Per existing coordination rules, routing logic (P4) must keep chain/settlement tasks with Codex; Claude takes UI/docs/etc.
+- **Truth-boundary discipline.** The board must keep its honest real/degraded/empty signaling (KPIs show `?` not `0` when a source is down). Don't make orchestration look more autonomous/live than it is.
+- **Narrow PRs, one branch per task** — every phase ships as small, independently reviewable PRs.
+
+---
+
+## 8. Immediate next steps (for the handoff agent)
+
+1. **Run Phase 0 discovery against `depre-dev/averray-reference-agent`.** Answer all six questions in §6. Produce a short "confirmed integration map" doc. *(Read-only; no code.)*
+2. **Spike P1 (attribution) as a thrown-away prototype** to confirm the branch-prefix mapping is as small as it looks, and to surface any aggregator surprises. *(Reference-agent.)*
+3. **Write the P2 runner design** (Claude headless invocation mode: `claude -p` vs Agent SDK, auth, sandboxing, worktree lifecycle, heartbeat, failure handling) as a 1-page design before coding.
+4. **Decide the dispatch authority model** for P3/P4 with the operator: what can Hermes enqueue autonomously vs. what needs operator approval in the `codex-needed` lane.
+5. **Bring the result back to the operator** to choose how far to push toward Rung C and on what timeline.
+
+---
+
+## 9. Key references
+
+**This repo (`averray-agent/agent`) — [verified]:**
+- [`AGENTS.md`](../AGENTS.md) — multi-agent coordination rules.
+- [`scripts/ops/start-agent-worktree.sh`](../scripts/ops/start-agent-worktree.sh) — `codex/*` / `claude/*` worktree convention.
+- [`.github/workflows/hermes-pr-handoff.yml`](../.github/workflows/hermes-pr-handoff.yml) — how Hermes is invoked (SSH + `hermes chat`).
+- [`.github/workflows/hermes-operator-report.yml`](../.github/workflows/hermes-operator-report.yml) — scheduled operator reports.
+- [`docs/HERMES_OPERATOR_REPORTS.md`](./HERMES_OPERATOR_REPORTS.md) — the Hermes routines + evidence/correlation-id model.
+- [`docs/HERMES_MONITOR_REDESIGN_SPEC.md`](./HERMES_MONITOR_REDESIGN_SPEC.md) — the monitor board spec (lanes, card types, data model, co-pilot).
+- [`docs/PROJECT_ROADMAP.md`](./PROJECT_ROADMAP.md) — canonical roadmap (Hermes would read this in Rung C).
+
+**External:**
+- `github.com/depre-dev/averray-reference-agent` — the Hermes deployment (workers, runners, monitor backend, MCP servers). **Where most of this plan executes.**
+- `github.com/nousresearch/hermes-agent` — the Hermes framework (agent loop, subagents, cron, skills, memory, MCP).
+
+---
+
+*End of plan. Feasibility/planning only — not approved implementation.*


### PR DESCRIPTION
## What changed

Two **docs-only**, feasibility/planning artifacts (no code, no behavior change):

- `docs/HERMES_MULTI_AGENT_ORCHESTRATION_PLAN.md` — the plan to evolve Hermes from PR-reviewer to orchestrator, with Codex and Claude Code as worker agents. Three rungs (reviewer → dispatcher → self-managing planner), phased workstreams P0–P5, and the safety constraints that must hold (human merge/deploy gate, two-repo split, Codex owns chain/settlement, truth-boundary).
- `docs/HERMES_INTEGRATION_MAP.md` — the Phase 0 discovery output, **read directly from `depre-dev/averray-reference-agent` @ main**, answering the plan's six open questions with `path:line` source citations and flagging the refinements each finding implies.

Key confirmed findings: `agentType` is derived from the board `owner` string (the head branch is dropped from the slim model), which is why every card renders `ext`; the Codex task queue/runner is JSON-backed and the runner is **command-agnostic** (reusable for a Claude worker); `claude` is modeled but has no runner; `invoke_agent_task` has **no enqueue intent**; the marketplace mutation policy does **not** cover code dispatch (a new guardrail is needed for autonomy); the board is served by `slack-operator`, with an optional Hermes gateway HTTP API on `:8642`.

## Checks run

None required — documentation only (no app/backend/indexer/contract/site source touched).

## Surfaces affected

Docs only. No backend, frontend, indexer, Caddy, contracts, or public site changes. No environment or VPS secret changes.