### PR TITLE
docs(punch-list): correct two stale P2 claims before the audit freeze

### DIFF
--- a/docs/GO_LIVE_PUNCHLIST.md
+++ b/docs/GO_LIVE_PUNCHLIST.md
@@ -66,9 +66,9 @@ fabrication.
 | Item | Why |
 | --- | --- |
 | `--profile` rotation footgun doc fix | Calendar/onboarding rotation notes recommend `--profile testnet` → resolves to the wrong wallet + drops the verifier role (doc-fix PR pending). |
-| Worker-loop refresh-flow (#529, in soak) | Retires the recurring 30-day manual `ADMIN_JWT` rotation toil; smoke moves to short-lived refresh-minted tokens. |
+| Worker-loop refresh-flow | **DONE:** shipped in PR #529 (recorded as shipped in `PROJECT_ROADMAP.md`) — retires the recurring 30-day manual `ADMIN_JWT` rotation toil; smoke moves to short-lived refresh-minted tokens. (Punch-list previously said "in soak.") |
 | Standalone API-only smoke ladder | `claim-readiness-smoke.sh` needs the full Docker/Hermes stack; an API-only probe (nonce→verify→authed read→preflight→funding) would catch the blockers in seconds. |
-| `/jobs/preflight` 404 | Referenced as a readiness endpoint but unimplemented. |
+| `/jobs/preflight` readiness endpoint | **DONE (stale claim corrected):** the endpoint is implemented — `GET /jobs/preflight` (`job-routes.js`) → `platformService.preflightJob` → `jobCatalogService.preflightJob`, and it's advertised in the discovery manifest. The earlier "unimplemented/404" note predated the implementation. |
 | Key-provisioning UX | Default to a non-echoing `read -rs` prompt; never placeholder-in-command. |
 | TreasuryPolicy `setTrustedSchemaIssuer` redeploy | Deployed policy predates the external-schema functions (pre-existing; confirm the feature is needed before acting). |
 


### PR DESCRIPTION
## Pre-audit truth-boundary pass

While sweeping for pre-audit hardening, two P2 rows in `GO_LIVE_PUNCHLIST.md` turned out to be **stale "open" claims about things that are already done** — the kind of contradiction an auditor reading the package + frozen commit would catch:

1. **`/jobs/preflight`** — listed as *"Referenced as a readiness endpoint but unimplemented (404)."* It's actually implemented: `GET /jobs/preflight` (`job-routes.js:53`) → `platformService.preflightJob` → `jobCatalogService.preflightJob`, and it's advertised in the discovery manifest. The note predated the implementation.
2. **Worker-loop refresh-flow** — listed as *"(#529, in soak)."* `PROJECT_ROADMAP.md` records it as **shipped in #529**.

Both corrected to reflect reality. Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)