### PR TITLE
refactor: extract operator activity feed

### DIFF
--- a/mcp-server/src/protocols/http/operator-activity-feed.js
+++ b/mcp-server/src/protocols/http/operator-activity-feed.js
@@ -1,0 +1,249 @@
+import { OPERATOR_SIGNERS } from "../../core/builtin-policies.js";
+
+export function createOperatorActivityFeed({
+  defaultVerifierAddress,
+  listDisputes,
+  listPolicies,
+  now = () => Date.now(),
+  operatorSigners = OPERATOR_SIGNERS,
+  service,
+  stateStore,
+}) {
+  return {
+    listAlerts: (limit = 20) => listAlerts({
+      limit,
+      listDisputes,
+      listPolicies,
+      service,
+    }),
+    listAuditEvents: (limit = 100) => listAuditEvents({
+      defaultVerifierAddress,
+      limit,
+      listPolicies,
+      now,
+      operatorSigners,
+      service,
+      stateStore,
+    }),
+  };
+}
+
+export async function listAuditEvents({
+  defaultVerifierAddress,
+  limit = 100,
+  listPolicies,
+  now = () => Date.now(),
+  operatorSigners = OPERATOR_SIGNERS,
+  service,
+  stateStore,
+}) {
+  const sessions = await service.listRecentSessions(limit);
+  const events = [];
+  for (const session of sessions) {
+    const actor = auditActor(`agent-${compactWallet(session.wallet)}`, compactWallet(session.wallet), "sage");
+    events.push(auditEvent({
+      id: `audit-${session.sessionId}-claimed`,
+      at: session.createdAt ?? session.updatedAt,
+      source: "system",
+      category: "runs",
+      action: "session.claimed",
+      actor,
+      summary: `Claimed ${session.jobId}.`,
+      target: session.sessionId,
+      hash: session.chainJobId,
+      link: { label: "Open run ->", href: "/runs" },
+      now,
+    }));
+    if (session.submittedAt || session.submission) {
+      events.push(auditEvent({
+        id: `audit-${session.sessionId}-submitted`,
+        at: session.submittedAt ?? session.updatedAt,
+        source: "system",
+        category: "runs",
+        action: "session.submitted",
+        actor,
+        summary: `Submitted evidence for ${session.jobId}.`,
+        target: session.sessionId,
+        link: { label: "Open session ->", href: "/sessions" },
+        now,
+      }));
+    }
+    if (session.verification || session.verificationSummary) {
+      events.push(auditEvent({
+        id: `audit-${session.sessionId}-verified`,
+        at: session.verifiedAt ?? session.updatedAt,
+        source: "operator",
+        category: "verifier",
+        action: "verification.resolved",
+        actor: auditActor("verifier", compactWallet(defaultVerifierAddress), "blue"),
+        summary: `Verifier resolved ${session.jobId} as ${session.status}.`,
+        target: session.sessionId,
+        tone: session.status === "disputed" ? "warn" : "accent",
+        link: { label: "Open receipt ->", href: "/receipts" },
+        now,
+      }));
+    }
+  }
+  for (const policy of listPolicies()) {
+    events.push(auditEvent({
+      id: `audit-policy-${policy.id}`,
+      at: policy.lastChange?.at,
+      source: "operator",
+      category: "policy",
+      action: policy.state === "Pending" ? "policy.proposed" : "policy.active",
+      actor: auditActor(
+        operatorSigners[policy.lastChange?.author]?.role ?? "operator",
+        operatorSigners[policy.lastChange?.author]?.addr,
+        "ink"
+      ),
+      summary: `${policy.tag}: ${policy.lastChange?.text}`,
+      target: policy.tag,
+      tone: policy.state === "Pending" ? "warn" : "neutral",
+      link: { label: "Open policy ->", href: "/policies" },
+      now,
+    }));
+  }
+  if (typeof stateStore?.listCapabilityGrants === "function") {
+    const grants = await stateStore.listCapabilityGrants({ limit: Math.min(limit, 100) }).catch(() => []);
+    for (const grant of grants) {
+      const issuer = compactWallet(grant.issuedBy);
+      const subject = compactWallet(grant.subject);
+      events.push(auditEvent({
+        id: `audit-capability-grant-${grant.id}`,
+        at: grant.issuedAt,
+        source: "operator",
+        category: "policy",
+        action: "capability.grant",
+        actor: auditActor("operator", issuer, "ink"),
+        summary: `Granted ${grant.capabilities.length} capabilit${grant.capabilities.length === 1 ? "y" : "ies"} to ${subject}${grant.scope ? ` (${grant.scope})` : ""}.`,
+        target: grant.id,
+        tone: "neutral",
+        link: { label: "Open grants ->", href: "/capabilities" },
+        now,
+      }));
+      if (grant.status === "revoked" && grant.revokedAt) {
+        events.push(auditEvent({
+          id: `audit-capability-revoke-${grant.id}`,
+          at: grant.revokedAt,
+          source: "operator",
+          category: "policy",
+          action: "capability.revoke",
+          actor: auditActor("operator", compactWallet(grant.revokedBy), "warn"),
+          summary: `Revoked grant ${grant.id} for ${subject}${grant.revokeNote ? ` - ${grant.revokeNote}` : ""}.`,
+          target: grant.id,
+          tone: "warn",
+          link: { label: "Open grants ->", href: "/capabilities" },
+          now,
+        }));
+      }
+    }
+  }
+  return events
+    .sort((left, right) => String(right.day + right.at).localeCompare(String(left.day + left.at)))
+    .slice(0, limit);
+}
+
+export async function listAlerts({
+  limit = 20,
+  listDisputes,
+  listPolicies,
+  service,
+}) {
+  const [sessions, disputes] = await Promise.all([
+    service.listRecentSessions(limit),
+    listDisputes(limit)
+  ]);
+  const alerts = [];
+  for (const dispute of disputes) {
+    alerts.push({
+      id: `alert-${dispute.id}`,
+      tone: "warn",
+      title: "Dispute awaiting verdict",
+      ref: dispute.sessionId,
+      body: `Stake of ${dispute.stakedAmount} DOT remains locked until a verifier verdict is recorded.`,
+      ctaLabel: "Open disputes ->",
+      ctaHref: "/disputes"
+    });
+  }
+  const pendingPolicies = listPolicies().filter((policy) => policy.state === "Pending");
+  for (const policy of pendingPolicies) {
+    alerts.push({
+      id: `alert-${policy.id}`,
+      tone: "warn",
+      title: "Policy awaiting second signer",
+      ref: policy.tag,
+      body: `${policy.signersReq} signatures required before this rule can gate live work.`,
+      ctaLabel: "Open policies ->",
+      ctaHref: "/policies"
+    });
+  }
+  const submitted = sessions.filter((session) => ["submitted", "disputed"].includes(session.status));
+  for (const session of submitted.slice(0, Math.max(0, limit - alerts.length))) {
+    alerts.push({
+      id: `alert-session-${session.sessionId}`,
+      tone: session.status === "disputed" ? "warn" : "accent",
+      title: session.status === "disputed" ? "Run needs human review" : "Submitted run ready for verification",
+      ref: session.sessionId,
+      body: `${session.jobId} is currently ${session.status}.`,
+      ctaLabel: "Open runs ->",
+      ctaHref: "/runs"
+    });
+  }
+  return alerts.slice(0, limit);
+}
+
+export function compactWallet(wallet) {
+  const value = String(wallet ?? "");
+  if (value.length <= 12) return value || "system";
+  return `${value.slice(0, 6)}...${value.slice(-4)}`;
+}
+
+function auditTime(value) {
+  const date = new Date(value ?? Date.now());
+  if (Number.isNaN(date.getTime())) return "00:00:00";
+  return date.toISOString().slice(11, 19);
+}
+
+function auditDay(value, now = () => Date.now()) {
+  const date = new Date(value ?? now());
+  if (Number.isNaN(date.getTime())) return "today";
+  const today = new Date(now()).toISOString().slice(0, 10);
+  const yesterday = new Date(now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  const day = date.toISOString().slice(0, 10);
+  if (day === today) return "today";
+  if (day === yesterday) return "yesterday";
+  return day;
+}
+
+function auditActor(handle, address, tone = "muted") {
+  const label = String(handle ?? "system");
+  return {
+    handle: label,
+    address: address ?? "averray.platform",
+    initials: label.slice(0, 2).toUpperCase(),
+    tone
+  };
+}
+
+function auditEvent({ id, at, source, category, action, actor, summary, target, hash, tone, link, now }) {
+  return compactObject({
+    id,
+    at: auditTime(at),
+    day: auditDay(at, now),
+    source,
+    category,
+    action,
+    actor,
+    summary,
+    target,
+    hash,
+    tone,
+    link
+  });
+}
+
+function compactObject(value) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined && entry !== null)
+  );
+}

--- a/mcp-server/src/protocols/http/operator-activity-feed.test.js
+++ b/mcp-server/src/protocols/http/operator-activity-feed.test.js
@@ -1,0 +1,163 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  compactWallet,
+  createOperatorActivityFeed,
+  listAlerts,
+  listAuditEvents
+} from "./operator-activity-feed.js";
+
+const NOW = new Date("2026-06-06T12:00:00.000Z").getTime();
+
+test("compactWallet preserves short values and compacts long wallets", () => {
+  assert.equal(compactWallet(""), "system");
+  assert.equal(compactWallet("0xabc"), "0xabc");
+  assert.equal(compactWallet("0x1234567890abcdef"), "0x1234...cdef");
+});
+
+test("listAuditEvents builds run, policy, and capability lifecycle events", async () => {
+  const events = await listAuditEvents({
+    defaultVerifierAddress: "0xVerifierAddress00000000000000000000000000000000",
+    limit: 20,
+    listPolicies: () => [
+      {
+        id: "policy-1",
+        tag: "claim/sample@v1",
+        state: "Pending",
+        lastChange: {
+          author: "fd2e",
+          at: "2026-06-06T11:00:00.000Z",
+          text: "Policy proposed"
+        }
+      }
+    ],
+    now: () => NOW,
+    operatorSigners: {
+      fd2e: {
+        role: "operator",
+        addr: "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519"
+      }
+    },
+    service: {
+      listRecentSessions: async () => [
+        {
+          sessionId: "session-1",
+          jobId: "job-1",
+          wallet: "0xWorker000000000000000000000000000000000000",
+          chainJobId: "0xjobhash",
+          status: "approved",
+          createdAt: "2026-06-06T10:00:00.000Z",
+          submittedAt: "2026-06-06T10:10:00.000Z",
+          verifiedAt: "2026-06-06T10:20:00.000Z",
+          submission: { ok: true },
+          verification: { verdict: "approved" }
+        }
+      ]
+    },
+    stateStore: {
+      listCapabilityGrants: async () => [
+        {
+          id: "grant-1",
+          capabilities: ["jobs:claim", "jobs:submit"],
+          issuedAt: "2026-06-06T09:00:00.000Z",
+          issuedBy: "0xIssuer000000000000000000000000000000000000",
+          subject: "0xSubject00000000000000000000000000000000000",
+          scope: "wikipedia",
+          status: "revoked",
+          revokedAt: "2026-06-06T09:30:00.000Z",
+          revokedBy: "0xRevoker0000000000000000000000000000000000",
+          revokeNote: "rotated"
+        }
+      ]
+    }
+  });
+
+  const actions = events.map((event) => event.action);
+  assert.deepEqual(actions, [
+    "policy.proposed",
+    "verification.resolved",
+    "session.submitted",
+    "session.claimed",
+    "capability.revoke",
+    "capability.grant"
+  ]);
+  assert.equal(events.find((event) => event.action === "session.claimed").day, "today");
+  assert.equal(events.find((event) => event.action === "policy.proposed").actor.address, "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519");
+  assert.match(events.find((event) => event.action === "capability.revoke").summary, /rotated/u);
+});
+
+test("listAuditEvents tolerates capability store failures", async () => {
+  const events = await listAuditEvents({
+    limit: 20,
+    listPolicies: () => [],
+    now: () => NOW,
+    service: { listRecentSessions: async () => [] },
+    stateStore: {
+      listCapabilityGrants: async () => {
+        throw new Error("store unavailable");
+      }
+    }
+  });
+
+  assert.deepEqual(events, []);
+});
+
+test("listAlerts keeps dispute and pending-policy alerts before session alerts", async () => {
+  const alerts = await listAlerts({
+    limit: 3,
+    listDisputes: async () => [
+      {
+        id: "dispute-1",
+        sessionId: "session-disputed",
+        stakedAmount: "3"
+      }
+    ],
+    listPolicies: () => [
+      {
+        id: "policy-1",
+        tag: "claim/sample@v1",
+        state: "Pending",
+        signersReq: 2
+      }
+    ],
+    service: {
+      listRecentSessions: async () => [
+        { sessionId: "session-1", jobId: "job-1", status: "submitted" },
+        { sessionId: "session-2", jobId: "job-2", status: "disputed" }
+      ]
+    }
+  });
+
+  assert.deepEqual(alerts.map((alert) => alert.id), [
+    "alert-dispute-1",
+    "alert-policy-1",
+    "alert-session-session-1"
+  ]);
+  assert.equal(alerts[0].ctaHref, "/disputes");
+  assert.equal(alerts[1].ctaHref, "/policies");
+  assert.equal(alerts[2].ctaHref, "/runs");
+});
+
+test("createOperatorActivityFeed wires alert and audit dependencies", async () => {
+  const feed = createOperatorActivityFeed({
+    listDisputes: async () => [],
+    listPolicies: () => [],
+    now: () => NOW,
+    service: {
+      listRecentSessions: async () => [
+        {
+          sessionId: "session-1",
+          jobId: "job-1",
+          wallet: "0xWorker000000000000000000000000000000000000",
+          createdAt: "2026-06-06T10:00:00.000Z",
+          status: "submitted"
+        }
+      ]
+    },
+    stateStore: {}
+  });
+
+  assert.equal((await feed.listAuditEvents(5))[0].action, "session.claimed");
+  assert.equal((await feed.listAlerts(5))[0].id, "alert-session-session-1");
+});

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -35,6 +35,7 @@ import { createGasRoutes } from "./gas-routes.js";
 import { createIdempotentMutationHelpers } from "./idempotent-mutations.js";
 import { createJobRoutes } from "./job-routes.js";
 import { createOperationalRoutes, resolveMetricsAuthConfig } from "./operational-routes.js";
+import { createOperatorActivityFeed } from "./operator-activity-feed.js";
 import { createPaymentRoutes } from "./payment-routes.js";
 import { createPolicyRoutes } from "./policy-routes.js";
 import { createProfileRoutes } from "./profile-routes.js";
@@ -45,7 +46,7 @@ import { createShareRoutes } from "./share-routes.js";
 import { createUsdcLiquidityRoutes } from "./usdc-liquidity-routes.js";
 import { createVerifierRoutes } from "./verifier-routes.js";
 import { createXcmRequestRoutes } from "./xcm-request-routes.js";
-import { OPERATOR_SIGNERS, makePolicy } from "../../core/builtin-policies.js";
+import { makePolicy } from "../../core/builtin-policies.js";
 import { createUsdcLiquidityStatusService } from "../../services/usdc-liquidity-status.js";
 
 const {
@@ -349,12 +350,6 @@ async function listBadgeReceipts(limit = 100) {
   return receipts;
 }
 
-function compactObject(value) {
-  return Object.fromEntries(
-    Object.entries(value).filter(([, entry]) => entry !== undefined && entry !== null)
-  );
-}
-
 // Package G (P2.5b) — policy state is now owned by `policyService`.
 // `OPERATOR_SIGNERS`, `signerApproval`, `makePolicy`, and the
 // `BUILTIN_POLICIES` seed array moved to
@@ -406,200 +401,6 @@ function buildPolicyProposal(payload, auth) {
       v1: body
     }
   });
-}
-
-function compactWallet(wallet) {
-  const value = String(wallet ?? "");
-  if (value.length <= 12) return value || "system";
-  return `${value.slice(0, 6)}...${value.slice(-4)}`;
-}
-
-function auditTime(value) {
-  const date = new Date(value ?? Date.now());
-  if (Number.isNaN(date.getTime())) return "00:00:00";
-  return date.toISOString().slice(11, 19);
-}
-
-function auditDay(value) {
-  const date = new Date(value ?? Date.now());
-  if (Number.isNaN(date.getTime())) return "today";
-  const today = new Date().toISOString().slice(0, 10);
-  const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-  const day = date.toISOString().slice(0, 10);
-  if (day === today) return "today";
-  if (day === yesterday) return "yesterday";
-  return day;
-}
-
-function auditActor(handle, address, tone = "muted") {
-  const label = String(handle ?? "system");
-  return {
-    handle: label,
-    address: address ?? "averray.platform",
-    initials: label.slice(0, 2).toUpperCase(),
-    tone
-  };
-}
-
-function auditEvent({ id, at, source, category, action, actor, summary, target, hash, tone, link }) {
-  return compactObject({
-    id,
-    at: auditTime(at),
-    day: auditDay(at),
-    source,
-    category,
-    action,
-    actor,
-    summary,
-    target,
-    hash,
-    tone,
-    link
-  });
-}
-
-async function listAuditEvents(limit = 100) {
-  const sessions = await service.listRecentSessions(limit);
-  const events = [];
-  for (const session of sessions) {
-    const actor = auditActor(`agent-${compactWallet(session.wallet)}`, compactWallet(session.wallet), "sage");
-    events.push(auditEvent({
-      id: `audit-${session.sessionId}-claimed`,
-      at: session.createdAt ?? session.updatedAt,
-      source: "system",
-      category: "runs",
-      action: "session.claimed",
-      actor,
-      summary: `Claimed ${session.jobId}.`,
-      target: session.sessionId,
-      hash: session.chainJobId,
-      link: { label: "Open run ->", href: "/runs" }
-    }));
-    if (session.submittedAt || session.submission) {
-      events.push(auditEvent({
-        id: `audit-${session.sessionId}-submitted`,
-        at: session.submittedAt ?? session.updatedAt,
-        source: "system",
-        category: "runs",
-        action: "session.submitted",
-        actor,
-        summary: `Submitted evidence for ${session.jobId}.`,
-        target: session.sessionId,
-        link: { label: "Open session ->", href: "/sessions" }
-      }));
-    }
-    if (session.verification || session.verificationSummary) {
-      events.push(auditEvent({
-        id: `audit-${session.sessionId}-verified`,
-        at: session.verifiedAt ?? session.updatedAt,
-        source: "operator",
-        category: "verifier",
-        action: "verification.resolved",
-        actor: auditActor("verifier", compactWallet(process.env.DEFAULT_VERIFIER_ADDRESS), "blue"),
-        summary: `Verifier resolved ${session.jobId} as ${session.status}.`,
-        target: session.sessionId,
-        tone: session.status === "disputed" ? "warn" : "accent",
-        link: { label: "Open receipt ->", href: "/receipts" }
-      }));
-    }
-  }
-  for (const policy of listPolicies()) {
-    events.push(auditEvent({
-      id: `audit-policy-${policy.id}`,
-      at: policy.lastChange?.at,
-      source: "operator",
-      category: "policy",
-      action: policy.state === "Pending" ? "policy.proposed" : "policy.active",
-      actor: auditActor(OPERATOR_SIGNERS[policy.lastChange?.author]?.role ?? "operator", OPERATOR_SIGNERS[policy.lastChange?.author]?.addr, "ink"),
-      summary: `${policy.tag}: ${policy.lastChange?.text}`,
-      target: policy.tag,
-      tone: policy.state === "Pending" ? "warn" : "neutral",
-      link: { label: "Open policy ->", href: "/policies" }
-    }));
-  }
-  // Surface capability grant/revoke audit events alongside policy
-  // and run lifecycle ones so the audit log has a single feed for
-  // governance changes. Read-only — no state mutation.
-  if (typeof stateStore?.listCapabilityGrants === "function") {
-    const grants = await stateStore.listCapabilityGrants({ limit: Math.min(limit, 100) }).catch(() => []);
-    for (const grant of grants) {
-      const issuer = compactWallet(grant.issuedBy);
-      const subject = compactWallet(grant.subject);
-      events.push(auditEvent({
-        id: `audit-capability-grant-${grant.id}`,
-        at: grant.issuedAt,
-        source: "operator",
-        category: "policy",
-        action: "capability.grant",
-        actor: auditActor("operator", issuer, "ink"),
-        summary: `Granted ${grant.capabilities.length} capabilit${grant.capabilities.length === 1 ? "y" : "ies"} to ${subject}${grant.scope ? ` (${grant.scope})` : ""}.`,
-        target: grant.id,
-        tone: "neutral",
-        link: { label: "Open grants ->", href: "/capabilities" }
-      }));
-      if (grant.status === "revoked" && grant.revokedAt) {
-        events.push(auditEvent({
-          id: `audit-capability-revoke-${grant.id}`,
-          at: grant.revokedAt,
-          source: "operator",
-          category: "policy",
-          action: "capability.revoke",
-          actor: auditActor("operator", compactWallet(grant.revokedBy), "warn"),
-          summary: `Revoked grant ${grant.id} for ${subject}${grant.revokeNote ? ` — ${grant.revokeNote}` : ""}.`,
-          target: grant.id,
-          tone: "warn",
-          link: { label: "Open grants ->", href: "/capabilities" }
-        }));
-      }
-    }
-  }
-  return events
-    .sort((left, right) => String(right.day + right.at).localeCompare(String(left.day + left.at)))
-    .slice(0, limit);
-}
-
-async function listAlerts(limit = 20) {
-  const [sessions, disputes] = await Promise.all([
-    service.listRecentSessions(limit),
-    listDisputes(limit)
-  ]);
-  const alerts = [];
-  for (const dispute of disputes) {
-    alerts.push({
-      id: `alert-${dispute.id}`,
-      tone: "warn",
-      title: "Dispute awaiting verdict",
-      ref: dispute.sessionId,
-      body: `Stake of ${dispute.stakedAmount} DOT remains locked until a verifier verdict is recorded.`,
-      ctaLabel: "Open disputes ->",
-      ctaHref: "/disputes"
-    });
-  }
-  const pendingPolicies = listPolicies().filter((policy) => policy.state === "Pending");
-  for (const policy of pendingPolicies) {
-    alerts.push({
-      id: `alert-${policy.id}`,
-      tone: "warn",
-      title: "Policy awaiting second signer",
-      ref: policy.tag,
-      body: `${policy.signersReq} signatures required before this rule can gate live work.`,
-      ctaLabel: "Open policies ->",
-      ctaHref: "/policies"
-    });
-  }
-  const submitted = sessions.filter((session) => ["submitted", "disputed"].includes(session.status));
-  for (const session of submitted.slice(0, Math.max(0, limit - alerts.length))) {
-    alerts.push({
-      id: `alert-session-${session.sessionId}`,
-      tone: session.status === "disputed" ? "warn" : "accent",
-      title: session.status === "disputed" ? "Run needs human review" : "Submitted run ready for verification",
-      ref: session.sessionId,
-      body: `${session.jobId} is currently ${session.status}.`,
-      ctaLabel: "Open runs ->",
-      ctaHref: "/runs"
-    });
-  }
-  return alerts.slice(0, limit);
 }
 
 async function persistContentRecord(record) {
@@ -936,6 +737,14 @@ const {
   readJsonBody,
   respond,
   respondWithMutationReceipt,
+  service,
+  stateStore,
+});
+
+const { listAlerts, listAuditEvents } = createOperatorActivityFeed({
+  defaultVerifierAddress: process.env.DEFAULT_VERIFIER_ADDRESS,
+  listDisputes,
+  listPolicies,
   service,
   stateStore,
 });


### PR DESCRIPTION
## Summary
- extracted `/alerts` and `/audit` feed construction from `server.js` into `operator-activity-feed.js`
- kept `activity-routes` as the route wrapper and wired the extracted feed through the existing dependency injection path
- added focused tests for audit run/policy/capability events, alert ordering, feed factory wiring, and wallet compaction

## Checks
- `node --test mcp-server/src/protocols/http/operator-activity-feed.test.js`
- `node --test mcp-server/src/protocols/http/activity-routes.test.js`
- `node --test mcp-server/src/protocols/http/server.smoke.test.js` (smoke cases skipped without RUN_HTTP_SMOKE)
- `npm --workspace mcp-server test` (868 tests passing after installing dependencies in this task worktree)
- `git diff --check`

## Surface
- Backend only: `mcp-server/src/protocols/http`
- No frontend/board changes, generated output, indexer, Caddy, contracts, public site, env, or VPS secret changes
- No chain behavior or Polkadot runtime semantics touched; this is a pure HTTP helper extraction, so Polkadot docs MCP was not needed for this slice