### PR TITLE
fix(verifier): make verifySubmission idempotent across a post-payout persist failure (pre-audit #5)

### DIFF
--- a/mcp-server/src/services/verifier-service.js
+++ b/mcp-server/src/services/verifier-service.js
@@ -9,6 +9,13 @@ import { normalizeSubmission } from "../core/submission.js";
 import { getJobSchema } from "../core/job-schema-registry.js";
 import { normalizeSubmitPayloadShape, validateSubmissionContract } from "../core/job-execution-service.js";
 
+// EscrowCore JobState enum: None=0, Open=1, Claimed=2, Submitted=3, Rejected=4,
+// Disputed=5, Closed=6. resolveSinglePayout only runs from Submitted and reverts
+// once the job has been resolved (approved→Closed, rejected→Rejected) — used to
+// make verifySubmission idempotent across a post-payout persistence failure.
+const ESCROW_JOB_STATE_REJECTED = 4;
+const ESCROW_JOB_STATE_CLOSED = 6;
+
 export class VerifierService {
   constructor(platformService, stateStore, blockchainGateway = undefined, registry = new VerifierRegistry()) {
     this.platformService = platformService;
@@ -33,8 +40,18 @@ export class VerifierService {
       details: verdict.details ?? null
     });
 
+    // Idempotent settle. resolveSinglePayout mutates on-chain state BEFORE the
+    // verdict is persisted below; if a prior attempt settled on-chain but then
+    // failed to persist (e.g. a Redis blip), the session is left 'submitted'
+    // while the reward was already paid, and a naive retry would call
+    // resolveSinglePayout again and revert InvalidState (the contract only
+    // settles from Submitted) — wedging the session forever. So skip the settle
+    // when the on-chain job has already been resolved, and let ingestVerification
+    // (re-run with the same deterministic verdict) converge submitted →
+    // resolved/rejected. Only a genuinely-unsettled job is settled here.
     let payoutTx;
-    if (this.blockchainGateway?.isEnabled() && this.blockchainGateway.resolveSinglePayout) {
+    const alreadySettled = await this.onChainAlreadySettled(chainJobId);
+    if (!alreadySettled && this.blockchainGateway?.isEnabled() && this.blockchainGateway.resolveSinglePayout) {
       payoutTx = await this.blockchainGateway.resolveSinglePayout(
         chainJobId,
         verdict.outcome === "approved",
@@ -63,6 +80,23 @@ export class VerifierService {
     };
 
     return this.stateStore.upsertVerificationResult(sessionId, result);
+  }
+
+  // True if the on-chain job has already been resolved by a prior settle
+  // (approved → Closed, rejected → Rejected), i.e. resolveSinglePayout must not
+  // run again. Any read failure returns false (we cannot confirm), so the caller
+  // falls back to attempting the settle rather than silently skipping a real one.
+  async onChainAlreadySettled(jobId) {
+    try {
+      if (!this.blockchainGateway?.isEnabled?.() || typeof this.blockchainGateway.getJob !== "function") {
+        return false;
+      }
+      const job = await this.blockchainGateway.getJob(jobId);
+      const state = Number(job?.state);
+      return state === ESCROW_JOB_STATE_REJECTED || state === ESCROW_JOB_STATE_CLOSED;
+    } catch {
+      return false;
+    }
   }
 
   async replayVerification(sessionId) {

--- a/mcp-server/src/services/verifier-service.test.js
+++ b/mcp-server/src/services/verifier-service.test.js
@@ -871,3 +871,79 @@ test("verifySubmission surfaces the on-chain payout tx on the result and the ses
   const stored = await stateStore.getSession(submitted.sessionId);
   assert.deepEqual(stored.payoutTx, payoutReceipt);
 });
+
+function makeIdempotencyHarness(onChainState) {
+  const stateStore = new MemoryStateStore();
+  const job = {
+    id: "idem-001",
+    outputSchemaRef: "schema://jobs/release-readiness-output",
+    verifierMode: "deterministic",
+    verifierConfig: {
+      version: 1,
+      handler: "deterministic",
+      expectedOutputs: ["release_id", "checks_passed", "go_no_go"],
+      matchMode: "contains_all"
+    }
+  };
+  const claimed = transitionSession({
+    sessionId: "idem-001:0xabc",
+    wallet: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    jobId: "idem-001",
+    submission: normalizeSubmission({
+      release_id: "release-2026-06-15",
+      checks_passed: ["api-health"],
+      checks_failed: [],
+      blockers: [],
+      go_no_go: "go"
+    })
+  }, "claimed", { reason: "job_claimed" });
+  const platformService = {
+    resumeSession: (id) => stateStore.getSession(id),
+    getJobDefinition: () => job,
+    ingestVerification: async (id, verdict) => {
+      const current = await stateStore.getSession(id);
+      const updated = transitionSession(current, verdict.outcome === "approved" ? "resolved" : "rejected", {
+        reason: "verification_resolved"
+      });
+      await stateStore.upsertSession(updated);
+      return updated;
+    }
+  };
+  const calls = { settle: 0 };
+  const blockchainGateway = {
+    isEnabled: () => true,
+    getJob: async () => ({ state: onChainState }),
+    resolveSinglePayout: async () => {
+      calls.settle += 1;
+      return { txHash: "0xpayout", blockNumber: 1, status: 1 };
+    }
+  };
+  return { stateStore, claimed, platformService, blockchainGateway, calls };
+}
+
+test("verifySubmission is idempotent: skips re-settling an already-resolved (Closed) on-chain job and still converges the session", async () => {
+  const h = makeIdempotencyHarness(6); // EscrowCore JobState.Closed — a prior attempt already settled
+  const submitted = transitionSession(h.claimed, "submitted", { reason: "work_submitted" });
+  await h.stateStore.upsertSession(submitted);
+
+  const service = new VerifierService(h.platformService, h.stateStore, h.blockchainGateway);
+  const result = await service.verifySubmission({ sessionId: submitted.sessionId });
+
+  assert.equal(h.calls.settle, 0, "must NOT re-settle a job the chain already resolved (would revert InvalidState)");
+  assert.equal(result.outcome, "approved");
+  const stored = await h.stateStore.getSession(submitted.sessionId);
+  assert.equal(stored.status, "resolved", "session converges to resolved despite the earlier persistence failure");
+});
+
+test("verifySubmission still settles when the on-chain job is genuinely unsettled (Submitted)", async () => {
+  const h = makeIdempotencyHarness(3); // EscrowCore JobState.Submitted — not yet settled
+  const submitted = transitionSession(h.claimed, "submitted", { reason: "work_submitted" });
+  await h.stateStore.upsertSession(submitted);
+
+  const service = new VerifierService(h.platformService, h.stateStore, h.blockchainGateway);
+  const result = await service.verifySubmission({ sessionId: submitted.sessionId });
+
+  assert.equal(h.calls.settle, 1, "an unsettled job must still be settled exactly once");
+  assert.equal(result.outcome, "approved");
+  assert.deepEqual(result.payoutTx, { txHash: "0xpayout", blockNumber: 1, status: 1 });
+});


### PR DESCRIPTION
Pre-audit finding **#5 (MEDIUM)**, adversarially verified.

## Bug
`verifySubmission` settles on-chain (`resolveSinglePayout`) **before** persisting the session transition. If the persist fails *after* the on-chain settle (a Redis blip/failover), the session is left `submitted` while the reward was already paid. The next auto-verify tick re-selects the still-`submitted` session and calls `resolveSinglePayout` again → EscrowCore reverts `InvalidState` (it only settles from `Submitted`). The session is wedged forever: paid on-chain, never `resolved`, `/verifier/result` stuck on `verifying`, accounting never reflecting the payout.

## Fix
Idempotency guard before the settle: if the on-chain job is already resolved (`Closed=6` for approved, `Rejected=4` for rejected), **skip** `resolveSinglePayout` and let `ingestVerification` (re-run with the same deterministic verdict) converge `submitted → resolved/rejected`. A genuinely-unsettled (`Submitted`) job still settles **exactly once**; a `getJob` read failure falls back to attempting the settle, so a real settlement is never silently skipped.

App-layer only — `getJob` is a read; no settlement-mutation or contract change.

## Tests
`node --test` — verifier-service **28/28** (new: idempotent-skip-and-converge, still-settles-when-unsettled), **full backend suite 960/960**.

Pre-audit remediation batch. #2/#4 (#649) and #3 (#650) merged; #1 (AgentAccountCore authz) is with Codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)