### PR TITLE
mcp-server: serialize submitWork on the session lock (pre-audit #6)

### DIFF
--- a/mcp-server/src/core/job-execution-service.js
+++ b/mcp-server/src/core/job-execution-service.js
@@ -238,6 +238,34 @@ export class JobExecutionService {
   async submitWork(sessionId, protocol, submissionInput = "submitted-via-service") {
     const session = await this.requireSession(sessionId);
     const job = this.getJobDefinition(session.jobId);
+    // Serialize on the session so concurrent/retried submits for the same claim
+    // cannot broker duplicate on-chain submitWork txs (pre-audit #6). Reuses the
+    // per-session claim lock, so a claim and a submit for one session also cannot
+    // race. On contention: return an already-advanced session idempotently, else
+    // surface a conflict rather than starting a second on-chain submit.
+    const sessionLockId = sessionId;
+    const lockOwner = randomUUID();
+    const lockAcquired = await this.stateStore.acquireClaimLock?.(
+      sessionLockId,
+      lockOwner,
+      this.getClaimLockTtlSeconds(job)
+    );
+    if (lockAcquired === false) {
+      const current = await this.stateStore.getSession(sessionId);
+      if (current && current.status && current.status !== "claimed") {
+        return current;
+      }
+      throw new ConflictError(`Submit already in progress for ${sessionId}`, "submit_in_progress");
+    }
+    try {
+      return await this.submitWorkLocked(session, job, protocol, submissionInput);
+    } finally {
+      await this.stateStore.releaseClaimLock?.(sessionLockId, lockOwner);
+    }
+  }
+
+  async submitWorkLocked(session, job, protocol, submissionInput) {
+    const sessionId = session.sessionId;
     const refreshed = await this.materializeExpiredClaim(session, job);
     if (refreshed.status === "expired") {
       throw new ConflictError(

--- a/mcp-server/src/core/job-execution-service.test.js
+++ b/mcp-server/src/core/job-execution-service.test.js
@@ -734,3 +734,32 @@ test("submitWork still stamps submitFailedAt + rethrows on a true revert (on-cha
   assert.ok(after.submitFailedAt, "true revert is still stamped as an infra failure");
   assert.equal(after.status, "claimed");
 });
+
+test("submitWork refuses to start a second submit while the session lock is held (pre-audit #6)", async () => {
+  const stateStore = new MemoryStateStore();
+  const job = makeJob();
+  const service = new JobExecutionService(stateStore, undefined, () => job);
+  const claimed = transitionSession(
+    { sessionId: `${job.id}:0xc6`, wallet: WALLET, jobId: job.id, chainJobId: `${job.id}:0xc6`, protocolHistory: [] },
+    "claimed",
+    { reason: "job_claimed" }
+  );
+  await stateStore.upsertSession(claimed);
+  // A concurrent submit/claim holds the per-session lock.
+  await stateStore.acquireClaimLock(claimed.sessionId, "other-owner", 30);
+
+  await assert.rejects(
+    () =>
+      service.submitWork(claimed.sessionId, "http", {
+        summary: "Auth flow has one blocker.",
+        findings: [{ severity: "high", file: "frontend/auth.js", issue: "x", recommendation: "y" }],
+        risk_level: "high",
+        files_touched: ["frontend/auth.js"],
+        recommended_next_step: "request_changes"
+      }),
+    (error) => error.code === "submit_in_progress"
+  );
+  // The contender did not advance the session.
+  const stored = await stateStore.getSession(claimed.sessionId);
+  assert.equal(stored.status, "claimed");
+});


### PR DESCRIPTION
## Pre-audit finding #6 (LOW) — submitWork lacked claim-lock/idempotency

`claimJob` serializes on a per-session claim lock so concurrent/retried claims can't broker duplicate on-chain txs. `submitWork` did **not** — two concurrent or retried `submitWork` calls for the same session could each broker an on-chain `submitWorkFor` tx, double-submitting work for one claim.

### Fix
- Wrap `submitWork` in the same per-session lock (`lockId = sessionId`, reusing `acquireClaimLock`/`releaseClaimLock`), body extracted into `submitWorkLocked`.
- On lock contention:
  - if a concurrent submit already advanced the session past `claimed`, return that session **idempotently**;
  - otherwise throw `ConflictError("submit_in_progress")` instead of starting a second on-chain submit.
- Sharing the claim lock means a **claim and a submit** for one session can no longer race either.
- Stores without `acquireClaimLock` degrade gracefully (`?.` → `undefined`, not `false` → no serialization, no crash) — same pattern as `claimJob`.

### Test
New test: a held session lock makes a second `submitWork` reject with `submit_in_progress` and leaves the session unchanged (`status: "claimed"`).

Full backend suite: **959/959** (+1 new = 960). `node --check` clean.

### Scope
Backend only (`mcp-server/src/core/job-execution-service.js` + test). No chain/contract changes. Part of the pre-audit remediation batch alongside #649 (#2/#4), #650 (#3, Codex), #652 (#5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)