### PR TITLE
refactor: extract platform service helpers

### DIFF
--- a/mcp-server/src/core/platform-service-helpers.js
+++ b/mcp-server/src/core/platform-service-helpers.js
@@ -1,0 +1,219 @@
+import { ValidationError } from "./errors.js";
+import { knownAssetMinBalanceRaw, normalizeAssetSymbol } from "./assets.js";
+import { getJobSchema } from "./job-schema-registry.js";
+
+export const DEFAULT_TREASURY_POLICY_STATUS = {
+  enabled: false,
+  policyAddress: undefined,
+  paused: undefined,
+  owner: undefined,
+  pauser: undefined,
+  settlementReady: false,
+  contracts: {
+    escrowCoreAddress: undefined,
+    agentAccountAddress: undefined,
+    reputationSbtAddress: undefined,
+    supportedAssets: []
+  },
+  roles: {
+    signerAddress: undefined,
+    signerIsVerifier: false,
+    escrowIsServiceOperator: false,
+    agentAccountIsServiceOperator: false
+  },
+  readErrors: [],
+  risk: {}
+};
+
+export const DEFAULT_XCM_SETTLEMENT_WATCHER_STATUS = {
+  enabled: false,
+  running: false,
+  pendingCount: 0,
+  pending: []
+};
+
+export const DEFAULT_XCM_OBSERVATION_RELAY_STATUS = {
+  enabled: false,
+  running: false,
+  syncing: false,
+  feedUrl: undefined,
+  batchSize: 0,
+  pollIntervalMs: 0,
+  cursor: undefined,
+  lastObservedCount: 0,
+  lastSyncedAt: undefined,
+  lastError: undefined,
+  updatedAt: undefined
+};
+
+export function sumSubJobRewards(jobs, asset) {
+  const normalizedAsset = normalizeAssetSymbol(asset);
+  return jobs
+    .filter((job) => normalizeAssetSymbol(job.rewardAsset) === normalizedAsset)
+    .reduce((total, job) => total + Math.max(Number(job.rewardAmount ?? 0), 0), 0);
+}
+
+export function minBalanceRawForAsset(asset) {
+  if (!asset) {
+    return undefined;
+  }
+  const raw = asset.minBalanceRaw ?? knownAssetMinBalanceRaw(asset);
+  if (raw === undefined || raw === null || raw === "") {
+    return undefined;
+  }
+  if (typeof raw === "bigint") {
+    return raw >= 0n ? raw : undefined;
+  }
+  const value = String(raw).trim();
+  return /^\d+$/u.test(value) ? BigInt(value) : undefined;
+}
+
+export function decimalToBaseUnits(amount, decimals, label) {
+  if (!Number.isInteger(decimals) || decimals < 0 || decimals > 30) {
+    throw new ValidationError(`${label} asset decimals must be an integer in [0, 30].`);
+  }
+  const normalized = normalizeDecimalString(amount, label);
+  const [whole, fractional = ""] = normalized.split(".");
+  if (fractional.length > decimals) {
+    throw new ValidationError(`${label} must fit ${decimals} decimal places.`);
+  }
+  return BigInt(whole) * (10n ** BigInt(decimals))
+    + BigInt(fractional.padEnd(decimals, "0") || "0");
+}
+
+export function formatBaseUnits(raw, decimals) {
+  const scale = 10n ** BigInt(decimals);
+  const whole = raw / scale;
+  const fractional = raw % scale;
+  if (fractional === 0n || decimals === 0) return whole.toString();
+  const padded = fractional.toString().padStart(decimals, "0").replace(/0+$/u, "");
+  return `${whole}.${padded}`;
+}
+
+export async function getTreasuryPolicyStatusSafely(blockchainGateway) {
+  if (!blockchainGateway?.getTreasuryPolicyStatus) {
+    return { ...DEFAULT_TREASURY_POLICY_STATUS };
+  }
+
+  try {
+    return await blockchainGateway.getTreasuryPolicyStatus();
+  } catch (error) {
+    return {
+      ...DEFAULT_TREASURY_POLICY_STATUS,
+      enabled: Boolean(blockchainGateway.isEnabled?.()),
+      policyAddress: blockchainGateway.config?.treasuryPolicyAddress || undefined,
+      error: {
+        code: error?.code ?? "policy_status_error",
+        message: error?.message ?? "Treasury policy status failed.",
+        details: error?.details
+      }
+    };
+  }
+}
+
+export async function getXcmSettlementWatcherStatusSafely(xcmSettlementWatcher) {
+  if (!xcmSettlementWatcher?.getStatus) {
+    return { ...DEFAULT_XCM_SETTLEMENT_WATCHER_STATUS };
+  }
+
+  try {
+    return await xcmSettlementWatcher.getStatus();
+  } catch (error) {
+    return {
+      ...DEFAULT_XCM_SETTLEMENT_WATCHER_STATUS,
+      enabled: Boolean(xcmSettlementWatcher.enabled),
+      running: Boolean(xcmSettlementWatcher.running),
+      error: normalizeStatusReadError(error, "xcm_settlement_watcher_status_error")
+    };
+  }
+}
+
+export async function getXcmObservationRelayStatusSafely(xcmObservationRelay) {
+  if (!xcmObservationRelay?.getStatus) {
+    return { ...DEFAULT_XCM_OBSERVATION_RELAY_STATUS };
+  }
+
+  try {
+    return await xcmObservationRelay.getStatus();
+  } catch (error) {
+    return {
+      ...DEFAULT_XCM_OBSERVATION_RELAY_STATUS,
+      enabled: Boolean(xcmObservationRelay.enabled),
+      running: Boolean(xcmObservationRelay.running),
+      syncing: Boolean(xcmObservationRelay.syncing),
+      feedUrl: xcmObservationRelay.feedUrl,
+      batchSize: xcmObservationRelay.batchSize ?? 0,
+      pollIntervalMs: xcmObservationRelay.pollIntervalMs ?? 0,
+      error: normalizeStatusReadError(error, "xcm_observation_relay_status_error")
+    };
+  }
+}
+
+export function buildSubmissionValidationContract(job) {
+  const schemaRef = job?.outputSchemaRef;
+  const schema = getJobSchema(schemaRef, { registrations: job?.schemaRegistrations });
+  const requiredTopLevelKeys = Array.isArray(schema?.required) ? schema.required : [];
+  return {
+    validationEndpoint: "POST /jobs/validate-submission",
+    submitEndpoint: "POST /jobs/submit",
+    submissionShape: "direct_schema_object",
+    schemaValidates: "payload.submission",
+    doNotWrapInOutput: true,
+    ...(requiredTopLevelKeys.length ? { requiredTopLevelKeys } : {})
+  };
+}
+
+export function validationPathFromError(error) {
+  const details = error?.details && typeof error.details === "object" ? error.details : {};
+  const directPath = [
+    details.path,
+    details.expectedPath,
+    details.expected,
+    details.received
+  ].find((entry) => typeof entry === "string" && entry.trim());
+  if (directPath) {
+    return normalizeValidationPath(directPath);
+  }
+  return normalizeValidationPath(parseValidationPathFromMessage(error?.message));
+}
+
+function normalizeDecimalString(value, label) {
+  const raw = typeof value === "number"
+    ? value.toLocaleString("en-US", { useGrouping: false, maximumFractionDigits: 30 })
+    : String(value ?? "").trim();
+  if (!/^(?:0|[1-9]\d*)(?:\.\d+)?$/u.test(raw)) {
+    throw new ValidationError(`${label} must be a positive decimal amount.`);
+  }
+  return raw;
+}
+
+function normalizeStatusReadError(error, code) {
+  return {
+    code: error?.code ?? code,
+    message: error?.message ?? "Status read failed.",
+    details: error?.details
+  };
+}
+
+function parseValidationPathFromMessage(message) {
+  if (typeof message !== "string") {
+    return undefined;
+  }
+  const payloadMatch = message.match(/\bpayload\.submission(?:\.[A-Za-z0-9_-]+|\[[0-9]+\])*/u);
+  if (payloadMatch) {
+    return payloadMatch[0];
+  }
+  const submissionMatch = message.match(/\bsubmission(?:\.[A-Za-z0-9_-]+|\[[0-9]+\])*/u);
+  if (submissionMatch) {
+    return submissionMatch[0];
+  }
+  return undefined;
+}
+
+function normalizeValidationPath(path) {
+  if (typeof path !== "string" || !path.trim()) {
+    return undefined;
+  }
+  const trimmed = path.trim();
+  return trimmed.startsWith("payload.") ? trimmed : `payload.${trimmed}`;
+}

--- a/mcp-server/src/core/platform-service-helpers.test.js
+++ b/mcp-server/src/core/platform-service-helpers.test.js
@@ -1,0 +1,115 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { DEFAULT_ESCROW_ASSET } from "./assets.js";
+import {
+  buildSubmissionValidationContract,
+  decimalToBaseUnits,
+  formatBaseUnits,
+  getTreasuryPolicyStatusSafely,
+  getXcmObservationRelayStatusSafely,
+  getXcmSettlementWatcherStatusSafely,
+  minBalanceRawForAsset,
+  sumSubJobRewards,
+  validationPathFromError
+} from "./platform-service-helpers.js";
+
+test("sumSubJobRewards normalizes asset symbols and ignores negative rewards", () => {
+  const total = sumSubJobRewards([
+    { rewardAsset: "dot", rewardAmount: 1.25 },
+    { rewardAsset: "DOT", rewardAmount: 2 },
+    { rewardAsset: "USDC", rewardAmount: 10 },
+    { rewardAsset: "DOT", rewardAmount: -5 },
+    { rewardAsset: "DOT", rewardAmount: undefined }
+  ], "DOT");
+
+  assert.equal(total, 3.25);
+});
+
+test("minBalanceRawForAsset reads explicit and known trust-backed min balances", () => {
+  assert.equal(minBalanceRawForAsset({ minBalanceRaw: " 12345 " }), 12345n);
+  assert.equal(minBalanceRawForAsset({ minBalanceRaw: 987n }), 987n);
+  assert.equal(minBalanceRawForAsset({ minBalanceRaw: -1n }), undefined);
+  assert.equal(minBalanceRawForAsset({ ...DEFAULT_ESCROW_ASSET, minBalanceRaw: undefined }), 70000n);
+  assert.equal(minBalanceRawForAsset({ symbol: "DOT" }), undefined);
+});
+
+test("decimal/base-unit helpers preserve exact token math", () => {
+  assert.equal(decimalToBaseUnits("0.07", 6, "rewardAmount"), 70000n);
+  assert.equal(decimalToBaseUnits(0.14, 6, "rewardAmount"), 140000n);
+  assert.equal(formatBaseUnits(70000n, 6), "0.07");
+  assert.equal(formatBaseUnits(140000n, 6), "0.14");
+  assert.throws(
+    () => decimalToBaseUnits("0.0000001", 6, "rewardAmount"),
+    /rewardAmount must fit 6 decimal places/u
+  );
+  assert.throws(
+    () => decimalToBaseUnits("1", 31, "rewardAmount"),
+    /asset decimals must be an integer/u
+  );
+});
+
+test("safe status readers return fallbacks instead of throwing", async () => {
+  const policyError = new Error("getTreasuryPolicyStatus failed");
+  policyError.code = "blockchain_revert";
+  policyError.details = { rawReason: "require(false)" };
+  const policy = await getTreasuryPolicyStatusSafely({
+    config: { treasuryPolicyAddress: "0x1111111111111111111111111111111111111111" },
+    isEnabled: () => true,
+    getTreasuryPolicyStatus: async () => {
+      throw policyError;
+    }
+  });
+  assert.equal(policy.enabled, true);
+  assert.equal(policy.policyAddress, "0x1111111111111111111111111111111111111111");
+  assert.equal(policy.error.code, "blockchain_revert");
+  assert.equal(policy.error.details.rawReason, "require(false)");
+
+  const settlement = await getXcmSettlementWatcherStatusSafely({
+    enabled: true,
+    running: true,
+    getStatus: async () => {
+      throw new Error("watcher unavailable");
+    }
+  });
+  assert.equal(settlement.enabled, true);
+  assert.equal(settlement.running, true);
+  assert.equal(settlement.error.code, "xcm_settlement_watcher_status_error");
+
+  const observation = await getXcmObservationRelayStatusSafely({
+    enabled: true,
+    running: false,
+    syncing: true,
+    feedUrl: "https://feed.example.invalid",
+    batchSize: 5,
+    pollIntervalMs: 1000,
+    getStatus: async () => {
+      throw new Error("relay unavailable");
+    }
+  });
+  assert.equal(observation.enabled, true);
+  assert.equal(observation.syncing, true);
+  assert.equal(observation.feedUrl, "https://feed.example.invalid");
+  assert.equal(observation.error.code, "xcm_observation_relay_status_error");
+});
+
+test("submission validation helpers expose schema shape and normalized error paths", () => {
+  const contract = buildSubmissionValidationContract({
+    outputSchemaRef: "schema://jobs/coding-output"
+  });
+
+  assert.equal(contract.schemaValidates, "payload.submission");
+  assert.equal(contract.submissionShape, "direct_schema_object");
+  assert.equal(contract.doNotWrapInOutput, true);
+  assert.deepEqual(contract.requiredTopLevelKeys, ["summary", "output", "status"]);
+
+  assert.equal(
+    validationPathFromError({ details: { expectedPath: "submission.output" } }),
+    "payload.submission.output"
+  );
+  assert.equal(
+    validationPathFromError({ message: "Invalid value at payload.submission.citations[0]" }),
+    "payload.submission.citations[0]"
+  );
+  assert.equal(validationPathFromError({ message: "no path here" }), undefined);
+});

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -10,7 +10,7 @@ import { VerificationIngestionService } from "../services/verification-ingestion
 import { ConflictError, InsufficientLiquidityError, ValidationError } from "./errors.js";
 import { normalizeSubmission } from "./submission.js";
 import { buildPlatformCapabilities } from "./discovery-manifest.js";
-import { getBuiltinJobSchema, getJobSchema, getRegisteredJobSchemaRegistration } from "./job-schema-registry.js";
+import { getBuiltinJobSchema, getRegisteredJobSchemaRegistration } from "./job-schema-registry.js";
 import {
   buildSessionLifecycle,
   getSessionStateMachineDefinition
@@ -30,10 +30,21 @@ import {
   PROVIDER_STATUS_FALLBACK,
   sanitizeProviderOperations
 } from "./provider-operations-status.js";
+import {
+  buildSubmissionValidationContract,
+  decimalToBaseUnits,
+  formatBaseUnits,
+  getTreasuryPolicyStatusSafely,
+  getXcmObservationRelayStatusSafely,
+  getXcmSettlementWatcherStatusSafely,
+  minBalanceRawForAsset,
+  sumSubJobRewards,
+  validationPathFromError
+} from "./platform-service-helpers.js";
 import { computeClaimEconomics, countClaimedSessions } from "./claim-economics.js";
 import { claimStatusFields, isTerminalSession, summarizeJobClaimState } from "./claim-state.js";
 import { capabilityMatrix } from "../auth/capabilities.js";
-import { knownAssetMinBalanceRaw, normalizeAssetSymbol } from "./assets.js";
+import { normalizeAssetSymbol } from "./assets.js";
 import { collectGithubOperatorStatus } from "./github-operator-helper.js";
 import { collectHostDiagnostics } from "./host-diagnostics.js";
 import { registerExternalSchema, validateSubmissionAgainstRegisteredSchema } from "../services/schema-registry.js";
@@ -45,50 +56,6 @@ const STARTER_REPUTATION = {
   reliability: 0,
   economic: 0,
   tier: "starter"
-};
-
-const DEFAULT_TREASURY_POLICY_STATUS = {
-  enabled: false,
-  policyAddress: undefined,
-  paused: undefined,
-  owner: undefined,
-  pauser: undefined,
-  settlementReady: false,
-  contracts: {
-    escrowCoreAddress: undefined,
-    agentAccountAddress: undefined,
-    reputationSbtAddress: undefined,
-    supportedAssets: []
-  },
-  roles: {
-    signerAddress: undefined,
-    signerIsVerifier: false,
-    escrowIsServiceOperator: false,
-    agentAccountIsServiceOperator: false
-  },
-  readErrors: [],
-  risk: {}
-};
-
-const DEFAULT_XCM_SETTLEMENT_WATCHER_STATUS = {
-  enabled: false,
-  running: false,
-  pendingCount: 0,
-  pending: []
-};
-
-const DEFAULT_XCM_OBSERVATION_RELAY_STATUS = {
-  enabled: false,
-  running: false,
-  syncing: false,
-  feedUrl: undefined,
-  batchSize: 0,
-  pollIntervalMs: 0,
-  cursor: undefined,
-  lastObservedCount: 0,
-  lastSyncedAt: undefined,
-  lastError: undefined,
-  updatedAt: undefined
 };
 
 export class PlatformService {
@@ -1351,176 +1318,4 @@ export class PlatformService {
       providerOperations: sanitizeProviderOperations(providerOperations)
     };
   }
-}
-
-function sumSubJobRewards(jobs, asset) {
-  const normalizedAsset = normalizeAssetSymbol(asset);
-  return jobs
-    .filter((job) => normalizeAssetSymbol(job.rewardAsset) === normalizedAsset)
-    .reduce((total, job) => total + Math.max(Number(job.rewardAmount ?? 0), 0), 0);
-}
-
-function minBalanceRawForAsset(asset) {
-  if (!asset) {
-    return undefined;
-  }
-  const raw = asset.minBalanceRaw ?? knownAssetMinBalanceRaw(asset);
-  if (raw === undefined || raw === null || raw === "") {
-    return undefined;
-  }
-  if (typeof raw === "bigint") {
-    return raw >= 0n ? raw : undefined;
-  }
-  const value = String(raw).trim();
-  return /^\d+$/u.test(value) ? BigInt(value) : undefined;
-}
-
-function decimalToBaseUnits(amount, decimals, label) {
-  if (!Number.isInteger(decimals) || decimals < 0 || decimals > 30) {
-    throw new ValidationError(`${label} asset decimals must be an integer in [0, 30].`);
-  }
-  const normalized = normalizeDecimalString(amount, label);
-  const [whole, fractional = ""] = normalized.split(".");
-  if (fractional.length > decimals) {
-    throw new ValidationError(`${label} must fit ${decimals} decimal places.`);
-  }
-  return BigInt(whole) * (10n ** BigInt(decimals))
-    + BigInt(fractional.padEnd(decimals, "0") || "0");
-}
-
-function normalizeDecimalString(value, label) {
-  const raw = typeof value === "number"
-    ? value.toLocaleString("en-US", { useGrouping: false, maximumFractionDigits: 30 })
-    : String(value ?? "").trim();
-  if (!/^(?:0|[1-9]\d*)(?:\.\d+)?$/u.test(raw)) {
-    throw new ValidationError(`${label} must be a positive decimal amount.`);
-  }
-  return raw;
-}
-
-function formatBaseUnits(raw, decimals) {
-  const scale = 10n ** BigInt(decimals);
-  const whole = raw / scale;
-  const fractional = raw % scale;
-  if (fractional === 0n || decimals === 0) return whole.toString();
-  const padded = fractional.toString().padStart(decimals, "0").replace(/0+$/u, "");
-  return `${whole}.${padded}`;
-}
-
-async function getTreasuryPolicyStatusSafely(blockchainGateway) {
-  if (!blockchainGateway?.getTreasuryPolicyStatus) {
-    return { ...DEFAULT_TREASURY_POLICY_STATUS };
-  }
-
-  try {
-    return await blockchainGateway.getTreasuryPolicyStatus();
-  } catch (error) {
-    return {
-      ...DEFAULT_TREASURY_POLICY_STATUS,
-      enabled: Boolean(blockchainGateway.isEnabled?.()),
-      policyAddress: blockchainGateway.config?.treasuryPolicyAddress || undefined,
-      error: {
-        code: error?.code ?? "policy_status_error",
-        message: error?.message ?? "Treasury policy status failed.",
-        details: error?.details
-      }
-    };
-  }
-}
-
-async function getXcmSettlementWatcherStatusSafely(xcmSettlementWatcher) {
-  if (!xcmSettlementWatcher?.getStatus) {
-    return { ...DEFAULT_XCM_SETTLEMENT_WATCHER_STATUS };
-  }
-
-  try {
-    return await xcmSettlementWatcher.getStatus();
-  } catch (error) {
-    return {
-      ...DEFAULT_XCM_SETTLEMENT_WATCHER_STATUS,
-      enabled: Boolean(xcmSettlementWatcher.enabled),
-      running: Boolean(xcmSettlementWatcher.running),
-      error: normalizeStatusReadError(error, "xcm_settlement_watcher_status_error")
-    };
-  }
-}
-
-async function getXcmObservationRelayStatusSafely(xcmObservationRelay) {
-  if (!xcmObservationRelay?.getStatus) {
-    return { ...DEFAULT_XCM_OBSERVATION_RELAY_STATUS };
-  }
-
-  try {
-    return await xcmObservationRelay.getStatus();
-  } catch (error) {
-    return {
-      ...DEFAULT_XCM_OBSERVATION_RELAY_STATUS,
-      enabled: Boolean(xcmObservationRelay.enabled),
-      running: Boolean(xcmObservationRelay.running),
-      syncing: Boolean(xcmObservationRelay.syncing),
-      feedUrl: xcmObservationRelay.feedUrl,
-      batchSize: xcmObservationRelay.batchSize ?? 0,
-      pollIntervalMs: xcmObservationRelay.pollIntervalMs ?? 0,
-      error: normalizeStatusReadError(error, "xcm_observation_relay_status_error")
-    };
-  }
-}
-
-function normalizeStatusReadError(error, code) {
-  return {
-    code: error?.code ?? code,
-    message: error?.message ?? "Status read failed.",
-    details: error?.details
-  };
-}
-
-function buildSubmissionValidationContract(job) {
-  const schemaRef = job?.outputSchemaRef;
-  const schema = getJobSchema(schemaRef, { registrations: job?.schemaRegistrations });
-  const requiredTopLevelKeys = Array.isArray(schema?.required) ? schema.required : [];
-  return {
-    validationEndpoint: "POST /jobs/validate-submission",
-    submitEndpoint: "POST /jobs/submit",
-    submissionShape: "direct_schema_object",
-    schemaValidates: "payload.submission",
-    doNotWrapInOutput: true,
-    ...(requiredTopLevelKeys.length ? { requiredTopLevelKeys } : {})
-  };
-}
-
-function validationPathFromError(error) {
-  const details = error?.details && typeof error.details === "object" ? error.details : {};
-  const directPath = [
-    details.path,
-    details.expectedPath,
-    details.expected,
-    details.received
-  ].find((entry) => typeof entry === "string" && entry.trim());
-  if (directPath) {
-    return normalizeValidationPath(directPath);
-  }
-  return normalizeValidationPath(parseValidationPathFromMessage(error?.message));
-}
-
-function parseValidationPathFromMessage(message) {
-  if (typeof message !== "string") {
-    return undefined;
-  }
-  const payloadMatch = message.match(/\bpayload\.submission(?:\.[A-Za-z0-9_-]+|\[[0-9]+\])*/u);
-  if (payloadMatch) {
-    return payloadMatch[0];
-  }
-  const submissionMatch = message.match(/\bsubmission(?:\.[A-Za-z0-9_-]+|\[[0-9]+\])*/u);
-  if (submissionMatch) {
-    return submissionMatch[0];
-  }
-  return undefined;
-}
-
-function normalizeValidationPath(path) {
-  if (typeof path !== "string" || !path.trim()) {
-    return undefined;
-  }
-  const trimmed = path.trim();
-  return trimmed.startsWith("payload.") ? trimmed : `payload.${trimmed}`;
 }


### PR DESCRIPTION
What changed:
- Extracted PlatformService helper logic into mcp-server/src/core/platform-service-helpers.js.
- Added focused helper tests for reward aggregation, min-balance/base-unit math, safe status fallbacks, and submission validation path helpers.
- Left PlatformService orchestration behavior unchanged and imported the extracted helpers.

Checks run:
- node --test mcp-server/src/core/platform-service-helpers.test.js
- node --test mcp-server/src/core/platform-service.test.js
- node --check mcp-server/src/core/platform-service.js
- node --check mcp-server/src/core/platform-service-helpers.js
- npm --workspace mcp-server test

Surface impact:
- Backend only.
- No frontend, indexer, Caddy, contracts, public site, env, or VPS secret changes.

Polkadot docs MCP:
- Checked Polkadot docs MCP availability. This is a structural extraction only; no chain semantics changed.