### PR TITLE
fix(auth): rotate admin/verifier allowlists off the leaked EOA

### DIFF
--- a/deploy/backend.env.template
+++ b/deploy/backend.env.template
@@ -137,8 +137,12 @@ GITHUB_TOKEN=op://prod-backend-external/github-pat-issue-ingestion/password
 REDIS_URL=redis://redis:6379
 REDIS_NAMESPACE=agent-platform
 
-AUTH_ADMIN_WALLETS=0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519
-AUTH_VERIFIER_WALLETS=0xFd2EAE2043243fDdD2721C0b42aF1b8284Fd6519
+# Rotated 2026-06-14 from the leaked admin EOA 0xFd2EAE…6519 to the post-rotation
+# admin EOA (1Password reference: prod-critical / admin-eoa-testnet). Do NOT revert
+# to 0xFd2EAE…6519: its private key is compromised — leaving it in either allowlist
+# re-grants the leaked key admin/verifier access.
+AUTH_ADMIN_WALLETS=0x6778F050eAc8313e4dbB176d7BAB44510E833ac8
+AUTH_VERIFIER_WALLETS=0x6778F050eAc8313e4dbB176d7BAB44510E833ac8
 AUTH_DOMAIN=api.averray.com
 AUTH_CHAIN_ID=420420417
 


### PR DESCRIPTION
## Security + activation blocker

`deploy/backend.env.template` still authorized the **leaked** admin EOA `0xFd2EAE…6519` in **both** allowlists:

```
AUTH_ADMIN_WALLETS=0xFd2EAE…6519
AUTH_VERIFIER_WALLETS=0xFd2EAE…6519
```

The admin-key rotation (task "rotate leaked admin EOA") generated the new key but never updated these allowlists. Consequences:

1. **🔒 Security:** the compromised key still held **admin *and* verifier** roles — the rotation wasn't actually complete. Anyone with the leaked key could SIWE-login and get admin/verifier.
2. **Activation blocker:** the post-rotation admin EOA `0x6778F050…3ac8` was treated as **roleless** — its SIWE token 403s on `/admin/jobs`. Caught live while running the auto-verify remote smoke (signed in fine as `0x6778…`, then 403 *"Requires admin role"*).

## Fix

Swap both allowlists to the post-rotation admin EOA `0x6778F050…3ac8` (`prod-critical / admin-eoa-testnet`), and add a comment so it isn't reverted. Completes the rotation: closes the leaked-key hole **and** unblocks admin/verifier actions (and the smoke) under the new key.

## Scope
`deploy/backend.env.template` only — takes effect on next deploy. The other lingering `0xFd2EAE…6519` references are **non-auth** and left out of scope: doc examples (`README.md`, `VPS_RUNBOOK.md`), a frontend `DEFAULT_REVIEWER` fallback (`app/lib/api/dispute-adapters.ts`), and generated build artifacts. Worth a cosmetic cleanup later, but none grant access.

## Verification
`node scripts/ops/check-env-template-structure.mjs` → `ok` (pre-existing warnings only).

After deploy, re-running the auto-verify smoke with the `0x6778…` key should get past `/admin/jobs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)