### PR TITLE
refactor: extract account raw amount helpers

### DIFF
--- a/mcp-server/src/core/account-mutation-service.js
+++ b/mcp-server/src/core/account-mutation-service.js
@@ -5,6 +5,16 @@ import {
   ValidationError
 } from "./errors.js";
 import { DEFAULT_ESCROW_ASSET_SYMBOL } from "./assets.js";
+import {
+  addRawAmount,
+  addRequestId,
+  applyRawDeallocation,
+  hasRequestId,
+  normalizeRequestIds,
+  normalizeUnsignedRawAmount,
+  removeRequestId,
+  subtractRawAmount
+} from "./account-raw-amounts.js";
 
 /**
  * Classification of every account-level field this service produces or
@@ -830,147 +840,4 @@ export class AccountMutationService {
     this.accounts.set(wallet, account);
     return account;
   }
-}
-
-function normalizeUnsignedRawAmount(value) {
-  if (value === undefined || value === null || value === "") {
-    return undefined;
-  }
-  if (typeof value === "bigint") {
-    if (value < 0n) {
-      throw new ValidationError("raw amount must be a non-negative integer.");
-    }
-    return value.toString();
-  }
-  if (typeof value === "number") {
-    if (!Number.isSafeInteger(value) || value < 0) {
-      throw new ValidationError("raw amount must be an exact non-negative integer.");
-    }
-    return String(value);
-  }
-  if (typeof value === "string") {
-    const normalized = value.trim();
-    if (!/^\d+$/u.test(normalized)) {
-      throw new ValidationError("raw amount must be a non-negative integer string.");
-    }
-    return BigInt(normalized).toString();
-  }
-  throw new ValidationError("raw amount must be a non-negative integer.");
-}
-
-function normalizeSignedRawAmount(value) {
-  if (value === undefined || value === null || value === "") {
-    return 0n;
-  }
-  if (typeof value === "bigint") {
-    return value;
-  }
-  if (typeof value === "number") {
-    if (!Number.isSafeInteger(value)) {
-      throw new ValidationError("signed raw amount must be an exact integer.");
-    }
-    return BigInt(value);
-  }
-  if (typeof value === "string") {
-    const normalized = value.trim();
-    if (!/^-?\d+$/u.test(normalized)) {
-      throw new ValidationError("signed raw amount must be an integer string.");
-    }
-    return BigInt(normalized);
-  }
-  throw new ValidationError("signed raw amount must be an integer.");
-}
-
-function addRawAmount(current, delta) {
-  const normalizedDelta = normalizeUnsignedRawAmount(delta);
-  if (normalizedDelta === undefined) {
-    return current;
-  }
-  const normalizedCurrent = normalizeUnsignedRawAmount(current);
-  return ((normalizedCurrent === undefined ? 0n : BigInt(normalizedCurrent)) + BigInt(normalizedDelta)).toString();
-}
-
-function subtractRawAmount(current, delta) {
-  const normalizedCurrent = normalizeUnsignedRawAmount(current);
-  if (normalizedCurrent === undefined) {
-    return current;
-  }
-  const normalizedDelta = normalizeUnsignedRawAmount(delta);
-  if (normalizedDelta === undefined) {
-    return normalizedCurrent;
-  }
-  const next = BigInt(normalizedCurrent) - BigInt(normalizedDelta);
-  return next > 0n ? next.toString() : "0";
-}
-
-function normalizeRequestId(requestId) {
-  if (typeof requestId !== "string" || !requestId.trim()) {
-    return undefined;
-  }
-  return requestId.trim().toLowerCase();
-}
-
-function normalizeRequestIds(requestIds) {
-  if (!Array.isArray(requestIds)) {
-    return [];
-  }
-  return requestIds.map(normalizeRequestId).filter(Boolean);
-}
-
-function hasRequestId(requestIds, requestId) {
-  const normalized = normalizeRequestId(requestId);
-  return Boolean(normalized && normalizeRequestIds(requestIds).includes(normalized));
-}
-
-function addRequestId(requestIds, requestId) {
-  const normalized = normalizeRequestId(requestId);
-  if (!normalized) {
-    return normalizeRequestIds(requestIds);
-  }
-  return [...new Set([...normalizeRequestIds(requestIds), normalized])];
-}
-
-function removeRequestId(requestIds, requestId) {
-  const normalized = normalizeRequestId(requestId);
-  if (!normalized) {
-    return normalizeRequestIds(requestIds);
-  }
-  return normalizeRequestIds(requestIds).filter((existing) => existing !== normalized);
-}
-
-function addSignedRawAmount(current, delta) {
-  return (normalizeSignedRawAmount(current) + normalizeSignedRawAmount(delta)).toString();
-}
-
-function maxBigInt(...values) {
-  return values.reduce((max, value) => (value > max ? value : max), values[0] ?? 0n);
-}
-
-function minBigInt(...values) {
-  return values.reduce((min, value) => (value < min ? value : min), values[0] ?? 0n);
-}
-
-function applyRawDeallocation(entry, assetsReturnedRaw) {
-  const normalizedAssetsReturnedRaw = normalizeUnsignedRawAmount(assetsReturnedRaw);
-  const normalizedPrincipalRaw = normalizeUnsignedRawAmount(entry.principalRaw);
-  if (normalizedAssetsReturnedRaw === undefined || normalizedPrincipalRaw === undefined) {
-    return {};
-  }
-
-  const assetsReturned = BigInt(normalizedAssetsReturnedRaw);
-  const principalBefore = BigInt(normalizedPrincipalRaw);
-  const markValueBefore = BigInt(normalizeUnsignedRawAmount(entry.markValueRaw ?? entry.principalRaw) ?? "0");
-  const denominator = maxBigInt(markValueBefore, assetsReturned, 0n);
-  const principalReleased = denominator > 0n
-    ? minBigInt(principalBefore, (principalBefore * assetsReturned) / denominator)
-    : minBigInt(principalBefore, assetsReturned);
-  const realizedYieldDeltaRaw = assetsReturned - principalReleased;
-
-  entry.principalRaw = (principalBefore > principalReleased ? principalBefore - principalReleased : 0n).toString();
-  entry.realizedYieldRaw = addSignedRawAmount(entry.realizedYieldRaw, realizedYieldDeltaRaw);
-  entry.markValueRaw = (markValueBefore > assetsReturned ? markValueBefore - assetsReturned : 0n).toString();
-
-  return {
-    realizedYieldDeltaRaw: realizedYieldDeltaRaw.toString()
-  };
 }

--- a/mcp-server/src/core/account-raw-amounts.js
+++ b/mcp-server/src/core/account-raw-amounts.js
@@ -1,0 +1,144 @@
+import { ValidationError } from "./errors.js";
+
+export function normalizeUnsignedRawAmount(value) {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+  if (typeof value === "bigint") {
+    if (value < 0n) {
+      throw new ValidationError("raw amount must be a non-negative integer.");
+    }
+    return value.toString();
+  }
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new ValidationError("raw amount must be an exact non-negative integer.");
+    }
+    return String(value);
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim();
+    if (!/^\d+$/u.test(normalized)) {
+      throw new ValidationError("raw amount must be a non-negative integer string.");
+    }
+    return BigInt(normalized).toString();
+  }
+  throw new ValidationError("raw amount must be a non-negative integer.");
+}
+
+export function addRawAmount(current, delta) {
+  const normalizedDelta = normalizeUnsignedRawAmount(delta);
+  if (normalizedDelta === undefined) {
+    return current;
+  }
+  const normalizedCurrent = normalizeUnsignedRawAmount(current);
+  return ((normalizedCurrent === undefined ? 0n : BigInt(normalizedCurrent)) + BigInt(normalizedDelta)).toString();
+}
+
+export function subtractRawAmount(current, delta) {
+  const normalizedCurrent = normalizeUnsignedRawAmount(current);
+  if (normalizedCurrent === undefined) {
+    return current;
+  }
+  const normalizedDelta = normalizeUnsignedRawAmount(delta);
+  if (normalizedDelta === undefined) {
+    return normalizedCurrent;
+  }
+  const next = BigInt(normalizedCurrent) - BigInt(normalizedDelta);
+  return next > 0n ? next.toString() : "0";
+}
+
+export function normalizeRequestId(requestId) {
+  if (typeof requestId !== "string" || !requestId.trim()) {
+    return undefined;
+  }
+  return requestId.trim().toLowerCase();
+}
+
+export function normalizeRequestIds(requestIds) {
+  if (!Array.isArray(requestIds)) {
+    return [];
+  }
+  return requestIds.map(normalizeRequestId).filter(Boolean);
+}
+
+export function hasRequestId(requestIds, requestId) {
+  const normalized = normalizeRequestId(requestId);
+  return Boolean(normalized && normalizeRequestIds(requestIds).includes(normalized));
+}
+
+export function addRequestId(requestIds, requestId) {
+  const normalized = normalizeRequestId(requestId);
+  if (!normalized) {
+    return normalizeRequestIds(requestIds);
+  }
+  return [...new Set([...normalizeRequestIds(requestIds), normalized])];
+}
+
+export function removeRequestId(requestIds, requestId) {
+  const normalized = normalizeRequestId(requestId);
+  if (!normalized) {
+    return normalizeRequestIds(requestIds);
+  }
+  return normalizeRequestIds(requestIds).filter((existing) => existing !== normalized);
+}
+
+export function applyRawDeallocation(entry, assetsReturnedRaw) {
+  const normalizedAssetsReturnedRaw = normalizeUnsignedRawAmount(assetsReturnedRaw);
+  const normalizedPrincipalRaw = normalizeUnsignedRawAmount(entry.principalRaw);
+  if (normalizedAssetsReturnedRaw === undefined || normalizedPrincipalRaw === undefined) {
+    return {};
+  }
+
+  const assetsReturned = BigInt(normalizedAssetsReturnedRaw);
+  const principalBefore = BigInt(normalizedPrincipalRaw);
+  const markValueBefore = BigInt(normalizeUnsignedRawAmount(entry.markValueRaw ?? entry.principalRaw) ?? "0");
+  const denominator = maxBigInt(markValueBefore, assetsReturned, 0n);
+  const principalReleased = denominator > 0n
+    ? minBigInt(principalBefore, (principalBefore * assetsReturned) / denominator)
+    : minBigInt(principalBefore, assetsReturned);
+  const realizedYieldDeltaRaw = assetsReturned - principalReleased;
+
+  entry.principalRaw = (principalBefore > principalReleased ? principalBefore - principalReleased : 0n).toString();
+  entry.realizedYieldRaw = addSignedRawAmount(entry.realizedYieldRaw, realizedYieldDeltaRaw);
+  entry.markValueRaw = (markValueBefore > assetsReturned ? markValueBefore - assetsReturned : 0n).toString();
+
+  return {
+    realizedYieldDeltaRaw: realizedYieldDeltaRaw.toString()
+  };
+}
+
+function normalizeSignedRawAmount(value) {
+  if (value === undefined || value === null || value === "") {
+    return 0n;
+  }
+  if (typeof value === "bigint") {
+    return value;
+  }
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value)) {
+      throw new ValidationError("signed raw amount must be an exact integer.");
+    }
+    return BigInt(value);
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim();
+    if (!/^-?\d+$/u.test(normalized)) {
+      throw new ValidationError("signed raw amount must be an integer string.");
+    }
+    return BigInt(normalized);
+  }
+  throw new ValidationError("signed raw amount must be an integer.");
+}
+
+function addSignedRawAmount(current, delta) {
+  return (normalizeSignedRawAmount(current) + normalizeSignedRawAmount(delta)).toString();
+}
+
+function maxBigInt(...values) {
+  return values.reduce((max, value) => (value > max ? value : max), values[0] ?? 0n);
+}
+
+function minBigInt(...values) {
+  return values.reduce((min, value) => (value < min ? value : min), values[0] ?? 0n);
+}

--- a/mcp-server/src/core/account-raw-amounts.test.js
+++ b/mcp-server/src/core/account-raw-amounts.test.js
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  addRawAmount,
+  addRequestId,
+  applyRawDeallocation,
+  hasRequestId,
+  normalizeRequestIds,
+  normalizeUnsignedRawAmount,
+  removeRequestId,
+  subtractRawAmount
+} from "./account-raw-amounts.js";
+import { ValidationError } from "./errors.js";
+
+test("normalizeUnsignedRawAmount accepts exact non-negative raw amounts", () => {
+  assert.equal(normalizeUnsignedRawAmount(undefined), undefined);
+  assert.equal(normalizeUnsignedRawAmount(null), undefined);
+  assert.equal(normalizeUnsignedRawAmount(""), undefined);
+  assert.equal(normalizeUnsignedRawAmount(0), "0");
+  assert.equal(normalizeUnsignedRawAmount(42), "42");
+  assert.equal(normalizeUnsignedRawAmount(42n), "42");
+  assert.equal(normalizeUnsignedRawAmount(" 00042 "), "42");
+});
+
+test("normalizeUnsignedRawAmount rejects negative, fractional, and unsafe values", () => {
+  assert.throws(() => normalizeUnsignedRawAmount(-1), ValidationError);
+  assert.throws(() => normalizeUnsignedRawAmount(1.5), ValidationError);
+  assert.throws(() => normalizeUnsignedRawAmount(Number.MAX_SAFE_INTEGER + 1), ValidationError);
+  assert.throws(() => normalizeUnsignedRawAmount(-1n), ValidationError);
+  assert.throws(() => normalizeUnsignedRawAmount("-1"), ValidationError);
+  assert.throws(() => normalizeUnsignedRawAmount("1.5"), ValidationError);
+  assert.throws(() => normalizeUnsignedRawAmount({ value: 1 }), ValidationError);
+});
+
+test("raw amount arithmetic keeps undefined current values and clamps subtraction at zero", () => {
+  assert.equal(addRawAmount(undefined, undefined), undefined);
+  assert.equal(addRawAmount(undefined, 5), "5");
+  assert.equal(addRawAmount("7", 5n), "12");
+  assert.equal(subtractRawAmount(undefined, 5), undefined);
+  assert.equal(subtractRawAmount("7", undefined), "7");
+  assert.equal(subtractRawAmount("7", 2), "5");
+  assert.equal(subtractRawAmount("7", 9), "0");
+});
+
+test("request id helpers normalize, dedupe, test, and remove ids", () => {
+  assert.deepEqual(normalizeRequestIds(undefined), []);
+  assert.deepEqual(normalizeRequestIds([" ABC ", "", undefined, "def"]), ["abc", "def"]);
+
+  const added = addRequestId([" ABC "], "abc");
+  assert.deepEqual(added, ["abc"]);
+  assert.equal(hasRequestId(added, " ABC "), true);
+  assert.equal(hasRequestId(added, "missing"), false);
+  assert.deepEqual(addRequestId(added, " DEF "), ["abc", "def"]);
+  assert.deepEqual(removeRequestId(["abc", "def"], " ABC "), ["def"]);
+  assert.deepEqual(removeRequestId(["abc", "def"], ""), ["abc", "def"]);
+});
+
+test("applyRawDeallocation updates raw principal, yield, and mark value proportionally", () => {
+  const entry = {
+    principalRaw: "1000",
+    markValueRaw: "1250",
+    realizedYieldRaw: "10"
+  };
+
+  const result = applyRawDeallocation(entry, "500");
+
+  assert.deepEqual(result, { realizedYieldDeltaRaw: "100" });
+  assert.equal(entry.principalRaw, "600");
+  assert.equal(entry.markValueRaw, "750");
+  assert.equal(entry.realizedYieldRaw, "110");
+});
+
+test("applyRawDeallocation is a no-op when raw principal is absent", () => {
+  const entry = {};
+
+  const result = applyRawDeallocation(entry, "500");
+
+  assert.deepEqual(result, {});
+  assert.deepEqual(entry, {});
+});


### PR DESCRIPTION
## Summary
- extracted raw amount normalization/arithmetic, request-id normalization, and raw deallocation math from `AccountMutationService` into `account-raw-amounts.js`
- kept the account mutation service public behavior unchanged while trimming its inline helper cluster
- added focused tests for exact raw amount handling, request id dedupe/removal, and proportional deallocation accounting

## Checks
- `node --test mcp-server/src/core/account-raw-amounts.test.js`
- `node --test mcp-server/src/core/account-mutation-service.test.js`
- `node --test mcp-server/src/core/platform-service.test.js`
- `npm --workspace mcp-server test` (874 tests passing after installing dependencies in this task worktree)
- `git diff --check`

## Surface
- Backend only: `mcp-server/src/core`
- No frontend/board changes, generated output, indexer, Caddy, contracts, public site, env, or VPS secret changes
- No chain behavior or Polkadot runtime semantics touched; this is a pure helper extraction, so Polkadot docs MCP was not needed for this slice