### PR TITLE
mcp-server: redact credentials from provider errors (pre-audit #8)

### DIFF
--- a/mcp-server/src/blockchain/event-listener.js
+++ b/mcp-server/src/blockchain/event-listener.js
@@ -1,3 +1,5 @@
+import { redactProviderError } from "../core/redact-provider-error.js";
+
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const DEFAULT_POLL_INTERVAL_MS = 4_000;
 const DEFAULT_MAX_BLOCKS_PER_QUERY = 1_000;
@@ -571,7 +573,7 @@ export class EventListener {
       timestamp: new Date().toISOString(),
       data: {
         eventName,
-        message: error?.message ?? "listener_error"
+        message: redactProviderError(error?.message ?? "listener_error")
       }
     });
   }
@@ -649,7 +651,7 @@ export class EventListener {
       topic: "system.provider_error",
       timestamp: new Date().toISOString(),
       data: {
-        message: error?.message ?? "provider_error"
+        message: redactProviderError(error?.message ?? "provider_error")
       }
     });
   }

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -31,6 +31,7 @@ import {
 import { buildXcmRequestPayload } from "./xcm-message-builder.js";
 import { hashCanonicalContent } from "../core/canonical-content.js";
 import { getRegisteredJobSchemaRegistration } from "../core/job-schema-registry.js";
+import { redactProviderError } from "../core/redact-provider-error.js";
 import {
   BlockchainRevertError,
   ConfigError,
@@ -1876,13 +1877,16 @@ export class BlockchainGateway {
   }
 
   extractGatewayReason(error) {
-    return (
+    // Redact credential-looking material (RPC URLs with embedded keys, Bearer
+    // tokens, JWTs) before this reason is surfaced on /health, logged, or
+    // stamped onto the thrown error's rawReason (pre-audit #8).
+    return redactProviderError(
       error?.reason ||
-      error?.shortMessage ||
-      error?.info?.error?.message ||
-      error?.info?.payload?.method ||
-      error?.message ||
-      "unknown_error"
+        error?.shortMessage ||
+        error?.info?.error?.message ||
+        error?.info?.payload?.method ||
+        error?.message ||
+        "unknown_error"
     );
   }
 }

--- a/mcp-server/src/core/redact-provider-error.js
+++ b/mcp-server/src/core/redact-provider-error.js
@@ -1,0 +1,55 @@
+// Redact credential-looking material from provider/RPC error strings before
+// they reach operator-visible surfaces (the gateway health endpoint and the
+// system.* event stream) — pre-audit #8.
+//
+// Raw ethers/provider errors frequently echo the configured RPC endpoint
+// verbatim, and many hosted providers (Infura, Alchemy, dwellir paid tiers,
+// …) carry the API key in the URL path or query — so a single reconnect
+// error can publish the signing-tier RPC key to anyone watching /health or
+// the event stream. Errors can likewise echo Authorization headers, JWTs, or
+// `apikey=`-style params from a request body.
+//
+// The redaction is deliberately narrow: it strips URL userinfo/path/query
+// (keeping scheme://host so operators still see *which* provider failed),
+// credential key=value params, Bearer tokens, and JWTs. It leaves revert
+// reasons, "insufficient funds"/"nonce" diagnostics, on-chain addresses, and
+// tx hashes intact so error classification and debugging are unaffected.
+
+// scheme://[userinfo@]host[:port][/path?query#frag] → scheme://host[/[redacted]]
+const URL_RE = /\b(https?|wss?):\/\/(?:[^\s/@'"]+@)?([^\s/:'"]+(?::\d+)?)(\/[^\s'"]*)?/gi;
+
+// key=value / key: value where the key names a credential. Keeps the key name
+// and delimiter; redacts only the value.
+const SECRET_PARAM_RE =
+  /\b(api[_-]?key|apikey|token|secret|password|passwd|access[_-]?key|private[_-]?key)\b(\s*[=:]\s*)("?)([^&\s'"]+)\3/gi;
+
+// Authorization: Bearer <token>
+const BEARER_RE = /\b(Bearer)\s+([A-Za-z0-9._~+/=-]+)/gi;
+
+// JSON Web Tokens always begin with the base64url of `{"` → "eyJ".
+const JWT_RE = /\beyJ[A-Za-z0-9._-]{8,}/g;
+
+/**
+ * Redact credential-looking substrings from a provider error string.
+ * Non-string input is coerced (objects via their `message`/`reason` field
+ * when present, else String()), so callers can hand it a raw error.
+ *
+ * @param {unknown} input
+ * @returns {string}
+ */
+export function redactProviderError(input) {
+  let text;
+  if (typeof input === "string") {
+    text = input;
+  } else if (input && typeof input === "object") {
+    text = String(input.message ?? input.reason ?? input);
+  } else {
+    text = String(input ?? "");
+  }
+
+  return text
+    .replace(URL_RE, (_match, scheme, host, rest) => `${scheme}://${host}${rest ? "/[redacted]" : ""}`)
+    .replace(SECRET_PARAM_RE, (_match, key, delim) => `${key}${delim}[redacted]`)
+    .replace(BEARER_RE, (_match, scheme) => `${scheme} [redacted]`)
+    .replace(JWT_RE, "[redacted-jwt]");
+}

--- a/mcp-server/src/core/redact-provider-error.test.js
+++ b/mcp-server/src/core/redact-provider-error.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { redactProviderError } from "./redact-provider-error.js";
+
+test("strips the path/query of an RPC URL but keeps scheme://host (pre-audit #8)", () => {
+  const out = redactProviderError("could not detect network (https://eth.example.io/v3/SUPERSECRETKEY123)");
+  assert.match(out, /https:\/\/eth\.example\.io\/\[redacted\]/);
+  assert.doesNotMatch(out, /SUPERSECRETKEY123/);
+});
+
+test("redacts a wss endpoint key and any userinfo", () => {
+  const out = redactProviderError("ws closed wss://user:pass@asset-hub.n.dwellir.com/abcd-key-1234");
+  assert.doesNotMatch(out, /abcd-key-1234/);
+  assert.doesNotMatch(out, /user:pass/);
+  assert.match(out, /wss:\/\/asset-hub\.n\.dwellir\.com\/\[redacted\]/);
+});
+
+test("redacts credential key=value params anywhere", () => {
+  const out = redactProviderError("request failed apikey=deadbeefcafe token: hunter2secret");
+  assert.match(out, /apikey=\[redacted\]/);
+  assert.match(out, /token:\s*\[redacted\]/);
+  assert.doesNotMatch(out, /deadbeefcafe/);
+  assert.doesNotMatch(out, /hunter2secret/);
+});
+
+test("redacts Bearer tokens and JWTs", () => {
+  const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIweGFiYyJ9.signaturepart";
+  const out = redactProviderError(`401 Authorization: Bearer ${jwt}`);
+  assert.match(out, /Bearer \[redacted\]/);
+  assert.doesNotMatch(out, /signaturepart/);
+});
+
+test("leaves revert reasons, addresses, and tx hashes intact", () => {
+  const msg =
+    "execution reverted: insufficient funds (nonce too low) job 0x" +
+    "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef" +
+    " from 0x6778F050eAc8313e4dbB176d7BAB44510E833ac8";
+  const out = redactProviderError(msg);
+  assert.equal(out, msg, "diagnostic + on-chain data must survive unredacted");
+});
+
+test("coerces a raw error object via its message", () => {
+  const out = redactProviderError(new Error("boom https://rpc.example.io/key/SECRET"));
+  assert.match(out, /https:\/\/rpc\.example\.io\/\[redacted\]/);
+  assert.doesNotMatch(out, /SECRET/);
+});


### PR DESCRIPTION
## Pre-audit finding #8 (INFO) — provider errors can leak RPC keys / tokens to /health + event stream

Raw ethers/provider error strings reach **operator-visible surfaces**:
- the gateway **health endpoint** — `extractGatewayReason` (`gateway.js:1878`) feeds `wrapGatewayError`'s `rawReason`;
- the **event stream** — `system.listener_error` (`event-listener.js:567`) and `system.provider_error` (`event-listener.js:646`) publish `error.message` verbatim.

These strings frequently echo the configured RPC endpoint, and hosted providers (Infura, Alchemy, dwellir paid tiers, …) carry the **API key in the URL path/query** — so a single reconnect error can publish the signing-tier RPC key to anyone watching `/health` or the event stream. Errors can likewise echo `Authorization: Bearer …` headers, JWTs, or `apikey=` params.

### Fix
New narrow shared redactor `core/redact-provider-error.js`:
- **URLs** → strip userinfo + path + query + fragment, keep `scheme://host` (operators still see *which* provider failed);
- **credential params** (`apikey`/`token`/`secret`/`password`/`access_key`/`private_key` `=`/`:` value) → value redacted;
- **`Bearer <token>`** → `Bearer [redacted]`;
- **JWTs** (`eyJ…`) → `[redacted-jwt]`.

Applied at the gateway chokepoint (`extractGatewayReason`, so health + thrown `rawReason` + logs all get the redacted form) and both event-listener publishers. **Revert reasons, insufficient-funds/nonce diagnostics, on-chain addresses, and tx hashes are left intact** — error classification (`wrapGatewayError`'s revert regex) and debugging are unaffected.

### Tests
6 cases: URL key, wss key + userinfo, `key=value` params, Bearer/JWT, *diagnostics-survive-unredacted*, raw-error-object coercion.

Full backend suite: **966/966**.

### Scope
Backend only (new util + gateway/event-listener wiring + test). No chain/contract changes. Final item of the pre-audit remediation batch alongside #649/#650/#651/#652/#653/#654.

🤖 Generated with [Claude Code](https://claude.com/claude-code)