### PR TITLE
feat(account): surface worker EOA wallet balance in /account

### DIFF
--- a/docs/GO_LIVE_PUNCHLIST.md
+++ b/docs/GO_LIVE_PUNCHLIST.md
@@ -55,7 +55,7 @@ fabrication.
 
 | Item | Why |
 | --- | --- |
-| Earnings → spendable-balance reconciliation | Reward settled to the worker **EOA** (confirmed 2 USDC), but `/account` reads the **AAC position** → shows 0 earned. Surface EOA balance in `/account`, or settle into the position so it's immediately stakeable. |
+| Earnings → spendable-balance reconciliation | **Visibility half DONE:** `/account` now surfaces a separate `walletBalance` (worker EOA) field, so a paid agent sees their reward (e.g. 2 USDC) instead of `0` — kept distinct from the AAC `liquid` position so paid-out funds aren't misrepresented as in-platform/stakeable. Remaining (**Codex — chain/settlement**): optionally settle the reward into the AAC position so it's immediately stakeable without a manual deposit. |
 | Expose settle/payout tx + verification-latency state | `/session` surfaces `chainJobId`/`evidenceHash` but no distinct payout tx; the job sat ~15 min in `submitted` with `/verifier/result` = `not_found` and no "verifying"/ETA state. |
 | Operator session-discovery | `/sessions` is caller-scoped, so a verifier can't find which submissions await verification (had to use `/admin/sessions`). |
 | Discovery reflects funding/settlement readiness | Jobs advertise `claimable: true` that can't actually settle (unfunded); `currentWalletCanClaim: null`. |

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -245,6 +245,31 @@ export class BlockchainGateway {
     });
   }
 
+  // Reads the worker's raw ERC-20 wallet (EOA) balance per supported asset.
+  // This is DISTINCT from getAccountSummary's `liquid`, which is the
+  // AgentAccountCore position. A settled job reward lands in the worker's EOA,
+  // not their AAC position — so it shows up here but NOT in `liquid` until the
+  // worker deposits it. Callers must keep the two separate: EOA funds are
+  // paid-out, not yet stakeable in-platform.
+  async getWalletTokenBalances(wallet) {
+    return this.withGatewayError("getWalletTokenBalances", async () => {
+      const walletBalance = {};
+      const raw = {};
+      const results = await Promise.all(
+        this.config.supportedAssets.map(async (asset) => {
+          const token = new Contract(asset.address, ERC20_MOCK_ABI, this.provider);
+          const balance = await token.balanceOf(wallet);
+          return { asset, balance };
+        })
+      );
+      for (const { asset, balance } of results) {
+        raw[asset.symbol] = this.toRawString(balance);
+        walletBalance[asset.symbol] = this.toDisplayUnits(balance, asset);
+      }
+      return { walletBalance, raw };
+    });
+  }
+
   async getAccountPosition(wallet, symbol) {
     return this.withGatewayError("getAccountPosition", async () => {
       const asset = this.requireAsset(String(symbol ?? "").trim().toUpperCase());

--- a/mcp-server/src/protocols/http/account-routes.js
+++ b/mcp-server/src/protocols/http/account-routes.js
@@ -138,8 +138,30 @@ export function createAccountRoutes({
     if (request.method === "GET" && pathname === "/account") {
       const auth = await authMiddleware(request, url);
       const account = await service.getAccountSummary(auth.wallet);
-      if (!gateway?.isEnabled?.() || !strategies.length) {
+      if (!gateway?.isEnabled?.()) {
         respond(response, 200, account);
+        return true;
+      }
+
+      // Surface the worker's EOA wallet balance alongside the AAC position. A
+      // settled job reward lands in the worker's EOA, not their AAC `liquid`
+      // position — so without this an agent that just got paid sees 0 earned.
+      // Kept as a SEPARATE field, never folded into `liquid`: EOA funds are
+      // paid-out, not yet stakeable in-platform until the worker deposits them.
+      let withWallet = account;
+      if (typeof gateway.getWalletTokenBalances === "function") {
+        const wallet = await gateway.getWalletTokenBalances(auth.wallet).catch(() => null);
+        if (wallet) {
+          withWallet = {
+            ...account,
+            walletBalance: wallet.walletBalance,
+            raw: { ...account.raw, walletBalance: wallet.raw }
+          };
+        }
+      }
+
+      if (!strategies.length) {
+        respond(response, 200, withWallet);
         return true;
       }
 
@@ -155,9 +177,9 @@ export function createAccountRoutes({
       });
 
       respond(response, 200, {
-        ...account,
+        ...withWallet,
         strategyAllocated: {
-          ...account.strategyAllocated,
+          ...withWallet.strategyAllocated,
           ...liveAllocatedByAsset
         }
       });

--- a/mcp-server/src/protocols/http/account-routes.test.js
+++ b/mcp-server/src/protocols/http/account-routes.test.js
@@ -229,6 +229,64 @@ test("GET /account overlays live strategy allocation by asset symbol", async () 
   assert.deepEqual(response.body.strategyAllocated, { DOT: 1, USDC: 10 });
 });
 
+test("GET /account surfaces the worker's EOA wallet balance as a separate field", async () => {
+  const gateway = {
+    isEnabled: () => true,
+    config: {
+      supportedAssets: [{ address: "0x0000000000000000000000000000000000000abc", symbol: "USDC" }]
+    },
+    getWalletTokenBalances: async () => ({
+      walletBalance: { USDC: 2 },
+      raw: { USDC: "2000000" }
+    }),
+    getStrategyPositions: async () => [],
+    getStrategyTelemetry: async () => []
+  };
+  const { response, route } = makeHarness({ gateway, strategies: [] });
+
+  const handled = await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/account"),
+    pathname: "/account",
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 200);
+  // EOA balance surfaced as its own field, with raw base units...
+  assert.deepEqual(response.body.walletBalance, { USDC: 2 });
+  assert.deepEqual(response.body.raw.walletBalance, { USDC: "2000000" });
+  // ...but NEVER folded into the AAC `liquid` position (truth boundary: EOA
+  // funds are paid-out, not yet stakeable in-platform).
+  assert.deepEqual(response.body.liquid, { DOT: 10 });
+});
+
+test("GET /account tolerates a wallet-balance read failure without 500ing", async () => {
+  const gateway = {
+    isEnabled: () => true,
+    config: {
+      supportedAssets: [{ address: "0x0000000000000000000000000000000000000abc", symbol: "USDC" }]
+    },
+    getWalletTokenBalances: async () => {
+      throw new Error("rpc unavailable");
+    },
+    getStrategyPositions: async () => [],
+    getStrategyTelemetry: async () => []
+  };
+  const { response, route } = makeHarness({ gateway, strategies: [] });
+
+  await route({
+    request: { method: "GET" },
+    response,
+    url: new URL("http://localhost/account"),
+    pathname: "/account",
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.walletBalance, undefined);
+  assert.deepEqual(response.body.liquid, { DOT: 10 });
+});
+
 test("GET /account/position returns chain-backed wallet asset position", async () => {
   const { calls, response, route } = makeHarness();
 


### PR DESCRIPTION
## Problem (P1 — external-agent UX)

When a job settles, the USDC reward lands in the worker's **EOA**, but `/account` reads the worker's **AgentAccountCore position** (`positions(wallet, asset).liquid`). The two diverge: the proof agent earned a confirmed **2 USDC** (`usdc.balanceOf(workerEOA) = 2.0`) yet `/account` showed `liquid: 0`. From the agent's side that reads as *"I did the work — where's my money?"* — the single most trust-damaging gap in the loop.

## Fix

Surface the EOA balance as a **new, clearly-separate `walletBalance` field** on `/account`.

- `gateway.getWalletTokenBalances(wallet)` — reads `balanceOf` per supported asset (read-only; reuses the existing `ERC20_MOCK_ABI` + provider + display/raw helpers). Additive; no existing method touched.
- `/account` overlays `walletBalance` (and `raw.walletBalance`) whenever the gateway is enabled — independent of whether strategies exist — and is resilient to a read failure (falls back to the plain summary, never 500s).

### Truth-boundary (the important part)

`walletBalance` is **never folded into `liquid`**. The EOA money is **paid-out, not yet deposited** into the platform position, so it is *not* stakeable/usable in-platform. Surfacing the two as distinct truths shows the agent they were paid **without** misrepresenting what's actually usable. Making the reward *immediately stakeable* (settle into the AAC position) is a **chain/settlement change owned by Codex** — flagged in the punch-list, not attempted here.

## Response shape (additive)
```jsonc
{
  "liquid":        { "USDC": 0 },          // AAC position — unchanged
  "walletBalance": { "USDC": 2 },          // NEW — worker EOA balance
  "raw": { /* ...existing... */, "walletBalance": { "USDC": "2000000" } }
}
```

## Tests
`node --test` — **account-routes.test.js 14/14**, **gateway.test.js 45/45**. New cases: surfaced-as-separate-field, `liquid` untouched (truth boundary), and read-failure tolerance.

## Punch-list
`docs/GO_LIVE_PUNCHLIST.md` P1 row updated: visibility half **done**; settle-into-position deferred to Codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)