### PR TITLE
P8: advertise the Hermes tester to building agents (request helper + AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,29 @@ CI is the merge gate. Do not bypass failing checks.
   GitHub Actions summary. CI remains the merge gate, and a human or explicitly
   authorized merge workflow still owns the final merge.
 
+## Hermes tester (request a browser-agent run)
+
+- A building agent here can ask the Hermes **browser tester** to run a mission
+  against the product (e.g. "can a fresh outside agent reach the first
+  receipt?") and read the report back. You are a **requester, never a runner**.
+- The contract is **Discover → Request → (operator) Approve → Run → Report**:
+  1. **Discover** `GET /monitor/tester/capabilities` — the self-describing
+     manifest; the per-flow `status` tells you what is actually runnable now.
+  2. **Request** `POST /monitor/testbed-missions/request` with
+     `requesterAgent` + `reason` (+ `targetUrl`, `goal`, `mode`) — this parks a
+     board-gated `requested` card; it does **not** run.
+  3. **Approve** — the operator approves on the Hermes board (or a trust policy).
+  4. **Run** — the Hermes testbed runner claims + runs it.
+  5. **Report** `GET /monitor/testbed-missions/:id` — read the structured report
+     back (poll by id).
+- Use the thin helper at
+  [examples/request-tester-run](./examples/request-tester-run/)
+  (`discoverTesterCapabilities`, `requestTesterRun`, `readTesterReport`). It is
+  **request-only, operator-gated, and read-only by default** — it sends no
+  run/approve/mutation field, and the server forces the mission to `requested` +
+  read-only and keeps mutation testnet-only. Do not add a "run" or "approve"
+  path here; that authority stays with the operator.
+
 ## Deployment
 
 - Agents do not SSH into production unless explicitly asked.

--- a/examples/request-tester-run/README.md
+++ b/examples/request-tester-run/README.md
@@ -1,0 +1,56 @@
+# Request a Hermes tester run (P8)
+
+A thin helper a building agent in this repo can use to ask the **Hermes browser
+tester** to run a mission against the product — without being able to run it
+directly. The contract is **Discover → Request → (operator) Approve → Run →
+Report**:
+
+| Step | Call | Endpoint |
+|------|------|----------|
+| 1. Discover | `discoverTesterCapabilities()` | `GET /monitor/tester/capabilities` |
+| 2. Request | `requestTesterRun({ requesterAgent, targetUrl, goal, reason, mode })` | `POST /monitor/testbed-missions/request` |
+| 3. Approve | — | the operator approves the `requested` card on the Hermes board |
+| 4. Run | — | the Hermes testbed runner claims + runs it |
+| 5. Report | `readTesterReport({ missionId })` | `GET /monitor/testbed-missions/:id` |
+
+## Security boundary (do not weaken)
+
+- **Request-only.** This module exposes no run / approve / mutate call. Every
+  actual run passes the operator approve gate (or an explicit trust policy).
+- **Attributable + justified.** `requesterAgent` and `reason` are mandatory.
+- **Read-only by default.** No mutation flag is ever sent; mutation stays
+  server-enforced (testnet-only per the env binding). The server forces the
+  mission to `requested` + read-only and ignores client-supplied run/mutation
+  fields.
+
+The tester is a separate Hermes service, not this repo's API. Point it at the
+monitor base URL.
+
+## Usage
+
+```sh
+# Discover what the tester can do
+node examples/request-tester-run/index.mjs --monitor "$HERMES_MONITOR_URL" --token "$HERMES_MONITOR_TOKEN"
+
+# Request a run (parks a board-gated card — the operator approves it)
+node examples/request-tester-run/index.mjs --monitor "$HERMES_MONITOR_URL" --token "$HERMES_MONITOR_TOKEN" \
+  --requester averray-agent --target https://app.averray.com/overview \
+  --reason "Pre-merge UX check for the onboarding change" --goal "Reach the first receipt" --mode fresh
+
+# Read a mission's report back by id
+node examples/request-tester-run/index.mjs --monitor "$HERMES_MONITOR_URL" --report testbed-mission-abc
+```
+
+```js
+import { requestTesterRun, readTesterReport } from "./index.mjs";
+
+const { run } = await requestTesterRun({
+  monitorUrl: process.env.HERMES_MONITOR_URL,
+  token: process.env.HERMES_MONITOR_TOKEN,
+  requesterAgent: "averray-agent",
+  targetUrl: "https://app.averray.com/overview",
+  reason: "Pre-merge UX check for the onboarding change",
+});
+// …operator approves on the board, the tester runs…
+const report = await readTesterReport({ monitorUrl, token, missionId: run.id });
+```

--- a/examples/request-tester-run/index.mjs
+++ b/examples/request-tester-run/index.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+
+/**
+ * Request a Hermes tester run from this product repo (P8).
+ *
+ * A building agent here is a REQUESTER of the tester, never a runner. The
+ * contract is Discover → Request → (operator) Approve → Run → Report:
+ *
+ *   1. DISCOVER  GET  /monitor/tester/capabilities   — what flows exist + which
+ *                                                       are actually runnable now
+ *   2. REQUEST   POST /monitor/testbed-missions/request
+ *                     { requesterAgent, targetUrl, goal, reason, mode }
+ *                — parks a board-gated `requested` mission (NOT a run)
+ *   3. APPROVE   the operator approves on the Hermes board (or a trust policy)
+ *   4. RUN       the Hermes testbed runner claims + runs it
+ *   5. REPORT    GET  /monitor/testbed-missions/:id    — read the structured
+ *                                                        report back (poll)
+ *
+ * Security boundary (do not weaken):
+ *   - request-only: this module exposes no "run", "approve", or "mutate" call.
+ *     Every actual run passes the operator approve gate.
+ *   - read-only by default: no mutation flag is ever sent; mutation stays
+ *     server-enforced (testnet-only per the env binding).
+ *
+ * The monitor is a separate service (Hermes), not this repo's API — point it at
+ * the monitor base URL (HERMES_MONITOR_URL) with the monitor token if set.
+ */
+
+import { pathToFileURL } from "node:url";
+
+const CAPABILITIES_PATH = "/monitor/tester/capabilities";
+const REQUEST_PATH = "/monitor/testbed-missions/request";
+const MISSION_PATH = "/monitor/testbed-missions/";
+const VALID_MODES = new Set(["fresh", "memory"]);
+
+export class TesterRequestError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "TesterRequestError";
+  }
+}
+
+/** 1. DISCOVER — the self-describing capabilities manifest. Read-only GET. */
+export async function discoverTesterCapabilities({
+  monitorUrl,
+  token = undefined,
+  fetchImpl = fetch
+} = {}) {
+  return getJson(monitorUrl, CAPABILITIES_PATH, { token, fetchImpl });
+}
+
+/**
+ * 2. REQUEST — park a board-gated `requested` mission. This never runs the
+ * mission; the operator approves it on the Hermes board. `requesterAgent` and
+ * `reason` are mandatory so every request is attributable + justified.
+ */
+export async function requestTesterRun({
+  monitorUrl,
+  token = undefined,
+  requesterAgent,
+  targetUrl,
+  goal = undefined,
+  reason,
+  mode = "fresh",
+  fetchImpl = fetch
+} = {}) {
+  if (!requesterAgent) {
+    throw new TesterRequestError("requesterAgent is required — the tester records who asked.");
+  }
+  if (!reason) {
+    throw new TesterRequestError("reason is required — every request must say why.");
+  }
+  if (!targetUrl) {
+    throw new TesterRequestError("targetUrl is required.");
+  }
+  if (!VALID_MODES.has(mode)) {
+    throw new TesterRequestError(`mode must be "fresh" or "memory", got "${mode}".`);
+  }
+  // Only the request fields the T6 endpoint accepts. No `initialStatus`,
+  // `allowTestMutations`, or any run/approve field — the server forces
+  // requested + read-only and ignores client-supplied mutation flags.
+  return postJson(monitorUrl, REQUEST_PATH, { requesterAgent, targetUrl, goal, reason, mode }, { token, fetchImpl });
+}
+
+/**
+ * 5. REPORT — read a mission (status + structured report) back by id. Read-only
+ * GET; poll this after requesting until the status is terminal.
+ */
+export async function readTesterReport({
+  monitorUrl,
+  token = undefined,
+  missionId,
+  fetchImpl = fetch
+} = {}) {
+  if (!missionId) {
+    throw new TesterRequestError("missionId is required.");
+  }
+  return getJson(monitorUrl, `${MISSION_PATH}${encodeURIComponent(missionId)}`, { token, fetchImpl });
+}
+
+// ── internals ───────────────────────────────────────────────────────
+
+function resolveBase(monitorUrl) {
+  const base = (monitorUrl ?? "").trim().replace(/\/+$/u, "");
+  if (!base) {
+    throw new TesterRequestError("monitorUrl is required (the Hermes monitor base URL).");
+  }
+  return base;
+}
+
+function authHeaders(token) {
+  return token ? { authorization: `Bearer ${token}` } : {};
+}
+
+async function getJson(monitorUrl, path, { token, fetchImpl }) {
+  const res = await fetchImpl(`${resolveBase(monitorUrl)}${path}`, {
+    method: "GET",
+    headers: { accept: "application/json", ...authHeaders(token) }
+  });
+  return parse(res, path);
+}
+
+async function postJson(monitorUrl, path, body, { token, fetchImpl }) {
+  const res = await fetchImpl(`${resolveBase(monitorUrl)}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "application/json", ...authHeaders(token) },
+    body: JSON.stringify(body)
+  });
+  return parse(res, path);
+}
+
+async function parse(res, path) {
+  const text = typeof res.text === "function" ? await res.text() : "";
+  let json;
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    json = { raw: text };
+  }
+  if (!res.ok) {
+    const detail = json?.error || json?.message || `HTTP ${res.status}`;
+    throw new TesterRequestError(`Tester request to ${path} failed: ${detail}`);
+  }
+  return json;
+}
+
+// ── CLI demo (discover, then optionally request / read) ─────────────
+
+export function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => argv[(i += 1)];
+    if (arg === "--help" || arg === "-h") out.help = true;
+    else if (arg === "--monitor") out.monitorUrl = next();
+    else if (arg === "--token") out.token = next();
+    else if (arg === "--requester") out.requesterAgent = next();
+    else if (arg === "--target") out.targetUrl = next();
+    else if (arg === "--goal") out.goal = next();
+    else if (arg === "--reason") out.reason = next();
+    else if (arg === "--mode") out.mode = next();
+    else if (arg === "--report") out.reportId = next();
+  }
+  return out;
+}
+
+function printHelp() {
+  console.log(`Request a Hermes tester run (request-only; operator-gated; read-only).
+
+Usage:
+  node examples/request-tester-run/index.mjs --monitor <url> [--token <t>] \\
+    [--requester <agent> --target <url> --reason <why> [--goal <g>] [--mode fresh|memory]] \\
+    [--report <missionId>]
+
+Env: HERMES_MONITOR_URL, HERMES_MONITOR_TOKEN.
+Always prints the capabilities manifest. With --target/--reason it also REQUESTS
+a run (parks a board-gated card — the operator approves it). With --report it
+reads a mission's report back by id.`);
+}
+
+export async function runTesterDemo(options) {
+  const monitorUrl = options.monitorUrl ?? process.env.HERMES_MONITOR_URL;
+  const token = options.token ?? process.env.HERMES_MONITOR_TOKEN;
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  const capabilities = await discoverTesterCapabilities({ monitorUrl, token, fetchImpl });
+  const result = { capabilities };
+
+  if (options.reportId) {
+    result.report = await readTesterReport({ monitorUrl, token, missionId: options.reportId, fetchImpl });
+  } else if (options.targetUrl && options.reason) {
+    result.requested = await requestTesterRun({
+      monitorUrl,
+      token,
+      requesterAgent: options.requesterAgent ?? "averray-agent",
+      targetUrl: options.targetUrl,
+      goal: options.goal,
+      reason: options.reason,
+      mode: options.mode ?? "fresh",
+      fetchImpl
+    });
+    result.note = "Requested — the run is board-gated and waits for operator approval before it runs.";
+  }
+  return result;
+}
+
+function isMain() {
+  return import.meta.url === pathToFileURL(process.argv[1] ?? "").href;
+}
+
+if (isMain()) {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    process.exit(0);
+  }
+  runTesterDemo(options)
+    .then((summary) => console.log(JSON.stringify(summary, null, 2)))
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    });
+}

--- a/examples/request-tester-run/index.test.mjs
+++ b/examples/request-tester-run/index.test.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import * as testerClient from "./index.mjs";
+import {
+  TesterRequestError,
+  discoverTesterCapabilities,
+  parseArgs,
+  readTesterReport,
+  requestTesterRun,
+  runTesterDemo
+} from "./index.mjs";
+
+const MONITOR = "https://monitor.averray.test/";
+
+/** A fetch stub that records calls and returns a canned JSON response. */
+function stubFetch(body, { ok = true, status = 200 } = {}) {
+  const calls = [];
+  const fetchImpl = async (url, init = {}) => {
+    calls.push({ url, init });
+    return { ok, status, text: async () => JSON.stringify(body) };
+  };
+  return { fetchImpl, calls };
+}
+
+test("discoverTesterCapabilities GETs the manifest with a Bearer token", async () => {
+  const { fetchImpl, calls } = stubFetch({ flows: [{ name: "surface_sweep", status: "available" }] });
+  const manifest = await discoverTesterCapabilities({ monitorUrl: MONITOR, token: "t0ken", fetchImpl });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://monitor.averray.test/monitor/tester/capabilities");
+  assert.equal(calls[0].init.method, "GET");
+  assert.equal(calls[0].init.headers.authorization, "Bearer t0ken");
+  assert.deepEqual(manifest.flows[0], { name: "surface_sweep", status: "available" });
+});
+
+test("requestTesterRun POSTs requester+reason to the T6 request endpoint (board-gated)", async () => {
+  const { fetchImpl, calls } = stubFetch({ ok: true, boardGated: true, run: { id: "testbed-mission-abc" } });
+  const result = await requestTesterRun({
+    monitorUrl: MONITOR,
+    token: "t0ken",
+    requesterAgent: "averray-agent",
+    targetUrl: "https://app.averray.com/overview",
+    goal: "Check a fresh agent can reach the first receipt.",
+    reason: "Pre-merge UX check for the onboarding change.",
+    mode: "fresh",
+    fetchImpl
+  });
+  assert.equal(calls[0].url, "https://monitor.averray.test/monitor/testbed-missions/request");
+  assert.equal(calls[0].init.method, "POST");
+  const sent = JSON.parse(calls[0].init.body);
+  assert.deepEqual(sent, {
+    requesterAgent: "averray-agent",
+    targetUrl: "https://app.averray.com/overview",
+    goal: "Check a fresh agent can reach the first receipt.",
+    reason: "Pre-merge UX check for the onboarding change.",
+    mode: "fresh"
+  });
+  // Security boundary: the request NEVER carries a run/approve/mutation field.
+  assert.ok(!("initialStatus" in sent));
+  assert.ok(!("allowTestMutations" in sent));
+  assert.ok(!("approve" in sent));
+  assert.equal(result.boardGated, true);
+});
+
+test("requestTesterRun requires an attributable, justified request", async () => {
+  const { fetchImpl } = stubFetch({});
+  const base = { monitorUrl: MONITOR, targetUrl: "https://x.test", reason: "why", requesterAgent: "a", fetchImpl };
+  await assert.rejects(() => requestTesterRun({ ...base, requesterAgent: undefined }), TesterRequestError);
+  await assert.rejects(() => requestTesterRun({ ...base, reason: undefined }), TesterRequestError);
+  await assert.rejects(() => requestTesterRun({ ...base, targetUrl: undefined }), TesterRequestError);
+  await assert.rejects(() => requestTesterRun({ ...base, mode: "live" }), TesterRequestError);
+});
+
+test("readTesterReport GETs the mission by id", async () => {
+  const { fetchImpl, calls } = stubFetch({ id: "testbed-mission-abc", status: "completed", verdict: "OK" });
+  const report = await readTesterReport({ monitorUrl: MONITOR, missionId: "testbed-mission-abc", fetchImpl });
+  assert.equal(calls[0].url, "https://monitor.averray.test/monitor/testbed-missions/testbed-mission-abc");
+  assert.equal(calls[0].init.method, "GET");
+  assert.equal(report.verdict, "OK");
+});
+
+test("a non-ok response surfaces an honest error, not a silent empty result", async () => {
+  const { fetchImpl } = stubFetch({ error: "monitor_unauthorized" }, { ok: false, status: 401 });
+  await assert.rejects(
+    () => discoverTesterCapabilities({ monitorUrl: MONITOR, fetchImpl }),
+    /monitor_unauthorized/u
+  );
+});
+
+test("the helper exposes ONLY discover/request/read — never run, approve, or mutate", () => {
+  // Exact allow-list: external agents are requesters, never runners. There is no
+  // exported way to RUN, APPROVE, or MUTATE a mission from this repo — that
+  // authority stays with the operator on the Hermes board.
+  const exportedFns = Object.keys(testerClient)
+    .filter((k) => typeof testerClient[k] === "function")
+    .sort();
+  assert.deepEqual(exportedFns, [
+    "TesterRequestError",
+    "discoverTesterCapabilities",
+    "parseArgs",
+    "readTesterReport",
+    "requestTesterRun",
+    "runTesterDemo"
+  ]);
+});
+
+test("runTesterDemo discovers, then requests when target+reason are given (and notes the gate)", async () => {
+  const { fetchImpl, calls } = stubFetch({ ok: true, boardGated: true, run: { id: "m1" } });
+  const summary = await runTesterDemo({
+    monitorUrl: MONITOR,
+    targetUrl: "https://app.averray.com",
+    reason: "smoke",
+    fetchImpl
+  });
+  assert.equal(calls[0].url.endsWith("/monitor/tester/capabilities"), true);
+  assert.equal(calls[1].url.endsWith("/monitor/testbed-missions/request"), true);
+  assert.match(summary.note, /operator approval/u);
+});
+
+test("parseArgs maps the request + report flags", () => {
+  assert.deepEqual(
+    parseArgs(["--monitor", "https://m", "--requester", "a", "--target", "https://t", "--reason", "why", "--mode", "memory"]),
+    { monitorUrl: "https://m", requesterAgent: "a", targetUrl: "https://t", reason: "why", mode: "memory" }
+  );
+});

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "prepare:mainnet-audit-freeze": "node scripts/ops/prepare-mainnet-audit-freeze.mjs",
     "example:profile-lookup": "node examples/profile-lookup/index.mjs",
     "example:claim-and-submit-job": "node examples/claim-and-submit-job/index.mjs",
-    "example:read-job-timeline": "node examples/read-job-timeline/index.mjs"
+    "example:read-job-timeline": "node examples/read-job-timeline/index.mjs",
+    "example:request-tester-run": "node examples/request-tester-run/index.mjs"
   },
   "devDependencies": {
     "@acala-network/chopsticks": "^1.3.1",


### PR DESCRIPTION
## What changed
Implements **P8** (§6 external-agent invocation protocol from the Hermes tester-UX plan). A building agent in this repo can now **discover** the Hermes browser tester, **request** a run, and **read the report back** — as a *requester, never a runner*.

- **`examples/request-tester-run/`** — a thin helper implementing the contract, plus a CLI demo + README:
  - `discoverTesterCapabilities()` → `GET /monitor/tester/capabilities` (the self-describing manifest; per-flow `status` says what's runnable now)
  - `requestTesterRun({ requesterAgent, targetUrl, goal, reason, mode })` → `POST /monitor/testbed-missions/request` (parks a **board-gated `requested`** mission — it does **not** run)
  - `readTesterReport({ missionId })` → `GET /monitor/testbed-missions/:id`
- **`AGENTS.md`** — a "Hermes tester" section documenting **Discover → Request → Approve → Run → Report** and pointing builders at the helper, with the requester-never-runner invariant.
- **`package.json`** — an `example:request-tester-run` script (matches the other `example:*` entries).

## Security boundary (the point of P8)
- **Request-only / operator-gated.** The module exposes **no run / approve / mutate** path; every actual run passes the operator approve gate on the Hermes board. A test asserts the *exact* exported surface, so a "run"/"approve" capability can't be added by accident.
- **Attributable + justified.** `requesterAgent` and `reason` are mandatory.
- **Read-only by default.** No mutation/`initialStatus` flag is ever sent; the server forces the mission to `requested` + read-only and keeps mutation server-enforced testnet-only.

## Checks run
- `npm run test:examples` — **green (31 tests, incl. 8 new)**.
- package.json validated.

## Surface affected
- Docs + `examples/` + one `package.json` script line. **No** backend / frontend / indexer / Caddy / contracts / public-site change. No env or VPS secret changes. No generated `frontend/`/`site/` output touched.

## Notes
The tester itself lives in the Hermes monitor service (reference-agent), not this repo — the helper points at the monitor base URL (`HERMES_MONITOR_URL`) with the optional monitor token. Depends on T7 (capabilities manifest) + T6 (request endpoint) + P7 (`GET /monitor/testbed-missions/:id` report read-back), which are already shipped on the Hermes side.