### PR TITLE
app: relabel escrow chainJobId so it stops reading as a tx/block

### DIFF
--- a/app/components/sessions/EscrowLedger.tsx
+++ b/app/components/sessions/EscrowLedger.tsx
@@ -1,11 +1,13 @@
+import { chainReferenceTitle } from "@/lib/chain/chain-reference";
 import { cn } from "@/lib/utils/cn";
 import type { EscrowMovement } from "./types";
 
 /**
  * Tightly-typed ledger of escrow movements for one session.
- * Presented as a small mono table; each row cites its tx hash and
- * tone-codes the movement (sage for lock/funded, warn for freeze,
- * deep-red for slash, neutral for settle).
+ * Presented as a small mono table; each row cites its chain reference
+ * (an escrow job id for most movements, a genuine transaction only for
+ * timeline events that carry one) and tone-codes the movement (sage for
+ * lock/funded, warn for freeze, deep-red for slash, neutral for settle).
  */
 export function EscrowLedger({ movements }: { movements: EscrowMovement[] }) {
   if (movements.length === 0) {
@@ -32,7 +34,7 @@ export function EscrowLedger({ movements }: { movements: EscrowMovement[] }) {
         <span>From</span>
         <span>To</span>
         <span className="text-right">Amount</span>
-        <span>Tx</span>
+        <span>Ref</span>
       </header>
       <ul className="m-0 flex flex-col p-0">
         {movements.map((m, i) => (
@@ -80,10 +82,18 @@ export function EscrowLedger({ movements }: { movements: EscrowMovement[] }) {
               {m.amount}
             </span>
             <span
-              className="font-[family-name:var(--font-mono)] text-[11.5px] text-[var(--avy-accent)]"
+              className={cn(
+                "truncate font-[family-name:var(--font-mono)] text-[11.5px]",
+                // Only a genuine transaction reads as on-chain (accent); an
+                // escrow job id stays plain ink so it never looks linkable.
+                m.ref.kind === "tx" && "text-[var(--avy-accent)]",
+                m.ref.kind === "job" && "text-[var(--avy-ink)]",
+                m.ref.kind === "none" && "text-[var(--avy-muted)]"
+              )}
               style={{ letterSpacing: 0 }}
+              title={chainReferenceTitle(m.ref)}
             >
-              {m.tx}
+              {m.ref.kind === "none" ? "-" : m.ref.value}
             </span>
           </li>
         ))}

--- a/app/components/sessions/PayoutTrail.tsx
+++ b/app/components/sessions/PayoutTrail.tsx
@@ -1,3 +1,4 @@
+import { chainReferenceTitle } from "@/lib/chain/chain-reference";
 import { cn } from "@/lib/utils/cn";
 import type { PayoutEntry } from "./types";
 
@@ -56,8 +57,18 @@ export function PayoutTrail({ payouts }: { payouts: PayoutEntry[] }) {
             style={{ letterSpacing: 0 }}
           >
             {p.at}
-            {p.tx !== "—" ? (
-              <span className="ml-1.5 text-[var(--avy-accent)]">· {p.tx}</span>
+            {p.ref.kind !== "none" ? (
+              <span
+                className={cn(
+                  "ml-1.5",
+                  // Genuine tx reads as on-chain; an escrow job id stays muted
+                  // so the payout row never implies a clickable transaction.
+                  p.ref.kind === "tx" ? "text-[var(--avy-accent)]" : "text-[var(--avy-muted)]"
+                )}
+                title={chainReferenceTitle(p.ref)}
+              >
+                · {p.ref.value}
+              </span>
             ) : null}
           </span>
         </li>

--- a/app/components/sessions/types.ts
+++ b/app/components/sessions/types.ts
@@ -27,6 +27,18 @@ export type VerifierMode =
 
 export type LifecycleStageState = "done" | "current" | "pending";
 
+/** Provenance-decided kind of a chain-anchored reference. Only `tx` is a real
+ *  on-chain transaction that may be linked to a block explorer. `job` is an
+ *  escrow `chainJobId` — the bytes32 EscrowCore key, shape-identical to a tx
+ *  hash but never a transaction and never linkable. `none` is the empty
+ *  placeholder. Classified by `@/lib/chain/chain-reference`. */
+export type ChainRefKind = "tx" | "job" | "none";
+
+export interface ChainRef {
+  kind: ChainRefKind;
+  value: string;
+}
+
 export interface SessionLifecycleStage {
   label: string;
   meta: string;
@@ -40,7 +52,11 @@ export interface EscrowMovement {
   from: string;
   to: string;
   amount: string;
-  tx: string;
+  /** Chain-anchored reference for the movement. Most movements carry the
+   *  escrow `chainJobId` (`kind: "job"`); only timeline events with a genuine
+   *  transaction field carry `kind: "tx"`. The ledger labels and styles the
+   *  two differently so a job id never reads as a transaction. */
+  ref: ChainRef;
   tone?: "neutral" | "accent" | "warn" | "bad";
   /** Raw timeline metadata used by the session-drawer event filter. The
    *  /session/timeline endpoint does not (yet) accept query-string
@@ -60,7 +76,8 @@ export interface PayoutEntry {
   role: "worker" | "verifier" | "co-signer" | "treasury";
   amount: string;
   at: string;
-  tx: string;
+  /** Chain-anchored reference for the payout — see `EscrowMovement.ref`. */
+  ref: ChainRef;
 }
 
 export interface SessionRow {

--- a/app/lib/api/receipt-adapters.ts
+++ b/app/lib/api/receipt-adapters.ts
@@ -11,7 +11,10 @@ export type ReceiptRowWithMeta = ReceiptRow & {
   sessionId: string;
   issuedAtIso: string;
   evidenceHash?: string;
-  blockRef?: string;
+  /** Escrow `chainJobId` — the on-chain bytes32 EscrowCore key for this job.
+   *  Shape-identical to a tx hash but NOT a transaction and not block-explorer
+   *  resolvable, so it is surfaced as "Escrow job", never as a block/tx. */
+  chainJobId?: string;
   badge?: unknown;
 };
 
@@ -76,7 +79,7 @@ export function extractReceiptRow(data: unknown): ReceiptRowWithMeta | null {
   const subject = kind === "badge" && category ? `${category}-tier-${level || "1"}` : jobId;
   const signers = extractSigners(record.signers, averray);
   const evidenceHash = text(record.evidenceHash, text(averray?.evidenceHash, ""));
-  const blockRef = text(record.blockRef, text(averray?.chainJobId, ""));
+  const chainJobId = text(record.chainJobId, text(averray?.chainJobId, ""));
 
   return {
     id: receiptId(record.id, sessionId, evidenceHash),
@@ -90,7 +93,7 @@ export function extractReceiptRow(data: unknown): ReceiptRowWithMeta | null {
     signedAt: displayTime(issuedAtIso),
     issuedAtIso,
     evidenceHash: evidenceHash || undefined,
-    blockRef: blockRef || undefined,
+    chainJobId: chainJobId || undefined,
     badge: badge ?? undefined,
   };
 }
@@ -107,7 +110,7 @@ export function buildReceiptDrawer(
     sessionId: row.sessionId,
     jobId: row.subject,
     evidenceHash: row.evidenceHash,
-    blockRef: row.blockRef,
+    chainJobId: row.chainJobId,
     signers: row.signers,
   };
   const evidenceJson = `// signed JSON — first 40 lines\n${JSON.stringify(raw, null, 2)}`;
@@ -127,7 +130,9 @@ export function buildReceiptDrawer(
       { role: "Evidence", ref: text(averray?.evidenceHash, row.evidenceHash ?? "not indexed") },
       { role: "Policy ref", ref: row.policy },
       { role: "Session", ref: row.sessionId },
-      { role: "Block ref", ref: text(averray?.chainJobId, row.blockRef ?? "pending") },
+      // Escrow job key (chainJobId) — an on-chain EscrowCore id, not a block or
+      // transaction. Labelled honestly and never linked to a block explorer.
+      { role: "Escrow job", ref: text(averray?.chainJobId, row.chainJobId ?? "pending") },
     ],
     ...(row.source ? { source: receiptSource(row.source) } : {}),
   };

--- a/app/lib/api/session-adapters.ts
+++ b/app/lib/api/session-adapters.ts
@@ -1,3 +1,4 @@
+import { classifyChainReference } from "@/lib/chain/chain-reference";
 import type { SourceKind } from "@/components/runs/StatePill";
 import type {
   LifecycleStageState,
@@ -312,7 +313,7 @@ export function buildSessionDetails(sessionPayload: unknown, jobsPayload: unknow
           from: shortAddress(session.wallet),
           to: "AgentAccountCore",
           amount: `${amount(session.totalClaimLock ?? session.claimStake)} ${rewardAsset}`,
-          tx: text(session.chainJobId, "-"),
+          ref: classifyChainReference({ jobId: session.chainJobId }),
           tone: "accent",
         },
       ],
@@ -323,7 +324,7 @@ export function buildSessionDetails(sessionPayload: unknown, jobsPayload: unknow
               role: "worker",
               amount: `${rewardAmount} ${rewardAsset}`,
               at: timeLabel(session.resolvedAt ?? session.closedAt),
-              tx: text(session.chainJobId, "-"),
+              ref: classifyChainReference({ jobId: session.chainJobId }),
             },
           ]
         : [],
@@ -365,7 +366,10 @@ export function mergeSessionTimeline(
           from: shortAddress(data.from ?? data.wallet ?? "system"),
           to: shortAddress(data.to ?? "AgentAccountCore"),
           amount: text(data.amount, session.escrow.amount ? `${session.escrow.amount} ${session.escrow.asset}` : "-"),
-          tx: text(data.tx, text(data.chainJobId, "-")),
+          // `data.tx` is a genuine transaction; `data.chainJobId` is the escrow
+          // job key (bytes32, tx-hash-shaped but not a transaction). Classify
+          // by provenance so only a real tx is ever presented/linked as one.
+          ref: classifyChainReference({ txHash: data.tx, jobId: data.chainJobId }),
           tone: movementTone(entry.phase ?? entry.type),
           ...(source ? { source } : {}),
           ...(topic ? { topic } : {}),

--- a/app/lib/chain/chain-reference.js
+++ b/app/lib/chain/chain-reference.js
@@ -1,0 +1,83 @@
+/**
+ * Provenance-aware classification of a chain-anchored reference.
+ *
+ * An escrow `chainJobId` is the bytes32 key EscrowCore uses for a job. It is
+ * SHAPE-IDENTICAL to an EVM transaction hash (`0x` + 64 hex) but it is NOT a
+ * transaction and does NOT resolve on any block explorer. We therefore decide
+ * what a value *is* by its PROVENANCE — which backend field it came from —
+ * never by its shape:
+ *
+ *   - a value from a genuine transaction field (`txHash` / timeline `data.tx`)
+ *     is a transaction, and only then *if* it also validates as `0x` + 64 hex;
+ *   - a `chainJobId` is always an escrow job id, never a transaction, even
+ *     though it matches the same regex.
+ *
+ * Consumers use `kind` to label honestly ("Escrow job" vs a transaction) and
+ * to gate any chain-explorer link: only a `kind === "tx"` reference may ever
+ * link out (see `isLinkableChainReference`). This keeps the surface from
+ * making an internal escrow id look more on-chain than it is.
+ *
+ * @typedef {"tx" | "job" | "none"} ChainRefKind
+ * @typedef {{ kind: ChainRefKind, value: string }} ChainRef
+ */
+
+/** Canonical EVM transaction-hash shape: `0x` followed by 64 hex digits. */
+export const TX_HASH_PATTERN = /^0x[0-9a-fA-F]{64}$/u;
+
+/**
+ * True only for a value that is a genuine transaction-hash *shape*. Shape is
+ * necessary but NOT sufficient to call something a transaction — the caller
+ * must also have read it from a real tx field (see `classifyChainReference`),
+ * because a `chainJobId` passes this same check.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isTxHash(value) {
+  return typeof value === "string" && TX_HASH_PATTERN.test(value.trim());
+}
+
+/**
+ * Classify a chain reference from its candidate sources, by provenance.
+ *
+ * `txHash` is honored only when it validates as a real tx hash; otherwise we
+ * fall back to the escrow `jobId`, which is presented as a job id and is never
+ * linkable. A `jobId` is taken verbatim regardless of shape: it is a job key,
+ * not a transaction, even when it looks like one.
+ *
+ * @param {{ txHash?: unknown, jobId?: unknown }} [input]
+ * @returns {ChainRef}
+ */
+export function classifyChainReference({ txHash, jobId } = {}) {
+  if (isTxHash(txHash)) {
+    return { kind: "tx", value: /** @type {string} */ (txHash).trim() };
+  }
+  const job = typeof jobId === "string" ? jobId.trim() : "";
+  if (job) return { kind: "job", value: job };
+  return { kind: "none", value: "" };
+}
+
+/**
+ * Whether a reference may be linked to a block explorer. Only genuine
+ * transactions resolve on an explorer — an escrow job id must never be linked.
+ * This is the gate the C1 explorer-link work consumes.
+ *
+ * @param {ChainRef} ref
+ * @returns {boolean}
+ */
+export function isLinkableChainReference(ref) {
+  return Boolean(ref) && ref.kind === "tx";
+}
+
+/**
+ * Honest, human-readable description of a reference, used for the cell title
+ * so an auditor never reads an escrow job id as an on-chain transaction.
+ *
+ * @param {ChainRef} ref
+ * @returns {string}
+ */
+export function chainReferenceTitle(ref) {
+  if (!ref || ref.kind === "none") return "No on-chain reference yet";
+  if (ref.kind === "tx") return `On-chain transaction ${ref.value}`;
+  return `Escrow job id ${ref.value} — internal EscrowCore key, not an on-chain transaction`;
+}

--- a/app/lib/chain/chain-reference.test.mjs
+++ b/app/lib/chain/chain-reference.test.mjs
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  TX_HASH_PATTERN,
+  isTxHash,
+  classifyChainReference,
+  isLinkableChainReference,
+  chainReferenceTitle,
+} from "./chain-reference.js";
+
+const TX = "0x" + "a".repeat(64);
+const JOB = "0x46519cdd46ce82dccff06907c750c625c8f3fa2537ec855cfe02966586c593aa";
+
+test("isTxHash accepts only the 0x + 64 hex shape", () => {
+  assert.equal(isTxHash(TX), true);
+  assert.equal(isTxHash(TX.toUpperCase().replace("0X", "0x")), true);
+  assert.equal(isTxHash(`  ${TX}  `), true, "trims surrounding whitespace");
+  assert.equal(isTxHash("0x" + "a".repeat(63)), false, "too short");
+  assert.equal(isTxHash("0x" + "a".repeat(65)), false, "too long");
+  assert.equal(isTxHash("0xZZZ"), false, "non-hex");
+  assert.equal(isTxHash("a".repeat(64)), false, "missing 0x prefix");
+  assert.equal(isTxHash(undefined), false);
+  assert.equal(isTxHash(123), false);
+});
+
+test("classifyChainReference treats a genuine txHash field as a transaction", () => {
+  assert.deepEqual(classifyChainReference({ txHash: TX }), {
+    kind: "tx",
+    value: TX,
+  });
+});
+
+test("classifyChainReference NEVER promotes a chainJobId to a transaction, even though it is the same shape", () => {
+  // This is the truth-boundary guarantee: a chainJobId is bytes32 and matches
+  // TX_HASH_PATTERN, but arriving via `jobId` it must stay an escrow job id.
+  assert.equal(TX_HASH_PATTERN.test(JOB), true, "fixture is tx-hash shaped");
+  assert.deepEqual(classifyChainReference({ jobId: JOB }), {
+    kind: "job",
+    value: JOB,
+  });
+});
+
+test("classifyChainReference prefers a valid tx over a job-id fallback", () => {
+  assert.deepEqual(classifyChainReference({ txHash: TX, jobId: JOB }), {
+    kind: "tx",
+    value: TX,
+  });
+});
+
+test("classifyChainReference falls back to the job id when txHash is not a real hash", () => {
+  assert.deepEqual(classifyChainReference({ txHash: "pending", jobId: JOB }), {
+    kind: "job",
+    value: JOB,
+  });
+});
+
+test("classifyChainReference returns 'none' when there is nothing to show", () => {
+  assert.deepEqual(classifyChainReference({}), { kind: "none", value: "" });
+  assert.deepEqual(classifyChainReference(), { kind: "none", value: "" });
+  assert.deepEqual(classifyChainReference({ jobId: "   " }), {
+    kind: "none",
+    value: "",
+  });
+});
+
+test("isLinkableChainReference only ever links a genuine transaction", () => {
+  assert.equal(isLinkableChainReference({ kind: "tx", value: TX }), true);
+  assert.equal(isLinkableChainReference({ kind: "job", value: JOB }), false);
+  assert.equal(isLinkableChainReference({ kind: "none", value: "" }), false);
+});
+
+test("chainReferenceTitle never calls an escrow job a transaction", () => {
+  assert.match(chainReferenceTitle({ kind: "tx", value: TX }), /transaction/u);
+  const jobTitle = chainReferenceTitle({ kind: "job", value: JOB });
+  assert.match(jobTitle, /Escrow job id/u);
+  assert.match(jobTitle, /not an on-chain transaction/u);
+  assert.match(chainReferenceTitle({ kind: "none", value: "" }), /No on-chain reference/u);
+});

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "test": "npm run test:backend && npm run test:sdk && npm run test:examples && npm run test:indexer:api && npm run test:contracts && npm run test:app",
-    "test:app": "node --test app/lib/api/*.test.mjs app/lib/auth/*.test.mjs app/lib/ui/*.test.mjs",
+    "test:app": "node --test app/lib/api/*.test.mjs app/lib/auth/*.test.mjs app/lib/ui/*.test.mjs app/lib/chain/*.test.mjs",
     "test:backend": "npm --workspace mcp-server test",
     "test:sdk": "node --test sdk/agent-platform-client.test.mjs && npm run check:sdk-types && npm run typecheck:sdk",
     "generate:sdk-types": "node scripts/generate-sdk-types.mjs",


### PR DESCRIPTION
## Why

An escrow `chainJobId` is the bytes32 EscrowCore job key. It is **shape-identical** to an EVM tx hash (`0x` + 64 hex) but it is **not** a transaction and does **not** resolve on any block explorer (per `docs/schemas/agent-badge-v1.md`: *"On-chain bytes32 identifier used by EscrowCore for this job"*, `^0x[a-fA-F0-9]{64}$`).

Two operator surfaces presented it as if it were on-chain:

1. **Receipts drawer** — `app/lib/api/receipt-adapters.ts` built a "Linked artifacts" row labelled **"Block ref"** whose value was the `chainJobId`.
2. **Session escrow ledger / payout trail** — `app/lib/api/session-adapters.ts` set movement/payout `tx` to the `chainJobId`, rendered under a **"Tx"** column in accent (link-like) styling.

This is the documented follow-up from the **C1** row of `docs/PROJECT_ROADMAP.md`.

## What changed (frontend-only, narrow)

- **Receipts:** `"Block ref"` → `"Escrow job"`; renamed the misleading internal `blockRef` field → `chainJobId` (fully contained to `receipt-adapters.ts`).
- **Sessions:** replaced the movement/payout `tx: string` with a provenance-tagged **`ref: ChainRef`** (`{ kind: "tx" | "job" | "none", value }`). The ledger column header becomes **"Ref"**; escrow-job refs now render in plain ink (no longer accent/link-like) so they never imply a clickable transaction, while a genuine timeline `data.tx` is still presented as a transaction.
- **New tested helper** `app/lib/chain/chain-reference.js`:
  - `classifyChainReference({ txHash, jobId })` decides what a value *is* by **provenance, never shape** — a value is a `tx` only when it arrives via a real tx field *and* validates as `0x`+64hex; a `chainJobId` is always classified `"job"`, even though it matches the same regex.
  - `isLinkableChainReference(ref)` returns true only for `kind === "tx"` — the gate the **C1** explorer-link work will consume so a `chainJobId` is never linked.
- `test:app` glob extended to run `app/lib/chain/*.test.mjs`.

## Scope boundary

**C1 stays its own PR.** The explorer infrastructure the original follow-up referenced (`app/components/common/ExplorerLink.tsx`, `app/lib/chain/explorer.js`, environment-aware explorer base URLs) does **not** exist on `main` and is **not** built here — folding it in would break one-package-one-PR. This PR only relabels honestly and leaves `isLinkableChainReference` as the clean seam C1 can wrap.

No `chainJobId` is linked anywhere.

## Verification

- `npm run test:app` — 54 pass, 0 fail (8 new helper tests, incl. the truth-boundary assertion that a tx-hash-shaped `chainJobId` is never promoted to a transaction)
- `npm run typecheck:app` — clean
- `npm run build:app` — compiled successfully, all 16 routes generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)