### PR TITLE
docs(secrets): track canary CI service-account token expiry

### DIFF
--- a/docs/SECRETS_CALENDAR.yml
+++ b/docs/SECRETS_CALENDAR.yml
@@ -192,6 +192,29 @@ entries:
       Smallest blast radius — leaked token can read the Smoke vault
       only.
 
+  - name: op-token-prod-backend-canary
+    description: 1Password service account token for the hosted worker canary CI workflow; reads the roleless canary worker key from prod-backend.
+    owner: operator
+    # No 1Password vault item — this token exists ONLY as the GitHub
+    # `production` environment secret OP_SERVICE_ACCOUNT_TOKEN_PROD_BACKEND.
+    # Rotation = mint a fresh service account (scope is immutable post-create).
+    expires_at: "2026-09-11"   # 90 days after creation on 2026-06-13 (op service-account create --expires-in 90d)
+    warn_days: 14
+    notes: |
+      Backs the `.github/workflows/hosted-worker-canary.yml` step that loads
+      op://prod-backend/canary-worker-testnet/private key. Service account
+      `canary-ci-prod-backend`, scoped read-only to prod-backend only
+      (prod-backend:read_items) — smallest blast radius for the worker key.
+
+      Rotation. This op CLI version has NO `service-account delete` — revoke
+      old/leaked service accounts in the 1Password WEB console (Developer →
+      Service Accounts), identifying them by UUID. Mint + reset the secret in
+      one pipe so the token never prints (one logical line):
+
+        op service-account create canary-ci-prod-backend --vault "prod-backend:read_items" --expires-in 90d | grep -oE 'ops_[^[:space:]]+' | head -1 | tr -d '\n' | gh secret set OP_SERVICE_ACCOUNT_TOKEN_PROD_BACKEND --env production --repo averray-agent/agent
+
+      Then revoke the previous SA in the web console and update this expires_at.
+
   # ── AWS signer access (NOT static IAM keys) ───────────────────────
   #
   # Revised in v2: we no longer store long-lived AWS IAM access keys


### PR DESCRIPTION
## What

Adds `op-token-prod-backend-canary` to `docs/SECRETS_CALENDAR.yml` — the 1Password service-account token that backs the hosted worker canary.

This is the token stored as the GitHub `production` environment secret **`OP_SERVICE_ACCOUNT_TOKEN_PROD_BACKEND`**, which `.github/workflows/hosted-worker-canary.yml` uses to read `op://prod-backend/canary-worker-testnet/private key`. It was provisioned on **2026-06-13** via `op service-account create … --expires-in 90d`, so it expires **~2026-09-11**.

## Why

The token has a hard vendor expiry but wasn't tracked, so the structural-lint **Secrets calendar expiry check** had no rotation horizon for it — it would silently lapse and break the canary's 1Password load step (the same fail-closed symptom that blocked the canary before provisioning). The entry gives the check a `warn_days: 14` window.

## Notes captured in the entry
- Scope: read-only to `prod-backend` only (`prod-backend:read_items`) — smallest blast radius for the worker key.
- No 1Password vault item — the token lives only as the GH env secret.
- The leak-free mint + `gh secret set` rotation pipe.
- This `op` CLI version has **no `service-account delete`** — revoke old/leaked SAs in the 1Password web console by UUID.

## Verification
`node scripts/ops/check-secrets-calendar.mjs` and the `SECRETS_CALENDAR_SIMPLE_YAML=1` (CI pre-install) path both parse the new entry: `✅ op-token-prod-backend-canary … expires in 90 days`, **0 fail / 0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)