### PR TITLE
refactor: extract account strategy view builder

### DIFF
--- a/mcp-server/src/protocols/http/account-routes.js
+++ b/mcp-server/src/protocols/http/account-routes.js
@@ -1,59 +1,11 @@
 import { keccak256, toUtf8Bytes } from "ethers";
 
 import { ValidationError } from "../../core/errors.js";
-
-function sumNumericValues(record = {}) {
-  return Object.values(record).reduce((sum, value) => sum + (Number(value) || 0), 0);
-}
-
-function ratioToBps(numerator, denominator) {
-  if (!Number.isFinite(numerator) || !Number.isFinite(denominator) || denominator <= 0) {
-    return 0;
-  }
-  return Math.round((numerator / denominator) * 10_000);
-}
-
-function normalizeRawIntegerString(value) {
-  if (value === undefined || value === null || value === "") {
-    return undefined;
-  }
-  if (typeof value === "bigint") {
-    return value >= 0n ? value.toString() : undefined;
-  }
-  if (typeof value === "number") {
-    return Number.isSafeInteger(value) && value >= 0 ? String(value) : undefined;
-  }
-  const normalized = String(value).trim();
-  if (!/^\d+$/u.test(normalized)) {
-    return undefined;
-  }
-  return BigInt(normalized).toString();
-}
-
-function calculateRoutedAmountRaw(sharesRaw, telemetry = {}) {
-  const normalizedSharesRaw = normalizeRawIntegerString(sharesRaw);
-  const totalAssetsRaw = normalizeRawIntegerString(telemetry.totalAssetsRaw);
-  const totalSharesRaw = normalizeRawIntegerString(telemetry.totalSharesRaw);
-  if (normalizedSharesRaw === undefined || totalAssetsRaw === undefined || totalSharesRaw === undefined) {
-    return undefined;
-  }
-  const denominator = BigInt(totalSharesRaw);
-  if (denominator <= 0n) {
-    return undefined;
-  }
-  return ((BigInt(normalizedSharesRaw) * BigInt(totalAssetsRaw)) / denominator).toString();
-}
-
-function resolveAssetSymbol(gateway, assetAddress) {
-  if (!assetAddress) return "DOT";
-  const supportedAssets = gateway?.config?.supportedAssets ?? [];
-  const match = supportedAssets.find((asset) => asset.address?.toLowerCase() === assetAddress.toLowerCase());
-  return match?.symbol ?? "DOT";
-}
-
-function resolveStrategyAssetSymbol(gateway, strategy) {
-  return strategy?.assetConfig?.symbol ?? resolveAssetSymbol(gateway, strategy?.asset);
-}
+import {
+  buildAccountStrategiesView,
+  buildLiveStrategyAllocationByAsset,
+  resolveStrategyAssetSymbol
+} from "./account-strategy-view.js";
 
 function findStrategyConfig({ gateway, strategies, strategyId }) {
   if (!strategyId) return undefined;
@@ -111,72 +63,6 @@ function parseAsyncTreasuryOptions(payload = {}, url, { defaultRecipient = undef
     idempotencyKey,
     recipient,
     requestedShares
-  };
-}
-
-function buildLaneAttention({ shares, isMock, debtTotal, borrowCapacity, deploymentShareBps }) {
-  if (!(shares > 0)) {
-    return undefined;
-  }
-  if (isMock) {
-    return {
-      code: "simulated_yield",
-      tone: "tier-warn",
-      message: "This lane is using the mock vDOT adapter, so yield is simulated rather than market-backed."
-    };
-  }
-  if (debtTotal > 0 && !(borrowCapacity > 0)) {
-    return {
-      code: "credit_constrained",
-      tone: "tier-warn",
-      message: "This wallet has debt outstanding and no additional live borrow headroom."
-    };
-  }
-  if (deploymentShareBps >= 7000) {
-    return {
-      code: "lane_concentration",
-      tone: "status-pending",
-      message: "Most deployed capital is concentrated in this lane right now."
-    };
-  }
-  return undefined;
-}
-
-function formatAdapterYieldLabel({ telemetry, isMock, shares }) {
-  if (!telemetry?.reported) {
-    return isMock
-      ? "Mock adapter is registered, but no simulated yield data is reported yet."
-      : "Adapter is registered, but it is not reporting a live yield/performance read yet.";
-  }
-  const sharePrice = Number(telemetry.sharePrice);
-  const performanceBps = Number(telemetry.performanceBps);
-  const sharePriceLabel = Number.isFinite(sharePrice) ? `${sharePrice.toFixed(4)}x share price` : "share price unavailable";
-  const driftLabel = Number.isFinite(performanceBps)
-    ? `${performanceBps >= 0 ? "+" : ""}${performanceBps} bps`
-    : "drift unavailable";
-  if (shares > 0) {
-    return `${sharePriceLabel} \u00b7 ${driftLabel} on the adapter for currently routed wallet capital.`;
-  }
-  return `${sharePriceLabel} \u00b7 ${driftLabel} on deployed adapter capital.`;
-}
-
-function normalizeTimelineEntry(entry = {}) {
-  const amount = Number(entry.amount ?? 0);
-  const yieldDelta = Number(entry.yieldDelta ?? entry.realizedYieldDelta ?? 0);
-  return {
-    id: entry.id,
-    type: entry.type ?? "treasury_event",
-    strategyId: entry.strategyId,
-    asset: entry.asset ?? "DOT",
-    amount,
-    ...(entry.amountRaw !== undefined ? { amountRaw: normalizeRawIntegerString(entry.amountRaw) ?? String(entry.amountRaw) } : {}),
-    yieldDelta,
-    ...(entry.yieldDeltaRaw !== undefined ? { yieldDeltaRaw: String(entry.yieldDeltaRaw) } : {}),
-    ...(entry.realizedYieldDeltaRaw !== undefined ? { realizedYieldDeltaRaw: String(entry.realizedYieldDeltaRaw) } : {}),
-    ...(entry.principalAfterRaw !== undefined ? { principalAfterRaw: String(entry.principalAfterRaw) } : {}),
-    ...(entry.markValueAfterRaw !== undefined ? { markValueAfterRaw: String(entry.markValueAfterRaw) } : {}),
-    ...(entry.requestedSharesRaw !== undefined ? { requestedSharesRaw: String(entry.requestedSharesRaw) } : {}),
-    at: entry.at
   };
 }
 
@@ -261,19 +147,12 @@ export function createAccountRoutes({
         gateway.getStrategyPositions(auth.wallet, strategies).catch(() => []),
         gateway.getStrategyTelemetry(strategies).catch(() => [])
       ]);
-      const sharesByStrategy = Object.fromEntries(strategyPositions.map((entry) => [entry.strategyId, Number(entry.shares ?? 0)]));
-      const telemetryByStrategy = Object.fromEntries(strategyTelemetry.map((entry) => [entry.strategyId, entry]));
-      const liveAllocatedByAsset = {};
-      for (const strategy of strategies) {
-        const shares = Number(sharesByStrategy[strategy.strategyId] ?? 0);
-        if (!(shares > 0)) continue;
-        const telemetry = telemetryByStrategy[strategy.strategyId];
-        const liveValue = telemetry?.reported && Number.isFinite(Number(telemetry.sharePrice))
-          ? shares * Number(telemetry.sharePrice)
-          : shares;
-        const symbol = resolveAssetSymbol(gateway, strategy.asset);
-        liveAllocatedByAsset[symbol] = (liveAllocatedByAsset[symbol] ?? 0) + liveValue;
-      }
+      const liveAllocatedByAsset = buildLiveStrategyAllocationByAsset({
+        gateway,
+        strategies,
+        strategyPositions,
+        strategyTelemetry
+      });
 
       respond(response, 200, {
         ...account,
@@ -471,142 +350,14 @@ export function createAccountRoutes({
       const auth = await authMiddleware(request, url);
       const account = await service.getAccountSummary(auth.wallet);
       const borrowCapacity = await service.getBorrowCapacity(auth.wallet, "DOT").catch(() => undefined);
-      const adapterTelemetryByStrategy = gateway?.isEnabled?.()
-        ? Object.fromEntries((await gateway.getStrategyTelemetry(strategies)).map((entry) => [entry.strategyId, entry]))
-        : {};
-      const strategyPositions = gateway?.isEnabled?.()
-        ? await gateway.getStrategyPositions(auth.wallet, strategies)
-        : [];
-      const sharesByStrategy = gateway?.isEnabled?.()
-        ? Object.fromEntries(strategyPositions.map((entry) => [entry.strategyId, entry.shares]))
-        : (account.strategyShares ?? {});
-      const pendingByStrategy = gateway?.isEnabled?.()
-        ? Object.fromEntries(strategyPositions.map((entry) => [entry.strategyId, entry]))
-        : (account.strategyPending ?? {});
-      const totalLiquid = sumNumericValues(account.liquid);
-      const debtTotal = sumNumericValues(account.debtOutstanding);
-      const strategyActivity = account.strategyActivity ?? {};
-      const strategyAccounting = account.strategyAccounting ?? {};
-      const positions = strategies.map((strategy) => {
-        const shares = Number(sharesByStrategy[strategy.strategyId] ?? 0);
-        const pendingPosition = pendingByStrategy[strategy.strategyId] ?? {};
-        const sharesRaw = normalizeRawIntegerString(pendingPosition.sharesRaw);
-        const pendingDepositAssets = Number(pendingPosition.pendingDepositAssets ?? 0);
-        const pendingDepositAssetsRaw = normalizeRawIntegerString(pendingPosition.pendingDepositAssetsRaw);
-        const pendingWithdrawalShares = Number(pendingPosition.pendingWithdrawalShares ?? 0);
-        const pendingWithdrawalSharesRaw = normalizeRawIntegerString(pendingPosition.pendingWithdrawalSharesRaw);
-        const lastMovement = strategyActivity[strategy.strategyId];
-        const accounting = strategyAccounting[strategy.strategyId] ?? {};
-        const isMock = String(strategy.kind ?? "").includes("mock");
-        const telemetry = adapterTelemetryByStrategy[strategy.strategyId];
-        const routedAmount = telemetry?.reported && Number.isFinite(Number(telemetry.sharePrice))
-          ? shares * Number(telemetry.sharePrice)
-          : shares;
-        const routedAmountRaw = calculateRoutedAmountRaw(sharesRaw, telemetry);
-        const principalValue = Number(accounting.principal ?? shares);
-        const realizedYield = Number(accounting.realizedYield ?? 0);
-        const unrealizedYield = routedAmount - principalValue;
-        return {
-          strategyId: strategy.strategyId,
-          asset: strategy.asset,
-          assetConfig: strategy.assetConfig,
-          assetSymbol: resolveStrategyAssetSymbol(gateway, strategy),
-          executionMode: strategy.executionMode ?? "sync",
-          shares,
-          ...(sharesRaw !== undefined ? { sharesRaw } : {}),
-          shareCount: shares,
-          pendingDepositAssets,
-          ...(pendingDepositAssetsRaw !== undefined ? { pendingDepositAssetsRaw } : {}),
-          pendingWithdrawalShares,
-          ...(pendingWithdrawalSharesRaw !== undefined ? { pendingWithdrawalSharesRaw } : {}),
-          routedAmount,
-          ...(routedAmountRaw !== undefined ? { routedAmountRaw } : {}),
-          principalValue,
-          ...(accounting.principalRaw !== undefined ? { principalValueRaw: String(accounting.principalRaw) } : {}),
-          ...(accounting.markValueRaw !== undefined ? { markValueRaw: String(accounting.markValueRaw) } : {}),
-          unrealizedYield,
-          realizedYield,
-          ...(accounting.realizedYieldRaw !== undefined ? { realizedYieldRaw: String(accounting.realizedYieldRaw) } : {}),
-          totalYield: realizedYield + unrealizedYield,
-          statusLabel: pendingDepositAssets > 0
-            ? "Pending deposit"
-            : pendingWithdrawalShares > 0
-              ? "Pending withdraw"
-              : shares > 0
-                ? "Routed"
-                : "Idle",
-          yieldReported: Boolean(telemetry?.reported),
-          yieldStatus: telemetry?.reported ? (isMock ? "simulated" : "live") : (isMock ? "simulated_unreported" : "unreported"),
-          yieldLabel: formatAdapterYieldLabel({ telemetry, isMock, shares }),
-          sharePrice: telemetry?.sharePrice,
-          performanceBps: telemetry?.performanceBps,
-          adapterTotalAssets: telemetry?.totalAssets,
-          ...(telemetry?.totalAssetsRaw !== undefined ? { adapterTotalAssetsRaw: String(telemetry.totalAssetsRaw) } : {}),
-          adapterTotalShares: telemetry?.totalShares,
-          ...(telemetry?.totalSharesRaw !== undefined ? { adapterTotalSharesRaw: String(telemetry.totalSharesRaw) } : {}),
-          adapterLinked: true,
-          adapterLinkStatus: shares > 0
-            ? "Wallet capital is now settled into the adapter and priced from live adapter reads."
-            : "Adapter performance is live even when this wallet has no routed capital in the lane.",
-          riskLabel: telemetry?.riskLabel || strategy.riskLabel || "",
-          lastAction: lastMovement?.action,
-          lastMovementAt: lastMovement?.at,
-          attention: buildLaneAttention({
-            shares,
-            isMock,
-            debtTotal,
-            borrowCapacity: Number(borrowCapacity),
-            deploymentShareBps: 0
-          })
-        };
-      });
-      const totalAllocated = positions.reduce((sum, entry) => sum + (Number(entry.routedAmount) || 0), 0);
-      const totalPrincipal = positions.reduce((sum, entry) => sum + (Number(entry.principalValue) || 0), 0);
-      const totalUnrealizedYield = positions.reduce((sum, entry) => sum + (Number(entry.unrealizedYield) || 0), 0);
-      const totalRealizedYield = positions.reduce((sum, entry) => sum + (Number(entry.realizedYield) || 0), 0);
-      const treasuryBase = totalLiquid + totalAllocated;
-      const normalizedPositions = positions.map((entry) => ({
-        ...entry,
-        deploymentShareBps: ratioToBps(Number(entry.routedAmount), totalAllocated),
-        treasuryShareBps: ratioToBps(Number(entry.routedAmount), treasuryBase),
-        attention: buildLaneAttention({
-          shares: Number(entry.routedAmount),
-          isMock: entry.yieldStatus === "simulated" || entry.yieldStatus === "simulated_unreported",
-          debtTotal,
-          borrowCapacity: Number(borrowCapacity),
-          deploymentShareBps: ratioToBps(Number(entry.routedAmount), totalAllocated)
-        })
-      }));
-      const treasuryTimeline = await service.recordStrategySnapshots(
-        auth.wallet,
-        normalizedPositions.map((entry) => ({
-          strategyId: entry.strategyId,
-          asset: entry.asset,
-          assetSymbol: entry.assetSymbol,
-          shares: entry.shares,
-          currentValue: entry.routedAmount,
-          currentValueRaw: entry.routedAmountRaw,
-          sharePrice: entry.sharePrice
-        }))
-      );
-      respond(response, 200, {
+      respond(response, 200, await buildAccountStrategiesView({
         wallet: auth.wallet,
-        summary: {
-          treasuryBase,
-          liquid: totalLiquid,
-          allocated: totalAllocated,
-          principal: totalPrincipal,
-          unrealizedYield: totalUnrealizedYield,
-          realizedYield: totalRealizedYield,
-          totalYield: totalRealizedYield + totalUnrealizedYield,
-          debt: debtTotal,
-          borrowCapacity: Number.isFinite(Number(borrowCapacity)) ? Number(borrowCapacity) : undefined,
-          deployedLanes: normalizedPositions.filter((entry) => entry.routedAmount > 0).length,
-          attentionCount: normalizedPositions.filter((entry) => entry.attention).length
-        },
-        positions: normalizedPositions,
-        timeline: (treasuryTimeline ?? []).map(normalizeTimelineEntry)
-      });
+        account,
+        borrowCapacity,
+        gateway,
+        service,
+        strategies
+      }));
       return true;
     }
 

--- a/mcp-server/src/protocols/http/account-strategy-view.js
+++ b/mcp-server/src/protocols/http/account-strategy-view.js
@@ -1,0 +1,286 @@
+function sumNumericValues(record = {}) {
+  return Object.values(record).reduce((sum, value) => sum + (Number(value) || 0), 0);
+}
+
+function ratioToBps(numerator, denominator) {
+  if (!Number.isFinite(numerator) || !Number.isFinite(denominator) || denominator <= 0) {
+    return 0;
+  }
+  return Math.round((numerator / denominator) * 10_000);
+}
+
+function normalizeRawIntegerString(value) {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+  if (typeof value === "bigint") {
+    return value >= 0n ? value.toString() : undefined;
+  }
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value >= 0 ? String(value) : undefined;
+  }
+  const normalized = String(value).trim();
+  if (!/^\d+$/u.test(normalized)) {
+    return undefined;
+  }
+  return BigInt(normalized).toString();
+}
+
+function calculateRoutedAmountRaw(sharesRaw, telemetry = {}) {
+  const normalizedSharesRaw = normalizeRawIntegerString(sharesRaw);
+  const totalAssetsRaw = normalizeRawIntegerString(telemetry.totalAssetsRaw);
+  const totalSharesRaw = normalizeRawIntegerString(telemetry.totalSharesRaw);
+  if (normalizedSharesRaw === undefined || totalAssetsRaw === undefined || totalSharesRaw === undefined) {
+    return undefined;
+  }
+  const denominator = BigInt(totalSharesRaw);
+  if (denominator <= 0n) {
+    return undefined;
+  }
+  return ((BigInt(normalizedSharesRaw) * BigInt(totalAssetsRaw)) / denominator).toString();
+}
+
+export function resolveAssetSymbol(gateway, assetAddress) {
+  if (!assetAddress) return "DOT";
+  const supportedAssets = gateway?.config?.supportedAssets ?? [];
+  const match = supportedAssets.find((asset) => asset.address?.toLowerCase() === assetAddress.toLowerCase());
+  return match?.symbol ?? "DOT";
+}
+
+export function resolveStrategyAssetSymbol(gateway, strategy) {
+  return strategy?.assetConfig?.symbol ?? resolveAssetSymbol(gateway, strategy?.asset);
+}
+
+function buildLaneAttention({ shares, isMock, debtTotal, borrowCapacity, deploymentShareBps }) {
+  if (!(shares > 0)) {
+    return undefined;
+  }
+  if (isMock) {
+    return {
+      code: "simulated_yield",
+      tone: "tier-warn",
+      message: "This lane is using the mock vDOT adapter, so yield is simulated rather than market-backed."
+    };
+  }
+  if (debtTotal > 0 && !(borrowCapacity > 0)) {
+    return {
+      code: "credit_constrained",
+      tone: "tier-warn",
+      message: "This wallet has debt outstanding and no additional live borrow headroom."
+    };
+  }
+  if (deploymentShareBps >= 7000) {
+    return {
+      code: "lane_concentration",
+      tone: "status-pending",
+      message: "Most deployed capital is concentrated in this lane right now."
+    };
+  }
+  return undefined;
+}
+
+function formatAdapterYieldLabel({ telemetry, isMock, shares }) {
+  if (!telemetry?.reported) {
+    return isMock
+      ? "Mock adapter is registered, but no simulated yield data is reported yet."
+      : "Adapter is registered, but it is not reporting a live yield/performance read yet.";
+  }
+  const sharePrice = Number(telemetry.sharePrice);
+  const performanceBps = Number(telemetry.performanceBps);
+  const sharePriceLabel = Number.isFinite(sharePrice) ? `${sharePrice.toFixed(4)}x share price` : "share price unavailable";
+  const driftLabel = Number.isFinite(performanceBps)
+    ? `${performanceBps >= 0 ? "+" : ""}${performanceBps} bps`
+    : "drift unavailable";
+  if (shares > 0) {
+    return `${sharePriceLabel} \u00b7 ${driftLabel} on the adapter for currently routed wallet capital.`;
+  }
+  return `${sharePriceLabel} \u00b7 ${driftLabel} on deployed adapter capital.`;
+}
+
+function normalizeTimelineEntry(entry = {}) {
+  const amount = Number(entry.amount ?? 0);
+  const yieldDelta = Number(entry.yieldDelta ?? entry.realizedYieldDelta ?? 0);
+  return {
+    id: entry.id,
+    type: entry.type ?? "treasury_event",
+    strategyId: entry.strategyId,
+    asset: entry.asset ?? "DOT",
+    amount,
+    ...(entry.amountRaw !== undefined ? { amountRaw: normalizeRawIntegerString(entry.amountRaw) ?? String(entry.amountRaw) } : {}),
+    yieldDelta,
+    ...(entry.yieldDeltaRaw !== undefined ? { yieldDeltaRaw: String(entry.yieldDeltaRaw) } : {}),
+    ...(entry.realizedYieldDeltaRaw !== undefined ? { realizedYieldDeltaRaw: String(entry.realizedYieldDeltaRaw) } : {}),
+    ...(entry.principalAfterRaw !== undefined ? { principalAfterRaw: String(entry.principalAfterRaw) } : {}),
+    ...(entry.markValueAfterRaw !== undefined ? { markValueAfterRaw: String(entry.markValueAfterRaw) } : {}),
+    ...(entry.requestedSharesRaw !== undefined ? { requestedSharesRaw: String(entry.requestedSharesRaw) } : {}),
+    at: entry.at
+  };
+}
+
+export function buildLiveStrategyAllocationByAsset({
+  gateway,
+  strategies,
+  strategyPositions = [],
+  strategyTelemetry = []
+}) {
+  const sharesByStrategy = Object.fromEntries(strategyPositions.map((entry) => [entry.strategyId, Number(entry.shares ?? 0)]));
+  const telemetryByStrategy = Object.fromEntries(strategyTelemetry.map((entry) => [entry.strategyId, entry]));
+  const liveAllocatedByAsset = {};
+  for (const strategy of strategies) {
+    const shares = Number(sharesByStrategy[strategy.strategyId] ?? 0);
+    if (!(shares > 0)) continue;
+    const telemetry = telemetryByStrategy[strategy.strategyId];
+    const liveValue = telemetry?.reported && Number.isFinite(Number(telemetry.sharePrice))
+      ? shares * Number(telemetry.sharePrice)
+      : shares;
+    const symbol = resolveAssetSymbol(gateway, strategy.asset);
+    liveAllocatedByAsset[symbol] = (liveAllocatedByAsset[symbol] ?? 0) + liveValue;
+  }
+  return liveAllocatedByAsset;
+}
+
+export async function buildAccountStrategiesView({
+  wallet,
+  account,
+  borrowCapacity,
+  gateway,
+  service,
+  strategies
+}) {
+  const adapterTelemetryByStrategy = gateway?.isEnabled?.()
+    ? Object.fromEntries((await gateway.getStrategyTelemetry(strategies)).map((entry) => [entry.strategyId, entry]))
+    : {};
+  const strategyPositions = gateway?.isEnabled?.()
+    ? await gateway.getStrategyPositions(wallet, strategies)
+    : [];
+  const sharesByStrategy = gateway?.isEnabled?.()
+    ? Object.fromEntries(strategyPositions.map((entry) => [entry.strategyId, entry.shares]))
+    : (account.strategyShares ?? {});
+  const pendingByStrategy = gateway?.isEnabled?.()
+    ? Object.fromEntries(strategyPositions.map((entry) => [entry.strategyId, entry]))
+    : (account.strategyPending ?? {});
+  const totalLiquid = sumNumericValues(account.liquid);
+  const debtTotal = sumNumericValues(account.debtOutstanding);
+  const strategyActivity = account.strategyActivity ?? {};
+  const strategyAccounting = account.strategyAccounting ?? {};
+  const positions = strategies.map((strategy) => {
+    const shares = Number(sharesByStrategy[strategy.strategyId] ?? 0);
+    const pendingPosition = pendingByStrategy[strategy.strategyId] ?? {};
+    const sharesRaw = normalizeRawIntegerString(pendingPosition.sharesRaw);
+    const pendingDepositAssets = Number(pendingPosition.pendingDepositAssets ?? 0);
+    const pendingDepositAssetsRaw = normalizeRawIntegerString(pendingPosition.pendingDepositAssetsRaw);
+    const pendingWithdrawalShares = Number(pendingPosition.pendingWithdrawalShares ?? 0);
+    const pendingWithdrawalSharesRaw = normalizeRawIntegerString(pendingPosition.pendingWithdrawalSharesRaw);
+    const lastMovement = strategyActivity[strategy.strategyId];
+    const accounting = strategyAccounting[strategy.strategyId] ?? {};
+    const isMock = String(strategy.kind ?? "").includes("mock");
+    const telemetry = adapterTelemetryByStrategy[strategy.strategyId];
+    const routedAmount = telemetry?.reported && Number.isFinite(Number(telemetry.sharePrice))
+      ? shares * Number(telemetry.sharePrice)
+      : shares;
+    const routedAmountRaw = calculateRoutedAmountRaw(sharesRaw, telemetry);
+    const principalValue = Number(accounting.principal ?? shares);
+    const realizedYield = Number(accounting.realizedYield ?? 0);
+    const unrealizedYield = routedAmount - principalValue;
+    return {
+      strategyId: strategy.strategyId,
+      asset: strategy.asset,
+      assetConfig: strategy.assetConfig,
+      assetSymbol: resolveStrategyAssetSymbol(gateway, strategy),
+      executionMode: strategy.executionMode ?? "sync",
+      shares,
+      ...(sharesRaw !== undefined ? { sharesRaw } : {}),
+      shareCount: shares,
+      pendingDepositAssets,
+      ...(pendingDepositAssetsRaw !== undefined ? { pendingDepositAssetsRaw } : {}),
+      pendingWithdrawalShares,
+      ...(pendingWithdrawalSharesRaw !== undefined ? { pendingWithdrawalSharesRaw } : {}),
+      routedAmount,
+      ...(routedAmountRaw !== undefined ? { routedAmountRaw } : {}),
+      principalValue,
+      ...(accounting.principalRaw !== undefined ? { principalValueRaw: String(accounting.principalRaw) } : {}),
+      ...(accounting.markValueRaw !== undefined ? { markValueRaw: String(accounting.markValueRaw) } : {}),
+      unrealizedYield,
+      realizedYield,
+      ...(accounting.realizedYieldRaw !== undefined ? { realizedYieldRaw: String(accounting.realizedYieldRaw) } : {}),
+      totalYield: realizedYield + unrealizedYield,
+      statusLabel: pendingDepositAssets > 0
+        ? "Pending deposit"
+        : pendingWithdrawalShares > 0
+          ? "Pending withdraw"
+          : shares > 0
+            ? "Routed"
+            : "Idle",
+      yieldReported: Boolean(telemetry?.reported),
+      yieldStatus: telemetry?.reported ? (isMock ? "simulated" : "live") : (isMock ? "simulated_unreported" : "unreported"),
+      yieldLabel: formatAdapterYieldLabel({ telemetry, isMock, shares }),
+      sharePrice: telemetry?.sharePrice,
+      performanceBps: telemetry?.performanceBps,
+      adapterTotalAssets: telemetry?.totalAssets,
+      ...(telemetry?.totalAssetsRaw !== undefined ? { adapterTotalAssetsRaw: String(telemetry.totalAssetsRaw) } : {}),
+      adapterTotalShares: telemetry?.totalShares,
+      ...(telemetry?.totalSharesRaw !== undefined ? { adapterTotalSharesRaw: String(telemetry.totalSharesRaw) } : {}),
+      adapterLinked: true,
+      adapterLinkStatus: shares > 0
+        ? "Wallet capital is now settled into the adapter and priced from live adapter reads."
+        : "Adapter performance is live even when this wallet has no routed capital in the lane.",
+      riskLabel: telemetry?.riskLabel || strategy.riskLabel || "",
+      lastAction: lastMovement?.action,
+      lastMovementAt: lastMovement?.at,
+      attention: buildLaneAttention({
+        shares,
+        isMock,
+        debtTotal,
+        borrowCapacity: Number(borrowCapacity),
+        deploymentShareBps: 0
+      })
+    };
+  });
+  const totalAllocated = positions.reduce((sum, entry) => sum + (Number(entry.routedAmount) || 0), 0);
+  const totalPrincipal = positions.reduce((sum, entry) => sum + (Number(entry.principalValue) || 0), 0);
+  const totalUnrealizedYield = positions.reduce((sum, entry) => sum + (Number(entry.unrealizedYield) || 0), 0);
+  const totalRealizedYield = positions.reduce((sum, entry) => sum + (Number(entry.realizedYield) || 0), 0);
+  const treasuryBase = totalLiquid + totalAllocated;
+  const normalizedPositions = positions.map((entry) => ({
+    ...entry,
+    deploymentShareBps: ratioToBps(Number(entry.routedAmount), totalAllocated),
+    treasuryShareBps: ratioToBps(Number(entry.routedAmount), treasuryBase),
+    attention: buildLaneAttention({
+      shares: Number(entry.routedAmount),
+      isMock: entry.yieldStatus === "simulated" || entry.yieldStatus === "simulated_unreported",
+      debtTotal,
+      borrowCapacity: Number(borrowCapacity),
+      deploymentShareBps: ratioToBps(Number(entry.routedAmount), totalAllocated)
+    })
+  }));
+  const treasuryTimeline = await service.recordStrategySnapshots(
+    wallet,
+    normalizedPositions.map((entry) => ({
+      strategyId: entry.strategyId,
+      asset: entry.asset,
+      assetSymbol: entry.assetSymbol,
+      shares: entry.shares,
+      currentValue: entry.routedAmount,
+      currentValueRaw: entry.routedAmountRaw,
+      sharePrice: entry.sharePrice
+    }))
+  );
+  return {
+    wallet,
+    summary: {
+      treasuryBase,
+      liquid: totalLiquid,
+      allocated: totalAllocated,
+      principal: totalPrincipal,
+      unrealizedYield: totalUnrealizedYield,
+      realizedYield: totalRealizedYield,
+      totalYield: totalRealizedYield + totalUnrealizedYield,
+      debt: debtTotal,
+      borrowCapacity: Number.isFinite(Number(borrowCapacity)) ? Number(borrowCapacity) : undefined,
+      deployedLanes: normalizedPositions.filter((entry) => entry.routedAmount > 0).length,
+      attentionCount: normalizedPositions.filter((entry) => entry.attention).length
+    },
+    positions: normalizedPositions,
+    timeline: (treasuryTimeline ?? []).map(normalizeTimelineEntry)
+  };
+}

--- a/mcp-server/src/protocols/http/account-strategy-view.test.js
+++ b/mcp-server/src/protocols/http/account-strategy-view.test.js
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildAccountStrategiesView,
+  buildLiveStrategyAllocationByAsset,
+  resolveStrategyAssetSymbol
+} from "./account-strategy-view.js";
+
+const GATEWAY = {
+  isEnabled: () => true,
+  config: {
+    supportedAssets: [
+      { address: "0x0000000000000000000000000000000000000abc", symbol: "USDC" },
+      { address: "0x0000000000000000000000000000000000000def", symbol: "DOT" }
+    ]
+  }
+};
+
+test("buildLiveStrategyAllocationByAsset groups live value by resolved asset symbol", () => {
+  const allocation = buildLiveStrategyAllocationByAsset({
+    gateway: GATEWAY,
+    strategies: [
+      { strategyId: "a", asset: "0x0000000000000000000000000000000000000abc" },
+      { strategyId: "b", asset: "0x0000000000000000000000000000000000000abc" },
+      { strategyId: "c", asset: "0x0000000000000000000000000000000000000def" }
+    ],
+    strategyPositions: [
+      { strategyId: "a", shares: 5 },
+      { strategyId: "b", shares: 7 },
+      { strategyId: "c", shares: 3 }
+    ],
+    strategyTelemetry: [
+      { strategyId: "a", reported: true, sharePrice: 2 },
+      { strategyId: "b", reported: false, sharePrice: 99 },
+      { strategyId: "c", reported: true, sharePrice: 4 }
+    ]
+  });
+
+  assert.deepEqual(allocation, {
+    USDC: 17,
+    DOT: 12
+  });
+});
+
+test("resolveStrategyAssetSymbol prefers explicit strategy asset metadata", () => {
+  assert.equal(resolveStrategyAssetSymbol(GATEWAY, {
+    asset: "0x0000000000000000000000000000000000000abc",
+    assetConfig: { symbol: "vUSDC" }
+  }), "vUSDC");
+
+  assert.equal(resolveStrategyAssetSymbol(GATEWAY, {
+    asset: "0x0000000000000000000000000000000000000abc"
+  }), "USDC");
+});
+
+test("buildAccountStrategiesView assembles strategy positions, summary, and normalized timeline", async () => {
+  const calls = [];
+  const gateway = {
+    ...GATEWAY,
+    getStrategyTelemetry: async () => {
+      calls.push(["getStrategyTelemetry"]);
+      return [{
+        strategyId: "default-low-risk",
+        reported: true,
+        sharePrice: 2,
+        performanceBps: 15,
+        totalAssets: 20,
+        totalAssetsRaw: "20000000",
+        totalShares: 10,
+        totalSharesRaw: "10000000",
+        riskLabel: "low"
+      }];
+    },
+    getStrategyPositions: async (wallet) => {
+      calls.push(["getStrategyPositions", wallet]);
+      return [{
+        strategyId: "default-low-risk",
+        shares: 3,
+        sharesRaw: "3000000",
+        pendingDepositAssets: 1,
+        pendingDepositAssetsRaw: "1000000",
+        pendingWithdrawalShares: 0
+      }];
+    }
+  };
+  const service = {
+    recordStrategySnapshots: async (wallet, snapshots) => {
+      calls.push(["recordStrategySnapshots", { wallet, snapshots }]);
+      return [{
+        id: "timeline-1",
+        amountRaw: "120000",
+        realizedYieldDeltaRaw: "3000",
+        requestedSharesRaw: 100n,
+        at: "2026-06-06T10:00:00.000Z"
+      }];
+    }
+  };
+
+  const view = await buildAccountStrategiesView({
+    wallet: "0xabc",
+    account: {
+      liquid: { DOT: 10 },
+      debtOutstanding: { DOT: 2 },
+      strategyShares: {},
+      strategyPending: {},
+      strategyActivity: {
+        "default-low-risk": { action: "allocated", at: "2026-06-01T00:00:00.000Z" }
+      },
+      strategyAccounting: {
+        "default-low-risk": {
+          principal: 5,
+          principalRaw: "5000000",
+          realizedYield: 1,
+          realizedYieldRaw: "1000000"
+        }
+      }
+    },
+    borrowCapacity: 0,
+    gateway,
+    service,
+    strategies: [{
+      strategyId: "default-low-risk",
+      asset: "0x0000000000000000000000000000000000000abc",
+      riskLabel: "medium"
+    }]
+  });
+
+  assert.equal(view.wallet, "0xabc");
+  assert.deepEqual(view.summary, {
+    treasuryBase: 16,
+    liquid: 10,
+    allocated: 6,
+    principal: 5,
+    unrealizedYield: 1,
+    realizedYield: 1,
+    totalYield: 2,
+    debt: 2,
+    borrowCapacity: 0,
+    deployedLanes: 1,
+    attentionCount: 1
+  });
+  assert.equal(view.positions[0].assetSymbol, "USDC");
+  assert.equal(view.positions[0].routedAmount, 6);
+  assert.equal(view.positions[0].routedAmountRaw, "6000000");
+  assert.equal(view.positions[0].statusLabel, "Pending deposit");
+  assert.equal(view.positions[0].yieldStatus, "live");
+  assert.equal(view.positions[0].attention.code, "credit_constrained");
+  assert.deepEqual(view.timeline[0], {
+    id: "timeline-1",
+    type: "treasury_event",
+    strategyId: undefined,
+    asset: "DOT",
+    amount: 0,
+    amountRaw: "120000",
+    yieldDelta: 0,
+    realizedYieldDeltaRaw: "3000",
+    requestedSharesRaw: "100",
+    at: "2026-06-06T10:00:00.000Z"
+  });
+  assert.deepEqual(calls, [
+    ["getStrategyTelemetry"],
+    ["getStrategyPositions", "0xabc"],
+    ["recordStrategySnapshots", {
+      wallet: "0xabc",
+      snapshots: [{
+        strategyId: "default-low-risk",
+        asset: "0x0000000000000000000000000000000000000abc",
+        assetSymbol: "USDC",
+        shares: 3,
+        currentValue: 6,
+        currentValueRaw: "6000000",
+        sharePrice: 2
+      }]
+    }]
+  ]);
+});


### PR DESCRIPTION
## What changed
- Extracted account strategy/timeline response assembly from account-routes.js into account-strategy-view.js.
- Kept account-routes.js focused on HTTP routing, auth, payload parsing, and mutation orchestration.
- Added module-level tests for live allocation grouping, asset symbol resolution, strategy summary assembly, raw-unit preservation, and timeline normalization.

## Checks run
- node --test mcp-server/src/protocols/http/account-strategy-view.test.js
- node --test mcp-server/src/protocols/http/account-routes.test.js
- npm --workspace mcp-server test (849 passing)

## Impact
- Backend only: mcp-server account HTTP read-model refactor.
- No frontend/board, indexer, Caddy, contracts, public site, environment, or VPS secret changes.
- No Polkadot chain behavior change; this only moves existing account strategy response assembly into a dedicated module.