### PR TITLE
feat(jobs): pre-fund auto-ingested rewards at ingestion + gate discovery on funding readiness

### DIFF
--- a/deploy/backend.env.template
+++ b/deploy/backend.env.template
@@ -278,6 +278,14 @@ OPEN_DATA_INGEST_MAX_OPEN_JOBS=20
 OPEN_DATA_INGEST_MIN_SCORE=55
 OPEN_DATA_INGEST_QUERY=traffic crashes
 OPEN_DATA_INGEST_QUERIES_JSON=["traffic crashes","food safety","water quality","building permits","public safety"]
+
+# Escrow auto-ingested job rewards on-chain at ingestion (reuses the idempotent
+# ensureJob), so a job is genuinely funded before discovery advertises it
+# claimable; unfundable jobs stay discoverable but report fundingState="pending"
+# and are never claimable (no claim-time 409 insufficient_liquidity). Requires
+# the backend signer to hold deposited reward liquidity (USDC is not
+# auto-mintable). TESTNET-ONLY: only enable on testnet deployments.
+INGESTION_PREFUND_ENABLED=false
 STANDARDS_INGEST_ENABLED=true
 STANDARDS_INGEST_DRY_RUN=false
 STANDARDS_INGEST_INTERVAL_MS=3600000

--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -240,6 +240,12 @@ AUTH_CHAIN_ID=420420417
 # DATA_GOV_CATALOG_SEARCH_URL=https://catalog.data.gov/search
 # OPEN_DATA_INGEST_DATASETS_JSON=[{"datasetTitle":"Federal sample spending data","datasetUrl":"https://catalog.data.gov/dataset/example","resourceUrl":"https://example.gov/data.csv","resourceFormat":"CSV","agency":"GSA"}]
 
+# Escrow auto-ingested job rewards on-chain at ingestion (reuses ensureJob) so a
+# job is funded before discovery advertises it claimable. Unfundable jobs stay
+# discoverable but report fundingState="pending" and are never claimable.
+# Requires the backend signer to hold deposited reward liquidity. TESTNET-ONLY.
+# INGESTION_PREFUND_ENABLED=false
+
 # --- Supported on-chain assets ------------------------------------------------
 # Legacy shorthand still works:
 # SUPPORTED_ASSETS=USDC:0x0000053900000000000000000000000001200000

--- a/mcp-server/src/core/claim-state.js
+++ b/mcp-server/src/core/claim-state.js
@@ -49,9 +49,17 @@ export function summarizeJobClaimState({
   const walletMatchesClaim = Boolean(normalizedWallet && claimedBy && normalizedWallet === claimedBy);
   const claimExpiresAtValue = claimExpiresAt(session, job);
   const expired = isExpiredClaim(session, job, now) || session?.status === "expired";
+  // Truth boundary: a job whose reward was scheduled for prefunding at ingestion
+  // but is not yet escrowed on-chain must never be advertised claimable — claiming
+  // it would revert insufficient_liquidity at funding time. Scoped to the
+  // ingestion_prefund funding source so manual/recurring jobs are unaffected.
+  const fundingState = job?.funding?.source === "ingestion_prefund"
+    ? job.funding.state
+    : undefined;
+  const fundingPending = fundingState !== undefined && fundingState !== "funded";
 
   if (!session) {
-    const claimable = lifecycleState === "open" && !retryExhausted;
+    const claimable = lifecycleState === "open" && !retryExhausted && !fundingPending;
     const claimState = retryExhausted ? "exhausted" : claimable ? "open" : lifecycleState;
     return compact({
       claimState,
@@ -59,7 +67,12 @@ export function summarizeJobClaimState({
       effectiveState: claimable ? "claimable" : claimState,
       claimable,
       currentWalletCanClaim: normalizedWallet ? claimable : null,
-      reason: retryExhausted ? "retry_limit_exhausted" : claimable ? "claimable" : `job_${lifecycleState}`,
+      fundingState,
+      reason: retryExhausted
+        ? "retry_limit_exhausted"
+        : fundingPending
+          ? "reward_funding_pending"
+          : claimable ? "claimable" : `job_${lifecycleState}`,
       retryLimit,
       claimAttemptCount,
       remainingClaimAttempts,
@@ -72,7 +85,7 @@ export function summarizeJobClaimState({
   }
 
   if (expired) {
-    const claimable = lifecycleState === "open" && !retryExhausted;
+    const claimable = lifecycleState === "open" && !retryExhausted && !fundingPending;
     const claimState = retryExhausted ? "exhausted" : "expired";
     return compact({
       claimState,
@@ -80,7 +93,12 @@ export function summarizeJobClaimState({
       effectiveState: claimable ? "claimable" : claimState,
       claimable,
       currentWalletCanClaim: normalizedWallet ? claimable : null,
-      reason: retryExhausted ? "retry_limit_exhausted" : "claim_ttl_expired_reopen_available",
+      fundingState,
+      reason: retryExhausted
+        ? "retry_limit_exhausted"
+        : fundingPending
+          ? "reward_funding_pending"
+          : "claim_ttl_expired_reopen_available",
       retryLimit,
       claimAttemptCount,
       remainingClaimAttempts,
@@ -100,6 +118,7 @@ export function summarizeJobClaimState({
       effectiveState: "claimed",
       claimable: false,
       currentWalletCanClaim: normalizedWallet ? false : null,
+      fundingState,
       reason: walletMatchesClaim ? "already_claimed_by_current_wallet" : "claimed_by_other_wallet",
       retryLimit,
       claimAttemptCount,
@@ -119,6 +138,7 @@ export function summarizeJobClaimState({
     effectiveState: claimState,
     claimable: false,
     currentWalletCanClaim: normalizedWallet ? false : null,
+    fundingState,
     reason: claimState === "exhausted" ? "job_session_completed" : `session_${claimState}`,
     retryLimit,
     claimAttemptCount,
@@ -143,6 +163,7 @@ export function claimStatusFields(claimStatus) {
     effectiveState: claimStatus.effectiveState ?? claimStatus.claimState,
     claimable: claimStatus.claimable,
     currentWalletCanClaim: claimStatus.currentWalletCanClaim,
+    fundingState: claimStatus.fundingState ?? null,
     reason: claimStatus.reason,
     retryLimit: claimStatus.retryLimit,
     claimAttemptCount: claimStatus.claimAttemptCount ?? null,

--- a/mcp-server/src/core/claim-state.test.js
+++ b/mcp-server/src/core/claim-state.test.js
@@ -53,3 +53,94 @@ test("summarizeJobClaimState uses chain expiry before local claimedAt ttl", () =
   assert.equal(status.effectiveState, "claimable");
   assert.equal(status.claimExpiresAt, "2026-05-01T10:00:45.000Z");
 });
+
+const OPEN_JOB = { id: "job-fund", lifecycle: { state: "open" }, retryLimit: 2 };
+const WALLET = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+test("ingestion-prefund pending job is never advertised claimable (no session)", () => {
+  const status = summarizeJobClaimState({
+    job: { ...OPEN_JOB, funding: { source: "ingestion_prefund", state: "pending" } },
+    wallet: WALLET
+  });
+  assert.equal(status.claimable, false);
+  assert.equal(status.currentWalletCanClaim, false);
+  assert.equal(status.reason, "reward_funding_pending");
+  assert.equal(status.fundingState, "pending");
+  assert.notEqual(status.effectiveState, "claimable");
+});
+
+test("ingestion-prefund pending job is null (not false) when no wallet is supplied", () => {
+  const status = summarizeJobClaimState({
+    job: { ...OPEN_JOB, funding: { source: "ingestion_prefund", state: "pending" } }
+  });
+  assert.equal(status.claimable, false);
+  assert.equal(status.currentWalletCanClaim, null);
+  assert.equal(status.reason, "reward_funding_pending");
+});
+
+test("ingestion-prefund funded job behaves exactly like a normal open job", () => {
+  const status = summarizeJobClaimState({
+    job: { ...OPEN_JOB, funding: { source: "ingestion_prefund", state: "funded" } },
+    wallet: WALLET
+  });
+  assert.equal(status.claimable, true);
+  assert.equal(status.currentWalletCanClaim, true);
+  assert.equal(status.reason, "claimable");
+  assert.equal(status.fundingState, "funded");
+  assert.equal(status.effectiveState, "claimable");
+});
+
+test("a job with no funding field is unaffected by the gate (no regression)", () => {
+  const status = summarizeJobClaimState({ job: OPEN_JOB, wallet: WALLET });
+  assert.equal(status.claimable, true);
+  assert.equal(status.reason, "claimable");
+  assert.equal(status.fundingState, undefined);
+});
+
+test("the gate is scoped to ingestion_prefund — recurring reserve jobs stay claimable", () => {
+  const status = summarizeJobClaimState({
+    job: {
+      ...OPEN_JOB,
+      funding: { source: "recurring_template_reserve", state: "pending", wallet: WALLET, templateId: "tpl-1" }
+    },
+    wallet: WALLET
+  });
+  assert.equal(status.claimable, true);
+  assert.equal(status.fundingState, undefined);
+});
+
+test("expired claim on an unfunded prefund job never re-advertises as claimable", () => {
+  const expiredSession = {
+    sessionId: "job-fund:0xexpired",
+    jobId: "job-fund",
+    wallet: WALLET,
+    status: "claimed",
+    claimedAt: "2026-05-01T10:00:00.000Z",
+    chainClaimExpiresAt: "2026-05-01T10:00:30.000Z"
+  };
+  const status = summarizeJobClaimState({
+    job: { ...OPEN_JOB, claimTtlSeconds: 30, funding: { source: "ingestion_prefund", state: "pending" } },
+    session: expiredSession,
+    sessions: [expiredSession],
+    wallet: WALLET,
+    now: new Date("2026-05-01T10:01:00.000Z")
+  });
+  assert.equal(status.claimState, "expired");
+  assert.equal(status.claimable, false);
+  assert.equal(status.reason, "reward_funding_pending");
+  assert.equal(status.effectiveState, "expired");
+});
+
+test("retry exhaustion takes precedence over funding-pending in the reason", () => {
+  const attempts = [
+    { sessionId: "job-fund:0x1", status: "expired", claimedAt: "2026-05-01T10:00:00.000Z" },
+    { sessionId: "job-fund:0x2", status: "expired", claimedAt: "2026-05-01T10:05:00.000Z" }
+  ];
+  const status = summarizeJobClaimState({
+    job: { ...OPEN_JOB, retryLimit: 2, funding: { source: "ingestion_prefund", state: "pending" } },
+    sessions: attempts,
+    wallet: WALLET
+  });
+  assert.equal(status.claimable, false);
+  assert.equal(status.reason, "retry_limit_exhausted");
+});

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -89,6 +89,10 @@ export class PlatformService {
     this.upstreamStatusPoller = undefined;
     this.bootstrapSelfReportScheduler = undefined;
     this.submittedJobAutoVerifier = undefined;
+    // Opt-in: pre-fund auto-ingested job rewards on-chain at ingestion time so a
+    // job is genuinely funded before it is advertised claimable. Set in bootstrap
+    // from INGESTION_PREFUND_ENABLED. Testnet-only is an operational invariant.
+    this.prefundIngestedJobs = false;
 
     this.accountMutationService = new AccountMutationService(
       this.accounts,
@@ -178,6 +182,72 @@ export class PlatformService {
       this.jobCatalogService.removeJob(created.id);
       throw error;
     }
+  }
+
+  /**
+   * Create an auto-ingested job and, when prefunding is enabled, escrow its
+   * reward on-chain immediately by reusing the idempotent gateway.ensureJob.
+   * This makes the job genuinely funded before discovery can advertise it
+   * claimable. A funding shortfall (e.g. the backend signer is short on a
+   * settlement asset that cannot be auto-minted) is the expected steady state
+   * until liquidity is topped up out-of-band — it must NEVER abort the ingest
+   * run, so the job is kept and stamped funding.state="pending"; the discovery
+   * gate (summarizeJobClaimState) then keeps it out of the claimable set.
+   */
+  async createIngestedJob(input, { now = new Date() } = {}) {
+    const created = this.createJob(input);
+    if (!this.shouldPrefundIngestedJobs()) {
+      return created;
+    }
+    try {
+      // claimStake 0: the worker funds their own claim stake at claim time;
+      // here we only escrow the reward (totalRequired = rewardAmount).
+      await this.blockchainGateway.ensureJob(created, created.id, 0);
+      created.funding = {
+        source: "ingestion_prefund",
+        state: "funded",
+        asset: created.rewardAsset,
+        amount: created.rewardAmount,
+        fundedAt: now.toISOString()
+      };
+      this.publishIngestionPrefundEvent(created, "funded");
+    } catch (error) {
+      created.funding = {
+        source: "ingestion_prefund",
+        state: "pending",
+        asset: created.rewardAsset,
+        amount: created.rewardAmount,
+        reason: error?.code ?? "prefund_failed",
+        attemptedAt: now.toISOString()
+      };
+      this.publishIngestionPrefundEvent(created, "pending", error);
+    }
+    return created;
+  }
+
+  shouldPrefundIngestedJobs() {
+    return this.prefundIngestedJobs === true
+      && Boolean(this.blockchainGateway?.isEnabled?.());
+  }
+
+  publishIngestionPrefundEvent(job, state, error = undefined) {
+    this.eventBus?.publish?.({
+      topic: state === "funded"
+        ? "funding.ingestion_prefund_funded"
+        : "funding.ingestion_prefund_pending",
+      jobId: job.id,
+      // "pending" is a normal, expected outcome (signer short of liquidity) —
+      // emit it at info severity, not as an error.
+      severity: "info",
+      data: {
+        jobId: job.id,
+        state,
+        asset: job.rewardAsset,
+        amount: job.rewardAmount,
+        source: job.source,
+        ...(error ? { reason: error?.code ?? "prefund_failed" } : {})
+      }
+    });
   }
 
   async withRegisteredExternalSchema(input = {}) {

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -4,6 +4,7 @@ import { Wallet, getBytes, id } from "ethers";
 
 import { PlatformService } from "./platform-service.js";
 import { EventBus } from "./event-bus.js";
+import { InsufficientLiquidityError } from "./errors.js";
 import { MemoryStateStore } from "./state-store.js";
 import {
   buildExternalSchemaRegistrationDigest,
@@ -1347,4 +1348,122 @@ test("getGithubOperatorStatus exposes the read-only GitHub helper", async () => 
   assert.equal(status.configured, false);
   assert.equal(status.selectedView.name, "prs");
   assert.equal(status.digest.pullRequestsNeedingAttention.length, 0);
+});
+
+const INGEST_JOB_INPUT = {
+  id: "open-data-job-001",
+  category: "coding",
+  tier: "starter",
+  rewardAmount: 2,
+  rewardAsset: "DOT",
+  verifierMode: "benchmark",
+  verifierTerms: ["complete"],
+  verifierMinimumMatches: 1,
+  source: { type: "open_data_dataset" }
+};
+
+function makePrefundGateway(ensureJob) {
+  const calls = [];
+  return {
+    calls,
+    isEnabled: () => true,
+    ensureJob: async (job, instanceJobId, claimStake) => {
+      calls.push({ jobId: instanceJobId, claimStake });
+      return ensureJob(job, instanceJobId, claimStake);
+    }
+  };
+}
+
+test("createIngestedJob does not prefund when the flag is off (no funding stamp)", async () => {
+  const gateway = makePrefundGateway(async () => ({ state: 1 }));
+  const service = makePlatformService(gateway);
+  // prefundIngestedJobs defaults to false
+  const created = await service.createIngestedJob(INGEST_JOB_INPUT);
+  assert.equal(created.funding, undefined);
+  assert.equal(gateway.calls.length, 0);
+});
+
+test("createIngestedJob does not prefund when the gateway is disabled", async () => {
+  const gateway = { isEnabled: () => false, calls: [], ensureJob: async () => { gateway.calls.push(1); } };
+  const service = makePlatformService(gateway);
+  service.prefundIngestedJobs = true;
+  const created = await service.createIngestedJob(INGEST_JOB_INPUT);
+  assert.equal(created.funding, undefined);
+  assert.equal(gateway.calls.length, 0);
+});
+
+test("createIngestedJob escrows the reward and stamps funded on success", async () => {
+  const bus = new EventBus();
+  const gateway = makePrefundGateway(async () => ({ state: 1 }));
+  const service = makePlatformService(gateway, bus);
+  service.prefundIngestedJobs = true;
+
+  const created = await service.createIngestedJob(INGEST_JOB_INPUT);
+
+  assert.equal(gateway.calls.length, 1);
+  assert.equal(gateway.calls[0].claimStake, 0); // worker funds their own stake
+  assert.equal(created.funding.source, "ingestion_prefund");
+  assert.equal(created.funding.state, "funded");
+  assert.equal(created.funding.asset, "DOT");
+  assert.equal(created.funding.amount, 2);
+  assert.ok(created.funding.fundedAt);
+  // Must NOT carry recurring-reserve keys, or gateway.usesRecurringTemplateReserve misfires.
+  assert.equal("wallet" in created.funding, false);
+  assert.equal("templateId" in created.funding, false);
+  // The stamp is persisted on the catalog job and surfaces through discovery.
+  const claimable = await service.attachClaimState(created, {});
+  assert.equal(claimable.claimable, true);
+  assert.equal(claimable.fundingState, "funded");
+  const events = bus.replay({}, undefined).events;
+  assert.ok(events.some((event) => event.topic === "funding.ingestion_prefund_funded"));
+});
+
+test("createIngestedJob keeps the job and stamps pending on insufficient liquidity", async () => {
+  const bus = new EventBus();
+  const gateway = makePrefundGateway(async () => {
+    throw new InsufficientLiquidityError("DOT", { operation: "ensureJob" });
+  });
+  const service = makePlatformService(gateway, bus);
+  service.prefundIngestedJobs = true;
+
+  // Resolves (never rejects) so the ingest run is not aborted.
+  const created = await service.createIngestedJob(INGEST_JOB_INPUT);
+
+  assert.equal(created.funding.state, "pending");
+  assert.equal(created.funding.reason, "insufficient_liquidity");
+  assert.ok(created.funding.attemptedAt);
+  // Job is still in the catalog, discoverable but NOT claimable.
+  const fetched = service.getJobDefinition("open-data-job-001");
+  assert.equal(fetched.id, "open-data-job-001");
+  const claimable = await service.attachClaimState(fetched, { wallet: WALLET });
+  assert.equal(claimable.claimable, false);
+  assert.equal(claimable.currentWalletCanClaim, false);
+  assert.equal(claimable.reason, "reward_funding_pending");
+  assert.equal(claimable.fundingState, "pending");
+  const events = bus.replay({}, undefined).events;
+  assert.ok(events.some((event) => event.topic === "funding.ingestion_prefund_pending"));
+});
+
+test("createIngestedJob stamps pending on an unexpected gateway error and never aborts", async () => {
+  const gateway = makePrefundGateway(async () => {
+    throw new Error("RPC timeout");
+  });
+  const service = makePlatformService(gateway);
+  service.prefundIngestedJobs = true;
+
+  const created = await service.createIngestedJob(INGEST_JOB_INPUT);
+  assert.equal(created.funding.state, "pending");
+  assert.equal(created.funding.reason, "prefund_failed");
+});
+
+test("createIngestedJob propagates creation errors and does not attempt prefund", async () => {
+  const gateway = makePrefundGateway(async () => ({ state: 1 }));
+  const service = makePlatformService(gateway);
+  service.prefundIngestedJobs = true;
+
+  await service.createIngestedJob(INGEST_JOB_INPUT);
+  assert.equal(gateway.calls.length, 1);
+  // Duplicate id must reject from createJob before any second prefund attempt.
+  await assert.rejects(() => service.createIngestedJob(INGEST_JOB_INPUT));
+  assert.equal(gateway.calls.length, 1);
 });

--- a/mcp-server/src/protocols/http/jobs-response.js
+++ b/mcp-server/src/protocols/http/jobs-response.js
@@ -101,6 +101,7 @@ function toCompactJobRow(job) {
     effectiveState: job.effectiveState ?? (claimable ? "claimable" : job.claimState ?? state),
     claimable,
     currentWalletCanClaim: job.currentWalletCanClaim ?? null,
+    fundingState: job.fundingState ?? null,
     reason: job.reason ?? null,
     claimedBy: job.claimedBy ?? null,
     claimedAt: job.claimedAt ?? null,

--- a/mcp-server/src/protocols/http/jobs-response.test.js
+++ b/mcp-server/src/protocols/http/jobs-response.test.js
@@ -84,6 +84,7 @@ test("public jobs response filters and compacts agent-friendly queries", () => {
     "effectiveState",
     "claimable",
     "currentWalletCanClaim",
+    "fundingState",
     "reason",
     "claimedBy",
     "claimedAt",

--- a/mcp-server/src/services/bootstrap.js
+++ b/mcp-server/src/services/bootstrap.js
@@ -350,6 +350,10 @@ export async function createPlatformRuntime() {
   platformService.bootstrapSelfReportScheduler = bootstrapSelfReportScheduler;
   platformService.jobStaleSweeper = jobStaleSweeper;
   platformService.submittedJobAutoVerifier = submittedJobAutoVerifier;
+  // Opt-in (testnet-only operational invariant): escrow auto-ingested job
+  // rewards on-chain at ingestion so they are funded before being advertised
+  // claimable. Off by default; see deploy/backend.env.template.
+  platformService.prefundIngestedJobs = parseBooleanEnv(process.env.INGESTION_PREFUND_ENABLED);
   recurringScheduler.start();
   githubIssueIngestionScheduler.start();
   wikipediaMaintenanceIngestionScheduler.start();

--- a/mcp-server/src/services/open-data-ingestion-scheduler.js
+++ b/mcp-server/src/services/open-data-ingestion-scheduler.js
@@ -149,7 +149,13 @@ export class OpenDataIngestionScheduler {
             }
           }
           if (!this.dryRun) {
-            this.platformService.createJob(job);
+            // Prefer the prefunding create path so the reward is escrowed at
+            // ingestion; fall back to createJob for callers/tests without it.
+            if (typeof this.platformService.createIngestedJob === "function") {
+              await this.platformService.createIngestedJob(job);
+            } else {
+              this.platformService.createJob(job);
+            }
           }
           if (resourceKey) seenResources.add(resourceKey);
           if (datasetKey) seenDatasets.add(datasetKey);

--- a/mcp-server/src/services/open-data-ingestion-scheduler.test.js
+++ b/mcp-server/src/services/open-data-ingestion-scheduler.test.js
@@ -241,3 +241,66 @@ test("loadOpenDataIngestionConfig parses env knobs safely", () => {
   assert.equal(config.maxOpenJobs, 11);
   assert.deepEqual(config.datasets, [TARGET]);
 });
+
+test("OpenDataIngestionScheduler prefers createIngestedJob (prefund path) when available", async () => {
+  const jobs = [];
+  const createIngestedJobCalls = [];
+  let createJobCalled = false;
+  const platform = {
+    listJobs: () => [...jobs],
+    createJob: (job) => { createJobCalled = true; jobs.unshift(job); return job; },
+    getJobDefinition: (jobId) => {
+      const job = jobs.find((candidate) => candidate.id === jobId);
+      if (!job) throw new Error("not found");
+      return job;
+    },
+    createIngestedJob: async (job) => {
+      createIngestedJobCalls.push(job.id);
+      jobs.unshift(job);
+      return job;
+    }
+  };
+  const scheduler = new OpenDataIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    datasets: [TARGET],
+    fetchImpl: makeFetch()
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-26T10:00:00.000Z"));
+  assert.equal(summary.createdCount, 1);
+  assert.equal(createIngestedJobCalls.length, 1);
+  assert.equal(createJobCalled, false);
+  assert.equal(jobs.length, 1);
+});
+
+test("OpenDataIngestionScheduler run is not aborted if prefund stamps pending", async () => {
+  // Mirrors PlatformService.createIngestedJob: it resolves even when on-chain
+  // funding is short, so the ingest run still records the created job.
+  const jobs = [];
+  const platform = {
+    listJobs: () => [...jobs],
+    createJob: (job) => { jobs.unshift(job); return job; },
+    getJobDefinition: (jobId) => {
+      const job = jobs.find((candidate) => candidate.id === jobId);
+      if (!job) throw new Error("not found");
+      return job;
+    },
+    createIngestedJob: async (job) => {
+      jobs.unshift(job);
+      job.funding = { source: "ingestion_prefund", state: "pending", reason: "insufficient_liquidity" };
+      return job;
+    }
+  };
+  const scheduler = new OpenDataIngestionScheduler(platform, undefined, {
+    enabled: true,
+    dryRun: false,
+    datasets: [TARGET],
+    fetchImpl: makeFetch()
+  });
+
+  const summary = await scheduler.runOnce(new Date("2026-04-26T10:00:00.000Z"));
+  assert.equal(summary.createdCount, 1);
+  assert.equal(summary.errors.length, 0);
+  assert.equal(jobs[0].funding.state, "pending");
+});

--- a/mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.js
+++ b/mcp-server/src/services/wikipedia-maintenance-ingestion-scheduler.js
@@ -141,7 +141,13 @@ export class WikipediaMaintenanceIngestionScheduler {
         }
         const replenishedJob = withReissueJobId(job, inventory.allJobIds, { now });
         if (!this.dryRun) {
-          this.platformService.createJob(replenishedJob);
+          // Prefer the prefunding create path so the reward is escrowed at
+          // ingestion; fall back to createJob for callers/tests without it.
+          if (typeof this.platformService.createIngestedJob === "function") {
+            await this.platformService.createIngestedJob(replenishedJob);
+          } else {
+            this.platformService.createJob(replenishedJob);
+          }
         }
         seenSources.add(sourceKey);
         summary.createdCount += 1;


### PR DESCRIPTION
## Problem
Auto-ingested open-data/wiki jobs are advertised `claimable: true` but aren't funded. The reward is funded lazily at **claim time** by `gateway.ensureJob` from the **backend signer's** AgentAccountCore position; USDC is a non-auto-mintable settlement asset, so a short signer makes the claim revert **409 `insufficient_liquidity`**. The first real external-worker loop (2026-06-13) hit this and needed a hand-topped signer (0.5 → 5.5 USDC). "Claimable" jobs that can't fund are a trap.

P0 ("auto-fund/pre-fund ingested-job rewards") + the related P1 ("discovery reflects funding/settlement readiness") of `docs/GO_LIVE_PUNCHLIST.md` ([#631](https://github.com/averray-agent/agent/pull/631)).

## Approach — (A) pre-fund at ingestion + discovery truth-boundary gate
Don't advertise unfunded jobs. Reuses the **already-audited, idempotent** `gateway.ensureJob` — **no chain-mutation code is changed** (chain/settlement stays Codex-owned). The operational safety net of keeping the signer topped from the treasury (the USDC auto-refiller, approach **B**) is built separately in sibling worktrees and is **not** touched here.

The codebase already proves "a funded job that doesn't draw from the signer at claim time" via the `recurring_template_reserve` funding-source pattern; this generalizes that to ingested jobs.

## Changes
- **`PlatformService.createIngestedJob(input)`** — after `createJob`, when prefunding is enabled, escrows the reward via `ensureJob(job, job.id, 0)` (claimStake 0 — the worker funds their own stake) and stamps `funding = { source: "ingestion_prefund", state: "funded" }`. A funding shortfall is the **expected** steady state (USDC isn't auto-mintable) — it **never aborts the ingest run**: the job is kept, stamped `state: "pending"`, and a `funding.ingestion_prefund_pending` event is emitted at info severity. The marker omits `wallet`/`templateId`, so `gateway.usesRecurringTemplateReserve` can never misfire on it.
- **open-data + wiki schedulers** call `createIngestedJob` (feature-detect fallback to `createJob` so existing test fakes keep working; dry-run still never touches chain).
- **Discovery gate** (`summarizeJobClaimState`): an `ingestion_prefund` job whose `state` isn't `"funded"` is forced `claimable: false`, `reason: "reward_funding_pending"`, in **every** claimable-capable branch (no-session + expired). Surfaces `fundingState` through `claimStatusFields` and the compact `/jobs` row. Jobs with no funding marker / recurring-reserve jobs / funded jobs are **unaffected** (no regression).
- **Opt-in** via `INGESTION_PREFUND_ENABLED` (default **off**, testnet-only operational invariant), documented in `deploy/backend.env.template` and `mcp-server/.env.example`.

## Idempotency / safety
- Prefund-then-claim: the claim-time `ensureJob` no-ops for an already-created on-chain job (`live.state !== 0`) — no double-fund.
- A paused chain/policy degrades gracefully to `state: "pending"` (the on-chain create reverts).
- `pending → funded` reconciliation once liquidity arrives (restart/re-trigger re-attempts) is a documented follow-up — intentionally out of scope (edges into approach B).

## Tests
- `claim-state.test.js`: pending → not claimable + `reward_funding_pending` (no-session **and** expired branches); funded → claimable; no funding → claimable; recurring-reserve → claimable (gate scoped); retry-exhaustion precedence.
- `platform-service.test.js`: flag off / gateway disabled → no stamp + no `ensureJob`; success → `funded` (no `wallet`/`templateId`); insufficient liquidity → **resolves** with `pending`, job present; generic error → `pending`; creation error propagates (not swallowed).
- scheduler test: prefers `createIngestedJob`; a `pending` stamp doesn't abort `runOnce`.
- Full `mcp-server` suite green **except the 27 pre-existing `@aws-sdk/*` import failures** (unrelated env noise).

## Acceptance / live-testnet (operator-executed)
With `INGESTION_PREFUND_ENABLED=true` and a signer funded via `scripts/ops/fund-signer-usdc-deposit.mjs`: ingest → `GET /jobs?state=claimable` shows `claimable:true, fundingState:"funded"` → external waived worker claims (no 409) → submit → verify → settle, **no per-claim top-up**. Drained signer → job is discoverable but `claimable:false, fundingState:"pending"` (trap gone) → top up + re-trigger promotes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)