### PR TITLE
refactor: extract job catalog gate helpers

### DIFF
--- a/mcp-server/src/core/job-catalog-gates.js
+++ b/mcp-server/src/core/job-catalog-gates.js
@@ -1,0 +1,94 @@
+import {
+  VALID_AGENT_ROLES,
+  VALID_TIERS
+} from "./job-catalog-normalization.js";
+
+export const ROLE_REQUIREMENTS = {
+  worker: { skill: 0 },
+  curator: { skill: 50 },
+  reviewer: { skill: 100 },
+  publisher: { skill: 200 },
+  verifier: { skill: 300 },
+  arbitrator: { skill: 500 }
+};
+
+/**
+ * Single source of truth for which reputation scores a wallet needs to
+ * unlock each job tier. `isEligible`, `summarizeTierGate`, and the
+ * public `/jobs/tiers` endpoint all read from this map so the numbers
+ * can't drift. v1 only gates on `skill`; future revisions can add
+ * `reliability`/`economic` minimums without changing call sites.
+ */
+export const TIER_REQUIREMENTS = {
+  starter: { skill: 0 },
+  pro: { skill: 100 },
+  elite: { skill: 200 }
+};
+
+export const TIER_ORDER = ["starter", "pro", "elite"];
+
+export function tierRequirements(tier) {
+  return TIER_REQUIREMENTS[tier] ?? TIER_REQUIREMENTS.starter;
+}
+
+/**
+ * Inspect whether `reputation` satisfies the minimums recorded for `tier`.
+ * Returns a plain-data summary the HTTP layer can serialise directly.
+ * `missing` is emitted sparse (only keys the wallet hasn't met) so the UI
+ * can render "need 25 more skill" without post-processing.
+ */
+export function summarizeTierGate(tier, reputation) {
+  const normalised = VALID_TIERS.has(tier) ? tier : "starter";
+  const requires = { ...tierRequirements(normalised) };
+  const has = reputationSnapshot(reputation);
+  const missing = missingRequirements(requires, has);
+  const unlocked = Object.keys(missing).length === 0;
+  return { tier: normalised, unlocked, requires, has, missing };
+}
+
+/**
+ * Given the current reputation, find the next tier the wallet has NOT
+ * yet unlocked and return what it would take to reach it. Returns null
+ * when the wallet is already at the highest tier.
+ */
+export function nextLockedTier(reputation) {
+  for (const tier of TIER_ORDER) {
+    const summary = summarizeTierGate(tier, reputation);
+    if (!summary.unlocked) {
+      return summary;
+    }
+  }
+  return null;
+}
+
+export function roleRequirements(role) {
+  return ROLE_REQUIREMENTS[role] ?? ROLE_REQUIREMENTS.worker;
+}
+
+export function summarizeRoleGate(role, reputation) {
+  const normalised = VALID_AGENT_ROLES.has(role) ? role : "worker";
+  const requires = { ...roleRequirements(normalised) };
+  const has = reputationSnapshot(reputation);
+  const missing = missingRequirements(requires, has);
+  const unlocked = Object.keys(missing).length === 0;
+  return { role: normalised, unlocked, requires, has, missing };
+}
+
+function reputationSnapshot(reputation) {
+  return {
+    skill: Number.isInteger(reputation?.skill) ? reputation.skill : 0,
+    reliability: Number.isInteger(reputation?.reliability) ? reputation.reliability : 0,
+    economic: Number.isInteger(reputation?.economic) ? reputation.economic : 0
+  };
+}
+
+function missingRequirements(requires, has) {
+  const missing = {};
+  for (const [key, required] of Object.entries(requires)) {
+    const current = has[key] ?? 0;
+    if (current < required) {
+      missing[key] = required - current;
+    }
+  }
+  return missing;
+}

--- a/mcp-server/src/core/job-catalog-service.js
+++ b/mcp-server/src/core/job-catalog-service.js
@@ -12,9 +12,7 @@ import {
 } from "./job-schema-registry.js";
 import {
   DEFAULT_STALE_AFTER_MS,
-  VALID_AGENT_ROLES,
   VALID_JOB_LIFECYCLE_STATUSES,
-  VALID_TIERS,
   effectiveJobType,
   effectiveRequiredRole,
   normaliseLifecycle,
@@ -23,7 +21,22 @@ import {
   normalizeJobId,
   normalizeJobInput as normalizeCatalogJobInput
 } from "./job-catalog-normalization.js";
+import {
+  TIER_ORDER,
+  summarizeRoleGate,
+  summarizeTierGate
+} from "./job-catalog-gates.js";
 import { buildVerificationContract } from "./verifier-contract.js";
+
+export {
+  ROLE_REQUIREMENTS,
+  TIER_REQUIREMENTS,
+  nextLockedTier,
+  roleRequirements,
+  summarizeRoleGate,
+  summarizeTierGate,
+  tierRequirements
+} from "./job-catalog-gates.js";
 
 const DEFAULT_AGENT_PROFILE = {
   capabilities: ["claim_job", "submit_work", "allocate_idle_funds"],
@@ -34,97 +47,6 @@ const DEFAULT_AGENT_PROFILE = {
   minLiquidReserve: 0,
   autoUnwindStrategies: false
 };
-
-export const ROLE_REQUIREMENTS = {
-  worker: { skill: 0 },
-  curator: { skill: 50 },
-  reviewer: { skill: 100 },
-  publisher: { skill: 200 },
-  verifier: { skill: 300 },
-  arbitrator: { skill: 500 }
-};
-
-/**
- * Single source of truth for which reputation scores a wallet needs to
- * unlock each job tier. `isEligible`, `summarizeTierGate`, and the
- * public `/jobs/tiers` endpoint all read from this map so the numbers
- * can't drift. v1 only gates on `skill`; future revisions can add
- * `reliability`/`economic` minimums without changing call sites.
- */
-export const TIER_REQUIREMENTS = {
-  starter: { skill: 0 },
-  pro: { skill: 100 },
-  elite: { skill: 200 }
-};
-
-const TIER_ORDER = ["starter", "pro", "elite"];
-
-export function tierRequirements(tier) {
-  return TIER_REQUIREMENTS[tier] ?? TIER_REQUIREMENTS.starter;
-}
-
-/**
- * Inspect whether `reputation` satisfies the minimums recorded for `tier`.
- * Returns a plain-data summary the HTTP layer can serialise directly.
- * `missing` is emitted sparse (only keys the wallet hasn't met) so the UI
- * can render "need 25 more skill" without post-processing.
- */
-export function summarizeTierGate(tier, reputation) {
-  const normalised = VALID_TIERS.has(tier) ? tier : "starter";
-  const requires = { ...tierRequirements(normalised) };
-  const has = {
-    skill: Number.isInteger(reputation?.skill) ? reputation.skill : 0,
-    reliability: Number.isInteger(reputation?.reliability) ? reputation.reliability : 0,
-    economic: Number.isInteger(reputation?.economic) ? reputation.economic : 0
-  };
-  const missing = {};
-  for (const [key, required] of Object.entries(requires)) {
-    const current = has[key] ?? 0;
-    if (current < required) {
-      missing[key] = required - current;
-    }
-  }
-  const unlocked = Object.keys(missing).length === 0;
-  return { tier: normalised, unlocked, requires, has, missing };
-}
-
-/**
- * Given the current reputation, find the next tier the wallet has NOT
- * yet unlocked and return what it would take to reach it. Returns null
- * when the wallet is already at the highest tier.
- */
-export function nextLockedTier(reputation) {
-  for (const tier of TIER_ORDER) {
-    const summary = summarizeTierGate(tier, reputation);
-    if (!summary.unlocked) {
-      return summary;
-    }
-  }
-  return null;
-}
-
-export function roleRequirements(role) {
-  return ROLE_REQUIREMENTS[role] ?? ROLE_REQUIREMENTS.worker;
-}
-
-export function summarizeRoleGate(role, reputation) {
-  const normalised = VALID_AGENT_ROLES.has(role) ? role : "worker";
-  const requires = { ...roleRequirements(normalised) };
-  const has = {
-    skill: Number.isInteger(reputation?.skill) ? reputation.skill : 0,
-    reliability: Number.isInteger(reputation?.reliability) ? reputation.reliability : 0,
-    economic: Number.isInteger(reputation?.economic) ? reputation.economic : 0
-  };
-  const missing = {};
-  for (const [key, required] of Object.entries(requires)) {
-    const current = has[key] ?? 0;
-    if (current < required) {
-      missing[key] = required - current;
-    }
-  }
-  const unlocked = Object.keys(missing).length === 0;
-  return { role: normalised, unlocked, requires, has, missing };
-}
 
 export class JobCatalogService {
   constructor(

--- a/mcp-server/src/core/tier-gate.test.js
+++ b/mcp-server/src/core/tier-gate.test.js
@@ -2,11 +2,14 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  ROLE_REQUIREMENTS,
   TIER_REQUIREMENTS,
   nextLockedTier,
+  roleRequirements,
+  summarizeRoleGate,
   summarizeTierGate,
   tierRequirements
-} from "./job-catalog-service.js";
+} from "./job-catalog-gates.js";
 
 test("TIER_REQUIREMENTS exposes starter/pro/elite with ascending skill gates", () => {
   assert.deepEqual(TIER_REQUIREMENTS, {
@@ -65,4 +68,31 @@ test("nextLockedTier starts from starter when reputation is empty", () => {
   // Pro is the first locked rung.
   const locked = nextLockedTier(undefined);
   assert.equal(locked.tier, "pro");
+});
+
+test("ROLE_REQUIREMENTS exposes autonomy unlock thresholds", () => {
+  assert.deepEqual(ROLE_REQUIREMENTS, {
+    worker: { skill: 0 },
+    curator: { skill: 50 },
+    reviewer: { skill: 100 },
+    publisher: { skill: 200 },
+    verifier: { skill: 300 },
+    arbitrator: { skill: 500 }
+  });
+  assert.deepEqual(roleRequirements("publisher"), { skill: 200 });
+});
+
+test("roleRequirements falls back to worker for unknown roles", () => {
+  assert.deepEqual(roleRequirements("unknown"), { skill: 0 });
+});
+
+test("summarizeRoleGate reports unlocked and missing role requirements", () => {
+  assert.equal(summarizeRoleGate("curator", { skill: 75 }).unlocked, true);
+  assert.deepEqual(summarizeRoleGate("verifier", { skill: 225 }).missing, { skill: 75 });
+});
+
+test("summarizeRoleGate normalises unknown roles to worker", () => {
+  const summary = summarizeRoleGate("unknown", { skill: 0 });
+  assert.equal(summary.role, "worker");
+  assert.equal(summary.unlocked, true);
 });


### PR DESCRIPTION
## What changed
- Extracted tier/role gate constants and summary helpers into mcp-server/src/core/job-catalog-gates.js.
- Kept JobCatalogService's existing public helper exports via re-export so callers do not change.
- Expanded gate tests for role thresholds, fallback behavior, and role summary output.

## Checks
- git diff --check
- npm --workspace mcp-server test

## Impact
- Backend only: mcp-server/src/core.
- No frontend/board, generated output, indexer, Caddy, contracts, public site, env, or VPS secret changes.
- No chain behavior or Polkadot runtime semantics touched; this is pure catalog helper extraction.