### PR TITLE
refactor: extract job schema validation helpers

### DIFF
--- a/mcp-server/src/core/job-schema-registry.js
+++ b/mcp-server/src/core/job-schema-registry.js
@@ -2,6 +2,18 @@ import { AbiCoder, getAddress, getBytes, id, isAddress, keccak256, toUtf8Bytes, 
 
 import { canonicalizeContent, hashCanonicalContent } from "./canonical-content.js";
 import { ValidationError } from "./errors.js";
+import {
+  arrayOfStrings,
+  booleanSchema,
+  enumString,
+  integerSchema,
+  isPlainObject,
+  objectSchema,
+  stringSchema,
+  validateAgainstSchema
+} from "./job-schema-validation.js";
+
+export { validateAgainstSchema } from "./job-schema-validation.js";
 
 export const EXTERNAL_SCHEMA_TRUST_BOUNDARY = "external_signed_schema";
 export const EXTERNAL_SCHEMA_EIP191_VERSION = "external-job-schema-eip191-v1";
@@ -916,144 +928,4 @@ function assertSupportedExternalSchema(schema, path) {
       throw new ValidationError(`${path}.enum values must match ${type}.`);
     }
   }
-}
-
-export function validateAgainstSchema(value, schema, path = "value") {
-  const expected = schema.type;
-  if (expected === "object") {
-    if (!isPlainObject(value)) {
-      throw new ValidationError(`${path} must be an object`);
-    }
-    const required = schema.required ?? [];
-    for (const key of required) {
-      if (!(key in value)) {
-        throw new ValidationError(`${path}.${key} is required`);
-      }
-    }
-    for (const [key, propertySchema] of Object.entries(schema.properties ?? {})) {
-      if (key in value) {
-        validateAgainstSchema(value[key], propertySchema, `${path}.${key}`);
-      }
-    }
-    if (schema.additionalProperties === false) {
-      const allowed = new Set(Object.keys(schema.properties ?? {}));
-      for (const key of Object.keys(value)) {
-        if (!allowed.has(key)) {
-          throw new ValidationError(`${path}.${key} is not an allowed field`);
-        }
-      }
-    }
-    return;
-  }
-
-  if (expected === "array") {
-    if (!Array.isArray(value)) {
-      throw new ValidationError(`${path} must be an array`);
-    }
-    if (Number.isInteger(schema.minItems) && value.length < schema.minItems) {
-      throw new ValidationError(`${path} must contain at least ${schema.minItems} item(s)`);
-    }
-    if (Number.isInteger(schema.maxItems) && value.length > schema.maxItems) {
-      throw new ValidationError(`${path} must contain at most ${schema.maxItems} item(s)`);
-    }
-    value.forEach((entry, index) => {
-      validateAgainstSchema(entry, schema.items ?? {}, `${path}[${index}]`);
-    });
-    return;
-  }
-
-  if (expected === "string") {
-    if (typeof value !== "string") {
-      throw new ValidationError(`${path} must be a string`);
-    }
-    if (Number.isInteger(schema.minLength) && value.length < schema.minLength) {
-      throw new ValidationError(`${path} must be at least ${schema.minLength} character(s)`);
-    }
-    if (Number.isInteger(schema.maxLength) && value.length > schema.maxLength) {
-      throw new ValidationError(`${path} must be at most ${schema.maxLength} character(s)`);
-    }
-    if (schema.pattern && !(new RegExp(schema.pattern, "u")).test(value)) {
-      throw new ValidationError(`${path} does not match the expected format`);
-    }
-    if (Array.isArray(schema.enum) && !schema.enum.includes(value)) {
-      throw new ValidationError(`${path} must be one of ${schema.enum.join(", ")}`);
-    }
-    return;
-  }
-
-  if (expected === "number") {
-    if (!Number.isFinite(value)) {
-      throw new ValidationError(`${path} must be a number`);
-    }
-    if (Number.isFinite(schema.minimum) && value < schema.minimum) {
-      throw new ValidationError(`${path} must be at least ${schema.minimum}`);
-    }
-    return;
-  }
-
-  if (expected === "integer") {
-    if (!Number.isInteger(value)) {
-      throw new ValidationError(`${path} must be an integer`);
-    }
-    if (Number.isFinite(schema.minimum) && value < schema.minimum) {
-      throw new ValidationError(`${path} must be at least ${schema.minimum}`);
-    }
-    return;
-  }
-
-  if (expected === "boolean") {
-    if (typeof value !== "boolean") {
-      throw new ValidationError(`${path} must be a boolean`);
-    }
-    return;
-  }
-}
-
-function stringSchema(options = {}) {
-  return {
-    type: "string",
-    ...options
-  };
-}
-
-function integerSchema(options = {}) {
-  return {
-    type: "integer",
-    ...options
-  };
-}
-
-function booleanSchema() {
-  return {
-    type: "boolean"
-  };
-}
-
-function enumString(values) {
-  return {
-    type: "string",
-    enum: values
-  };
-}
-
-function arrayOfStrings(options = {}) {
-  return {
-    type: "array",
-    items: { type: "string", minLength: 1 },
-    ...options
-  };
-}
-
-function objectSchema({ properties = {}, required = [], additionalProperties = false, ...rest }) {
-  return {
-    type: "object",
-    properties,
-    required,
-    additionalProperties,
-    ...rest
-  };
-}
-
-function isPlainObject(value) {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }

--- a/mcp-server/src/core/job-schema-validation.js
+++ b/mcp-server/src/core/job-schema-validation.js
@@ -1,0 +1,141 @@
+import { ValidationError } from "./errors.js";
+
+export function validateAgainstSchema(value, schema, path = "value") {
+  const expected = schema.type;
+  if (expected === "object") {
+    if (!isPlainObject(value)) {
+      throw new ValidationError(`${path} must be an object`);
+    }
+    const required = schema.required ?? [];
+    for (const key of required) {
+      if (!(key in value)) {
+        throw new ValidationError(`${path}.${key} is required`);
+      }
+    }
+    for (const [key, propertySchema] of Object.entries(schema.properties ?? {})) {
+      if (key in value) {
+        validateAgainstSchema(value[key], propertySchema, `${path}.${key}`);
+      }
+    }
+    if (schema.additionalProperties === false) {
+      const allowed = new Set(Object.keys(schema.properties ?? {}));
+      for (const key of Object.keys(value)) {
+        if (!allowed.has(key)) {
+          throw new ValidationError(`${path}.${key} is not an allowed field`);
+        }
+      }
+    }
+    return;
+  }
+
+  if (expected === "array") {
+    if (!Array.isArray(value)) {
+      throw new ValidationError(`${path} must be an array`);
+    }
+    if (Number.isInteger(schema.minItems) && value.length < schema.minItems) {
+      throw new ValidationError(`${path} must contain at least ${schema.minItems} item(s)`);
+    }
+    if (Number.isInteger(schema.maxItems) && value.length > schema.maxItems) {
+      throw new ValidationError(`${path} must contain at most ${schema.maxItems} item(s)`);
+    }
+    value.forEach((entry, index) => {
+      validateAgainstSchema(entry, schema.items ?? {}, `${path}[${index}]`);
+    });
+    return;
+  }
+
+  if (expected === "string") {
+    if (typeof value !== "string") {
+      throw new ValidationError(`${path} must be a string`);
+    }
+    if (Number.isInteger(schema.minLength) && value.length < schema.minLength) {
+      throw new ValidationError(`${path} must be at least ${schema.minLength} character(s)`);
+    }
+    if (Number.isInteger(schema.maxLength) && value.length > schema.maxLength) {
+      throw new ValidationError(`${path} must be at most ${schema.maxLength} character(s)`);
+    }
+    if (schema.pattern && !(new RegExp(schema.pattern, "u")).test(value)) {
+      throw new ValidationError(`${path} does not match the expected format`);
+    }
+    if (Array.isArray(schema.enum) && !schema.enum.includes(value)) {
+      throw new ValidationError(`${path} must be one of ${schema.enum.join(", ")}`);
+    }
+    return;
+  }
+
+  if (expected === "number") {
+    if (!Number.isFinite(value)) {
+      throw new ValidationError(`${path} must be a number`);
+    }
+    if (Number.isFinite(schema.minimum) && value < schema.minimum) {
+      throw new ValidationError(`${path} must be at least ${schema.minimum}`);
+    }
+    return;
+  }
+
+  if (expected === "integer") {
+    if (!Number.isInteger(value)) {
+      throw new ValidationError(`${path} must be an integer`);
+    }
+    if (Number.isFinite(schema.minimum) && value < schema.minimum) {
+      throw new ValidationError(`${path} must be at least ${schema.minimum}`);
+    }
+    return;
+  }
+
+  if (expected === "boolean") {
+    if (typeof value !== "boolean") {
+      throw new ValidationError(`${path} must be a boolean`);
+    }
+    return;
+  }
+}
+
+export function stringSchema(options = {}) {
+  return {
+    type: "string",
+    ...options
+  };
+}
+
+export function integerSchema(options = {}) {
+  return {
+    type: "integer",
+    ...options
+  };
+}
+
+export function booleanSchema() {
+  return {
+    type: "boolean"
+  };
+}
+
+export function enumString(values) {
+  return {
+    type: "string",
+    enum: values
+  };
+}
+
+export function arrayOfStrings(options = {}) {
+  return {
+    type: "array",
+    items: { type: "string", minLength: 1 },
+    ...options
+  };
+}
+
+export function objectSchema({ properties = {}, required = [], additionalProperties = false, ...rest }) {
+  return {
+    type: "object",
+    properties,
+    required,
+    additionalProperties,
+    ...rest
+  };
+}
+
+export function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/mcp-server/src/core/job-schema-validation.test.js
+++ b/mcp-server/src/core/job-schema-validation.test.js
@@ -1,0 +1,118 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { ValidationError } from "./errors.js";
+import {
+  arrayOfStrings,
+  booleanSchema,
+  enumString,
+  integerSchema,
+  isPlainObject,
+  objectSchema,
+  stringSchema,
+  validateAgainstSchema
+} from "./job-schema-validation.js";
+
+function assertValidationError(fn, message) {
+  assert.throws(fn, (error) => {
+    assert.ok(error instanceof ValidationError);
+    assert.equal(error.message, message);
+    return true;
+  });
+}
+
+test("validateAgainstSchema validates object requirements and field paths", () => {
+  const schema = objectSchema({
+    required: ["summary"],
+    properties: {
+      summary: stringSchema({ minLength: 1 }),
+      result: objectSchema({
+        required: ["status"],
+        properties: {
+          status: enumString(["pass", "fail"])
+        }
+      })
+    }
+  });
+
+  assert.doesNotThrow(() => {
+    validateAgainstSchema({ summary: "ready", result: { status: "pass" } }, schema, "submission");
+  });
+  assertValidationError(() => {
+    validateAgainstSchema({ result: { status: "pass" } }, schema, "submission");
+  }, "submission.summary is required");
+  assertValidationError(() => {
+    validateAgainstSchema({ summary: "ready", result: { status: "maybe" } }, schema, "submission");
+  }, "submission.result.status must be one of pass, fail");
+  assertValidationError(() => {
+    validateAgainstSchema({ summary: "ready", extra: true }, schema, "submission");
+  }, "submission.extra is not an allowed field");
+});
+
+test("validateAgainstSchema validates arrays and nested item paths", () => {
+  const schema = {
+    type: "array",
+    minItems: 1,
+    maxItems: 2,
+    items: objectSchema({
+      required: ["url"],
+      properties: {
+        url: stringSchema({ minLength: 1 })
+      }
+    })
+  };
+
+  assert.doesNotThrow(() => {
+    validateAgainstSchema([{ url: "https://example.com/source" }], schema, "evidence");
+  });
+  assertValidationError(() => {
+    validateAgainstSchema([], schema, "evidence");
+  }, "evidence must contain at least 1 item(s)");
+  assertValidationError(() => {
+    validateAgainstSchema([{ url: "a" }, { url: "b" }, { url: "c" }], schema, "evidence");
+  }, "evidence must contain at most 2 item(s)");
+  assertValidationError(() => {
+    validateAgainstSchema([{ url: "" }], schema, "evidence");
+  }, "evidence[0].url must be at least 1 character(s)");
+});
+
+test("validateAgainstSchema validates scalar constraints", () => {
+  assertValidationError(() => {
+    validateAgainstSchema("", stringSchema({ minLength: 1 }), "title");
+  }, "title must be at least 1 character(s)");
+  assertValidationError(() => {
+    validateAgainstSchema("toolong", stringSchema({ maxLength: 3 }), "title");
+  }, "title must be at most 3 character(s)");
+  assertValidationError(() => {
+    validateAgainstSchema("abc", stringSchema({ pattern: "^[0-9]+$" }), "revision_id");
+  }, "revision_id does not match the expected format");
+  assertValidationError(() => {
+    validateAgainstSchema("draft", enumString(["complete", "blocked"]), "status");
+  }, "status must be one of complete, blocked");
+  assertValidationError(() => {
+    validateAgainstSchema(0.5, integerSchema({ minimum: 1 }), "attempts");
+  }, "attempts must be an integer");
+  assertValidationError(() => {
+    validateAgainstSchema(0, integerSchema({ minimum: 1 }), "attempts");
+  }, "attempts must be at least 1");
+  assertValidationError(() => {
+    validateAgainstSchema("yes", booleanSchema(), "claimable");
+  }, "claimable must be a boolean");
+});
+
+test("schema constructor helpers preserve expected defaults", () => {
+  assert.deepEqual(arrayOfStrings({ minItems: 1 }), {
+    type: "array",
+    items: { type: "string", minLength: 1 },
+    minItems: 1
+  });
+  assert.deepEqual(objectSchema({ properties: { title: stringSchema() } }), {
+    type: "object",
+    properties: { title: { type: "string" } },
+    required: [],
+    additionalProperties: false
+  });
+  assert.equal(isPlainObject({}), true);
+  assert.equal(isPlainObject([]), false);
+  assert.equal(isPlainObject(null), false);
+});


### PR DESCRIPTION
### What changed
- Extracted the low-level schema validator and schema constructor helpers into `mcp-server/src/core/job-schema-validation.js`.
- Kept `validateAgainstSchema` re-exported from `job-schema-registry.js` so existing callers stay stable.
- Added focused validator tests for object, array, scalar, path, and constructor helper behavior.

### Checks run
- `node --test mcp-server/src/core/job-schema-validation.test.js`
- `node --test mcp-server/src/core/job-schema-registry.test.js`
- `node --test mcp-server/src/services/schema-registry.test.js`
- `node --test mcp-server/src/core/job-execution-service.test.js`
- `npm --workspace mcp-server test` (853 passing after `npm install` in the fresh worktree)
- `git diff --check`

### Surface impact
- Backend only: `mcp-server/src/core`.
- No frontend/board, indexer, Caddy, contracts, public site, environment, or VPS secret changes.
- No chain behavior or Polkadot runtime semantics touched.