### PR TITLE
fix(claims): self-heal mined-but-lost submits + bound the retry budget (pre-audit #2,#4)

### DIFF
--- a/mcp-server/src/core/claim-state.js
+++ b/mcp-server/src/core/claim-state.js
@@ -191,12 +191,19 @@ export function countClaimAttempts(sessions = undefined, session = undefined) {
     if (!candidate?.sessionId || seen.has(candidate.sessionId)) continue;
     seen.add(candidate.sessionId);
     // A claim whose on-chain submit failed (infra revert / RPC outage) and that
-    // never reached a real submission must NOT burn the job's retry budget — the
-    // worker never got a fair shot. submittedAt is the ground-truth that a real
-    // submission landed (set only on the → submitted transition); an infra-failed
-    // claim carries submitFailedAt but no submittedAt. Genuine no-shows (claim
-    // left to expire without an attempt) and rejections still count.
-    if (candidate.submitFailedAt && !candidate.submittedAt) {
+    // never reached a real submission must NOT burn the job's retry budget WHILE
+    // the claim is still live — the worker can re-submit on the same claim, so it
+    // gets a fair shot. submittedAt is the ground-truth that a real submission
+    // landed (set only on the → submitted transition). But once the claim reaches
+    // a TERMINAL state (it expired / timed out without a successful re-submit), it
+    // must count — otherwise a job whose submit always reverts could be claimed
+    // forever and never reach retry_limit_exhausted (anti-grief). Genuine no-shows
+    // and rejections still count regardless.
+    if (
+      candidate.submitFailedAt &&
+      !candidate.submittedAt &&
+      !TERMINAL_SESSION_STATUSES.has(candidate.status)
+    ) {
       continue;
     }
     if (candidate.claimedAt || candidate.status) {

--- a/mcp-server/src/core/claim-state.test.js
+++ b/mcp-server/src/core/claim-state.test.js
@@ -178,3 +178,22 @@ test("countClaimAttempts still counts normal claims, no-show expiries, and rejec
     1
   );
 });
+
+test("countClaimAttempts counts an infra-failed claim once it reaches a terminal state (retry budget must exhaust)", () => {
+  // While the claim is still live (non-terminal), an infra-failed submit is skipped
+  // so the worker can re-submit on the same claim (preserves the original guard)...
+  assert.equal(
+    countClaimAttempts([{ sessionId: "live", claimedAt: "t", status: "claimed", submitFailedAt: "t2" }]),
+    0
+  );
+  // ...but once it expires / times out without a successful re-submit, it MUST count —
+  // otherwise a job whose submit always reverts could be claimed forever.
+  assert.equal(
+    countClaimAttempts([{ sessionId: "exp", claimedAt: "t", status: "expired", submitFailedAt: "t2" }]),
+    1
+  );
+  assert.equal(
+    countClaimAttempts([{ sessionId: "to", claimedAt: "t", status: "timed_out", submitFailedAt: "t2" }]),
+    1
+  );
+});

--- a/mcp-server/src/core/job-execution-service.js
+++ b/mcp-server/src/core/job-execution-service.js
@@ -34,6 +34,10 @@ import {
 } from "./maintainer-surface-policy.js";
 import { claimExpiresAt, countClaimAttempts, isExpiredClaim, isTerminalSession } from "./claim-state.js";
 
+// EscrowCore JobState enum: None=0, Open=1, Claimed=2, Submitted=3, Rejected=4,
+// Disputed=5, Closed=6. Used to reconcile a mined-but-receipt-lost submit.
+const ESCROW_JOB_STATE_SUBMITTED = 3;
+
 export class JobExecutionService {
   constructor(
     stateStore,
@@ -265,16 +269,22 @@ export class JobExecutionService {
           session.wallet
         );
       } catch (error) {
-        // The submission passed validation but the on-chain submit failed (a
-        // contract revert or an RPC outage) — an infra failure, not a delivered
-        // attempt. Stamp the still-claimed session so countClaimAttempts won't
-        // burn the job's retry budget for it, then surface the error so the
-        // worker can retry the submit on the same claim.
-        await this.stateStore.upsertSession({
-          ...refreshed,
-          submitFailedAt: new Date().toISOString()
-        });
-        throw error;
+        // Reconcile against on-chain state before treating this as a failed
+        // attempt: a mined-but-receipt-lost submit (a flaky RPC dropping the
+        // connection before tx.wait() returns) still advanced the job to
+        // Submitted on-chain. If so, the submit really landed — fall through to
+        // the normal 'submitted' transition so the (auto-)verifier can settle it,
+        // instead of stranding the job and its escrowed reward with submitFailedAt.
+        // Only a genuine failure (true revert, or the chain unreachable so we
+        // cannot confirm) stamps submitFailedAt and rethrows.
+        const landed = await this.onChainSubmitLanded(session.chainJobId ?? session.jobId);
+        if (!landed) {
+          await this.stateStore.upsertSession({
+            ...refreshed,
+            submitFailedAt: new Date().toISOString()
+          });
+          throw error;
+        }
       }
     }
     const protocolHistory = [...new Set([...refreshed.protocolHistory, protocol])];
@@ -300,6 +310,19 @@ export class JobExecutionService {
       schemaRef: job.outputSchemaRef
     });
     return persisted;
+  }
+
+  // True only if the on-chain job has already advanced to Submitted (i.e. a prior
+  // submitWork tx mined even though its receipt was lost). Any read failure — e.g.
+  // the same RPC outage that dropped the receipt — returns false, so the caller
+  // safely treats the submit as a failed attempt rather than assuming it landed.
+  async onChainSubmitLanded(jobId) {
+    try {
+      const job = await this.blockchainGateway?.getJob?.(jobId);
+      return Number(job?.state) === ESCROW_JOB_STATE_SUBMITTED;
+    } catch {
+      return false;
+    }
   }
 
   async resumeSession(sessionId) {

--- a/mcp-server/src/core/job-execution-service.test.js
+++ b/mcp-server/src/core/job-execution-service.test.js
@@ -663,3 +663,74 @@ test("submitWork stamps submitFailedAt and re-throws on a chain-revert, preservi
   // The infra-failed attempt must NOT burn the job's retry budget.
   assert.equal(countClaimAttempts([after]), 0);
 });
+
+test("submitWork self-heals a mined-but-receipt-lost submit (on-chain already Submitted) instead of stranding it", async () => {
+  const stateStore = new MemoryStateStore();
+  const job = makeJob();
+  // submitWork throws (lost receipt) but the tx actually mined → on-chain job is Submitted (3).
+  const gateway = {
+    isEnabled: () => true,
+    submitWork: async () => {
+      throw new Error("RPC connection dropped before tx.wait() returned");
+    },
+    getJob: async () => ({ state: 3 })
+  };
+  const service = new JobExecutionService(stateStore, gateway, () => job);
+
+  const claimed = transitionSession(
+    { sessionId: `${job.id}:0xa1`, wallet: WALLET, jobId: job.id, chainJobId: `${job.id}:0xa1`, protocolHistory: [] },
+    "claimed",
+    { reason: "job_claimed" }
+  );
+  await stateStore.upsertSession(claimed);
+
+  const submitted = await service.submitWork(claimed.sessionId, "http", {
+    summary: "Auth flow has one blocker.",
+    findings: [{ severity: "high", file: "frontend/auth.js", issue: "x", recommendation: "y" }],
+    risk_level: "high",
+    files_touched: ["frontend/auth.js"],
+    recommended_next_step: "request_changes"
+  });
+
+  assert.equal(submitted.status, "submitted", "session advanced to submitted, not stranded");
+  assert.equal(submitted.submitFailedAt, undefined, "not marked as an infra failure");
+  const stored = await stateStore.getSession(claimed.sessionId);
+  assert.equal(stored.status, "submitted");
+});
+
+test("submitWork still stamps submitFailedAt + rethrows on a true revert (on-chain not Submitted)", async () => {
+  const stateStore = new MemoryStateStore();
+  const job = makeJob();
+  // submitWork reverts AND the on-chain job is still Claimed (2) → genuine failure.
+  const gateway = {
+    isEnabled: () => true,
+    submitWork: async () => {
+      throw new BlockchainRevertError("submit reverted", { reason: "InvalidState" });
+    },
+    getJob: async () => ({ state: 2 })
+  };
+  const service = new JobExecutionService(stateStore, gateway, () => job);
+
+  const claimed = transitionSession(
+    { sessionId: `${job.id}:0xb2`, wallet: WALLET, jobId: job.id, chainJobId: `${job.id}:0xb2`, protocolHistory: [] },
+    "claimed",
+    { reason: "job_claimed" }
+  );
+  await stateStore.upsertSession(claimed);
+
+  await assert.rejects(
+    () =>
+      service.submitWork(claimed.sessionId, "http", {
+        summary: "Auth flow has one blocker.",
+        findings: [{ severity: "high", file: "frontend/auth.js", issue: "x", recommendation: "y" }],
+        risk_level: "high",
+        files_touched: ["frontend/auth.js"],
+        recommended_next_step: "request_changes"
+      }),
+    (error) => error.code === "blockchain_revert"
+  );
+
+  const after = await stateStore.getSession(claimed.sessionId);
+  assert.ok(after.submitFailedAt, "true revert is still stamped as an infra failure");
+  assert.equal(after.status, "claimed");
+});


### PR DESCRIPTION
First batch of backend pre-audit remediation — two confirmed findings from the adversarial review (both PoC-verified by the independent verifier).

## #2 (HIGH) — mined-but-receipt-lost submit stranded the job + reward
`submitWork` treated **every** error from the on-chain submit as a failed attempt. A flaky RPC that drops the connection *after* the tx mines (no attacker needed) left the session `claimed` with `submitFailedAt`, while the on-chain job was already `Submitted` — so the auto-verifier (scans for `submitted`) never picked it up, and the claim couldn't be reopened (`handleClaimTimeout` reverts on a `Submitted` job). The escrowed reward was stuck: no settle, no refund, no auto-verify.

**Fix:** the catch now reconciles against on-chain state via `getJob`. If the job is already `Submitted` (`JobState == 3`), the submit really landed → the session advances to `submitted` (verifier settles it). Only a genuine failure (true revert, or chain unreachable so we can't confirm) stamps `submitFailedAt` and rethrows — a read failure safely falls back to the old behavior.

## #4 (MEDIUM) — retry budget never exhausted (edge in my #640)
The `submitFailedAt` skip I added to `countClaimAttempts` in #640 excluded a session **even after it expired**, so a job whose submit always reverts could be claimed forever and never reach `retry_limit_exhausted` (a runnable PoC claimed a `retryLimit=1` job 5 rounds running, count pinned at 0).

**Fix:** scope the skip to **non-terminal** sessions. An infra-failed submit is still spared while the claim is live (the worker can re-submit on the same claim — #640's intent), but a timed-out/expired no-show now burns the budget.

## Scope / safety
App-layer only — `getJob` is a read; no settlement mutation, no contract change. Tests: new self-heal + true-revert cases (job-exec) and terminal-counts case (claim-state); **full backend suite 957/957**.

Part of the pre-audit remediation batch. Contract findings **#1** (AgentAccountCore settlement authz) and **#3** (resolveDispute raw-unit mispay) are going to Codex separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)