### PR TITLE
feat(api): add USDC liquidity status

### DIFF
--- a/deploy/backend.env.template
+++ b/deploy/backend.env.template
@@ -230,6 +230,16 @@ XCM_WRAPPER_ADDRESS=
 SUPPORTED_ASSETS_JSON=[{"symbol":"USDC","assetClass":"trust_backed","assetId":1337,"address":"0x0000053900000000000000000000000001200000","decimals":6,"minBalanceRaw":"70000"}]
 SUPPORTED_ASSETS=
 
+# Read-only USDC liquidity monitor. The accounts JSON is a registry of
+# managed poster/worker AgentAccountCore balances to read via
+# positions(account, USDC). Operators fill accounts and reserve address
+# when the hosted preflight should watch live testnet replenishment needs.
+USDC_LIQUIDITY_CHAIN=testnet
+USDC_LIQUIDITY_ASSET=USDC
+USDC_LIQUIDITY_ACCOUNTS_JSON=[]
+USDC_LIQUIDITY_TREASURY_RESERVE_ACCOUNT=
+USDC_LIQUIDITY_TREASURY_RESERVE_FLOOR_USDC=0
+
 UPSTREAM_STATUS_POLLER_ENABLED=true
 UPSTREAM_STATUS_POLLER_INTERVAL_MS=86400000
 UPSTREAM_STATUS_POLLER_BATCH_SIZE=50

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -43,9 +43,11 @@ import { createPublicMetadataRoutes } from "./public-metadata-routes.js";
 import { createSchemaRoutes } from "./schema-routes.js";
 import { createSessionRoutes } from "./session-routes.js";
 import { createShareRoutes } from "./share-routes.js";
+import { createUsdcLiquidityRoutes } from "./usdc-liquidity-routes.js";
 import { createVerifierRoutes } from "./verifier-routes.js";
 import { createXcmRequestRoutes } from "./xcm-request-routes.js";
 import { OPERATOR_SIGNERS, makePolicy } from "../../core/builtin-policies.js";
+import { createUsdcLiquidityStatusService } from "../../services/usdc-liquidity-status.js";
 
 const {
   platformService: service,
@@ -911,6 +913,13 @@ const handleAdminStatusRoute = createAdminStatusRoutes({
   service,
 });
 
+const usdcLiquidityStatusService = createUsdcLiquidityStatusService({ gateway });
+const handleUsdcLiquidityRoute = createUsdcLiquidityRoutes({
+  authMiddleware,
+  respond,
+  usdcLiquidityStatusService,
+});
+
 const handleAdminJobsRoute = createAdminJobsRoutes({
   authMiddleware,
   buildIdempotentMutationContext,
@@ -1303,6 +1312,10 @@ const server = createServer(async (request, response) => {
     }
 
     if (await handleAdminStatusRoute({ request, response, url, pathname })) {
+      return;
+    }
+
+    if (await handleUsdcLiquidityRoute({ request, response, url, pathname })) {
       return;
     }
 

--- a/mcp-server/src/protocols/http/usdc-liquidity-routes.js
+++ b/mcp-server/src/protocols/http/usdc-liquidity-routes.js
@@ -1,0 +1,15 @@
+export function createUsdcLiquidityRoutes({
+  authMiddleware,
+  respond,
+  usdcLiquidityStatusService,
+}) {
+  return async function handleUsdcLiquidityRoute({ request, response, url, pathname }) {
+    if (request.method === "GET" && pathname === "/admin/usdc-liquidity/status") {
+      await authMiddleware(request, url, { requireRole: "admin" });
+      respond(response, 200, await usdcLiquidityStatusService.getStatus());
+      return true;
+    }
+
+    return false;
+  };
+}

--- a/mcp-server/src/protocols/http/usdc-liquidity-routes.test.js
+++ b/mcp-server/src/protocols/http/usdc-liquidity-routes.test.js
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createUsdcLiquidityRoutes } from "./usdc-liquidity-routes.js";
+
+const AUTH = { wallet: "0xadmin", claims: { roles: ["admin"] } };
+
+function makeHarness(overrides = {}) {
+  const calls = [];
+  const response = {};
+  const status = overrides.status ?? {
+    asOf: "2026-06-02T12:00:00.000Z",
+    chain: "testnet",
+    accounts: [],
+    treasuryReserveHealthy: true,
+    treasuryReserveUsdc: 420
+  };
+  const route = createUsdcLiquidityRoutes({
+    authMiddleware: async (_request, _url, options) => {
+      calls.push(["auth", options]);
+      return overrides.auth ?? AUTH;
+    },
+    respond: (res, statusCode, body) => {
+      calls.push(["respond", { statusCode, body }]);
+      res.statusCode = statusCode;
+      res.body = body;
+    },
+    usdcLiquidityStatusService: {
+      async getStatus() {
+        calls.push(["getStatus"]);
+        return status;
+      }
+    }
+  });
+  return { calls, response, route, status };
+}
+
+test("USDC liquidity routes ignore unrelated paths", async () => {
+  const { calls, response, route } = makeHarness();
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/admin/not-usdc-liquidity/status"),
+    pathname: "/admin/not-usdc-liquidity/status",
+  });
+
+  assert.equal(handled, false);
+  assert.deepEqual(calls, []);
+  assert.deepEqual(response, {});
+});
+
+test("GET /admin/usdc-liquidity/status requires admin auth and returns status", async () => {
+  const { calls, response, route, status } = makeHarness();
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/admin/usdc-liquidity/status"),
+    pathname: "/admin/usdc-liquidity/status",
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body, status);
+  assert.deepEqual(calls, [
+    ["auth", { requireRole: "admin" }],
+    ["getStatus"],
+    ["respond", { statusCode: 200, body: status }]
+  ]);
+});

--- a/mcp-server/src/services/usdc-liquidity-status.js
+++ b/mcp-server/src/services/usdc-liquidity-status.js
@@ -1,0 +1,231 @@
+import { getAddress } from "ethers";
+
+import { ConfigError, ExternalServiceError } from "../core/errors.js";
+
+const USDC_SCALE = 1_000_000n;
+const DEFAULT_CHAIN = "testnet";
+const DEFAULT_ASSET = "USDC";
+const VALID_ROLES = new Set(["poster", "worker"]);
+
+function parseJsonArray(raw, label) {
+  if (raw === undefined || raw === null || raw === "") {
+    return [];
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new ConfigError(`${label} must be valid JSON.`, { cause: error.message });
+  }
+  if (!Array.isArray(parsed)) {
+    throw new ConfigError(`${label} must decode to an array.`);
+  }
+  return parsed;
+}
+
+function normalizeAddress(raw, label) {
+  try {
+    return getAddress(raw);
+  } catch {
+    throw new ConfigError(`${label} must be a valid EVM address.`);
+  }
+}
+
+function normalizeRole(raw, idx) {
+  if (typeof raw !== "string" || !VALID_ROLES.has(raw)) {
+    throw new ConfigError(`USDC_LIQUIDITY_ACCOUNTS_JSON[${idx}].role must be "poster" or "worker".`);
+  }
+  return raw;
+}
+
+function normalizeOptionalIso(raw, label) {
+  if (raw === undefined || raw === null || raw === "") {
+    return null;
+  }
+  if (typeof raw !== "string" || Number.isNaN(Date.parse(raw))) {
+    throw new ConfigError(`${label} must be an ISO timestamp when set.`);
+  }
+  return raw;
+}
+
+function normalizeBoolean(raw, fallback = false) {
+  if (raw === undefined || raw === null || raw === "") {
+    return fallback;
+  }
+  if (typeof raw === "boolean") {
+    return raw;
+  }
+  if (typeof raw === "string") {
+    const normalized = raw.trim().toLowerCase();
+    if (normalized === "true") return true;
+    if (normalized === "false") return false;
+  }
+  return Boolean(raw);
+}
+
+export function parseUsdcAmountToRaw(value, label) {
+  if (value === undefined || value === null || value === "") {
+    throw new ConfigError(`${label} is required.`);
+  }
+  const text = typeof value === "number" ? String(value) : String(value).trim();
+  if (!/^\d+(\.\d{1,6})?$/u.test(text)) {
+    throw new ConfigError(`${label} must be a non-negative USDC decimal with at most 6 fractional digits.`);
+  }
+  const [whole, fraction = ""] = text.split(".");
+  return BigInt(whole) * USDC_SCALE + BigInt(fraction.padEnd(6, "0"));
+}
+
+export function formatUsdcRaw(raw) {
+  const value = BigInt(raw ?? 0n);
+  const whole = value / USDC_SCALE;
+  const fraction = value % USDC_SCALE;
+  const fractionText = fraction.toString().padStart(6, "0").replace(/0+$/u, "");
+  return fractionText ? `${whole}.${fractionText}` : whole.toString();
+}
+
+function rawToNumber(raw) {
+  return Number(formatUsdcRaw(raw));
+}
+
+function normalizeAccountEntry(entry, idx) {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    throw new ConfigError(`USDC_LIQUIDITY_ACCOUNTS_JSON[${idx}] must be an object.`);
+  }
+  const floorRaw = parseUsdcAmountToRaw(entry.floorUsdc, `USDC_LIQUIDITY_ACCOUNTS_JSON[${idx}].floorUsdc`);
+  const targetRaw = parseUsdcAmountToRaw(entry.targetUsdc, `USDC_LIQUIDITY_ACCOUNTS_JSON[${idx}].targetUsdc`);
+  if (targetRaw < floorRaw) {
+    throw new ConfigError(`USDC_LIQUIDITY_ACCOUNTS_JSON[${idx}].targetUsdc must be >= floorUsdc.`);
+  }
+  return {
+    role: normalizeRole(entry.role, idx),
+    account: normalizeAddress(entry.account, `USDC_LIQUIDITY_ACCOUNTS_JSON[${idx}].account`),
+    floorRaw,
+    targetRaw,
+    refillPending: normalizeBoolean(entry.refillPending, false),
+    lastRefillAt: normalizeOptionalIso(entry.lastRefillAt, `USDC_LIQUIDITY_ACCOUNTS_JSON[${idx}].lastRefillAt`)
+  };
+}
+
+export function loadUsdcLiquidityConfig(env = process.env) {
+  const accounts = parseJsonArray(env.USDC_LIQUIDITY_ACCOUNTS_JSON, "USDC_LIQUIDITY_ACCOUNTS_JSON")
+    .map(normalizeAccountEntry);
+  const reserveAccountRaw = env.USDC_LIQUIDITY_TREASURY_RESERVE_ACCOUNT === undefined
+    || env.USDC_LIQUIDITY_TREASURY_RESERVE_ACCOUNT === null
+    ? ""
+    : String(env.USDC_LIQUIDITY_TREASURY_RESERVE_ACCOUNT).trim();
+  const reserveFloorRawInput = env.USDC_LIQUIDITY_TREASURY_RESERVE_FLOOR_USDC === undefined
+    || env.USDC_LIQUIDITY_TREASURY_RESERVE_FLOOR_USDC === null
+    ? ""
+    : String(env.USDC_LIQUIDITY_TREASURY_RESERVE_FLOOR_USDC).trim();
+  const reserveAccount = reserveAccountRaw
+    ? normalizeAddress(env.USDC_LIQUIDITY_TREASURY_RESERVE_ACCOUNT, "USDC_LIQUIDITY_TREASURY_RESERVE_ACCOUNT")
+    : undefined;
+  const reserveFloorRaw = reserveFloorRawInput
+    ? parseUsdcAmountToRaw(reserveFloorRawInput, "USDC_LIQUIDITY_TREASURY_RESERVE_FLOOR_USDC")
+    : 0n;
+  return {
+    chain: env.USDC_LIQUIDITY_CHAIN?.trim() || DEFAULT_CHAIN,
+    asset: env.USDC_LIQUIDITY_ASSET?.trim() || DEFAULT_ASSET,
+    accounts,
+    treasuryReserve: {
+      account: reserveAccount,
+      floorRaw: reserveFloorRaw
+    }
+  };
+}
+
+function extractLiquidRaw(position) {
+  if (position === undefined || position === null) {
+    return 0n;
+  }
+  if (typeof position === "bigint" || typeof position === "number" || typeof position === "string") {
+    return BigInt(position);
+  }
+  return BigInt(
+    position.liquidRaw
+      ?? position.liquid
+      ?? position.position?.liquidRaw
+      ?? position.position?.liquid
+      ?? position[0]
+      ?? 0n
+  );
+}
+
+export async function buildUsdcLiquidityStatus({
+  config,
+  readLiquidRaw,
+  now = () => new Date()
+}) {
+  const accountRows = [];
+  let totalDesiredRaw = 0n;
+
+  for (const accountConfig of config.accounts) {
+    const liquidRaw = extractLiquidRaw(await readLiquidRaw(accountConfig.account));
+    const desiredRaw = accountConfig.targetRaw > liquidRaw ? accountConfig.targetRaw - liquidRaw : 0n;
+    totalDesiredRaw += desiredRaw;
+    accountRows.push({
+      role: accountConfig.role,
+      account: accountConfig.account,
+      liquidUsdc: rawToNumber(liquidRaw),
+      liquidUsdcRaw: liquidRaw.toString(),
+      floorUsdc: rawToNumber(accountConfig.floorRaw),
+      floorUsdcRaw: accountConfig.floorRaw.toString(),
+      targetUsdc: rawToNumber(accountConfig.targetRaw),
+      targetUsdcRaw: accountConfig.targetRaw.toString(),
+      desiredUsdc: rawToNumber(desiredRaw),
+      desiredUsdcRaw: desiredRaw.toString(),
+      refillPending: accountConfig.refillPending,
+      lastRefillAt: accountConfig.lastRefillAt
+    });
+  }
+
+  const reserveAccount = config.treasuryReserve?.account;
+  const treasuryReserveRaw = reserveAccount
+    ? extractLiquidRaw(await readLiquidRaw(reserveAccount))
+    : 0n;
+  const treasuryFloorRaw = BigInt(config.treasuryReserve?.floorRaw ?? 0n);
+  const treasuryReserveHealthy = Boolean(
+    reserveAccount
+      && treasuryReserveRaw >= treasuryFloorRaw
+      && treasuryReserveRaw >= totalDesiredRaw
+  );
+
+  return {
+    asOf: now().toISOString(),
+    chain: config.chain,
+    accounts: accountRows,
+    treasuryReserveHealthy,
+    treasuryReserveUsdc: rawToNumber(treasuryReserveRaw),
+    treasuryReserveUsdcRaw: treasuryReserveRaw.toString(),
+    treasuryReserveAccount: reserveAccount,
+    treasuryReserveFloorUsdc: rawToNumber(treasuryFloorRaw),
+    treasuryReserveFloorUsdcRaw: treasuryFloorRaw.toString(),
+    totalDesiredUsdc: rawToNumber(totalDesiredRaw),
+    totalDesiredUsdcRaw: totalDesiredRaw.toString()
+  };
+}
+
+export function createUsdcLiquidityStatusService({
+  gateway,
+  config = loadUsdcLiquidityConfig(process.env),
+  now = () => new Date()
+} = {}) {
+  return {
+    async getStatus() {
+      if (!gateway?.isEnabled?.()) {
+        throw new ExternalServiceError(
+          "USDC liquidity status requires an enabled blockchain gateway.",
+          "chain_backend_unavailable"
+        );
+      }
+      return buildUsdcLiquidityStatus({
+        config,
+        now,
+        readLiquidRaw: async (account) => {
+          const position = await gateway.getAccountPosition(account, config.asset);
+          return position?.position?.liquidRaw;
+        }
+      });
+    }
+  };
+}

--- a/mcp-server/src/services/usdc-liquidity-status.test.js
+++ b/mcp-server/src/services/usdc-liquidity-status.test.js
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildUsdcLiquidityStatus,
+  createUsdcLiquidityStatusService,
+  formatUsdcRaw,
+  loadUsdcLiquidityConfig,
+  parseUsdcAmountToRaw
+} from "./usdc-liquidity-status.js";
+
+const POSTER = "0x1111111111111111111111111111111111111111";
+const WORKER = "0x2222222222222222222222222222222222222222";
+const RESERVE = "0x3333333333333333333333333333333333333333";
+
+test("parseUsdcAmountToRaw handles 6-decimal USDC amounts", () => {
+  assert.equal(parseUsdcAmountToRaw("0", "amount"), 0n);
+  assert.equal(parseUsdcAmountToRaw("8.5", "amount"), 8_500_000n);
+  assert.equal(parseUsdcAmountToRaw("0.000001", "amount"), 1n);
+  assert.equal(formatUsdcRaw(8_500_000n), "8.5");
+  assert.throws(
+    () => parseUsdcAmountToRaw("0.0000001", "amount"),
+    /at most 6 fractional digits/u
+  );
+});
+
+test("loadUsdcLiquidityConfig parses a generic account registry", () => {
+  const config = loadUsdcLiquidityConfig({
+    USDC_LIQUIDITY_CHAIN: "testnet",
+    USDC_LIQUIDITY_ACCOUNTS_JSON: JSON.stringify([
+      { role: "poster", account: POSTER, floorUsdc: 10, targetUsdc: 50, lastRefillAt: "2026-06-01T00:00:00.000Z" },
+      { role: "worker", account: WORKER, floorUsdc: "0.25", targetUsdc: "1.5", refillPending: "true" }
+    ]),
+    USDC_LIQUIDITY_TREASURY_RESERVE_ACCOUNT: RESERVE,
+    USDC_LIQUIDITY_TREASURY_RESERVE_FLOOR_USDC: "100"
+  });
+
+  assert.equal(config.chain, "testnet");
+  assert.equal(config.accounts[0].account, POSTER);
+  assert.equal(config.accounts[0].floorRaw, 10_000_000n);
+  assert.equal(config.accounts[1].account, "0x2222222222222222222222222222222222222222");
+  assert.equal(config.accounts[1].refillPending, true);
+  assert.equal(config.treasuryReserve.account, RESERVE);
+  assert.equal(config.treasuryReserve.floorRaw, 100_000_000n);
+});
+
+test("loadUsdcLiquidityConfig rejects target below floor", () => {
+  assert.throws(
+    () => loadUsdcLiquidityConfig({
+      USDC_LIQUIDITY_ACCOUNTS_JSON: JSON.stringify([
+        { role: "poster", account: POSTER, floorUsdc: 10, targetUsdc: 5 }
+      ])
+    }),
+    /targetUsdc must be >= floorUsdc/u
+  );
+});
+
+test("buildUsdcLiquidityStatus returns pinned shape plus desired refill math", async () => {
+  const status = await buildUsdcLiquidityStatus({
+    config: loadUsdcLiquidityConfig({
+      USDC_LIQUIDITY_CHAIN: "testnet",
+      USDC_LIQUIDITY_ACCOUNTS_JSON: JSON.stringify([
+        { role: "poster", account: POSTER, floorUsdc: 10, targetUsdc: 50 },
+        { role: "worker", account: WORKER, floorUsdc: 1, targetUsdc: 10 }
+      ]),
+      USDC_LIQUIDITY_TREASURY_RESERVE_ACCOUNT: RESERVE,
+      USDC_LIQUIDITY_TREASURY_RESERVE_FLOOR_USDC: 20
+    }),
+    now: () => new Date("2026-06-02T12:00:00.000Z"),
+    readLiquidRaw: async (account) => ({
+      [POSTER]: "8500000",
+      [WORKER]: "12000000",
+      [RESERVE]: "420000000"
+    })[account]
+  });
+
+  assert.deepEqual(status, {
+    asOf: "2026-06-02T12:00:00.000Z",
+    chain: "testnet",
+    accounts: [
+      {
+        role: "poster",
+        account: POSTER,
+        liquidUsdc: 8.5,
+        liquidUsdcRaw: "8500000",
+        floorUsdc: 10,
+        floorUsdcRaw: "10000000",
+        targetUsdc: 50,
+        targetUsdcRaw: "50000000",
+        desiredUsdc: 41.5,
+        desiredUsdcRaw: "41500000",
+        refillPending: false,
+        lastRefillAt: null
+      },
+      {
+        role: "worker",
+        account: WORKER,
+        liquidUsdc: 12,
+        liquidUsdcRaw: "12000000",
+        floorUsdc: 1,
+        floorUsdcRaw: "1000000",
+        targetUsdc: 10,
+        targetUsdcRaw: "10000000",
+        desiredUsdc: 0,
+        desiredUsdcRaw: "0",
+        refillPending: false,
+        lastRefillAt: null
+      }
+    ],
+    treasuryReserveHealthy: true,
+    treasuryReserveUsdc: 420,
+    treasuryReserveUsdcRaw: "420000000",
+    treasuryReserveAccount: RESERVE,
+    treasuryReserveFloorUsdc: 20,
+    treasuryReserveFloorUsdcRaw: "20000000",
+    totalDesiredUsdc: 41.5,
+    totalDesiredUsdcRaw: "41500000"
+  });
+});
+
+test("buildUsdcLiquidityStatus marks reserve unhealthy when it cannot cover desired refill", async () => {
+  const status = await buildUsdcLiquidityStatus({
+    config: loadUsdcLiquidityConfig({
+      USDC_LIQUIDITY_ACCOUNTS_JSON: JSON.stringify([
+        { role: "poster", account: POSTER, floorUsdc: 10, targetUsdc: 50 }
+      ]),
+      USDC_LIQUIDITY_TREASURY_RESERVE_ACCOUNT: RESERVE,
+      USDC_LIQUIDITY_TREASURY_RESERVE_FLOOR_USDC: 20
+    }),
+    readLiquidRaw: async (account) => ({
+      [POSTER]: "8500000",
+      [RESERVE]: "30000000"
+    })[account]
+  });
+
+  assert.equal(status.accounts[0].desiredUsdcRaw, "41500000");
+  assert.equal(status.treasuryReserveHealthy, false);
+});
+
+test("createUsdcLiquidityStatusService reads AgentAccountCore positions through the gateway", async () => {
+  const calls = [];
+  const service = createUsdcLiquidityStatusService({
+    config: loadUsdcLiquidityConfig({
+      USDC_LIQUIDITY_ACCOUNTS_JSON: JSON.stringify([
+        { role: "poster", account: POSTER, floorUsdc: 10, targetUsdc: 50 }
+      ]),
+      USDC_LIQUIDITY_TREASURY_RESERVE_ACCOUNT: RESERVE
+    }),
+    gateway: {
+      isEnabled: () => true,
+      async getAccountPosition(account, asset) {
+        calls.push({ account, asset });
+        return {
+          position: {
+            liquidRaw: account === POSTER ? "8500000" : "420000000"
+          }
+        };
+      }
+    },
+    now: () => new Date("2026-06-02T12:00:00.000Z")
+  });
+
+  const status = await service.getStatus();
+
+  assert.deepEqual(calls, [
+    { account: POSTER, asset: "USDC" },
+    { account: RESERVE, asset: "USDC" }
+  ]);
+  assert.equal(status.accounts[0].desiredUsdcRaw, "41500000");
+});
+
+test("createUsdcLiquidityStatusService fails closed when chain gateway is disabled", async () => {
+  const service = createUsdcLiquidityStatusService({
+    config: loadUsdcLiquidityConfig({}),
+    gateway: { isEnabled: () => false }
+  });
+
+  await assert.rejects(
+    () => service.getStatus(),
+    /requires an enabled blockchain gateway/u
+  );
+});

--- a/scripts/ops/audit-launch-readiness.mjs
+++ b/scripts/ops/audit-launch-readiness.mjs
@@ -30,6 +30,11 @@
  *     calling deposit() leaves liquid=0; surfacing balanceOf separately
  *     points the operator at fund-signer-usdc-deposit.mjs instead of
  *     "where did my USDC go".
+ *   - Optional USDC liquidity monitor registry — if
+ *     USDC_LIQUIDITY_ACCOUNTS_JSON is configured, read every registered
+ *     poster/worker position plus the treasury reserve account through
+ *     AgentAccountCore.positions(account, USDC), then print the same
+ *     desired-refill math the hosted status endpoint exposes.
  *   - Deployed-bytecode selector presence — for every contract the
  *     BlockchainGateway holds an ABI for, confirm the deployed runtime
  *     bytecode at `deployments.contracts.<address>` contains the 4-byte
@@ -63,6 +68,10 @@ import {
   REPUTATION_SBT_ABI,
   TREASURY_POLICY_ABI
 } from "../../mcp-server/src/blockchain/abis.js";
+import {
+  buildUsdcLiquidityStatus,
+  loadUsdcLiquidityConfig
+} from "../../mcp-server/src/services/usdc-liquidity-status.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "..", "..");
@@ -463,6 +472,15 @@ async function main() {
       missing
     };
   });
+  const usdcLiquidityConfig = loadUsdcLiquidityConfig(process.env);
+  const usdcLiquidityRegistryConfigured = usdcLiquidityConfig.accounts.length > 0
+    || Boolean(usdcLiquidityConfig.treasuryReserve?.account);
+  const usdcLiquidityStatus = usdcLiquidityRegistryConfigured
+    ? await buildUsdcLiquidityStatus({
+        config: usdcLiquidityConfig,
+        readLiquidRaw: (account) => agentAccount.positions(account, usdcAddress)
+      })
+    : undefined;
 
   // Drift check: confirm we're talking to the chain we expected.
   const chainOk = chainId === EXPECTED_CHAIN_ID;
@@ -530,6 +548,20 @@ async function main() {
   // at the precompile, position stays empty, claims keep reverting.
   const balanceHintsAtUndeposited = !liquidityOk && signerUsdcBalanceRaw > 0n;
   console.log(`USDC.balanceOf(signer)           ${signerUsdcBalanceRaw === 0n ? "ℹ" : "•"}  ${formatUsdc(signerUsdcBalanceRaw)} USDC (${signerUsdcBalanceRaw} raw)${balanceHintsAtUndeposited ? "  ← un-deposited; run fund-signer-usdc-deposit.mjs" : ""}`);
+
+  console.log("");
+  console.log(`## USDC liquidity monitor registry`);
+  if (!usdcLiquidityRegistryConfigured) {
+    console.log(`not configured — set USDC_LIQUIDITY_ACCOUNTS_JSON and USDC_LIQUIDITY_TREASURY_RESERVE_ACCOUNT to audit managed replenishment targets`);
+  } else {
+    console.log(`asOf: ${usdcLiquidityStatus.asOf}`);
+    for (const account of usdcLiquidityStatus.accounts) {
+      const belowFloor = BigInt(account.liquidUsdcRaw) < BigInt(account.floorUsdcRaw);
+      const needsRefill = BigInt(account.desiredUsdcRaw) > 0n;
+      console.log(`${account.role.padEnd(6, " ")} ${short(account.account)}  ${belowFloor ? "❌" : needsRefill ? "⚠" : "✅"}  liquid=${account.liquidUsdc} USDC  floor=${account.floorUsdc}  target=${account.targetUsdc}  desired=${account.desiredUsdc}`);
+    }
+    console.log(`reserve ${short(usdcLiquidityStatus.treasuryReserveAccount ?? "")}  ${usdcLiquidityStatus.treasuryReserveHealthy ? "✅" : "❌"}  liquid=${usdcLiquidityStatus.treasuryReserveUsdc} USDC  floor=${usdcLiquidityStatus.treasuryReserveFloorUsdc}  totalDesired=${usdcLiquidityStatus.totalDesiredUsdc}`);
+  }
 
   console.log("");
   console.log(`## Parameter drift vs deployments/${args.profile}.json`);
@@ -647,6 +679,27 @@ async function main() {
       reasonCode: "signer_liquidity_short",
       runbook: `node scripts/ops/fund-signer-usdc-deposit.mjs --amount ${liquidityGap.toString()} --use-kms --commit`
     });
+  }
+  if (usdcLiquidityRegistryConfigured) {
+    for (const account of usdcLiquidityStatus.accounts) {
+      if (BigInt(account.desiredUsdcRaw) === 0n) continue;
+      fixes.push({
+        label: `USDC liquidity monitor target gap for ${account.role} ${short(account.account)}: liquid ${account.liquidUsdc} USDC, target ${account.targetUsdc} USDC, desired ${account.desiredUsdc} USDC`,
+        reasonCode: "usdc_liquidity_target_gap",
+        runbook: "PR 1 is read-only; top up the AgentAccountCore position manually or wait for the mutating refiller PR."
+      });
+    }
+    if (!usdcLiquidityStatus.treasuryReserveAccount) {
+      fixes.push({
+        label: "USDC liquidity monitor has managed accounts but no treasury reserve account configured",
+        reasonCode: "usdc_liquidity_reserve_missing"
+      });
+    } else if (!usdcLiquidityStatus.treasuryReserveHealthy) {
+      fixes.push({
+        label: `USDC liquidity treasury reserve is not healthy: reserve ${usdcLiquidityStatus.treasuryReserveUsdc} USDC, floor ${usdcLiquidityStatus.treasuryReserveFloorUsdc} USDC, desired ${usdcLiquidityStatus.totalDesiredUsdc} USDC`,
+        reasonCode: "usdc_liquidity_reserve_short"
+      });
+    }
   }
   // Bytecode-selector mismatches are not fixable on the multisig — the
   // remediation is a redeploy from a source that includes the missing

--- a/scripts/ops/audit-launch-readiness.test.mjs
+++ b/scripts/ops/audit-launch-readiness.test.mjs
@@ -349,6 +349,17 @@ test("end-to-end: every gateway ABI yields a non-empty selector list", () => {
   }
 });
 
+test("end-to-end: AGENT_ACCOUNT_ABI exposes positions for USDC liquidity status", () => {
+  // The read-only replenisher status endpoint and audit registry both depend
+  // on AgentAccountCore.positions(account, USDC). Keep that getter inside the
+  // bytecode selector audit so a source/deploy drift cannot make liquidity
+  // preflight silently go blind.
+  const selectors = selectorsFromAbi(AGENT_ACCOUNT_ABI);
+  const positions = selectors.find((s) => s.signature === "positions(address,address)");
+  assert.ok(positions, "AGENT_ACCOUNT_ABI must include positions(address,address)");
+  assert.equal(positions.selector, "0x4bd21445");
+});
+
 test("end-to-end: ESCROW_CORE_ABI exposes claimJobFor — the selector the 2026-05-25 incident missed", () => {
   // This is the specific selector PR #357 added. If the gateway ABI
   // ever drops it, the audit would never have caught the original


### PR DESCRIPTION
## Summary
- add read-only USDC liquidity status service for managed poster/worker AgentAccountCore balances
- expose admin-gated `GET /admin/usdc-liquidity/status` with desired refill math and treasury reserve health
- add `USDC_LIQUIDITY_*` env template knobs and extend launch readiness audit to read the same registry

## Scope
This is PR 1 only: detection/status. It does not add a refiller, mutate balances, deploy contracts, or bump any address manifest.

Operators can populate `USDC_LIQUIDITY_ACCOUNTS_JSON` plus the reserve account envs when the hosted preflight should watch live testnet replenishment needs.

## Polkadot Check
Verified against the official Polkadot docs MCP before implementing the chain assumption: Asset Hub USDC is the trust-backed asset with 6 decimals, and the ERC20/precompile surface supports balance-style reads. The status service reads positions through the existing AgentAccountCore gateway path and the audit script pins the `positions(address,address)` selector.

## Checks
- `node --test mcp-server/src/services/usdc-liquidity-status.test.js mcp-server/src/protocols/http/usdc-liquidity-routes.test.js scripts/ops/audit-launch-readiness.test.mjs`
- `npm --workspace mcp-server test`
- `npm run test:ops`
- `node scripts/ops/check-env-template-structure.mjs`

## Impact
- Backend HTTP: yes
- Deploy env template: yes
- Ops audit: yes
- Contracts/indexer/frontend/public site/Caddy: no
- New secrets: no
