### PR TITLE
chore(deploy): enable INGESTION_PREFUND_ENABLED on testnet

### DIFF
--- a/deploy/backend.env.template
+++ b/deploy/backend.env.template
@@ -285,7 +285,10 @@ OPEN_DATA_INGEST_QUERIES_JSON=["traffic crashes","food safety","water quality","
 # and are never claimable (no claim-time 409 insufficient_liquidity). Requires
 # the backend signer to hold deposited reward liquidity (USDC is not
 # auto-mintable). TESTNET-ONLY: only enable on testnet deployments.
-INGESTION_PREFUND_ENABLED=false
+# Enabled 2026-06-14 on the Polkadot Hub TestNet deployment (chainId 420420417)
+# to activate the self-sustaining loop; keep OFF until a mainnet cutover funds the
+# signer for mainnet reward liquidity.
+INGESTION_PREFUND_ENABLED=true
 STANDARDS_INGEST_ENABLED=true
 STANDARDS_INGEST_DRY_RUN=false
 STANDARDS_INGEST_INTERVAL_MS=3600000


### PR DESCRIPTION
## Activation — #1

Flips `INGESTION_PREFUND_ENABLED` `false → true` in `deploy/backend.env.template`, turning on auto-ingested-job reward pre-funding (PR #635) for the Polkadot Hub TestNet deployment.

**Effect on deploy:** auto-ingested jobs escrow their reward on-chain at ingestion, so discovery only advertises **genuinely-funded** jobs as claimable (the #635 funding gate). This eliminates the claim-time `409 insufficient_liquidity` class — the exact failure the first product job hit.

**Pairs with `AUTO_VERIFY_ENABLED` (already `true`)** to run the loop end-to-end with no operator at the wheel: ingest → (funded) → claim → submit → **auto-verify → settle**.

## Why it's safe

Graceful by design (confirmed in `platform-service.js`): if the backend signer is short, the job **stays discoverable but reports `fundingState=pending` and is never claimable** — an info-level event, not a failure. So enabling this only ever *improves* the truth boundary; it can't strand or 409 a claimer.

## Operational notes (for the deploy)

- **Fund the backend signer** with deposited USDC reward liquidity for the ingestion volume — otherwise jobs sit `pending` (honest, but not claimable) until funded.
- **Testnet-only.** The template comment + this flag must stay OFF for any future mainnet cutover until the mainnet signer is funded.
- After deploy, confirm the loop with `node src/demo/auto-verify-remote-smoke.js` (auto-verify) and watch a real ingested job reach `resolved` with a `payoutTx` (#642).

## Verification
`node scripts/ops/check-env-template-structure.mjs` → `ok` (the 5 warnings are pre-existing, unrelated to this line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)