### PR TITLE
refactor: extract platform timeline builders

### DIFF
--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -13,9 +13,18 @@ import { buildPlatformCapabilities } from "./discovery-manifest.js";
 import { getBuiltinJobSchema, getJobSchema, getRegisteredJobSchemaRegistration } from "./job-schema-registry.js";
 import {
   buildSessionLifecycle,
-  describeSessionStatus,
   getSessionStateMachineDefinition
 } from "./session-state-machine.js";
+import {
+  buildChildJobTimelineEntry,
+  buildChildSessionTimelineEntry,
+  buildDerivativeJobTimelineEntry,
+  buildEventBusTimelineEntry,
+  buildJobStateTimelineEntry,
+  buildSessionTimelineEntries,
+  buildVerificationTimelineEntry,
+  compareTimelineEntries
+} from "./platform-timeline.js";
 import { computeClaimEconomics, countClaimedSessions } from "./claim-economics.js";
 import { claimStatusFields, isTerminalSession, summarizeJobClaimState } from "./claim-state.js";
 import { capabilityMatrix } from "../auth/capabilities.js";
@@ -1348,261 +1357,11 @@ export class PlatformService {
   }
 }
 
-function buildJobStateTimelineEntry(job, sessions) {
-  return buildTimelineEntry({
-    id: `${job.id}:job-state`,
-    type: "job_state",
-    at: firstDefined(job.lifecycle?.updatedAt, job.createdAt, job.firedAt, sessions[0]?.updatedAt),
-    correlationId: job.id,
-    phase: "job",
-    source: "state",
-    topic: "job.state",
-    jobId: job.id,
-    sessionId: job.sessionId,
-    wallet: job.claimedBy,
-    data: compactTimelineData({
-      category: job.category,
-      tier: job.tier,
-      verifierMode: job.verifierMode,
-      lifecycle: job.lifecycle,
-      claimState: job.claimState,
-      effectiveState: job.effectiveState,
-      claimable: job.claimable,
-      reason: job.reason,
-      sessionId: job.sessionId,
-      claimedBy: job.claimedBy,
-      claimExpiresAt: job.claimExpiresAt
-    })
-  });
-}
-
-function buildSessionTimelineEntries(session, options = {}) {
-  const correlationId = options.correlationId ?? session.sessionId;
-  const history = Array.isArray(session.statusHistory) ? session.statusHistory : [];
-  if (!history.length) {
-    return [buildTimelineEntry({
-      id: `${session.sessionId}:session-snapshot`,
-      type: "session_snapshot",
-      at: firstDefined(session.updatedAt, session.claimedAt),
-      correlationId,
-      phase: describeSessionStatus(session.status).phase,
-      source: "state",
-      topic: "session.snapshot",
-      severity: timelineSeverityForSessionStatus(session.status),
-      jobId: session.jobId,
-      sessionId: session.sessionId,
-      wallet: session.wallet,
-      data: compactTimelineData({
-        status: session.status
-      })
-    })];
-  }
-  return history.map((entry, index) => buildTimelineEntry({
-    id: `${session.sessionId}:transition:${index}`,
-    type: "session_transition",
-    at: entry.at,
-    correlationId,
-    phase: describeSessionStatus(entry.to).phase,
-    source: "state",
-    topic: "session.transition",
-    severity: timelineSeverityForSessionStatus(entry.to),
-    jobId: session.jobId,
-    sessionId: session.sessionId,
-    wallet: session.wallet,
-    data: {
-      ...entry
-    }
-  }));
-}
-
-function buildVerificationTimelineEntry(session, verificationOverride = undefined, options = {}) {
-  const verification = verificationOverride ?? session.verification ?? session.verificationSummary;
-  if (!verification) {
-    return undefined;
-  }
-  return buildTimelineEntry({
-    id: `${session.sessionId}:verification`,
-    type: "verification",
-    at: firstDefined(
-      verification.session?.updatedAt,
-      verification.session?.resolvedAt,
-      session.resolvedAt,
-      session.updatedAt
-    ),
-    correlationId: options.correlationId ?? session.sessionId,
-    phase: "verification",
-    source: "verification",
-    topic: "session.verification",
-    severity: verification.outcome === "rejected" ? "error" : "info",
-    jobId: session.jobId,
-    sessionId: session.sessionId,
-    wallet: session.wallet,
-    data: compactTimelineData({
-      outcome: verification.outcome,
-      reasonCode: verification.reasonCode,
-      handler: verification.handler,
-      handlerVersion: verification.handlerVersion,
-      verifierPolicyVersion: verification.verifierPolicyVersion,
-      verifierConfigVersion: verification.verifierConfigVersion
-    })
-  });
-}
-
-function buildChildJobTimelineEntry(job, options = {}) {
-  return buildTimelineEntry({
-    id: `${job.id}:child-job`,
-    type: "child_job",
-    at: firstDefined(job.createdAt, job.firedAt, job.lifecycle?.updatedAt),
-    correlationId: options.correlationId ?? job.parentSessionId ?? job.id,
-    phase: "child_job",
-    source: "lineage",
-    topic: "job.child_created",
-    jobId: job.id,
-    sessionId: job.parentSessionId,
-    data: compactTimelineData({
-      parentSessionId: job.parentSessionId,
-      category: job.category,
-      tier: job.tier,
-      verifierMode: job.verifierMode,
-      lifecycle: job.lifecycle
-    })
-  });
-}
-
-function buildChildSessionTimelineEntry(session, options = {}) {
-  return buildTimelineEntry({
-    id: `${session.sessionId}:child-session`,
-    type: "child_session",
-    at: firstDefined(session.updatedAt, session.claimedAt),
-    correlationId: options.correlationId ?? session.sessionId,
-    phase: describeSessionStatus(session.status).phase,
-    source: "lineage",
-    topic: "session.child_snapshot",
-    severity: timelineSeverityForSessionStatus(session.status),
-    jobId: session.jobId,
-    sessionId: session.sessionId,
-    wallet: session.wallet,
-    data: compactTimelineData({
-      status: session.status
-    })
-  });
-}
-
-function buildDerivativeJobTimelineEntry(job) {
-  return buildTimelineEntry({
-    id: `${job.id}:derivative-job`,
-    type: "derivative_job",
-    at: firstDefined(job.firedAt, job.createdAt, job.lifecycle?.updatedAt),
-    correlationId: job.templateId ?? job.id,
-    phase: "recurring",
-    source: "lineage",
-    topic: "job.recurring_fired",
-    jobId: job.id,
-    data: compactTimelineData({
-      templateId: job.templateId,
-      firedAt: job.firedAt,
-      category: job.category,
-      tier: job.tier,
-      lifecycle: job.lifecycle
-    })
-  });
-}
-
 function sumSubJobRewards(jobs, asset) {
   const normalizedAsset = normalizeAssetSymbol(asset);
   return jobs
     .filter((job) => normalizeAssetSymbol(job.rewardAsset) === normalizedAsset)
     .reduce((total, job) => total + Math.max(Number(job.rewardAmount ?? 0), 0), 0);
-}
-
-function buildEventBusTimelineEntry(event, index) {
-  return buildTimelineEntry({
-    id: event.id ?? `event-bus:${index}`,
-    type: event.type ?? "event_bus",
-    at: event.timestamp,
-    correlationId: event.correlationId ?? event.sessionId ?? event.jobId,
-    phase: event.phase ?? event.topic,
-    source: event.source ?? "event_bus",
-    topic: event.topic,
-    severity: event.severity ?? "info",
-    jobId: event.jobId,
-    sessionId: event.sessionId,
-    wallet: event.wallet,
-    data: compactTimelineData({
-      blockNumber: event.blockNumber,
-      txHash: event.txHash,
-      ...event.data
-    })
-  });
-}
-
-function buildTimelineEntry({
-  id,
-  type,
-  at,
-  correlationId,
-  phase,
-  source = "state",
-  topic,
-  severity = "info",
-  jobId,
-  sessionId,
-  wallet,
-  data = {}
-}) {
-  const timestamp = firstDefined(at);
-  return {
-    id,
-    type,
-    at: timestamp,
-    timestamp,
-    correlationId,
-    phase,
-    source,
-    topic,
-    severity,
-    jobId,
-    sessionId,
-    wallet,
-    data: compactTimelineData({
-      topic,
-      jobId,
-      sessionId,
-      wallet,
-      ...data
-    })
-  };
-}
-
-function timelineSeverityForSessionStatus(status) {
-  if (["failed", "rejected", "slashed"].includes(status)) {
-    return "error";
-  }
-  if (status === "disputed") {
-    return "warn";
-  }
-  return "info";
-}
-
-function compareTimelineEntries(left, right) {
-  const leftTime = timelineTime(left.at);
-  const rightTime = timelineTime(right.at);
-  if (leftTime !== rightTime) {
-    return leftTime - rightTime;
-  }
-  return String(left.id ?? "").localeCompare(String(right.id ?? ""));
-}
-
-function timelineTime(value) {
-  if (!value) {
-    return Number.MAX_SAFE_INTEGER;
-  }
-  const parsed = Date.parse(value);
-  return Number.isFinite(parsed) ? parsed : Number.MAX_SAFE_INTEGER;
-}
-
-function firstDefined(...values) {
-  return values.find((value) => value !== undefined && value !== null) ?? null;
 }
 
 function minBalanceRawForAsset(asset) {
@@ -1650,12 +1409,6 @@ function formatBaseUnits(raw, decimals) {
   if (fractional === 0n || decimals === 0) return whole.toString();
   const padded = fractional.toString().padStart(decimals, "0").replace(/0+$/u, "");
   return `${whole}.${padded}`;
-}
-
-function compactTimelineData(value) {
-  return Object.fromEntries(
-    Object.entries(value).filter(([, entry]) => entry !== undefined)
-  );
 }
 
 /**

--- a/mcp-server/src/core/platform-timeline.js
+++ b/mcp-server/src/core/platform-timeline.js
@@ -1,0 +1,257 @@
+import { describeSessionStatus } from "./session-state-machine.js";
+
+export function buildJobStateTimelineEntry(job, sessions) {
+  return buildTimelineEntry({
+    id: `${job.id}:job-state`,
+    type: "job_state",
+    at: firstDefined(job.lifecycle?.updatedAt, job.createdAt, job.firedAt, sessions[0]?.updatedAt),
+    correlationId: job.id,
+    phase: "job",
+    source: "state",
+    topic: "job.state",
+    jobId: job.id,
+    sessionId: job.sessionId,
+    wallet: job.claimedBy,
+    data: compactTimelineData({
+      category: job.category,
+      tier: job.tier,
+      verifierMode: job.verifierMode,
+      lifecycle: job.lifecycle,
+      claimState: job.claimState,
+      effectiveState: job.effectiveState,
+      claimable: job.claimable,
+      reason: job.reason,
+      sessionId: job.sessionId,
+      claimedBy: job.claimedBy,
+      claimExpiresAt: job.claimExpiresAt
+    })
+  });
+}
+
+export function buildSessionTimelineEntries(session, options = {}) {
+  const correlationId = options.correlationId ?? session.sessionId;
+  const history = Array.isArray(session.statusHistory) ? session.statusHistory : [];
+  if (!history.length) {
+    return [buildTimelineEntry({
+      id: `${session.sessionId}:session-snapshot`,
+      type: "session_snapshot",
+      at: firstDefined(session.updatedAt, session.claimedAt),
+      correlationId,
+      phase: describeSessionStatus(session.status).phase,
+      source: "state",
+      topic: "session.snapshot",
+      severity: timelineSeverityForSessionStatus(session.status),
+      jobId: session.jobId,
+      sessionId: session.sessionId,
+      wallet: session.wallet,
+      data: compactTimelineData({
+        status: session.status
+      })
+    })];
+  }
+  return history.map((entry, index) => buildTimelineEntry({
+    id: `${session.sessionId}:transition:${index}`,
+    type: "session_transition",
+    at: entry.at,
+    correlationId,
+    phase: describeSessionStatus(entry.to).phase,
+    source: "state",
+    topic: "session.transition",
+    severity: timelineSeverityForSessionStatus(entry.to),
+    jobId: session.jobId,
+    sessionId: session.sessionId,
+    wallet: session.wallet,
+    data: {
+      ...entry
+    }
+  }));
+}
+
+export function buildVerificationTimelineEntry(session, verificationOverride = undefined, options = {}) {
+  const verification = verificationOverride ?? session.verification ?? session.verificationSummary;
+  if (!verification) {
+    return undefined;
+  }
+  return buildTimelineEntry({
+    id: `${session.sessionId}:verification`,
+    type: "verification",
+    at: firstDefined(
+      verification.session?.updatedAt,
+      verification.session?.resolvedAt,
+      session.resolvedAt,
+      session.updatedAt
+    ),
+    correlationId: options.correlationId ?? session.sessionId,
+    phase: "verification",
+    source: "verification",
+    topic: "session.verification",
+    severity: verification.outcome === "rejected" ? "error" : "info",
+    jobId: session.jobId,
+    sessionId: session.sessionId,
+    wallet: session.wallet,
+    data: compactTimelineData({
+      outcome: verification.outcome,
+      reasonCode: verification.reasonCode,
+      handler: verification.handler,
+      handlerVersion: verification.handlerVersion,
+      verifierPolicyVersion: verification.verifierPolicyVersion,
+      verifierConfigVersion: verification.verifierConfigVersion
+    })
+  });
+}
+
+export function buildChildJobTimelineEntry(job, options = {}) {
+  return buildTimelineEntry({
+    id: `${job.id}:child-job`,
+    type: "child_job",
+    at: firstDefined(job.createdAt, job.firedAt, job.lifecycle?.updatedAt),
+    correlationId: options.correlationId ?? job.parentSessionId ?? job.id,
+    phase: "child_job",
+    source: "lineage",
+    topic: "job.child_created",
+    jobId: job.id,
+    sessionId: job.parentSessionId,
+    data: compactTimelineData({
+      parentSessionId: job.parentSessionId,
+      category: job.category,
+      tier: job.tier,
+      verifierMode: job.verifierMode,
+      lifecycle: job.lifecycle
+    })
+  });
+}
+
+export function buildChildSessionTimelineEntry(session, options = {}) {
+  return buildTimelineEntry({
+    id: `${session.sessionId}:child-session`,
+    type: "child_session",
+    at: firstDefined(session.updatedAt, session.claimedAt),
+    correlationId: options.correlationId ?? session.sessionId,
+    phase: describeSessionStatus(session.status).phase,
+    source: "lineage",
+    topic: "session.child_snapshot",
+    severity: timelineSeverityForSessionStatus(session.status),
+    jobId: session.jobId,
+    sessionId: session.sessionId,
+    wallet: session.wallet,
+    data: compactTimelineData({
+      status: session.status
+    })
+  });
+}
+
+export function buildDerivativeJobTimelineEntry(job) {
+  return buildTimelineEntry({
+    id: `${job.id}:derivative-job`,
+    type: "derivative_job",
+    at: firstDefined(job.firedAt, job.createdAt, job.lifecycle?.updatedAt),
+    correlationId: job.templateId ?? job.id,
+    phase: "recurring",
+    source: "lineage",
+    topic: "job.recurring_fired",
+    jobId: job.id,
+    data: compactTimelineData({
+      templateId: job.templateId,
+      firedAt: job.firedAt,
+      category: job.category,
+      tier: job.tier,
+      lifecycle: job.lifecycle
+    })
+  });
+}
+
+export function buildEventBusTimelineEntry(event, index) {
+  return buildTimelineEntry({
+    id: event.id ?? `event-bus:${index}`,
+    type: event.type ?? "event_bus",
+    at: event.timestamp,
+    correlationId: event.correlationId ?? event.sessionId ?? event.jobId,
+    phase: event.phase ?? event.topic,
+    source: event.source ?? "event_bus",
+    topic: event.topic,
+    severity: event.severity ?? "info",
+    jobId: event.jobId,
+    sessionId: event.sessionId,
+    wallet: event.wallet,
+    data: compactTimelineData({
+      blockNumber: event.blockNumber,
+      txHash: event.txHash,
+      ...event.data
+    })
+  });
+}
+
+export function buildTimelineEntry({
+  id,
+  type,
+  at,
+  correlationId,
+  phase,
+  source = "state",
+  topic,
+  severity = "info",
+  jobId,
+  sessionId,
+  wallet,
+  data = {}
+}) {
+  const timestamp = firstDefined(at);
+  return {
+    id,
+    type,
+    at: timestamp,
+    timestamp,
+    correlationId,
+    phase,
+    source,
+    topic,
+    severity,
+    jobId,
+    sessionId,
+    wallet,
+    data: compactTimelineData({
+      topic,
+      jobId,
+      sessionId,
+      wallet,
+      ...data
+    })
+  };
+}
+
+export function compareTimelineEntries(left, right) {
+  const leftTime = timelineTime(left.at);
+  const rightTime = timelineTime(right.at);
+  if (leftTime !== rightTime) {
+    return leftTime - rightTime;
+  }
+  return String(left.id ?? "").localeCompare(String(right.id ?? ""));
+}
+
+export function compactTimelineData(value) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined)
+  );
+}
+
+function timelineSeverityForSessionStatus(status) {
+  if (["failed", "rejected", "slashed"].includes(status)) {
+    return "error";
+  }
+  if (status === "disputed") {
+    return "warn";
+  }
+  return "info";
+}
+
+function timelineTime(value) {
+  if (!value) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : Number.MAX_SAFE_INTEGER;
+}
+
+function firstDefined(...values) {
+  return values.find((value) => value !== undefined && value !== null) ?? null;
+}

--- a/mcp-server/src/core/platform-timeline.test.js
+++ b/mcp-server/src/core/platform-timeline.test.js
@@ -1,0 +1,119 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildEventBusTimelineEntry,
+  buildSessionTimelineEntries,
+  buildTimelineEntry,
+  buildVerificationTimelineEntry,
+  compactTimelineData,
+  compareTimelineEntries
+} from "./platform-timeline.js";
+
+test("buildSessionTimelineEntries turns status history into ordered session transition entries", () => {
+  const entries = buildSessionTimelineEntries({
+    jobId: "job-1",
+    sessionId: "session-1",
+    wallet: "0xworker",
+    status: "resolved",
+    statusHistory: [
+      { from: "claimed", to: "submitted", at: "2026-01-01T00:00:01.000Z" },
+      { from: "submitted", to: "resolved", at: "2026-01-01T00:00:02.000Z" }
+    ]
+  }, { correlationId: "corr-1" });
+
+  assert.equal(entries.length, 2);
+  assert.deepEqual(entries.map((entry) => entry.type), ["session_transition", "session_transition"]);
+  assert.deepEqual(entries.map((entry) => entry.phase), ["verification", "terminal"]);
+  assert.ok(entries.every((entry) => entry.correlationId === "corr-1"));
+  assert.ok(entries.every((entry) => entry.timestamp === entry.at));
+  assert.equal(entries[0].data.to, "submitted");
+});
+
+test("buildSessionTimelineEntries creates a snapshot when history is absent", () => {
+  const [entry] = buildSessionTimelineEntries({
+    jobId: "job-1",
+    sessionId: "session-1",
+    wallet: "0xworker",
+    status: "disputed",
+    updatedAt: "2026-01-01T00:00:03.000Z"
+  });
+
+  assert.equal(entry.type, "session_snapshot");
+  assert.equal(entry.topic, "session.snapshot");
+  assert.equal(entry.phase, "verification");
+  assert.equal(entry.severity, "warn");
+  assert.equal(entry.data.status, "disputed");
+});
+
+test("buildVerificationTimelineEntry includes verification metadata and omits undefined fields", () => {
+  const entry = buildVerificationTimelineEntry({
+    jobId: "job-1",
+    sessionId: "session-1",
+    wallet: "0xworker",
+    updatedAt: "2026-01-01T00:00:04.000Z"
+  }, {
+    outcome: "rejected",
+    reasonCode: "BAD_OUTPUT",
+    handler: "benchmark",
+    handlerVersion: 2,
+    verifierConfigVersion: undefined
+  });
+
+  assert.equal(entry.type, "verification");
+  assert.equal(entry.source, "verification");
+  assert.equal(entry.severity, "error");
+  assert.equal(entry.data.reasonCode, "BAD_OUTPUT");
+  assert.ok(!("verifierConfigVersion" in entry.data));
+});
+
+test("buildEventBusTimelineEntry preserves durable event metadata", () => {
+  const entry = buildEventBusTimelineEntry({
+    id: "chain-funded-1",
+    topic: "escrow.job_funded",
+    source: "chain",
+    phase: "funding",
+    jobId: "job-1",
+    sessionId: "session-1",
+    wallet: "0xworker",
+    blockNumber: 123n,
+    txHash: "0xabc",
+    timestamp: "2026-01-01T00:00:05.000Z",
+    data: {
+      amountRaw: "1000000"
+    }
+  }, 0);
+
+  assert.equal(entry.id, "chain-funded-1");
+  assert.equal(entry.type, "event_bus");
+  assert.equal(entry.correlationId, "session-1");
+  assert.equal(entry.data.topic, "escrow.job_funded");
+  assert.equal(entry.data.blockNumber, 123n);
+  assert.equal(entry.data.amountRaw, "1000000");
+});
+
+test("timeline helpers compact data and provide stable ordering", () => {
+  assert.deepEqual(compactTimelineData({ a: 1, b: undefined, c: null }), {
+    a: 1,
+    c: null
+  });
+
+  const later = buildTimelineEntry({
+    id: "b",
+    type: "custom",
+    at: "2026-01-01T00:00:02.000Z",
+    correlationId: "corr",
+    phase: "phase",
+    topic: "topic"
+  });
+  const earlier = buildTimelineEntry({
+    id: "a",
+    type: "custom",
+    at: "2026-01-01T00:00:01.000Z",
+    correlationId: "corr",
+    phase: "phase",
+    topic: "topic"
+  });
+
+  assert.deepEqual([later, earlier].sort(compareTimelineEntries).map((entry) => entry.id), ["a", "b"]);
+});


### PR DESCRIPTION
### What changed
- Extracted the pure platform timeline entry builders from `platform-service.js` into `mcp-server/src/core/platform-timeline.js`.
- Left `PlatformService` responsible for orchestration/data loading while the new helper owns entry shape, severity, compaction, and ordering.
- Added focused unit coverage for session transitions, snapshots, verification entries, durable event entries, compaction, and stable sorting.

### Checks run
- `node --test mcp-server/src/core/platform-timeline.test.js`
- `node --test mcp-server/src/core/platform-service.test.js`
- `npm --workspace mcp-server test` (854 passing after `npm install` in the fresh worktree)
- `git diff --check`

### Surface impact
- Backend only: `mcp-server/src/core`.
- No frontend/board, indexer, Caddy, contracts, public site, environment, or VPS secret changes.
- No chain behavior or Polkadot runtime semantics touched; Polkadot docs MCP was available but not needed for this non-runtime refactor.