### PR TITLE
ci(canary): ephemeral wallets for scheduled + post-deploy canary runs

### DIFF
--- a/.github/workflows/hosted-worker-canary.yml
+++ b/.github/workflows/hosted-worker-canary.yml
@@ -11,10 +11,13 @@ name: Hosted Worker Canary
 # them because they all used the pre-minted multi-role ADMIN_JWT and bypassed the
 # SIWE front door.
 #
-# The WORKER stages use a dedicated roleless testnet wallet
-# (op://prod-backend/canary-worker-testnet). Only the OPERATOR stages
-# (create/fund/verify/cleanup) use the ADMIN_JWT. Testnet-only — the script
-# refuses any other chain.
+# The WORKER stages use a roleless testnet wallet. Scheduled + post-deploy runs
+# mint a fresh EPHEMERAL wallet each time — always within the onboarding waiver,
+# so the loop stays green indefinitely with no stake funding to maintain. Manual
+# dispatches use the dedicated 1Password key (op://prod-backend/canary-worker-testnet)
+# unless allow_ephemeral is set, so the persistent/funded-claim path stays testable
+# on demand. Only the OPERATOR stages (create/fund/verify/cleanup) use the ADMIN_JWT.
+# Testnet-only — the script refuses any other chain.
 
 on:
   # Manual run, with knobs for one-off debugging.
@@ -81,7 +84,9 @@ jobs:
       WORKER_CANARY_REWARD_AMOUNT: ${{ inputs.reward_amount }}
       WORKER_CANARY_VERIFY_MODE: ${{ inputs.verify_mode }}
       WORKER_CANARY_TOKEN_MIN_DAYS: ${{ inputs.token_min_days }}
-      WORKER_CANARY_ALLOW_EPHEMERAL: ${{ inputs.allow_ephemeral && '1' || '' }}
+      # Scheduled + post-deploy runs use a throwaway wallet (always within the
+      # onboarding waiver — no stake funding needed); manual dispatch opts in via input.
+      WORKER_CANARY_ALLOW_EPHEMERAL: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run' || inputs.allow_ephemeral) && '1' || '' }}
       WORKER_CANARY_KEEP_JOB: ${{ inputs.keep_job && '1' || '' }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -106,9 +111,11 @@ jobs:
 
       # The roleless worker key lives in prod-backend (VPS-readable; prod-critical
       # is not). Loaded with a least-privilege service account scoped to
-      # prod-backend. Skipped for one-off ephemeral dispatches.
+      # prod-backend. Only the persistent-wallet path needs it — a manual dispatch
+      # that didn't opt into allow_ephemeral. Scheduled + post-deploy runs mint an
+      # ephemeral wallet and skip this step (and its prod-backend token dependency).
       - name: Load canary worker key from 1Password (fail-closed)
-        if: ${{ inputs.allow_ephemeral != true }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.allow_ephemeral != true }}
         uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
         with:
           export-env: true
@@ -130,7 +137,7 @@ jobs:
             *) echo "::error::ADMIN_JWT_OP does not look like a JWT (expected ey<...>.<...>.<...>)"; exit 1 ;;
           esac
 
-          if [ "${{ inputs.allow_ephemeral }}" != "true" ] && [ -z "${WORKER_CANARY_WORKER_PRIVATE_KEY:-}" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.allow_ephemeral }}" != "true" ] && [ -z "${WORKER_CANARY_WORKER_PRIVATE_KEY:-}" ]; then
             echo "::error::WORKER_CANARY_WORKER_PRIVATE_KEY is empty — check op://prod-backend/canary-worker-testnet/private key and OP_SERVICE_ACCOUNT_TOKEN_PROD_BACKEND."
             exit 1
           fi

--- a/docs/WORKER_CANARY.md
+++ b/docs/WORKER_CANARY.md
@@ -83,11 +83,15 @@ the public board. It never consumes claim attempts on real board jobs.
    - `OP_SERVICE_ACCOUNT_TOKEN_PROD_BACKEND` — a least-privilege service account scoped to **read** `op://prod-backend/canary-worker-testnet`.
 
 4. **Keep the worker claimable.** A fresh wallet's first
-   `onboardingWaiverClaimCount` (3) claims are stake/fee-waived. The dedicated
-   canary wallet exhausts that after a few runs, so for ongoing daily runs
-   **pre-fund** its `AgentAccountCore` position with ≥ the per-claim lock (operator
-   step; becomes a no-op once auto-fund lands). Until then, stage 3 fails loud if
-   the wallet is both waiver-exhausted and underfunded.
+   `onboardingWaiverClaimCount` (3) claims are stake/fee-waived. The **scheduled
+   and post-deploy runs mint a fresh ephemeral wallet each time**, so every run is
+   a first claim inside the waiver — they stay green indefinitely with no funding
+   to maintain, and don't depend on `OP_SERVICE_ACCOUNT_TOKEN_PROD_BACKEND`. The
+   **dedicated persistent wallet** is used only by manual dispatch (without
+   `allow_ephemeral`); after its 3 waiver claims it needs its `AgentAccountCore`
+   position **pre-funded** with ≥ the per-claim lock to keep claiming — use that
+   path on demand to exercise the funded/staked-claim flow. Stage 3 fails loud if a
+   persistent wallet is both waiver-exhausted and underfunded.
 
 ## Running it locally
 


### PR DESCRIPTION
## Problem

The hosted worker canary's dedicated wallet only gets **3 stake-free claims** (the `onboardingWaiverClaimCount` waiver). The daily `37 6 * * *` cron + the post-deploy `workflow_run` burn through those quickly, after which stage 3 (claim) 409s on insufficient stake — turning the canary permanently red — unless someone keeps pre-funding the worker's `AgentAccountCore` position.

The first green run ([27478295654](https://github.com/averray-agent/agent/actions/runs/27478295654)) was waiver claim 1/3, so this would have started failing within ~2 runs.

## Fix

Make the **automated cadence** (`schedule` + `workflow_run`) mint a **fresh ephemeral wallet per run**. Each run is then a first claim inside its own onboarding waiver → stake-free → green **indefinitely, with zero funding to maintain**. The canary still walks the *full real loop* (SIWE → claim → submit → verify → settle) through the real front door with a real roleless wallet — it just doesn't reuse one identity across runs.

**Manual dispatch keeps the persistent provisioned key** (unless `allow_ephemeral` is checked), so the persistent / funded-claim path stays testable on demand.

### Changes
- `WORKER_CANARY_ALLOW_EPHEMERAL` env is `'1'` for `schedule` + `workflow_run` (and still honors the dispatch input).
- The prod-backend **key-load step is skipped for non-dispatch events** — necessary because an explicit `WORKER_CANARY_WORKER_PRIVATE_KEY` *wins over* the ephemeral flag in `resolveWorkerWallet` (`scripts/ops/run-worker-canary.mjs:772`), which would re-exhaust the waiver. Scheduled runs also no longer depend on `OP_SERVICE_ACCOUNT_TOKEN_PROD_BACKEND`.
- The key-present **guard only fires for a persistent manual dispatch**.
- `docs/WORKER_CANARY.md`: documents the ephemeral-scheduled / persistent-manual split.

## Coverage note (truth-boundary)

The scheduled canary now exercises the **waiver / first-claim** path (what every genuinely new external worker hits first), not the post-waiver *staked* claim path. The staked path remains coverable on demand via a manual dispatch against the funded persistent wallet — called out explicitly in the runbook so the gap is visible, not silent.

## Verification
Workflow YAML parses clean. Logic traced for all four trigger/input combinations (schedule, workflow_run, dispatch-default, dispatch-ephemeral) — each resolves to the intended wallet path. Script unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)