### PR TITLE
refactor: extract event log query helper

### DIFF
--- a/mcp-server/src/core/event-log-query.js
+++ b/mcp-server/src/core/event-log-query.js
@@ -1,0 +1,23 @@
+import { matchesFilter } from "./event-bus.js";
+
+export function listEventLogFromRecords(records, filter = {}) {
+  const limit = normalizeListLimit(filter.limit, 100, 500);
+  const lastEventId = String(filter.lastEventId ?? "").trim();
+  const cursorIndex = lastEventId
+    ? records.findIndex((event) => event.id === lastEventId)
+    : -1;
+  const scoped = cursorIndex >= 0
+    ? records.slice(cursorIndex + 1)
+    : records;
+  const filtered = scoped.filter((event) => matchesFilter(event, filter));
+  return {
+    events: lastEventId ? filtered.slice(0, limit) : filtered.slice(-limit),
+    gap: Boolean(lastEventId && cursorIndex === -1 && records.length > 0)
+  };
+}
+
+export function normalizeListLimit(value, fallback, max) {
+  const parsed = Number(value ?? fallback);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.min(Math.trunc(parsed), max);
+}

--- a/mcp-server/src/core/event-log-query.test.js
+++ b/mcp-server/src/core/event-log-query.test.js
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { listEventLogFromRecords, normalizeListLimit } from "./event-log-query.js";
+
+const records = [
+  {
+    id: "event-1",
+    topic: "escrow.job_funded",
+    source: "chain",
+    phase: "funding",
+    severity: "info",
+    wallet: "0xaaa",
+    wallets: ["0xaaa"],
+    jobId: "job-1",
+    correlationId: "job-1",
+    timestamp: "2026-01-01T00:00:00.000Z"
+  },
+  {
+    id: "event-2",
+    topic: "xcm.settlement_failed",
+    source: "settlement",
+    phase: "settlement",
+    severity: "error",
+    wallet: "0xaaa",
+    wallets: ["0xaaa"],
+    jobId: "job-1",
+    correlationId: "settlement-1",
+    timestamp: "2026-01-01T00:00:01.000Z"
+  },
+  {
+    id: "event-3",
+    topic: "session.claimed",
+    source: "state",
+    phase: "claim",
+    severity: "info",
+    wallet: "0xbbb",
+    wallets: ["0xbbb"],
+    jobId: "job-2",
+    correlationId: "session-1",
+    timestamp: "2026-01-01T00:00:02.000Z"
+  }
+];
+
+test("listEventLogFromRecords returns the latest limited events without a cursor", () => {
+  const result = listEventLogFromRecords(records, { limit: 2 });
+
+  assert.equal(result.gap, false);
+  assert.deepEqual(result.events.map((event) => event.id), ["event-2", "event-3"]);
+});
+
+test("listEventLogFromRecords filters the latest page without a cursor", () => {
+  const result = listEventLogFromRecords(records, {
+    wallet: "0xaaa",
+    sources: ["settlement"],
+    limit: 10
+  });
+
+  assert.equal(result.gap, false);
+  assert.deepEqual(result.events.map((event) => event.id), ["event-2"]);
+});
+
+test("listEventLogFromRecords returns a forward page after a cursor", () => {
+  const result = listEventLogFromRecords(records, {
+    jobId: "job-1",
+    lastEventId: "event-1",
+    limit: 10
+  });
+
+  assert.equal(result.gap, false);
+  assert.deepEqual(result.events.map((event) => event.id), ["event-2"]);
+});
+
+test("listEventLogFromRecords reports a gap only when a missing cursor has records behind it", () => {
+  const missingCursor = listEventLogFromRecords(records, { lastEventId: "missing", limit: 2 });
+  assert.equal(missingCursor.gap, true);
+  assert.deepEqual(missingCursor.events.map((event) => event.id), ["event-1", "event-2"]);
+
+  const empty = listEventLogFromRecords([], { lastEventId: "missing", limit: 2 });
+  assert.equal(empty.gap, false);
+  assert.deepEqual(empty.events, []);
+});
+
+test("normalizeListLimit falls back for invalid limits and caps valid limits", () => {
+  assert.equal(normalizeListLimit(undefined, 100, 500), 100);
+  assert.equal(normalizeListLimit("nope", 100, 500), 100);
+  assert.equal(normalizeListLimit(0, 100, 500), 100);
+  assert.equal(normalizeListLimit(-3, 100, 500), 100);
+  assert.equal(normalizeListLimit(12.9, 100, 500), 12);
+  assert.equal(normalizeListLimit(900, 100, 500), 500);
+});

--- a/mcp-server/src/core/state-store.js
+++ b/mcp-server/src/core/state-store.js
@@ -1,6 +1,6 @@
 import { createClient } from "redis";
 import { ExternalServiceError } from "./errors.js";
-import { matchesFilter } from "./event-bus.js";
+import { listEventLogFromRecords } from "./event-log-query.js";
 
 const DEFAULT_EVENT_LOG_RETENTION = 5_000;
 
@@ -946,28 +946,6 @@ export class RedisStateStore {
   key(kind, id) {
     return `${this.namespace}:${kind}:${id}`;
   }
-}
-
-function listEventLogFromRecords(records, filter = {}) {
-  const limit = normalizeListLimit(filter.limit, 100, 500);
-  const lastEventId = String(filter.lastEventId ?? "").trim();
-  const cursorIndex = lastEventId
-    ? records.findIndex((event) => event.id === lastEventId)
-    : -1;
-  const scoped = cursorIndex >= 0
-    ? records.slice(cursorIndex + 1)
-    : records;
-  const filtered = scoped.filter((event) => matchesFilter(event, filter));
-  return {
-    events: lastEventId ? filtered.slice(0, limit) : filtered.slice(-limit),
-    gap: Boolean(lastEventId && cursorIndex === -1 && records.length > 0)
-  };
-}
-
-function normalizeListLimit(value, fallback, max) {
-  const parsed = Number(value ?? fallback);
-  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
-  return Math.min(Math.trunc(parsed), max);
 }
 
 export function createStateStore(env = process.env, { logger = console } = {}) {


### PR DESCRIPTION
## Summary
- Extract durable event-log filtering, cursor, gap, and limit handling from `state-store.js` into `event-log-query.js`.
- Keep MemoryStateStore and RedisStateStore on the same shared helper.
- Add focused helper coverage for latest-page, filtered-page, cursor, missing-cursor gap, and limit normalization behavior.

## Checks
- `node --test mcp-server/src/core/event-log-query.test.js`
- `node --test mcp-server/src/core/state-store.test.js`
- `node --test mcp-server/src/core/event-bus.test.js`
- `npm --workspace mcp-server test`
- `git diff --check`

## Impact
- Backend only: `mcp-server/src/core`.
- No frontend/board, indexer, Caddy, contracts, public site, environment, or VPS secret changes.
- No chain behavior or Polkadot runtime semantics touched; Polkadot docs MCP was not needed for this pure event-log data-shaping refactor.