### PR TITLE
chore(secrets): bump ADMIN_JWT calendar expiry to 2026-07-11 after KMS re-mint

### DIFF
--- a/docs/SECRETS_CALENDAR.yml
+++ b/docs/SECRETS_CALENDAR.yml
@@ -31,7 +31,7 @@ entries:
     description: Long-lived admin JWT used by hosted product-proof smoke and ops scripts. TRANSITIONAL — replaced by short-lived asymmetric JWTs in Phase 4b.
     owner: deployer
     vault_path: op://prod-smoke/admin-jwt
-    expires_at: "2026-06-12"   # 30 days after the verifier-role re-mint on 2026-05-13
+    expires_at: "2026-07-11"   # 30 days after the KMS (ES256) re-mint on 2026-06-11
     warn_days: 7
     notes: |
       Mint a fresh one, capture into a shell variable, store in


### PR DESCRIPTION
## What

Bumps the `ADMIN_JWT` entry in `docs/SECRETS_CALENDAR.yml` — `expires_at: "2026-06-12" → "2026-07-11"` — to match a fresh re-mint of the hosted product-proof smoke's admin token. **Calendar-only change.**

## Why

The 30-day hosted-smoke admin JWT (`op://prod-smoke/admin-jwt`) was within `fail_within_days=1`, so the **Secrets calendar expiry check** was failing on every PR, and the token would have started 401-ing the hosted smoke + anything using `ADMIN_JWT` once it expired.

## Rotation (done out-of-band, before this PR)

Re-minted a fresh **30-day ES256 / KMS** token via `scripts/ops/mint-admin-jwt.mjs --use-kms`, **preserving the captured identity exactly** (minted with `--wallet <captured sub>`, not profile defaults, so the smoke's identity is unchanged):

| claim | value |
|-------|-------|
| `sub` | `0xfd2e…6519` (lowercase, per #626) |
| `roles` | `[admin, verifier]` |
| `iss` / `aud` | `averray-backend-testnet` / `averray-backend` |
| `typ` | `averray-auth+jwt` |
| `exp` | `2026-07-11T11:52Z` (~30 days) |

Updated `op://prod-smoke/admin-jwt` and **verified end-to-end**: an authed `GET https://api.averray.com/admin/status` with the new token returned **200** (the #625/#626 auth fixes are deployed). The token value never left the operator's shell.

## Verification

```
$ node scripts/ops/check-secrets-calendar.mjs
✅  ADMIN_JWT   owner=deployer   expires=2026-07-11   expires in 30 days
# exit 0 (was exit 2 — ADMIN_JWT past fail_within_days=1)
```

## Durable fix (not in this PR)

This recurring 30-day **manual** rotation is exactly the toil the worker-loop refresh flow (**#529**, currently in 30-day soak) is meant to eliminate. Once that's proven stable, the smoke should switch to short-lived refresh-minted tokens and this calendar entry can retire — tracked in `SECRETS_INTEGRATION_PLAN.md` Phase 4b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)