### PR TITLE
mcp-server: gate net-reward haircut to native-gas rewards (invariant-9)

### DIFF
--- a/mcp-server/src/core/assets.js
+++ b/mcp-server/src/core/assets.js
@@ -19,6 +19,16 @@ export const ASSET_DECIMALS_BY_SYMBOL = {
   VDOT: 10
 };
 
+// Symbols that ARE the chain's native gas token (Polkadot DOT, Paseo testnet
+// PAS). Used to gate native-gas-denominated heuristics — e.g. a gas-cost or
+// risk haircut calibrated in DOT must not be subtracted from a USDC reward,
+// which would mix units and silently shrink the payout (USDC unit invariant).
+export const NATIVE_GAS_ASSET_SYMBOLS = new Set(["DOT", "PAS"]);
+
+export function isNativeGasAsset(symbol) {
+  return NATIVE_GAS_ASSET_SYMBOLS.has(normalizeAssetSymbol(symbol));
+}
+
 export function normalizeAssetSymbol(value, fallback = DEFAULT_ESCROW_ASSET_SYMBOL) {
   const symbol = String(value ?? fallback).trim();
   return symbol ? symbol.toUpperCase() : fallback;

--- a/mcp-server/src/core/assets.test.js
+++ b/mcp-server/src/core/assets.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { isNativeGasAsset, NATIVE_GAS_ASSET_SYMBOLS } from "./assets.js";
+
+test("native gas symbols are exactly DOT and PAS", () => {
+  assert.deepEqual([...NATIVE_GAS_ASSET_SYMBOLS].sort(), ["DOT", "PAS"]);
+});
+
+test("isNativeGasAsset is case-insensitive and true only for native gas", () => {
+  assert.equal(isNativeGasAsset("DOT"), true);
+  assert.equal(isNativeGasAsset("dot"), true);
+  assert.equal(isNativeGasAsset(" PAS "), true);
+  assert.equal(isNativeGasAsset("USDC"), false);
+  assert.equal(isNativeGasAsset("usdt"), false);
+  // undefined normalizes to the default escrow asset (USDC) → not native gas.
+  assert.equal(isNativeGasAsset(undefined), false);
+});

--- a/mcp-server/src/core/job-catalog-net-reward.test.js
+++ b/mcp-server/src/core/job-catalog-net-reward.test.js
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { JobCatalogService } from "./job-catalog-service.js";
+
+const WALLET = "0xworker";
+
+function makeService(jobs) {
+  const profiles = new Map();
+  // A low-risk worker on an elite job is what arms the risk haircut.
+  profiles.set(WALLET, { wallet: WALLET, preferredRiskLevel: "low" });
+  const svc = new JobCatalogService(
+    jobs,
+    profiles,
+    async () => ({}),
+    async () => ({}),
+    async () => 0
+  );
+  return svc;
+}
+
+test("a USDC reward is NOT docked the native-gas haircut (invariant-9)", async () => {
+  const svc = makeService([
+    { id: "usdc", rewardAmount: 0.2, rewardAsset: "USDC", tier: "elite", requiresSponsoredGas: false }
+  ]);
+  // Pre-fix this returned max(0.2 - 0.5 - 5, 0) = 0 — the reward vanished.
+  assert.equal(await svc.estimateNetReward(WALLET, "usdc"), 0.2);
+});
+
+test("a DOT reward still takes the gas + risk haircut", async () => {
+  const svc = makeService([
+    { id: "dot", rewardAmount: 50, rewardAsset: "DOT", tier: "elite", requiresSponsoredGas: false }
+  ]);
+  assert.equal(await svc.estimateNetReward(WALLET, "dot"), 50 - 0.5 - 5);
+});
+
+test("a sponsored-gas DOT reward takes only the risk haircut", async () => {
+  const svc = makeService([
+    { id: "dot2", rewardAmount: 50, rewardAsset: "DOT", tier: "elite", requiresSponsoredGas: true }
+  ]);
+  assert.equal(await svc.estimateNetReward(WALLET, "dot2"), 50 - 5);
+});
+
+test("a non-native reward defaults (undefined asset → USDC) take no haircut", async () => {
+  const svc = makeService([
+    { id: "def", rewardAmount: 3, tier: "elite", requiresSponsoredGas: false }
+  ]);
+  assert.equal(await svc.estimateNetReward(WALLET, "def"), 3);
+});

--- a/mcp-server/src/core/job-catalog-service.js
+++ b/mcp-server/src/core/job-catalog-service.js
@@ -27,6 +27,7 @@ import {
   summarizeTierGate
 } from "./job-catalog-gates.js";
 import { buildVerificationContract } from "./verifier-contract.js";
+import { isNativeGasAsset } from "./assets.js";
 
 export {
   ROLE_REQUIREMENTS,
@@ -456,6 +457,14 @@ export class JobCatalogService {
   async estimateNetReward(wallet, jobId) {
     const job = this.requireJob(jobId);
     const profile = this.requireProfile(wallet);
+    // The gas and risk haircuts are heuristics calibrated in the chain's
+    // native gas token (DOT/PAS). Subtracting them from a non-native reward
+    // (e.g. a USDC bounty) mixes units and silently shrinks the payout — a
+    // 0.5+5 haircut would zero out a sub-unit USDC reward (invariant-9, the
+    // USDC unit invariant). Only apply them when the reward IS native gas.
+    if (!isNativeGasAsset(job.rewardAsset)) {
+      return Math.max(job.rewardAmount, 0);
+    }
     const gasPenalty = job.requiresSponsoredGas ? 0 : 0.5;
     const riskPenalty = profile.preferredRiskLevel === "low" && job.tier === "elite" ? 5 : 0;
     return Math.max(job.rewardAmount - gasPenalty - riskPenalty, 0);


### PR DESCRIPTION
## invariant-9 (LOW) — net-reward haircut mixes units, zeroes USDC rewards

`estimateNetReward` subtracts a **gas haircut (0.5)** and a **risk haircut (5)** from `job.rewardAmount` for *every* reward asset (`job-catalog-service.js:456`). Those heuristics are calibrated in the chain's **native gas token** (DOT/PAS). Subtracting them from a non-native reward — a USDC bounty — mixes units and silently shrinks the displayed payout:

> a `0.2` USDC reward returned `max(0.2 − 0.5 − 5, 0) = 0` net.

This is the **USDC unit invariant** (invariant-9): native-gas/DOT-denominated math must never be applied to a stable-asset amount.

### Fix
- `core/assets.js`: add `NATIVE_GAS_ASSET_SYMBOLS` (`{DOT, PAS}`) + `isNativeGasAsset(symbol)` (case-insensitive, normalizes via `normalizeAssetSymbol`).
- `estimateNetReward`: apply the gas + risk haircuts **only when the reward asset is native gas**; non-native rewards return `max(rewardAmount, 0)` unmodified.

### Tests
- `assets.test.js` — `isNativeGasAsset` true only for DOT/PAS, case-insensitive; symbol set is exactly `{DOT, PAS}`.
- `job-catalog-net-reward.test.js` — USDC keeps full reward (the regression); DOT still takes gas+risk; sponsored-gas DOT takes only risk; undefined asset (→ USDC default) takes no haircut.

Full backend suite: **966/966** — existing `netReward` assertions (discovery-manifest, job-routes, smoke) unaffected.

### Scope
Backend only (assets + job-catalog-service + 2 tests). No chain/contract changes. Clean re-implementation of the parked invariant-9 fix. Pre-audit batch alongside #649/#650/#651/#652/#653/#654/#655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)