### PR TITLE
feat(canary): full external-worker loop canary in CI (guards the 2026-06-13 blocker class)

### DIFF
--- a/.github/workflows/hosted-worker-canary.yml
+++ b/.github/workflows/hosted-worker-canary.yml
@@ -1,0 +1,187 @@
+name: Hosted Worker Canary
+
+# End-to-end EXTERNAL-WORKER CANARY. A fresh, ROLELESS worker wallet walks the
+# real SIWE front door and drives the full paid loop on a disposable,
+# operator-funded benchmark job: SIWE → account → claim → submit → verify →
+# settle, plus an operator-token freshness check. Each stage fails loud with the
+# launch-blocker class it guards (#625 roleless-mint 500, #626 JWT sub-casing
+# 401, claim-funding 409 + claimJobFor brokering, #627 submitWork revert,
+# settlement stall, #628 ADMIN_JWT expiry). This is the regression guard for the
+# whole class found on 2026-06-13 — none of the prior hosted proofs could see
+# them because they all used the pre-minted multi-role ADMIN_JWT and bypassed the
+# SIWE front door.
+#
+# The WORKER stages use a dedicated roleless testnet wallet
+# (op://prod-backend/canary-worker-testnet). Only the OPERATOR stages
+# (create/fund/verify/cleanup) use the ADMIN_JWT. Testnet-only — the script
+# refuses any other chain.
+
+on:
+  # Manual run, with knobs for one-off debugging.
+  workflow_dispatch:
+    inputs:
+      reward_amount:
+        description: Reward in USDC for the disposable canary job (blank = 0.1).
+        required: false
+        default: ""
+        type: string
+      verify_mode:
+        description: How stage 5 verifies. "operator" triggers /verifier/run; "auto" polls the public result (no-op once auto-verify lands).
+        required: false
+        default: operator
+        type: choice
+        options:
+          - operator
+          - auto
+      token_min_days:
+        description: Fail if the operator ADMIN_JWT is within this many days of expiry (blank = 7).
+        required: false
+        default: ""
+        type: string
+      allow_ephemeral:
+        description: Use a throwaway random worker wallet instead of the dedicated 1Password key (one-off override; always within the onboarding waiver).
+        required: false
+        default: false
+        type: boolean
+      keep_job:
+        description: Leave the disposable canary job live instead of archiving it (debugging only).
+        required: false
+        default: false
+        type: boolean
+  # Daily evidence lane — catches the blocker class before an external agent does.
+  schedule:
+    - cron: "37 6 * * *"
+  # Post-deploy gate — re-walk the whole loop right after every production deploy.
+  workflow_run:
+    workflows: ["Deploy Production"]
+    branches: [main]
+    types: [completed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hosted-worker-canary
+  cancel-in-progress: false
+
+jobs:
+  canary:
+    name: Run hosted external-worker canary
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Skip the post-deploy run when the deploy itself failed.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    environment: production
+    env:
+      APP_ALLOW_PROTECTED_SHELL: "1"
+      CHECK_INDEXER: "0"
+      CHECK_WORKER_CANARY_PROOF: "1"
+      WORKER_CANARY_PROFILE: testnet
+      WORKER_CANARY_EVIDENCE_FILE: artifacts/worker-canary-hosted-${{ github.run_id }}.json
+      WORKER_CANARY_REWARD_AMOUNT: ${{ inputs.reward_amount }}
+      WORKER_CANARY_VERIFY_MODE: ${{ inputs.verify_mode }}
+      WORKER_CANARY_TOKEN_MIN_DAYS: ${{ inputs.token_min_days }}
+      WORKER_CANARY_ALLOW_EPHEMERAL: ${{ inputs.allow_ephemeral && '1' || '' }}
+      WORKER_CANARY_KEEP_JOB: ${{ inputs.keep_job && '1' || '' }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      # The canary signs the SIWE message and reads on-chain settlement state
+      # with `ethers` (a prod dependency of mcp-server), so it needs node_modules.
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Load operator ADMIN_JWT from 1Password (fail-closed)
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE }}
+          ADMIN_JWT_OP: op://prod-smoke/admin-jwt/password
+
+      # The roleless worker key lives in prod-backend (VPS-readable; prod-critical
+      # is not). Loaded with a least-privilege service account scoped to
+      # prod-backend. Skipped for one-off ephemeral dispatches.
+      - name: Load canary worker key from 1Password (fail-closed)
+        if: ${{ inputs.allow_ephemeral != true }}
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PROD_BACKEND }}
+          WORKER_CANARY_WORKER_PRIVATE_KEY: op://prod-backend/canary-worker-testnet/private key
+
+      - name: Verify operator credential loaded and shape-valid
+        run: |
+          set -euo pipefail
+          set +x
+
+          if [ -z "${ADMIN_JWT_OP:-}" ]; then
+            echo "::error::ADMIN_JWT_OP is empty after load step — check op://prod-smoke/admin-jwt/password and OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE."
+            exit 1
+          fi
+          case "$ADMIN_JWT_OP" in
+            ey*.*.*) echo "ADMIN_JWT_OP: JWT shape valid" ;;
+            *) echo "::error::ADMIN_JWT_OP does not look like a JWT (expected ey<...>.<...>.<...>)"; exit 1 ;;
+          esac
+
+          if [ "${{ inputs.allow_ephemeral }}" != "true" ] && [ -z "${WORKER_CANARY_WORKER_PRIVATE_KEY:-}" ]; then
+            echo "::error::WORKER_CANARY_WORKER_PRIVATE_KEY is empty — check op://prod-backend/canary-worker-testnet/private key and OP_SERVICE_ACCOUNT_TOKEN_PROD_BACKEND."
+            exit 1
+          fi
+
+      - name: Run hosted worker canary
+        run: |
+          set -euo pipefail
+          set +x
+
+          ADMIN_JWT="$ADMIN_JWT_OP" ./scripts/ops/check-hosted-stack.sh
+
+      - name: Summarize canary evidence
+        if: always()
+        run: |
+          set -euo pipefail
+
+          evidence_file="$WORKER_CANARY_EVIDENCE_FILE"
+          if [ ! -s "$evidence_file" ]; then
+            echo "No worker-canary evidence file was produced (the canary failed before writing it — see the run log for the failing stage)." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          worker="$(jq -r '.workerWallet' "$evidence_file")"
+          job_id="$(jq -r '.jobId' "$evidence_file")"
+          chain_job_id="$(jq -r '.chainJobId // "—"' "$evidence_file")"
+          claim_mechanism="$(jq -r '.stages.claim.mechanism // "—"' "$evidence_file")"
+          submit_status="$(jq -r '.stages.submit.status // "—"' "$evidence_file")"
+          verify_outcome="$(jq -r '.stages.verify.outcome // "—"' "$evidence_file")"
+          job_state="$(jq -r '.stages.settle.jobState // "—"' "$evidence_file")"
+          released="$(jq -r '.stages.settle.released // "—"' "$evidence_file")"
+          credited_to="$(jq -r '.stages.settle.creditedTo // "—"' "$evidence_file")"
+          token_days="$(jq -r '.stages.tokenFreshness.daysToExpiry // "n/a"' "$evidence_file")"
+          total_ms="$(jq -r '.timings.totalMs // "—"' "$evidence_file")"
+
+          {
+            echo "## Hosted Worker Canary"
+            echo
+            echo "- Worker (roleless): \`${worker}\`"
+            echo "- Job: \`${job_id}\` (chainJobId \`${chain_job_id}\`)"
+            echo "- Claim: \`${claim_mechanism}\` · Submit: \`${submit_status}\` · Verify: \`${verify_outcome}\`"
+            echo "- Settle: job \`${job_state}\`, released \`${released}\` USDC → \`${credited_to}\`"
+            echo "- Operator token: \`${token_days}\` day(s) to expiry"
+            echo "- Total: \`${total_ms} ms\`"
+            echo "- Evidence artifact: \`hosted-worker-canary-${GITHUB_RUN_ID}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload sanitized worker-canary evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: hosted-worker-canary-${{ github.run_id }}
+          path: ${{ env.WORKER_CANARY_EVIDENCE_FILE }}
+          if-no-files-found: warn
+          retention-days: 90

--- a/docs/WORKER_CANARY.md
+++ b/docs/WORKER_CANARY.md
@@ -1,0 +1,124 @@
+# External-Worker Canary
+
+A CI canary that walks the **real external-worker loop** end to end — the same
+front door an outside agent uses — and asserts every stage, so the class of
+launch-blockers found on 2026-06-13 can never silently reach production again.
+
+- **Script:** [`scripts/ops/run-worker-canary.mjs`](../scripts/ops/run-worker-canary.mjs)
+- **Tests:** [`scripts/ops/run-worker-canary.test.mjs`](../scripts/ops/run-worker-canary.test.mjs) (offline; one deliberate per-stage break flips the right assertion red)
+- **Gate:** `CHECK_WORKER_CANARY_PROOF=1 ./scripts/ops/check-hosted-stack.sh`
+- **Workflow:** [`.github/workflows/hosted-worker-canary.yml`](../.github/workflows/hosted-worker-canary.yml) — dispatchable + daily (`37 6 * * *`) + post-deploy (`workflow_run` on **Deploy Production**)
+
+## Why it exists
+
+The first fully-settled product job surfaced five blockers **one user-round-trip
+at a time** (SIWE roleless-mint 500 · JWT `sub`-casing 401 · claim 409 ·
+`submitWork` revert · `ADMIN_JWT` expiry). Every prior hosted proof used the
+pre-minted multi-role `ADMIN_JWT` and bypassed the SIWE front door, so none of
+them could see those bugs. This canary uses a **roleless** wallet for the worker
+stages and only the `ADMIN_JWT` for the operator stages, so the whole class
+fails loud here — in CI — before it reaches an external agent. See
+`docs/GO_LIVE_PUNCHLIST.md` (P0).
+
+## Stages (each failure names the bug-class it guards)
+
+| # | Stage | Asserts | Guards |
+| - | --- | --- | --- |
+| 1 | SIWE | nonce → sign → verify → roleless token | #625 roleless-mint 500 |
+| 2 | Account | authed `GET /account`, not 401 `claims_mismatch` | #626 `sub`-casing |
+| 3 | Claim | claim the disposable job, not 409; onboarding waiver applies **or** worker pre-funded | claim-funding 409 + `claimJobFor` brokering |
+| 4 | Submit | structured output → `submitted`, no on-chain revert | #627 `submitWorkFor` |
+| 5 | Verify | operator `/verifier/run` → `approved` (until auto-verify lands) | verification stall |
+| 6 | Settle | EscrowCore job `Closed` + `released == reward`, and worker balance rose by reward in **`usdc.balanceOf(workerEOA)` AND `AAC.positions(worker).liquid`** | settlement / payout reconciliation |
+| 7 | Freshness | the long-lived operator `ADMIN_JWT` isn't within N days (default 7) of expiry | #628 `ADMIN_JWT` expiry |
+
+The worker stages (1–4) run on the roleless token; the operator stages
+(create/fund/verify/cleanup) run on the `ADMIN_JWT`. Stages 5 and 7 are
+structured to become **no-ops** once auto-verify and the short-lived
+refresh-token flow land (a short-lived operator token skips the freshness gate;
+`WORKER_CANARY_VERIFY_MODE=auto` polls the public verifier result instead of
+operator-triggering).
+
+## Disposable job + cleanup
+
+Each run posts its own **upfront-funded** benchmark job (small reward, default
+`0.1 USDC`) so the loop never depends on the lazy `ensureJob` path, then
+**archives it in a `finally` block** so canary jobs never accumulate or pollute
+the public board. It never consumes claim attempts on real board jobs.
+
+## Safety
+
+- **Testnet-only.** The script loads `deployments/testnet.json`, refuses any
+  profile but `testnet`, and asserts the live `chainId` is `420420417`
+  (Polkadot Hub Paseo). It will not drive a paid loop against mainnet.
+- **Never the admin JWT for worker stages.** The worker identity is a dedicated,
+  roleless testnet wallet; the `ADMIN_JWT` is used only for the operator stages.
+
+## One-time provisioning (operator)
+
+1. **Generate the roleless worker key** (address-only output; the private key is
+   written to a gitignored `.keys/` file at mode 0600, never echoed):
+
+   ```sh
+   node scripts/ops/rotate-admin-generate-key.mjs --out .keys/canary-worker-testnet.txt
+   # note the printed address; it is the canary worker EOA
+   ```
+
+2. **Store it in 1Password** in `prod-backend` (VPS-readable; `prod-critical` is
+   not). Single item, no archived-ghost duplicate:
+
+   ```sh
+   op item create --vault prod-backend --category 'API Credential' \
+     --title 'canary-worker-testnet' \
+     "private key[concealed]=$(cat .keys/canary-worker-testnet.txt)" \
+     'address[text]=0x…' \
+     'chain[text]=Paseo Asset Hub TestNet (chainId 420420417)' \
+     'notes[text]=Roleless external-worker CI canary wallet. NOT admin/verifier.'
+   op read 'op://prod-backend/canary-worker-testnet/private key' >/dev/null  # verify
+   rm .keys/canary-worker-testnet.txt
+   ```
+
+3. **GitHub Actions secrets** the workflow needs:
+   - `OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE` — reads `op://prod-smoke/admin-jwt/password` (operator `ADMIN_JWT`). Already used by the dispute-verdict proof.
+   - `OP_SERVICE_ACCOUNT_TOKEN_PROD_BACKEND` — a least-privilege service account scoped to **read** `op://prod-backend/canary-worker-testnet`.
+
+4. **Keep the worker claimable.** A fresh wallet's first
+   `onboardingWaiverClaimCount` (3) claims are stake/fee-waived. The dedicated
+   canary wallet exhausts that after a few runs, so for ongoing daily runs
+   **pre-fund** its `AgentAccountCore` position with ≥ the per-claim lock (operator
+   step; becomes a no-op once auto-fund lands). Until then, stage 3 fails loud if
+   the wallet is both waiver-exhausted and underfunded.
+
+## Running it locally
+
+```sh
+# Against prod testnet with the dedicated wallet + a refresh/admin operator token:
+CHECK_WORKER_CANARY_PROOF=1 \
+ADMIN_JWT="$(op read op://prod-smoke/admin-jwt/password)" \
+WORKER_CANARY_WORKER_PRIVATE_KEY="$(op read 'op://prod-backend/canary-worker-testnet/private key')" \
+WORKER_CANARY_EVIDENCE_FILE=artifacts/worker-canary.json \
+  ./scripts/ops/check-hosted-stack.sh
+
+# One-off with a throwaway wallet (always within the onboarding waiver), no op needed:
+WORKER_CANARY_ALLOW_EPHEMERAL=1 \
+ADMIN_JWT="…" \
+  node scripts/ops/run-worker-canary.mjs
+```
+
+### Knobs
+
+| Env / dispatch input | Default | Purpose |
+| --- | --- | --- |
+| `WORKER_CANARY_REWARD_AMOUNT` | `0.1` | Disposable-job reward (USDC). |
+| `WORKER_CANARY_VERIFY_MODE` | `operator` | `operator` triggers `/verifier/run`; `auto` polls the public result (no-op once auto-verify lands). |
+| `WORKER_CANARY_TOKEN_MIN_DAYS` | `7` | Fail if the operator `ADMIN_JWT` is within this many days of expiry. |
+| `WORKER_CANARY_ALLOW_EPHEMERAL` | off | Use a throwaway random worker wallet instead of the 1Password key. |
+| `WORKER_CANARY_KEEP_JOB` | off | Leave the disposable job live instead of archiving (debug). |
+| `WORKER_CANARY_EVIDENCE_FILE` | — | Where to write the sanitized evidence JSON. |
+
+## Evidence artifact
+
+The run writes a sanitized JSON doc (no tokens or keys) — stage timings, tx
+hashes, claim mechanism, verifier outcome, on-chain release amount, and where
+the payout landed (EOA vs AAC) — uploaded as `hosted-worker-canary-<run_id>`
+and summarized in the job step summary.

--- a/scripts/ops/check-hosted-stack.sh
+++ b/scripts/ops/check-hosted-stack.sh
@@ -47,6 +47,17 @@ CHECK_SIWE_FRESH_WALLET_PROOF=${CHECK_SIWE_FRESH_WALLET_PROOF:-0}
 SIWE_FRESH_WALLET_PROOF_NODE_IMAGE=${SIWE_FRESH_WALLET_PROOF_NODE_IMAGE:-node:22-bookworm-slim}
 SIWE_FRESH_WALLET_PROOF_EVIDENCE_FILE=${SIWE_FRESH_WALLET_PROOF_EVIDENCE_FILE:-}
 SIWE_FRESH_WALLET_PRIVATE_KEY=${SIWE_FRESH_WALLET_PRIVATE_KEY:-}
+CHECK_WORKER_CANARY_PROOF=${CHECK_WORKER_CANARY_PROOF:-0}
+WORKER_CANARY_NODE_IMAGE=${WORKER_CANARY_NODE_IMAGE:-node:22-bookworm-slim}
+WORKER_CANARY_EVIDENCE_FILE=${WORKER_CANARY_EVIDENCE_FILE:-}
+WORKER_CANARY_WORKER_PRIVATE_KEY=${WORKER_CANARY_WORKER_PRIVATE_KEY:-}
+WORKER_CANARY_WORKER_KEY_OP=${WORKER_CANARY_WORKER_KEY_OP:-}
+WORKER_CANARY_PROFILE=${WORKER_CANARY_PROFILE:-}
+WORKER_CANARY_REWARD_AMOUNT=${WORKER_CANARY_REWARD_AMOUNT:-}
+WORKER_CANARY_TOKEN_MIN_DAYS=${WORKER_CANARY_TOKEN_MIN_DAYS:-}
+WORKER_CANARY_VERIFY_MODE=${WORKER_CANARY_VERIFY_MODE:-}
+WORKER_CANARY_ALLOW_EPHEMERAL=${WORKER_CANARY_ALLOW_EPHEMERAL:-}
+WORKER_CANARY_KEEP_JOB=${WORKER_CANARY_KEEP_JOB:-}
 CHECK_METRICS_AUTH=${CHECK_METRICS_AUTH:-0}
 METRICS_BEARER_TOKEN=${METRICS_BEARER_TOKEN:-}
 TIMEOUT_SEC=${TIMEOUT_SEC:-20}
@@ -123,7 +134,7 @@ enabled() {
   esac
 }
 
-if { enabled "$CHECK_PRODUCT_PROOF_GATE" || enabled "$CHECK_SERVICE_TOKEN_PROOF" || enabled "$CHECK_EXTERNAL_SCHEMA_PROOF" || enabled "$CHECK_DISPUTE_VERDICT_PROOF" || enabled "$CHECK_SIWE_FRESH_WALLET_PROOF"; } && ! command -v node >/dev/null 2>&1; then
+if { enabled "$CHECK_PRODUCT_PROOF_GATE" || enabled "$CHECK_SERVICE_TOKEN_PROOF" || enabled "$CHECK_EXTERNAL_SCHEMA_PROOF" || enabled "$CHECK_DISPUTE_VERDICT_PROOF" || enabled "$CHECK_SIWE_FRESH_WALLET_PROOF" || enabled "$CHECK_WORKER_CANARY_PROOF"; } && ! command -v node >/dev/null 2>&1; then
   require_command docker
 fi
 
@@ -618,6 +629,66 @@ if enabled "$CHECK_SIWE_FRESH_WALLET_PROOF"; then
       -e SIWE_FRESH_WALLET_PRIVATE_KEY="$SIWE_FRESH_WALLET_PRIVATE_KEY" \
       "$SIWE_FRESH_WALLET_PROOF_NODE_IMAGE" \
       node scripts/ops/check-siwe-fresh-wallet-proof.mjs
+  fi
+fi
+
+if enabled "$CHECK_WORKER_CANARY_PROOF"; then
+  # End-to-end external-worker canary: a FRESH ROLELESS wallet walks the real
+  # SIWE front door, then claim→submit→verify→settle on a disposable,
+  # operator-funded testnet job. Worker stages use the roleless token; only the
+  # operator stages (create/fund/verify/cleanup) use the ADMIN_JWT. Each stage
+  # fails loud with the launch-blocker class it guards (#625/#626/claim-409/
+  # #627/settlement/#628). Testnet-only — it refuses any other chain.
+  if [[ -z "$ADMIN_JWT" && -z "$AVERRAY_TOKEN" ]]; then
+    echo "CHECK_WORKER_CANARY_PROOF=1 requires an operator credential (ADMIN_JWT or AVERRAY_TOKEN) for the create/verify/cleanup stages." >&2
+    exit 1
+  fi
+  echo "Checking external-worker canary"
+  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  repo_root="$(cd "$script_dir/../.." && pwd)"
+  if [[ -n "$WORKER_CANARY_EVIDENCE_FILE" ]]; then
+    if [[ "$WORKER_CANARY_EVIDENCE_FILE" != /* ]]; then
+      WORKER_CANARY_EVIDENCE_FILE="$repo_root/$WORKER_CANARY_EVIDENCE_FILE"
+    fi
+    worker_canary_evidence_dir="$(dirname "$WORKER_CANARY_EVIDENCE_FILE")"
+    mkdir -p "$worker_canary_evidence_dir"
+  fi
+  if command -v node >/dev/null 2>&1; then
+    API_BASE_URL="${API_HEALTH_URL%/health}" \
+      ADMIN_JWT="$ADMIN_JWT" \
+      AVERRAY_TOKEN="$AVERRAY_TOKEN" \
+      WORKER_CANARY_EVIDENCE_FILE="$WORKER_CANARY_EVIDENCE_FILE" \
+      WORKER_CANARY_WORKER_PRIVATE_KEY="$WORKER_CANARY_WORKER_PRIVATE_KEY" \
+      WORKER_CANARY_WORKER_KEY_OP="$WORKER_CANARY_WORKER_KEY_OP" \
+      WORKER_CANARY_PROFILE="$WORKER_CANARY_PROFILE" \
+      WORKER_CANARY_REWARD_AMOUNT="$WORKER_CANARY_REWARD_AMOUNT" \
+      WORKER_CANARY_TOKEN_MIN_DAYS="$WORKER_CANARY_TOKEN_MIN_DAYS" \
+      WORKER_CANARY_VERIFY_MODE="$WORKER_CANARY_VERIFY_MODE" \
+      WORKER_CANARY_ALLOW_EPHEMERAL="$WORKER_CANARY_ALLOW_EPHEMERAL" \
+      WORKER_CANARY_KEEP_JOB="$WORKER_CANARY_KEEP_JOB" \
+      node "$script_dir/run-worker-canary.mjs"
+  else
+    worker_canary_docker_volume_args=(-v "$repo_root:/workspace")
+    if [[ -n "${worker_canary_evidence_dir:-}" ]]; then
+      worker_canary_docker_volume_args+=(-v "$worker_canary_evidence_dir:$worker_canary_evidence_dir")
+    fi
+    docker run --rm \
+      "${worker_canary_docker_volume_args[@]}" \
+      -w /workspace \
+      -e API_BASE_URL="${API_HEALTH_URL%/health}" \
+      -e ADMIN_JWT="$ADMIN_JWT" \
+      -e AVERRAY_TOKEN="$AVERRAY_TOKEN" \
+      -e WORKER_CANARY_EVIDENCE_FILE="$WORKER_CANARY_EVIDENCE_FILE" \
+      -e WORKER_CANARY_WORKER_PRIVATE_KEY="$WORKER_CANARY_WORKER_PRIVATE_KEY" \
+      -e WORKER_CANARY_WORKER_KEY_OP="$WORKER_CANARY_WORKER_KEY_OP" \
+      -e WORKER_CANARY_PROFILE="$WORKER_CANARY_PROFILE" \
+      -e WORKER_CANARY_REWARD_AMOUNT="$WORKER_CANARY_REWARD_AMOUNT" \
+      -e WORKER_CANARY_TOKEN_MIN_DAYS="$WORKER_CANARY_TOKEN_MIN_DAYS" \
+      -e WORKER_CANARY_VERIFY_MODE="$WORKER_CANARY_VERIFY_MODE" \
+      -e WORKER_CANARY_ALLOW_EPHEMERAL="$WORKER_CANARY_ALLOW_EPHEMERAL" \
+      -e WORKER_CANARY_KEEP_JOB="$WORKER_CANARY_KEEP_JOB" \
+      "$WORKER_CANARY_NODE_IMAGE" \
+      node scripts/ops/run-worker-canary.mjs
   fi
 fi
 

--- a/scripts/ops/run-worker-canary.mjs
+++ b/scripts/ops/run-worker-canary.mjs
@@ -1,0 +1,928 @@
+#!/usr/bin/env node
+//
+// End-to-end EXTERNAL-WORKER CANARY.
+//
+// Walks the REAL SIWE front door with a FRESH, ROLELESS worker wallet and
+// drives the full paid loop on a disposable, operator-funded benchmark job:
+//
+//   1. SIWE   — nonce → sign → verify → usable roleless token   (guards #625)
+//   2. Account— authed GET /account with that token, not 401     (guards #626)
+//   3. Claim  — claim the disposable job, not 409; waiver|funded  (guards claim 409 + claimJobFor)
+//   4. Submit — submit structured output, status submitted, no revert (guards #627 submitWorkFor)
+//   5. Verify — operator-triggered benchmark verify → approved    (until auto-verify lands)
+//   6. Settle — on-chain job Closed + released == reward, and the
+//               worker's balance rose by the reward — checked in BOTH
+//               usdc.balanceOf(workerEOA) AND AAC.positions(worker).liquid
+//   7. Freshness — the long-lived OPERATOR token isn't within N days
+//               of expiry                                          (guards #628 ADMIN_JWT expiry)
+//
+// WHY THIS EXISTS: the 2026-06-13 first-settled-job round-trip surfaced five
+// launch-blockers one at a time (auth mint 500, JWT sub-casing 401, claim 409,
+// submitWork revert, ADMIN_JWT expiry). Every prior hosted proof used the
+// pre-minted multi-role ADMIN_JWT and bypassed the SIWE front door, so none of
+// them could see those bugs. This canary uses a roleless wallet for the worker
+// stages (auth/claim/submit) — only the operator stages (create/fund/verify/
+// cleanup) use the ADMIN_JWT — so the whole class fails LOUD here, in CI, before
+// it reaches an external agent.
+//
+// SAFETY:
+//   - Refuses to run anywhere but Polkadot Hub TestNet (chainId 420420417).
+//     The worker stages never touch the admin JWT; the worker key is a
+//     dedicated roleless testnet wallet (op://prod-backend/canary-worker-testnet).
+//   - Posts its own disposable, UPFRONT-funded job each run and archives it in a
+//     finally block, so canary jobs never accumulate or pollute the public board
+//     and the loop never depends on the lazy ensureJob path.
+//
+// Mirrors run-hosted-worker-loop.mjs / run-dispute-verdict-proof.mjs: an
+// exported async function + a CLI entry, gated in check-hosted-stack.sh behind
+// CHECK_WORKER_CANARY_PROOF=1, exercised offline by run-worker-canary.test.mjs.
+
+import { readFileSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Contract, JsonRpcProvider, Wallet } from "ethers";
+
+import { AgentPlatformClient } from "../../sdk/agent-platform-client.js";
+import { DEFAULT_ESCROW_ASSET } from "../../mcp-server/src/core/assets.js";
+import { AGENT_ACCOUNT_ABI, ESCROW_CORE_ABI } from "../../mcp-server/src/blockchain/abis.js";
+import { resolveHostedWorkerLoopAuth } from "./run-hosted-worker-loop.mjs";
+import { readOpSecret } from "./get-admin-refresh-token.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..", "..");
+
+const DEFAULT_API_BASE_URL = "https://api.averray.com";
+const DEFAULT_PROFILE = "testnet";
+// The ONLY chain this canary is allowed to drive. Polkadot Hub (Asset Hub
+// Paseo) TestNet. A mainnet manifest or RPC must fail-closed here.
+const EXPECTED_TESTNET_CHAIN_ID = 420420417n;
+const DEFAULT_REWARD_AMOUNT = "0.1"; // 100_000 base units > USDC minBalance 70_000
+const DEFAULT_TOKEN_MIN_DAYS = 7;
+const DEFAULT_SETTLE_TIMEOUT_MS = 180_000;
+const DEFAULT_SETTLE_POLL_MS = 5_000;
+const DEFAULT_WORKER_KEY_OP = "op://prod-backend/canary-worker-testnet/private key";
+const OUTPUT_SCHEMA_REF = "schema://jobs/product-proof-worker-loop";
+const VERIFIER_TERMS = ["complete", "verified", "output"];
+const ERC20_BALANCE_ABI = ["function balanceOf(address) view returns (uint256)"];
+
+// Operator capabilities the canary depends on. If the ADMIN_JWT loses any of
+// these (mis-minted, wrong roles), fail loud BEFORE creating a stranded job.
+const REQUIRED_OPERATOR_CAPABILITIES = ["jobs:create", "jobs:lifecycle", "verifier:run", "admin:status"];
+
+export async function runWorkerCanary({
+  env = process.env,
+  workerClient = undefined, // injected (tests): authed worker client (skips real SIWE mint)
+  operatorClient = undefined, // injected (tests)
+  operatorAuth: injectedOperatorAuth = undefined, // injected (tests): { mode, token }
+  chainReader = undefined, // injected (tests): { getChainId, snapshotWorker, readEscrowJob }
+  fetchImpl = globalThis.fetch,
+  wallet: injectedWallet = undefined,
+  resolveOperatorAuth = resolveHostedWorkerLoopAuth,
+  readSecretImpl = readOpSecret,
+  now = () => Date.now(),
+  log = console.log
+} = {}) {
+  const config = parseConfig(env);
+  const startedAt = now();
+  const timings = {};
+  const stages = {};
+  const txHashes = {};
+  let createdJobId = null;
+  let archived = false;
+  let operatorPlatform = operatorClient ?? null;
+
+  const stage = async (name, fn) => {
+    const t0 = now();
+    try {
+      return await fn();
+    } finally {
+      timings[name] = now() - t0;
+    }
+  };
+
+  try {
+    // ── operator auth (NEVER the worker identity) ─────────────────────────
+    const operatorAuth =
+      injectedOperatorAuth ??
+      (operatorClient
+        ? { mode: "injected_client", source: "client", token: config.injectedOperatorToken }
+        : await resolveOperatorAuth({
+            env: { ...env, API_BASE_URL: config.apiBaseUrl },
+            apiBaseUrl: config.apiBaseUrl,
+            fetchImpl,
+            readSecretImpl
+          }));
+    log(`Worker canary against ${config.apiBaseUrl} (operator auth: ${operatorAuth.mode})`);
+    operatorPlatform =
+      operatorClient ?? new AgentPlatformClient({ baseUrl: config.apiBaseUrl, token: operatorAuth.token, fetchImpl });
+
+    // ── chain-env gate: refuse anything that is not testnet ───────────────
+    const reader = chainReader ?? buildChainReader(config);
+    const chainId = await reader.getChainId();
+    assertTestnet({ chainId, profile: config.profile });
+
+    // ── operator readiness: capabilities + settlement, BEFORE creating a job
+    await stage("operatorReadiness", () => assertOperatorReady(operatorPlatform));
+
+    // ── worker identity: a fresh, roleless wallet — NOT the admin JWT ─────
+    const wallet = injectedWallet ?? (await resolveWorkerWallet({ env, config, readSecretImpl, log }));
+    const workerAddress = wallet.address;
+    log(`Worker wallet: ${workerAddress} (roleless${config.workerEphemeral ? ", ephemeral" : ""})`);
+
+    // ── create the disposable, UPFRONT-funded benchmark job ───────────────
+    const jobId = config.jobId || `worker-canary-${startedAt}`;
+    createdJobId = jobId;
+    await stage("createJob", async () => {
+      log(`Creating disposable canary job ${jobId} (reward ${config.rewardAmount} USDC, funded upfront)`);
+      const created = await operatorPlatform.createJob(buildCanaryJob({ jobId, rewardAmount: config.rewardAmount }));
+      if (created?.id !== jobId) {
+        throw new Error(`created canary job id mismatch: expected ${jobId}, got ${created?.id ?? "missing"}`);
+      }
+    });
+
+    // ── snapshot worker on-chain balances BEFORE the payout ───────────────
+    const before = await reader.snapshotWorker(workerAddress);
+
+    // ── STAGE 1: SIWE front door (guards #625 roleless-mint 500) ──────────
+    let authedWorker;
+    if (workerClient) {
+      // Tests inject an already-authed worker client and skip the live mint.
+      stages.siwe = { mode: "injected", roleless: true };
+      authedWorker = workerClient;
+    } else {
+      const siwe = await stage("siwe", () => runSiweStage({ apiBaseUrl: config.apiBaseUrl, wallet, fetchImpl }));
+      stages.siwe = siwe.summary;
+      authedWorker = new AgentPlatformClient({ baseUrl: config.apiBaseUrl, token: siwe.token, fetchImpl });
+    }
+
+    // ── STAGE 2: authed read (guards #626 JWT sub-casing 401) ─────────────
+    stages.account = await stage("account", () => runAccountStage({ authedWorker, workerAddress }));
+
+    // ── STAGE 3: claim (guards claim 409 + claimJobFor brokering) ─────────
+    const claim = await stage("claim", () =>
+      runClaimStage({ authedWorker, jobId, workerAddress, idempotencyKey: `worker-canary:${jobId}`, before })
+    );
+    stages.claim = claim.summary;
+    const sessionId = claim.sessionId;
+    captureTxHash(txHashes, "claim", claim.raw);
+
+    // ── STAGE 4: submit (guards #627 submitWorkFor revert) ────────────────
+    const submit = await stage("submit", () =>
+      runSubmitStage({ authedWorker, sessionId, jobId, timestamp: startedAt })
+    );
+    stages.submit = submit.summary;
+    captureTxHash(txHashes, "submit", submit.raw);
+
+    // chainJobId comes from the worker's own session record
+    const chainJobId = await resolveChainJobId({ authedWorker, sessionId, claim, submit });
+
+    // ── STAGE 5: verify (operator path until auto-verify lands) ───────────
+    const verify = await stage("verify", () =>
+      runVerifyStage({ operatorPlatform, authedWorker, sessionId, mode: config.verifyMode })
+    );
+    stages.verify = verify.summary;
+    captureTxHash(txHashes, "verify", verify.raw);
+
+    // ── wait for settlement to land, then STAGE 6 assertions ──────────────
+    const settle = await stage("settle", () =>
+      runSettleStage({
+        reader,
+        authedWorker,
+        sessionId,
+        chainJobId,
+        workerAddress,
+        before,
+        rewardRaw: config.rewardRaw,
+        settleTimeoutMs: config.settleTimeoutMs,
+        settlePollMs: config.settlePollMs,
+        now,
+        log
+      })
+    );
+    stages.settle = settle.summary;
+
+    // ── STAGE 7: operator token freshness (guards #628 ADMIN_JWT expiry) ──
+    // Run last: let the loop prove itself, then flag an about-to-expire
+    // long-lived operator credential before it silently 401s every smoke.
+    stages.tokenFreshness = assertOperatorTokenFreshness({ operatorAuth, minDays: config.tokenMinDays, now });
+
+    const evidence = {
+      proof: "worker-canary",
+      apiBaseUrl: config.apiBaseUrl,
+      profile: config.profile,
+      chainId: chainId.toString(),
+      workerWallet: workerAddress,
+      workerEphemeral: config.workerEphemeral,
+      operatorAuthMode: operatorAuth.mode,
+      jobId,
+      sessionId,
+      chainJobId,
+      reward: { amount: config.rewardAmount, raw: config.rewardRaw.toString(), asset: DEFAULT_ESCROW_ASSET.symbol },
+      stages,
+      txHashes,
+      timings: { ...timings, totalMs: now() - startedAt },
+      cleanup: { jobArchived: false, jobKept: false },
+      checkedAt: new Date(startedAt).toISOString()
+    };
+
+    // Archive the disposable job so canary jobs never accumulate (unless the
+    // operator asked to keep it). Either way, cleanup is handled — suppress the
+    // finally retry.
+    const didArchive = await archiveCanaryJob({ operatorPlatform, jobId, config, log });
+    archived = true;
+    evidence.cleanup.jobArchived = didArchive;
+    evidence.cleanup.jobKept = !didArchive;
+    createdJobId = null;
+
+    if (config.evidenceFile) {
+      await mkdir(dirname(config.evidenceFile), { recursive: true });
+      await writeFile(config.evidenceFile, `${JSON.stringify(evidence, null, 2)}\n`, "utf8");
+      log(`Wrote worker-canary evidence to ${config.evidenceFile}`);
+    }
+
+    log(
+      `Worker canary PASSED — roleless ${workerAddress} walked SIWE→claim→submit→verify→settle; ` +
+        `released ${settle.summary.released} ${DEFAULT_ESCROW_ASSET.symbol}, ` +
+        `worker credited ${settle.summary.creditedRaw} base units.`
+    );
+    return evidence;
+  } finally {
+    // Best-effort cleanup if we created a job but bailed before archiving it.
+    if (createdJobId && !archived) {
+      try {
+        await archiveCanaryJob({ operatorPlatform, jobId: createdJobId, config, log });
+        log(`Archived stranded canary job ${createdJobId} during cleanup.`);
+      } catch (cleanupError) {
+        log(`WARNING: failed to archive canary job ${createdJobId}: ${cleanupError?.message ?? cleanupError}`);
+      }
+    }
+  }
+}
+
+// ── STAGE 1: SIWE ───────────────────────────────────────────────────────────
+export async function runSiweStage({
+  apiBaseUrl,
+  wallet,
+  fetchImpl,
+  anonClient = new AgentPlatformClient({ baseUrl: apiBaseUrl, token: undefined, fetchImpl })
+}) {
+  const anon = anonClient;
+
+  const nonce = await anon.issueNonce(wallet.address);
+  const message = nonce?.message;
+  if (typeof message !== "string" || message.length === 0) {
+    throw new Error("SIWE stage: /auth/nonce did not return a non-empty SIWE message.");
+  }
+
+  const signature = await wallet.signMessage(message);
+
+  let verify;
+  try {
+    verify = await anon.verifySignature(message, signature);
+  } catch (error) {
+    if (error?.status === 500) {
+      throw new Error(
+        `SIWE stage FAILED at /auth/verify with HTTP 500 (${describeApiError(error)}). ` +
+          "This is the roleless-wallet SIWE→JWT mint regression (#625): the ES256 sign path " +
+          "rejected a roleless worker token. EVERY external agent is locked out at the front door."
+      );
+    }
+    if (error?.status === 401) {
+      throw new Error(
+        `SIWE stage FAILED at /auth/verify with HTTP 401 (${describeApiError(error)}). ` +
+          "The freshly-signed SIWE signature was rejected — the front door is broken for new wallets."
+      );
+    }
+    throw error;
+  }
+
+  const token = verify?.token;
+  if (typeof token !== "string" || token.split(".").length !== 3) {
+    throw new Error("SIWE stage: /auth/verify did not return a JWT bearer token.");
+  }
+  const roles = Array.isArray(verify?.roles) ? verify.roles : [];
+  if (roles.length !== 0) {
+    throw new Error(
+      `SIWE stage: canary worker must be ROLELESS, but /auth/verify returned roles ${JSON.stringify(roles)}. ` +
+        "Use a dedicated roleless wallet — never the admin/verifier identity."
+    );
+  }
+  return {
+    token,
+    summary: { mode: "live", status: 200, roleless: true, expiresAt: verify?.expiresAt ?? null }
+  };
+}
+
+// ── STAGE 2: authed read ────────────────────────────────────────────────────
+export async function runAccountStage({ authedWorker, workerAddress }) {
+  let account;
+  try {
+    account = await authedWorker.getAccountSummary();
+  } catch (error) {
+    if (error?.status === 401) {
+      const code = error?.payload?.error ?? error?.payload?.code ?? "";
+      throw new Error(
+        `Account stage FAILED: GET /account returned HTTP 401 (${describeApiError(error)}). ` +
+          (String(code).includes("claims_mismatch") || code === ""
+            ? "This is the JWT sub-casing regression (#626): the SIWE-minted token's `sub` does not pass " +
+              "the verifier's own check (checksummed vs lowercase). The worker's freshly-minted token is unusable."
+            : "The worker's freshly-minted token was rejected on a base, non-role-gated route.")
+      );
+    }
+    throw error;
+  }
+  if (account?.wallet && account.wallet.toLowerCase() !== workerAddress.toLowerCase()) {
+    throw new Error(
+      `Account stage: /account wallet ${account.wallet} does not match the SIWE worker ${workerAddress}.`
+    );
+  }
+  return { status: 200, wallet: account?.wallet ?? workerAddress };
+}
+
+// ── STAGE 3: claim ──────────────────────────────────────────────────────────
+export async function runClaimStage({ authedWorker, jobId, workerAddress, idempotencyKey, before }) {
+  const preflight = await authedWorker.preflightJob(jobId);
+  if (!preflight || preflight.jobId !== jobId) {
+    throw new Error(`Claim stage: /jobs/preflight job id mismatch: expected ${jobId}, got ${preflight?.jobId ?? "missing"}.`);
+  }
+  if (preflight.eligible !== true || preflight.claimable !== true || preflight.currentWalletCanClaim === false) {
+    throw new Error(
+      `Claim stage: preflight says the worker cannot claim — eligible=${String(preflight.eligible)}; ` +
+        `claimable=${String(preflight.claimable)}; currentWalletCanClaim=${String(preflight.currentWalletCanClaim)}; ` +
+        `reason=${preflight.reason ?? "none"}. A funded, claimable canary job should always be claimable by a fresh worker.`
+    );
+  }
+
+  // The claim must be payable: EITHER the fresh-wallet onboarding waiver still
+  // applies, OR the worker is pre-funded enough to cover the claim lock. If
+  // neither holds, the claim would 409 insufficient_liquidity — the exact bug.
+  const waived = preflight.claimEconomicsWaived === true;
+  const totalClaimLock = preflight.totalClaimLock ?? null;
+  const lockRaw = totalClaimLock === null ? 0n : toBaseUnits(totalClaimLock);
+  let mechanism;
+  if (waived || lockRaw === 0n) {
+    mechanism = "onboarding_waiver";
+  } else {
+    // Pre-funded path: the worker's liquid position must cover the lock. This
+    // is operator-assisted today (the operator tops the worker up out of band);
+    // it becomes a no-op once auto-fund lands.
+    const liquid = before.aacLiquidRaw;
+    if (liquid < lockRaw) {
+      throw new Error(
+        `Claim stage WOULD 409 (insufficient_liquidity): the fresh-wallet onboarding waiver is exhausted ` +
+          `(claimEconomicsWaived=false) and the worker is underfunded — totalClaimLock=${lockRaw} base units, ` +
+          `worker AAC liquid=${liquid} base units. Pre-fund the canary worker's AgentAccountCore position with ` +
+          `≥ the claim lock, or rotate to a wallet still within its onboarding waiver. ` +
+          "(Guards the claim-funding 409 class + claimJobFor brokering.)"
+      );
+    }
+    mechanism = "prefunded";
+  }
+
+  let claim;
+  try {
+    claim = await authedWorker.claimJob(jobId, idempotencyKey);
+  } catch (error) {
+    if (error?.status === 409) {
+      throw new Error(
+        `Claim stage FAILED: /jobs/claim returned HTTP 409 (${describeApiError(error)}). ` +
+          "This is the claim-funding 409 class: the brokered on-chain claimJobFor could not lock the claim " +
+          "(backend signer underfunded, or stake/fee not waived for this worker). " +
+          `mechanism=${mechanism}; totalClaimLock=${lockRaw}.`
+      );
+    }
+    throw error;
+  }
+  const sessionId = claim?.sessionId;
+  if (!sessionId) {
+    throw new Error(`Claim stage: /jobs/claim succeeded but returned no sessionId (${JSON.stringify(claim)}).`);
+  }
+  return {
+    sessionId,
+    raw: claim,
+    summary: {
+      status: claim.status ?? "claimed",
+      sessionId,
+      mechanism,
+      claimEconomicsWaived: waived,
+      totalClaimLockRaw: lockRaw.toString()
+    }
+  };
+}
+
+// ── STAGE 4: submit ─────────────────────────────────────────────────────────
+export async function runSubmitStage({ authedWorker, sessionId, jobId, timestamp }) {
+  const submission = buildCanarySubmission({ jobId, timestamp });
+  let submit;
+  try {
+    submit = await authedWorker.submitWork(sessionId, submission);
+  } catch (error) {
+    if (isBlockchainRevert(error)) {
+      throw new Error(
+        `Submit stage FAILED: /jobs/submit reverted on-chain (${describeApiError(error)}). ` +
+          "This is the submitWork revert class (#627): the operator-brokered submitWorkFor path is missing or broken. " +
+          "Re-check the EscrowCore redeploy and that the backend signer is a registered service operator."
+      );
+    }
+    throw error;
+  }
+  if (submit?.status !== "submitted") {
+    throw new Error(
+      `Submit stage: expected status "submitted", got "${submit?.status ?? "missing"}" (${JSON.stringify(submit)}).`
+    );
+  }
+  // A 200 with an embedded revert/local-only chain status is still a failure.
+  const chainStatus = submit?.chainStatus ?? submit?.verification?.chainStatus;
+  if (chainStatus === "reverted" || submit?.blockchain_revert === true) {
+    throw new Error(
+      `Submit stage FAILED: /jobs/submit returned status=submitted but chainStatus=${chainStatus}. ` +
+        "The brokered submitWorkFor did not land on-chain (#627 class)."
+    );
+  }
+  return { raw: submit, summary: { status: submit.status, chainStatus: chainStatus ?? null } };
+}
+
+// ── STAGE 5: verify ─────────────────────────────────────────────────────────
+export async function runVerifyStage({ operatorPlatform, authedWorker, sessionId, mode }) {
+  // mode "auto" lets the canary become a no-op verifier once a scheduler
+  // auto-verifies submitted benchmark jobs: it polls the public result instead
+  // of operator-triggering. Default "operator" triggers the verify itself.
+  if (mode === "auto") {
+    const result = await authedWorker.getVerifierResult(sessionId);
+    const outcome = result?.outcome ?? result?.verification?.status;
+    if (outcome !== "approved" && outcome !== "passed") {
+      throw new Error(
+        `Verify stage (auto): expected an "approved" auto-verification, got "${outcome ?? "missing"}". ` +
+          "Auto-verify has not approved this submission."
+      );
+    }
+    return { raw: result, summary: { mode: "auto", outcome: "approved", reasonCode: result?.reasonCode ?? null } };
+  }
+
+  const verification = await operatorPlatform.runVerifier(sessionId);
+  const outcome = verification?.outcome ?? verification?.status;
+  if (outcome !== "approved") {
+    throw new Error(
+      `Verify stage FAILED: operator /verifier/run returned outcome "${outcome ?? "missing"}", expected "approved". ` +
+        `reasonCode=${verification?.reasonCode ?? "none"}.`
+    );
+  }
+  return {
+    raw: verification,
+    summary: { mode: "operator", outcome, reasonCode: verification?.reasonCode ?? null }
+  };
+}
+
+// ── STAGE 6: settle ─────────────────────────────────────────────────────────
+export async function runSettleStage({
+  reader,
+  authedWorker,
+  sessionId,
+  chainJobId,
+  workerAddress,
+  before,
+  rewardRaw,
+  settleTimeoutMs,
+  settlePollMs,
+  now,
+  log
+}) {
+  // Wait until either the session resolves or the chain job closes.
+  const deadline = now() + settleTimeoutMs;
+  let job = await reader.readEscrowJob(chainJobId);
+  let session = await safeGetSession(authedWorker, sessionId);
+  while (Number(job.state) !== JOB_STATE.Closed && session?.status !== "resolved" && now() < deadline) {
+    await sleep(settlePollMs);
+    job = await reader.readEscrowJob(chainJobId);
+    session = await safeGetSession(authedWorker, sessionId);
+    log(`Settling… session=${session?.status ?? "?"} jobState=${jobStateName(job.state)}`);
+  }
+
+  if (Number(job.state) !== JOB_STATE.Closed) {
+    throw new Error(
+      `Settle stage FAILED: EscrowCore job ${chainJobId} is "${jobStateName(job.state)}", not "Closed", after ` +
+        `${Math.round(settleTimeoutMs / 1000)}s. The verified job never settled on-chain ` +
+        "(verification approved but no release / payout). This is the settlement-stall class."
+    );
+  }
+  if (job.releasedRaw !== rewardRaw) {
+    throw new Error(
+      `Settle stage FAILED: EscrowCore released ${job.releasedRaw} base units but reward was ${rewardRaw}. ` +
+        "Released amount must equal the full reward on a benchmark approval."
+    );
+  }
+  if (job.worker && job.worker.toLowerCase() !== workerAddress.toLowerCase()) {
+    throw new Error(
+      `Settle stage: EscrowCore job worker ${job.worker} does not match the canary worker ${workerAddress}.`
+    );
+  }
+
+  // Where did the money actually land? This run's payout credits the EOA; a
+  // future settle-into-position would credit AAC.liquid. Check BOTH and require
+  // the reward to show up in one of them — so the canary stays green across the
+  // P1 "earnings → spendable-balance" reconciliation either way.
+  const after = await reader.snapshotWorker(workerAddress);
+  const eoaDelta = after.usdcRaw - before.usdcRaw;
+  const aacLiquidDelta = after.aacLiquidRaw - before.aacLiquidRaw;
+  const creditedRaw = eoaDelta + aacLiquidDelta;
+  if (creditedRaw < rewardRaw) {
+    throw new Error(
+      `Settle stage FAILED: job Closed and released ${rewardRaw} base units, but the worker's balance did not rise ` +
+        `by the reward. usdc.balanceOf delta=${eoaDelta}; AAC.positions.liquid delta=${aacLiquidDelta}; ` +
+        `total credited=${creditedRaw}; expected ≥ ${rewardRaw}. The reward settled but never reached the worker.`
+    );
+  }
+
+  return {
+    summary: {
+      jobState: "Closed",
+      released: formatBaseUnits(job.releasedRaw),
+      releasedRaw: job.releasedRaw.toString(),
+      sessionStatus: session?.status ?? null,
+      eoaDeltaRaw: eoaDelta.toString(),
+      aacLiquidDeltaRaw: aacLiquidDelta.toString(),
+      creditedRaw: creditedRaw.toString(),
+      creditedTo: eoaDelta >= rewardRaw ? "worker_eoa" : aacLiquidDelta >= rewardRaw ? "aac_liquid" : "split"
+    }
+  };
+}
+
+// ── STAGE 7: operator token freshness ────────────────────────────────────────
+export function assertOperatorTokenFreshness({ operatorAuth, minDays, now }) {
+  const mode = operatorAuth?.mode ?? "unknown";
+  const token = operatorAuth?.token;
+  const exp = token ? decodeJwtExpSeconds(token) : null;
+  const nowMs = now();
+  const daysToExpiry = exp === null ? null : (exp * 1000 - nowMs) / 86_400_000;
+
+  // Short-lived, self-rotating operator tokens (the refresh flow, #529) don't
+  // belong to the ADMIN_JWT-calendar-expiry class — they're minted per run and
+  // rotated automatically. The days-from-expiry guard is N/A for them, so it
+  // becomes a no-op once the refresh flow lands.
+  const longLived = mode === "legacy_admin_jwt";
+  if (!longLived) {
+    return {
+      mode,
+      enforced: false,
+      reason: "operator token is short-lived/self-rotating; expiry-class guard N/A",
+      expiresAt: exp === null ? null : new Date(exp * 1000).toISOString(),
+      daysToExpiry: daysToExpiry === null ? null : round1(daysToExpiry)
+    };
+  }
+
+  if (exp === null) {
+    throw new Error(
+      "Token-freshness stage FAILED: the long-lived operator ADMIN_JWT has no `exp` claim, so its calendar expiry " +
+        "cannot be guarded. This is the ADMIN_JWT-expiry class (#628) — mint a token with a bounded expiry."
+    );
+  }
+  if (daysToExpiry < minDays) {
+    throw new Error(
+      `Token-freshness stage FAILED: the operator ADMIN_JWT expires in ${round1(daysToExpiry)} day(s) ` +
+        `(< ${minDays}-day threshold), at ${new Date(exp * 1000).toISOString()}. ` +
+        "Rotate it now — once it expires, every hosted smoke/proof silently 401s. (Guards #628.)"
+    );
+  }
+  return {
+    mode,
+    enforced: true,
+    thresholdDays: minDays,
+    expiresAt: new Date(exp * 1000).toISOString(),
+    daysToExpiry: round1(daysToExpiry)
+  };
+}
+
+// ── operator readiness ───────────────────────────────────────────────────────
+async function assertOperatorReady(operatorPlatform) {
+  const authSession = await operatorPlatform.getAuthSession();
+  const capabilities = Array.isArray(authSession?.capabilities) ? authSession.capabilities : [];
+  const missing = REQUIRED_OPERATOR_CAPABILITIES.filter((cap) => !capabilities.includes(cap));
+  if (missing.length > 0) {
+    throw new Error(
+      `Operator readiness FAILED: the operator token is missing capabilities [${missing.join(", ")}]. ` +
+        "The canary needs an admin+verifier token to create, verify, and archive the disposable job. " +
+        `roles=${(authSession?.roles ?? []).join(",") || "none"}.`
+    );
+  }
+
+  const status = await operatorPlatform.getAdminStatus();
+  const policy = status?.maintenance?.policy;
+  if (!policy?.enabled || policy.settlementReady !== true) {
+    throw new Error(
+      "Operator readiness FAILED: on-chain settlement is not ready (/admin/status). " +
+        `enabled=${String(policy?.enabled)}; settlementReady=${String(policy?.settlementReady)}. ` +
+        "Brokered claim/submit/settle cannot complete."
+    );
+  }
+  if (policy.roles?.escrowIsServiceOperator !== true) {
+    throw new Error(
+      "Operator readiness FAILED: the backend signer is not a registered EscrowCore service operator, so the " +
+        "brokered claimJobFor/submitWorkFor path is disabled. (This is what #627 + the EscrowCore redeploy fixed.)"
+    );
+  }
+  return {
+    capabilities: REQUIRED_OPERATOR_CAPABILITIES,
+    settlementReady: true,
+    escrowIsServiceOperator: true
+  };
+}
+
+// ── disposable job + submission shape ─────────────────────────────────────────
+function buildCanaryJob({ jobId, rewardAmount }) {
+  return {
+    id: jobId,
+    title: "External-worker CI canary (disposable, proof-only)",
+    category: "coding",
+    tier: "starter",
+    rewardAsset: DEFAULT_ESCROW_ASSET.symbol,
+    rewardAmount: Number(rewardAmount),
+    verifierMode: "benchmark",
+    verifierTerms: VERIFIER_TERMS,
+    verifierMinimumMatches: 2,
+    requiresSponsoredGas: true,
+    claimTtlSeconds: 3600,
+    retryLimit: 1,
+    outputSchemaRef: OUTPUT_SCHEMA_REF
+  };
+}
+
+function buildCanarySubmission({ jobId, timestamp }) {
+  const completedAt = new Date(timestamp).toISOString();
+  const evidence = `complete verified output for ${jobId}`;
+  return {
+    summary: evidence,
+    output: evidence,
+    status: "complete",
+    job_id: jobId,
+    completed_at: completedAt,
+    checks: [
+      { name: "worker_output", status: "pass", evidence },
+      { name: "schema_contract", status: "pass", evidence: `Submission targets ${OUTPUT_SCHEMA_REF}.` }
+    ]
+  };
+}
+
+async function archiveCanaryJob({ operatorPlatform, jobId, config, log }) {
+  if (config.keepJob) {
+    log(`WORKER_CANARY_KEEP_JOB set — leaving canary job ${jobId} live (no archive).`);
+    return false;
+  }
+  await operatorPlatform.request("/admin/jobs/lifecycle", {
+    method: "POST",
+    body: { jobId, action: "archive", reason: "worker-canary cleanup" }
+  });
+  return true;
+}
+
+// ── chain reader (ethers) ─────────────────────────────────────────────────────
+function buildChainReader(config) {
+  const provider = new JsonRpcProvider(config.rpcUrl);
+  const usdc = new Contract(config.assetAddress, ERC20_BALANCE_ABI, provider);
+  const aac = new Contract(config.agentAccountAddress, AGENT_ACCOUNT_ABI, provider);
+  const escrow = new Contract(config.escrowAddress, ESCROW_CORE_ABI, provider);
+  return {
+    async getChainId() {
+      const network = await provider.getNetwork();
+      return network.chainId;
+    },
+    async snapshotWorker(workerAddress) {
+      const [usdcRaw, position] = await Promise.all([
+        usdc.balanceOf(workerAddress),
+        aac.positions(workerAddress, config.assetAddress)
+      ]);
+      return { usdcRaw: BigInt(usdcRaw), aacLiquidRaw: BigInt(position.liquid ?? position[0]) };
+    },
+    async readEscrowJob(chainJobId) {
+      const job = await escrow.jobs(chainJobId);
+      return {
+        state: Number(job.state),
+        releasedRaw: BigInt(job.released),
+        rewardRaw: BigInt(job.reward),
+        worker: job.worker
+      };
+    }
+  };
+}
+
+// ── config + helpers ──────────────────────────────────────────────────────────
+function parseConfig(env) {
+  const apiBaseUrl = stripTrailingSlash(pick(env.API_BASE_URL) || DEFAULT_API_BASE_URL);
+  const profile = pick(env.WORKER_CANARY_PROFILE) || DEFAULT_PROFILE;
+  const deployment = loadDeployment(profile);
+  const rewardAmount = pick(env.WORKER_CANARY_REWARD_AMOUNT) || DEFAULT_REWARD_AMOUNT;
+  if (!/^(?:0|[1-9]\d*)(?:\.\d+)?$/u.test(rewardAmount) || Number(rewardAmount) <= 0) {
+    throw new Error(`WORKER_CANARY_REWARD_AMOUNT must be a positive decimal; got ${JSON.stringify(rewardAmount)}.`);
+  }
+  return {
+    apiBaseUrl,
+    profile,
+    rpcUrl: pick(env.WORKER_CANARY_RPC_URL) || deployment.rpcUrl,
+    assetAddress: DEFAULT_ESCROW_ASSET.address,
+    agentAccountAddress: deployment.contracts.agentAccountCore,
+    escrowAddress: deployment.contracts.escrowCore,
+    rewardAmount,
+    rewardRaw: toBaseUnits(rewardAmount),
+    tokenMinDays: parsePositiveInt(env.WORKER_CANARY_TOKEN_MIN_DAYS, DEFAULT_TOKEN_MIN_DAYS),
+    settleTimeoutMs: parsePositiveInt(env.WORKER_CANARY_SETTLE_TIMEOUT_MS, DEFAULT_SETTLE_TIMEOUT_MS),
+    settlePollMs: parsePositiveInt(env.WORKER_CANARY_SETTLE_POLL_MS, DEFAULT_SETTLE_POLL_MS),
+    jobId: pick(env.WORKER_CANARY_JOB_ID),
+    verifyMode: pick(env.WORKER_CANARY_VERIFY_MODE) === "auto" ? "auto" : "operator",
+    keepJob: enabled(env.WORKER_CANARY_KEEP_JOB),
+    evidenceFile: pick(env.WORKER_CANARY_EVIDENCE_FILE),
+    workerEphemeral: false, // set during wallet resolution
+    injectedOperatorToken: pick(env.WORKER_CANARY_OPERATOR_TOKEN) || undefined
+  };
+}
+
+function loadDeployment(profile) {
+  if (profile !== DEFAULT_PROFILE) {
+    // Hard fail-closed: the canary is a TESTNET-only instrument. A non-testnet
+    // profile must never be loaded, even before we read the live chainId.
+    throw new Error(
+      `Worker canary refuses to run with profile "${profile}". This canary is testnet-only ` +
+        `(${DEFAULT_PROFILE}); it must never drive a paid loop against mainnet.`
+    );
+  }
+  const file = resolve(repoRoot, "deployments", `${profile}.json`);
+  const deployment = JSON.parse(readFileSync(file, "utf8"));
+  if (deployment.profile !== DEFAULT_PROFILE) {
+    throw new Error(`deployments/${profile}.json declares profile "${deployment.profile}", expected "${DEFAULT_PROFILE}".`);
+  }
+  if (!deployment.rpcUrl || !deployment.contracts?.escrowCore || !deployment.contracts?.agentAccountCore) {
+    throw new Error(`deployments/${profile}.json is missing rpcUrl / escrowCore / agentAccountCore.`);
+  }
+  return deployment;
+}
+
+function assertTestnet({ chainId, profile }) {
+  if (profile !== DEFAULT_PROFILE) {
+    throw new Error(`Worker canary chain-env gate: profile "${profile}" is not "${DEFAULT_PROFILE}".`);
+  }
+  if (BigInt(chainId) !== EXPECTED_TESTNET_CHAIN_ID) {
+    throw new Error(
+      `Worker canary chain-env gate: live chainId ${chainId} is not Polkadot Hub TestNet ` +
+        `(${EXPECTED_TESTNET_CHAIN_ID}). Refusing to run — this canary must never touch mainnet.`
+    );
+  }
+}
+
+async function resolveWorkerWallet({ env, config, readSecretImpl, log }) {
+  const explicit = pick(env.WORKER_CANARY_WORKER_PRIVATE_KEY);
+  if (explicit) {
+    return new Wallet(explicit);
+  }
+  const opRef = pick(env.WORKER_CANARY_WORKER_KEY_OP) || DEFAULT_WORKER_KEY_OP;
+  try {
+    const key = (await readSecretImpl(opRef)).trim();
+    if (key) {
+      return new Wallet(key);
+    }
+  } catch (error) {
+    if (!enabled(env.WORKER_CANARY_ALLOW_EPHEMERAL)) {
+      throw new Error(
+        `Could not read the canary worker key from ${opRef} (${error?.message ?? error}). ` +
+          "Provision it (rotate-admin-generate-key.mjs --out ... then store the private key there), " +
+          "set WORKER_CANARY_WORKER_PRIVATE_KEY, or set WORKER_CANARY_ALLOW_EPHEMERAL=1 for local dev."
+      );
+    }
+  }
+  if (enabled(env.WORKER_CANARY_ALLOW_EPHEMERAL)) {
+    log("WORKER_CANARY_ALLOW_EPHEMERAL set — using a throwaway random worker wallet (local dev only).");
+    config.workerEphemeral = true;
+    return Wallet.createRandom();
+  }
+  throw new Error(
+    `No canary worker key available. Set WORKER_CANARY_WORKER_PRIVATE_KEY, provision ${opRef}, ` +
+      "or set WORKER_CANARY_ALLOW_EPHEMERAL=1 for local dev."
+  );
+}
+
+async function resolveChainJobId({ authedWorker, sessionId, claim, submit }) {
+  const direct = claim?.chainJobId ?? submit?.chainJobId;
+  if (typeof direct === "string" && /^0x[a-fA-F0-9]{64}$/u.test(direct)) {
+    return direct;
+  }
+  const session = await safeGetSession(authedWorker, sessionId);
+  const chainJobId = session?.chainJobId;
+  if (typeof chainJobId !== "string" || !/^0x[a-fA-F0-9]{64}$/u.test(chainJobId)) {
+    throw new Error(
+      `Could not resolve a chainJobId for session ${sessionId} — needed to read on-chain settlement state. ` +
+        `got ${chainJobId ?? "missing"}.`
+    );
+  }
+  return chainJobId;
+}
+
+async function safeGetSession(authedWorker, sessionId) {
+  try {
+    return await authedWorker.getSession(sessionId);
+  } catch {
+    return undefined;
+  }
+}
+
+function captureTxHash(txHashes, stage, raw) {
+  const candidate = raw?.txHash ?? raw?.transactionHash ?? raw?.verification?.txHash;
+  if (typeof candidate === "string" && /^0x[a-fA-F0-9]{64}$/u.test(candidate)) {
+    txHashes[stage] = candidate;
+  }
+}
+
+function isBlockchainRevert(error) {
+  if (!error) return false;
+  const code = String(error?.payload?.error ?? error?.payload?.code ?? "").toLowerCase();
+  const message = String(error?.payload?.message ?? error?.message ?? "").toLowerCase();
+  if (error.status === 500 && (code.includes("revert") || message.includes("revert"))) return true;
+  return code.includes("blockchain_revert") || message.includes("execution reverted");
+}
+
+const JOB_STATE = { None: 0, Open: 1, Claimed: 2, Submitted: 3, Rejected: 4, Disputed: 5, Closed: 6 };
+function jobStateName(state) {
+  const n = Number(state);
+  return Object.keys(JOB_STATE).find((k) => JOB_STATE[k] === n) ?? `Unknown(${state})`;
+}
+
+function decodeJwtExpSeconds(token) {
+  const parts = String(token).split(".");
+  if (parts.length !== 3) return null;
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8"));
+    return Number.isFinite(payload?.exp) ? Number(payload.exp) : null;
+  } catch {
+    return null;
+  }
+}
+
+// USDC has 6 decimals (DEFAULT_ESCROW_ASSET.decimals). Decimal-string → base units.
+function toBaseUnits(amount) {
+  const decimals = DEFAULT_ESCROW_ASSET.decimals;
+  const normalized = String(amount).trim();
+  if (!/^(?:0|[1-9]\d*)(?:\.\d+)?$/u.test(normalized)) {
+    throw new Error(`amount must be a positive decimal; got ${JSON.stringify(amount)}.`);
+  }
+  const [whole, fractional = ""] = normalized.split(".");
+  if (fractional.length > decimals) {
+    throw new Error(`amount must fit ${decimals} decimal places; got ${normalized}.`);
+  }
+  return BigInt(whole) * 10n ** BigInt(decimals) + BigInt(fractional.padEnd(decimals, "0") || "0");
+}
+
+function formatBaseUnits(raw) {
+  const decimals = DEFAULT_ESCROW_ASSET.decimals;
+  const value = BigInt(raw);
+  const scale = 10n ** BigInt(decimals);
+  const whole = value / scale;
+  const fractional = value % scale;
+  if (fractional === 0n) return whole.toString();
+  return `${whole}.${fractional.toString().padStart(decimals, "0").replace(/0+$/u, "")}`;
+}
+
+function describeApiError(error) {
+  const code = error?.payload?.error ?? error?.payload?.code ?? "";
+  const message = error?.payload?.message ?? error?.message ?? "";
+  const requestId = error?.payload?.requestId ? `; requestId=${error.payload.requestId}` : "";
+  return `status=${error?.status ?? "?"}; code=${code || "?"}; message=${message}${requestId}`;
+}
+
+function round1(value) {
+  return Math.round(value * 10) / 10;
+}
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function pick(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function enabled(value) {
+  return ["1", "true", "yes"].includes(String(value ?? "").trim().toLowerCase());
+}
+
+function parsePositiveInt(value, fallback) {
+  const raw = pick(typeof value === "string" ? value : value === undefined ? "" : String(value));
+  if (!raw) return fallback;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`expected a positive integer; got ${JSON.stringify(value)}.`);
+  }
+  return n;
+}
+
+function stripTrailingSlash(value) {
+  return String(value).replace(/\/+$/u, "");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runWorkerCanary()
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2));
+    })
+    .catch((error) => {
+      console.error(error?.message ?? String(error));
+      process.exitCode = 1;
+    });
+}

--- a/scripts/ops/run-worker-canary.test.mjs
+++ b/scripts/ops/run-worker-canary.test.mjs
@@ -1,0 +1,487 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  runWorkerCanary,
+  runSiweStage,
+  runAccountStage,
+  runClaimStage,
+  runSubmitStage,
+  runVerifyStage,
+  runSettleStage,
+  assertOperatorTokenFreshness
+} from "./run-worker-canary.mjs";
+
+// ── fixtures ──────────────────────────────────────────────────────────────
+const WORKER = "0x30BC468dA4E95a8FA4b3f2043c86687a57CdeE05";
+const CHAIN_JOB_ID = "0xa4b8e4ab00000000000000000000000000000000000000000000000000cb4db0";
+const JOB_ID = "worker-canary-test-1";
+const FIXED_MS = 1_900_000_000_000;
+const REWARD_RAW = 100_000n; // 0.1 USDC, 6 decimals
+
+class FakeApiError extends Error {
+  constructor(status, payload) {
+    super(payload?.message ?? `api error ${status}`);
+    this.status = status;
+    this.payload = payload;
+  }
+}
+
+function makeJwt(expSeconds) {
+  const enc = (obj) => Buffer.from(JSON.stringify(obj)).toString("base64url");
+  return `${enc({ alg: "ES256", typ: "JWT" })}.${enc({ sub: WORKER.toLowerCase(), exp: expSeconds })}.sig`;
+}
+
+function farFutureOperatorAuth() {
+  return { mode: "legacy_admin_jwt", source: "ADMIN_JWT", token: makeJwt(Math.floor(FIXED_MS / 1000) + 30 * 86_400) };
+}
+
+function okOperatorClient(overrides = {}) {
+  const calls = [];
+  return {
+    calls,
+    async getAuthSession() {
+      calls.push(["getAuthSession"]);
+      return { roles: ["admin", "verifier"], capabilities: ["jobs:create", "jobs:lifecycle", "verifier:run", "admin:status"] };
+    },
+    async getAdminStatus() {
+      calls.push(["getAdminStatus"]);
+      return { maintenance: { policy: { enabled: true, settlementReady: true, roles: { escrowIsServiceOperator: true } } } };
+    },
+    async createJob(payload) {
+      calls.push(["createJob", payload]);
+      return { id: payload.id };
+    },
+    async runVerifier(sessionId) {
+      calls.push(["runVerifier", sessionId]);
+      return { outcome: "approved", reasonCode: "benchmark_pass" };
+    },
+    async request(path, opts) {
+      calls.push(["request", path, opts?.body]);
+      return { ok: true };
+    },
+    ...overrides
+  };
+}
+
+function okWorkerClient(overrides = {}) {
+  const calls = [];
+  return {
+    calls,
+    async getAccountSummary() {
+      calls.push(["getAccountSummary"]);
+      return { wallet: WORKER };
+    },
+    async preflightJob(jobId) {
+      calls.push(["preflightJob", jobId]);
+      return { jobId, eligible: true, claimable: true, currentWalletCanClaim: true, claimEconomicsWaived: true, totalClaimLock: 0 };
+    },
+    async claimJob(jobId, idem) {
+      calls.push(["claimJob", jobId, idem]);
+      return { sessionId: "sess-1", status: "claimed", chainJobId: CHAIN_JOB_ID };
+    },
+    async submitWork(sessionId, submission) {
+      calls.push(["submitWork", sessionId, submission]);
+      return { status: "submitted" };
+    },
+    async getSession(sessionId) {
+      calls.push(["getSession", sessionId]);
+      return { status: "resolved", chainJobId: CHAIN_JOB_ID };
+    },
+    ...overrides
+  };
+}
+
+function okChainReader(overrides = {}) {
+  let snapshots = 0;
+  return {
+    async getChainId() {
+      return 420420417n;
+    },
+    async snapshotWorker() {
+      // First snapshot (before) is empty; later snapshots show the EOA payout.
+      snapshots += 1;
+      return snapshots === 1 ? { usdcRaw: 0n, aacLiquidRaw: 0n } : { usdcRaw: REWARD_RAW, aacLiquidRaw: 0n };
+    },
+    async readEscrowJob() {
+      return { state: 6, releasedRaw: REWARD_RAW, rewardRaw: REWARD_RAW, worker: WORKER };
+    },
+    ...overrides
+  };
+}
+
+function okEnv(overrides = {}) {
+  return {
+    API_BASE_URL: "https://api.example.test/",
+    WORKER_CANARY_PROFILE: "testnet",
+    WORKER_CANARY_JOB_ID: JOB_ID,
+    WORKER_CANARY_REWARD_AMOUNT: "0.1",
+    WORKER_CANARY_SETTLE_TIMEOUT_MS: "1000",
+    WORKER_CANARY_SETTLE_POLL_MS: "10",
+    ...overrides
+  };
+}
+
+function runFull(overrides = {}) {
+  return runWorkerCanary({
+    env: okEnv(overrides.env),
+    wallet: { address: WORKER },
+    operatorClient: overrides.operatorClient ?? okOperatorClient(),
+    operatorAuth: overrides.operatorAuth ?? farFutureOperatorAuth(),
+    workerClient: overrides.workerClient ?? okWorkerClient(),
+    chainReader: overrides.chainReader ?? okChainReader(),
+    now: () => FIXED_MS,
+    log: () => {}
+  });
+}
+
+// ── full-flow integration ───────────────────────────────────────────────────
+test("full canary loop walks SIWE→claim→submit→verify→settle and asserts every stage", async () => {
+  const operatorClient = okOperatorClient();
+  const workerClient = okWorkerClient();
+  const evidence = await runFull({ operatorClient, workerClient });
+
+  assert.equal(evidence.proof, "worker-canary");
+  assert.equal(evidence.workerWallet, WORKER);
+  assert.equal(evidence.jobId, JOB_ID);
+  assert.equal(evidence.sessionId, "sess-1");
+  assert.equal(evidence.chainJobId, CHAIN_JOB_ID);
+  assert.equal(evidence.stages.siwe.mode, "injected");
+  assert.equal(evidence.stages.account.status, 200);
+  assert.equal(evidence.stages.claim.mechanism, "onboarding_waiver");
+  assert.equal(evidence.stages.submit.status, "submitted");
+  assert.equal(evidence.stages.verify.outcome, "approved");
+  assert.equal(evidence.stages.settle.jobState, "Closed");
+  assert.equal(evidence.stages.settle.released, "0.1");
+  assert.equal(evidence.stages.settle.creditedRaw, REWARD_RAW.toString());
+  assert.equal(evidence.stages.settle.creditedTo, "worker_eoa");
+  assert.equal(evidence.stages.tokenFreshness.enforced, true);
+  assert.ok(evidence.stages.tokenFreshness.daysToExpiry >= 29);
+  assert.equal(evidence.cleanup.jobArchived, true);
+
+  // Identity separation: worker stages NEVER use the operator client and vice versa.
+  const workerCalled = workerClient.calls.map(([n]) => n);
+  const operatorCalled = operatorClient.calls.map(([n]) => n);
+  assert.ok(workerCalled.includes("claimJob") && workerCalled.includes("submitWork"));
+  assert.ok(!workerCalled.includes("createJob") && !workerCalled.includes("runVerifier"));
+  assert.ok(operatorCalled.includes("createJob") && operatorCalled.includes("runVerifier"));
+  assert.ok(!operatorCalled.includes("claimJob") && !operatorCalled.includes("submitWork"));
+
+  // Cleanup archives the disposable job so canary jobs never accumulate.
+  const archive = operatorClient.calls.find(([n, path]) => n === "request" && path === "/admin/jobs/lifecycle");
+  assert.ok(archive, "expected an /admin/jobs/lifecycle archive call");
+  assert.equal(archive[2].action, "archive");
+  assert.equal(archive[2].jobId, JOB_ID);
+});
+
+test("evidence file is written and sanitized (no tokens or keys)", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "worker-canary-"));
+  const evidenceFile = join(dir, "evidence.json");
+  await runFull({ env: { WORKER_CANARY_EVIDENCE_FILE: evidenceFile } });
+  const doc = JSON.parse(await readFile(evidenceFile, "utf8"));
+  assert.equal(doc.jobId, JOB_ID);
+  const serialized = JSON.stringify(doc);
+  assert.ok(!/eyJ|private|signature|Bearer/u.test(serialized), "evidence must not leak tokens/keys");
+});
+
+test("a mid-loop failure still archives the disposable job (cleanup finally)", async () => {
+  const operatorClient = okOperatorClient();
+  const workerClient = okWorkerClient({
+    async submitWork() {
+      throw new Error("boom mid-loop");
+    }
+  });
+  await assert.rejects(() => runFull({ operatorClient, workerClient }), /boom mid-loop/u);
+  const archive = operatorClient.calls.find(([n, path]) => n === "request" && path === "/admin/jobs/lifecycle");
+  assert.ok(archive, "stranded canary job must still be archived on failure");
+});
+
+test("WORKER_CANARY_KEEP_JOB leaves the job live (no archive)", async () => {
+  const operatorClient = okOperatorClient();
+  await runFull({ operatorClient, env: { WORKER_CANARY_KEEP_JOB: "1" } });
+  const archive = operatorClient.calls.find(([n, path]) => n === "request" && path === "/admin/jobs/lifecycle");
+  assert.ok(!archive, "KEEP_JOB must skip archive");
+});
+
+// ── chain-env gate (testnet only) ────────────────────────────────────────────
+test("chain-env gate: refuses a non-testnet chainId", async () => {
+  await assert.rejects(
+    () => runFull({ chainReader: okChainReader({ async getChainId() { return 1n; } }) }),
+    /not Polkadot Hub TestNet|chain-env gate/u
+  );
+});
+
+test("chain-env gate: refuses a non-testnet profile before any chain read", async () => {
+  await assert.rejects(() => runFull({ env: { WORKER_CANARY_PROFILE: "mainnet" } }), /testnet-only/u);
+});
+
+// ── operator readiness ───────────────────────────────────────────────────────
+test("operator readiness fails loud if the operator token lacks a required capability", async () => {
+  const operatorClient = okOperatorClient({
+    async getAuthSession() {
+      return { roles: ["admin"], capabilities: ["jobs:create", "jobs:lifecycle", "admin:status"] }; // missing verifier:run
+    }
+  });
+  await assert.rejects(() => runFull({ operatorClient }), /missing capabilities.*verifier:run/u);
+});
+
+test("operator readiness fails loud if the escrow service-operator broker is disabled (#627 regressed)", async () => {
+  const operatorClient = okOperatorClient({
+    async getAdminStatus() {
+      return { maintenance: { policy: { enabled: true, settlementReady: true, roles: { escrowIsServiceOperator: false } } } };
+    }
+  });
+  await assert.rejects(() => runFull({ operatorClient }), /service operator/u);
+});
+
+// ── STAGE 1: SIWE (guards #625) ──────────────────────────────────────────────
+test("stage 1 SIWE: HTTP 500 on /auth/verify names the #625 roleless-mint regression", async () => {
+  const anonClient = {
+    async issueNonce() {
+      return { message: "siwe-message" };
+    },
+    async verifySignature() {
+      throw new FakeApiError(500, { error: "invalid_configuration" });
+    }
+  };
+  await assert.rejects(
+    () => runSiweStage({ wallet: signingWallet(), anonClient }),
+    /#625|roleless-wallet SIWE/u
+  );
+});
+
+test("stage 1 SIWE: a non-empty roles array fails the roleless assertion", async () => {
+  const anonClient = {
+    async issueNonce() {
+      return { message: "siwe-message" };
+    },
+    async verifySignature() {
+      return { token: "a.b.c", roles: ["verifier"] };
+    }
+  };
+  await assert.rejects(() => runSiweStage({ wallet: signingWallet(), anonClient }), /ROLELESS/u);
+});
+
+test("stage 1 SIWE: happy path returns a roleless token", async () => {
+  const anonClient = {
+    async issueNonce() {
+      return { message: "siwe-message" };
+    },
+    async verifySignature() {
+      return { token: "a.b.c", roles: [], expiresAt: "2026-06-14T00:00:00.000Z" };
+    }
+  };
+  const result = await runSiweStage({ wallet: signingWallet(), anonClient });
+  assert.equal(result.token, "a.b.c");
+  assert.equal(result.summary.roleless, true);
+});
+
+// ── STAGE 2: account (guards #626) ───────────────────────────────────────────
+test("stage 2 account: HTTP 401 claims_mismatch names the #626 sub-casing regression", async () => {
+  const authedWorker = {
+    async getAccountSummary() {
+      throw new FakeApiError(401, { error: "claims_mismatch" });
+    }
+  };
+  await assert.rejects(() => runAccountStage({ authedWorker, workerAddress: WORKER }), /#626|sub-casing/u);
+});
+
+test("stage 2 account: happy path returns 200", async () => {
+  const authedWorker = { async getAccountSummary() { return { wallet: WORKER }; } };
+  const out = await runAccountStage({ authedWorker, workerAddress: WORKER });
+  assert.equal(out.status, 200);
+});
+
+// ── STAGE 3: claim (guards claim 409 + claimJobFor) ──────────────────────────
+test("stage 3 claim: a 409 from /jobs/claim names the claim-funding class", async () => {
+  const authedWorker = {
+    async preflightJob(jobId) {
+      return { jobId, eligible: true, claimable: true, currentWalletCanClaim: true, claimEconomicsWaived: true, totalClaimLock: 0 };
+    },
+    async claimJob() {
+      throw new FakeApiError(409, { error: "insufficient_liquidity" });
+    }
+  };
+  await assert.rejects(
+    () => runClaimStage({ authedWorker, jobId: JOB_ID, workerAddress: WORKER, idempotencyKey: "k", before: { aacLiquidRaw: 0n } }),
+    /409 class|claim-funding/u
+  );
+});
+
+test("stage 3 claim: waiver exhausted AND worker underfunded fails before claiming (would-409)", async () => {
+  const authedWorker = {
+    async preflightJob(jobId) {
+      return { jobId, eligible: true, claimable: true, currentWalletCanClaim: true, claimEconomicsWaived: false, totalClaimLock: "0.05" };
+    },
+    async claimJob() {
+      throw new Error("should not reach claim");
+    }
+  };
+  await assert.rejects(
+    () => runClaimStage({ authedWorker, jobId: JOB_ID, workerAddress: WORKER, idempotencyKey: "k", before: { aacLiquidRaw: 0n } }),
+    /WOULD 409|insufficient_liquidity/u
+  );
+});
+
+test("stage 3 claim: prefunded path is accepted when the worker covers the lock", async () => {
+  const authedWorker = {
+    async preflightJob(jobId) {
+      return { jobId, eligible: true, claimable: true, currentWalletCanClaim: true, claimEconomicsWaived: false, totalClaimLock: "0.05" };
+    },
+    async claimJob() {
+      return { sessionId: "sess-1", status: "claimed" };
+    }
+  };
+  const out = await runClaimStage({
+    authedWorker,
+    jobId: JOB_ID,
+    workerAddress: WORKER,
+    idempotencyKey: "k",
+    before: { aacLiquidRaw: 100_000n }
+  });
+  assert.equal(out.summary.mechanism, "prefunded");
+});
+
+test("stage 3 claim: non-claimable preflight fails loud", async () => {
+  const authedWorker = {
+    async preflightJob(jobId) {
+      return { jobId, eligible: false, claimable: false, currentWalletCanClaim: false, reason: "unfunded" };
+    }
+  };
+  await assert.rejects(
+    () => runClaimStage({ authedWorker, jobId: JOB_ID, workerAddress: WORKER, idempotencyKey: "k", before: { aacLiquidRaw: 0n } }),
+    /cannot claim/u
+  );
+});
+
+// ── STAGE 4: submit (guards #627) ────────────────────────────────────────────
+test("stage 4 submit: an on-chain revert names the #627 submitWorkFor regression", async () => {
+  const authedWorker = {
+    async submitWork() {
+      throw new FakeApiError(500, { error: "blockchain_revert", message: "execution reverted" });
+    }
+  };
+  await assert.rejects(
+    () => runSubmitStage({ authedWorker, sessionId: "s", jobId: JOB_ID, timestamp: FIXED_MS }),
+    /#627|submitWorkFor/u
+  );
+});
+
+test("stage 4 submit: a non-submitted status fails", async () => {
+  const authedWorker = { async submitWork() { return { status: "rejected" }; } };
+  await assert.rejects(
+    () => runSubmitStage({ authedWorker, sessionId: "s", jobId: JOB_ID, timestamp: FIXED_MS }),
+    /expected status "submitted"/u
+  );
+});
+
+test("stage 4 submit: status submitted but reverted chainStatus still fails", async () => {
+  const authedWorker = { async submitWork() { return { status: "submitted", chainStatus: "reverted" }; } };
+  await assert.rejects(
+    () => runSubmitStage({ authedWorker, sessionId: "s", jobId: JOB_ID, timestamp: FIXED_MS }),
+    /did not land on-chain|#627/u
+  );
+});
+
+// ── STAGE 5: verify ──────────────────────────────────────────────────────────
+test("stage 5 verify: a non-approved operator verdict fails loud", async () => {
+  const operatorPlatform = { async runVerifier() { return { outcome: "rejected", reasonCode: "keyword_miss" }; } };
+  await assert.rejects(
+    () => runVerifyStage({ operatorPlatform, authedWorker: {}, sessionId: "s", mode: "operator" }),
+    /expected "approved"/u
+  );
+});
+
+test("stage 5 verify: auto mode passes when the public result is approved (no-op once auto-verify lands)", async () => {
+  const authedWorker = { async getVerifierResult() { return { outcome: "approved" }; } };
+  const out = await runVerifyStage({ operatorPlatform: {}, authedWorker, sessionId: "s", mode: "auto" });
+  assert.equal(out.summary.mode, "auto");
+  assert.equal(out.summary.outcome, "approved");
+});
+
+// ── STAGE 6: settle ──────────────────────────────────────────────────────────
+const settleArgs = (overrides = {}) => ({
+  authedWorker: { async getSession() { return { status: "resolved" }; } },
+  sessionId: "s",
+  chainJobId: CHAIN_JOB_ID,
+  workerAddress: WORKER,
+  before: { usdcRaw: 0n, aacLiquidRaw: 0n },
+  rewardRaw: REWARD_RAW,
+  settleTimeoutMs: 40,
+  settlePollMs: 10,
+  now: () => Date.now(),
+  log: () => {},
+  ...overrides
+});
+
+test("stage 6 settle: a job that never closes fails loud", async () => {
+  const reader = {
+    async readEscrowJob() { return { state: 3, releasedRaw: 0n, rewardRaw: REWARD_RAW, worker: WORKER }; },
+    async snapshotWorker() { return { usdcRaw: 0n, aacLiquidRaw: 0n }; }
+  };
+  await assert.rejects(() => runSettleStage(settleArgs({ reader })), /not "Closed"|settlement-stall/u);
+});
+
+test("stage 6 settle: released != reward fails", async () => {
+  const reader = {
+    async readEscrowJob() { return { state: 6, releasedRaw: 50_000n, rewardRaw: REWARD_RAW, worker: WORKER }; },
+    async snapshotWorker() { return { usdcRaw: REWARD_RAW, aacLiquidRaw: 0n }; }
+  };
+  await assert.rejects(() => runSettleStage(settleArgs({ reader })), /released .* but reward was/u);
+});
+
+test("stage 6 settle: the worker balance not rising by the reward fails (checks EOA AND AAC)", async () => {
+  const reader = {
+    async readEscrowJob() { return { state: 6, releasedRaw: REWARD_RAW, rewardRaw: REWARD_RAW, worker: WORKER }; },
+    async snapshotWorker() { return { usdcRaw: 0n, aacLiquidRaw: 0n }; } // never credited
+  };
+  await assert.rejects(() => runSettleStage(settleArgs({ reader })), /did not rise|never reached the worker/u);
+});
+
+test("stage 6 settle: payout credited into the AAC liquid position passes", async () => {
+  // `before` is supplied via settleArgs (zeros); runSettleStage takes only the
+  // "after" snapshot — here the reward landed in AAC.liquid rather than the EOA.
+  const reader = {
+    async readEscrowJob() { return { state: 6, releasedRaw: REWARD_RAW, rewardRaw: REWARD_RAW, worker: WORKER }; },
+    async snapshotWorker() { return { usdcRaw: 0n, aacLiquidRaw: REWARD_RAW }; }
+  };
+  const out = await runSettleStage(settleArgs({ reader }));
+  assert.equal(out.summary.creditedTo, "aac_liquid");
+});
+
+// ── STAGE 7: operator token freshness (guards #628) ──────────────────────────
+test("stage 7 freshness: a legacy ADMIN_JWT within N days of expiry fails loud (#628)", () => {
+  const expSoon = Math.floor(FIXED_MS / 1000) + 3 * 86_400; // 3 days
+  assert.throws(
+    () => assertOperatorTokenFreshness({ operatorAuth: { mode: "legacy_admin_jwt", token: makeJwt(expSoon) }, minDays: 7, now: () => FIXED_MS }),
+    /#628|expires in/u
+  );
+});
+
+test("stage 7 freshness: a legacy ADMIN_JWT with no exp claim fails loud", () => {
+  const noExp = `${Buffer.from(JSON.stringify({ alg: "ES256" })).toString("base64url")}.${Buffer.from(JSON.stringify({ sub: WORKER })).toString("base64url")}.sig`;
+  assert.throws(
+    () => assertOperatorTokenFreshness({ operatorAuth: { mode: "legacy_admin_jwt", token: noExp }, minDays: 7, now: () => FIXED_MS }),
+    /no `exp` claim|#628/u
+  );
+});
+
+test("stage 7 freshness: a far-future legacy ADMIN_JWT is enforced and passes", () => {
+  const out = assertOperatorTokenFreshness({ operatorAuth: farFutureOperatorAuth(), minDays: 7, now: () => FIXED_MS });
+  assert.equal(out.enforced, true);
+  assert.ok(out.daysToExpiry >= 29);
+});
+
+test("stage 7 freshness: a short-lived refresh-minted operator token is a no-op (self-rotating)", () => {
+  const shortExp = Math.floor(FIXED_MS / 1000) + 600; // 10 minutes
+  const out = assertOperatorTokenFreshness({ operatorAuth: { mode: "admin_refresh", token: makeJwt(shortExp) }, minDays: 7, now: () => FIXED_MS });
+  assert.equal(out.enforced, false);
+});
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+function signingWallet() {
+  return { address: WORKER, async signMessage() { return "0xsignature"; } };
+}


### PR DESCRIPTION
## What

A CI canary that walks the **real external-worker loop** end to end with a fresh, **ROLELESS** worker wallet — the same SIWE front door an outside agent uses — and asserts **every stage**, so the class of launch-blockers found on 2026-06-13 (auth mint 500, JWT `sub`-casing 401, claim 409, `submitWork` revert, `ADMIN_JWT` expiry) can never silently reach production again.

Context + backlog: `docs/GO_LIVE_PUNCHLIST.md` (P0 — "End-to-end synthetic-worker canary in CI"), PR #631.

## Why this is different from every prior proof

Every prior hosted proof used the pre-minted multi-role `ADMIN_JWT` and bypassed the SIWE front door — so none of them could see the five blockers, which were caught **one user-round-trip at a time**. This canary walks the real front door: the **worker stages (1–4) use the roleless token**; only the **operator stages (create/fund/verify/cleanup) use the `ADMIN_JWT`**. The whole class now fails loud in CI.

## Stages (each failure names the bug-class it guards)

| # | Stage | Asserts | Guards |
| - | --- | --- | --- |
| 1 | SIWE | nonce → sign → verify → roleless token | #625 roleless-mint 500 |
| 2 | Account | authed `GET /account`, not 401 `claims_mismatch` | #626 `sub`-casing |
| 3 | Claim | claim disposable job, not 409; onboarding waiver **or** worker pre-funded | claim-funding 409 + `claimJobFor` |
| 4 | Submit | structured output → `submitted`, no on-chain revert | #627 `submitWorkFor` |
| 5 | Verify | operator `/verifier/run` → `approved` | verification stall |
| 6 | Settle | EscrowCore `Closed` + `released == reward`; worker credited in **`usdc.balanceOf(EOA)` AND `AAC.positions(worker).liquid`** | settlement / payout reconciliation |
| 7 | Freshness | operator `ADMIN_JWT` not within N days (default 7) of expiry | #628 `ADMIN_JWT` expiry |

Stages 5 and 7 are structured to become **no-ops** once auto-verify and the short-lived refresh-token flow land (`WORKER_CANARY_VERIFY_MODE=auto` polls the public result; a short-lived operator token skips the freshness gate).

## Disposable job + cleanup + safety

- Posts its **own upfront-funded** benchmark job per run (so the loop never depends on the lazy `ensureJob` path) and **archives it in a `finally` block** — canary jobs never accumulate or pollute the public board, and real board claim attempts are never consumed.
- **Testnet-only:** loads `deployments/testnet.json`, refuses any profile but `testnet`, and asserts the live `chainId` is `420420417`. Refuses mainnet.
- The worker identity is a dedicated roleless testnet wallet (`op://prod-backend/canary-worker-testnet`); the `ADMIN_JWT` is used only for operator stages.

## Files

- `scripts/ops/run-worker-canary.mjs` — the canary (exported async fn + CLI), mirrors `run-hosted-worker-loop.mjs` / `run-dispute-verdict-proof.mjs`.
- `scripts/ops/run-worker-canary.test.mjs` — **30 offline tests**; one deliberate per-stage break flips the right assertion red (no network).
- `scripts/ops/check-hosted-stack.sh` — `CHECK_WORKER_CANARY_PROOF=1` gate (node + docker paths).
- `.github/workflows/hosted-worker-canary.yml` — **dispatch + daily (`37 6 * * *`) + post-deploy** (`workflow_run` on **Deploy Production**); emits a sanitized evidence artifact (stage timings, tx hashes, verifier outcome, on-chain release, where the payout landed).
- `docs/WORKER_CANARY.md` — provisioning + operating runbook.

## Operator setup required before the workflow is green

1. **Provision the roleless worker wallet** (address-only output; key never echoed):
   `node scripts/ops/rotate-admin-generate-key.mjs --out .keys/canary-worker-testnet.txt`, then store the private key at `op://prod-backend/canary-worker-testnet/private key` (single item; prod-backend is VPS-readable, prod-critical is not). See the runbook for the exact `op item create` command.
2. **GitHub Actions secrets:**
   - `OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE` — reads `op://prod-smoke/admin-jwt/password` (already used by the dispute-verdict proof).
   - `OP_SERVICE_ACCOUNT_TOKEN_PROD_BACKEND` — **new**, least-privilege, scoped to read `op://prod-backend/canary-worker-testnet`.
3. **Keep the dedicated wallet claimable** for ongoing daily runs: a fresh wallet's first 3 claims are waived; pre-fund its `AgentAccountCore` position beyond that (operator step; becomes a no-op once auto-fund lands). Until then, stage 3 fails loud if the wallet is both waiver-exhausted and underfunded.

## Testing

- `node --test scripts/ops/run-worker-canary.test.mjs` → **30/30 pass** offline (each stage's red path covered).
- Existing `scripts/ops/check-hosted-stack.test.mjs` and the imported modules (`run-hosted-worker-loop`, `run-dispute-verdict-proof`, `get-admin-refresh-token`) still pass (87 total).
- The createJob payload + submission shape reuse the proven `schema://jobs/product-proof-worker-loop` contract; on-chain reads use the live `deployments/testnet.json` addresses + `mcp-server` ABIs.
- Not run against prod from here (no prod secrets in this environment) — green-against-prod is gated on the operator setup above; operator-assisted verify/fund is OK for now per the punchlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)