### PR TITLE
fix(gateway): convert dispute payouts to base units

### DIFF
--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -1017,9 +1017,12 @@ export class BlockchainGateway {
   async resolveDispute(jobId, workerPayout, reasonCode, metadataURI = "") {
     return this.withGatewayError("resolveDispute", async () => {
       this.requireArbitratorSigner("resolveDispute");
+      const job = await this.getJob(jobId);
+      const asset = this.assetForAddress(job.asset);
+      const workerPayoutBase = this.toBaseUnits(workerPayout, asset, "dispute worker payout");
       const tx = await this.arbitratorEscrowContract.resolveDispute(
         this.toJobId(jobId),
-        workerPayout,
+        workerPayoutBase,
         this.toDisputeReasonCode(reasonCode),
         metadataURI
       );

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { encodeBytes32String } from "ethers";
+import { encodeBytes32String, Interface } from "ethers";
 
 import { BlockchainGateway } from "./gateway.js";
 import { InsufficientLiquidityError, ValidationError } from "../core/errors.js";
@@ -146,16 +146,61 @@ test("resolveDispute uses the arbitrator signer contract when configured", async
       };
     }
   };
+  gateway.getJob = async (jobId) => {
+    assert.equal(jobId, "wiki-job");
+    return { asset: DOT_ASSET.address };
+  };
 
   const receipt = await gateway.resolveDispute("wiki-job", 0, "DISPUTE_LOST", "https://api.example.test/content/0xabc");
 
   assert.deepEqual(calls, [[
     gateway.toJobId("wiki-job"),
-    0,
+    0n,
     gateway.toDisputeReasonCode("DISPUTE_LOST"),
     "https://api.example.test/content/0xabc"
   ]]);
   assert.deepEqual(receipt, { txHash: "0xresolve", blockNumber: 8, status: 1 });
+});
+
+test("resolveDispute converts display worker payout to asset base units", async () => {
+  const gateway = new BlockchainGateway({ enabled: false, supportedAssets: [USDC_TRUST_ASSET] });
+  const iface = new Interface([
+    "function resolveDispute(bytes32 jobId,uint256 workerPayout,bytes32 reasonCode,string metadataURI)"
+  ]);
+  const encodedCalls = [];
+  gateway.signer = {
+    marker: "service"
+  };
+  gateway.escrowContract = {
+    async resolveDispute() {
+      throw new Error("service signer must not resolve disputes when an arbitrator signer exists");
+    }
+  };
+  gateway.arbitratorSigner = {
+    marker: "arbitrator"
+  };
+  gateway.arbitratorEscrowContract = {
+    async resolveDispute(...args) {
+      encodedCalls.push(iface.encodeFunctionData("resolveDispute", args));
+      return {
+        hash: "0xresolve",
+        async wait() {
+          return { blockNumber: 9, status: 1 };
+        }
+      };
+    }
+  };
+  gateway.getJob = async (jobId) => {
+    assert.equal(jobId, "wiki-job");
+    return { asset: USDC_TRUST_ASSET.address };
+  };
+
+  const receipt = await gateway.resolveDispute("wiki-job", 2, "WORKER_WINS", "averray://disputes/dispute-1");
+
+  assert.deepEqual(receipt, { txHash: "0xresolve", blockNumber: 9, status: 1 });
+  assert.equal(encodedCalls.length, 1);
+  const [, workerPayout] = iface.decodeFunctionData("resolveDispute", encodedCalls[0]);
+  assert.equal(workerPayout, 2_000_000n);
 });
 
 test("resolveSinglePayout returns the settle/payout tx receipt", async () => {


### PR DESCRIPTION
## What changed
- Convert resolveDispute worker payouts from display units to asset base units before calling EscrowCore.resolveDispute.
- Reuse the gateway asset metadata path so USDC payouts encode with 6 decimals and DOT/non-integer validation follows existing toBaseUnits behavior.
- Add a regression test that ABI-encodes the dispute settlement call and asserts the uint256 payout is 2_000_000 for a display payout of 2 USDC.

## Checks
- node --test mcp-server/src/blockchain/gateway.test.js
- npm --workspace mcp-server test

## Impact
- Backend settlement path only.
- No contract, frontend, indexer, Caddy, or public-site changes.
- No environment or VPS secret changes required.