### PR TITLE
refactor: extract provider operations status helpers

### DIFF
--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -25,6 +25,11 @@ import {
   buildVerificationTimelineEntry,
   compareTimelineEntries
 } from "./platform-timeline.js";
+import {
+  buildProviderOperations,
+  PROVIDER_STATUS_FALLBACK,
+  sanitizeProviderOperations
+} from "./provider-operations-status.js";
 import { computeClaimEconomics, countClaimedSessions } from "./claim-economics.js";
 import { claimStatusFields, isTerminalSession, summarizeJobClaimState } from "./claim-state.js";
 import { capabilityMatrix } from "../auth/capabilities.js";
@@ -41,15 +46,6 @@ const STARTER_REPUTATION = {
   economic: 0,
   tier: "starter"
 };
-
-const INGESTION_PROVIDER_DEFINITIONS = [
-  ["github", "githubIngestion", "GitHub issues", "queryCount"],
-  ["wikipedia", "wikipediaIngestion", "Wikipedia maintenance", "categoryCount"],
-  ["osv", "osvIngestion", "OSV advisories", "targetCount"],
-  ["openData", "openDataIngestion", "Open data", "targetCount"],
-  ["standards", "standardsIngestion", "Standards freshness", "specCount"],
-  ["openApi", "openApiIngestion", "OpenAPI quality", "specCount"]
-];
 
 const DEFAULT_TREASURY_POLICY_STATUS = {
   enabled: false,
@@ -1411,49 +1407,6 @@ function formatBaseUnits(raw, decimals) {
   return `${whole}.${padded}`;
 }
 
-/**
- * Default empty status used when an ingestion scheduler is not wired in
- * the current process. Matches the shape produced by every concrete
- * scheduler's `getStatus()` so `buildProviderOperations` can treat all
- * providers uniformly.
- */
-const PROVIDER_STATUS_FALLBACK = Object.freeze({
-  enabled: false,
-  running: false,
-  dryRun: true,
-  intervalMs: 0,
-  maxJobsPerRun: 0,
-  maxOpenJobs: 0,
-  currentOpenJobs: 0,
-  lastRun: undefined
-});
-
-/**
- * Strip `lastRun.errors[]` and `lastRun.skipped[]` from every provider in
- * a providerOperations object, preserving every other field including
- * `errorCount` and `skippedCount`. Used to derive the public sanitized
- * payload from the admin one.
- */
-function sanitizeProviderOperations(providerOperations) {
-  const entries = Object.entries(providerOperations).map(([key, value]) => [
-    key,
-    sanitizeProviderOperationStatus(value)
-  ]);
-  return Object.fromEntries(entries);
-}
-
-function sanitizeProviderOperationStatus(status) {
-  if (!status?.lastRun) return status;
-  return {
-    ...status,
-    lastRun: {
-      ...status.lastRun,
-      skipped: [],
-      errors: []
-    }
-  };
-}
-
 async function getTreasuryPolicyStatusSafely(blockchainGateway) {
   if (!blockchainGateway?.getTreasuryPolicyStatus) {
     return { ...DEFAULT_TREASURY_POLICY_STATUS };
@@ -1519,141 +1472,6 @@ function normalizeStatusReadError(error, code) {
     message: error?.message ?? "Status read failed.",
     details: error?.details
   };
-}
-
-function buildProviderOperations(statuses) {
-  const entries = INGESTION_PROVIDER_DEFINITIONS.map(([key, statusKey, label, targetCountField]) => {
-    const status = statuses[statusKey] ?? {};
-    return [key, buildProviderOperationStatus({
-      label,
-      status,
-      targetCountField
-    })];
-  });
-  return Object.fromEntries(entries);
-}
-
-function buildProviderOperationStatus({ label, status, targetCountField }) {
-  const lastRun = summarizeProviderLastRun(status.lastRun);
-  const currentOpenJobs = status.currentOpenJobs !== undefined
-    ? toNonNegativeInteger(status.currentOpenJobs)
-    : inferCurrentOpenJobs(status.lastRun);
-  // queryCount/nextQuery describe the rotation pool — only meaningful
-  // when the provider rotates a query list distinct from its
-  // targetCount. github's queryCount IS its targetCount, so don't
-  // duplicate it; openData rotates queries against a dataset list, so
-  // queryCount and targetCount are genuinely different signals.
-  const queryCount = status.queryCount !== undefined && targetCountField !== "queryCount"
-    ? toNonNegativeInteger(status.queryCount)
-    : undefined;
-  const nextQuery = stringOrUndefined(status.nextQuery);
-  return {
-    label,
-    enabled: Boolean(status.enabled),
-    running: Boolean(status.running),
-    dryRun: status.dryRun !== false,
-    mode: !status.enabled ? "disabled" : (status.dryRun === false ? "live" : "dry_run"),
-    intervalMs: toNonNegativeInteger(status.intervalMs),
-    maxJobsPerRun: toNonNegativeInteger(status.maxJobsPerRun),
-    ...(status.maxJobsPerQuery !== undefined ? { maxJobsPerQuery: toNonNegativeInteger(status.maxJobsPerQuery) } : {}),
-    maxOpenJobs: toNonNegativeInteger(status.maxOpenJobs),
-    currentOpenJobs,
-    ...(status.minClaimableJobs !== undefined ? { minClaimableJobs: toNonNegativeInteger(status.minClaimableJobs) } : {}),
-    ...(status.currentClaimableJobs !== undefined
-      ? { currentClaimableJobs: toNonNegativeInteger(status.currentClaimableJobs) }
-      : {}),
-    targetCount: toNonNegativeInteger(status[targetCountField]),
-    ...(queryCount !== undefined ? { queryCount } : {}),
-    ...(nextQuery ? { nextQuery } : {}),
-    lastRunAt: lastRun?.finishedAt ?? lastRun?.startedAt,
-    lastRun,
-    health: summarizeProviderHealth({
-      enabled: Boolean(status.enabled),
-      dryRun: status.dryRun !== false,
-      currentOpenJobs,
-      maxOpenJobs: toNonNegativeInteger(status.maxOpenJobs),
-      lastRun
-    })
-  };
-}
-
-function summarizeProviderLastRun(lastRun) {
-  if (!lastRun || typeof lastRun !== "object") {
-    return undefined;
-  }
-  const skippedCount = countSkipped(lastRun);
-  const errorCount = Array.isArray(lastRun.errors) ? lastRun.errors.length : 0;
-  const createdCount = toNonNegativeInteger(lastRun.createdCount);
-  const candidateCount = toNonNegativeInteger(lastRun.candidateCount);
-  const skipped = collectSkipped(lastRun);
-  return {
-    startedAt: stringOrUndefined(lastRun.startedAt),
-    finishedAt: stringOrUndefined(lastRun.finishedAt),
-    dryRun: lastRun.dryRun !== false,
-    candidateCount,
-    createdCount,
-    skippedCount,
-    errorCount,
-    summary: summarizeLastRunText({ candidateCount, createdCount, skippedCount, errorCount }),
-    skipped: skipped.slice(0, 5),
-    errors: Array.isArray(lastRun.errors) ? lastRun.errors.slice(0, 5) : []
-  };
-}
-
-function summarizeLastRunText({ candidateCount, createdCount, skippedCount, errorCount }) {
-  return `${candidateCount} candidate(s), ${createdCount} created, ${skippedCount} skipped, ${errorCount} error(s)`;
-}
-
-function summarizeProviderHealth({ enabled, dryRun, currentOpenJobs, maxOpenJobs, lastRun }) {
-  if (!enabled) {
-    return "disabled";
-  }
-  if (lastRun?.errorCount > 0) {
-    return "error";
-  }
-  if (maxOpenJobs > 0 && currentOpenJobs >= maxOpenJobs) {
-    return "at_capacity";
-  }
-  if (dryRun) {
-    return "dry_run";
-  }
-  return "healthy";
-}
-
-function countSkipped(lastRun) {
-  return collectSkipped(lastRun).length;
-}
-
-function collectSkipped(lastRun) {
-  const topLevel = Array.isArray(lastRun.skipped) ? lastRun.skipped : [];
-  const queryLevel = Array.isArray(lastRun.queries)
-    ? lastRun.queries.flatMap((query) => Array.isArray(query.skipped) ? query.skipped : [])
-    : [];
-  return [...topLevel, ...queryLevel];
-}
-
-function inferCurrentOpenJobs(lastRun) {
-  if (!lastRun || typeof lastRun !== "object") {
-    return 0;
-  }
-  for (const key of ["openGithubJobs", "openWikipediaJobs", "openOsvJobs", "openDataJobs", "openStandardsJobs", "openApiJobs"]) {
-    if (lastRun[key] !== undefined) {
-      return toNonNegativeInteger(lastRun[key]);
-    }
-  }
-  return 0;
-}
-
-function toNonNegativeInteger(value) {
-  const number = Number(value ?? 0);
-  if (!Number.isFinite(number) || number < 0) {
-    return 0;
-  }
-  return Math.trunc(number);
-}
-
-function stringOrUndefined(value) {
-  return typeof value === "string" && value.trim() ? value : undefined;
 }
 
 function buildSubmissionValidationContract(job) {

--- a/mcp-server/src/core/provider-operations-status.js
+++ b/mcp-server/src/core/provider-operations-status.js
@@ -1,0 +1,186 @@
+const INGESTION_PROVIDER_DEFINITIONS = [
+  ["github", "githubIngestion", "GitHub issues", "queryCount"],
+  ["wikipedia", "wikipediaIngestion", "Wikipedia maintenance", "categoryCount"],
+  ["osv", "osvIngestion", "OSV advisories", "targetCount"],
+  ["openData", "openDataIngestion", "Open data", "targetCount"],
+  ["standards", "standardsIngestion", "Standards freshness", "specCount"],
+  ["openApi", "openApiIngestion", "OpenAPI quality", "specCount"]
+];
+
+/**
+ * Default empty status used when an ingestion scheduler is not wired in
+ * the current process. Matches the shape produced by every concrete
+ * scheduler's `getStatus()` so `buildProviderOperations` can treat all
+ * providers uniformly.
+ */
+export const PROVIDER_STATUS_FALLBACK = Object.freeze({
+  enabled: false,
+  running: false,
+  dryRun: true,
+  intervalMs: 0,
+  maxJobsPerRun: 0,
+  maxOpenJobs: 0,
+  currentOpenJobs: 0,
+  lastRun: undefined
+});
+
+export function buildProviderOperations(statuses) {
+  const entries = INGESTION_PROVIDER_DEFINITIONS.map(([key, statusKey, label, targetCountField]) => {
+    const status = statuses[statusKey] ?? {};
+    return [key, buildProviderOperationStatus({
+      label,
+      status,
+      targetCountField
+    })];
+  });
+  return Object.fromEntries(entries);
+}
+
+/**
+ * Strip `lastRun.errors[]` and `lastRun.skipped[]` from every provider in
+ * a providerOperations object, preserving every other field including
+ * `errorCount` and `skippedCount`. Used to derive the public sanitized
+ * payload from the admin one.
+ */
+export function sanitizeProviderOperations(providerOperations) {
+  const entries = Object.entries(providerOperations).map(([key, value]) => [
+    key,
+    sanitizeProviderOperationStatus(value)
+  ]);
+  return Object.fromEntries(entries);
+}
+
+function buildProviderOperationStatus({ label, status, targetCountField }) {
+  const lastRun = summarizeProviderLastRun(status.lastRun);
+  const currentOpenJobs = status.currentOpenJobs !== undefined
+    ? toNonNegativeInteger(status.currentOpenJobs)
+    : inferCurrentOpenJobs(status.lastRun);
+  // queryCount/nextQuery describe the rotation pool — only meaningful
+  // when the provider rotates a query list distinct from its
+  // targetCount. github's queryCount IS its targetCount, so don't
+  // duplicate it; openData rotates queries against a dataset list, so
+  // queryCount and targetCount are genuinely different signals.
+  const queryCount = status.queryCount !== undefined && targetCountField !== "queryCount"
+    ? toNonNegativeInteger(status.queryCount)
+    : undefined;
+  const nextQuery = stringOrUndefined(status.nextQuery);
+  return {
+    label,
+    enabled: Boolean(status.enabled),
+    running: Boolean(status.running),
+    dryRun: status.dryRun !== false,
+    mode: !status.enabled ? "disabled" : (status.dryRun === false ? "live" : "dry_run"),
+    intervalMs: toNonNegativeInteger(status.intervalMs),
+    maxJobsPerRun: toNonNegativeInteger(status.maxJobsPerRun),
+    ...(status.maxJobsPerQuery !== undefined ? { maxJobsPerQuery: toNonNegativeInteger(status.maxJobsPerQuery) } : {}),
+    maxOpenJobs: toNonNegativeInteger(status.maxOpenJobs),
+    currentOpenJobs,
+    ...(status.minClaimableJobs !== undefined ? { minClaimableJobs: toNonNegativeInteger(status.minClaimableJobs) } : {}),
+    ...(status.currentClaimableJobs !== undefined
+      ? { currentClaimableJobs: toNonNegativeInteger(status.currentClaimableJobs) }
+      : {}),
+    targetCount: toNonNegativeInteger(status[targetCountField]),
+    ...(queryCount !== undefined ? { queryCount } : {}),
+    ...(nextQuery ? { nextQuery } : {}),
+    lastRunAt: lastRun?.finishedAt ?? lastRun?.startedAt,
+    lastRun,
+    health: summarizeProviderHealth({
+      enabled: Boolean(status.enabled),
+      dryRun: status.dryRun !== false,
+      currentOpenJobs,
+      maxOpenJobs: toNonNegativeInteger(status.maxOpenJobs),
+      lastRun
+    })
+  };
+}
+
+function sanitizeProviderOperationStatus(status) {
+  if (!status?.lastRun) return status;
+  return {
+    ...status,
+    lastRun: {
+      ...status.lastRun,
+      skipped: [],
+      errors: []
+    }
+  };
+}
+
+function summarizeProviderLastRun(lastRun) {
+  if (!lastRun || typeof lastRun !== "object") {
+    return undefined;
+  }
+  const skippedCount = countSkipped(lastRun);
+  const errorCount = Array.isArray(lastRun.errors) ? lastRun.errors.length : 0;
+  const createdCount = toNonNegativeInteger(lastRun.createdCount);
+  const candidateCount = toNonNegativeInteger(lastRun.candidateCount);
+  const skipped = collectSkipped(lastRun);
+  return {
+    startedAt: stringOrUndefined(lastRun.startedAt),
+    finishedAt: stringOrUndefined(lastRun.finishedAt),
+    dryRun: lastRun.dryRun !== false,
+    candidateCount,
+    createdCount,
+    skippedCount,
+    errorCount,
+    summary: summarizeLastRunText({ candidateCount, createdCount, skippedCount, errorCount }),
+    skipped: skipped.slice(0, 5),
+    errors: Array.isArray(lastRun.errors) ? lastRun.errors.slice(0, 5) : []
+  };
+}
+
+function summarizeLastRunText({ candidateCount, createdCount, skippedCount, errorCount }) {
+  return `${candidateCount} candidate(s), ${createdCount} created, ${skippedCount} skipped, ${errorCount} error(s)`;
+}
+
+function summarizeProviderHealth({ enabled, dryRun, currentOpenJobs, maxOpenJobs, lastRun }) {
+  if (!enabled) {
+    return "disabled";
+  }
+  if (lastRun?.errorCount > 0) {
+    return "error";
+  }
+  if (maxOpenJobs > 0 && currentOpenJobs >= maxOpenJobs) {
+    return "at_capacity";
+  }
+  if (dryRun) {
+    return "dry_run";
+  }
+  return "healthy";
+}
+
+function countSkipped(lastRun) {
+  return collectSkipped(lastRun).length;
+}
+
+function collectSkipped(lastRun) {
+  const topLevel = Array.isArray(lastRun.skipped) ? lastRun.skipped : [];
+  const queryLevel = Array.isArray(lastRun.queries)
+    ? lastRun.queries.flatMap((query) => Array.isArray(query.skipped) ? query.skipped : [])
+    : [];
+  return [...topLevel, ...queryLevel];
+}
+
+function inferCurrentOpenJobs(lastRun) {
+  if (!lastRun || typeof lastRun !== "object") {
+    return 0;
+  }
+  for (const key of ["openGithubJobs", "openWikipediaJobs", "openOsvJobs", "openDataJobs", "openStandardsJobs", "openApiJobs"]) {
+    if (lastRun[key] !== undefined) {
+      return toNonNegativeInteger(lastRun[key]);
+    }
+  }
+  return 0;
+}
+
+function toNonNegativeInteger(value) {
+  const number = Number(value ?? 0);
+  if (!Number.isFinite(number) || number < 0) {
+    return 0;
+  }
+  return Math.trunc(number);
+}
+
+function stringOrUndefined(value) {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}

--- a/mcp-server/src/core/provider-operations-status.test.js
+++ b/mcp-server/src/core/provider-operations-status.test.js
@@ -1,0 +1,150 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildProviderOperations,
+  PROVIDER_STATUS_FALLBACK,
+  sanitizeProviderOperations
+} from "./provider-operations-status.js";
+
+test("buildProviderOperations projects scheduler statuses into provider rows", () => {
+  const operations = buildProviderOperations({
+    githubIngestion: {
+      enabled: true,
+      running: true,
+      dryRun: true,
+      intervalMs: 60_000,
+      maxJobsPerRun: 4,
+      maxJobsPerQuery: 2,
+      maxOpenJobs: 10,
+      currentOpenJobs: 3,
+      queryCount: 3,
+      lastRun: {
+        startedAt: "2026-01-01T00:00:00.000Z",
+        finishedAt: "2026-01-01T00:00:05.000Z",
+        candidateCount: 4,
+        createdCount: 1,
+        skipped: [{ reason: "source_already_ingested" }],
+        errors: []
+      }
+    },
+    wikipediaIngestion: {
+      enabled: true,
+      dryRun: false,
+      categoryCount: 9,
+      minClaimableJobs: 2,
+      currentClaimableJobs: 0,
+      maxOpenJobs: 5,
+      currentOpenJobs: 5
+    },
+    openDataIngestion: {
+      enabled: true,
+      dryRun: false,
+      targetCount: 3,
+      queryCount: 7,
+      nextQuery: "transport",
+      maxOpenJobs: 10,
+      currentOpenJobs: 1,
+      lastRun: {
+        candidateCount: 2,
+        createdCount: 1,
+        queries: [
+          { skipped: [{ reason: "dataset_already_ingested" }] }
+        ],
+        errors: []
+      }
+    },
+    openApiIngestion: {
+      enabled: true,
+      dryRun: false,
+      specCount: 1,
+      lastRun: {
+        candidateCount: 1,
+        createdCount: 0,
+        errors: [{ message: "fetch failed" }]
+      }
+    }
+  });
+
+  assert.deepEqual(Object.keys(operations).sort(), ["github", "openApi", "openData", "osv", "standards", "wikipedia"]);
+  assert.equal(operations.github.label, "GitHub issues");
+  assert.equal(operations.github.mode, "dry_run");
+  assert.equal(operations.github.currentOpenJobs, 3);
+  assert.equal(operations.github.maxJobsPerQuery, 2);
+  assert.equal(operations.github.lastRunAt, "2026-01-01T00:00:05.000Z");
+  assert.equal(operations.github.lastRun.summary, "4 candidate(s), 1 created, 1 skipped, 0 error(s)");
+  assert.equal(operations.github.lastRun.skipped[0].reason, "source_already_ingested");
+  assert.equal(operations.github.queryCount, undefined);
+  assert.equal(operations.github.nextQuery, undefined);
+
+  assert.equal(operations.wikipedia.mode, "live");
+  assert.equal(operations.wikipedia.health, "at_capacity");
+  assert.equal(operations.wikipedia.minClaimableJobs, 2);
+  assert.equal(operations.wikipedia.currentClaimableJobs, 0);
+
+  assert.equal(operations.openData.health, "healthy");
+  assert.equal(operations.openData.targetCount, 3);
+  assert.equal(operations.openData.queryCount, 7);
+  assert.equal(operations.openData.nextQuery, "transport");
+  assert.equal(operations.openData.lastRun.skipped[0].reason, "dataset_already_ingested");
+
+  assert.equal(operations.openApi.health, "error");
+  assert.equal(operations.openApi.lastRun.errorCount, 1);
+  assert.equal(operations.osv.health, "disabled");
+  assert.equal(operations.standards.mode, "disabled");
+});
+
+test("buildProviderOperations infers current open jobs from lastRun fields", () => {
+  const operations = buildProviderOperations({
+    osvIngestion: {
+      enabled: true,
+      dryRun: false,
+      targetCount: 4,
+      maxOpenJobs: 10,
+      lastRun: {
+        candidateCount: 4,
+        createdCount: 2,
+        openOsvJobs: 6,
+        skipped: [],
+        errors: []
+      }
+    }
+  });
+
+  assert.equal(operations.osv.currentOpenJobs, 6);
+  assert.equal(operations.osv.health, "healthy");
+});
+
+test("sanitizeProviderOperations preserves counts and clears detail arrays", () => {
+  const operations = buildProviderOperations({
+    githubIngestion: {
+      enabled: true,
+      dryRun: true,
+      queryCount: 1,
+      lastRun: {
+        candidateCount: 3,
+        createdCount: 1,
+        skipped: [{ reason: "private_url", url: "https://internal.example/path" }],
+        errors: [{ message: "stack trace" }]
+      }
+    }
+  });
+
+  const sanitized = sanitizeProviderOperations(operations);
+
+  assert.equal(sanitized.github.lastRun.skippedCount, 1);
+  assert.equal(sanitized.github.lastRun.errorCount, 1);
+  assert.deepEqual(sanitized.github.lastRun.skipped, []);
+  assert.deepEqual(sanitized.github.lastRun.errors, []);
+});
+
+test("PROVIDER_STATUS_FALLBACK is a disabled dry-run status", () => {
+  const operations = buildProviderOperations({
+    githubIngestion: PROVIDER_STATUS_FALLBACK
+  });
+
+  assert.equal(operations.github.enabled, false);
+  assert.equal(operations.github.dryRun, true);
+  assert.equal(operations.github.mode, "disabled");
+  assert.equal(operations.github.health, "disabled");
+});


### PR DESCRIPTION
## Summary
- Move provider-operations status projection from `platform-service.js` into `provider-operations-status.js`.
- Keep admin/public status behavior unchanged while shrinking the platform service.
- Add focused coverage for provider row projection, skipped/error sanitization, inferred open jobs, and fallback status behavior.

## Checks
- `node --test mcp-server/src/core/provider-operations-status.test.js`
- `node --test mcp-server/src/core/platform-service.test.js`
- `npm --workspace mcp-server test`
- `git diff --check`

## Impact
- Backend only: `mcp-server/src/core`.
- No frontend/board, indexer, Caddy, contracts, public site, generated output, environment, or VPS secret changes.
- No chain behavior or Polkadot runtime semantics touched; Polkadot docs MCP was not needed for this pure status-projection refactor.