### PR TITLE
docs(secrets): require --roles admin,verifier in the admin-JWT mint runbook

### DIFF
--- a/docs/GO_LIVE_PUNCHLIST.md
+++ b/docs/GO_LIVE_PUNCHLIST.md
@@ -65,7 +65,7 @@ fabrication.
 
 | Item | Why |
 | --- | --- |
-| `--profile` rotation footgun doc fix | Calendar/onboarding rotation notes recommend `--profile testnet` → resolves to the wrong wallet + drops the verifier role (doc-fix PR pending). |
+| `--profile` rotation footgun doc fix | **DONE / clarified:** confirmed the backend authorizes on the token's `roles` claim, not `sub` (`middleware.js` `enforceRole`→`hasRole`; `AUTH_*_WALLETS` only seed roles at SIWE sign-in). So the "wrong wallet" `sub` (`--profile testnet` → `testnet.json#verifier` = the KMS signer) is **cosmetic**; the real bug was the **missing `--roles admin,verifier`** (script defaults to `admin` only) in one `SECRETS.md` mint command — fixed, with a clarifying note. The calendar's command already passed `--roles admin,verifier`. |
 | Worker-loop refresh-flow | **DONE:** shipped in PR #529 (recorded as shipped in `PROJECT_ROADMAP.md`) — retires the recurring 30-day manual `ADMIN_JWT` rotation toil; smoke moves to short-lived refresh-minted tokens. (Punch-list previously said "in soak.") |
 | Standalone API-only smoke ladder | `claim-readiness-smoke.sh` needs the full Docker/Hermes stack; an API-only probe (nonce→verify→authed read→preflight→funding) would catch the blockers in seconds. |
 | `/jobs/preflight` readiness endpoint | **DONE (stale claim corrected):** the endpoint is implemented — `GET /jobs/preflight` (`job-routes.js`) → `platformService.preflightJob` → `jobCatalogService.preflightJob`, and it's advertised in the discovery manifest. The earlier "unimplemented/404" note predated the implementation. |

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -324,7 +324,7 @@ which this entry retires.
 **Mint with the script** (current procedure):
 ```bash
 NEW_JWT=$(AUTH_JWT_SECRETS=$(op read "op://prod-backend/auth-jwt-secrets/password") \
-  node scripts/ops/mint-admin-jwt.mjs --profile testnet --expires-in-days 30 --quiet)
+  node scripts/ops/mint-admin-jwt.mjs --profile testnet --roles admin,verifier --expires-in-days 30 --quiet)
 
 # Store in 1Password (canonical home, used by Phase 2 PR 2.5 onward):
 op item create --vault=prod-smoke --category=password --title=admin-jwt \
@@ -337,9 +337,21 @@ unset NEW_JWT
 ```
 
 Notes:
+- `--roles admin,verifier` is **required**. The script defaults to
+  `admin` only, and the backend authorizes each request from the
+  verified token's `roles` claim — NOT from `sub`/the wallet allowlists
+  (`AUTH_ADMIN_WALLETS` / `AUTH_VERIFIER_WALLETS` only *seed* roles at
+  SIWE sign-in; see `mcp-server/src/auth/middleware.js` `enforceRole` →
+  `hasRole`). Omitting `--roles` mints an admin-only token that 403s on
+  `/verifier/*`.
 - `--profile testnet` — the current production system runs against
-  Polkadot Hub TestNet, so the mint script reads the verifier wallet
-  from `deployments/testnet.json`. After Phase 5 cutover provisions
+  Polkadot Hub TestNet, so the mint script reads the wallet from
+  `deployments/testnet.json` (`verifier ?? deployer`). Note
+  `testnet.json#verifier` is the **KMS signer** `0x31ad…ab7F`, so the
+  token's `sub` becomes the signer, not the admin EOA — harmless for
+  access (authorization is role-based, above), but pass
+  `--wallet 0x6778F050eAc8313e4dbB176d7BAB44510E833ac8` if you want the
+  token identity to be the admin EOA. After Phase 5 cutover provisions
   `deployments/mainnet.json`, this becomes `--profile mainnet`.
   (Earlier v3 doc drafts said `--profile production`, which doesn't
   match a real profile file — corrected in Phase 2 PR 2.1.)


### PR DESCRIPTION
## Closes the `--profile` rotation footgun (GO_LIVE_PUNCHLIST P2)

**Confirmed the auth model first** (`mcp-server/src/auth/middleware.js`): strict-mode requests authorize on the **verified token's `roles` claim** (`enforceRole → hasRole → claims.roles.includes(role)`), **not** on `sub`/the wallet allowlists. `AUTH_ADMIN_WALLETS` / `AUTH_VERIFIER_WALLETS` only *seed* the roles claim at SIWE sign-in.

That makes the footgun **doc-only**, with one real and one cosmetic part:

- **Real:** `mint-admin-jwt.mjs` defaults `roles: ["admin"]`, and the "create the admin-jwt item" command in `SECRETS.md` omitted `--roles` → following it literally mints an **admin-only** token that 403s on `/verifier/*`. **Added `--roles admin,verifier`** (the Phase-A rotation command and the secrets calendar already had it; only this one drifted).
- **Cosmetic:** `--profile testnet` resolves `sub` from `testnet.json#verifier`, which is the **KMS signer** `0x31ad…ab7F`, not the admin EOA. Harmless for access (role-based), but documented + offered `--wallet 0x6778F050…3ac8` to pin the admin identity.

**Live system is unaffected:** the canary's `verify_mode=operator` stage settles jobs (requires the verifier role), so the deployed `ADMIN_JWT` was minted correctly.

Doc-only: `SECRETS.md` (command + clarifying notes) and the `GO_LIVE_PUNCHLIST` P2 row → resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)