### PR TITLE
feat(verifier): auto-verify + settle submitted machine-decidable jobs

### DIFF
--- a/deploy/backend.env.template
+++ b/deploy/backend.env.template
@@ -297,6 +297,16 @@ JOB_STALE_SWEEPER_ACTION=archive
 JOB_STALE_SWEEPER_INTERVAL_MS=3600000
 JOB_STALE_SWEEPER_MAX_JOBS_PER_RUN=25
 
+# Submitted-job auto-verifier. Verifies + settles machine-decidable submissions
+# (benchmark, deterministic) so an external worker's job settles without a manual
+# POST /verifier/run. Skips while the protocol is paused or settlement is not
+# ready; human_fallback and github_pr are never auto-verified.
+AUTO_VERIFY_ENABLED=true
+AUTO_VERIFY_DRY_RUN=false
+AUTO_VERIFY_INTERVAL_MS=60000
+AUTO_VERIFY_SCAN_LIMIT=200
+AUTO_VERIFY_MAX_PER_RUN=25
+
 # Observability (required to flip PRODUCTION_CHECKLIST.md section 5 boxes).
 # Secret-backed values below render from prod-backend so the VPS backend
 # service account can read them at deploy/boot time.

--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -122,6 +122,24 @@ AUTH_CHAIN_ID=420420417
 # XCM_OBSERVER_POLL_MS=30000
 # XCM_OBSERVER_BATCH_SIZE=25
 
+# --- Submitted-job auto-verification -----------------------------------------
+# Off by default. When enabled, a periodic scheduler verifies + settles
+# submitted jobs whose verifier mode is machine-decidable (benchmark,
+# deterministic) so an external worker's submission settles without a manual
+# POST /verifier/run. human_fallback and github_pr are never auto-verified.
+# The on-chain settlement is brokered by the gateway signer (which must hold the
+# on-chain verifier role); the scheduler skips while the protocol is paused or
+# settlement is not ready, so it never advances a session past a real payout.
+# AUTO_VERIFY_ENABLED=true
+# AUTO_VERIFY_DRY_RUN=false
+# AUTO_VERIFY_INTERVAL_MS=60000
+# AUTO_VERIFY_SCAN_LIMIT=200
+# AUTO_VERIFY_MAX_PER_RUN=25
+# Comma-separated; silently filtered to the {benchmark,deterministic} allowlist.
+# AUTO_VERIFY_MODES=benchmark,deterministic
+# Set to false only on non-chain testnets where settlementReady flaps.
+# AUTO_VERIFY_REQUIRE_SETTLEMENT_READY=true
+
 # --- GitHub issue job ingestion ----------------------------------------------
 # Disabled by default. When enabled, the server runs a conservative pull loop
 # that turns allowlisted GitHub issue searches into Averray jobs. Keep dry-run

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -9,6 +9,7 @@
     "test": "node --test src/**/*.test.js",
     "demo:e2e": "node src/demo/e2e-local.js",
     "demo:e2e:remote": "node src/demo/e2e-remote.js",
+    "demo:auto-verify:remote": "node src/demo/auto-verify-remote-smoke.js",
     "check:redis": "node src/demo/redis-persistence-check.js",
     "replay:content-recovery": "node src/demo/replay-content-recovery-log.js",
     "ingest:github-issues": "node src/jobs/ingest-github-issues.js",

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -88,6 +88,7 @@ export class PlatformService {
     this.xcmObservationRelay = undefined;
     this.upstreamStatusPoller = undefined;
     this.bootstrapSelfReportScheduler = undefined;
+    this.submittedJobAutoVerifier = undefined;
 
     this.accountMutationService = new AccountMutationService(
       this.accounts,
@@ -269,6 +270,7 @@ export class PlatformService {
       upstreamStatus,
       bootstrapSelfReport,
       jobStaleSweeper,
+      submittedJobAutoVerifier,
       recentSessions,
       hostDiagnostics
     ] = await Promise.all([
@@ -398,6 +400,18 @@ export class PlatformService {
         intervalMs: 0,
         action: "archive",
         maxJobsPerRun: 0,
+        lastRun: undefined
+      },
+      this.submittedJobAutoVerifier?.getStatus?.() ?? {
+        enabled: false,
+        running: false,
+        dryRun: false,
+        mode: "live",
+        intervalMs: 0,
+        scanLimit: 0,
+        maxPerRun: 0,
+        autoModes: ["benchmark", "deterministic"],
+        requireSettlementReady: true,
         lastRun: undefined
       },
       this.jobExecutionService.listRecentSessions(14),
@@ -530,6 +544,7 @@ export class PlatformService {
       recurring: recurring,
       jobLifecycle: this.jobCatalogService.getJobLifecycleSummary(),
       jobStaleSweeper,
+      submittedJobAutoVerifier,
       scheduler,
       hostDiagnostics,
       providerOperations,

--- a/mcp-server/src/demo/auto-verify-remote-smoke.js
+++ b/mcp-server/src/demo/auto-verify-remote-smoke.js
@@ -1,0 +1,190 @@
+// Live smoke for the submitted-job auto-verifier (GO_LIVE_PUNCHLIST P0).
+//
+// Proves the self-sustaining loop end-to-end against a deployed backend that
+// has AUTO_VERIFY_ENABLED=1: create a benchmark job, claim it, submit work, and
+// then WAIT — without ever calling /verifier/run — for the backend's scheduler
+// to verify + settle the submission on its own. Asserts the session reaches
+// `resolved` and that the worker wallet's liquid reward balance rises.
+//
+// Contrast with e2e-remote.js, which drives the verification manually via
+// POST /verifier/run. This script deliberately omits that call: if the session
+// settles, auto-verify did it.
+//
+// Usage (against the testnet backend):
+//   REMOTE_E2E_BASE_URL=https://<backend> \
+//   REMOTE_E2E_PRIVATE_KEY=0x<worker-eoa-key> \
+//   AUTO_VERIFY_SMOKE_REWARD_ASSET=DOT \
+//   node src/demo/auto-verify-remote-smoke.js
+//
+// The signing wallet must be allowed to POST /admin/jobs (AUTH_ADMIN_WALLETS)
+// on a strict deployment. The backend — not this script — must hold the
+// verifier role and run the scheduler; this caller never needs it.
+
+import { Wallet } from "ethers";
+import { loginTestWallet } from "./auth-helper.js";
+
+const DEFAULT_BASE_URL = "https://api.averray.com";
+const DEFAULT_WALLET = "0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519";
+const DEFAULT_TIMEOUT_MS = 180_000;
+const DEFAULT_POLL_MS = 5_000;
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function readJson(baseUrl, path, init = undefined) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      ...(init?.headers ?? {})
+    }
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(`${path} failed with ${response.status}: ${payload?.message ?? payload?.error ?? "unknown_error"}`);
+  }
+  return payload;
+}
+
+function liquidBalance(account, asset) {
+  const liquid = account?.liquid ?? {};
+  const raw = liquid[asset] ?? liquid[asset?.toUpperCase?.()] ?? 0;
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : 0;
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function main() {
+  const baseUrl = (process.env.REMOTE_E2E_BASE_URL ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+  const privateKey = process.env.REMOTE_E2E_PRIVATE_KEY;
+  const legacyWallet = process.env.REMOTE_E2E_WALLET ?? DEFAULT_WALLET;
+  const rewardAsset = (process.env.AUTO_VERIFY_SMOKE_REWARD_ASSET ?? "DOT").trim();
+  const rewardAmount = Number(process.env.AUTO_VERIFY_SMOKE_REWARD_AMOUNT ?? 6);
+  const timeoutMs = Number(process.env.AUTO_VERIFY_SMOKE_TIMEOUT_MS ?? DEFAULT_TIMEOUT_MS);
+  const pollMs = Number(process.env.AUTO_VERIFY_SMOKE_POLL_MS ?? DEFAULT_POLL_MS);
+  const timestamp = Date.now();
+  const jobId = `auto-verify-smoke-${timestamp}`;
+  const evidence = `complete verified output for ${jobId}`;
+
+  console.log(`Base URL: ${baseUrl}`);
+
+  const health = await readJson(baseUrl, "/health");
+  assert(health.status === "ok", `Expected healthy API, got ${health.status}`);
+  const authMode = health.auth?.mode ?? "unknown";
+  console.log(`Auth mode: ${authMode}`);
+
+  let wallet = legacyWallet;
+  let authHeader = {};
+  if (privateKey) {
+    const signed = await loginTestWallet({ baseUrl, privateKey });
+    wallet = signed.wallet;
+    authHeader = signed.authHeader;
+    console.log(`Signed in as ${wallet} (token expires ${signed.expiresAt})`);
+  } else {
+    if (authMode !== "permissive") {
+      throw new Error(
+        "REMOTE_E2E_PRIVATE_KEY is required when the API is not in permissive mode. " +
+          "Set it to an ethers-compatible hex private key for the worker wallet."
+      );
+    }
+    try {
+      wallet = new Wallet(legacyWallet).address; // eslint-disable-line no-new
+    } catch {
+      // legacyWallet is already an address, not a private key — use as-is.
+    }
+    console.log(`Wallet (permissive, unsigned): ${wallet}`);
+  }
+
+  console.log(`Job: ${jobId} (reward ${rewardAmount} ${rewardAsset})`);
+
+  const before = await readJson(baseUrl, "/account", { headers: { ...authHeader } });
+  const startingBalance = liquidBalance(before, rewardAsset);
+  console.log(`Worker ${rewardAsset} liquid balance before: ${startingBalance}`);
+
+  const createdJob = await readJson(baseUrl, "/admin/jobs", {
+    method: "POST",
+    headers: { ...authHeader },
+    body: JSON.stringify({
+      id: jobId,
+      category: "coding",
+      tier: "starter",
+      rewardAsset,
+      rewardAmount,
+      verifierMode: "benchmark",
+      verifierTerms: ["complete", "verified", "output"],
+      verifierMinimumMatches: 2,
+      requiresSponsoredGas: true,
+      claimTtlSeconds: 3600,
+      retryLimit: 1,
+      outputSchemaRef: "schema://jobs/auto-verify-smoke-output"
+    })
+  });
+  assert(createdJob.id === jobId, `Expected created job id ${jobId}, got ${createdJob.id}`);
+
+  const walletQs = `wallet=${encodeURIComponent(wallet)}`;
+
+  const claim = await readJson(
+    baseUrl,
+    `/jobs/claim?${walletQs}&jobId=${encodeURIComponent(jobId)}&idempotencyKey=${encodeURIComponent(`auto-verify-smoke:${jobId}:${wallet}`)}`,
+    { method: "POST", headers: { ...authHeader } }
+  );
+  assert(claim.status === "claimed", `Expected claimed session, got ${claim.status}`);
+
+  const submitted = await readJson(
+    baseUrl,
+    `/jobs/submit?sessionId=${encodeURIComponent(claim.sessionId)}&evidence=${encodeURIComponent(evidence)}`,
+    { method: "POST", headers: { ...authHeader } }
+  );
+  assert(submitted.status === "submitted", `Expected submitted session, got ${submitted.status}`);
+
+  // The whole point of the smoke: do NOT call /verifier/run. Poll until the
+  // backend's auto-verifier settles the session on its own.
+  console.log("Submitted. Waiting for auto-verify to settle (no manual /verifier/run)...");
+  const deadline = Date.now() + timeoutMs;
+  let session;
+  let settled = false;
+  while (Date.now() < deadline) {
+    await sleep(pollMs);
+    session = await readJson(baseUrl, `/session?sessionId=${encodeURIComponent(claim.sessionId)}`, {
+      headers: { ...authHeader }
+    });
+    console.log(`  session status: ${session.status}`);
+    if (session.status === "resolved" || session.status === "rejected") {
+      settled = true;
+      break;
+    }
+  }
+
+  assert(settled, `Session ${claim.sessionId} did not auto-settle within ${timeoutMs}ms (last status: ${session?.status ?? "unknown"}). Is AUTO_VERIFY_ENABLED=1 on the backend?`);
+  assert(session.status === "resolved", `Expected auto-resolved (approved) session, got ${session.status}`);
+
+  const after = await readJson(baseUrl, "/account", { headers: { ...authHeader } });
+  const endingBalance = liquidBalance(after, rewardAsset);
+  const delta = endingBalance - startingBalance;
+  console.log(`Worker ${rewardAsset} liquid balance after: ${endingBalance} (delta ${delta})`);
+  assert(delta > 0, `Expected worker ${rewardAsset} balance to rise after auto-settle, got delta ${delta}`);
+
+  console.log("Auto-verify remote smoke passed");
+  console.log(JSON.stringify({
+    baseUrl,
+    wallet,
+    jobId,
+    sessionId: claim.sessionId,
+    sessionStatus: session.status,
+    rewardAsset,
+    startingBalance,
+    endingBalance,
+    rewardDelta: delta,
+    authMode,
+    signedIn: Boolean(privateKey)
+  }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/mcp-server/src/services/bootstrap.js
+++ b/mcp-server/src/services/bootstrap.js
@@ -59,6 +59,10 @@ import {
   JobStaleSweeperService,
   loadJobStaleSweeperConfig
 } from "./job-stale-sweeper.js";
+import {
+  SubmittedJobAutoVerifierService,
+  loadSubmittedJobAutoVerifierConfig
+} from "./submitted-job-auto-verifier.js";
 import { normaliseStrategyAssetConfig } from "./strategy-asset-config.js";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -327,6 +331,12 @@ export async function createPlatformRuntime() {
       logger
     })
   );
+  const submittedJobAutoVerifier = initStep("init-submitted-job-auto-verifier", logger, () =>
+    new SubmittedJobAutoVerifierService(platformService, verifierService, gateway, eventBus, {
+      ...loadSubmittedJobAutoVerifierConfig(process.env),
+      logger
+    })
+  );
   platformService.recurringScheduler = recurringScheduler;
   platformService.githubIssueIngestionScheduler = githubIssueIngestionScheduler;
   platformService.wikipediaMaintenanceIngestionScheduler = wikipediaMaintenanceIngestionScheduler;
@@ -339,6 +349,7 @@ export async function createPlatformRuntime() {
   platformService.upstreamStatusPoller = upstreamStatusPoller;
   platformService.bootstrapSelfReportScheduler = bootstrapSelfReportScheduler;
   platformService.jobStaleSweeper = jobStaleSweeper;
+  platformService.submittedJobAutoVerifier = submittedJobAutoVerifier;
   recurringScheduler.start();
   githubIssueIngestionScheduler.start();
   wikipediaMaintenanceIngestionScheduler.start();
@@ -351,6 +362,7 @@ export async function createPlatformRuntime() {
   upstreamStatusPoller.start();
   bootstrapSelfReportScheduler.start();
   jobStaleSweeper.start();
+  submittedJobAutoVerifier.start();
 
   const authMiddleware = createAuthMiddleware({ authConfig, stateStore, logger });
   const rateLimiter = createRateLimiter({ stateStore, logger });
@@ -386,6 +398,7 @@ export async function createPlatformRuntime() {
     xcmObservationRelay,
     upstreamStatusPoller,
     jobStaleSweeper,
+    submittedJobAutoVerifier,
     authConfig,
     authMiddleware,
     authCapabilities: {

--- a/mcp-server/src/services/submitted-job-auto-verifier.js
+++ b/mcp-server/src/services/submitted-job-auto-verifier.js
@@ -1,0 +1,302 @@
+// Auto-verify submitted jobs whose verifier mode is machine-decidable, so an
+// external worker's submission settles on its own instead of sitting in
+// `submitted` forever waiting for an operator to call POST /verifier/run.
+//
+// This is the backend counterpart to the manual `/verifier/run` route
+// (protocols/http/verifier-routes.js): both ultimately call the same
+// `verifierService.verifySubmission({ sessionId })`. The HTTP route gates that
+// call behind `requireRole: "verifier"`; this scheduler is an in-process caller
+// and so needs no JWT principal — exactly how the manual route reaches the
+// service after its auth check. On an `approved`/`rejected` verdict
+// verifySubmission also brokers the on-chain settlement (resolveSinglePayout)
+// using the gateway's configured signer, which holds the on-chain verifier role
+// (see BlockchainGateway.getTreasuryPolicyStatus → settlementReady). So a single
+// verifySubmission call takes a job from `submitted` all the way to settled.
+//
+// Only `benchmark` and `deterministic` modes are auto-decidable. `human_fallback`
+// and `github_pr` legitimately need a human or external trigger, so they are
+// never auto-verified here — the allowlist below is enforced even against
+// operator misconfiguration.
+
+const DEFAULT_INTERVAL_MS = 60 * 1000;
+const DEFAULT_SCAN_LIMIT = 200;
+const DEFAULT_MAX_PER_RUN = 25;
+
+// Hard allowlist of machine-decidable verifier handlers. human_fallback and
+// github_pr are intentionally excluded and cannot be re-enabled via config.
+const AUTO_DECIDABLE_MODES = Object.freeze(["benchmark", "deterministic"]);
+
+export class SubmittedJobAutoVerifierService {
+  constructor(platformService, verifierService, gateway = undefined, eventBus = undefined, {
+    enabled = false,
+    dryRun = false,
+    intervalMs = DEFAULT_INTERVAL_MS,
+    scanLimit = DEFAULT_SCAN_LIMIT,
+    maxPerRun = DEFAULT_MAX_PER_RUN,
+    autoModes = AUTO_DECIDABLE_MODES,
+    requireSettlementReady = true,
+    logger = console
+  } = {}) {
+    this.platformService = platformService;
+    this.verifierService = verifierService;
+    this.gateway = gateway;
+    this.eventBus = eventBus;
+    this.enabled = enabled;
+    this.dryRun = dryRun;
+    this.intervalMs = intervalMs;
+    this.scanLimit = scanLimit;
+    this.maxPerRun = maxPerRun;
+    this.autoModes = normalizeAutoModes(autoModes);
+    this.requireSettlementReady = requireSettlementReady;
+    this.logger = logger;
+    this.running = false;
+    this.timer = undefined;
+    this.inFlight = new Set();
+    this.lastRun = undefined;
+  }
+
+  start() {
+    if (!this.enabled || this.running) return;
+    this.running = true;
+    void this.runOnceAndSchedule();
+  }
+
+  stop() {
+    this.running = false;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  async getStatus() {
+    return {
+      enabled: this.enabled,
+      running: this.running,
+      dryRun: this.dryRun,
+      mode: this.dryRun ? "dry_run" : "live",
+      intervalMs: this.intervalMs,
+      scanLimit: this.scanLimit,
+      maxPerRun: this.maxPerRun,
+      autoModes: [...this.autoModes],
+      requireSettlementReady: this.requireSettlementReady,
+      lastRun: this.lastRun
+    };
+  }
+
+  async runOnce(now = new Date()) {
+    const summary = {
+      startedAt: now.toISOString(),
+      finishedAt: undefined,
+      dryRun: this.dryRun,
+      scanned: 0,
+      candidateCount: 0,
+      verifiedCount: 0,
+      approvedCount: 0,
+      rejectedCount: 0,
+      deferredCount: 0,
+      skipped: [],
+      errors: []
+    };
+
+    if (!this.enabled) {
+      summary.skipped.push({ reason: "disabled" });
+      return this.finishRun(summary);
+    }
+
+    // Honor pause/HALT before touching any session. When the chain is wired we
+    // refuse to auto-verify while the protocol is paused (the on-chain
+    // whenNotPaused kill-switch) or while settlement is not ready — auto-verifying
+    // then would either revert on-chain (spamming failed txs) or, worse, advance
+    // a session to a "resolved" state without a real payout, breaking the
+    // truth boundary between settled and not-settled.
+    const gate = await this.checkSettlementGate();
+    if (!gate.ok) {
+      summary.skipped.push({ reason: gate.reason, ...(gate.detail ? { detail: gate.detail } : {}) });
+      return this.finishRun(summary);
+    }
+
+    const sessions = await this.platformService.listRecentSessions?.(this.scanLimit) ?? [];
+    summary.scanned = sessions.length;
+
+    const candidates = [];
+    for (const session of sessions) {
+      if (session?.status !== "submitted") continue;
+      const sessionId = session.sessionId;
+      if (this.inFlight.has(sessionId)) {
+        summary.skipped.push({ sessionId, reason: "in_flight" });
+        continue;
+      }
+      // A submitted session should never already carry a verification result,
+      // but if one is present treat it as resolved-in-flight and leave it alone.
+      if (session.verification) {
+        summary.skipped.push({ sessionId, reason: "already_verified" });
+        continue;
+      }
+      let job;
+      try {
+        job = this.platformService.getJobDefinition(session.jobId);
+      } catch (error) {
+        summary.skipped.push({
+          sessionId,
+          jobId: session.jobId,
+          reason: "job_not_found",
+          message: error?.message ?? String(error)
+        });
+        continue;
+      }
+      const mode = job?.verifierConfig?.handler ?? job?.verifierMode;
+      if (!this.autoModes.has(mode)) {
+        summary.skipped.push({ sessionId, jobId: session.jobId, reason: "non_auto_mode", mode: mode ?? null });
+        continue;
+      }
+      candidates.push({ sessionId, jobId: session.jobId, mode });
+    }
+    summary.candidateCount = candidates.length;
+
+    const actionable = candidates.slice(0, this.maxPerRun);
+    summary.deferredCount = candidates.length - actionable.length;
+    if (summary.deferredCount > 0) {
+      // Surface the cap rather than silently dropping the tail — the remainder
+      // is picked up on the next tick.
+      summary.skipped.push({ reason: "max_per_run_reached", deferred: summary.deferredCount });
+    }
+
+    for (const candidate of actionable) {
+      if (this.dryRun) {
+        summary.skipped.push({ sessionId: candidate.sessionId, jobId: candidate.jobId, reason: "dry_run", mode: candidate.mode });
+        continue;
+      }
+      await this.verifyCandidate(candidate, summary);
+    }
+
+    return this.finishRun(summary);
+  }
+
+  async verifyCandidate(candidate, summary) {
+    const { sessionId, jobId, mode } = candidate;
+    this.inFlight.add(sessionId);
+    try {
+      const result = await this.verifierService.verifySubmission({ sessionId });
+      const outcome = result?.outcome;
+      summary.verifiedCount += 1;
+      if (outcome === "approved") summary.approvedCount += 1;
+      else if (outcome === "rejected") summary.rejectedCount += 1;
+      this.logger.info?.(
+        { sessionId, jobId, mode, outcome, reasonCode: result?.reasonCode },
+        "auto_verify.verified"
+      );
+      this.eventBus?.publish?.({
+        id: `auto-verify-${sessionId}-${Date.now()}`,
+        topic: "verifier.auto.resolved",
+        jobId,
+        timestamp: new Date().toISOString(),
+        data: { sessionId, jobId, mode, outcome, reasonCode: result?.reasonCode }
+      });
+    } catch (error) {
+      // A session that flipped out of `submitted` between scan and verify (e.g.
+      // a manual /verifier/run ran first), or a settlement tx that reverted,
+      // lands here. Both are safe to retry next tick: a verdict is committed
+      // only after settlement succeeds, so a failed run leaves the session in
+      // `submitted`.
+      summary.errors.push({ sessionId, jobId, message: error?.message ?? String(error) });
+      this.logger.warn?.({ sessionId, jobId, mode, err: error }, "auto_verify.verify_failed");
+    } finally {
+      this.inFlight.delete(sessionId);
+    }
+  }
+
+  // Returns { ok: true } when it is safe to settle, otherwise { ok: false,
+  // reason, detail? }. When no chain gateway is wired (memory backend / dev)
+  // there is no on-chain HALT to honor, so the gate passes and verifySubmission
+  // advances session state without an on-chain payout (the simulated path).
+  async checkSettlementGate() {
+    if (!this.gateway?.isEnabled?.()) {
+      return { ok: true };
+    }
+    let status;
+    try {
+      status = await this.gateway.getTreasuryPolicyStatus();
+    } catch (error) {
+      // Fail closed: if we cannot read protocol posture we must not move value.
+      return { ok: false, reason: "policy_status_unavailable", detail: error?.message ?? String(error) };
+    }
+    if (status?.paused === true) {
+      return { ok: false, reason: "protocol_paused" };
+    }
+    if (this.requireSettlementReady && status?.settlementReady === false) {
+      return { ok: false, reason: "settlement_not_ready" };
+    }
+    return { ok: true };
+  }
+
+  async runOnceAndSchedule() {
+    await this.runOnce(new Date());
+    if (!this.running) return;
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      void this.runOnceAndSchedule();
+    }, this.intervalMs);
+  }
+
+  finishRun(summary) {
+    summary.finishedAt = new Date().toISOString();
+    this.lastRun = summary;
+    return summary;
+  }
+}
+
+export function loadSubmittedJobAutoVerifierConfig(env = process.env) {
+  return {
+    enabled: parseBooleanEnv(env.AUTO_VERIFY_ENABLED),
+    dryRun: parseBooleanEnv(env.AUTO_VERIFY_DRY_RUN),
+    intervalMs: parsePositiveInt(env.AUTO_VERIFY_INTERVAL_MS, DEFAULT_INTERVAL_MS),
+    scanLimit: parsePositiveInt(env.AUTO_VERIFY_SCAN_LIMIT, DEFAULT_SCAN_LIMIT),
+    maxPerRun: parsePositiveInt(env.AUTO_VERIFY_MAX_PER_RUN, DEFAULT_MAX_PER_RUN),
+    autoModes: parseAutoModesEnv(env.AUTO_VERIFY_MODES),
+    requireSettlementReady: env.AUTO_VERIFY_REQUIRE_SETTLEMENT_READY === undefined
+      ? true
+      : parseBooleanEnv(env.AUTO_VERIFY_REQUIRE_SETTLEMENT_READY)
+  };
+}
+
+// Intersect the requested modes with the hard allowlist. An empty or
+// fully-invalid configuration falls back to the full allowlist so the feature
+// is never silently turned into a no-op; human_fallback/github_pr requests are
+// dropped regardless.
+function normalizeAutoModes(requested) {
+  const allow = new Set(AUTO_DECIDABLE_MODES);
+  const list = Array.isArray(requested) ? requested : [...(requested ?? [])];
+  const filtered = list
+    .map((mode) => String(mode ?? "").trim().toLowerCase())
+    .filter((mode) => allow.has(mode));
+  return new Set(filtered.length > 0 ? filtered : AUTO_DECIDABLE_MODES);
+}
+
+function parseAutoModesEnv(raw) {
+  if (raw === undefined || raw === null || String(raw).trim() === "") {
+    return [...AUTO_DECIDABLE_MODES];
+  }
+  return String(raw)
+    .split(",")
+    .map((mode) => mode.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function parsePositiveInt(raw, fallback) {
+  if (raw === undefined || raw === null || raw === "") {
+    return fallback;
+  }
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    return fallback;
+  }
+  return value;
+}
+
+function parseBooleanEnv(raw) {
+  if (raw === undefined || raw === null || raw === "") {
+    return false;
+  }
+  return ["1", "true", "yes", "on"].includes(String(raw).trim().toLowerCase());
+}

--- a/mcp-server/src/services/submitted-job-auto-verifier.test.js
+++ b/mcp-server/src/services/submitted-job-auto-verifier.test.js
@@ -1,0 +1,319 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  SubmittedJobAutoVerifierService,
+  loadSubmittedJobAutoVerifierConfig
+} from "./submitted-job-auto-verifier.js";
+
+const JOBS = {
+  "bench-001": { id: "bench-001", verifierMode: "benchmark", verifierConfig: { handler: "benchmark" } },
+  "det-001": { id: "det-001", verifierMode: "deterministic", verifierConfig: { handler: "deterministic" } },
+  "human-001": { id: "human-001", verifierMode: "human_fallback", verifierConfig: { handler: "human_fallback" } },
+  "gh-001": { id: "gh-001", verifierMode: "github_pr", verifierConfig: { handler: "github_pr" } }
+};
+
+// Builds a harness with a shared session store. The fake verifierService mutates
+// session.status the way the real one does (submitted -> resolved/rejected via
+// ingestVerification), so re-listing on the next tick proves idempotency.
+function makeHarness({ sessions = [], jobs = JOBS, outcomeFor = () => "approved", gateway } = {}) {
+  const store = sessions.map((session) => ({ ...session }));
+  const verifyCalls = [];
+  const platformService = {
+    async listRecentSessions() {
+      return store.map((session) => ({ ...session }));
+    },
+    getJobDefinition(jobId) {
+      const job = jobs[jobId];
+      if (!job) throw new Error(`Unknown job: ${jobId}`);
+      return job;
+    }
+  };
+  const verifierService = {
+    async verifySubmission({ sessionId }) {
+      verifyCalls.push(sessionId);
+      const session = store.find((entry) => entry.sessionId === sessionId);
+      if (!session) throw new Error(`Unknown session: ${sessionId}`);
+      if (session.status !== "submitted") {
+        throw new Error(`Session ${sessionId} cannot receive verification while ${session.status}.`);
+      }
+      const outcome = outcomeFor(session);
+      session.status = outcome === "approved" ? "resolved" : "rejected";
+      session.verification = { outcome };
+      return { outcome, reasonCode: outcome === "approved" ? "OK" : "NO", sessionId };
+    }
+  };
+  return { store, verifyCalls, platformService, verifierService, gateway };
+}
+
+function makeService(harness, options = {}) {
+  return new SubmittedJobAutoVerifierService(
+    harness.platformService,
+    harness.verifierService,
+    harness.gateway,
+    undefined,
+    { enabled: true, logger: { info() {}, warn() {} }, ...options }
+  );
+}
+
+test("verifies submitted benchmark and deterministic jobs and settles each", async () => {
+  const harness = makeHarness({
+    sessions: [
+      { sessionId: "s-bench", jobId: "bench-001", status: "submitted" },
+      { sessionId: "s-det", jobId: "det-001", status: "submitted" }
+    ],
+    outcomeFor: (session) => (session.jobId === "bench-001" ? "approved" : "rejected")
+  });
+  const service = makeService(harness);
+
+  const run = await service.runOnce(new Date("2026-06-13T10:00:00.000Z"));
+
+  assert.equal(run.candidateCount, 2);
+  assert.equal(run.verifiedCount, 2);
+  assert.equal(run.approvedCount, 1);
+  assert.equal(run.rejectedCount, 1);
+  assert.deepEqual(harness.verifyCalls.sort(), ["s-bench", "s-det"]);
+  assert.equal(harness.store.find((s) => s.sessionId === "s-bench").status, "resolved");
+  assert.equal(harness.store.find((s) => s.sessionId === "s-det").status, "rejected");
+});
+
+test("never auto-verifies human_fallback or github_pr", async () => {
+  const harness = makeHarness({
+    sessions: [
+      { sessionId: "s-human", jobId: "human-001", status: "submitted" },
+      { sessionId: "s-gh", jobId: "gh-001", status: "submitted" }
+    ]
+  });
+  const service = makeService(harness);
+
+  const run = await service.runOnce();
+
+  assert.equal(run.candidateCount, 0);
+  assert.equal(run.verifiedCount, 0);
+  assert.equal(harness.verifyCalls.length, 0);
+  const reasons = run.skipped.filter((s) => s.reason === "non_auto_mode").map((s) => s.mode).sort();
+  assert.deepEqual(reasons, ["github_pr", "human_fallback"]);
+});
+
+test("ignores sessions that are not in submitted state", async () => {
+  const harness = makeHarness({
+    sessions: [
+      { sessionId: "s-claimed", jobId: "bench-001", status: "claimed" },
+      { sessionId: "s-resolved", jobId: "bench-001", status: "resolved" },
+      { sessionId: "s-disputed", jobId: "bench-001", status: "disputed" }
+    ]
+  });
+  const service = makeService(harness);
+
+  const run = await service.runOnce();
+
+  assert.equal(run.candidateCount, 0);
+  assert.equal(harness.verifyCalls.length, 0);
+});
+
+test("is idempotent across ticks — a settled session is not re-verified", async () => {
+  const harness = makeHarness({
+    sessions: [{ sessionId: "s-bench", jobId: "bench-001", status: "submitted" }]
+  });
+  const service = makeService(harness);
+
+  const first = await service.runOnce();
+  const second = await service.runOnce();
+
+  assert.equal(first.verifiedCount, 1);
+  assert.equal(second.verifiedCount, 0);
+  assert.deepEqual(harness.verifyCalls, ["s-bench"]);
+});
+
+test("skips a submitted session that already carries a verification result", async () => {
+  const harness = makeHarness({
+    sessions: [{ sessionId: "s-bench", jobId: "bench-001", status: "submitted", verification: { outcome: "approved" } }]
+  });
+  const service = makeService(harness);
+
+  const run = await service.runOnce();
+
+  assert.equal(run.candidateCount, 0);
+  assert.equal(harness.verifyCalls.length, 0);
+  assert.equal(run.skipped[0].reason, "already_verified");
+});
+
+test("skips a submitted session whose job has been removed", async () => {
+  const harness = makeHarness({
+    sessions: [{ sessionId: "s-ghost", jobId: "missing-001", status: "submitted" }]
+  });
+  const service = makeService(harness);
+
+  const run = await service.runOnce();
+
+  assert.equal(run.candidateCount, 0);
+  assert.equal(harness.verifyCalls.length, 0);
+  assert.equal(run.skipped[0].reason, "job_not_found");
+});
+
+test("does nothing when disabled", async () => {
+  const harness = makeHarness({
+    sessions: [{ sessionId: "s-bench", jobId: "bench-001", status: "submitted" }]
+  });
+  const service = makeService(harness, { enabled: false });
+
+  const run = await service.runOnce();
+
+  assert.equal(run.skipped[0].reason, "disabled");
+  assert.equal(harness.verifyCalls.length, 0);
+});
+
+test("dry-run reports candidates without verifying", async () => {
+  const harness = makeHarness({
+    sessions: [{ sessionId: "s-bench", jobId: "bench-001", status: "submitted" }]
+  });
+  const service = makeService(harness, { dryRun: true });
+
+  const run = await service.runOnce();
+
+  assert.equal(run.candidateCount, 1);
+  assert.equal(run.verifiedCount, 0);
+  assert.equal(harness.verifyCalls.length, 0);
+  assert.ok(run.skipped.some((s) => s.reason === "dry_run"));
+});
+
+test("caps work per run and defers the remainder to the next tick", async () => {
+  const harness = makeHarness({
+    sessions: [
+      { sessionId: "s1", jobId: "bench-001", status: "submitted" },
+      { sessionId: "s2", jobId: "bench-001", status: "submitted" },
+      { sessionId: "s3", jobId: "bench-001", status: "submitted" }
+    ]
+  });
+  const service = makeService(harness, { maxPerRun: 2 });
+
+  const run = await service.runOnce();
+
+  assert.equal(run.candidateCount, 3);
+  assert.equal(run.verifiedCount, 2);
+  assert.equal(run.deferredCount, 1);
+  assert.ok(run.skipped.some((s) => s.reason === "max_per_run_reached" && s.deferred === 1));
+});
+
+test("honors HALT — skips the whole run while the protocol is paused", async () => {
+  const harness = makeHarness({
+    sessions: [{ sessionId: "s-bench", jobId: "bench-001", status: "submitted" }],
+    gateway: {
+      isEnabled: () => true,
+      getTreasuryPolicyStatus: async () => ({ enabled: true, paused: true, settlementReady: false })
+    }
+  });
+  const service = makeService(harness);
+
+  const run = await service.runOnce();
+
+  assert.equal(run.skipped[0].reason, "protocol_paused");
+  assert.equal(harness.verifyCalls.length, 0);
+});
+
+test("skips the run when settlement is not ready", async () => {
+  const harness = makeHarness({
+    sessions: [{ sessionId: "s-bench", jobId: "bench-001", status: "submitted" }],
+    gateway: {
+      isEnabled: () => true,
+      getTreasuryPolicyStatus: async () => ({ enabled: true, paused: false, settlementReady: false })
+    }
+  });
+  const service = makeService(harness);
+
+  const run = await service.runOnce();
+
+  assert.equal(run.skipped[0].reason, "settlement_not_ready");
+  assert.equal(harness.verifyCalls.length, 0);
+});
+
+test("fails closed when protocol posture cannot be read", async () => {
+  const harness = makeHarness({
+    sessions: [{ sessionId: "s-bench", jobId: "bench-001", status: "submitted" }],
+    gateway: {
+      isEnabled: () => true,
+      getTreasuryPolicyStatus: async () => { throw new Error("rpc down"); }
+    }
+  });
+  const service = makeService(harness);
+
+  const run = await service.runOnce();
+
+  assert.equal(run.skipped[0].reason, "policy_status_unavailable");
+  assert.equal(harness.verifyCalls.length, 0);
+});
+
+test("verifies when the chain is enabled, unpaused and settlement-ready", async () => {
+  const harness = makeHarness({
+    sessions: [{ sessionId: "s-bench", jobId: "bench-001", status: "submitted" }],
+    gateway: {
+      isEnabled: () => true,
+      getTreasuryPolicyStatus: async () => ({ enabled: true, paused: false, settlementReady: true })
+    }
+  });
+  const service = makeService(harness);
+
+  const run = await service.runOnce();
+
+  assert.equal(run.verifiedCount, 1);
+  assert.deepEqual(harness.verifyCalls, ["s-bench"]);
+});
+
+test("settlement-readiness gate can be relaxed for non-chain testnets", async () => {
+  const harness = makeHarness({
+    sessions: [{ sessionId: "s-bench", jobId: "bench-001", status: "submitted" }],
+    gateway: {
+      isEnabled: () => true,
+      getTreasuryPolicyStatus: async () => ({ enabled: true, paused: false, settlementReady: false })
+    }
+  });
+  const service = makeService(harness, { requireSettlementReady: false });
+
+  const run = await service.runOnce();
+
+  assert.equal(run.verifiedCount, 1);
+});
+
+test("constructor drops non-auto modes from the requested allowlist", () => {
+  const harness = makeHarness();
+  const service = makeService(harness, { autoModes: ["benchmark", "human_fallback", "github_pr"] });
+  assert.deepEqual([...service.autoModes].sort(), ["benchmark"]);
+});
+
+test("constructor falls back to the full allowlist when no valid mode is requested", () => {
+  const harness = makeHarness();
+  const service = makeService(harness, { autoModes: ["github_pr"] });
+  assert.deepEqual([...service.autoModes].sort(), ["benchmark", "deterministic"]);
+});
+
+test("loadSubmittedJobAutoVerifierConfig parses conservative defaults", () => {
+  assert.deepEqual(loadSubmittedJobAutoVerifierConfig({}), {
+    enabled: false,
+    dryRun: false,
+    intervalMs: 60 * 1000,
+    scanLimit: 200,
+    maxPerRun: 25,
+    autoModes: ["benchmark", "deterministic"],
+    requireSettlementReady: true
+  });
+});
+
+test("loadSubmittedJobAutoVerifierConfig honors env overrides", () => {
+  assert.deepEqual(loadSubmittedJobAutoVerifierConfig({
+    AUTO_VERIFY_ENABLED: "true",
+    AUTO_VERIFY_DRY_RUN: "1",
+    AUTO_VERIFY_INTERVAL_MS: "30000",
+    AUTO_VERIFY_SCAN_LIMIT: "500",
+    AUTO_VERIFY_MAX_PER_RUN: "5",
+    AUTO_VERIFY_MODES: "benchmark, human_fallback",
+    AUTO_VERIFY_REQUIRE_SETTLEMENT_READY: "false"
+  }), {
+    enabled: true,
+    dryRun: true,
+    intervalMs: 30000,
+    scanLimit: 500,
+    maxPerRun: 5,
+    autoModes: ["benchmark", "human_fallback"],
+    requireSettlementReady: false
+  });
+});


### PR DESCRIPTION
## Problem (GO_LIVE_PUNCHLIST P0, confirmed 2026-06-13)

When the first external worker submitted a benchmark job, it sat in `submitted` until an operator manually called `POST /verifier/run` with a verifier-role JWT. There was **no scheduler/auto-trigger**:

- `/verifier/run` is `requireRole:"verifier"` gated ([verifier-routes.js](mcp-server/src/protocols/http/verifier-routes.js)) — an external roleless worker cannot self-verify.
- No cron/scheduler picked up `submitted` jobs.

So external workers' jobs never settled on their own. (The product-proof loop only worked because it held the verifier role and called the verifier inline.)

## Fix

New **`SubmittedJobAutoVerifierService`** ([submitted-job-auto-verifier.js](mcp-server/src/services/submitted-job-auto-verifier.js)) — a periodic, config-gated scheduler that mirrors the existing `job-stale-sweeper` / ingestion-scheduler pattern. Each tick it scans recent sessions for ones in `submitted` whose verifier mode is **machine-decidable** (`benchmark`, `deterministic`) and calls the same `verifierService.verifySubmission()` the manual route uses.

**That single call both verifies *and* settles.** `verifySubmission` brokers `resolveSinglePayout` for approved *and* rejected verdicts whenever the gateway is enabled ([verifier-service.js:36](mcp-server/src/services/verifier-service.js)) — so `submitted` reaches **settled with no operator action**.

### Decisions surfaced (per task)
- **Verifier identity** — the scheduler is an in-process caller, exactly how the HTTP route reaches the service *after* its role check; no JWT principal is involved. On-chain settlement is brokered by the **gateway's configured signer, which holds the on-chain verifier role** (confirmed: `getTreasuryPolicyStatus().settlementReady` requires `verifiers(signerAddress) && !paused && escrowIsServiceOperator`). That signer is the real verifier-role principal.
- **Settlement is automatic** — no separate release step; `verifySubmission` does it.
- **Enablement** — **off by default**, opt in via `AUTO_VERIFY_ENABLED` (the testnet/prod deploy template flips it on). Conservative defaults: 60s interval, 25 verifications/run, scan 200.

### Safety
- **Hard allowlist `{benchmark, deterministic}`** — `human_fallback` and `github_pr` are never auto-verified (they legitimately need a human/external trigger), even if `AUTO_VERIFY_MODES` is misconfigured.
- **Honors HALT/pause** — when the chain is wired it reads `getTreasuryPolicyStatus()` and skips the whole run while the protocol is paused or settlement is not ready, and **fails closed** if posture can't be read. It never advances a session past a real payout (truth boundary).
- **Idempotent** — only `submitted` sessions are eligible; the state machine rejects re-verification, plus an in-flight guard and an already-verified skip. A failed settlement leaves the session `submitted` to retry next tick.
- Surfaces `submittedJobAutoVerifier` status in `getAdminStatus`.

## Tests

- **Unit** ([submitted-job-auto-verifier.test.js](mcp-server/src/services/submitted-job-auto-verifier.test.js), 18 tests, all green): pickup of benchmark+deterministic, skips `human_fallback`/`github_pr`, ignores non-`submitted`, idempotent across ticks, already-verified/job-removed skips, HALT/pause/settlement-not-ready/fail-closed gating, dry-run, per-run cap + defer, config parsing + allowlist enforcement.
- **Live** ([auto-verify-remote-smoke.js](mcp-server/src/demo/auto-verify-remote-smoke.js), `npm run demo:auto-verify:remote`): submits a benchmark job and **waits for auto-settle — no `/verifier/run`** — asserting the session reaches `resolved` and the worker's reward balance rises. To be run against the testnet backend with `AUTO_VERIFY_ENABLED=1` (operator runs it; the sandbox can't reach the KMS/operator secrets).

Full suite: `737 pass / 27 fail`, where the 27 failures are the **pre-existing** missing-dependency files (`@aws-sdk/*`, `@paraspell/sdk-core`) — confirmed identical on the clean base; zero new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)