### PR TITLE
refactor: extract job catalog normalization

### DIFF
--- a/mcp-server/src/core/job-catalog-normalization.js
+++ b/mcp-server/src/core/job-catalog-normalization.js
@@ -1,0 +1,421 @@
+import { normalizeAssetSymbol } from "./assets.js";
+import { ValidationError } from "./errors.js";
+import {
+  isBuiltinJobSchemaRef,
+  normalizeExternalSchemaRegistrations
+} from "./job-schema-registry.js";
+
+export const VALID_TIERS = new Set(["starter", "pro", "elite"]);
+export const VALID_VERIFIER_MODES = new Set(["benchmark", "deterministic", "human_fallback", "github_pr"]);
+export const VALID_JOB_TYPES = new Set(["work", "curation", "review", "publish", "verification"]);
+export const VALID_AGENT_ROLES = new Set(["worker", "curator", "reviewer", "publisher", "verifier", "arbitrator"]);
+export const VALID_JOB_LIFECYCLE_STATUSES = new Set(["open", "paused", "archived"]);
+export const DEFAULT_STALE_AFTER_MS = 14 * 24 * 60 * 60 * 1000;
+
+const DEFAULT_ROLE_BY_JOB_TYPE = {
+  work: "worker",
+  curation: "curator",
+  review: "reviewer",
+  publish: "publisher",
+  verification: "verifier"
+};
+
+export function normalizeJobInput(input) {
+  const id = normalizeJobId(input?.id);
+  const category = String(input?.category ?? "").trim().toLowerCase();
+  const tier = String(input?.tier ?? "").trim().toLowerCase();
+  const verifierMode = String(input?.verifierMode ?? "").trim().toLowerCase();
+  const rewardAmount = Number(input?.rewardAmount ?? 0);
+  const claimTtlSeconds = Number(input?.claimTtlSeconds ?? 3600);
+  const retryLimit = Number(input?.retryLimit ?? 1);
+  const rewardAsset = normalizeAssetSymbol(input?.rewardAsset);
+  const jobType = normalizeJobType(input?.jobType);
+  const requiredRole = normalizeAgentRole(input?.requiredRole ?? DEFAULT_ROLE_BY_JOB_TYPE[jobType]);
+
+  if (!id) {
+    throw new ValidationError("Job id is required.");
+  }
+  if (!category) {
+    throw new ValidationError("Category is required.");
+  }
+  if (!VALID_TIERS.has(tier)) {
+    throw new ValidationError(`Invalid tier: ${tier}`);
+  }
+  if (!VALID_VERIFIER_MODES.has(verifierMode)) {
+    throw new ValidationError(`Invalid verifier mode: ${verifierMode}`);
+  }
+  if (!jobType) {
+    throw new ValidationError(`Invalid job type: ${input?.jobType}`);
+  }
+  if (!requiredRole) {
+    throw new ValidationError(`Invalid required role: ${input?.requiredRole}`);
+  }
+  if (!Number.isFinite(rewardAmount) || rewardAmount <= 0) {
+    throw new ValidationError("Reward amount must be greater than zero.");
+  }
+  if (!Number.isInteger(claimTtlSeconds) || claimTtlSeconds < 60) {
+    throw new ValidationError("Claim TTL must be at least 60 seconds.");
+  }
+  if (!Number.isInteger(retryLimit) || retryLimit < 0) {
+    throw new ValidationError("Retry limit must be zero or higher.");
+  }
+
+  const inputSchemaRef = String(input?.inputSchemaRef ?? `schema://jobs/${category}-input`).trim();
+  const outputSchemaRef = String(input?.outputSchemaRef ?? `schema://jobs/${category}-output`).trim();
+  validateSchemaRef(inputSchemaRef, "inputSchemaRef");
+  validateSchemaRef(outputSchemaRef, "outputSchemaRef");
+  const schemaTrustPolicy = normaliseSchemaTrustPolicy(input?.schemaTrustPolicy);
+  const schemaRegistrations = normalizeExternalSchemaRegistrations(input?.schemaRegistrations, {
+    allowedSchemaRefs: [inputSchemaRef, outputSchemaRef],
+    trustedIssuers: schemaTrustPolicy?.trustedIssuers ?? []
+  });
+
+  const parentSessionId = typeof input?.parentSessionId === "string"
+    ? input.parentSessionId.trim()
+    : "";
+  const recurring = Boolean(input?.recurring);
+  const schedule = normaliseSchedule(input?.schedule, recurring);
+  const title = normaliseTextField(input?.title);
+  const description = normaliseTextField(input?.description);
+  const acceptanceCriteria = normaliseStringList(input?.acceptanceCriteria);
+  const agentInstructions = normaliseStringList(input?.agentInstructions);
+  const estimatedDifficulty = normaliseTextField(input?.estimatedDifficulty);
+  const source = normalisePlainObject(input?.source, "source");
+  const verification = normalisePlainObject(input?.verification, "verification");
+  const delegationPolicy = normaliseDelegationPolicy(input?.delegationPolicy, { rewardAmount, rewardAsset });
+  const lineage = normalisePlainObject(input?.lineage, "lineage");
+  const lifecycle = normaliseLifecycle(input?.lifecycle, { disableStale: recurring });
+  const recurringPolicy = normaliseRecurringPolicy(input?.recurringPolicy, {
+    recurring,
+    rewardAmount,
+    rewardAsset
+  });
+
+  return {
+    id,
+    category,
+    tier,
+    jobType,
+    requiredRole,
+    rewardAsset,
+    rewardAmount,
+    verifierMode,
+    verifierConfig: buildVerifierConfig(verifierMode, input),
+    inputSchemaRef,
+    outputSchemaRef,
+    ...(schemaRegistrations.length ? { schemaRegistrations } : {}),
+    ...(schemaTrustPolicy ? { schemaTrustPolicy } : {}),
+    claimTtlSeconds,
+    retryLimit,
+    requiresSponsoredGas: Boolean(input?.requiresSponsoredGas),
+    lifecycle,
+    ...(title ? { title } : {}),
+    ...(description ? { description } : {}),
+    ...(source ? { source } : {}),
+    ...(acceptanceCriteria.length ? { acceptanceCriteria } : {}),
+    ...(estimatedDifficulty ? { estimatedDifficulty } : {}),
+    ...(agentInstructions.length ? { agentInstructions } : {}),
+    ...(verification ? { verification } : {}),
+    ...(delegationPolicy ? { delegationPolicy } : {}),
+    ...(lineage ? { lineage } : {}),
+    ...(parentSessionId ? { parentSessionId } : {}),
+    ...(recurring ? { recurring: true } : {}),
+    ...(schedule ? { schedule } : {}),
+    ...(recurringPolicy ? { recurringPolicy } : {})
+  };
+}
+
+export function buildVerifierConfig(verifierMode, input) {
+  const verifierTerms = Array.isArray(input?.verifierTerms)
+    ? input.verifierTerms.map((value) => String(value).trim()).filter(Boolean)
+    : [];
+
+  if (verifierMode === "benchmark") {
+    const minimumMatches = Number(input?.verifierMinimumMatches ?? Math.min(verifierTerms.length || 1, 2));
+    if (!verifierTerms.length) {
+      throw new ValidationError("Benchmark jobs need at least one verifier keyword.");
+    }
+    if (!Number.isInteger(minimumMatches) || minimumMatches < 1) {
+      throw new ValidationError("Benchmark minimum matches must be at least 1.");
+    }
+    return {
+      version: 1,
+      handler: "benchmark",
+      requiredKeywords: verifierTerms,
+      minimumMatches: Math.min(minimumMatches, verifierTerms.length)
+    };
+  }
+
+  if (verifierMode === "deterministic") {
+    const matchMode = String(input?.verifierMatchMode ?? "contains_all").trim();
+    if (!verifierTerms.length) {
+      throw new ValidationError("Deterministic jobs need at least one expected output.");
+    }
+    if (!["exact", "contains_all"].includes(matchMode)) {
+      throw new ValidationError(`Invalid deterministic match mode: ${matchMode}`);
+    }
+    return {
+      version: 1,
+      handler: "deterministic",
+      expectedOutputs: verifierTerms,
+      matchMode
+    };
+  }
+
+  if (verifierMode === "github_pr") {
+    const minimumScore = Number(input?.verifierMinimumScore ?? input?.minimumScore ?? 60);
+    if (!Number.isInteger(minimumScore) || minimumScore < 1 || minimumScore > 100) {
+      throw new ValidationError("GitHub PR verifier minimum score must be an integer from 1 to 100.");
+    }
+    return {
+      version: 1,
+      handler: "github_pr",
+      minimumScore,
+      requireIssueReference: input?.requireIssueReference !== false,
+      requireTestEvidence: input?.requireTestEvidence !== false,
+      acceptMergedAsApproved: input?.acceptMergedAsApproved !== false
+    };
+  }
+
+  return {
+    version: 1,
+    handler: "human_fallback",
+    escalationMessage: String(input?.escalationMessage ?? "Escalate to human reviewer.").trim(),
+    autoApprove: Boolean(input?.autoApprove)
+  };
+}
+
+export function normalizeJobId(value) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function validateSchemaRef(value, field) {
+  if (!/^schema:\/\/jobs\/[a-z0-9-]+$/u.test(value)) {
+    throw new ValidationError(`${field} must be a schema://jobs/<name> ref.`);
+  }
+  if (isBuiltinJobSchemaRef(value)) {
+    return;
+  }
+}
+
+export function normaliseSchedule(raw, recurring) {
+  if (!raw && !recurring) return undefined;
+  if (!raw) {
+    throw new ValidationError("recurring jobs must include a schedule");
+  }
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw new ValidationError("schedule must be an object");
+  }
+  const cron = typeof raw.cron === "string" ? raw.cron.trim() : "";
+  if (!cron) {
+    throw new ValidationError("schedule.cron is required for recurring jobs");
+  }
+  const parts = cron.split(/\s+/u);
+  if (parts.length !== 5) {
+    throw new ValidationError(`schedule.cron must have 5 fields; got: "${cron}"`);
+  }
+  const normalised = { cron };
+  if (typeof raw.timezone === "string" && raw.timezone.trim()) {
+    normalised.timezone = raw.timezone.trim();
+  }
+  for (const key of ["startAt", "endAt"]) {
+    if (typeof raw[key] === "string" && raw[key].trim()) {
+      const parsed = Date.parse(raw[key]);
+      if (Number.isNaN(parsed)) {
+        throw new ValidationError(`schedule.${key} must be ISO-8601 if provided`);
+      }
+      normalised[key] = new Date(parsed).toISOString();
+    }
+  }
+  return normalised;
+}
+
+export function normaliseRecurringPolicy(raw, { recurring, rewardAmount, rewardAsset }) {
+  if (!raw) {
+    return undefined;
+  }
+  if (!recurring) {
+    throw new ValidationError("recurringPolicy is only valid for recurring jobs");
+  }
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw new ValidationError("recurringPolicy must be an object if provided.");
+  }
+
+  const policy = {};
+  if (raw.reserveAmount !== undefined && raw.reserveAmount !== null && raw.reserveAmount !== "") {
+    const reserveAmount = Number(raw.reserveAmount);
+    if (!Number.isFinite(reserveAmount) || reserveAmount <= 0) {
+      throw new ValidationError("recurringPolicy.reserveAmount must be greater than zero.");
+    }
+    if (reserveAmount < rewardAmount) {
+      throw new ValidationError("recurringPolicy.reserveAmount must cover at least one run.");
+    }
+    policy.reserveAmount = reserveAmount;
+    policy.reserveAsset = typeof raw.reserveAsset === "string" && raw.reserveAsset.trim()
+      ? normalizeAssetSymbol(raw.reserveAsset)
+      : rewardAsset;
+    if (policy.reserveAsset !== rewardAsset) {
+      throw new ValidationError("recurringPolicy.reserveAsset must match rewardAsset.");
+    }
+  }
+
+  if (raw.maxRuns !== undefined && raw.maxRuns !== null && raw.maxRuns !== "") {
+    const maxRuns = Number(raw.maxRuns);
+    if (!Number.isInteger(maxRuns) || maxRuns < 1) {
+      throw new ValidationError("recurringPolicy.maxRuns must be a positive integer.");
+    }
+    policy.maxRuns = maxRuns;
+    const impliedReserve = maxRuns * rewardAmount;
+    if (policy.reserveAmount === undefined) {
+      policy.reserveAmount = impliedReserve;
+      policy.reserveAsset = rewardAsset;
+    } else if (policy.reserveAmount < impliedReserve) {
+      throw new ValidationError("recurringPolicy.reserveAmount must cover maxRuns * rewardAmount.");
+    }
+  }
+
+  return Object.keys(policy).length ? policy : undefined;
+}
+
+export function normaliseDelegationPolicy(raw, { rewardAmount, rewardAsset }) {
+  if (!raw) {
+    return undefined;
+  }
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw new ValidationError("delegationPolicy must be an object if provided.");
+  }
+
+  const policy = {};
+  if (raw.maxDepth !== undefined && raw.maxDepth !== null && raw.maxDepth !== "") {
+    const maxDepth = Number(raw.maxDepth);
+    if (!Number.isInteger(maxDepth) || maxDepth < 0) {
+      throw new ValidationError("delegationPolicy.maxDepth must be a non-negative integer.");
+    }
+    policy.maxDepth = maxDepth;
+  }
+  if (raw.maxSubJobs !== undefined && raw.maxSubJobs !== null && raw.maxSubJobs !== "") {
+    const maxSubJobs = Number(raw.maxSubJobs);
+    if (!Number.isInteger(maxSubJobs) || maxSubJobs < 1) {
+      throw new ValidationError("delegationPolicy.maxSubJobs must be a positive integer.");
+    }
+    policy.maxSubJobs = maxSubJobs;
+  }
+  if (raw.budgetAmount !== undefined && raw.budgetAmount !== null && raw.budgetAmount !== "") {
+    const budgetAmount = Number(raw.budgetAmount);
+    if (!Number.isFinite(budgetAmount) || budgetAmount < 0) {
+      throw new ValidationError("delegationPolicy.budgetAmount must be zero or higher.");
+    }
+    if (budgetAmount > rewardAmount) {
+      throw new ValidationError("delegationPolicy.budgetAmount cannot exceed rewardAmount.");
+    }
+    policy.budgetAmount = budgetAmount;
+    policy.budgetAsset = typeof raw.budgetAsset === "string" && raw.budgetAsset.trim()
+      ? normalizeAssetSymbol(raw.budgetAsset)
+      : rewardAsset;
+    if (policy.budgetAsset !== rewardAsset) {
+      throw new ValidationError("delegationPolicy.budgetAsset must match rewardAsset.");
+    }
+  }
+
+  return Object.keys(policy).length ? policy : undefined;
+}
+
+export function normalizeJobType(value) {
+  const normalised = String(value ?? "work").trim().toLowerCase();
+  return VALID_JOB_TYPES.has(normalised) ? normalised : undefined;
+}
+
+export function normalizeAgentRole(value) {
+  const normalised = String(value ?? "worker").trim().toLowerCase();
+  return VALID_AGENT_ROLES.has(normalised) ? normalised : undefined;
+}
+
+export function effectiveJobType(job) {
+  return normalizeJobType(job?.jobType) ?? "work";
+}
+
+export function effectiveRequiredRole(job) {
+  return normalizeAgentRole(job?.requiredRole) ?? DEFAULT_ROLE_BY_JOB_TYPE[effectiveJobType(job)] ?? "worker";
+}
+
+export function normaliseTextField(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function normaliseStringList(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map((entry) => String(entry).trim()).filter(Boolean);
+}
+
+export function normalisePlainObject(value, field) {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new ValidationError(`${field} must be an object if provided.`);
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
+export function normaliseSchemaTrustPolicy(value) {
+  const raw = normalisePlainObject(value, "schemaTrustPolicy");
+  if (!raw) {
+    return undefined;
+  }
+  const trustedIssuers = normaliseStringList(raw.trustedIssuers);
+  return trustedIssuers.length ? { trustedIssuers } : undefined;
+}
+
+export function normaliseLifecycle(value, { disableStale = false, now = new Date() } = {}) {
+  const raw = normalisePlainObject(value, "lifecycle") ?? {};
+  const createdAt = typeof raw.createdAt === "string" && raw.createdAt.trim()
+    ? normalizeIsoTimestamp(raw.createdAt, "lifecycle.createdAt")
+    : now.toISOString();
+  const updatedAt = typeof raw.updatedAt === "string" && raw.updatedAt.trim()
+    ? normalizeIsoTimestamp(raw.updatedAt, "lifecycle.updatedAt")
+    : createdAt;
+  const status = typeof raw.status === "string" && raw.status.trim()
+    ? raw.status.trim().toLowerCase()
+    : "open";
+  if (!VALID_JOB_LIFECYCLE_STATUSES.has(status)) {
+    throw new ValidationError(`Invalid job lifecycle status: ${status}`);
+  }
+  const lifecycle = {
+    status,
+    createdAt,
+    updatedAt
+  };
+  const defaultStaleAt = disableStale
+    ? undefined
+    : new Date(Date.parse(createdAt) + DEFAULT_STALE_AFTER_MS).toISOString();
+  const staleAt = typeof raw.staleAt === "string" && raw.staleAt.trim()
+    ? normalizeIsoTimestamp(raw.staleAt, "lifecycle.staleAt")
+    : defaultStaleAt;
+  if (staleAt) lifecycle.staleAt = staleAt;
+
+  for (const key of ["pausedAt", "archivedAt", "reopenedAt"]) {
+    if (typeof raw[key] === "string" && raw[key].trim()) {
+      lifecycle[key] = normalizeIsoTimestamp(raw[key], `lifecycle.${key}`);
+    }
+  }
+  for (const key of ["reason", "staleReason"]) {
+    if (typeof raw[key] === "string" && raw[key].trim()) {
+      lifecycle[key] = raw[key].trim().slice(0, 500);
+    }
+  }
+  return lifecycle;
+}
+
+export function normalizeIsoTimestamp(value, field) {
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) {
+    throw new ValidationError(`${field} must be ISO-8601 if provided.`);
+  }
+  return new Date(parsed).toISOString();
+}

--- a/mcp-server/src/core/job-catalog-normalization.test.js
+++ b/mcp-server/src/core/job-catalog-normalization.test.js
@@ -1,0 +1,147 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { ValidationError } from "./errors.js";
+import {
+  buildVerifierConfig,
+  normalizeJobId,
+  normalizeJobInput,
+  normaliseDelegationPolicy,
+  normaliseLifecycle,
+  normaliseRecurringPolicy,
+  validateSchemaRef
+} from "./job-catalog-normalization.js";
+
+const BASE_JOB = {
+  id: " GitHub Issue Review 001 ",
+  category: " Coding ",
+  tier: "starter",
+  rewardAmount: 1.5,
+  verifierMode: "benchmark",
+  verifierTerms: ["github", "tests", "pr"],
+  verifierMinimumMatches: 2,
+  inputSchemaRef: "schema://jobs/coding-input",
+  outputSchemaRef: "schema://jobs/coding-output",
+  lifecycle: {
+    createdAt: "2026-05-01T12:00:00.000Z"
+  }
+};
+
+test("normalizeJobInput returns the canonical job record shape", () => {
+  const job = normalizeJobInput({
+    ...BASE_JOB,
+    jobType: "review",
+    requiredRole: "reviewer",
+    rewardAsset: "usdc",
+    source: { type: "github_issue", repo: "example/project" },
+    acceptanceCriteria: [" Open a PR ", "", "Run tests"],
+    agentInstructions: ["Keep the patch narrow."],
+    delegationPolicy: {
+      maxDepth: 1,
+      maxSubJobs: 2,
+      budgetAmount: 1,
+      budgetAsset: "USDC"
+    }
+  });
+
+  assert.equal(job.id, "github-issue-review-001");
+  assert.equal(job.category, "coding");
+  assert.equal(job.rewardAsset, "USDC");
+  assert.equal(job.jobType, "review");
+  assert.equal(job.requiredRole, "reviewer");
+  assert.deepEqual(job.acceptanceCriteria, ["Open a PR", "Run tests"]);
+  assert.deepEqual(job.source, { type: "github_issue", repo: "example/project" });
+  assert.deepEqual(job.delegationPolicy, {
+    maxDepth: 1,
+    maxSubJobs: 2,
+    budgetAmount: 1,
+    budgetAsset: "USDC"
+  });
+  assert.deepEqual(job.verifierConfig, {
+    version: 1,
+    handler: "benchmark",
+    requiredKeywords: ["github", "tests", "pr"],
+    minimumMatches: 2
+  });
+  assert.equal(job.lifecycle.createdAt, "2026-05-01T12:00:00.000Z");
+  assert.equal(job.lifecycle.staleAt, "2026-05-15T12:00:00.000Z");
+});
+
+test("normalizeJobInput preserves recurring schedule and finite reserve policy", () => {
+  const job = normalizeJobInput({
+    ...BASE_JOB,
+    id: "weekly-digest",
+    rewardAmount: 5,
+    recurring: true,
+    schedule: { cron: "0 9 * * 1", timezone: "Europe/Zurich" },
+    recurringPolicy: { maxRuns: 3 }
+  });
+
+  assert.equal(job.recurring, true);
+  assert.deepEqual(job.schedule, { cron: "0 9 * * 1", timezone: "Europe/Zurich" });
+  assert.deepEqual(job.recurringPolicy, {
+    maxRuns: 3,
+    reserveAmount: 15,
+    reserveAsset: "USDC"
+  });
+  assert.equal(job.lifecycle.staleAt, undefined);
+});
+
+test("buildVerifierConfig supports deterministic, github_pr, and human fallback modes", () => {
+  assert.deepEqual(
+    buildVerifierConfig("deterministic", {
+      verifierTerms: ["expected output"],
+      verifierMatchMode: "exact"
+    }),
+    {
+      version: 1,
+      handler: "deterministic",
+      expectedOutputs: ["expected output"],
+      matchMode: "exact"
+    }
+  );
+  assert.deepEqual(
+    buildVerifierConfig("github_pr", { verifierMinimumScore: 70, requireTestEvidence: false }),
+    {
+      version: 1,
+      handler: "github_pr",
+      minimumScore: 70,
+      requireIssueReference: true,
+      requireTestEvidence: false,
+      acceptMergedAsApproved: true
+    }
+  );
+  assert.deepEqual(
+    buildVerifierConfig("human_fallback", { escalationMessage: "Please review.", autoApprove: true }),
+    {
+      version: 1,
+      handler: "human_fallback",
+      escalationMessage: "Please review.",
+      autoApprove: true
+    }
+  );
+});
+
+test("policy helpers reject invalid budget, reserve, lifecycle, and schema shapes", () => {
+  assert.throws(
+    () => normaliseDelegationPolicy({ budgetAmount: 2 }, { rewardAmount: 1, rewardAsset: "DOT" }),
+    (err) => err instanceof ValidationError && /cannot exceed rewardAmount/.test(err.message)
+  );
+  assert.throws(
+    () => normaliseRecurringPolicy({ reserveAmount: 4 }, { recurring: true, rewardAmount: 5, rewardAsset: "DOT" }),
+    (err) => err instanceof ValidationError && /cover at least one run/.test(err.message)
+  );
+  assert.throws(
+    () => normaliseLifecycle({ status: "closed" }),
+    (err) => err instanceof ValidationError && /Invalid job lifecycle status/.test(err.message)
+  );
+  assert.throws(
+    () => validateSchemaRef("https://example.com/schema.json", "outputSchemaRef"),
+    (err) => err instanceof ValidationError && /schema:\/\/jobs/.test(err.message)
+  );
+});
+
+test("normalizeJobId preserves the catalog slug semantics", () => {
+  assert.equal(normalizeJobId("  Some Job: 123 "), "some-job-123");
+  assert.equal(normalizeJobId("!!!"), "");
+});

--- a/mcp-server/src/core/job-catalog-service.js
+++ b/mcp-server/src/core/job-catalog-service.js
@@ -4,16 +4,26 @@ import {
   ValidationError
 } from "./errors.js";
 import {
-  getBuiltinJobSchema,
   getJobSchema,
   getRegisteredJobSchemaRegistration,
   isBuiltinJobSchemaRef,
   isRegisteredJobSchemaRef,
-  normalizeExternalSchemaRegistrations,
   schemaRefToJobSchemaPath
 } from "./job-schema-registry.js";
+import {
+  DEFAULT_STALE_AFTER_MS,
+  VALID_AGENT_ROLES,
+  VALID_JOB_LIFECYCLE_STATUSES,
+  VALID_TIERS,
+  effectiveJobType,
+  effectiveRequiredRole,
+  normaliseLifecycle,
+  normalisePlainObject,
+  normalizeIsoTimestamp,
+  normalizeJobId,
+  normalizeJobInput as normalizeCatalogJobInput
+} from "./job-catalog-normalization.js";
 import { buildVerificationContract } from "./verifier-contract.js";
-import { normalizeAssetSymbol } from "./assets.js";
 
 const DEFAULT_AGENT_PROFILE = {
   capabilities: ["claim_job", "submit_work", "allocate_idle_funds"],
@@ -25,13 +35,6 @@ const DEFAULT_AGENT_PROFILE = {
   autoUnwindStrategies: false
 };
 
-const VALID_TIERS = new Set(["starter", "pro", "elite"]);
-const VALID_VERIFIER_MODES = new Set(["benchmark", "deterministic", "human_fallback", "github_pr"]);
-const VALID_JOB_TYPES = new Set(["work", "curation", "review", "publish", "verification"]);
-const VALID_AGENT_ROLES = new Set(["worker", "curator", "reviewer", "publisher", "verifier", "arbitrator"]);
-const VALID_JOB_LIFECYCLE_STATUSES = new Set(["open", "paused", "archived"]);
-const DEFAULT_STALE_AFTER_MS = 14 * 24 * 60 * 60 * 1000;
-
 export const ROLE_REQUIREMENTS = {
   worker: { skill: 0 },
   curator: { skill: 50 },
@@ -39,14 +42,6 @@ export const ROLE_REQUIREMENTS = {
   publisher: { skill: 200 },
   verifier: { skill: 300 },
   arbitrator: { skill: 500 }
-};
-
-const DEFAULT_ROLE_BY_JOB_TYPE = {
-  work: "worker",
-  curation: "curator",
-  review: "reviewer",
-  publish: "publisher",
-  verification: "verifier"
 };
 
 /**
@@ -661,119 +656,7 @@ export class JobCatalogService {
   }
 
   normalizeJobInput(input) {
-    const id = this.normalizeId(input?.id);
-    const category = String(input?.category ?? "").trim().toLowerCase();
-    const tier = String(input?.tier ?? "").trim().toLowerCase();
-    const verifierMode = String(input?.verifierMode ?? "").trim().toLowerCase();
-    const rewardAmount = Number(input?.rewardAmount ?? 0);
-    const claimTtlSeconds = Number(input?.claimTtlSeconds ?? 3600);
-    const retryLimit = Number(input?.retryLimit ?? 1);
-    const rewardAsset = normalizeAssetSymbol(input?.rewardAsset);
-    const jobType = normalizeJobType(input?.jobType);
-    const requiredRole = normalizeAgentRole(input?.requiredRole ?? DEFAULT_ROLE_BY_JOB_TYPE[jobType]);
-
-    if (!id) {
-      throw new ValidationError("Job id is required.");
-    }
-    if (!category) {
-      throw new ValidationError("Category is required.");
-    }
-    if (!VALID_TIERS.has(tier)) {
-      throw new ValidationError(`Invalid tier: ${tier}`);
-    }
-    if (!VALID_VERIFIER_MODES.has(verifierMode)) {
-      throw new ValidationError(`Invalid verifier mode: ${verifierMode}`);
-    }
-    if (!jobType) {
-      throw new ValidationError(`Invalid job type: ${input?.jobType}`);
-    }
-    if (!requiredRole) {
-      throw new ValidationError(`Invalid required role: ${input?.requiredRole}`);
-    }
-    if (!Number.isFinite(rewardAmount) || rewardAmount <= 0) {
-      throw new ValidationError("Reward amount must be greater than zero.");
-    }
-    if (!Number.isInteger(claimTtlSeconds) || claimTtlSeconds < 60) {
-      throw new ValidationError("Claim TTL must be at least 60 seconds.");
-    }
-    if (!Number.isInteger(retryLimit) || retryLimit < 0) {
-      throw new ValidationError("Retry limit must be zero or higher.");
-    }
-
-    const inputSchemaRef = String(input?.inputSchemaRef ?? `schema://jobs/${category}-input`).trim();
-    const outputSchemaRef = String(input?.outputSchemaRef ?? `schema://jobs/${category}-output`).trim();
-    this.validateSchemaRef(inputSchemaRef, "inputSchemaRef");
-    this.validateSchemaRef(outputSchemaRef, "outputSchemaRef");
-    const schemaTrustPolicy = normaliseSchemaTrustPolicy(input?.schemaTrustPolicy);
-    const schemaRegistrations = normalizeExternalSchemaRegistrations(input?.schemaRegistrations, {
-      allowedSchemaRefs: [inputSchemaRef, outputSchemaRef],
-      trustedIssuers: schemaTrustPolicy?.trustedIssuers ?? []
-    });
-
-    // Optional sub-job lineage. When an agent spawns a sub-job from inside
-    // its own session, include `parentSessionId` so the indexer + profile
-    // surfaces can reconstruct who hired whom. We validate the shape but
-    // do not enforce that it points to a real session — state-store
-    // consistency is surfaced by the dashboard, not the contract.
-    const parentSessionId = typeof input?.parentSessionId === "string"
-      ? input.parentSessionId.trim()
-      : "";
-
-    // Optional recurring-job schedule. v1 just normalises + validates the
-    // schedule field; the actual scheduler worker is a follow-up (see
-    // docs/patterns/recurring-jobs.md). A recurring template is a job
-    // record with `recurring: true` and a cron-style `schedule.cron`
-    // expression; each firing mints a derivative job with its own id.
-    const recurring = Boolean(input?.recurring);
-    const schedule = normaliseSchedule(input?.schedule, recurring);
-    const title = normaliseTextField(input?.title);
-    const description = normaliseTextField(input?.description);
-    const acceptanceCriteria = normaliseStringList(input?.acceptanceCriteria);
-    const agentInstructions = normaliseStringList(input?.agentInstructions);
-    const estimatedDifficulty = normaliseTextField(input?.estimatedDifficulty);
-    const source = normalisePlainObject(input?.source, "source");
-    const verification = normalisePlainObject(input?.verification, "verification");
-    const delegationPolicy = normaliseDelegationPolicy(input?.delegationPolicy, { rewardAmount, rewardAsset });
-    const lineage = normalisePlainObject(input?.lineage, "lineage");
-    const lifecycle = normaliseLifecycle(input?.lifecycle, { disableStale: recurring });
-    const recurringPolicy = normaliseRecurringPolicy(input?.recurringPolicy, {
-      recurring,
-      rewardAmount,
-      rewardAsset
-    });
-
-    return {
-      id,
-      category,
-      tier,
-      jobType,
-      requiredRole,
-      rewardAsset,
-      rewardAmount,
-      verifierMode,
-      verifierConfig: this.buildVerifierConfig(verifierMode, input),
-      inputSchemaRef,
-      outputSchemaRef,
-      ...(schemaRegistrations.length ? { schemaRegistrations } : {}),
-      ...(schemaTrustPolicy ? { schemaTrustPolicy } : {}),
-      claimTtlSeconds,
-      retryLimit,
-      requiresSponsoredGas: Boolean(input?.requiresSponsoredGas),
-      lifecycle,
-      ...(title ? { title } : {}),
-      ...(description ? { description } : {}),
-      ...(source ? { source } : {}),
-      ...(acceptanceCriteria.length ? { acceptanceCriteria } : {}),
-      ...(estimatedDifficulty ? { estimatedDifficulty } : {}),
-      ...(agentInstructions.length ? { agentInstructions } : {}),
-      ...(verification ? { verification } : {}),
-      ...(delegationPolicy ? { delegationPolicy } : {}),
-      ...(lineage ? { lineage } : {}),
-      ...(parentSessionId ? { parentSessionId } : {}),
-      ...(recurring ? { recurring: true } : {}),
-      ...(schedule ? { schedule } : {}),
-      ...(recurringPolicy ? { recurringPolicy } : {})
-    };
+    return normalizeCatalogJobInput(input);
   }
 
   /**
@@ -856,316 +739,9 @@ export class JobCatalogService {
     return derivative;
   }
 
-  buildVerifierConfig(verifierMode, input) {
-    const verifierTerms = Array.isArray(input?.verifierTerms)
-      ? input.verifierTerms.map((value) => String(value).trim()).filter(Boolean)
-      : [];
-
-    if (verifierMode === "benchmark") {
-      const minimumMatches = Number(input?.verifierMinimumMatches ?? Math.min(verifierTerms.length || 1, 2));
-      if (!verifierTerms.length) {
-        throw new ValidationError("Benchmark jobs need at least one verifier keyword.");
-      }
-      if (!Number.isInteger(minimumMatches) || minimumMatches < 1) {
-        throw new ValidationError("Benchmark minimum matches must be at least 1.");
-      }
-      return {
-        version: 1,
-        handler: "benchmark",
-        requiredKeywords: verifierTerms,
-        minimumMatches: Math.min(minimumMatches, verifierTerms.length)
-      };
-    }
-
-    if (verifierMode === "deterministic") {
-      const matchMode = String(input?.verifierMatchMode ?? "contains_all").trim();
-      if (!verifierTerms.length) {
-        throw new ValidationError("Deterministic jobs need at least one expected output.");
-      }
-      if (!["exact", "contains_all"].includes(matchMode)) {
-        throw new ValidationError(`Invalid deterministic match mode: ${matchMode}`);
-      }
-      return {
-        version: 1,
-        handler: "deterministic",
-        expectedOutputs: verifierTerms,
-        matchMode
-      };
-    }
-
-    if (verifierMode === "github_pr") {
-      const minimumScore = Number(input?.verifierMinimumScore ?? input?.minimumScore ?? 60);
-      if (!Number.isInteger(minimumScore) || minimumScore < 1 || minimumScore > 100) {
-        throw new ValidationError("GitHub PR verifier minimum score must be an integer from 1 to 100.");
-      }
-      return {
-        version: 1,
-        handler: "github_pr",
-        minimumScore,
-        requireIssueReference: input?.requireIssueReference !== false,
-        requireTestEvidence: input?.requireTestEvidence !== false,
-        acceptMergedAsApproved: input?.acceptMergedAsApproved !== false
-      };
-    }
-
-    return {
-      version: 1,
-      handler: "human_fallback",
-      escalationMessage: String(input?.escalationMessage ?? "Escalate to human reviewer.").trim(),
-      autoApprove: Boolean(input?.autoApprove)
-    };
-  }
-
   normalizeId(value) {
-    return String(value ?? "")
-      .trim()
-      .toLowerCase()
-      .replace(/[^a-z0-9-]+/g, "-")
-      .replace(/^-+|-+$/g, "");
+    return normalizeJobId(value);
   }
-
-  validateSchemaRef(value, field) {
-    if (!/^schema:\/\/jobs\/[a-z0-9-]+$/u.test(value)) {
-      throw new ValidationError(`${field} must be a schema://jobs/<name> ref.`);
-    }
-    // Built-in schemas are first-class and used for structured submission
-    // validation. Unknown refs are still allowed so custom/off-platform schema
-    // contracts remain usable, but callers won't get structured validation
-    // unless the schema is registered here.
-    if (isBuiltinJobSchemaRef(value)) {
-      return;
-    }
-  }
-}
-
-/**
- * Validate an input schedule block and return a canonicalised copy, or
- * undefined when the caller didn't supply one. Requires a 5-field cron
- * string; the scheduler worker (future) reads `schedule.cron`. Other
- * fields (`timezone`, `startAt`, `endAt`) are recorded but not yet
- * enforced — documented as v2 in docs/patterns/recurring-jobs.md.
- */
-function normaliseSchedule(raw, recurring) {
-  if (!raw && !recurring) return undefined;
-  if (!raw) {
-    throw new ValidationError("recurring jobs must include a schedule");
-  }
-  if (typeof raw !== "object" || Array.isArray(raw)) {
-    throw new ValidationError("schedule must be an object");
-  }
-  const cron = typeof raw.cron === "string" ? raw.cron.trim() : "";
-  if (!cron) {
-    throw new ValidationError("schedule.cron is required for recurring jobs");
-  }
-  const parts = cron.split(/\s+/u);
-  if (parts.length !== 5) {
-    throw new ValidationError(`schedule.cron must have 5 fields; got: "${cron}"`);
-  }
-  const normalised = { cron };
-  if (typeof raw.timezone === "string" && raw.timezone.trim()) {
-    normalised.timezone = raw.timezone.trim();
-  }
-  for (const key of ["startAt", "endAt"]) {
-    if (typeof raw[key] === "string" && raw[key].trim()) {
-      const parsed = Date.parse(raw[key]);
-      if (Number.isNaN(parsed)) {
-        throw new ValidationError(`schedule.${key} must be ISO-8601 if provided`);
-      }
-      normalised[key] = new Date(parsed).toISOString();
-    }
-  }
-  return normalised;
-}
-
-function normaliseRecurringPolicy(raw, { recurring, rewardAmount, rewardAsset }) {
-  if (!raw) {
-    return undefined;
-  }
-  if (!recurring) {
-    throw new ValidationError("recurringPolicy is only valid for recurring jobs");
-  }
-  if (typeof raw !== "object" || Array.isArray(raw)) {
-    throw new ValidationError("recurringPolicy must be an object if provided.");
-  }
-
-  const policy = {};
-  if (raw.reserveAmount !== undefined && raw.reserveAmount !== null && raw.reserveAmount !== "") {
-    const reserveAmount = Number(raw.reserveAmount);
-    if (!Number.isFinite(reserveAmount) || reserveAmount <= 0) {
-      throw new ValidationError("recurringPolicy.reserveAmount must be greater than zero.");
-    }
-    if (reserveAmount < rewardAmount) {
-      throw new ValidationError("recurringPolicy.reserveAmount must cover at least one run.");
-    }
-    policy.reserveAmount = reserveAmount;
-    policy.reserveAsset = typeof raw.reserveAsset === "string" && raw.reserveAsset.trim()
-      ? normalizeAssetSymbol(raw.reserveAsset)
-      : rewardAsset;
-    if (policy.reserveAsset !== rewardAsset) {
-      throw new ValidationError("recurringPolicy.reserveAsset must match rewardAsset.");
-    }
-  }
-
-  if (raw.maxRuns !== undefined && raw.maxRuns !== null && raw.maxRuns !== "") {
-    const maxRuns = Number(raw.maxRuns);
-    if (!Number.isInteger(maxRuns) || maxRuns < 1) {
-      throw new ValidationError("recurringPolicy.maxRuns must be a positive integer.");
-    }
-    policy.maxRuns = maxRuns;
-    const impliedReserve = maxRuns * rewardAmount;
-    if (policy.reserveAmount === undefined) {
-      policy.reserveAmount = impliedReserve;
-      policy.reserveAsset = rewardAsset;
-    } else if (policy.reserveAmount < impliedReserve) {
-      throw new ValidationError("recurringPolicy.reserveAmount must cover maxRuns * rewardAmount.");
-    }
-  }
-
-  return Object.keys(policy).length ? policy : undefined;
-}
-
-function normaliseDelegationPolicy(raw, { rewardAmount, rewardAsset }) {
-  if (!raw) {
-    return undefined;
-  }
-  if (typeof raw !== "object" || Array.isArray(raw)) {
-    throw new ValidationError("delegationPolicy must be an object if provided.");
-  }
-
-  const policy = {};
-  if (raw.maxDepth !== undefined && raw.maxDepth !== null && raw.maxDepth !== "") {
-    const maxDepth = Number(raw.maxDepth);
-    if (!Number.isInteger(maxDepth) || maxDepth < 0) {
-      throw new ValidationError("delegationPolicy.maxDepth must be a non-negative integer.");
-    }
-    policy.maxDepth = maxDepth;
-  }
-  if (raw.maxSubJobs !== undefined && raw.maxSubJobs !== null && raw.maxSubJobs !== "") {
-    const maxSubJobs = Number(raw.maxSubJobs);
-    if (!Number.isInteger(maxSubJobs) || maxSubJobs < 1) {
-      throw new ValidationError("delegationPolicy.maxSubJobs must be a positive integer.");
-    }
-    policy.maxSubJobs = maxSubJobs;
-  }
-  if (raw.budgetAmount !== undefined && raw.budgetAmount !== null && raw.budgetAmount !== "") {
-    const budgetAmount = Number(raw.budgetAmount);
-    if (!Number.isFinite(budgetAmount) || budgetAmount < 0) {
-      throw new ValidationError("delegationPolicy.budgetAmount must be zero or higher.");
-    }
-    if (budgetAmount > rewardAmount) {
-      throw new ValidationError("delegationPolicy.budgetAmount cannot exceed rewardAmount.");
-    }
-    policy.budgetAmount = budgetAmount;
-    policy.budgetAsset = typeof raw.budgetAsset === "string" && raw.budgetAsset.trim()
-      ? normalizeAssetSymbol(raw.budgetAsset)
-      : rewardAsset;
-    if (policy.budgetAsset !== rewardAsset) {
-      throw new ValidationError("delegationPolicy.budgetAsset must match rewardAsset.");
-    }
-  }
-
-  return Object.keys(policy).length ? policy : undefined;
-}
-
-/**
- * Produce a human-readable explanation that mentions the tier gate when
- * it's the blocker. Pulled out of `recommendJobs` so the string is easy
- * to tweak without touching the rest of the request flow.
- */
-function normalizeJobType(value) {
-  const normalised = String(value ?? "work").trim().toLowerCase();
-  return VALID_JOB_TYPES.has(normalised) ? normalised : undefined;
-}
-
-function normalizeAgentRole(value) {
-  const normalised = String(value ?? "worker").trim().toLowerCase();
-  return VALID_AGENT_ROLES.has(normalised) ? normalised : undefined;
-}
-
-function effectiveJobType(job) {
-  return normalizeJobType(job?.jobType) ?? "work";
-}
-
-function effectiveRequiredRole(job) {
-  return normalizeAgentRole(job?.requiredRole) ?? DEFAULT_ROLE_BY_JOB_TYPE[effectiveJobType(job)] ?? "worker";
-}
-
-function normaliseTextField(value) {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-function normaliseStringList(value) {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-  return value.map((entry) => String(entry).trim()).filter(Boolean);
-}
-
-function normalisePlainObject(value, field) {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  if (typeof value !== "object" || Array.isArray(value)) {
-    throw new ValidationError(`${field} must be an object if provided.`);
-  }
-  return JSON.parse(JSON.stringify(value));
-}
-
-function normaliseSchemaTrustPolicy(value) {
-  const raw = normalisePlainObject(value, "schemaTrustPolicy");
-  if (!raw) {
-    return undefined;
-  }
-  const trustedIssuers = normaliseStringList(raw.trustedIssuers);
-  return trustedIssuers.length ? { trustedIssuers } : undefined;
-}
-
-function normaliseLifecycle(value, { disableStale = false, now = new Date() } = {}) {
-  const raw = normalisePlainObject(value, "lifecycle") ?? {};
-  const createdAt = typeof raw.createdAt === "string" && raw.createdAt.trim()
-    ? normalizeIsoTimestamp(raw.createdAt, "lifecycle.createdAt")
-    : now.toISOString();
-  const updatedAt = typeof raw.updatedAt === "string" && raw.updatedAt.trim()
-    ? normalizeIsoTimestamp(raw.updatedAt, "lifecycle.updatedAt")
-    : createdAt;
-  const status = typeof raw.status === "string" && raw.status.trim()
-    ? raw.status.trim().toLowerCase()
-    : "open";
-  if (!VALID_JOB_LIFECYCLE_STATUSES.has(status)) {
-    throw new ValidationError(`Invalid job lifecycle status: ${status}`);
-  }
-  const lifecycle = {
-    status,
-    createdAt,
-    updatedAt
-  };
-  const defaultStaleAt = disableStale
-    ? undefined
-    : new Date(Date.parse(createdAt) + DEFAULT_STALE_AFTER_MS).toISOString();
-  const staleAt = typeof raw.staleAt === "string" && raw.staleAt.trim()
-    ? normalizeIsoTimestamp(raw.staleAt, "lifecycle.staleAt")
-    : defaultStaleAt;
-  if (staleAt) lifecycle.staleAt = staleAt;
-
-  for (const key of ["pausedAt", "archivedAt", "reopenedAt"]) {
-    if (typeof raw[key] === "string" && raw[key].trim()) {
-      lifecycle[key] = normalizeIsoTimestamp(raw[key], `lifecycle.${key}`);
-    }
-  }
-  for (const key of ["reason", "staleReason"]) {
-    if (typeof raw[key] === "string" && raw[key].trim()) {
-      lifecycle[key] = raw[key].trim().slice(0, 500);
-    }
-  }
-  return lifecycle;
-}
-
-function normalizeIsoTimestamp(value, field) {
-  const parsed = Date.parse(value);
-  if (Number.isNaN(parsed)) {
-    throw new ValidationError(`${field} must be ISO-8601 if provided.`);
-  }
-  return new Date(parsed).toISOString();
 }
 
 function buildPublicJobDetails(job) {


### PR DESCRIPTION
## What changed
- Extracted pure job catalog normalization into mcp-server/src/core/job-catalog-normalization.js.
- Kept JobCatalogService focused on catalog state, lifecycle, recommendations, recurring firing, and public contract projections.
- Added focused tests for canonical job input shape, recurring policy normalization, verifier config, schema/lifecycle validation, and slug semantics.

## Checks run
- node --test mcp-server/src/core/job-catalog-normalization.test.js
- node --test mcp-server/src/core/job-catalog-metadata.test.js
- node --test mcp-server/src/core/recurring-jobs.test.js
- node --test mcp-server/src/core/tier-gate.test.js
- npm --workspace mcp-server test
- git diff --check

## Impact
Backend only. No frontend/board, indexer, Caddy, contracts, public site, environment, or VPS secret changes. No chain behavior changes or Polkadot runtime semantics touched.