### PR TITLE
fix(claims): don't burn a job's retry budget on an infra-failed submit

### DIFF
--- a/docs/GO_LIVE_PUNCHLIST.md
+++ b/docs/GO_LIVE_PUNCHLIST.md
@@ -59,7 +59,7 @@ fabrication.
 | Expose settle/payout tx + verification-latency state | **Latency half DONE:** `/verifier/result` is now session-aware — a submitted/disputed job without a verdict returns `{ status: "verifying", awaitingSince }` instead of an indistinguishable `not_found`, so a just-submitted worker sees in-progress + elapsed wait. Remaining (**Codex — chain/settlement**): capture the settle tx hash (`resolveSinglePayout` discards it; mirror `openDispute`'s `{ txHash, blockNumber }`) and persist `payoutTx` on the session — once persisted it auto-surfaces in `/session` and I can add it to the `verifying`→resolved result. |
 | Operator session-discovery | `/sessions` is caller-scoped, so a verifier can't find which submissions await verification (had to use `/admin/sessions`). |
 | Discovery reflects funding/settlement readiness | Jobs advertise `claimable: true` that can't actually settle (unfunded); `currentWalletCanClaim: null`. |
-| Don't burn claims on contract-reverted submits | "Crashes in DC" is stuck `retry_limit_exhausted` — its one attempt was spent on a round that reverted on-chain. |
+| Don't burn claims on contract-reverted submits | **DONE:** a submit whose on-chain call fails (contract revert / RPC outage) now stamps `submitFailedAt` on the still-claimed session, and `countClaimAttempts` skips sessions with `submitFailedAt` but no `submittedAt` — so an infra-failed submit no longer burns the job's retry budget (the worker can re-submit on the same claim; the job stays claimable). Genuine no-shows and rejections still consume an attempt. |
 
 ## P2 — polish & docs
 

--- a/mcp-server/src/core/claim-state.js
+++ b/mcp-server/src/core/claim-state.js
@@ -190,6 +190,15 @@ export function countClaimAttempts(sessions = undefined, session = undefined) {
   for (const candidate of candidates) {
     if (!candidate?.sessionId || seen.has(candidate.sessionId)) continue;
     seen.add(candidate.sessionId);
+    // A claim whose on-chain submit failed (infra revert / RPC outage) and that
+    // never reached a real submission must NOT burn the job's retry budget — the
+    // worker never got a fair shot. submittedAt is the ground-truth that a real
+    // submission landed (set only on the → submitted transition); an infra-failed
+    // claim carries submitFailedAt but no submittedAt. Genuine no-shows (claim
+    // left to expire without an attempt) and rejections still count.
+    if (candidate.submitFailedAt && !candidate.submittedAt) {
+      continue;
+    }
     if (candidate.claimedAt || candidate.status) {
       count += 1;
     }

--- a/mcp-server/src/core/claim-state.test.js
+++ b/mcp-server/src/core/claim-state.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { claimExpiresAt, isExpiredClaim, summarizeJobClaimState } from "./claim-state.js";
+import { claimExpiresAt, countClaimAttempts, isExpiredClaim, summarizeJobClaimState } from "./claim-state.js";
 
 const CLAIMED_SESSION = {
   sessionId: "job-001:0xabc",
@@ -143,4 +143,38 @@ test("retry exhaustion takes precedence over funding-pending in the reason", () 
   });
   assert.equal(status.claimable, false);
   assert.equal(status.reason, "retry_limit_exhausted");
+});
+
+test("countClaimAttempts excludes an infra-failed submit that never reached submitted", () => {
+  const sessions = [
+    {
+      sessionId: "job-x:0x1",
+      claimedAt: "2026-05-01T10:00:00.000Z",
+      status: "claimed",
+      submitFailedAt: "2026-05-01T10:00:05.000Z"
+    }
+  ];
+  assert.equal(countClaimAttempts(sessions), 0);
+});
+
+test("countClaimAttempts counts a session that reached submitted even if an earlier submit failed", () => {
+  const sessions = [
+    {
+      sessionId: "job-x:0x1",
+      claimedAt: "2026-05-01T10:00:00.000Z",
+      status: "submitted",
+      submitFailedAt: "2026-05-01T10:00:05.000Z",
+      submittedAt: "2026-05-01T10:00:10.000Z"
+    }
+  ];
+  assert.equal(countClaimAttempts(sessions), 1);
+});
+
+test("countClaimAttempts still counts normal claims, no-show expiries, and rejections", () => {
+  assert.equal(countClaimAttempts([{ sessionId: "a", claimedAt: "t", status: "claimed" }]), 1);
+  assert.equal(countClaimAttempts([{ sessionId: "b", claimedAt: "t", status: "expired" }]), 1);
+  assert.equal(
+    countClaimAttempts([{ sessionId: "c", claimedAt: "t", status: "rejected", submittedAt: "t2" }]),
+    1
+  );
 });

--- a/mcp-server/src/core/job-execution-service.js
+++ b/mcp-server/src/core/job-execution-service.js
@@ -258,11 +258,24 @@ export class JobExecutionService {
     const guardedSubmission = this.applyMaintainerSubmissionGuards(job, refreshed, submission);
     await validateJobSubmissionAgainstSchema(job, guardedSubmission);
     if (this.blockchainGateway?.isEnabled()) {
-      await this.blockchainGateway.submitWork(
-        session.chainJobId ?? session.jobId,
-        hashSubmission(guardedSubmission),
-        session.wallet
-      );
+      try {
+        await this.blockchainGateway.submitWork(
+          session.chainJobId ?? session.jobId,
+          hashSubmission(guardedSubmission),
+          session.wallet
+        );
+      } catch (error) {
+        // The submission passed validation but the on-chain submit failed (a
+        // contract revert or an RPC outage) — an infra failure, not a delivered
+        // attempt. Stamp the still-claimed session so countClaimAttempts won't
+        // burn the job's retry budget for it, then surface the error so the
+        // worker can retry the submit on the same claim.
+        await this.stateStore.upsertSession({
+          ...refreshed,
+          submitFailedAt: new Date().toISOString()
+        });
+        throw error;
+      }
     }
     const protocolHistory = [...new Set([...refreshed.protocolHistory, protocol])];
     const transitioned = transitionSession({

--- a/mcp-server/src/core/job-execution-service.test.js
+++ b/mcp-server/src/core/job-execution-service.test.js
@@ -2,11 +2,12 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { Wallet } from "ethers";
 
-import { ValidationError } from "./errors.js";
+import { BlockchainRevertError, ValidationError } from "./errors.js";
 import { JobExecutionService } from "./job-execution-service.js";
 import { MemoryStateStore } from "./state-store.js";
 import { computeClaimEconomics } from "./claim-economics.js";
-import { claimExpiresAt } from "./claim-state.js";
+import { claimExpiresAt, countClaimAttempts } from "./claim-state.js";
+import { transitionSession } from "./session-state-machine.js";
 import { buildAverrayDisclosureFooter } from "./maintainer-surface-policy.js";
 import {
   buildExternalSchemaRegistrationMessage,
@@ -608,4 +609,57 @@ test("submitWork does not duplicate an existing Averray disclosure footer", asyn
   });
 
   assert.equal(submitted.submission.structured.prBody, prBody);
+});
+
+test("submitWork stamps submitFailedAt and re-throws on a chain-revert, preserving the claim's retry budget", async () => {
+  const stateStore = new MemoryStateStore();
+  const job = makeJob();
+  const revertingGateway = {
+    isEnabled: () => true,
+    submitWork: async () => {
+      throw new BlockchainRevertError("submit reverted", { reason: "ClaimNotActive" });
+    }
+  };
+  const service = new JobExecutionService(stateStore, revertingGateway, () => job);
+
+  // Seed a claimed session directly so the reverting gateway is only exercised
+  // on the submit path (claimJob has its own on-chain dependencies, irrelevant here).
+  const claimed = transitionSession(
+    {
+      sessionId: `${job.id}:0xaaa`,
+      wallet: WALLET,
+      jobId: job.id,
+      chainJobId: `${job.id}:0xaaa`,
+      protocolHistory: []
+    },
+    "claimed",
+    { reason: "job_claimed" }
+  );
+  await stateStore.upsertSession(claimed);
+
+  await assert.rejects(
+    () =>
+      service.submitWork(claimed.sessionId, "http", {
+        summary: "Auth flow has one blocker.",
+        findings: [
+          {
+            severity: "high",
+            file: "frontend/auth.js",
+            issue: "Session refresh is hidden behind retry logic.",
+            recommendation: "Show a visible sign-in refresh path."
+          }
+        ],
+        risk_level: "high",
+        files_touched: ["frontend/auth.js"],
+        recommended_next_step: "request_changes"
+      }),
+    (error) => error.code === "blockchain_revert"
+  );
+
+  const after = await stateStore.getSession(claimed.sessionId);
+  assert.ok(after.submitFailedAt, "submitFailedAt should be stamped on a chain-reverted submit");
+  assert.equal(after.submittedAt, undefined, "the session never reached submitted");
+  assert.equal(after.status, "claimed", "the claim is preserved, not consumed");
+  // The infra-failed attempt must NOT burn the job's retry budget.
+  assert.equal(countClaimAttempts([after]), 0);
 });


### PR DESCRIPTION
## Problem (P1 — external-agent UX, punch-list item #3)

A worker's submit that passed validation but **failed on-chain** (a contract revert or RPC outage) left the session stuck in `claimed` — it never reached `submitted`. But `countClaimAttempts` counts **any** session with `claimedAt`, so that infra failure consumed the job's single retry attempt and stranded the job in `retry_limit_exhausted`, **claimable by nobody** (this is why the "Crashes in DC" job was stuck).

## Fix (app-layer retry bookkeeping only)

1. **`submitWork`** wraps the on-chain submit call: on failure it stamps `submitFailedAt` on the still-`claimed` session and re-throws — so the worker can retry the submit on the **same claim**, and the session is marked as an infra failure.
2. **`countClaimAttempts`** skips sessions that have `submitFailedAt` **but no `submittedAt`**.

`submittedAt` is the ground-truth that a real submission landed (it's set **only** on the `→ submitted` transition). So the exclusion can only ever **spare** an infra-failed submit — it can never miscount a real attempt:

| Session | counts? |
|---|---|
| normal claim → submit ok | ✅ yes (`submittedAt` set) |
| claim → submit reverted, no `submittedAt` | ❌ **no** (the fix) |
| claim → submit reverted, then re-submitted ok | ✅ yes (`submittedAt` now set) |
| claim left to expire (no-show) | ✅ yes (unchanged) |
| submitted → rejected | ✅ yes (unchanged) |

The on-chain `submitWork`/`submitWorkFor` calls are **untouched** — this is purely app-layer state.

## Tests
`node --test` — **job-execution-service.test.js 20/20**, **claim-state.test.js 13/13**. New: countClaimAttempts exclude/include matrix; submitWork stamps `submitFailedAt`, preserves the `claimed` status, and leaves `countClaimAttempts === 0` after a chain-revert.

## Punch-list
`docs/GO_LIVE_PUNCHLIST.md` P1 row #3 → **DONE**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)