### PR TITLE
fix(auth): mint roleless ES256 JWTs so ordinary worker wallets can sign in

### DIFF
--- a/.github/workflows/hosted-siwe-fresh-wallet-proof.yml
+++ b/.github/workflows/hosted-siwe-fresh-wallet-proof.yml
@@ -1,0 +1,86 @@
+name: Hosted SIWE Fresh-Wallet Proof
+
+# Regression guard for the roleless-wallet SIWE→JWT mint. Performs a REAL
+# SIWE login with a FRESH, non-admin/non-verifier wallet end to end
+# (nonce → sign → verify → /account) and asserts a usable roleless bearer
+# token is minted. This is the exact front door every external agent uses
+# and that no other hosted proof exercises (they all use the pre-minted
+# multi-role ADMIN_JWT). It needs NO secrets — a fresh random wallet is
+# the whole point.
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hosted-siwe-fresh-wallet-proof
+  cancel-in-progress: false
+
+jobs:
+  proof:
+    name: Run hosted SIWE fresh-wallet proof
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    env:
+      APP_ALLOW_PROTECTED_SHELL: "1"
+      CHECK_INDEXER: "0"
+      CHECK_SIWE_FRESH_WALLET_PROOF: "1"
+      SIWE_FRESH_WALLET_PROOF_EVIDENCE_FILE: artifacts/siwe-fresh-wallet-proof-hosted-${{ github.run_id }}.json
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      # The proof script signs the SIWE message with `ethers` (a prod
+      # dependency of mcp-server), so unlike the source-only hosted proofs
+      # this one needs node_modules installed.
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Run hosted proof
+        run: |
+          set -euo pipefail
+          set +x
+
+          ./scripts/ops/check-hosted-stack.sh
+
+      - name: Summarize proof evidence
+        if: always()
+        run: |
+          set -euo pipefail
+
+          evidence_file="$SIWE_FRESH_WALLET_PROOF_EVIDENCE_FILE"
+          if [ ! -s "$evidence_file" ]; then
+            echo "No SIWE fresh-wallet evidence file was produced." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          wallet="$(jq -r '.wallet' "$evidence_file")"
+          verify_status="$(jq -r '.verifyStatus' "$evidence_file")"
+          account_status="$(jq -r '.accountStatus' "$evidence_file")"
+          roles="$(jq -c '.roles' "$evidence_file")"
+
+          {
+            echo "## Hosted SIWE Fresh-Wallet Proof"
+            echo
+            echo "- Wallet: \`${wallet}\` (ephemeral)"
+            echo "- /auth/verify: \`HTTP ${verify_status}\`"
+            echo "- /account: \`HTTP ${account_status}\`"
+            echo "- Roles: \`${roles}\` (roleless worker)"
+            echo "- Evidence artifact: \`hosted-siwe-fresh-wallet-proof-${GITHUB_RUN_ID}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload SIWE fresh-wallet proof evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: hosted-siwe-fresh-wallet-proof-${{ github.run_id }}
+          path: ${{ env.SIWE_FRESH_WALLET_PROOF_EVIDENCE_FILE }}
+          if-no-files-found: error
+          retention-days: 90

--- a/mcp-server/src/auth/jwt-dispatcher.test.js
+++ b/mcp-server/src/auth/jwt-dispatcher.test.js
@@ -19,13 +19,14 @@ import { generateKeyPairSync } from "node:crypto";
 
 import { p256 } from "@noble/curves/nist.js";
 
-import { loadAuthConfig } from "./config.js";
+import { loadAuthConfig, hasRole } from "./config.js";
 import {
   signToken,
   signTokenFromConfig,
   verifyTokenFromConfig,
 } from "./jwt.js";
 import { createAuthMiddleware } from "./middleware.js";
+import { resolveCapabilities } from "./capabilities.js";
 import { ConfigError, AuthenticationError } from "../core/errors.js";
 
 // ───────────────────────────────────────────────────────────────────
@@ -276,6 +277,92 @@ test("dispatcher kms: signTokenFromConfig with payload.roles array mints multi-r
   // Verify round-trips with both roles preserved.
   const verified = await verifyTokenFromConfig(token, cfg);
   assert.deepEqual(verified.roles, ["admin", "verifier"]);
+});
+
+test("dispatcher kms: roleless wallet mints a valid ES256 token (LAUNCH-CRITICAL regression)", async () => {
+  // The exact bug: once prod went ES256-only (JWT_BACKEND=kms), the SIWE
+  // handler called signTokenFromConfig({ sub, roles: [] }, ...) for every
+  // ordinary worker wallet, and the ES256 path THREW ConfigError →
+  // HTTP 500 invalid_configuration. resolveRoles returns [] for any
+  // non-admin/non-verifier wallet, so this is the common external-agent
+  // path. It must mint, not throw.
+  const cfg = buildAuthConfig({ jwtBackend: "kms", withKms: true });
+  const { token, claims } = await signTokenFromConfig(
+    { sub: SUBJECT, roles: [] }, // ← exactly what auth-routes.js passes for a roleless wallet
+    { expiresInSeconds: 60 },
+    cfg,
+  );
+  const [headerB64] = token.split(".");
+  const header = JSON.parse(b64uDecode(headerB64).toString("utf8"));
+  assert.equal(header.alg, "ES256");
+  assert.equal(claims.sub, SUBJECT);
+  // Canonical shape: roles is an (empty) array, never a singular role.
+  assert.deepEqual(claims.roles, []);
+  assert.equal(claims.role, undefined);
+});
+
+test("dispatcher kms: signTokenFromConfig with no derivable role does not throw and mints roleless", async () => {
+  // Covers the path where neither opts.role, payload.roles, nor
+  // payload.role is present — the dispatcher must default to a roleless
+  // mint rather than the old ConfigError throw.
+  const cfg = buildAuthConfig({ jwtBackend: "kms", withKms: true });
+  const { token, claims } = await signTokenFromConfig(
+    { sub: SUBJECT }, // no roles/role anywhere
+    { issuer: ISSUER, audience: AUDIENCE, subject: SUBJECT, expiresInSeconds: 60 },
+    cfg,
+  );
+  assert.deepEqual(claims.roles, []);
+  // Sanity: with-roles path is unaffected — still emits the array verbatim.
+  const { claims: adminClaims } = await signTokenFromConfig(
+    { sub: SUBJECT, roles: ["admin"] },
+    { issuer: ISSUER, audience: AUDIENCE, subject: SUBJECT, expiresInSeconds: 60 },
+    cfg,
+  );
+  assert.deepEqual(adminClaims.roles, ["admin"]);
+  // Token is structurally valid (verifies below in the round-trip test).
+  assert.equal(typeof token, "string");
+});
+
+test("dispatcher kms: roleless ES256 token round-trips through verify and hasRole returns false gracefully", async () => {
+  const cfg = buildAuthConfig({ jwtBackend: "kms", withKms: true });
+  const { token } = await signTokenFromConfig(
+    { sub: SUBJECT, roles: [] },
+    { expiresInSeconds: 60 },
+    cfg,
+  );
+  const claims = await verifyTokenFromConfig(token, cfg);
+  assert.equal(claims.sub, SUBJECT);
+  assert.deepEqual(claims.roles, []);
+  // hasRole must not throw and must report false for a roleless token.
+  assert.equal(hasRole(claims, "admin"), false);
+  assert.equal(hasRole(claims, "verifier"), false);
+  // A roleless wallet still receives the base capabilities — including
+  // jobs:claim / jobs:submit, which are auth-gated, not role-gated. This
+  // is what makes an ordinary worker functional after sign-in.
+  const capabilities = resolveCapabilities(claims);
+  assert.ok(capabilities.includes("jobs:claim"), "roleless token should carry jobs:claim");
+  assert.ok(capabilities.includes("jobs:submit"), "roleless token should carry jobs:submit");
+  assert.ok(capabilities.includes("account:read"), "roleless token should carry account:read");
+  // ...but NOT any admin capability.
+  assert.ok(!capabilities.includes("jobs:create"), "roleless token must NOT carry admin caps");
+});
+
+test("middleware integration: roleless ES256 token authenticates and can reach /jobs/claim", async () => {
+  // End-to-end through the real middleware: a roleless wallet's token
+  // must authenticate AND satisfy the jobs:claim route capability
+  // (auth-gated, not role-gated). This is the path the first real
+  // product test exercised and that 500'd before the fix.
+  const cfg = buildAuthConfig({ jwtBackend: "kms", withKms: true });
+  const middleware = createAuthMiddleware({ authConfig: cfg, logger: silentLogger() });
+  const { token } = await signTokenFromConfig(
+    { sub: SUBJECT, roles: [] },
+    { expiresInSeconds: 60 },
+    cfg,
+  );
+  const request = { method: "POST", headers: { authorization: `Bearer ${token}` } };
+  const result = await middleware(request, new URL("http://localhost/jobs/claim"));
+  assert.equal(result.wallet.toLowerCase(), SUBJECT.toLowerCase());
+  assert.deepEqual(result.claims.roles, []);
 });
 
 test("dispatcher kms: legacy single-`role` token (minted pre-2B) still verifies and is normalized", async () => {

--- a/mcp-server/src/auth/jwt.js
+++ b/mcp-server/src/auth/jwt.js
@@ -209,6 +209,20 @@ export async function signTokenFromConfig(payload, opts, authConfig) {
   // multi-role wallets (admin + verifier) keep both capabilities under
   // ES256 issuance. KmsJwtSigner.signAsync normalizes string → [string]
   // internally, so legacy callers passing a single string still work.
+  // `role` is OPTIONAL. Ordinary worker wallets are roleless by design
+  // (config.resolveRoles returns [] for any non-admin/non-verifier
+  // wallet), and claiming / submitting jobs is auth-gated, not
+  // role-gated. When no role is derivable we mint a ROLELESS token
+  // (KmsJwtSigner.signAsync emits `roles: []`) instead of throwing —
+  // matching the HS256 path, which has never required a role. Only
+  // iss / aud / sub stay mandatory.
+  //
+  // Before this fix the ES256 path threw ConfigError → HTTP 500
+  // invalid_configuration for every roleless SIWE login once prod went
+  // ES256-only (JWT_BACKEND=kms). The HS256 path had no such check; that
+  // asymmetry was the bug. A roleless token grants NO privileges
+  // (capabilities derive from role membership via capabilities.js); it
+  // only identifies the wallet via `sub` for auth-gated actions.
   const role =
     opts.role
     ?? (Array.isArray(payload?.roles) && payload.roles.length > 0 ? payload.roles : undefined)
@@ -216,9 +230,9 @@ export async function signTokenFromConfig(payload, opts, authConfig) {
   const issuer = opts.issuer ?? authConfig.kmsJwt?.expectedIssuer;
   const audience = opts.audience ?? authConfig.kmsJwt?.expectedAudience;
 
-  if (!issuer || !audience || !subject || !role) {
+  if (!issuer || !audience || !subject) {
     throw new ConfigError(
-      "signTokenFromConfig (ES256): issuer/audience/subject/role(s) must each be derivable from opts or authConfig.kmsJwt + payload.",
+      "signTokenFromConfig (ES256): issuer/audience/subject must each be derivable from opts or authConfig.kmsJwt + payload.",
     );
   }
 

--- a/mcp-server/src/auth/kms-jwt-signer.js
+++ b/mcp-server/src/auth/kms-jwt-signer.js
@@ -33,7 +33,8 @@
  * Claims validation:
  *   - iss, aud match configured expected values
  *   - sub present, non-empty, lowercase
- *   - role in the configured allowlist
+ *   - role(s), when present, all in the configured allowlist; an empty
+ *     roles array is valid (a roleless ordinary-worker token)
  *   - iat, nbf, exp numeric; exp - iat ≤ MAX_TTL_SECONDS
  *   - clock skew bounded by ±clockSkewSeconds (default 60)
  *   - jti is a UUIDv4-shaped string
@@ -253,18 +254,21 @@ export class KmsJwtSigner {
    * Phase 4b.6 Stage 2B: `opts.role` accepts either a single string
    * (legacy single-role admin JWTs minted via `mint-admin-jwt.mjs
    * --use-kms`) or an array (SIWE multi-role wallets that hold both
-   * admin AND verifier). Emitted tokens always carry a `roles` array
-   * claim — never the singular `role` — so downstream consumers
-   * (middleware, capabilities) have one canonical shape. The dispatcher
-   * (jwt.js verifyEs256) still bridges legacy single-`role` tokens
-   * minted before this PR for backward compat.
+   * admin AND verifier). It may also be ABSENT (undefined / "" / []),
+   * which mints a roleless ordinary-worker token (`roles: []`) — the
+   * common case for external agents that hold no admin/verifier role.
+   * Emitted tokens always carry a `roles` array claim — never the
+   * singular `role` — so downstream consumers (middleware, capabilities)
+   * have one canonical shape. The dispatcher (jwt.js verifyEs256) still
+   * bridges legacy single-`role` tokens minted before this PR for
+   * backward compat.
    *
    * @param {object} payload                       Extra claims to merge in (must not override registered claims).
    * @param {object} opts
    * @param {string} opts.issuer                   `iss` claim value.
    * @param {string} opts.audience                 `aud` claim value.
    * @param {string} opts.subject                  `sub` claim value (lowercase EVM address or canonical user id).
-   * @param {string | string[]} opts.role          `roles` claim source — single string or non-empty array of strings.
+   * @param {string | string[]} [opts.role]        `roles` claim source — single string, array of strings, or absent (→ roleless `roles: []`).
    * @param {number} opts.expiresInSeconds         Token lifetime; will set exp = iat + this.
    * @returns {Promise<string>}                    The serialized ES256 JWT.
    */
@@ -282,16 +286,27 @@ export class KmsJwtSigner {
     if (!subject || typeof subject !== "string") {
       throw new Error("KmsJwtSigner.signAsync: subject is required");
     }
-    // Normalize role/roles input. Caller may pass a single string
-    // (admin-JWT minting path) or an array (SIWE multi-role wallet).
-    const rolesArr = Array.isArray(role)
-      ? role
-      : typeof role === "string" && role.length > 0
-        ? [role]
-        : null;
-    if (!rolesArr || rolesArr.length === 0) {
+    // Normalize role/roles input. Caller may pass:
+    //   - a single string   → admin-JWT minting path
+    //   - an array           → SIWE multi-role wallet (admin + verifier)
+    //   - nothing / "" / []  → ROLELESS ordinary-worker wallet (the
+    //                          common case for external agents; see
+    //                          jwt.js signTokenFromConfig + the SIWE
+    //                          handler in auth-routes.js)
+    // A roleless mint emits `roles: []` so downstream consumers always
+    // see a `roles` array. Roleless tokens grant NO privileges —
+    // capabilities derive from role membership — so an empty array just
+    // identifies the wallet via `sub` for auth-gated actions.
+    let rolesArr;
+    if (Array.isArray(role)) {
+      rolesArr = role;
+    } else if (typeof role === "string" && role.length > 0) {
+      rolesArr = [role];
+    } else if (role === undefined || role === null || role === "") {
+      rolesArr = [];
+    } else {
       throw new Error(
-        "KmsJwtSigner.signAsync: role (string or non-empty array of strings) is required",
+        `KmsJwtSigner.signAsync: role must be a string, an array of strings, or absent (got ${JSON.stringify(role)})`,
       );
     }
     for (const r of rolesArr) {
@@ -527,9 +542,10 @@ export class KmsJwtSigner {
     } else {
       throw new Error("KmsJwtSigner.verify: roles/role claim missing");
     }
-    if (claimedRoles.length === 0) {
-      throw new Error("KmsJwtSigner.verify: roles claim is empty");
-    }
+    // An empty `roles` array is the canonical roleless-worker shape — a
+    // valid token that simply carries no role-derived capabilities. It is
+    // NOT rejected (the allowlist loop below is a no-op for it). Only a
+    // non-empty array containing an out-of-allowlist entry is rejected.
     for (const r of claimedRoles) {
       if (typeof r !== "string" || !expectedRoles.has(r)) {
         throw new Error(`KmsJwtSigner.verify: role "${r}" not in allowlist`);

--- a/mcp-server/src/auth/kms-jwt-signer.test.js
+++ b/mcp-server/src/auth/kms-jwt-signer.test.js
@@ -271,11 +271,45 @@ test("KmsJwtSigner: signAsync accepts multi-role array and emits canonical roles
   assert.deepEqual(claims.roles, ["admin", "verifier"]);
 });
 
-test("KmsJwtSigner: signAsync rejects empty role array", async () => {
+test("KmsJwtSigner: signAsync with an empty role array mints a roleless token (roles: [])", async () => {
+  // Roleless ordinary-worker wallet — the common case for external
+  // agents. An empty role array is no longer an error; it mints a token
+  // carrying `roles: []`, which round-trips through verify.
+  const signer = buildSigner();
+  const token = await signer.signAsync({}, { ...defaultSignOpts(), role: [] });
+  const claims = signer.verify(token);
+  assert.deepEqual(claims.roles, []);
+  assert.equal(claims.role, undefined);
+  assert.equal(claims.sub, SUBJECT);
+});
+
+test("KmsJwtSigner: signAsync with no role at all mints a roleless token that verifies", async () => {
+  // Mirrors the dispatcher path where opts.role is undefined for a
+  // roleless wallet. signAsync must NOT throw and must emit roles: [].
+  const signer = buildSigner();
+  const { role: _role, ...optsWithoutRole } = defaultSignOpts();
+  const token = await signer.signAsync({}, optsWithoutRole);
+  const claims = signer.verify(token);
+  assert.deepEqual(claims.roles, []);
+});
+
+test("KmsJwtSigner: verify accepts a roleless token even with a non-empty expectedRoles allowlist", async () => {
+  // The verifier-side allowlist is configured (prod = VALID_ROLES), but
+  // a roleless token's empty array makes the allowlist check a no-op —
+  // it must still verify.
+  const signer = buildSigner({ expectedRoles: ["admin", "verifier"] });
+  const token = await signer.signAsync({}, { ...defaultSignOpts(), role: [] });
+  const claims = signer.verify(token);
+  assert.deepEqual(claims.roles, []);
+});
+
+test("KmsJwtSigner: signAsync still rejects a non-string role value", async () => {
+  // Guard against regressing the validation for genuinely malformed
+  // input — a number is neither a string, an array, nor "absent".
   const signer = buildSigner();
   await assert.rejects(
-    () => signer.signAsync({}, { ...defaultSignOpts(), role: [] }),
-    /role .* is required/,
+    () => signer.signAsync({}, { ...defaultSignOpts(), role: 42 }),
+    /role must be a string, an array of strings, or absent/,
   );
 });
 

--- a/scripts/ops/check-hosted-stack.sh
+++ b/scripts/ops/check-hosted-stack.sh
@@ -43,6 +43,10 @@ EXTERNAL_SCHEMA_PROOF_IDEMPOTENCY_KEY=${EXTERNAL_SCHEMA_PROOF_IDEMPOTENCY_KEY:-}
 CHECK_DISPUTE_VERDICT_PROOF=${CHECK_DISPUTE_VERDICT_PROOF:-0}
 DISPUTE_PROOF_NODE_IMAGE=${DISPUTE_PROOF_NODE_IMAGE:-node:22-bookworm-slim}
 DISPUTE_PROOF_EVIDENCE_FILE=${DISPUTE_PROOF_EVIDENCE_FILE:-}
+CHECK_SIWE_FRESH_WALLET_PROOF=${CHECK_SIWE_FRESH_WALLET_PROOF:-0}
+SIWE_FRESH_WALLET_PROOF_NODE_IMAGE=${SIWE_FRESH_WALLET_PROOF_NODE_IMAGE:-node:22-bookworm-slim}
+SIWE_FRESH_WALLET_PROOF_EVIDENCE_FILE=${SIWE_FRESH_WALLET_PROOF_EVIDENCE_FILE:-}
+SIWE_FRESH_WALLET_PRIVATE_KEY=${SIWE_FRESH_WALLET_PRIVATE_KEY:-}
 CHECK_METRICS_AUTH=${CHECK_METRICS_AUTH:-0}
 METRICS_BEARER_TOKEN=${METRICS_BEARER_TOKEN:-}
 TIMEOUT_SEC=${TIMEOUT_SEC:-20}
@@ -119,7 +123,7 @@ enabled() {
   esac
 }
 
-if { enabled "$CHECK_PRODUCT_PROOF_GATE" || enabled "$CHECK_SERVICE_TOKEN_PROOF" || enabled "$CHECK_EXTERNAL_SCHEMA_PROOF" || enabled "$CHECK_DISPUTE_VERDICT_PROOF"; } && ! command -v node >/dev/null 2>&1; then
+if { enabled "$CHECK_PRODUCT_PROOF_GATE" || enabled "$CHECK_SERVICE_TOKEN_PROOF" || enabled "$CHECK_EXTERNAL_SCHEMA_PROOF" || enabled "$CHECK_DISPUTE_VERDICT_PROOF" || enabled "$CHECK_SIWE_FRESH_WALLET_PROOF"; } && ! command -v node >/dev/null 2>&1; then
   require_command docker
 fi
 
@@ -578,6 +582,43 @@ if enabled "$CHECK_DISPUTE_VERDICT_PROOF"; then
     .persisted.status == "resolved" and
     .persisted.reasoningHash == .response.reasoningHash
   ' >/dev/null <<<"$dispute_proof_json"
+fi
+
+if enabled "$CHECK_SIWE_FRESH_WALLET_PROOF"; then
+  # Real SIWE login with a FRESH, non-admin/non-verifier wallet — the
+  # regression guard for the roleless-wallet JWT mint. Needs no ADMIN_JWT
+  # (that's the whole point: it exercises the live front door, not a
+  # pre-minted multi-role token). Must FAIL before the auth fix (verify
+  # 500s) and PASS after.
+  echo "Checking SIWE fresh-wallet proof"
+  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  repo_root="$(cd "$script_dir/../.." && pwd)"
+  if [[ -n "$SIWE_FRESH_WALLET_PROOF_EVIDENCE_FILE" ]]; then
+    if [[ "$SIWE_FRESH_WALLET_PROOF_EVIDENCE_FILE" != /* ]]; then
+      SIWE_FRESH_WALLET_PROOF_EVIDENCE_FILE="$repo_root/$SIWE_FRESH_WALLET_PROOF_EVIDENCE_FILE"
+    fi
+    siwe_fresh_wallet_proof_evidence_dir="$(dirname "$SIWE_FRESH_WALLET_PROOF_EVIDENCE_FILE")"
+    mkdir -p "$siwe_fresh_wallet_proof_evidence_dir"
+  fi
+  if command -v node >/dev/null 2>&1; then
+    API_BASE_URL="${API_HEALTH_URL%/health}" \
+      SIWE_FRESH_WALLET_PROOF_EVIDENCE_FILE="$SIWE_FRESH_WALLET_PROOF_EVIDENCE_FILE" \
+      SIWE_FRESH_WALLET_PRIVATE_KEY="$SIWE_FRESH_WALLET_PRIVATE_KEY" \
+      node "$script_dir/check-siwe-fresh-wallet-proof.mjs"
+  else
+    siwe_fresh_wallet_proof_docker_volume_args=(-v "$repo_root:/workspace")
+    if [[ -n "${siwe_fresh_wallet_proof_evidence_dir:-}" ]]; then
+      siwe_fresh_wallet_proof_docker_volume_args+=(-v "$siwe_fresh_wallet_proof_evidence_dir:$siwe_fresh_wallet_proof_evidence_dir")
+    fi
+    docker run --rm \
+      "${siwe_fresh_wallet_proof_docker_volume_args[@]}" \
+      -w /workspace \
+      -e API_BASE_URL="${API_HEALTH_URL%/health}" \
+      -e SIWE_FRESH_WALLET_PROOF_EVIDENCE_FILE="$SIWE_FRESH_WALLET_PROOF_EVIDENCE_FILE" \
+      -e SIWE_FRESH_WALLET_PRIVATE_KEY="$SIWE_FRESH_WALLET_PRIVATE_KEY" \
+      "$SIWE_FRESH_WALLET_PROOF_NODE_IMAGE" \
+      node scripts/ops/check-siwe-fresh-wallet-proof.mjs
+  fi
 fi
 
 echo "Hosted stack smoke check passed."

--- a/scripts/ops/check-siwe-fresh-wallet-proof.mjs
+++ b/scripts/ops/check-siwe-fresh-wallet-proof.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+//
+// Hosted regression guard for the roleless-wallet SIWE→JWT mint.
+//
+// Background: external agents authenticate with an ORDINARY wallet that
+// holds no admin/verifier role. config.resolveRoles returns [] for such
+// wallets, so the SIWE handler mints a roleless JWT. When prod went
+// ES256-only (JWT_BACKEND=kms), the ES256 sign path REQUIRED a role and
+// threw ConfigError → HTTP 500 invalid_configuration for every roleless
+// login — i.e. EVERY external agent was locked out at the front door.
+// No existing proof caught it because every other hosted proof uses the
+// pre-minted multi-role ADMIN_JWT and never exercises the live SIWE mint
+// for a roleless wallet.
+//
+// This proof closes that gap by doing a REAL SIWE login with a FRESH,
+// non-admin/non-verifier wallet end to end:
+//
+//   1. Generate an ephemeral wallet (NOT in AUTH_ADMIN_WALLETS /
+//      AUTH_VERIFIER_WALLETS — a brand-new random key never can be).
+//   2. POST /auth/nonce { wallet }     → 200 + SIWE message.
+//   3. Sign the SIWE message (EIP-191 personal_sign).
+//   4. POST /auth/verify { message, signature } → assert 200 + a usable
+//      bearer token whose roles claim is [] (roleless). Before the fix
+//      this step returns HTTP 500 invalid_configuration.
+//   5. GET /account with the bearer token → assert 200 (account:read is
+//      a BASE capability every wallet holds), proving the token works
+//      for an auth-gated, non-role-gated action.
+//
+// Run against prod this MUST FAIL before the auth fix and PASS after.
+//
+// Mirrors the other hosted proofs (check-product-proof-gate.mjs etc.):
+// an exported async function + a CLI entry, gated in
+// check-hosted-stack.sh behind CHECK_SIWE_FRESH_WALLET_PROOF=1.
+
+import assert from "node:assert/strict";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import { Wallet } from "ethers";
+
+const DEFAULT_API_BASE_URL = "https://api.averray.com";
+const TIMEOUT_MS = 20_000;
+
+export async function checkSiweFreshWalletProof({
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+  log = console.log,
+  makeWallet = () => Wallet.createRandom(),
+} = {}) {
+  if (typeof fetchImpl !== "function") {
+    throw new Error("fetch is not available in this Node runtime.");
+  }
+
+  const apiBaseUrl = stripTrailingSlash(env.API_BASE_URL || DEFAULT_API_BASE_URL);
+  const evidenceFile = env.SIWE_FRESH_WALLET_PROOF_EVIDENCE_FILE || "";
+
+  // An override private key is supported for reproducible local runs, but
+  // the default — a fresh random key every run — is the point: it is
+  // guaranteed not to be an admin/verifier wallet and never accrues
+  // state, so it always exercises the true roleless front door.
+  const overrideKey = (env.SIWE_FRESH_WALLET_PRIVATE_KEY || "").trim();
+  const wallet = overrideKey ? new Wallet(overrideKey) : makeWallet();
+  const address = wallet.address;
+
+  log(`SIWE fresh-wallet proof against ${apiBaseUrl} (wallet ${address})`);
+
+  // ── 1. nonce ──────────────────────────────────────────────────────
+  log("POST /auth/nonce");
+  const nonceResult = await postJson(fetchImpl, `${apiBaseUrl}/auth/nonce`, {
+    wallet: address,
+  });
+  assert.equal(
+    nonceResult.status,
+    200,
+    `/auth/nonce expected HTTP 200, got ${nonceResult.status}: ${describeBody(nonceResult.body)}`,
+  );
+  const message = nonceResult.body?.message;
+  assert.ok(
+    typeof message === "string" && message.length > 0,
+    "/auth/nonce must return a non-empty SIWE message",
+  );
+
+  // ── 2. sign (EIP-191 personal_sign) ───────────────────────────────
+  const signature = await wallet.signMessage(message);
+
+  // ── 3. verify — the step that 500'd before the fix ────────────────
+  log("POST /auth/verify");
+  const verifyResult = await postJson(fetchImpl, `${apiBaseUrl}/auth/verify`, {
+    message,
+    signature,
+  });
+
+  // A precise, actionable failure when we hit the exact regression: the
+  // signature verified (else this would be 401), but the platform failed
+  // to MINT the roleless JWT.
+  if (verifyResult.status === 500) {
+    const code = verifyResult.body?.error ?? verifyResult.body?.code ?? "";
+    throw new Error(
+      `/auth/verify returned HTTP 500 (${describeBody(verifyResult.body)}). ` +
+        (String(code).includes("invalid_configuration") || code === ""
+          ? "This is the roleless-wallet SIWE→JWT mint regression: the ES256 sign path " +
+            "rejected a roleless worker token. Fix signTokenFromConfig to make `role` optional."
+          : "Unexpected server error while minting the SIWE token."),
+    );
+  }
+  assert.equal(
+    verifyResult.status,
+    200,
+    `/auth/verify expected HTTP 200, got ${verifyResult.status}: ${describeBody(verifyResult.body)}`,
+  );
+
+  const token = verifyResult.body?.token;
+  assert.ok(
+    typeof token === "string" && token.split(".").length === 3,
+    "/auth/verify must return a JWT bearer token",
+  );
+  const roles = verifyResult.body?.roles ?? [];
+  assert.ok(Array.isArray(roles), "/auth/verify response roles must be an array");
+  assert.equal(
+    roles.length,
+    0,
+    `fresh wallet must be ROLELESS, but /auth/verify returned roles: ${JSON.stringify(roles)}`,
+  );
+  assert.ok(
+    !roles.includes("admin") && !roles.includes("verifier"),
+    "fresh wallet must not be granted admin/verifier",
+  );
+
+  // ── 4. use the token on an auth-gated, non-role-gated route ───────
+  log("GET /account with the minted bearer token");
+  const accountResult = await getJson(fetchImpl, `${apiBaseUrl}/account`, token);
+  assert.equal(
+    accountResult.status,
+    200,
+    `GET /account with the fresh-wallet token expected HTTP 200, got ${accountResult.status}: ${describeBody(accountResult.body)}`,
+  );
+
+  const evidence = {
+    proof: "siwe-fresh-wallet",
+    apiBaseUrl,
+    wallet: address,
+    ephemeral: overrideKey.length === 0,
+    nonceStatus: nonceResult.status,
+    verifyStatus: verifyResult.status,
+    accountStatus: accountResult.status,
+    roles,
+    tokenMinted: true,
+    checkedAt: new Date().toISOString(),
+  };
+
+  if (evidenceFile) {
+    await mkdir(dirname(evidenceFile), { recursive: true });
+    await writeFile(evidenceFile, `${JSON.stringify(evidence, null, 2)}\n`, "utf8");
+    log(`Wrote evidence to ${evidenceFile}`);
+  }
+
+  log(
+    `SIWE fresh-wallet proof passed — roleless wallet ${address} minted a usable bearer token and reached /account.`,
+  );
+  return evidence;
+}
+
+async function postJson(fetchImpl, url, body) {
+  const response = await fetchImpl(url, {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "application/json" },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  return { status: response.status, body: await readBody(response) };
+}
+
+async function getJson(fetchImpl, url, token) {
+  const response = await fetchImpl(url, {
+    method: "GET",
+    headers: { accept: "application/json", authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  return { status: response.status, body: await readBody(response) };
+}
+
+async function readBody(response) {
+  const text = await response.text().catch(() => "");
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function describeBody(body) {
+  if (body && typeof body === "object") {
+    return JSON.stringify(body);
+  }
+  const text = String(body ?? "");
+  return text.length > 200 ? `${text.slice(0, 200)}…` : text;
+}
+
+function stripTrailingSlash(value) {
+  return String(value).replace(/\/+$/u, "");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  checkSiweFreshWalletProof().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Launch-critical auth fix

The first real product test found that the platform's SIWE→JWT mint **rejects every ordinary (roleless) worker wallet**, so no external agent can sign in. A valid SIWE signature from a fresh wallet (`0x30BC468dA4E95a8FA4b3f2043c86687a57CdeE05`) at `POST https://api.averray.com/auth/verify` returns **HTTP 500 `invalid_configuration`** (RequestIds `f1e42c4e-…`, `b6c6d481-…`). The signature verifies — the platform accepts the nonce, then fails to *mint* the JWT.

### Root cause (verified on current main, not re-diagnosed)
- `config.resolveRoles` returns `[]` for any non-admin/non-verifier wallet — ordinary workers are roleless **by design** (`VALID_ROLES = {admin, verifier, service}` has no "worker" role; claiming/submitting jobs is **auth-gated, not role-gated**).
- [`jwt.js` `signTokenFromConfig` ES256 path](mcp-server/src/auth/jwt.js) required a `role` and threw `ConfigError` → HTTP 500 when none was derivable. The **HS256 path had no such check** — the asymmetry was the bug. Nobody noticed because every prior proof used the pre-minted multi-role `ADMIN_JWT`, never the live SIWE mint for a roleless wallet.
- `KmsJwtSigner.signAsync` and `.verify` also rejected empty roles.

**Pre-coding checks (as required):**
1. `kmsJwt.expectedIssuer` / `expectedAudience` are **not** an additional gap — [`config.js`](mcp-server/src/auth/config.js) hardcodes non-empty defaults (`averray-backend-testnet` / `averray-backend`), so they're always derivable. `role` was the sole missing piece.
2. Job claim/submit in [`job-routes.js`](mcp-server/src/protocols/http/job-routes.js) are **auth-gated, not role-gated** (`authMiddleware(request, url)` with no `requireRole`). No second bug. Base capabilities include `jobs:claim`/`jobs:submit` for any wallet.

### The fix (minimal — roleless is the correct shape)
- **`signTokenFromConfig` (ES256):** require only `iss`/`aud`/`sub`; mint a roleless token when no role is derivable instead of throwing.
- **`KmsJwtSigner.signAsync`:** absent / `""` / `[]` role → emit `roles: []`.
- **`KmsJwtSigner.verify`:** accept an empty roles array (the allowlist loop no-ops for it).

A roleless token grants **no** privileges — admin/verifier capabilities require those roles. It only identifies the wallet via `sub`. **Not** a new "worker" role; **not** a capability broadening. The HS256 path, KMS key config, and admin/verifier multi-role resolution are untouched.

### Regression guard (the missing front-door proof)
- [`scripts/ops/check-siwe-fresh-wallet-proof.mjs`](scripts/ops/check-siwe-fresh-wallet-proof.mjs): a **real SIWE login with a fresh ephemeral wallet** — `POST /auth/nonce` → sign → `POST /auth/verify` (asserts 200 + a usable **roleless** bearer token) → `GET /account` 200. Run against prod it **FAILS before this fix** (verify 500s) and **PASSES after**.
- Wired into [`check-hosted-stack.sh`](scripts/ops/check-hosted-stack.sh) behind `CHECK_SIWE_FRESH_WALLET_PROOF=1`, mirroring the other hosted proofs, plus a dispatchable [`hosted-siwe-fresh-wallet-proof.yml`](.github/workflows/hosted-siwe-fresh-wallet-proof.yml) (needs no secrets — a fresh wallet is the point).

### Tests
- `signTokenFromConfig` ES256 with no role → mints a valid roleless token (does not throw); the exact regression (`{sub, roles: []}` → mints); with-roles path emits the array unchanged.
- Roleless ES256 token round-trips through verify; `hasRole(claims, "admin")` returns `false` gracefully; base caps (`jobs:claim`/`jobs:submit`/`account:read`) present, admin caps absent.
- Middleware integration: roleless ES256 token authenticates and reaches `/jobs/claim`.
- Proof control-flow validated against mocked healthy/500-regression/admin-leak/`/account`-403 scenarios.

**Full backend suite green** (1102 pass, 0 fail). Backend is plain JS (no tsc); SDK/app/indexer typecheck targets untouched.

### Acceptance
Roleless ES256 token mints + verifies + can claim; admin/verifier multi-role unchanged; new hosted smoke fails-before/passes-after; tests green. After merge + deploy, a fresh-wallet `POST /auth/verify` against api.averray.com should return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)