### PR TITLE
fix(contracts): guard strategy-lifecycle entrypoints with nonReentrant

### DIFF
--- a/contracts/AgentAccountCore.sol
+++ b/contracts/AgentAccountCore.sol
@@ -248,6 +248,7 @@ contract AgentAccountCore is ReentrancyGuard {
 
     function allocateIdleFunds(address account, bytes32 strategyId, uint256 amount)
         external
+        nonReentrant
         whenNotPaused
         onlyOwnerOrOperator(account)
     {
@@ -270,6 +271,7 @@ contract AgentAccountCore is ReentrancyGuard {
 
     function deallocateIdleFunds(address account, bytes32 strategyId, uint256 amount)
         external
+        nonReentrant
         whenNotPaused
         onlyOwnerOrOperator(account)
     {
@@ -297,6 +299,7 @@ contract AgentAccountCore is ReentrancyGuard {
 
     function requestStrategyDeposit(address account, StrategyDepositRequestParams calldata params)
         external
+        nonReentrant
         whenNotPaused
         onlyOwnerOrOperator(account)
         returns (bytes32 requestId)
@@ -322,6 +325,7 @@ contract AgentAccountCore is ReentrancyGuard {
 
     function requestStrategyWithdraw(address account, StrategyWithdrawRequestParams calldata params)
         external
+        nonReentrant
         whenNotPaused
         onlyOwnerOrOperator(account)
         returns (bytes32 requestId)
@@ -369,7 +373,7 @@ contract AgentAccountCore is ReentrancyGuard {
         uint256 settledShares,
         bytes32 remoteRef,
         bytes32 failureCode
-    ) external whenNotPaused onlyOperator {
+    ) external nonReentrant whenNotPaused onlyOperator {
         if (status == IXcmWrapper.RequestStatus.Unknown || status == IXcmWrapper.RequestStatus.Pending) {
             revert InvalidStrategyRequest();
         }


### PR DESCRIPTION
## What

Adds the `nonReentrant` modifier to the five strategy-lifecycle entrypoints in `AgentAccountCore`, placed right after `external` to mirror the existing posture:

- `allocateIdleFunds` — guards the external `adapter.deposit()` before the `strategyShares` update
- `deallocateIdleFunds` — guards `adapter.withdraw()` before the `strategyShares`/`liquid` update
- `requestStrategyDeposit` — guards `adapter.requestDeposit` (pulls tokens) + the `safeApprove` in `_createPendingDepositRequest`
- `requestStrategyWithdraw` — guards `adapter.requestWithdraw`
- `settleStrategyRequest` — guards `adapter.settleRequest()` before the `positions`/`strategyShares` updates

This mirrors the guard already used by `deposit`/`withdraw`/`repay`/`settleReservedTo`/`slashJobStake`/`slashClaimFee` in the same contract, and by `MockVDotAdapter`/`XcmVdotAdapter`, which guard every state-changing entrypoint.

## Why — defense-in-depth, not a live bug

This is **not** a known-exploitable issue today: the asset must pass `onlySupportedAsset` (owner-curated `policy.approvedAssets`), the adapter must be owner-registered in `StrategyAdapterRegistry` + `policy.approvedStrategies`, and both existing adapters already wrap their entrypoints in `nonReentrant` on a shared guard slot — so the cross-contract reentrancy path is already blocked. This purely closes the checks-effects-interactions gap so a future or buggy (but owner-approved) adapter cannot re-enter the strategy lane.

`allocateIdleFunds`/`deallocateIdleFunds`/`settleStrategyRequest` transitively call `_refreshStrategyAllocated`, which makes only `staticcall`/view reads to the registry/adapters — so the new guard introduces no self-reentrancy.

## Testing

- `forge build` ✅
- `forge test` ✅ — **107/107** passing, 0 failed
- Strategy paths exercised by `test/AgentAccountAsyncStrategy.t.sol` (7/7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
