### PR TITLE
fix(auth): lowercase SIWE-minted JWT sub so tokens pass their own verify

### DIFF
--- a/mcp-server/src/protocols/http/auth-routes.js
+++ b/mcp-server/src/protocols/http/auth-routes.js
@@ -154,9 +154,19 @@ export function createAuthRoutes({
         throw new AuthenticationError("Nonce was issued for a different wallet.", "nonce_wallet_mismatch");
       }
 
-      const roles = authConfig.resolveRoles?.(verified.recoveredAddress) ?? [];
+      // ethers' signature recovery returns the EIP-55 *checksummed* address,
+      // but the canonical wallet form across the platform is lowercase: every
+      // JWT `sub` is minted lowercase and KmsJwtSigner.verify REJECTS a non-
+      // lowercase `sub` ("sub claim must be lowercase" → 401 claims_mismatch).
+      // Normalize once here so the access-token `sub`, the refresh record
+      // (whose wallet seeds future `sub`s on /auth/refresh), and the response
+      // wallet all use the canonical lowercase form. Without this, /auth/verify
+      // returns 200 yet every authed call with the minted token self-rejects.
+      const wallet = verified.recoveredAddress.toLowerCase();
+
+      const roles = authConfig.resolveRoles?.(wallet) ?? [];
       const { token, claims } = await signTokenFromConfigImpl(
-        { sub: verified.recoveredAddress, roles },
+        { sub: wallet, roles },
         { expiresInSeconds: authConfig.tokenTtlSeconds },
         authConfig,
       );
@@ -166,7 +176,7 @@ export function createAuthRoutes({
         if (supportsRefreshStore(stateStore)) {
           const refreshAdapter = makeRefreshStoreAdapterImpl(stateStore);
           const refreshIssue = await issueRefreshTokenImpl({
-            wallet: verified.recoveredAddress,
+            wallet,
             role: roles[0] ?? "user",
             store: refreshAdapter,
           });
@@ -174,7 +184,7 @@ export function createAuthRoutes({
         }
       } catch (err) {
         logger?.warn?.(
-          { err, wallet: verified.recoveredAddress },
+          { err, wallet },
           "auth_verify.refresh_issue_failed"
         );
       }
@@ -185,7 +195,7 @@ export function createAuthRoutes({
         buildTokenResponse({
           token,
           claims,
-          wallet: verified.recoveredAddress,
+          wallet,
           roles,
           authCapabilities,
         }),
@@ -303,8 +313,12 @@ export function createAuthRoutes({
           store: refreshAdapter,
         });
 
+        // Defensive lowercase: new refresh records seed a lowercase wallet
+        // (see /auth/verify), but records issued before that fix landed hold a
+        // checksummed wallet. Every minted `sub` must be lowercase or the
+        // verifier rejects it (claims_mismatch).
         const { token, claims } = await signTokenFromConfigImpl(
-          { sub: consumed.record.wallet, roles },
+          { sub: consumed.record.wallet.toLowerCase(), roles },
           { expiresInSeconds: authConfig.tokenTtlSeconds },
           authConfig,
         );
@@ -346,8 +360,11 @@ export function createAuthRoutes({
       }
 
       const roles = authConfig.resolveRoles?.(auth.wallet) ?? auth.claims?.roles ?? [];
+      // auth.wallet derives from a verified token's `sub`, which the verifier
+      // already enforces lowercase — lowercased here too to keep the "every
+      // minted sub is lowercase" invariant explicit at every mint site.
       const { token, claims } = await signTokenFromConfigImpl(
-        { sub: auth.wallet, roles },
+        { sub: auth.wallet.toLowerCase(), roles },
         { expiresInSeconds: authConfig.tokenTtlSeconds },
         authConfig,
       );

--- a/mcp-server/src/protocols/http/auth-routes.siwe-roundtrip.test.js
+++ b/mcp-server/src/protocols/http/auth-routes.siwe-roundtrip.test.js
@@ -1,0 +1,189 @@
+// End-to-end regression for the SIWE `sub`-casing bug, exercising the REAL
+// ES256 verifier (KmsJwtSigner.verify — the backend prod runs under).
+//
+// The bug: ethers' signature recovery returns an EIP-55 *checksummed* address.
+// The /auth/verify handler minted that verbatim as the JWT `sub`, but the
+// ES256 verifier REJECTS a non-lowercase `sub` ("sub claim must be lowercase").
+// verifyTokenFromConfig classifies that exact error as 401 claims_mismatch, so
+// /auth/verify returned 200 yet every authed call self-rejected.
+//
+// What this test does:
+//   • Test 1 drives the real /auth/verify handler with a CHECKSUMMED recovered
+//     address. The injected signer mints a genuine ES256 token from the claims
+//     the handler hands it (signed locally with Node crypto — a faithful stand
+//     -in for the KMS signer, producing the exact ES256 shape KmsJwtSigner.verify
+//     accepts). The minted token then ROUND-TRIPS through KmsJwtSigner.verify
+//     with no error, and its sub is the lowercased address. Before the fix the
+//     handler passed the checksummed address through and this verify step threw.
+//   • Test 2 is the negative control: a checksummed `sub` ES256 token is
+//     REJECTED by KmsJwtSigner.verify with "sub claim must be lowercase" —
+//     proving the lowercase fix is load-bearing, not cosmetic.
+//
+// We verify against KmsJwtSigner directly rather than verifyTokenFromConfig
+// because the latter eagerly wires an AWS credentials provider (for the SIGN
+// path) that isn't needed — and isn't installable — for a verify-only test.
+// The lowercase enforcement under test lives entirely in KmsJwtSigner.verify.
+// Minting locally with Node crypto (standard ES256, no AWS / no @noble/curves
+// pre-hash dance) keeps the test self-contained while feeding the REAL verifier.
+// The HS256 backend does NOT enforce lowercase, so only ES256 reproduces it.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { generateKeyPairSync, randomUUID, sign as cryptoSign } from "node:crypto";
+
+import { getAddress } from "ethers";
+
+import { createAuthRoutes } from "./auth-routes.js";
+import { KmsJwtSigner } from "../../auth/kms-jwt-signer.js";
+
+// P-256 keypair generated at module load — the public PEM goes into the
+// verifier, the private key signs the test tokens.
+const { privateKey: PRIVATE_KEY, publicKey: PUBLIC_KEY } = generateKeyPairSync("ec", {
+  namedCurve: "prime256v1",
+});
+const PUBLIC_PEM = PUBLIC_KEY.export({ type: "spki", format: "pem" });
+
+const KID = "jwt-1";
+const ISSUER = "averray-backend-testnet";
+const AUDIENCE = "averray-backend";
+// Mirror KmsJwtSigner's emitted JOSE header (see HEADER_TYP / HEADER_ALG).
+const HEADER = { alg: "ES256", typ: "averray-auth+jwt", kid: KID };
+
+// Use the same function siwe.js uses to produce `recoveredAddress`, so the test
+// input is exactly what production recovers from a signature.
+const LOWER_WALLET = "0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed";
+const CHECKSUMMED_WALLET = getAddress(LOWER_WALLET);
+
+function b64url(obj) {
+  return Buffer.from(JSON.stringify(obj)).toString("base64url");
+}
+
+// Mint a genuine ES256 JWT: ECDSA-P256 over SHA-256 of the signing input, with
+// the signature in raw R||S (JOSE / IEEE-P1363) form — exactly what
+// KmsJwtSigner.verify expects (64-byte raw sig, alg ES256, typ averray-auth+jwt).
+function mintEs256(claims) {
+  const signingInput = `${b64url(HEADER)}.${b64url(claims)}`;
+  const sig = cryptoSign("sha256", Buffer.from(signingInput), {
+    key: PRIVATE_KEY,
+    dsaEncoding: "ieee-p1363",
+  });
+  return `${signingInput}.${sig.toString("base64url")}`;
+}
+
+// A faithful stand-in for production's signTokenFromConfig: mints a real ES256
+// token carrying whatever `sub` the caller (the /auth/verify handler) provides.
+function mintFromConfigImpl(payload, opts, cfg) {
+  const iat = Math.floor(Date.now() / 1000);
+  const claims = {
+    iss: cfg.kmsJwt.expectedIssuer,
+    aud: cfg.kmsJwt.expectedAudience,
+    sub: payload.sub,
+    roles: Array.isArray(payload.roles) ? payload.roles : [],
+    iat,
+    nbf: iat,
+    exp: iat + opts.expiresInSeconds,
+    jti: randomUUID(),
+  };
+  return { token: mintEs256(claims), claims };
+}
+
+function buildVerifier() {
+  return new KmsJwtSigner({
+    // verify uses only publicKeyPem; kmsClient is required by the constructor
+    // but never called on the verify path.
+    kmsClient: { async send() { throw new Error("sign path not exercised in this test"); } },
+    keyId: "arn:aws:kms:eu-central-2:000000000000:key/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    kid: KID,
+    publicKeyPem: PUBLIC_PEM,
+    expectedIssuer: ISSUER,
+    expectedAudience: AUDIENCE,
+    expectedRoles: ["admin", "verifier"],
+    maxTtlSeconds: 3600,
+    clockSkewSeconds: 60,
+  });
+}
+
+function makeHandlerAuthConfig() {
+  return {
+    domain: "app.example.test",
+    chainId: 420420,
+    nonceTtlSeconds: 60,
+    tokenTtlSeconds: 900,
+    // /auth/verify gates on a truthy signingSecret; the injected ES256 signer
+    // never reads it, but prod sets AUTH_JWT_SECRETS alongside JWT_BACKEND=kms.
+    signingSecret: "present-but-unused-under-es256",
+    resolveRoles: () => [], // fresh wallet → roleless, mirroring the hosted proof
+    kmsJwt: { expectedIssuer: ISSUER, expectedAudience: AUDIENCE },
+  };
+}
+
+async function postAuthVerify(authConfig, recoveredAddress) {
+  const route = createAuthRoutes({
+    authCapabilities: {
+      capabilityMatrix: () => ({}),
+      resolveCapabilities: () => [],
+    },
+    authConfig,
+    authMiddleware: async () => ({ wallet: recoveredAddress, claims: {} }),
+    clientIp: () => "ip",
+    enforceLimit: async () => {},
+    logger: { warn: () => {} },
+    rateLimitConfig: { authNonce: {}, authVerify: {}, authRefresh: {} },
+    readJsonBody: async () => ({ message: "siwe-message", signature: `0x${"1".repeat(130)}` }),
+    respond: (res, statusCode, body, headers = {}) => {
+      res.statusCode = statusCode;
+      res.body = body;
+      res.headers = headers;
+    },
+    signTokenFromConfigImpl: mintFromConfigImpl,
+    verifySiweMessageImpl: () => ({ nonce: "nonce-1", recoveredAddress }),
+    stateStore: {
+      consumeNonce: async () => recoveredAddress.toLowerCase(), // nonce stored lowercase
+      // no refresh-store methods → cookie path skipped
+    },
+  });
+
+  const response = {};
+  await route({
+    request: { method: "POST", headers: {} },
+    response,
+    url: new URL("http://localhost/auth/verify"),
+    pathname: "/auth/verify",
+  });
+  return response;
+}
+
+test("SIWE login with a checksummed wallet mints a token whose sub passes ES256 verify (no claims_mismatch)", async () => {
+  // Guard the test's own premise: the input really is mixed-case.
+  assert.notEqual(CHECKSUMMED_WALLET, LOWER_WALLET);
+
+  const response = await postAuthVerify(makeHandlerAuthConfig(), CHECKSUMMED_WALLET);
+
+  assert.equal(response.statusCode, 200);
+  const token = response.body.token;
+  assert.ok(typeof token === "string" && token.split(".").length === 3, "expected a JWT");
+  assert.equal(response.body.wallet, LOWER_WALLET); // canonical lowercase form
+
+  // THE REGRESSION: the SIWE-minted token round-trips through the REAL ES256
+  // verifier with no error, and its sub is the lowercased address.
+  const claims = buildVerifier().verify(token);
+  assert.equal(claims.sub, LOWER_WALLET);
+  assert.equal(claims.sub, claims.sub.toLowerCase());
+  assert.notEqual(claims.sub, CHECKSUMMED_WALLET);
+});
+
+test("a checksummed sub is rejected by ES256 verify — proves the lowercase fix is load-bearing", () => {
+  // The pre-fix token: a perfectly-signed ES256 JWT whose only flaw is a
+  // checksummed (non-lowercase) sub.
+  const { token } = mintFromConfigImpl(
+    { sub: CHECKSUMMED_WALLET, roles: [] },
+    { expiresInSeconds: 900 },
+    makeHandlerAuthConfig(),
+  );
+
+  assert.throws(
+    () => buildVerifier().verify(token),
+    /KmsJwtSigner\.verify: sub claim must be lowercase/u,
+    "verifier must reject a non-lowercase sub",
+  );
+});

--- a/mcp-server/src/protocols/http/auth-routes.test.js
+++ b/mcp-server/src/protocols/http/auth-routes.test.js
@@ -6,6 +6,10 @@ import { createAuthRoutes } from "./auth-routes.js";
 
 const WALLET = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const OTHER_WALLET = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+// A real EIP-55 *checksummed* address (mixed case) — the exact form ethers'
+// signature recovery returns. The platform's canonical wallet form (and every
+// minted JWT `sub`) is lowercase, so the mint sites must lowercase this.
+const CHECKSUMMED_WALLET = "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed";
 const VALID_SIGNATURE = `0x${"1".repeat(130)}`;
 
 function makeHarness(overrides = {}) {
@@ -242,6 +246,76 @@ test("POST /auth/verify rejects nonce wallet mismatch", async () => {
     (error) => error instanceof AuthenticationError && error.code === "nonce_wallet_mismatch"
   );
   assert.ok(!calls.some(([name]) => name === "signToken"));
+});
+
+test("POST /auth/verify lowercases a checksummed recovered address before minting (regression)", async () => {
+  // ethers recovers an EIP-55 *checksummed* address, but the verifier
+  // requires a lowercase `sub` (KmsJwtSigner.verify: "sub claim must be
+  // lowercase"). Before the fix the handler minted the checksummed address
+  // verbatim, so /auth/verify returned 200 yet every authed call with the
+  // minted token self-rejected with 401 claims_mismatch.
+  const { calls, response, route } = makeHarness({
+    payload: { message: "siwe", signature: VALID_SIGNATURE },
+    refreshStore: true,
+    roles: [],
+    consumedWallet: CHECKSUMMED_WALLET.toLowerCase(),
+    verified: { nonce: "nonce-1", recoveredAddress: CHECKSUMMED_WALLET },
+  });
+
+  assert.equal(await callRoute(route, response, "POST", "/auth/verify"), true);
+  assert.equal(response.statusCode, 200);
+
+  // The minted `sub` is the input address lowercased — NOT the checksummed form.
+  const mintedSub = calls.find(([name]) => name === "signToken")?.[1].claims.sub;
+  assert.equal(mintedSub, CHECKSUMMED_WALLET.toLowerCase());
+  assert.notEqual(mintedSub, CHECKSUMMED_WALLET);
+  assert.equal(mintedSub, mintedSub.toLowerCase());
+
+  // The refresh record seeds future /auth/refresh subs — it must be lowercase too.
+  const refreshWallet = calls.find(([name]) => name === "issueRefreshToken")?.[1].wallet;
+  assert.equal(refreshWallet, CHECKSUMMED_WALLET.toLowerCase());
+
+  // The response wallet uses the canonical lowercase form.
+  assert.equal(response.body.wallet, CHECKSUMMED_WALLET.toLowerCase());
+});
+
+test("POST /auth/refresh lowercases a legacy checksummed refresh-record wallet before minting", async () => {
+  // Refresh records issued before the /auth/verify fix hold a checksummed
+  // wallet; the cookie-rotation path must still mint a lowercase `sub`.
+  const { calls, response, route } = makeHarness({
+    refreshCookie: "refresh-cookie",
+    refreshStore: true,
+    roles: ["admin"],
+    consumedRefresh: {
+      hash: "refresh-hash",
+      record: { wallet: CHECKSUMMED_WALLET, role: "admin" },
+    },
+  });
+
+  assert.equal(await callRoute(route, response, "POST", "/auth/refresh"), true);
+  assert.equal(response.statusCode, 200);
+
+  const mintedSub = calls.find(([name]) => name === "signToken")?.[1].claims.sub;
+  assert.equal(mintedSub, CHECKSUMMED_WALLET.toLowerCase());
+  assert.equal(mintedSub, mintedSub.toLowerCase());
+});
+
+test("POST /auth/refresh (bearer path) lowercases a checksummed auth wallet before minting", async () => {
+  const { calls, response, route } = makeHarness({
+    roles: ["verifier"],
+    auth: {
+      wallet: CHECKSUMMED_WALLET,
+      claims: { roles: ["verifier"], jti: "old-jti", exp: Math.floor(Date.now() / 1000) + 120 },
+      capabilities: ["*"],
+    },
+  });
+
+  assert.equal(await callRoute(route, response, "POST", "/auth/refresh"), true);
+  assert.equal(response.statusCode, 200);
+
+  const mintedSub = calls.find(([name]) => name === "signToken")?.[1].claims.sub;
+  assert.equal(mintedSub, CHECKSUMMED_WALLET.toLowerCase());
+  assert.equal(mintedSub, mintedSub.toLowerCase());
 });
 
 test("GET /auth/session returns wallet, token kind, grants, and capability matrix", async () => {


### PR DESCRIPTION
## Problem

Second auth-layer bug, surfaced by the live product test right after #625. #625 cleared the 500 (tokens mint again), but the platform then **self-rejected every token it issued** with `401 claims_mismatch`.

Root cause, confirmed in code:

- The ES256 verifier requires a lowercase `sub` — [`kms-jwt-signer.js:528`](mcp-server/src/auth/kms-jwt-signer.js#L528) throws `"sub claim must be lowercase"`, which [`jwt.js`'s `classifyKmsVerifyError`](mcp-server/src/auth/jwt.js) maps to `claims_mismatch`. Lowercase is the canonical convention (admin/service tokens already mint lowercase).
- The SIWE verify path violated it: [`auth-routes.js:159`](mcp-server/src/protocols/http/auth-routes.js) minted `{ sub: verified.recoveredAddress }`, and `recoveredAddress` is the **EIP-55 checksummed** address ethers returns ([`siwe.js:190`](mcp-server/src/auth/siwe.js#L190) → `getAddress(recovered)`). It was never lowercased.
- Net: `/auth/verify` returned 200 and minted a JWT, but every authed call (`/account`, `/jobs/claim`, `/jobs/submit`) 401'd with `claims_mismatch`. Confirmed live (requestIds `ae258f1b-…`, `0f7d087c-…`). No client-side workaround — the server re-checksums a lowercase input at `/auth/nonce`.

## Fix

Lowercase the minter, **not** the verifier:

- **SIWE verify path** — normalize `recoveredAddress` to lowercase **once** and use it for the access-token `sub`, the refresh record (whose wallet seeds future `sub`s on `/auth/refresh`), and the response `wallet`. Fixing the refresh-record seed closes a *latent identical bug*: `issueRefreshToken` documents its `wallet` as canonical lowercase, but the SIWE path was seeding it checksummed.
- **`/auth/refresh` (cookie + bearer paths)** — defensively `.toLowerCase()` the `sub`, so refresh records written **before** this fix (checksummed) don't reproduce the bug during rollover.
- The verifier's lowercase enforcement, the #625 roleless-mint logic, and the KMS key config are **untouched**.

## Tests

- **Handler-level (3 new, one per mint site)** — a checksummed-address SIWE login mints a `sub` equal to the input **lowercased, not checksummed**; the refresh-record seed and response wallet are lowercase too; `/auth/refresh` lowercases a legacy checksummed record / auth wallet.
- **End-to-end round-trip (new file)** — a checksummed-wallet SIWE login is driven through the real `/auth/verify` handler; the minted token then **round-trips through the real ES256 verifier (`KmsJwtSigner.verify`) with no `claims_mismatch`**, and its `sub` is lowercase. A **negative control** confirms a checksummed `sub` is still rejected with `"sub claim must be lowercase"` — proving the fix is load-bearing.

Backend suite: **998 tests, 920 pass** (+5 from this PR), 27 pre-existing failures that are missing-dependency errors in unrelated KMS/AWS/blockchain test files (`@aws-sdk/*`, `jose`, `@noble/curves/nist.js`) — identical count before and after this change.

## Post-merge acceptance (manual)

After this merges **and deploys**, run the existing hosted proof against live prod to confirm a fresh wallet can mint a token **and** make an authed read:

```
gh workflow run "Hosted SIWE Fresh Wallet Proof"
```

Its `GET /account 200` assertion fails on the current casing mismatch and passes after this fix — closing the gap that let this second bug slip through mock-only verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)