### PR TITLE
refactor: extract HTTP idempotent mutation helpers

### DIFF
--- a/mcp-server/src/protocols/http/idempotent-mutations.js
+++ b/mcp-server/src/protocols/http/idempotent-mutations.js
@@ -1,0 +1,168 @@
+import { hashCanonicalContent } from "../../core/canonical-content.js";
+import { ConflictError } from "../../core/errors.js";
+
+export function createIdempotentMutationHelpers({ stateStore, respond, now = () => new Date() }) {
+  const inFlightIdempotentMutations = new Map();
+
+  function parseIdempotencyKey(payload = {}) {
+    return typeof payload?.idempotencyKey === "string" && payload.idempotencyKey.trim()
+      ? payload.idempotencyKey.trim()
+      : undefined;
+  }
+
+  function stripIdempotencyKey(payload = {}) {
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+      return payload;
+    }
+    const { idempotencyKey, ...rest } = payload;
+    return rest;
+  }
+
+  function buildMutationRequestHash({ route, wallet, payload }) {
+    return hashCanonicalContent({
+      route,
+      wallet,
+      payload: stripIdempotencyKey(payload)
+    });
+  }
+
+  function buildIdempotentMutationContext({ route, auth, payload, normalizedPayload, bucket }) {
+    const idempotencyKey = parseIdempotencyKey(payload);
+    return {
+      bucket,
+      key: idempotencyKey ? `${auth.wallet}:${idempotencyKey}` : undefined,
+      requestHash: buildMutationRequestHash({
+        route,
+        wallet: auth.wallet,
+        payload: normalizedPayload ?? payload
+      })
+    };
+  }
+
+  function buildScopedIdempotentMutationContext({ route, auth, scope, payload, normalizedPayload, bucket }) {
+    const idempotencyKey = parseIdempotencyKey(payload);
+    return {
+      bucket,
+      key: idempotencyKey ? `${auth.wallet}:${scope}:${idempotencyKey}` : undefined,
+      requestHash: buildMutationRequestHash({
+        route,
+        wallet: auth.wallet,
+        payload: normalizedPayload ?? payload
+      })
+    };
+  }
+
+  function isMutationReceiptEnvelope(receipt) {
+    return Boolean(
+      receipt
+      && typeof receipt === "object"
+      && typeof receipt.requestHash === "string"
+      && Object.prototype.hasOwnProperty.call(receipt, "response")
+    );
+  }
+
+  async function getIdempotentMutationReplay({ bucket, key, requestHash }) {
+    if (!key) {
+      return undefined;
+    }
+    const existing = await stateStore.getMutationReceipt?.(bucket, key);
+    if (!existing) {
+      return undefined;
+    }
+    if (!isMutationReceiptEnvelope(existing)) {
+      return { statusCode: 200, body: existing };
+    }
+    if (existing.requestHash !== requestHash) {
+      throw new ConflictError(
+        "Idempotency key was already used with a different request payload.",
+        "idempotency_key_payload_mismatch",
+        {
+          bucket,
+          originalRequestHash: existing.requestHash,
+          requestHash
+        }
+      );
+    }
+    return { statusCode: 200, body: existing.response };
+  }
+
+  async function storeIdempotentMutationReceipt({ bucket, key, requestHash, response, statusCode }) {
+    if (!key) {
+      return response;
+    }
+    await stateStore.upsertMutationReceipt?.(bucket, key, {
+      requestHash,
+      statusCode,
+      response,
+      createdAt: now().toISOString()
+    });
+    return response;
+  }
+
+  async function respondWithMutationReceipt(response, context, statusCode, body) {
+    await storeIdempotentMutationReceipt({
+      ...context,
+      response: body,
+      statusCode
+    });
+    return respond(response, statusCode, body);
+  }
+
+  async function runIdempotentMutation(response, context, statusCode, operation) {
+    const replay = await getIdempotentMutationReplay(context);
+    if (replay) {
+      return respond(response, replay.statusCode, replay.body);
+    }
+
+    const inFlightKey = context.key ? `${context.bucket}:${context.key}` : undefined;
+    if (inFlightKey) {
+      const inFlight = inFlightIdempotentMutations.get(inFlightKey);
+      if (inFlight) {
+        if (inFlight.requestHash !== context.requestHash) {
+          throw new ConflictError(
+            "Idempotency key was already used with a different request payload.",
+            "idempotency_key_payload_mismatch",
+            {
+              bucket: context.bucket,
+              originalRequestHash: inFlight.requestHash,
+              requestHash: context.requestHash
+            }
+          );
+        }
+        throw new ConflictError(
+          "Idempotent mutation is already in flight. Retry with the same payload after the first request completes.",
+          "idempotency_key_in_flight",
+          {
+            bucket: context.bucket,
+            requestHash: context.requestHash
+          }
+        );
+      }
+      inFlightIdempotentMutations.set(inFlightKey, {
+        requestHash: context.requestHash,
+        startedAt: now().toISOString()
+      });
+    }
+
+    try {
+      const body = await operation();
+      return respondWithMutationReceipt(response, context, statusCode, body);
+    } finally {
+      if (inFlightKey) {
+        inFlightIdempotentMutations.delete(inFlightKey);
+      }
+    }
+  }
+
+  return {
+    buildIdempotentMutationContext,
+    buildMutationRequestHash,
+    buildScopedIdempotentMutationContext,
+    getIdempotentMutationReplay,
+    parseIdempotencyKey,
+    respondWithMutationReceipt,
+    runIdempotentMutation,
+    storeIdempotentMutationReceipt,
+    stripIdempotencyKey
+  };
+}

--- a/mcp-server/src/protocols/http/idempotent-mutations.test.js
+++ b/mcp-server/src/protocols/http/idempotent-mutations.test.js
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ConflictError } from "../../core/errors.js";
+import { createIdempotentMutationHelpers } from "./idempotent-mutations.js";
+
+function makeHarness(overrides = {}) {
+  const calls = [];
+  const receipts = new Map(Object.entries(overrides.receipts ?? {}));
+  const stateStore = {
+    getMutationReceipt: async (bucket, key) => {
+      calls.push(["getMutationReceipt", { bucket, key }]);
+      return receipts.get(`${bucket}:${key}`);
+    },
+    upsertMutationReceipt: async (bucket, key, receipt) => {
+      calls.push(["upsertMutationReceipt", { bucket, key, receipt }]);
+      receipts.set(`${bucket}:${key}`, receipt);
+    },
+  };
+  const helpers = createIdempotentMutationHelpers({
+    stateStore,
+    now: () => new Date("2026-06-06T10:00:00.000Z"),
+    respond: (response, statusCode, body) => {
+      calls.push(["respond", { statusCode, body }]);
+      response.statusCode = statusCode;
+      response.body = body;
+    },
+  });
+  return { calls, helpers, receipts };
+}
+
+test("buildIdempotentMutationContext strips idempotencyKey from the request hash", () => {
+  const { helpers } = makeHarness();
+  const auth = { wallet: "0xabc" };
+  const payload = { amount: 10, idempotencyKey: "same-key" };
+
+  const withKey = helpers.buildIdempotentMutationContext({
+    route: "/account/fund",
+    auth,
+    payload,
+    bucket: "account_fund",
+  });
+  const withoutKey = helpers.buildMutationRequestHash({
+    route: "/account/fund",
+    wallet: auth.wallet,
+    payload: { amount: 10 },
+  });
+
+  assert.equal(withKey.key, "0xabc:same-key");
+  assert.equal(withKey.requestHash, withoutKey);
+});
+
+test("getIdempotentMutationReplay returns matching stored receipt envelopes", async () => {
+  const { calls, helpers } = makeHarness({
+    receipts: {
+      "bucket:wallet:key": {
+        requestHash: "hash-1",
+        statusCode: 201,
+        response: { ok: true },
+      },
+    },
+  });
+
+  const replay = await helpers.getIdempotentMutationReplay({
+    bucket: "bucket",
+    key: "wallet:key",
+    requestHash: "hash-1",
+  });
+
+  assert.deepEqual(replay, { statusCode: 200, body: { ok: true } });
+  assert.deepEqual(calls, [
+    ["getMutationReceipt", { bucket: "bucket", key: "wallet:key" }],
+  ]);
+});
+
+test("getIdempotentMutationReplay rejects payload drift", async () => {
+  const { helpers } = makeHarness({
+    receipts: {
+      "bucket:wallet:key": {
+        requestHash: "hash-original",
+        statusCode: 200,
+        response: { ok: true },
+      },
+    },
+  });
+
+  await assert.rejects(
+    helpers.getIdempotentMutationReplay({
+      bucket: "bucket",
+      key: "wallet:key",
+      requestHash: "hash-new",
+    }),
+    (error) => {
+      assert.ok(error instanceof ConflictError);
+      assert.equal(error.code, "idempotency_key_payload_mismatch");
+      assert.deepEqual(error.details, {
+        bucket: "bucket",
+        originalRequestHash: "hash-original",
+        requestHash: "hash-new",
+      });
+      return true;
+    }
+  );
+});
+
+test("runIdempotentMutation stores a receipt and responds", async () => {
+  const { calls, helpers } = makeHarness();
+  const response = {};
+  const context = {
+    bucket: "bucket",
+    key: "wallet:key",
+    requestHash: "hash-1",
+  };
+
+  await helpers.runIdempotentMutation(response, context, 202, async () => ({ queued: true }));
+
+  assert.equal(response.statusCode, 202);
+  assert.deepEqual(response.body, { queued: true });
+  assert.deepEqual(calls, [
+    ["getMutationReceipt", { bucket: "bucket", key: "wallet:key" }],
+    ["upsertMutationReceipt", {
+      bucket: "bucket",
+      key: "wallet:key",
+      receipt: {
+        requestHash: "hash-1",
+        statusCode: 202,
+        response: { queued: true },
+        createdAt: "2026-06-06T10:00:00.000Z",
+      },
+    }],
+    ["respond", { statusCode: 202, body: { queued: true } }],
+  ]);
+});
+
+test("runIdempotentMutation rejects duplicate in-flight keys before rerunning side effects", async () => {
+  const { helpers } = makeHarness();
+  const context = {
+    bucket: "bucket",
+    key: "wallet:key",
+    requestHash: "hash-1",
+  };
+  let operationCount = 0;
+  let release;
+  const blocker = new Promise((resolve) => {
+    release = resolve;
+  });
+
+  const first = helpers.runIdempotentMutation({}, context, 200, async () => {
+    operationCount += 1;
+    await blocker;
+    return { ok: true };
+  });
+
+  await assert.rejects(
+    helpers.runIdempotentMutation({}, context, 200, async () => {
+      operationCount += 1;
+      return { duplicate: true };
+    }),
+    (error) => {
+      assert.ok(error instanceof ConflictError);
+      assert.equal(error.code, "idempotency_key_in_flight");
+      return true;
+    }
+  );
+
+  release();
+  await first;
+  assert.equal(operationCount, 1);
+});

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -3,11 +3,9 @@ import { createPlatformRuntime } from "../../services/bootstrap.js";
 import { assertMutationBackendAvailable } from "../../core/mutation-backend.js";
 import {
   AuthorizationError,
-  ConflictError,
   normalizeError,
   ValidationError
 } from "../../core/errors.js";
-import { hashCanonicalContent } from "../../core/canonical-content.js";
 import { extractClientKey } from "../../auth/rate-limit.js";
 import { hasRole } from "../../auth/config.js";
 import { resolveRequestId } from "../../core/logger.js";
@@ -34,6 +32,7 @@ import { createContentRoutes } from "./content-routes.js";
 import { createDisputeRoutes } from "./dispute-routes.js";
 import { createEventRoutes } from "./event-routes.js";
 import { createGasRoutes } from "./gas-routes.js";
+import { createIdempotentMutationHelpers } from "./idempotent-mutations.js";
 import { createJobRoutes } from "./job-routes.js";
 import { createOperationalRoutes, resolveMetricsAuthConfig } from "./operational-routes.js";
 import { createPaymentRoutes } from "./payment-routes.js";
@@ -80,8 +79,6 @@ metrics.gauge("state_store_backend", "1 when state store backend matches the lab
 
 const { metricsBearerToken, metricsAuthRequired } = resolveMetricsAuthConfig(process.env);
 const port = Number(process.env.PORT ?? 8787);
-
-const inFlightIdempotentMutations = new Map();
 
 function respond(response, statusCode, payload, extraHeaders = {}) {
   const headers = {
@@ -739,54 +736,6 @@ function metricPathLabel(pathname) {
   return "other";
 }
 
-function parseIdempotencyKey(payload = {}) {
-  return typeof payload?.idempotencyKey === "string" && payload.idempotencyKey.trim()
-    ? payload.idempotencyKey.trim()
-    : undefined;
-}
-
-function stripIdempotencyKey(payload = {}) {
-  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
-    return payload;
-  }
-  const { idempotencyKey, ...rest } = payload;
-  return rest;
-}
-
-function buildMutationRequestHash({ route, wallet, payload }) {
-  return hashCanonicalContent({
-    route,
-    wallet,
-    payload: stripIdempotencyKey(payload)
-  });
-}
-
-function buildIdempotentMutationContext({ route, auth, payload, normalizedPayload, bucket }) {
-  const idempotencyKey = parseIdempotencyKey(payload);
-  return {
-    bucket,
-    key: idempotencyKey ? `${auth.wallet}:${idempotencyKey}` : undefined,
-    requestHash: buildMutationRequestHash({
-      route,
-      wallet: auth.wallet,
-      payload: normalizedPayload ?? payload
-    })
-  };
-}
-
-function buildScopedIdempotentMutationContext({ route, auth, scope, payload, normalizedPayload, bucket }) {
-  const idempotencyKey = parseIdempotencyKey(payload);
-  return {
-    bucket,
-    key: idempotencyKey ? `${auth.wallet}:${scope}:${idempotencyKey}` : undefined,
-    requestHash: buildMutationRequestHash({
-      route,
-      wallet: auth.wallet,
-      payload: normalizedPayload ?? payload
-    })
-  };
-}
-
 function normalizeOptionalString(value) {
   return typeof value === "string" ? value.trim() : undefined;
 }
@@ -799,107 +748,17 @@ function normalizeNumberLike(value) {
   return Number.isFinite(parsed) ? parsed : value;
 }
 
-function isMutationReceiptEnvelope(receipt) {
-  return Boolean(
-    receipt
-    && typeof receipt === "object"
-    && typeof receipt.requestHash === "string"
-    && Object.prototype.hasOwnProperty.call(receipt, "response")
-  );
-}
-
-async function getIdempotentMutationReplay({ bucket, key, requestHash }) {
-  if (!key) {
-    return undefined;
-  }
-  const existing = await stateStore.getMutationReceipt?.(bucket, key);
-  if (!existing) {
-    return undefined;
-  }
-  if (!isMutationReceiptEnvelope(existing)) {
-    return { statusCode: 200, body: existing };
-  }
-  if (existing.requestHash !== requestHash) {
-    throw new ConflictError(
-      "Idempotency key was already used with a different request payload.",
-      "idempotency_key_payload_mismatch",
-      {
-        bucket,
-        originalRequestHash: existing.requestHash,
-        requestHash
-      }
-    );
-  }
-  return { statusCode: 200, body: existing.response };
-}
-
-async function storeIdempotentMutationReceipt({ bucket, key, requestHash, response, statusCode }) {
-  if (!key) {
-    return response;
-  }
-  await stateStore.upsertMutationReceipt?.(bucket, key, {
-    requestHash,
-    statusCode,
-    response,
-    createdAt: new Date().toISOString()
-  });
-  return response;
-}
-
-async function respondWithMutationReceipt(response, context, statusCode, body) {
-  await storeIdempotentMutationReceipt({
-    ...context,
-    response: body,
-    statusCode
-  });
-  return respond(response, statusCode, body);
-}
-
-async function runIdempotentMutation(response, context, statusCode, operation) {
-  const replay = await getIdempotentMutationReplay(context);
-  if (replay) {
-    return respond(response, replay.statusCode, replay.body);
-  }
-
-  const inFlightKey = context.key ? `${context.bucket}:${context.key}` : undefined;
-  if (inFlightKey) {
-    const inFlight = inFlightIdempotentMutations.get(inFlightKey);
-    if (inFlight) {
-      if (inFlight.requestHash !== context.requestHash) {
-        throw new ConflictError(
-          "Idempotency key was already used with a different request payload.",
-          "idempotency_key_payload_mismatch",
-          {
-            bucket: context.bucket,
-            originalRequestHash: inFlight.requestHash,
-            requestHash: context.requestHash
-          }
-        );
-      }
-      throw new ConflictError(
-        "Idempotent mutation is already in flight. Retry with the same payload after the first request completes.",
-        "idempotency_key_in_flight",
-        {
-          bucket: context.bucket,
-          requestHash: context.requestHash
-        }
-      );
-    }
-    inFlightIdempotentMutations.set(inFlightKey, {
-      requestHash: context.requestHash,
-      startedAt: new Date().toISOString()
-    });
-  }
-
-  try {
-    const body = await operation();
-    return respondWithMutationReceipt(response, context, statusCode, body);
-  } finally {
-    if (inFlightKey) {
-      inFlightIdempotentMutations.delete(inFlightKey);
-    }
-  }
-}
+const {
+  buildIdempotentMutationContext,
+  buildMutationRequestHash,
+  buildScopedIdempotentMutationContext,
+  getIdempotentMutationReplay,
+  parseIdempotencyKey,
+  respondWithMutationReceipt,
+  runIdempotentMutation,
+  storeIdempotentMutationReceipt,
+  stripIdempotencyKey,
+} = createIdempotentMutationHelpers({ stateStore, respond });
 
 const handleAdminStatusRoute = createAdminStatusRoutes({
   authMiddleware,


### PR DESCRIPTION
## What changed
- Extracted the HTTP idempotent mutation helper logic from server.js into idempotent-mutations.js.
- Kept the existing helper names and route wiring intact so route modules keep the same surface.
- Added focused regression tests for request hashing, replay, payload drift, receipt storage, and duplicate in-flight guards.

## Checks run
- node --test mcp-server/src/protocols/http/idempotent-mutations.test.js
- npm --workspace mcp-server test (849 passing)

## Impact
- Backend only: mcp-server HTTP helper refactor.
- No frontend, indexer, Caddy, contracts, public site, environment, or VPS secret changes.