### PR TITLE
refactor: extract HTTP server helpers

### DIFF
--- a/mcp-server/src/protocols/http/http-helpers.js
+++ b/mcp-server/src/protocols/http/http-helpers.js
@@ -1,0 +1,203 @@
+import { ValidationError } from "../../core/errors.js";
+
+export function respond(response, statusCode, payload, extraHeaders = {}) {
+  const headers = {
+    "content-type": "application/json",
+    ...(response._corsHeaders ?? {}),
+    ...extraHeaders
+  };
+  if (response._requestId && !headers["x-request-id"]) {
+    headers["x-request-id"] = response._requestId;
+  }
+  response.writeHead(statusCode, headers);
+  response.end(JSON.stringify(payload, null, 2));
+}
+
+export function createJsonBodyReader({ maxBytes }) {
+  return (request, options = {}) => readJsonBody(request, {
+    maxBytes: options.maxBytes ?? maxBytes
+  });
+}
+
+export async function readJsonBody(request, { maxBytes } = {}) {
+  const chunks = [];
+  let received = 0;
+  for await (const chunk of request) {
+    received += chunk.length;
+    if (Number.isFinite(maxBytes) && received > maxBytes) {
+      throw new ValidationError(`Request body exceeds ${maxBytes} bytes.`);
+    }
+    chunks.push(chunk);
+  }
+
+  const body = Buffer.concat(chunks).toString("utf8");
+  if (!body.trim()) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(body);
+  } catch {
+    throw new ValidationError("Invalid JSON body.");
+  }
+}
+
+export function parseTopics(url) {
+  return parseCsvParam(url, "topics");
+}
+
+export function parseCsvParam(url, name) {
+  return url.searchParams
+    .get(name)
+    ?.split(",")
+    .map((topic) => topic.trim())
+    .filter(Boolean) ?? [];
+}
+
+export function parseEventFilters(url, { includeWallet = false } = {}) {
+  const filters = {
+    topics: parseTopics(url),
+    sources: parseCsvParam(url, "sources").concat(parseCsvParam(url, "source")),
+    phases: parseCsvParam(url, "phases").concat(parseCsvParam(url, "phase")),
+    severities: parseCsvParam(url, "severities").concat(parseCsvParam(url, "severity")),
+    correlationId: url.searchParams.get("correlationId")?.trim() || undefined
+  };
+  if (includeWallet) {
+    filters.eventWallet = url.searchParams.get("eventWallet")?.trim() || url.searchParams.get("wallet")?.trim() || undefined;
+  }
+  return filters;
+}
+
+export function parseLimit(url, fallback = 50, max = 250) {
+  const raw = Number(url.searchParams.get("limit") ?? fallback);
+  if (!Number.isFinite(raw) || raw <= 0) {
+    return fallback;
+  }
+  return Math.min(Math.trunc(raw), max);
+}
+
+export function parsePositiveInteger(value, fallback, max = Number.MAX_SAFE_INTEGER) {
+  const raw = Number(value ?? fallback);
+  if (!Number.isFinite(raw) || raw <= 0) {
+    return fallback;
+  }
+  return Math.min(Math.trunc(raw), max);
+}
+
+export function createCorsHeaderResolver(httpConfig) {
+  return (request) => resolveCorsHeaders(request, httpConfig);
+}
+
+export function resolveCorsHeaders(request, httpConfig) {
+  const origin = request.headers?.origin;
+  if (!origin || typeof origin !== "string") {
+    return {};
+  }
+  if (httpConfig.allowAllOrigins) {
+    return buildCorsHeaders("*", httpConfig);
+  }
+  if (httpConfig.allowedOrigins.has(origin)) {
+    return buildCorsHeaders(origin, httpConfig);
+  }
+  return {};
+}
+
+export function buildCorsHeaders(allowOrigin, httpConfig) {
+  return {
+    "access-control-allow-origin": allowOrigin,
+    "access-control-allow-methods": httpConfig.allowedMethods,
+    "access-control-allow-headers": httpConfig.allowedHeaders,
+    "access-control-expose-headers": httpConfig.exposedHeaders,
+    "access-control-max-age": String(httpConfig.maxAgeSeconds),
+    vary: "origin"
+  };
+}
+
+/**
+ * Normalise a URL path into a low-cardinality metric label. Without this
+ * every unique `sessionId` / `jobId` becomes its own Prometheus series,
+ * which defeats the purpose. Known static paths pass through; anything
+ * else collapses to a bucket label so scrape payloads stay small.
+ */
+export function metricPathLabel(pathname) {
+  const known = new Set([
+    "/",
+    "/health",
+    "/metrics",
+    "/agent-tools.json",
+    "/.well-known/agent-tools.json",
+    "/onboarding",
+    "/jobs",
+    "/jobs/definition",
+    "/jobs/recommendations",
+    "/jobs/preflight",
+    "/jobs/claim",
+    "/jobs/submit",
+    "/jobs/tiers",
+    "/shares",
+    "/session/state-machine",
+    "/strategies",
+    "/admin/jobs",
+    "/admin/jobs/timeline",
+    "/admin/sessions",
+    "/admin/jobs/ingest/github",
+    "/admin/jobs/ingest/openapi",
+    "/admin/jobs/ingest/open-data",
+    "/admin/jobs/ingest/osv",
+    "/admin/jobs/ingest/standards",
+    "/admin/jobs/ingest/wikipedia",
+    "/admin/jobs/lifecycle",
+    "/admin/jobs/pause",
+    "/admin/jobs/resume",
+    "/admin/xcm/observe",
+    "/admin/xcm/finalize",
+    "/account",
+    "/account/allocate",
+    "/account/borrow",
+    "/account/borrow-capacity",
+    "/account/deallocate",
+    "/account/fund",
+    "/account/position",
+    "/account/repay",
+    "/account/strategies",
+    "/auth/session",
+    "/payments/send",
+    "/reputation",
+    "/session",
+    "/session/timeline",
+    "/sessions",
+    "/xcm/request",
+    "/jobs/sub",
+    "/events",
+    "/auth/nonce",
+    "/auth/verify",
+    "/agents",
+    "/badges",
+    "/alerts",
+    "/audit",
+    "/policies",
+    "/content",
+    "/disputes",
+    "/verifier/handlers",
+    "/verifier/result",
+    "/verifier/replay",
+    "/verifier/run",
+    "/gas/health",
+    "/gas/capabilities",
+    "/gas/quote",
+    "/gas/sponsor"
+  ]);
+  if (known.has(pathname)) return pathname;
+  // Collapse sessionId/wallet-scoped routes to a single label so Prometheus
+  // doesn't create one series per session or wallet.
+  if (/^\/disputes\/[^/]+\/verdict$/u.test(pathname)) return "/disputes/:id/verdict";
+  if (/^\/disputes\/[^/]+\/release$/u.test(pathname)) return "/disputes/:id/release";
+  if (pathname.startsWith("/disputes/")) return "/disputes/:id";
+  if (/^\/content\/[^/]+\/publish$/u.test(pathname)) return "/content/:hash/publish";
+  if (pathname.startsWith("/content/")) return "/content/:hash";
+  if (pathname.startsWith("/policies/")) return "/policies/:tag";
+  if (pathname.startsWith("/badges/")) return "/badges/:sessionId";
+  if (pathname.startsWith("/agents/")) return "/agents/:wallet";
+  if (pathname.startsWith("/shares/")) return "/shares/:token";
+  return "other";
+}

--- a/mcp-server/src/protocols/http/http-helpers.test.js
+++ b/mcp-server/src/protocols/http/http-helpers.test.js
@@ -1,0 +1,113 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+
+import { ValidationError } from "../../core/errors.js";
+import {
+  createCorsHeaderResolver,
+  createJsonBodyReader,
+  metricPathLabel,
+  parseEventFilters,
+  parseLimit,
+  parsePositiveInteger,
+  respond
+} from "./http-helpers.js";
+
+function readableBody(body) {
+  return Readable.from([Buffer.from(body)]);
+}
+
+test("createJsonBodyReader parses empty and JSON bodies", async () => {
+  const readJsonBody = createJsonBodyReader({ maxBytes: 100 });
+
+  assert.deepEqual(await readJsonBody(readableBody("")), {});
+  assert.deepEqual(await readJsonBody(readableBody('{"ok":true}')), { ok: true });
+});
+
+test("createJsonBodyReader rejects oversized and invalid JSON bodies", async () => {
+  const readJsonBody = createJsonBodyReader({ maxBytes: 4 });
+
+  await assert.rejects(
+    () => readJsonBody(readableBody('{"too":"large"}')),
+    /Request body exceeds 4 bytes/
+  );
+
+  await assert.rejects(
+    () => createJsonBodyReader({ maxBytes: 100 })(readableBody("{broken")),
+    ValidationError
+  );
+});
+
+test("parseEventFilters accepts aliases and optional event wallet", () => {
+  const url = new URL("http://localhost/events?topics=a,b&source=chain&sources=api&phase=claim&severity=error&correlationId=run-1&wallet=0xabc");
+
+  assert.deepEqual(parseEventFilters(url, { includeWallet: true }), {
+    topics: ["a", "b"],
+    sources: ["api", "chain"],
+    phases: ["claim"],
+    severities: ["error"],
+    correlationId: "run-1",
+    eventWallet: "0xabc"
+  });
+});
+
+test("parseLimit and parsePositiveInteger clamp invalid and oversized values", () => {
+  assert.equal(parseLimit(new URL("http://localhost/jobs?limit=12"), 50, 100), 12);
+  assert.equal(parseLimit(new URL("http://localhost/jobs?limit=999"), 50, 100), 100);
+  assert.equal(parseLimit(new URL("http://localhost/jobs?limit=nope"), 50, 100), 50);
+
+  assert.equal(parsePositiveInteger("7", 3, 10), 7);
+  assert.equal(parsePositiveInteger("999", 3, 10), 10);
+  assert.equal(parsePositiveInteger("-1", 3, 10), 3);
+});
+
+test("createCorsHeaderResolver only emits headers for allowed origins", () => {
+  const resolveCorsHeaders = createCorsHeaderResolver({
+    allowAllOrigins: false,
+    allowedOrigins: new Set(["https://app.averray.com"]),
+    allowedMethods: "GET,POST",
+    allowedHeaders: "authorization,content-type",
+    exposedHeaders: "x-request-id",
+    maxAgeSeconds: 600
+  });
+
+  assert.deepEqual(resolveCorsHeaders({ headers: { origin: "https://other.example" } }), {});
+  assert.deepEqual(resolveCorsHeaders({ headers: { origin: "https://app.averray.com" } }), {
+    "access-control-allow-origin": "https://app.averray.com",
+    "access-control-allow-methods": "GET,POST",
+    "access-control-allow-headers": "authorization,content-type",
+    "access-control-expose-headers": "x-request-id",
+    "access-control-max-age": "600",
+    vary: "origin"
+  });
+});
+
+test("metricPathLabel keeps known routes and buckets dynamic routes", () => {
+  assert.equal(metricPathLabel("/jobs"), "/jobs");
+  assert.equal(metricPathLabel("/disputes/dispute-1/verdict"), "/disputes/:id/verdict");
+  assert.equal(metricPathLabel("/content/0xabc/publish"), "/content/:hash/publish");
+  assert.equal(metricPathLabel("/agents/0xabc"), "/agents/:wallet");
+  assert.equal(metricPathLabel("/something/else"), "other");
+});
+
+test("respond adds JSON, CORS, and request id headers", () => {
+  const response = {
+    _requestId: "req-123",
+    _corsHeaders: { "access-control-allow-origin": "https://app.averray.com" },
+    writeHead(statusCode, headers) {
+      this.statusCode = statusCode;
+      this.headers = headers;
+    },
+    end(body) {
+      this.body = body;
+    }
+  };
+
+  respond(response, 201, { ok: true });
+
+  assert.equal(response.statusCode, 201);
+  assert.equal(response.headers["content-type"], "application/json");
+  assert.equal(response.headers["x-request-id"], "req-123");
+  assert.equal(response.headers["access-control-allow-origin"], "https://app.averray.com");
+  assert.deepEqual(JSON.parse(response.body), { ok: true });
+});

--- a/mcp-server/src/protocols/http/server.js
+++ b/mcp-server/src/protocols/http/server.js
@@ -4,7 +4,6 @@ import { assertMutationBackendAvailable } from "../../core/mutation-backend.js";
 import {
   AuthorizationError,
   normalizeError,
-  ValidationError
 } from "../../core/errors.js";
 import { extractClientKey } from "../../auth/rate-limit.js";
 import { hasRole } from "../../auth/config.js";
@@ -32,6 +31,15 @@ import { createContentRoutes } from "./content-routes.js";
 import { createDisputeRoutes } from "./dispute-routes.js";
 import { createEventRoutes } from "./event-routes.js";
 import { createGasRoutes } from "./gas-routes.js";
+import {
+  createCorsHeaderResolver,
+  createJsonBodyReader,
+  metricPathLabel,
+  parseEventFilters,
+  parseLimit,
+  parsePositiveInteger,
+  respond
+} from "./http-helpers.js";
 import { createIdempotentMutationHelpers } from "./idempotent-mutations.js";
 import { createJobRoutes } from "./job-routes.js";
 import { createOperationalRoutes, resolveMetricsAuthConfig } from "./operational-routes.js";
@@ -80,68 +88,8 @@ metrics.gauge("state_store_backend", "1 when state store backend matches the lab
 
 const { metricsBearerToken, metricsAuthRequired } = resolveMetricsAuthConfig(process.env);
 const port = Number(process.env.PORT ?? 8787);
-
-function respond(response, statusCode, payload, extraHeaders = {}) {
-  const headers = {
-    "content-type": "application/json",
-    ...(response._corsHeaders ?? {}),
-    ...extraHeaders
-  };
-  if (response._requestId && !headers["x-request-id"]) {
-    headers["x-request-id"] = response._requestId;
-  }
-  response.writeHead(statusCode, headers);
-  response.end(JSON.stringify(payload, null, 2));
-}
-
-async function readJsonBody(request, { maxBytes = httpConfig.maxBodyBytes } = {}) {
-  const chunks = [];
-  let received = 0;
-  for await (const chunk of request) {
-    received += chunk.length;
-    if (received > maxBytes) {
-      throw new ValidationError(`Request body exceeds ${maxBytes} bytes.`);
-    }
-    chunks.push(chunk);
-  }
-
-  const body = Buffer.concat(chunks).toString("utf8");
-  if (!body.trim()) {
-    return {};
-  }
-
-  try {
-    return JSON.parse(body);
-  } catch {
-    throw new ValidationError("Invalid JSON body.");
-  }
-}
-
-function parseTopics(url) {
-  return parseCsvParam(url, "topics");
-}
-
-function parseCsvParam(url, name) {
-  return url.searchParams
-    .get(name)
-    ?.split(",")
-    .map((topic) => topic.trim())
-    .filter(Boolean) ?? [];
-}
-
-function parseEventFilters(url, { includeWallet = false } = {}) {
-  const filters = {
-    topics: parseTopics(url),
-    sources: parseCsvParam(url, "sources").concat(parseCsvParam(url, "source")),
-    phases: parseCsvParam(url, "phases").concat(parseCsvParam(url, "phase")),
-    severities: parseCsvParam(url, "severities").concat(parseCsvParam(url, "severity")),
-    correlationId: url.searchParams.get("correlationId")?.trim() || undefined
-  };
-  if (includeWallet) {
-    filters.eventWallet = url.searchParams.get("eventWallet")?.trim() || url.searchParams.get("wallet")?.trim() || undefined;
-  }
-  return filters;
-}
+const readJsonBody = createJsonBodyReader({ maxBytes: httpConfig.maxBodyBytes });
+const resolveCorsHeaders = createCorsHeaderResolver(httpConfig);
 
 function walletsMatch(a, b) {
   if (!a || !b) {
@@ -264,22 +212,6 @@ async function requireChainBackedMutation(route) {
 
 function clientIp(request) {
   return extractClientKey(request, { trustProxy });
-}
-
-function parseLimit(url, fallback = 50, max = 250) {
-  const raw = Number(url.searchParams.get("limit") ?? fallback);
-  if (!Number.isFinite(raw) || raw <= 0) {
-    return fallback;
-  }
-  return Math.min(Math.trunc(raw), max);
-}
-
-function parsePositiveInteger(value, fallback, max = Number.MAX_SAFE_INTEGER) {
-  const raw = Number(value ?? fallback);
-  if (!Number.isFinite(raw) || raw <= 0) {
-    return fallback;
-  }
-  return Math.min(Math.trunc(raw), max);
 }
 
 function buildBadgeReceipt(badge) {
@@ -409,31 +341,6 @@ async function persistContentRecord(record) {
   return record;
 }
 
-function resolveCorsHeaders(request) {
-  const origin = request.headers?.origin;
-  if (!origin || typeof origin !== "string") {
-    return {};
-  }
-  if (httpConfig.allowAllOrigins) {
-    return buildCorsHeaders("*");
-  }
-  if (httpConfig.allowedOrigins.has(origin)) {
-    return buildCorsHeaders(origin);
-  }
-  return {};
-}
-
-function buildCorsHeaders(allowOrigin) {
-  return {
-    "access-control-allow-origin": allowOrigin,
-    "access-control-allow-methods": httpConfig.allowedMethods,
-    "access-control-allow-headers": httpConfig.allowedHeaders,
-    "access-control-expose-headers": httpConfig.exposedHeaders,
-    "access-control-max-age": String(httpConfig.maxAgeSeconds),
-    vary: "origin"
-  };
-}
-
 async function enforceLimit(bucket, key, limits) {
   if (!rateLimiter) {
     return;
@@ -446,107 +353,6 @@ async function enforceLimit(bucket, key, limits) {
     }
     throw error;
   }
-}
-
-/**
- * Normalise a URL path into a low-cardinality metric label. Without this
- * every unique `sessionId` / `jobId` becomes its own Prometheus series,
- * which defeats the purpose. Known static paths pass through; anything
- * else collapses to a bucket label so scrape payloads stay small.
- */
-function metricPathLabel(pathname) {
-  const known = new Set([
-    "/",
-    "/health",
-    "/metrics",
-    "/agent-tools.json",
-    "/.well-known/agent-tools.json",
-    "/onboarding",
-    "/jobs",
-    "/jobs/definition",
-    "/jobs/recommendations",
-    "/jobs/preflight",
-    "/jobs/claim",
-    "/jobs/submit",
-    "/jobs/tiers",
-    "/shares",
-    "/session/state-machine",
-    "/strategies",
-    "/admin/jobs",
-    "/admin/jobs/timeline",
-    "/admin/sessions",
-    "/admin/jobs/ingest/github",
-    "/admin/jobs/ingest/openapi",
-    "/admin/jobs/ingest/open-data",
-    "/admin/jobs/ingest/osv",
-    "/admin/jobs/ingest/standards",
-    "/admin/jobs/ingest/wikipedia",
-    "/admin/jobs/lifecycle",
-    "/admin/jobs/pause",
-    "/admin/jobs/resume",
-    "/admin/xcm/observe",
-    "/admin/xcm/finalize",
-    "/account",
-    "/account/allocate",
-    "/account/borrow",
-    "/account/borrow-capacity",
-    "/account/deallocate",
-    "/account/fund",
-    "/account/position",
-    "/account/repay",
-    "/account/strategies",
-    "/auth/session",
-    "/payments/send",
-    "/reputation",
-    "/session",
-    "/session/timeline",
-    "/sessions",
-    "/xcm/request",
-    "/jobs/sub",
-    "/events",
-    "/auth/nonce",
-    "/auth/verify",
-    "/agents",
-    "/badges",
-    "/alerts",
-    "/audit",
-    "/policies",
-    "/content",
-    "/disputes",
-    "/verifier/handlers",
-    "/verifier/result",
-    "/verifier/replay",
-    "/verifier/run",
-    "/gas/health",
-    "/gas/capabilities",
-    "/gas/quote",
-    "/gas/sponsor"
-  ]);
-  if (known.has(pathname)) return pathname;
-  // Collapse sessionId/wallet-scoped routes to a single label so Prometheus
-  // doesn't create one series per session or wallet.
-  if (/^\/disputes\/[^/]+\/verdict$/u.test(pathname)) return "/disputes/:id/verdict";
-  if (/^\/disputes\/[^/]+\/release$/u.test(pathname)) return "/disputes/:id/release";
-  if (pathname.startsWith("/disputes/")) return "/disputes/:id";
-  if (/^\/content\/[^/]+\/publish$/u.test(pathname)) return "/content/:hash/publish";
-  if (pathname.startsWith("/content/")) return "/content/:hash";
-  if (pathname.startsWith("/policies/")) return "/policies/:tag";
-  if (pathname.startsWith("/badges/")) return "/badges/:sessionId";
-  if (pathname.startsWith("/agents/")) return "/agents/:wallet";
-  if (pathname.startsWith("/shares/")) return "/shares/:token";
-  return "other";
-}
-
-function normalizeOptionalString(value) {
-  return typeof value === "string" ? value.trim() : undefined;
-}
-
-function normalizeNumberLike(value) {
-  if (value === undefined || value === null || value === "") {
-    return undefined;
-  }
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : value;
 }
 
 const {


### PR DESCRIPTION
## What changed
- Extracted shared HTTP server utilities into `mcp-server/src/protocols/http/http-helpers.js`.
- Moved JSON response/body parsing, query filter parsing, CORS header resolution, and metric path bucketing out of `server.js`.
- Added focused tests for the extracted helpers.

## Checks run
- `node --test mcp-server/src/protocols/http/http-helpers.test.js`
- `node --test mcp-server/src/protocols/http/server.smoke.test.js` (loads; smoke cases skipped by current env)
- `node --check mcp-server/src/protocols/http/http-helpers.js`
- `node --check mcp-server/src/protocols/http/server.js`
- `npm --workspace mcp-server test`

## Surface affected
- Backend HTTP server only.
- No frontend, indexer, Caddy, contracts, or public site changes.

## Env / deployment notes
- No env or VPS secret changes required.
- No behavior change intended; this is a helper extraction from the backend monolith.