### PR TITLE
ci(deploy): make Hermes post-deploy verification advisory, not a gate

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -559,13 +559,29 @@ jobs:
           if-no-files-found: error
           retention-days: 90
 
-      - name: Fail if Hermes post-deploy verification failed
+      # ADVISORY (not a gate). By this point the averray deploy has already
+      # completed and passed its own readiness wait + rollback checks, so the
+      # backend's health is established independently. Hermes post-deploy
+      # verification runs inside the avg-hermes testbed sidecar — a Hermes-side
+      # problem (e.g. avg-hermes crash-looping on an /opt/data/skills volume
+      # permission, which red-flagged every deploy on 2026-06-16 while
+      # api.averray.com/health was a clean 200 the whole time) must NOT red an
+      # otherwise-good averray deploy. So surface a non-zero result loudly as a
+      # warning annotation + step summary instead of exiting 1. The Hosted
+      # Worker Canary remains the hard gate for the brokered
+      # claim/submit/settle path.
+      - name: Surface Hermes post-deploy verification result (advisory)
         if: always() && env.DEPLOY_RUN_HERMES_POST_DEPLOY == '1' && steps.hermes_post_deploy.outcome != 'skipped' && steps.hermes_post_deploy.outputs.exit_status != '0'
         run: |
-          echo "Hermes post-deploy verification failed with status ${HERMES_STATUS:-unknown}."
-          exit 1
+          echo "::warning title=Hermes post-deploy verification not OK::Hermes returned status ${HERMES_STATUS:-unknown} (outcome=${HERMES_OUTCOME:-unknown}). The averray deploy completed and passed its own health checks; this is an advisory signal about the Hermes testbed sidecar, not a deploy failure. Inspect the uploaded hermes-post-deploy log."
+          {
+            echo "> [!WARNING]"
+            echo "> **Hermes post-deploy verification advisory** — returned status \`${HERMES_STATUS:-unknown}\` (outcome \`${HERMES_OUTCOME:-unknown}\`)."
+            echo "> The averray deploy itself succeeded and is **not** gated on this. See the uploaded \`hermes-post-deploy\` log, and the Hosted Worker Canary for the brokered claim/submit/settle path."
+          } >> "$GITHUB_STEP_SUMMARY"
         env:
           HERMES_STATUS: ${{ steps.hermes_post_deploy.outputs.exit_status }}
+          HERMES_OUTCOME: ${{ steps.hermes_post_deploy.outputs.outcome }}
 
       # Tier-1 surface sweep (depre-dev/averray-reference-agent). Read-only:
       # walks the public surfaces, flags console/network errors per route, and


### PR DESCRIPTION
## Problem — a Hermes sidecar issue reds the whole averray deploy

The `Deploy Production` job ends with a **"Fail if Hermes post-deploy verification failed"** step that does `exit 1` whenever the Hermes testbed returns non-zero. But the Hermes check runs *inside* the `avg-hermes` container — so a Hermes-side problem fails the gate regardless of averray's actual health.

**This bit on 2026-06-16.** `avg-hermes` crash-looped on an `/opt/data/skills` volume permission (the volume root got recreated `root:root 0700`, locking out the UID-10000 Hermes user — 508 restarts). Every `Deploy Production` run failed at the Hermes step for hours, and the **Hosted Worker Canary was skipped each time** (it's gated on deploy success) — all while `https://api.averray.com/health` was a clean **200** the entire time. The averray backend deployed perfectly; a sidecar's volume permission held the pipeline red.

By the time this step runs, the deploy has already completed and passed its own **readiness wait + rollback** checks, so backend health is established independently of Hermes.

## Change

Convert the hard gate into a **loud advisory**:
- on a non-zero Hermes result, emit a `::warning::` annotation + a `> [!WARNING]` step-summary callout, then **exit 0**;
- the deploy is no longer reddened by a Hermes-sidecar failure.

This matches the **surface-sweep** step immediately below it, which is already "REPORT-ONLY by design … a detection signal, never a gate."

### What still gates
- **Pre-deploy OP-validation** steps (`exit 1` on missing/invalid secrets) — untouched.
- The deploy's own **readiness wait + rollback** — untouched.
- The **Hosted Worker Canary** remains the hard gate for the brokered claim/submit/settle path, so settlement regressions are still caught (separately from a green deploy).

### Scope
One file (`.github/workflows/deploy-production.yml`), +19/-3. YAML validated. No averray code change.

> Context: discovered while verifying the pre-audit batch (#648–#656) deployed. The batch is healthy in prod; this removes the false-red. Separately, the worker canary is currently red on `settlementReady=false` (signer USDC liquidity exhausted) — tracked for the chain/settlement owner, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)