### PR TITLE
mcp-server: fail closed on permissive auth + live gateway (pre-audit #7)

### DIFF
--- a/deploy/backend.env.template
+++ b/deploy/backend.env.template
@@ -146,6 +146,13 @@ AUTH_VERIFIER_WALLETS=0x6778F050eAc8313e4dbB176d7BAB44510E833ac8
 AUTH_DOMAIN=api.averray.com
 AUTH_CHAIN_ID=420420417
 
+# AUTH_MODE defaults to "strict" under NODE_ENV=production (leave it unset here).
+# The backend refuses to boot if AUTH_MODE=permissive while the blockchain
+# gateway is enabled — permissive auth accepts an unauthenticated ?wallet= and
+# would let any caller broker on-chain operations as an allowlisted wallet
+# (pre-audit #7). AUTH_ALLOW_PERMISSIVE_BROKERING=1 overrides this guard for
+# local dev against a live chain; never set it in production.
+
 # Phase 4b dispatcher mode. Controls which JWT algorithm(s) the backend
 # accepts and emits. Valid values: hmac | kms | both. Default: hmac.
 # - hmac:  HS256-only, current pre-4b behavior

--- a/mcp-server/src/services/bootstrap-auth-brokering-posture.test.js
+++ b/mcp-server/src/services/bootstrap-auth-brokering-posture.test.js
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { assertSafeAuthBrokeringPosture } from "./bootstrap.js";
+import { ConfigError } from "../core/errors.js";
+
+const enabledGateway = { isEnabled: () => true };
+const disabledGateway = { isEnabled: () => false };
+
+test("permissive auth + enabled gateway refuses to boot (pre-audit #7)", () => {
+  assert.throws(
+    () =>
+      assertSafeAuthBrokeringPosture({
+        authConfig: { permissive: true },
+        gateway: enabledGateway,
+        env: {}
+      }),
+    (error) => error instanceof ConfigError && /AUTH_MODE=permissive/.test(error.message)
+  );
+});
+
+test("strict auth + enabled gateway boots cleanly", () => {
+  assert.doesNotThrow(() =>
+    assertSafeAuthBrokeringPosture({
+      authConfig: { permissive: false },
+      gateway: enabledGateway,
+      env: {}
+    })
+  );
+});
+
+test("permissive auth + disabled gateway boots cleanly (dev default)", () => {
+  assert.doesNotThrow(() =>
+    assertSafeAuthBrokeringPosture({
+      authConfig: { permissive: true },
+      gateway: disabledGateway,
+      env: {}
+    })
+  );
+});
+
+test("explicit AUTH_ALLOW_PERMISSIVE_BROKERING opt-in boots but warns loudly", () => {
+  const warnings = [];
+  assert.doesNotThrow(() =>
+    assertSafeAuthBrokeringPosture({
+      authConfig: { permissive: true },
+      gateway: enabledGateway,
+      env: { AUTH_ALLOW_PERMISSIVE_BROKERING: "1" },
+      logger: { warn: (...args) => warnings.push(args) }
+    })
+  );
+  assert.equal(warnings.length, 1, "the dangerous posture is logged, never silent");
+  assert.equal(warnings[0][1], "auth.permissive_brokering_explicitly_allowed");
+});
+
+test("a non-truthy opt-in value does not disarm the guard", () => {
+  assert.throws(
+    () =>
+      assertSafeAuthBrokeringPosture({
+        authConfig: { permissive: true },
+        gateway: enabledGateway,
+        env: { AUTH_ALLOW_PERMISSIVE_BROKERING: "no" }
+      }),
+    ConfigError
+  );
+});

--- a/mcp-server/src/services/bootstrap.js
+++ b/mcp-server/src/services/bootstrap.js
@@ -67,6 +67,7 @@ import { normaliseStrategyAssetConfig } from "./strategy-asset-config.js";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { DEFAULT_ESCROW_ASSET_SYMBOL } from "../core/assets.js";
+import { ConfigError } from "../core/errors.js";
 
 const moduleDir = dirname(fileURLToPath(import.meta.url));
 loadLocalEnv(process.cwd(), resolve(moduleDir, "../../"));
@@ -209,6 +210,14 @@ export async function createPlatformRuntime() {
   logger.info(
     describeMutationBackendStartup(mutationBackendConfig, gateway),
     "mutation_backend.configured"
+  );
+  // Refuse to boot a real on-chain broker behind permissive auth (pre-audit
+  // #7). Permissive mode accepts an unauthenticated `?wallet=` and resolves
+  // that wallet's roles with no signature — harmless against a disabled
+  // gateway, but with chain brokering live it lets any caller broker on-chain
+  // operations as any allowlisted wallet.
+  initStep("check-auth-brokering-posture", logger, () =>
+    assertSafeAuthBrokeringPosture({ authConfig, gateway, env: process.env, logger })
   );
   const pimlicoClient = initStep("init-pimlico-client", logger, () => new PimlicoClient());
   const stateStore = initStep("init-state-store", logger, () => createStateStore(process.env, { logger }));
@@ -441,6 +450,44 @@ function initStep(name, logger, factory) {
     );
     throw error;
   }
+}
+
+/**
+ * Fail closed when a real on-chain broker is paired with permissive auth
+ * (pre-audit #7). In permissive mode, requireAuth accepts an unauthenticated
+ * `?wallet=<addr>` and grants that wallet's allowlisted roles with no
+ * signature check. That is acceptable for local dev against a disabled
+ * gateway, but if `gateway.isEnabled()` is true the same path lets any
+ * unauthenticated caller broker on-chain operations (claim/submit/settle) as
+ * any AUTH_*_WALLETS member. Refuse to boot that combination unless an
+ * operator has explicitly opted in via AUTH_ALLOW_PERMISSIVE_BROKERING — in
+ * which case we still log a loud warning so the posture is never silent.
+ *
+ * @param {object} args
+ * @param {{ permissive?: boolean }} args.authConfig
+ * @param {{ isEnabled?: () => boolean }} args.gateway
+ * @param {Record<string, string | undefined>} [args.env]
+ * @param {{ warn?: Function }} [args.logger]
+ */
+export function assertSafeAuthBrokeringPosture({ authConfig, gateway, env = process.env, logger } = {}) {
+  const permissive = authConfig?.permissive === true;
+  const gatewayEnabled = typeof gateway?.isEnabled === "function" && gateway.isEnabled() === true;
+  if (!permissive || !gatewayEnabled) {
+    return;
+  }
+  if (parseBooleanEnv(env.AUTH_ALLOW_PERMISSIVE_BROKERING)) {
+    logger?.warn?.(
+      { authMode: "permissive", gatewayEnabled: true },
+      "auth.permissive_brokering_explicitly_allowed"
+    );
+    return;
+  }
+  throw new ConfigError(
+    "AUTH_MODE=permissive with the blockchain gateway enabled lets an unauthenticated " +
+      "?wallet= caller broker on-chain operations as any allowlisted wallet. Set AUTH_MODE=strict " +
+      "(recommended), or, only if you intentionally want unauthenticated brokering (e.g. local dev " +
+      "against a live chain), set AUTH_ALLOW_PERMISSIVE_BROKERING=1."
+  );
 }
 
 function loadRateLimitConfig(env = process.env) {


### PR DESCRIPTION
## Pre-audit finding #7 (LOW) — permissive auth + live gateway = unauthenticated on-chain brokering

In permissive `AUTH_MODE`, `requireAuth` accepts an unauthenticated `?wallet=<addr>` query param and grants that wallet's allowlisted roles **with no signature check** (`auth/middleware.js:135-164`). Against a disabled gateway that's a harmless dev convenience. But if `gateway.isEnabled()` is true, the same path lets **any unauthenticated caller broker on-chain operations** (claim / submit / settle) as any `AUTH_ADMIN_WALLETS` / `AUTH_VERIFIER_WALLETS` member.

### Fix — fail closed at boot
New guard `assertSafeAuthBrokeringPosture` (called as a bootstrap init step right after the gateway is constructed) **refuses to boot** when `authConfig.permissive && gateway.isEnabled()`:

- escape hatch: `AUTH_ALLOW_PERMISSIVE_BROKERING=1` re-enables the combination for local dev against a live chain, and still **logs a loud warning** (`auth.permissive_brokering_explicitly_allowed`) so the posture is never silent;
- a non-truthy value does **not** disarm the guard.

Production is unaffected — `NODE_ENV=production` already defaults `AUTH_MODE=strict`. This converts a dangerous *misconfiguration* into a hard, self-documenting boot failure rather than a silently-exploitable runtime state.

### Tests
5 cases on the exported pure helper: permissive+enabled → `ConfigError`; strict+enabled → ok; permissive+disabled → ok (dev default); explicit opt-in → boots + warns exactly once; non-truthy opt-in → still throws.

Full backend suite: **965/965**. Documented the var + behavior in `deploy/backend.env.template`.

### Scope
Backend only (`bootstrap.js` + new test + env-template comment). No chain/contract changes. Pre-audit remediation batch alongside #649/#650/#651/#652/#653.

🤖 Generated with [Claude Code](https://claude.com/claude-code)