### PR TITLE
docs: route polkadot ios research findings

### DIFF
--- a/docs/AVERRAY_VERIFICATION_LEDGER.md
+++ b/docs/AVERRAY_VERIFICATION_LEDGER.md
@@ -3,7 +3,7 @@
 **Purpose:** Track every empirical claim in `AVERRAY_WORKING_SPEC.md` against authoritative documentation.
 **Status:** Verification pass complete. All previously-⏳ items have been resolved against the authoritative Polkadot docs MCP (`https://docs-mcp.polkadot.com`) or the explicit upstream sources cited in each row.
 **Owner:** Pascal
-**Last updated:** 2026-04-28
+**Last updated:** 2026-05-27
 
 ---
 
@@ -11,9 +11,9 @@
 
 After this pass:
 
-- ✅ **Verified:** 32
-- ⚠️ **Verified with corrections needed:** 19
-- 🔬 **Empirical (cannot be answered from docs):** 8
+- ✅ **Verified:** 36
+- ⚠️ **Verified with corrections needed:** 20
+- 🔬 **Empirical (cannot be answered from docs):** 9
 - ⏳ **Still pending:** 0
 
 **Items not fully resolvable from docs alone:**
@@ -118,26 +118,31 @@ claude mcp add --transport http polkadot-docs https://docs-mcp.polkadot.com --sc
 |---|---|---|
 | Bulletin Chain provides decentralized, content-addressable storage | ✅ | "Decentralized data storage with IPFS-compatible content addressing" |
 | CID is the content identifier; IPFS-compatible | ✅ | Default Blake2b-256 hash, Raw codec |
+| `transactionStorage.store(data)` is the prototype write path in `polkadot-ios-community` | ✅ | Source review of `Packages/BulletinChain/` confirms the Swift `StoreCall` wraps the `TransactionStorage.store` runtime call, and `HexToCIDConverter` builds CIDv1 values from Blake2b-256 content hashes. This is reference implementation evidence only; it does not un-defer Phase 2 storage. |
 | No native token; access via authorization, not fees | ✅ | Confirmed |
 | Authorization grants transactions + bytes allowance, with optional expiration block | ✅ | Documented schema |
 | Currently OpenGov is the only authorization source on mainnet; PoP planned | ✅ | "Currently, only OpenGov can provide authorizations but the PoP subsystem is also planned to have this privilege in the future" |
 | `authorize_account` extrinsic requires Root origin | ⚠️ | Spec said "OpenGov for mainnet" but reality is **Root origin everywhere**. OpenGov is one path to Root on mainnet. |
 | Polkadot Mainnet authorization model "being finalized" | ⚠️ | Not yet finalized — adds uncertainty to Phase 2 timeline |
-| Retention period ~2 weeks on Polkadot TestNet | ⚠️ | **Spec was wrong.** Spec described per-blob retention up to ~7 months. Reality: fixed ~2 weeks; must renew. |
+| `polkadot-ios-community` does not resolve Bulletin Chain mainnet authorization maturity | 🔬 | The prototype is explicitly testnet/prototype-oriented. Treat the production path to obtaining storage authorization as an open Phase 2 dependency until Bulletin Chain mainnet authorization is production-final. |
+| Retention period ~2 weeks on Polkadot TestNet | ⚠️ | **Spec was wrong.** Spec described per-blob retention up to ~7 months. Reality: fixed ~2 weeks on Polkadot TestNet; retention duration is a network/runtime-specific value and must be re-verified before quoting mainnet numbers. |
+| `AuthorizationPeriod` is a network/runtime constant, not a universal protocol constant | ✅ | The 2026-05-27 `polkadot-ios-community` verification confirmed the authorization/expiration shape in source and the "~2 weeks" figure only for Polkadot TestNet via docs MCP. |
 | Renewal extends retention for another full period | ✅ | `renew(block, index)` extrinsic |
 | Each renewal generates new `(block, index)` pair; original values fail after renewal | ⚠️ | **Spec didn't account for this.** Real ops complexity: persistent `(cid, latest_block, latest_index, expires_at)` tracking required. |
 | CID stays stable across renewals; future plans to reference data by CID alone | ✅ | Documented as future improvement |
 | Max transaction size ~8 MiB; max chunked file ~64 MiB | ✅ | Documented |
 | Retrieval: P2P (Helia), IPFS gateway, Smoldot light client (coming soon) | ✅ | Multiple paths confirmed |
 | Generic public IPFS gateways (`ipfs.io`, `cloudflare-ipfs.com`) **deprecated** for Bulletin retrieval | ✅ | Important: do NOT cite these as fallback in spec |
+| `polkadot-ios-community` fetches through a configurable gateway, but Averray should prefer Bulletin gateway / P2P-Helia if adopted | ⚠️ | The iOS prototype's `IpfsFetcher` can fetch by gateway URL, but official docs discourage generic public IPFS gateways for Bulletin retrieval. Treat public-gateway language in research notes as corrected. |
 | Polkadot TestNet Bulletin RPC: `wss://paseo-bulletin-rpc.polkadot.io` | ✅ | Documented endpoint |
 | Polkadot TestNet IPFS gateway: `https://paseo-ipfs.polkadot.io` | ✅ | Documented endpoint |
 
 **Sources:**
 - https://docs.polkadot.com/reference/polkadot-hub/data-storage/
 - https://docs.polkadot.com/chain-interactions/store-data/bulletin-chain/
+- https://github.com/paritytech/polkadot-ios-community/tree/main/Packages/BulletinChain
 
-**Last verified:** 2026-04-25
+**Last verified:** 2026-05-27
 
 **Spec actions required:**
 
@@ -160,14 +165,18 @@ claude mcp add --transport http polkadot-docs https://docs-mcp.polkadot.com --sc
 | EVM-mapped Substrate multisig can own EVM contracts on Asset Hub | 🔬 | The docs state mapped 32-byte accounts can interact with the EVM layer (transfer funds, call contracts via Ethereum tooling) but make **no specific claim about pallet_multisig accounts being valid `map_account` callers** or about a multisig acting as a contract owner. The mechanism (multisig → derived AccountId32 → map_account → 20-byte H160) is plausible from the documented primitives but not confirmed end-to-end in the docs. **Empirical test required on Polkadot Hub TestNet** before treating as fact in `MULTISIG_SETUP.md §4`. |
 | `0xEE` suffix convention for EVM ↔ AccountId32 mapping | ✅ | *"Ethereum to Polkadot: The system adds twelve `0xEE` bytes to the end of the address, which is a reversible operation."* And: *"Takes a 20-byte Ethereum address and extends it to 32 bytes by adding twelve `0xEE` bytes at the end. The key benefits of this approach are: Able to fully revert ... Provides clear identification of Ethereum-controlled accounts through the `0xEE` suffix pattern."* **Source URL correction needed:** the ledger originally cited `https://docs.polkadot.com/reference/parachains/accounts/`, which covers SS58 format only. The `0xEE` suffix is documented at https://docs.polkadot.com/smart-contracts/for-eth-devs/accounts/#ethereum-to-polkadot-mapping. |
 | Native DOT precompile address on Asset Hub | ⚠️ | **There is no "native DOT precompile address" on Asset Hub.** The ERC20 precompile (https://docs.polkadot.com/smart-contracts/precompiles/erc20/) is documented to support exactly three asset categories — *"Polkadot Hub runs three instances of the Assets pallet — Trust-Backed Assets, Foreign Assets, and Pool Assets — each mapped to a distinct ERC20 precompile address suffix."* Native DOT is the chain's intrinsic balance, not in the Assets pallet, and has no ERC20 precompile address. The "Common Trust-Backed Asset IDs" table lists USDt and USDC; native DOT is **not** present. The ETH-native precompile list (`0x01`–`0x09`) covers cryptographic helpers (ECRecover, sha256, etc.), not currency. |
+| People Chain allowance solves Asset Hub escrow onboarding friction | ✅ verified-negative | Source review found resource-scoped allowance managers for Bulletin storage, StatementStore messaging, and PGAS, with no evidence of a path to arbitrary Asset Hub EVM escrow transactions. This is absence-of-evidence strong enough to keep Averray's onboarding-friction answer on Path A, not categorical proof of impossibility. |
+| People Chain Score pallet is reputation prior art for recognition/streak concepts | ✅ | `Packages/Individuality/Score/` exposes recognition states (`recognized`, `notRecognized`, `suspended`, `externallyRecognized`) and attended/absent streak tracking. This validates a similar pattern but is not adopted: People Chain Score is personhood-tied; Averray reputation remains Asset Hub EVM soulbound-token/account-work based. |
 
 **Sources:**
 - https://docs.polkadot.com/smart-contracts/for-eth-devs/accounts/
 - https://docs.polkadot.com/reference/parachains/accounts/
 - https://docs.polkadot.com/smart-contracts/precompiles/erc20/
 - https://docs.polkadot.com/smart-contracts/precompiles/eth-native/
+- https://docs.polkadot.com/reference/polkadot-hub/people-and-identity/
+- https://github.com/paritytech/polkadot-ios-community/tree/main/Packages/Individuality
 
-**Last verified:** 2026-04-28
+**Last verified:** 2026-05-27
 
 **⚠️ Spec correction (Native DOT precompile):** `MULTISIG_SETUP.md §5` references `TOKEN_ADDRESS=0x<hub-dot-precompile-or-testdot>` as if a native DOT precompile address existed. It does not. The correct deployment recipe is one of:
 

--- a/docs/AVERRAY_WORKING_SPEC.md
+++ b/docs/AVERRAY_WORKING_SPEC.md
@@ -1,7 +1,7 @@
 # Averray — Working Spec (v1.0.0-rc1)
 
 **Status:** Reconciled with deployed reality and operational docs
-**Spec version:** 2.12 (spec-consolidation pass: v2.5 Phase 1 storage discipline restored into the consolidated spec without downgrading v2.10/v2.11 status)
+**Spec version:** 2.14 (Bulletin Chain retention wording narrowed to TestNet-specific / network-runtime-specific after 2026-05-27 ledger verification)
 **Owner:** Pascal
 
 > Current roadmap/status source: [`PROJECT_ROADMAP.md`](./PROJECT_ROADMAP.md).
@@ -419,7 +419,7 @@ Every on-chain event referencing off-chain content carries `sha256(canonicalJSON
 | Content addressing | CID (IPFS-compatible, Blake2b-256 default) | CID (IPFS-compatible) |
 | Cost model | No fees; authorization grants tx + byte allowances | Per-byte pinning fees, paid in CRU |
 | Authorization gate | **Root origin required** (OpenGov on mainnet — model still being finalized; testnet via faucet UI) | Self-service (purchase CRU; pin) |
-| Retention | **Fixed ~2 weeks; mandatory `renew(block, index)` per blob** | Pin duration controlled by user |
+| Retention | **Network-specific runtime value (Polkadot TestNet ~2 weeks); mandatory `renew(block, index)` per blob** | Pin duration controlled by user |
 | Per-blob ops complexity | Track `(cid, latest_block, latest_index, expires_at)`; auto-renew before expiry | Track expiry; renew pin |
 | Renewal generates new identifier | **Yes — `(block, index)` mutates with each renewal**; CID stays stable | No |
 | Acceptable IPFS gateways for retrieval | **Only Bulletin Chain's own gateway / collator P2P / Smoldot** — generic gateways like `ipfs.io` are deprecated for Bulletin retrieval | Standard IPFS infrastructure |
@@ -1127,6 +1127,11 @@ Stripe Link's launch and Stripe Sessions 2026 announcements positioned agents as
 
 For traceability.
 
+### v2.14 (polkadot-ios reference verification routing)
+
+1. **§6** Narrowed Bulletin Chain retention wording from a bare "fixed ~2 weeks" to "network-specific runtime value (Polkadot TestNet ~2 weeks)." The source was the 2026-05-27 verification entries added to `AVERRAY_VERIFICATION_LEDGER.md` from Polkadot docs MCP and `polkadot-ios-community` source review. Phase 2 storage remains deferred and this change does not make Bulletin Chain the selected backend.
+2. **Ledger routing only:** the `polkadot-ios-community` reference note was added as a roadmap-update research fragment, and its six verification findings were folded into the verification ledger. No roadmap status was moved to Done or Proofed.
+
 ### v2.13 (external schema registration first slice)
 
 1. **§8** Added the external output schema registration flow. External schemas
@@ -1305,7 +1310,7 @@ External verification work resolved every ⏳ item in `AVERRAY_VERIFICATION_LEDG
 ### v1.8 (Bulletin Chain corrections from official-doc verification)
 
 1. **§6** Replaced "Why Bulletin Chain is the primary candidate" subsection with corrected "Phase 2 storage candidates: comparison" — explicit table of differences between Bulletin Chain and Crust, grounded in the official Bulletin Chain reference docs.
-2. **§6** Corrected Bulletin Chain retention claim. Spec previously implied configurable per-blob retention covering the 6-month disclosure window. Reality (per docs): fixed ~2 weeks on Polkadot TestNet, mandatory `renew(block, index)` per blob to extend.
+2. **§6** Corrected Bulletin Chain retention claim. Spec previously implied configurable per-blob retention covering the 6-month disclosure window. Reality (per docs): fixed ~2 weeks on Polkadot TestNet, mandatory `renew(block, index)` per blob to extend; treat the duration as a network-specific runtime value before quoting it for any other network.
 3. **§6** Corrected authorization claim. Spec previously said "OpenGov for mainnet, PoP eventually." Reality (per docs): `authorize_account` and `authorize_preimage` extrinsics require Root origin; OpenGov is the production path to Root, but the mainnet authorization model is "still being finalized."
 4. **§6** Documented operational implication of renewal: each renewal generates new `(block, index)` pair; CID stays stable for retrieval, but renewal requires the most recent identifier pair — persistent `(cid, latest_block, latest_index, expires_at)` tracking is required.
 5. **§6** Added "Choice deferred" section explicitly. Phase 2 backend choice between Bulletin Chain and Crust is now treated as a real choice to defer, not a commitment to either.

--- a/docs/roadmap-updates/polkadot-ios-reference-primitives-2026-05-27.md
+++ b/docs/roadmap-updates/polkadot-ios-reference-primitives-2026-05-27.md
@@ -1,0 +1,167 @@
+# Reference primitives from polkadot-ios-community — 2026-05-27
+
+**Type:** Research note / reference bookmark — NOT a planning decision
+**Source:** Direct code review of `github.com/paritytech/polkadot-ios-community` (cloned, read the actual Swift package sources — not just the README)
+**Polkadot-specific claims herein:** require ledger verification before binding into spec or roadmap
+**Status:** Open for review — research only
+
+**[VERIFICATION COMPLETE 2026-05-27]** All three flagged Polkadot claims verified against docs MCP + source. Verdict: note is mostly accurate; three wording corrections applied inline (marked `[VERIFIED 2026-05-27]`): (1) IPFS retrieval should use Bulletin gateway / P2P-Helia, not generic public gateways; (2) "~2 weeks" retention is TestNet-specific, not a protocol constant; (3) People Chain allowance conclusion softened to "no evidence it solves Asset Hub escrow onboarding" rather than categorical impossibility. Sources: docs MCP `reference/polkadot-hub/data-storage.md`, `chain-interactions/store-data/bulletin-chain.md`, `reference/polkadot-hub/people-and-identity.md`. Verified-negative results should be recorded in `AVERRAY_VERIFICATION_LEDGER.md`.
+
+---
+
+## Why this matters and what it is NOT
+
+The Polkadot iOS community repo is Parity's prototype self-custodial superapp (messaging, identity, payments, dApp hosting). **The superapp itself is not relevant to Averray** and is explicitly out of scope.
+
+What IS relevant: the repo contains working reference implementations of three Polkadot primitives that map onto Averray's deferred or open architecture decisions. This fragment captures what the *actual code* (not the README marketing copy) shows about each, with honest assessment of availability and applicability.
+
+Critical caveat: this is a **prototype exercised against the Paseo testnet contour**, not mainnet, and explicitly unaudited. Everything below is "reference for how it could work," not "production-ready dependency." Parity is in roughly the same not-yet-production position with these primitives that Averray would be.
+
+Three primitives reviewed: Bulletin Chain storage, People Chain identity/allowance/score, and the device-handoff/remote-signing transport.
+
+---
+
+## 1. Bulletin Chain storage — direct reference for our deferred Phase 2 storage decision
+
+**Package:** `Packages/BulletinChain/` (7 Swift files)
+
+**What the code actually shows:**
+
+The storage mechanism is the `TransactionStorage` pallet. The relevant call is dead simple:
+
+- `store(data: Data)` — a single runtime call that writes bytes to the chain's temporary storage. That's the whole write path.
+
+Content addressing works via blake2b-256 hashing → IPFS CID conversion:
+
+- `HexToCIDConverter` takes a blake2b-256 hash and builds a CIDv1 with a fixed multihash prefix (`0xA0 0xE4 0x02 0x20` = blake2b-256 codec), supporting `json`, `raw`, and `dag-pb` (directory) codecs.
+- `IpfsFetcher.lookupBy(rawHash:)` converts the on-chain hash to an IPFS gateway URL and fetches the content over HTTPS.
+
+So the model is: **write bytes on-chain via `store`, address them by blake2b-256 hash, retrieve via IPFS CID through a gateway.** The chain holds the authorization + commitment; IPFS-compatible retrieval serves the content.
+
+**[VERIFIED 2026-05-27 — correction]** The iOS code fetches via an IPFS gateway URL, but Polkadot docs (`chain-interactions/store-data/bulletin-chain.md`) **recommend the Bulletin Chain gateway or direct P2P/Helia, and explicitly discourage generic public IPFS gateways.** If Averray implements Phase 2 retrieval, build against the Bulletin gateway or P2P/Helia path, not a generic public gateway. The iOS app's gateway URL is configurable (`ipfsBaseURL` is injected), so this is a config choice, not a hardcoded constraint — but the discouraged-public-gateway guidance is the operative rule.
+
+**The authorization/allowance model (important detail the README glosses):**
+
+`TransactionStoragePallet.Authorization` and `AuthorizationExtent` reveal the real mechanics:
+- An account is granted an authorization with `transactionsAllowance` (count) and `bytesAllowance` (size).
+- Usage is tracked: `transactions` consumed, `bytes` consumed, with `remainedTransactions` / `remainedBytes` computed.
+- Every authorization has an `expiration` block number — **"block number starting from which submission is not allowed anymore."**
+- There's an `AuthorizationPeriod` constant and a `MaxTransactionSize` constant.
+
+This **confirms our spec's v1.8 corrections from code**: Bulletin Chain storage is authorization-gated (per-account allowances) AND has an expiration model requiring renewal. Our spec said "~2-week retention requiring renewals, Root-origin authorization." The code confirms the *shape* (authorization + expiration + renewal) though the exact period is a runtime constant (`AuthorizationPeriod`) not hardcoded — so the "~2 weeks" figure is a runtime parameter, not a protocol constant.
+
+**[VERIFIED 2026-05-27]** Polkadot docs confirm "~2 weeks" is correct **for Polkadot TestNet specifically** — it is network/runtime-specific, NOT a universal protocol constant. Mainnet (when finalized) may differ. Always treat retention as a per-network runtime value; verify against the target network's `AuthorizationPeriod` before quoting a figure.
+
+**How it maps to Averray:**
+
+This is *exactly* our deferred Phase 2 storage backend (the Bulletin Chain vs. Crust decision). Our Phase 1 is VPS hot storage + S3 recovery log + hash verification. The iOS code shows Phase 2 Bulletin Chain working in prototype:
+- Their `store(data:)` ≈ our content-write path
+- Their blake2b-256 → CID addressing ≈ our `sha256(canonicalJSON)` content addressing (different hash function — they use blake2b-256, we use sha256 — but same content-addressing discipline)
+- Their `IpfsFetcher` ≈ our `GET /content/:hash` retrieval
+- Their authorization/expiration model ≈ the renewal-tracking burden our spec flagged as Bulletin Chain's operational cost
+
+**Honest assessment:**
+- **Availability: testnet only, same boat as us.** Not production-ready for either party. But this is a concrete code reference for when we make the Phase 2 call.
+- **One real divergence to note:** they hash with blake2b-256, we committed to sha256. If we ever adopt Bulletin Chain storage, we'd either switch hash functions or build a sha256→CID path. Not blocking, but a real detail.
+- **Phase 2 stays deferred.** This doesn't change the deferral; it gives us a reference for when the deferral lifts.
+
+**Recommended action:** bookmark `Packages/BulletinChain/` as the reference implementation for the Phase 2 Bulletin Chain option. Re-examine when volume/operations justify the Phase 1→Phase 2 migration. Do NOT adopt now. Verify the `AuthorizationPeriod` runtime value against the ledger if we ever quote retention figures.
+
+---
+
+## 2. People Chain identity + allowance + score — onboarding-friction research, with a surprise reputation parallel
+
+**Package:** `Packages/Individuality/` (128 Swift files — much larger than README implied)
+
+Three sub-systems here, all relevant in different ways.
+
+### 2a. The Allowance subsystem — the "free transactions" mechanism
+
+**What the code shows:** there are *three* allowance backends, not one:
+- `Allowance/Bulletin/` — `BulletInAllowanceManager` allocates storage slots on Bulletin Chain
+- `Allowance/StatementStore/` — allowance for the statement store (the chat-without-server backend)
+- `Allowance/PGAS/` — "PGAS" allowance (likely People-chain gas abstraction)
+
+The `BulletInAllowanceManager.allocate(accountId:policy:)` flow: check current allowance → if available and policy is `.ignore`, return → otherwise `assignSlot` → wait for on-chain authorization. The allowance is **per-account, slot-based, and tied to specific resources** (Bulletin storage slots, statement-store slots, PGAS).
+
+**This is the critical finding for Averray's onboarding-friction question, and it cuts against the easy interpretation:** the "free transactions allowance" is NOT a general free-transaction mechanism. It's **resource-specific slot allocation** — you get an allowance for Bulletin storage, or for statement-store messaging, or for PGAS-scoped operations. It is not "do any transaction free."
+
+**Honest implication:** my earlier framing (that this might solve Averray's "agents need funded wallets before doing anything" problem) is **probably too optimistic**. The allowance model is scoped to specific People Chain / Bulletin / statement-store resources, not arbitrary Asset Hub escrow operations. An Averray agent doing USDC escrow on Asset Hub would NOT obviously benefit from a People Chain proof-of-personhood allowance.
+
+**[VERIFIED 2026-05-27 — wording corrected]** The honest claim is **"no evidence the allowance solves Asset Hub escrow onboarding directly"** — NOT absolute proof of impossibility. The source strongly suggests scoped allowances (separate Bulletin/StatementStore/PGAS managers, no path to Asset Hub found), and docs (`reference/polkadot-hub/people-and-identity.md`) support resource-scoping, but not every runtime path was verified on-chain. Treat as: absence of evidence it works for our case, strong enough to keep onboarding-friction on Path A, not strong enough to claim categorical impossibility.
+
+### 2b. ProofOfInk — the personhood mechanism
+
+`Packages/Individuality/Sources/ProofOfInk/` implements the proof-of-personhood verification (the "DIM2 gesture game" from the README is the UX; ProofOfInk is the on-chain mechanism). Includes design families, person records, participant origins. Relevant only if Averray ever wanted human-personhood verification for operators — which is NOT our current model (we're wallet + soulbound reputation, deliberately not requiring human identity). **Out of scope for Averray's current direction.**
+
+### 2c. Score pallet — an unexpected reputation parallel worth noting
+
+**This is a genuine surprise.** `Packages/Individuality/Sources/Score/` is an on-chain reputation/scoring pallet on People Chain. The code shows:
+- `Recognition` enum: `recognized(PersonalId)`, `notRecognized`, `suspended(PersonalId)`, `externallyRecognized`
+- `Streak` enum: `attended(UInt32)` / `absent(UInt32)` with `makeIntegerStreak()` producing positive for attended, negative for absent
+- Participant, recognition, and streak storage paths
+
+**How it maps to Averray:** this is conceptually adjacent to our reputation primitive. Their `Recognition` (recognized/suspended/not-recognized) parallels our tier/slash model. Their `Streak` (attended/absent) parallels the streak-bonus mechanism in our spec §10 reputation-engagement subsection. The *concepts* are similar — on-chain reputation with recognition states and streak tracking.
+
+**Honest assessment:** interesting parallel, but **not adoptable**. Their Score pallet lives on People Chain and is tied to proof-of-personhood (human participants). Averray's reputation is soulbound-token-based on Asset Hub EVM, tied to wallets-doing-work, deliberately not requiring personhood. Different substrate, different identity model, different purpose. Worth knowing it exists as prior art / conceptual validation that "on-chain reputation with streaks and recognition states" is a pattern others are building — but not something we integrate.
+
+**Recommended action:** note the Score pallet as conceptual prior art for our reputation model (validates the streak + recognition-state design). No integration. The allowance subsystem is a **research item that probably does NOT solve our onboarding friction** — verify against ledger, but set expectations low.
+
+---
+
+## 3. Device handoff / remote signing — narrower than the README implied
+
+**Package:** `Packages/HandoffService/` (17 files) + `Packages/MessageExchangeKit/`
+
+**What the code actually shows:** `HandoffService` is NOT a transaction co-signing service. It's an **encrypted data-handoff service** — `submitData(_:from:recipients:)` and `claimData(by:recipient:)`. It moves encrypted blobs between paired devices via an RPC pool, with blake2b hashing, sender/recipient proofs, and `MultiSigner` recipient addressing. It's the transport for syncing contacts/chats/account-data between paired devices (Mobile ↔ Desktop ↔ Web).
+
+The actual peer/session transport is `MessageExchangeKit/PeerSession`, which runs over the **StatementStore** (People Chain statement store) with encryption — the same mechanism that powers serverless chat.
+
+**The "use Mobile as a signer" feature from the README** is built ON TOP of these primitives (encrypted handoff + statement-store peer sessions) but isn't a single dedicated "remote signing" module. It's a composition: pair devices → establish encrypted peer session → desktop sends a signing request as an encrypted message → mobile (holding keys in secure enclave) signs → returns signature over the same channel.
+
+**How it maps to Averray:** loosely. Averray's operator control-room needs a signer story for sensitive actions (treasury moves, policy changes, capability grants, multisig). A mobile-signer pattern is one option. But:
+- The iOS implementation is deeply tied to their device-pairing + statement-store + secure-enclave stack — not portable as a drop-in.
+- Averray's v1 signer story (SIWE web auth + multisig via Signet/Talisman) is already specced and doesn't need this.
+- This is a **pattern to be aware of**, not a dependency or even a clear reference. If Averray ever wants native mobile signing, the building blocks (encrypted peer channel + secure-enclave signing) are standard; we'd build our own, not lift theirs.
+
+**Honest assessment:** lowest priority of the three. Not gated, not blocked, but also not a clean reference — it's woven into their whole-app architecture. v2 operator-experience consideration at most.
+
+**[VERIFIED 2026-05-27 — scope caveat]** Verification confirmed the *transport primitives* (encrypted data handoff via `HandoffService`, peer sessions via `MessageExchangeKit` over StatementStore) but did NOT verify a complete end-to-end transaction-signing flow. The "mobile as signer" composition is plausible from the README plus these primitives, but no single module implements full remote transaction signing — it's an inferred composition, not a verified working flow. If Averray ever pursues this, treat the signing flow as unproven and design it ourselves.
+
+**Recommended action:** note as a v2-or-later operator-experience pattern (mobile-as-signer for sensitive control-room actions). No action now. Our v1 signer story is sufficient.
+
+---
+
+## Summary table
+
+| Primitive | Package | Maps to Averray | Availability | Recommended action |
+|---|---|---|---|---|
+| Bulletin Chain storage | `BulletinChain/` | Deferred Phase 2 storage backend | Testnet only — same boat as Parity | Bookmark as Phase 2 reference; retention is per-network (TestNet ~2wk verified); use Bulletin gateway / P2P-Helia not public gateways; stays deferred |
+| Allowance subsystem | `Individuality/Allowance/` | Onboarding friction (Path A) | Resource-scoped, NOT general | No evidence it solves Asset Hub escrow onboarding (verified); onboarding stays Path A |
+| ProofOfInk personhood | `Individuality/ProofOfInk/` | Nothing — we don't do personhood | N/A | Out of scope |
+| Score pallet | `Individuality/Score/` | Conceptual parallel to our reputation | People Chain, personhood-tied | Note as prior art; no integration |
+| Handoff / remote signing | `HandoffService/`, `MessageExchangeKit/` | Operator signer story (loosely) | Not gated, but not portable; only transport primitives verified, not full signing flow | v2 operator-experience pattern; no action now |
+
+---
+
+## Routing recommendation
+
+This is research, not a decision. It touches:
+- **Deferred Phase 2 storage** (Bulletin Chain) — when reviewed, update the Phase 2 storage row in `PROJECT_ROADMAP.md` to reference this code as the Bulletin Chain implementation reference. Do not un-defer Phase 2.
+- **Onboarding friction** (allowance) — a research sub-item; the honest finding is that it probably doesn't apply to Asset Hub escrow. Verify against ledger before recording any conclusion. If verified-negative, record that so we don't re-investigate.
+- **Reputation prior-art** (Score pallet) — conceptual validation only; no doc change needed beyond optionally noting prior art in the spec's reputation section.
+
+**Polkadot-specific claims requiring ledger verification before binding:**
+1. Bulletin Chain `AuthorizationPeriod` actual value (the "~2 week retention" figure)
+2. Whether People Chain allowance can extend to non-People-Chain (e.g. Asset Hub escrow) operations — code strongly suggests NO
+3. Bulletin Chain mainnet authorization model maturity (still "being finalized" per our spec v1.8)
+
+None of these should become locked decisions from this code read. The repo is a prototype on testnet; treat it as reference, not authority.
+
+---
+
+## One honest limitation
+
+I read the package sources but not exhaustively — 28 packages, 128 files in `Individuality` alone. I read the files most relevant to the three primitives you asked about (storage, identity/allowance, signing). I did not read the full dependency graph, the runtime-config delivery, or the test suites in depth. If Averray decides to actually use any of this as a reference for implementation, someone should read the relevant package's full source — this fragment tells you *which packages matter and what they do at the interface level*, not every implementation detail.
+
+*— Drafted 2026-05-27 from direct source review (cloned repo, read Swift package sources).*


### PR DESCRIPTION
## Summary
- add the polkadot-ios reference-primitives research note to docs/roadmap-updates as a fragment, not an authority/spec replacement
- fold the six 2026-05-27 verification findings into AVERRAY_VERIFICATION_LEDGER.md under Bulletin Chain storage and Account/identity
- update AVERRAY_WORKING_SPEC.md to qualify Bulletin Chain retention as Polkadot TestNet ~2 weeks / network-runtime-specific, with a v2.14 reconciliation entry

## Notes
- No roadmap row was moved to Done or Proofed.
- Phase 2 storage remains deferred.
- control-room-ui-observations-2026-05-27.md already existed in docs/roadmap-updates with a triage header, so I preserved the repo copy.
- ledger-verification-queries-polkadot-ios-2026-05-27.md was not present in files.zip or the repo, so I did not create a placeholder.

## Checks
- git diff --check

## Surface
- Docs only. No backend, frontend, indexer, Caddy, contracts, public site, env, or VPS secret changes.