### PR TITLE
ops: make proof-freshness CLI tests date-independent (--now injection, 6 scripts)

### DIFF
--- a/scripts/ops/check-hardware-mfa-evidence.mjs
+++ b/scripts/ops/check-hardware-mfa-evidence.mjs
@@ -20,7 +20,7 @@ const REQUIRED_ACCOUNT_IDS = [
 const ALLOWED_METHODS = new Set(["provider_ui", "provider_api", "operator_attestation"]);
 
 function usage() {
-  return `Usage: node scripts/ops/${SCRIPT_NAME} --file docs/evidence/hardware-mfa-YYYY-MM-DD.json [--json] [--max-completed-age-hours N]
+  return `Usage: node scripts/ops/${SCRIPT_NAME} --file docs/evidence/hardware-mfa-YYYY-MM-DD.json [--json] [--max-completed-age-hours N] [--now <iso>]
 
 Validates the operator evidence that hardware-backed MFA is enrolled across the
 admin trust chain. This check is read-only; it does not call providers or store
@@ -28,7 +28,21 @@ recovery codes.
 
 Use --max-completed-age-hours when validating live launch evidence so stale
 historical artifacts cannot be reused as current admin-trust proof.
+
+Use --now <iso> to pin the freshness comparison clock to an ISO-8601 date/time
+(defaults to the current time); primarily for deterministic tests.
 `;
+}
+
+function parseIsoNow(value) {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}T/u.test(value.trim())) {
+    throw new Error("--now must be an ISO-8601 date/time");
+  }
+  const date = new Date(value.trim());
+  if (!Number.isFinite(date.getTime())) {
+    throw new Error("--now must be an ISO-8601 date/time");
+  }
+  return date;
 }
 
 function parseArgs(argv) {
@@ -36,7 +50,8 @@ function parseArgs(argv) {
     file: undefined,
     json: false,
     help: false,
-    maxCompletedAgeHours: undefined
+    maxCompletedAgeHours: undefined,
+    now: undefined
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -51,6 +66,9 @@ function parseArgs(argv) {
         throw new Error("--max-completed-age-hours must be a positive number");
       }
       args.maxCompletedAgeHours = value;
+      index += 1;
+    } else if (arg === "--now") {
+      args.now = parseIsoNow(argv[index + 1]);
       index += 1;
     } else if (arg === "-h" || arg === "--help") {
       args.help = true;
@@ -341,7 +359,8 @@ async function main() {
   const raw = await readFile(args.file, "utf8");
   const parsed = JSON.parse(raw);
   const result = validateEvidence(parsed, {
-    maxCompletedAgeHours: args.maxCompletedAgeHours
+    maxCompletedAgeHours: args.maxCompletedAgeHours,
+    now: args.now
   });
   if (args.json) {
     process.stdout.write(`${JSON.stringify({

--- a/scripts/ops/check-hardware-mfa-evidence.test.mjs
+++ b/scripts/ops/check-hardware-mfa-evidence.test.mjs
@@ -92,8 +92,12 @@ function validEvidence(overrides = {}) {
   };
 }
 
+// Fixed clock the CLI freshness happy-path pins via --now, mirroring the
+// in-process "fresh launch proof" case so wall-clock drift cannot expire it.
+const FRESH_NOW_ISO = "2026-05-22T13:30:00.000Z";
+
 function freshEvidence() {
-  const now = new Date();
+  const now = new Date(FRESH_NOW_ISO);
   const verifiedAt = new Date(now.getTime() - 10 * 60 * 1000).toISOString();
   return validEvidence({
     completedAt: now.toISOString(),
@@ -299,6 +303,8 @@ test("CLI accepts max completed age for fresh evidence", async () => {
     file,
     "--max-completed-age-hours",
     "1",
+    "--now",
+    FRESH_NOW_ISO,
     "--json"
   ]);
   const parsed = JSON.parse(stdout);

--- a/scripts/ops/check-incident-response-proof.mjs
+++ b/scripts/ops/check-incident-response-proof.mjs
@@ -36,7 +36,7 @@ const ROLLBACK_COMPONENTS = [
 const SAFE_HEX_PATH_PATTERN = /(blockHash|callHash|contentHash|evidenceHash|explorerUrl|explorerUrls\[\d+\]|proofHash|receiptHash|reasoningHash|transactionHash|txHash|pauseTxHash|unpauseTxHash)$/iu;
 
 function usage() {
-  return `Usage: node scripts/ops/${SCRIPT_NAME} --file docs/evidence/incident-response-YYYY-MM-DD.json [--json] [--max-completed-age-hours N] [--require-mainnet]
+  return `Usage: node scripts/ops/${SCRIPT_NAME} --file docs/evidence/incident-response-YYYY-MM-DD.json [--json] [--max-completed-age-hours N] [--require-mainnet] [--now <iso>]
 
 Validates a redacted incident-response rehearsal proof artifact. This check is
 offline and read-only: it does not call RPC, send alerts, pause contracts, or
@@ -45,7 +45,8 @@ roll back services.
 The evidence file must use schema ${SCHEMA_VERSION}. Use
 --max-completed-age-hours when validating launch evidence so stale rehearsal
 artifacts cannot be reused. Add --require-mainnet before closing the mainnet
-incident-response launch row.
+incident-response launch row. Use --now <iso> to pin the freshness clock to a
+fixed ISO-8601 instant (primarily for deterministic tests).
 `;
 }
 
@@ -55,6 +56,7 @@ export function parseArgs(argv) {
     json: false,
     maxCompletedAgeHours: undefined,
     requireMainnet: false,
+    now: undefined,
     help: false
   };
 
@@ -70,6 +72,9 @@ export function parseArgs(argv) {
       index += 1;
     } else if (arg === "--require-mainnet") {
       args.requireMainnet = true;
+    } else if (arg === "--now") {
+      args.now = parseIsoDateTime(argv[index + 1]);
+      index += 1;
     } else if (arg === "-h" || arg === "--help") {
       args.help = true;
     } else if (!args.file && !arg.startsWith("-")) {
@@ -88,6 +93,13 @@ function parsePositiveNumber(value, flag) {
     throw new Error(`${flag} must be a positive number`);
   }
   return number;
+}
+
+function parseIsoDateTime(value) {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}T/u.test(value) || !Number.isFinite(Date.parse(value))) {
+    throw new Error("--now must be an ISO-8601 date/time");
+  }
+  return new Date(value);
 }
 
 function assertObject(value, path, errors) {
@@ -561,7 +573,8 @@ async function main() {
   const parsed = JSON.parse(raw);
   const result = validateEvidence(parsed, {
     maxCompletedAgeHours: args.maxCompletedAgeHours,
-    requireMainnet: args.requireMainnet
+    requireMainnet: args.requireMainnet,
+    now: args.now
   });
 
   if (args.json) {

--- a/scripts/ops/check-incident-response-proof.test.mjs
+++ b/scripts/ops/check-incident-response-proof.test.mjs
@@ -386,10 +386,7 @@ test("CLI exits zero and prints JSON for valid evidence", async () => {
 });
 
 test("CLI accepts fresh mainnet evidence with hardening flags", async () => {
-  const file = await writeEvidenceFile(mainnetEvidence({
-    proofDate: new Date().toISOString().slice(0, 10),
-    completedAt: new Date().toISOString()
-  }));
+  const file = await writeEvidenceFile(mainnetEvidence());
   const { stdout } = await execFileAsync(process.execPath, [
     scriptPath,
     "--file",
@@ -397,6 +394,8 @@ test("CLI accepts fresh mainnet evidence with hardening flags", async () => {
     "--max-completed-age-hours",
     "1",
     "--require-mainnet",
+    "--now",
+    "2026-05-28T15:00:00.000Z",
     "--json"
   ]);
   const parsed = JSON.parse(stdout);

--- a/scripts/ops/check-mainnet-env-secrets-proof.mjs
+++ b/scripts/ops/check-mainnet-env-secrets-proof.mjs
@@ -42,14 +42,15 @@ const REQUIRED_POLKADOT_DOCS = [
 ];
 
 function usage() {
-  return `Usage: node scripts/ops/${SCRIPT_NAME} --file docs/evidence/mainnet-env-secrets-YYYY-MM-DD.json [--json] [--max-completed-age-hours N]
+  return `Usage: node scripts/ops/${SCRIPT_NAME} --file docs/evidence/mainnet-env-secrets-YYYY-MM-DD.json [--json] [--max-completed-age-hours N] [--now <iso>]
 
 Validates a redacted mainnet env/secrets proof artifact. This check is offline
 and read-only: it does not render secrets, call providers, call chain RPC, or
 store raw credentials.
 
 The evidence file must use schema ${SCHEMA_VERSION}. Use --max-completed-age-hours
-when validating launch evidence so a stale artifact cannot be reused.
+when validating launch evidence so a stale artifact cannot be reused. Use --now to
+pin the freshness clock to an ISO-8601 date/time (deterministic tests).
 `;
 }
 
@@ -58,6 +59,7 @@ export function parseArgs(argv) {
     file: undefined,
     json: false,
     maxCompletedAgeHours: undefined,
+    now: undefined,
     help: false
   };
   for (let index = 0; index < argv.length; index += 1) {
@@ -69,6 +71,9 @@ export function parseArgs(argv) {
       args.json = true;
     } else if (arg === "--max-completed-age-hours") {
       args.maxCompletedAgeHours = parsePositiveInteger(argv[index + 1], "--max-completed-age-hours");
+      index += 1;
+    } else if (arg === "--now") {
+      args.now = parseIsoDate(argv[index + 1]);
       index += 1;
     } else if (arg === "-h" || arg === "--help") {
       args.help = true;
@@ -86,6 +91,14 @@ function parsePositiveInteger(value, flag) {
     throw new Error(`${flag} must be a positive integer`);
   }
   return Number(value);
+}
+
+function parseIsoDate(value) {
+  const raw = String(value ?? "");
+  if (!/^\d{4}-\d{2}-\d{2}([T ].*)?$/u.test(raw) || !Number.isFinite(Date.parse(raw))) {
+    throw new Error("--now must be an ISO-8601 date/time");
+  }
+  return new Date(Date.parse(raw));
 }
 
 function assertObject(value, path, errors) {
@@ -504,7 +517,8 @@ async function main() {
 
   const parsed = JSON.parse(await readFile(args.file, "utf8"));
   const result = validateEvidence(parsed, {
-    maxCompletedAgeHours: args.maxCompletedAgeHours
+    maxCompletedAgeHours: args.maxCompletedAgeHours,
+    now: args.now
   });
 
   if (args.json) {

--- a/scripts/ops/check-mainnet-env-secrets-proof.test.mjs
+++ b/scripts/ops/check-mainnet-env-secrets-proof.test.mjs
@@ -290,7 +290,7 @@ test("validateEvidence rejects stale and future-dated proof when freshness is re
 
 test("CLI exits zero and prints JSON for valid evidence", async () => {
   const file = await writeEvidenceFile(validEvidence({
-    completedAt: new Date().toISOString()
+    completedAt: "2026-05-28T12:00:00.000Z"
   }));
 
   const { stdout, stderr } = await execFileAsync(process.execPath, [
@@ -299,6 +299,8 @@ test("CLI exits zero and prints JSON for valid evidence", async () => {
     file,
     "--max-completed-age-hours",
     "24",
+    "--now",
+    "2026-05-28T13:00:00.000Z",
     "--json"
   ]);
 

--- a/scripts/ops/check-mainnet-smoke-proof.mjs
+++ b/scripts/ops/check-mainnet-smoke-proof.mjs
@@ -61,13 +61,14 @@ const CANONICAL_USDC = Object.freeze({
 });
 
 function usage() {
-  return `Usage: node scripts/ops/${SCRIPT_NAME} --file docs/evidence/mainnet-smoke-YYYY-MM-DD.json [--json] [--max-completed-age-hours N] [--min-runs N] [--max-reward-raw N]
+  return `Usage: node scripts/ops/${SCRIPT_NAME} --file docs/evidence/mainnet-smoke-YYYY-MM-DD.json [--json] [--max-completed-age-hours N] [--min-runs N] [--max-reward-raw N] [--now <iso>]
 
 Validates a redacted mainnet smoke proof artifact. This check is offline and
 read-only: it does not call chain RPC, mutate jobs, or settle funds.
 
 The evidence file must use schema ${SCHEMA_VERSION}. Use --max-completed-age-hours
 when validating launch evidence so stale smoke artifacts cannot be reused.
+--now <iso> pins the freshness clock (ISO-8601); defaults to the current time.
 `;
 }
 
@@ -78,6 +79,7 @@ export function parseArgs(argv) {
     maxCompletedAgeHours: undefined,
     minRuns: DEFAULT_MIN_RUNS,
     maxRewardRaw: DEFAULT_MAX_REWARD_RAW,
+    now: undefined,
     help: false
   };
   for (let index = 0; index < argv.length; index += 1) {
@@ -96,6 +98,9 @@ export function parseArgs(argv) {
     } else if (arg === "--max-reward-raw") {
       args.maxRewardRaw = parsePositiveBigInt(argv[index + 1], "--max-reward-raw");
       index += 1;
+    } else if (arg === "--now") {
+      args.now = parseTimestampArg(argv[index + 1], "--now");
+      index += 1;
     } else if (arg === "-h" || arg === "--help") {
       args.help = true;
     } else if (!args.file && !arg.startsWith("-")) {
@@ -112,6 +117,15 @@ function parsePositiveInteger(value, flag) {
     throw new Error(`${flag} must be a positive integer`);
   }
   return Number(value);
+}
+
+function parseTimestampArg(value, flag) {
+  const text = String(value ?? "");
+  const parsed = new Date(text);
+  if (!/^\d{4}-\d{2}-\d{2}T/u.test(text) || Number.isNaN(parsed.getTime())) {
+    throw new Error(`${flag} must be an ISO-8601 date/time`);
+  }
+  return parsed;
 }
 
 function parsePositiveBigInt(value, flag) {

--- a/scripts/ops/check-mainnet-smoke-proof.test.mjs
+++ b/scripts/ops/check-mainnet-smoke-proof.test.mjs
@@ -278,7 +278,9 @@ test("CLI prints JSON for a valid evidence file", async () => {
     file,
     "--json",
     "--max-completed-age-hours",
-    "24"
+    "24",
+    "--now",
+    "2026-05-28T13:00:00.000Z"
   ]);
 
   const parsed = JSON.parse(stdout);

--- a/scripts/ops/check-observability-proof.mjs
+++ b/scripts/ops/check-observability-proof.mjs
@@ -9,7 +9,7 @@ const SCHEMA_VERSION = "observability-proof-v1";
 const FUTURE_SKEW_MS = 5 * 60 * 1000;
 
 function usage() {
-  return `Usage: node scripts/ops/${SCRIPT_NAME} --file docs/evidence/observability-YYYY-MM-DD.json [--json] [--max-completed-age-hours N]
+  return `Usage: node scripts/ops/${SCRIPT_NAME} --file docs/evidence/observability-YYYY-MM-DD.json [--json] [--max-completed-age-hours N] [--now <iso>]
 
 Validates the operator evidence for the RC1 observability gates:
 metrics bearer auth, hosted alert delivery, and Sentry/logging posture.
@@ -17,14 +17,28 @@ This check is read-only; it does not call the hosted stack or alert vendors.
 
 Use --max-completed-age-hours when validating live launch evidence so stale
 historical artifacts cannot be reused as current production proof.
+Use --now <iso> to pin the freshness comparison clock (defaults to the wall
+clock); the value must be an ISO-8601 date/time.
 `;
+}
+
+function parseIsoNow(raw) {
+  if (typeof raw !== "string" || !/^\d{4}-\d{2}-\d{2}T/u.test(raw.trim())) {
+    throw new Error("--now must be an ISO-8601 date/time");
+  }
+  const date = new Date(raw.trim());
+  if (!Number.isFinite(date.getTime())) {
+    throw new Error("--now must be an ISO-8601 date/time");
+  }
+  return date;
 }
 
 function parseArgs(argv) {
   const args = {
     file: undefined,
     json: false,
-    maxCompletedAgeHours: undefined
+    maxCompletedAgeHours: undefined,
+    now: undefined
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -40,6 +54,9 @@ function parseArgs(argv) {
         throw new Error("--max-completed-age-hours must be a positive number");
       }
       args.maxCompletedAgeHours = value;
+      index += 1;
+    } else if (arg === "--now") {
+      args.now = parseIsoNow(argv[index + 1]);
       index += 1;
     } else if (arg === "-h" || arg === "--help") {
       args.help = true;
@@ -289,7 +306,8 @@ async function main() {
   const raw = await readFile(args.file, "utf8");
   const parsed = JSON.parse(raw);
   const result = validateEvidence(parsed, {
-    maxCompletedAgeHours: args.maxCompletedAgeHours
+    maxCompletedAgeHours: args.maxCompletedAgeHours,
+    now: args.now
   });
   if (args.json) {
     process.stdout.write(`${JSON.stringify({

--- a/scripts/ops/check-observability-proof.test.mjs
+++ b/scripts/ops/check-observability-proof.test.mjs
@@ -56,27 +56,6 @@ function validEvidence(overrides = {}) {
   };
 }
 
-function freshEvidence() {
-  const now = new Date();
-  const observedAt = new Date(now.getTime() - 5 * 60 * 1000).toISOString();
-  return validEvidence({
-    proofDate: now.toISOString().slice(0, 10),
-    completedAt: now.toISOString(),
-    metricsAuth: {
-      ...validEvidence().metricsAuth,
-      observedAt
-    },
-    alertDestination: {
-      ...validEvidence().alertDestination,
-      receivedAt: observedAt
-    },
-    sentryLogging: {
-      ...validEvidence().sentryLogging,
-      observedAt
-    }
-  });
-}
-
 async function writeEvidenceFile(doc) {
   const dir = await mkdtemp(join(tmpdir(), "observability-proof-"));
   const file = join(dir, "evidence.json");
@@ -230,13 +209,15 @@ test("CLI exits zero and prints JSON for valid evidence", async () => {
 });
 
 test("CLI accepts max completed age for fresh evidence", async () => {
-  const file = await writeEvidenceFile(freshEvidence());
+  const file = await writeEvidenceFile(validEvidence());
   const { stdout } = await execFileAsync(process.execPath, [
     scriptPath,
     "--file",
     file,
     "--max-completed-age-hours",
-    "1",
+    "2",
+    "--now",
+    "2026-05-22T19:00:00.000Z",
     "--json"
   ]);
   const parsed = JSON.parse(stdout);

--- a/scripts/ops/check-pauser-rehearsal-evidence.mjs
+++ b/scripts/ops/check-pauser-rehearsal-evidence.mjs
@@ -38,7 +38,7 @@ const ADDRESS_PATTERN = /^0x[a-fA-F0-9]{40}$/u;
 const TX_HASH_PATTERN = /^0x[a-fA-F0-9]{64}$/u;
 
 function usage() {
-  return `Usage: node scripts/ops/${SCRIPT_NAME} --file docs/evidence/pauser-rehearsal-YYYY-MM-DD.json [--json] [--require-live] [--require-dedicated-pauser] [--max-generated-age-hours N]
+  return `Usage: node scripts/ops/${SCRIPT_NAME} --file docs/evidence/pauser-rehearsal-YYYY-MM-DD.json [--json] [--require-live] [--require-dedicated-pauser] [--max-generated-age-hours N] [--now <iso>]
 
 Validates the machine-readable evidence produced by run-pauser-rehearsal.mjs.
 This check is read-only; it does not call RPC, sign transactions, pause, or
@@ -46,7 +46,17 @@ unpause contracts.
 
 Use --max-generated-age-hours when validating live launch evidence so stale
 historical artifacts cannot be reused as current pauser proof.
+
+Use --now <iso> to pin the reference clock (ISO-8601 date/time) when checking
+freshness; defaults to the current time.
 `;
+}
+
+function parseIsoNow(value) {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}T/u.test(value) || !Number.isFinite(Date.parse(value))) {
+    throw new Error("--now must be an ISO-8601 date/time");
+  }
+  return new Date(value);
 }
 
 function parseArgs(argv) {
@@ -56,6 +66,7 @@ function parseArgs(argv) {
     requireLive: false,
     requireDedicatedPauser: false,
     maxGeneratedAgeHours: undefined,
+    now: undefined,
     help: false
   };
 
@@ -76,6 +87,9 @@ function parseArgs(argv) {
         throw new Error("--max-generated-age-hours must be a positive number");
       }
       args.maxGeneratedAgeHours = value;
+      index += 1;
+    } else if (arg === "--now") {
+      args.now = parseIsoNow(argv[index + 1]);
       index += 1;
     } else if (arg === "-h" || arg === "--help") {
       args.help = true;
@@ -362,7 +376,8 @@ async function main() {
   const result = validateEvidence(parsed, {
     requireLive: args.requireLive,
     requireDedicatedPauser: args.requireDedicatedPauser,
-    maxGeneratedAgeHours: args.maxGeneratedAgeHours
+    maxGeneratedAgeHours: args.maxGeneratedAgeHours,
+    now: args.now
   });
 
   if (args.json) {

--- a/scripts/ops/check-pauser-rehearsal-evidence.test.mjs
+++ b/scripts/ops/check-pauser-rehearsal-evidence.test.mjs
@@ -137,7 +137,7 @@ function liveEvidence(overrides = {}) {
 
 function freshLiveEvidence(overrides = {}) {
   return liveEvidence({
-    generatedAt: new Date().toISOString(),
+    generatedAt: "2026-05-24T10:00:00.000Z",
     ...overrides
   });
 }
@@ -283,6 +283,8 @@ test("CLI accepts max generated age for fresh live evidence", async () => {
     "--require-dedicated-pauser",
     "--max-generated-age-hours",
     "1",
+    "--now",
+    "2026-05-24T10:30:00.000Z",
     "--json"
   ]);
   const parsed = JSON.parse(stdout);


### PR DESCRIPTION
## Summary

Six ops *proof* checks share one **CI time-bomb**: a CLI-subprocess test runs the script against a hard-coded 2026-05 fixture timestamp using **real wall-clock**, so once the freshness window (`--max-completed/generated-age-hours`) lapses the test fails forever — independent of the diff. (In-process tests already inject a fixed `now:`; only the subprocess path was exposed.) `check-mainnet-smoke-proof`'s 24h window already detonated and was reding the whole `Backend — node --test` job.

**Fix (deterministic clock injection):** each script gets a `--now <iso>` flag (validated ISO-8601, else rejected with `--now must be an ISO-8601 date/time`), threaded into the options object the existing `validateFreshness` already reads via `options.now`. Each CLI happy-path test passes a fixed `--now` matching its fixture. **No freshness logic or audit semantics changed — test-determinism only.**

Scripts (6): `check-mainnet-smoke-proof`, `check-hardware-mfa-evidence`, `check-incident-response-proof`, `check-mainnet-env-secrets-proof`, `check-observability-proof`, `check-pauser-rehearsal-evidence` (last uses `maxGeneratedAgeHours`).

`node --test` across the six: **75/75 pass**. Each `--help` shows `--now <iso>`; invalid input → exit 1 with the error message.

## Why all six in one PR
The `Backend — node --test` job runs the **whole** `scripts/ops/*.test.mjs` suite, so any single unfixed bomb reds the job for every PR. Splitting these across PRs deadlocks (each is red until the others land). Consolidated so the suite goes green in one shot — **supersedes any separate smoke-proof PR.**

## Not bombs (left untouched)
`check-restore-drill-evidence` (validates `ageSeconds` as data, no clock compare) and `collect-observability-proof` (bash collector, no JS freshness gate).

> `scripts/ops/*` audit/mainnet lane — heads-up @Codex; additive (a flag + one test arg per script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)