### PR TITLE
deploy: queue a read-only Tier-1 surface sweep after production deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -108,6 +108,14 @@ on:
         options:
           - "1"
           - "0"
+      run_surface_sweep:
+        description: Run the read-only Tier-1 surface sweep (public-routes load + truth-boundary honesty) after a successful deploy. Report-only — never blocks the deploy.
+        required: false
+        default: "1"
+        type: choice
+        options:
+          - "1"
+          - "0"
 
 concurrency:
   group: production
@@ -183,6 +191,7 @@ jobs:
       DEPLOY_PRODUCT_PROOF_REQUIRE_WORKER_LOOP: ${{ github.event_name == 'workflow_dispatch' && inputs.product_proof_require_worker_loop || '0' }}
       DEPLOY_PRODUCT_PROOF_REWARD_ASSET: ${{ github.event_name == 'workflow_dispatch' && inputs.product_proof_reward_asset || '' }}
       DEPLOY_RUN_HERMES_POST_DEPLOY: ${{ github.event_name == 'workflow_dispatch' && inputs.run_hermes_post_deploy || '1' }}
+      DEPLOY_RUN_SURFACE_SWEEP: ${{ github.event_name == 'workflow_dispatch' && inputs.run_surface_sweep || '1' }}
       HERMES_POST_DEPLOY_TIMEOUT: 12m
     steps:
       - name: Validate required secrets
@@ -557,3 +566,79 @@ jobs:
           exit 1
         env:
           HERMES_STATUS: ${{ steps.hermes_post_deploy.outputs.exit_status }}
+
+      # Tier-1 surface sweep (depre-dev/averray-reference-agent). Read-only:
+      # walks the public surfaces, flags console/network errors per route, and
+      # asserts each surface labels its state honestly (real/degraded/empty/
+      # demo/local-simulation). REPORT-ONLY by design — the deploy has already
+      # completed, so this is a detection signal, never a gate. The per-route
+      # report lands on the /monitor board; this step only queues the mission.
+      # (Promote to a deploy gate later, once it's proven low-false-positive.)
+      - name: Queue post-deploy surface sweep (T1)
+        id: surface_sweep
+        if: env.DEPLOY_RUN_SURFACE_SWEEP == '1'
+        continue-on-error: true
+        env:
+          SWEEP_BASE_URL: https://app.averray.com
+        run: |
+          # Public surfaces to sweep. Relative routes resolve against the app
+          # base URL; the marketing site is passed as an absolute URL.
+          body=$(cat <<JSON
+          {"targetUrl":"${SWEEP_BASE_URL}","mode":"surface_sweep","goal":"Post-deploy surface sweep: public surfaces load clean + truth-boundary honesty (read-only).","routes":["/","/onboarding","/jobs","/strategies","https://averray.com/"]}
+          JSON
+          )
+          remote_env=$(printf 'SWEEP_BODY=%q ' "$body")
+
+          : > surface-sweep.log
+          set +e
+          timeout 120 ssh -p "${VPS_PORT:-22}" \
+            -o ServerAliveInterval=30 \
+            -o ServerAliveCountMax=120 \
+            "$VPS_USER@$VPS_HOST" \
+            "${remote_env} bash -s" <<'REMOTE' | tee surface-sweep.log
+          set -euo pipefail
+          cd /srv/averray-reference-agent
+          token=$(grep -E '^SLACK_OPERATOR_MONITOR_TOKEN=' .env.prod 2>/dev/null | head -1 | cut -d= -f2- || true)
+          port=$(grep -E '^SLACK_OPERATOR_HTTP_PORT=' .env.prod 2>/dev/null | head -1 | cut -d= -f2- || true)
+          port=${port:-8790}
+          hdr=(-H "content-type: application/json")
+          [ -n "$token" ] && hdr+=(-H "Authorization: Bearer $token")
+          resp=$(curl -fsS -X POST "http://127.0.0.1:${port}/monitor/testbed-missions" "${hdr[@]}" --data "$SWEEP_BODY" || echo '{"error":"surface_sweep_queue_failed"}')
+          echo "$resp"
+          id=$(printf '%s' "$resp" | grep -oE '"id":"[^"]+"' | head -1 | cut -d'"' -f4 || true)
+          if [ -n "$id" ]; then
+            echo "queued_mission_id=$id"
+          else
+            echo "surface sweep was NOT queued — is SLACK_OPERATOR_MONITOR_ENABLED=1 and the endpoint reachable?"
+          fi
+          echo "Note: the per-route report appears on the board once the testbed-mission-runner (profile testbed-runner, TESTBED_MISSION_RUNNER_ENABLED=1) claims it."
+          REMOTE
+          status=${PIPESTATUS[0]}
+          set -e
+
+          {
+            echo "## Post-Deploy Surface Sweep (T1, report-only)"
+            echo
+            echo "- Read-only public-surface sweep + truth-boundary honesty check."
+            echo "- Result: board → https://monitor.averray.com/monitor (the queued mission card + its per-route report)."
+            echo "- This step does NOT gate the deploy."
+            echo
+            echo '```text'
+            sed -n '1,120p' surface-sweep.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Report-only: surface SSH/transport problems in the log, never fail the deploy.
+          if [ "$status" -ne 0 ]; then
+            echo "Surface sweep queue step exited ${status} (report-only; deploy is unaffected)."
+          fi
+          exit 0
+
+      - name: Upload surface sweep log
+        if: always() && env.DEPLOY_RUN_SURFACE_SWEEP == '1' && steps.surface_sweep.outcome != 'skipped'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: surface-sweep-${{ github.run_id }}
+          path: surface-sweep.log
+          if-no-files-found: ignore
+          retention-days: 90


### PR DESCRIPTION
## What changed & why

After a successful production deploy, **queue a read-only `surface_sweep` mission**
(the T1 tester in `depre-dev/averray-reference-agent`, merged in #273) against the
deployed env — so it becomes a per-deploy safety signal instead of a manual
mission. The sweep walks the public surfaces, flags console/network errors per
route, and asserts each surface labels its state **honestly** (real / degraded /
empty / demo / local-simulation). The per-route report lands on the **/monitor**
board.

- New step **"Queue post-deploy surface sweep (T1)"**, gated by its own flag
  **`DEPLOY_RUN_SURFACE_SWEEP`** (default `1`) + a `workflow_dispatch` input
  (`run_surface_sweep`), mirroring the existing post-deploy verification step.
- **Report-only / non-gating:** `continue-on-error` + **no "fail if" step**. The
  deploy has already completed — this is a detection signal, never a gate.
  (Promote to a gate later once it's proven low-false-positive — noted inline.)
- **Read-only:** `surface_sweep` is public-surfaces only, no mutations — safe on
  every deploy.

## Wiring note (verified before wiring, per the task)
The MCP tool `averray_testbed_agent_mission` returns a prompt **packet** and
accepts only `targetUrl`/`goal` — it neither queues a run nor supports
`mode`/`routes`. The path that actually **queues** a `surface_sweep` run (and
supports `mode` + `routes`, which T1 built) is the slack-operator HTTP endpoint
**`POST /monitor/testbed-missions`**. So this step SSHes into the VPS (mirroring
the existing post-deploy step) and `POST`s the mission to
`127.0.0.1:${SLACK_OPERATOR_HTTP_PORT:-8790}` with the monitor token read from
`.env.prod` — and never fails the deploy if that call errors.

## Affected surface
- `.github/workflows/deploy-production.yml` (deploy workflow only) — one new gated step + its log upload + the `run_surface_sweep` input + the `DEPLOY_RUN_SURFACE_SWEEP` env. The existing post-deploy verification step is untouched.

## Checks run
- YAML parses (full workflow); the deploy job + new step + input + env all resolve.
- Both the new step **and** the untouched existing post-deploy step pass `bash -n` (heredocs balanced, closers dedent to col 0).
- Confirmed there is **no fail-on-sweep step** (report-only).

## Durable invariants (AGENTS.md)
- No auto-merge / auto-deploy and no new gate — report-only, the deploy is never blocked by sweep findings.
- Read-only sweep (public surfaces, no mutations); safe on any env.
- No secrets in the workflow — the monitor token is read from `.env.prod` on the VPS at runtime, never logged.
- No chain facts asserted (Polkadot-MCP verify rule N/A — this is a deploy-workflow trigger).

## Dependencies / follow-ups
- **Depends on T1** (`surface_sweep` mode + routes), merged in the reference-agent (#273). ✅
- **Runtime provisioning:** the queued sweep only *executes* if the reference-agent's `testbed-mission-runner` is enabled on the VPS (compose profile `testbed-runner`, `TESTBED_MISSION_RUNNER_ENABLED=1`). Until then the mission queues and waits — visible on the board.
- The base URL + route list live in the step (`SWEEP_BASE_URL` + the `routes` array) and are easy to tune; report-only means a wrong host just surfaces as a flagged route, not a deploy failure.
- **Promote to a gate** once low-false-positive: add a "Fail if sweep verdict == fail" step behind a separate flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)