### PR TITLE
ops: standalone API-only claim-readiness smoke (go-live P2)

### DIFF
--- a/scripts/ops/api-readiness-smoke.mjs
+++ b/scripts/ops/api-readiness-smoke.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+//
+// STANDALONE API-ONLY CLAIM-READINESS SMOKE.
+//
+// A fast, READ-ONLY probe of the external-worker front door. Walks the real
+// SIWE login as a fresh roleless wallet and checks a job is claimable + funded
+// — WITHOUT claiming, submitting, settling, or touching the chain RPC:
+//
+//   1. SIWE     — nonce → sign → verify → usable roleless token   (guards #625)
+//   2. Account  — authed GET /account with that token, not 401     (guards #626)
+//   3. Preflight— GET /jobs/preflight for a claimable job: eligible + claimable
+//                 + currentWalletCanClaim, surfacing fundingState/reason
+//                 (guards the claim-409 / reward_funding_pending class)
+//   4. Funding  — OPTIONAL operator tier: if an admin token is supplied, assert
+//                 /admin/status maintenance.policy.enabled + settlementReady and
+//                 report escrowIsServiceOperator + signerFunding
+//
+// WHY THIS EXISTS: run-worker-canary.mjs is the full proof, but stages 6-7
+// (on-chain settle + token freshness) need a live RPC + functional settlement,
+// so it can't run as a quick liveness probe and is gated behind the Docker/
+// Hermes stack via check-hosted-stack.sh. The 2026-06-13 round-trip showed the
+// front-door blockers (SIWE mint 500, JWT sub-casing 401, claim 409) each cost
+// a full user round-trip to find. This probe catches that whole class against
+// the live API in seconds, with no stack and no on-chain mutation — so it's
+// safe to run on every deploy and in a tight loop.
+//
+// It deliberately does NOT claim/submit/settle: zero on-chain writes, no funds
+// spent, no disposable job created. The worker stages run as a FRESH ROLELESS
+// wallet (ephemeral by default — read-only needs no provisioned key); the
+// optional operator tier reuses the hosted-loop admin auth only to read
+// /admin/status.
+//
+// Reuses runSiweStage / runAccountStage from run-worker-canary.mjs so the
+// #625/#626 guard semantics stay identical. Mirrors the ops-script shape:
+// an exported async fn + a CLI entry, exercised offline by
+// api-readiness-smoke.test.mjs.
+
+import { Wallet } from "ethers";
+
+import { AgentPlatformClient } from "../../sdk/agent-platform-client.js";
+import { runSiweStage, runAccountStage } from "./run-worker-canary.mjs";
+import { readOpSecret } from "./get-admin-refresh-token.mjs";
+import { resolveHostedWorkerLoopAuth } from "./run-hosted-worker-loop.mjs";
+
+const DEFAULT_API_BASE_URL = "https://api.averray.com";
+// Same dedicated roleless testnet wallet the canary uses, when provisioned.
+const DEFAULT_WORKER_KEY_OP = "op://prod-backend/canary-worker-testnet/private key";
+
+function pick(value) {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  return trimmed.length ? trimmed : undefined;
+}
+
+function enabled(value) {
+  return ["1", "true", "yes", "on"].includes(String(value ?? "").trim().toLowerCase());
+}
+
+// A fresh roleless wallet is the right SIWE subject (mirrors a real external
+// agent). Read-only means no funds are needed, so ephemeral is the zero-config
+// default; a provisioned key is honored when present for parity with the canary.
+async function resolveWorkerWallet({ env, readSecretImpl, log }) {
+  const explicit = pick(env.API_SMOKE_WORKER_PRIVATE_KEY) ?? pick(env.WORKER_CANARY_WORKER_PRIVATE_KEY);
+  if (explicit) {
+    return { wallet: new Wallet(explicit), source: "private_key" };
+  }
+  const opRef = pick(env.API_SMOKE_WORKER_KEY_OP) ?? pick(env.WORKER_CANARY_WORKER_KEY_OP);
+  if (opRef) {
+    try {
+      const key = (await readSecretImpl(opRef)).trim();
+      if (key) {
+        return { wallet: new Wallet(key), source: `op:${opRef}` };
+      }
+    } catch (error) {
+      log(`Could not read worker key from ${opRef} (${error?.message ?? error}); falling back to ephemeral.`);
+    }
+  }
+  // Default: a throwaway roleless wallet. Read-only — it never spends or claims.
+  log("Using an ephemeral roleless worker wallet (read-only probe; no funds required).");
+  return { wallet: Wallet.createRandom(), source: "ephemeral" };
+}
+
+// Resolve an operator token for the OPTIONAL /admin/status tier. Returns null
+// when no admin credential is configured — the probe stays worker-only then.
+async function resolveOperatorAuth({ env, readSecretImpl, log }) {
+  if (!pick(env.ADMIN_JWT) && !pick(env.ADMIN_REFRESH_TOKEN) && !pick(env.ADMIN_REFRESH_TOKEN_OP)) {
+    return null;
+  }
+  try {
+    return await resolveHostedWorkerLoopAuth({ env, readSecretImpl });
+  } catch (error) {
+    log(`Operator tier skipped: could not resolve admin auth (${error?.message ?? error}).`);
+    return null;
+  }
+}
+
+function firstClaimableJobId(listing) {
+  const jobs = Array.isArray(listing)
+    ? listing
+    : Array.isArray(listing?.jobs)
+      ? listing.jobs
+      : Array.isArray(listing?.items)
+        ? listing.items
+        : [];
+  for (const job of jobs) {
+    const id = job?.id ?? job?.jobId;
+    if (typeof id === "string" && id.length) {
+      return id;
+    }
+  }
+  return undefined;
+}
+
+// ── STAGE 3: preflight (read-only) ──────────────────────────────────────────
+// Resolves a claimable job (explicit id, else discovers one) and asserts a
+// fresh worker CAN claim it — surfacing fundingState/reason so a stuck
+// reward_funding_pending job is reported, not silently passed.
+export async function runPreflightStage({ authedWorker, explicitJobId, log }) {
+  let jobId = explicitJobId;
+  if (!jobId) {
+    const listing = await authedWorker.listClaimableJobs();
+    jobId = firstClaimableJobId(listing);
+  }
+  if (!jobId) {
+    // No claimable job advertised. That is itself a readiness signal (an empty
+    // or fully funding-pending board), not a transport failure — report it.
+    return {
+      ok: false,
+      reason: "no_claimable_job",
+      detail: "Discovery returned no claimable job to preflight (empty board or all rewards funding-pending)."
+    };
+  }
+
+  const preflight = await authedWorker.preflightJob(jobId);
+  if (!preflight || preflight.jobId !== jobId) {
+    throw new Error(
+      `Preflight stage: /jobs/preflight job id mismatch: expected ${jobId}, got ${preflight?.jobId ?? "missing"}.`
+    );
+  }
+  const claimable =
+    preflight.eligible === true &&
+    preflight.claimable === true &&
+    preflight.currentWalletCanClaim !== false;
+  if (!claimable) {
+    return {
+      ok: false,
+      jobId,
+      reason: preflight.reason ?? "not_claimable",
+      detail:
+        `preflight says the worker cannot claim — eligible=${String(preflight.eligible)}; ` +
+        `claimable=${String(preflight.claimable)}; currentWalletCanClaim=${String(preflight.currentWalletCanClaim)}; ` +
+        `fundingState=${preflight.fundingState ?? "n/a"}; reason=${preflight.reason ?? "none"}.`
+    };
+  }
+  log?.(`preflight OK — ${jobId} is claimable by a fresh worker.`);
+  return {
+    ok: true,
+    jobId,
+    fundingState: preflight.fundingState ?? null,
+    claimEconomicsWaived: preflight.claimEconomicsWaived ?? null,
+    totalClaimLock: preflight.totalClaimLock ?? null
+  };
+}
+
+// ── STAGE 4: funding/settlement readiness (optional operator tier) ──────────
+export async function runFundingStage({ operatorClient }) {
+  const status = await operatorClient.getAdminStatus();
+  const policy = status?.maintenance?.policy;
+  if (!policy?.enabled || policy.settlementReady !== true) {
+    return {
+      ok: false,
+      reason: "settlement_not_ready",
+      detail:
+        `/admin/status maintenance.policy not settlement-ready — enabled=${String(policy?.enabled)}; ` +
+        `settlementReady=${String(policy?.settlementReady)}. Brokered claim/submit/settle cannot complete.`,
+      signerFunding: policy?.signerFunding ?? null
+    };
+  }
+  return {
+    ok: true,
+    settlementReady: true,
+    escrowIsServiceOperator: policy.roles?.escrowIsServiceOperator ?? null,
+    signerFunding: policy.signerFunding ?? null
+  };
+}
+
+export async function runApiReadinessSmoke({
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+  readSecretImpl = readOpSecret,
+  workerWallet = undefined, // injected (tests)
+  anonClient = undefined, // injected (tests): pre-SIWE worker client
+  authedWorker = undefined, // injected (tests): post-SIWE worker client
+  operatorClient = undefined, // injected (tests)
+  operatorAuth = undefined, // injected (tests): truthy to force the operator tier
+  log = (message) => console.error(message)
+} = {}) {
+  const apiBaseUrl = pick(env.API_SMOKE_API_BASE_URL) ?? pick(env.API_BASE_URL) ?? DEFAULT_API_BASE_URL;
+  const startedAt = Date.now();
+  const stages = {};
+
+  const { wallet, source: workerSource } =
+    workerWallet ? { wallet: workerWallet, source: "injected" } : await resolveWorkerWallet({ env, readSecretImpl, log });
+
+  // Stage 1 — SIWE (reused: identical #625 guard).
+  const siwe = await runSiweStage({
+    apiBaseUrl,
+    wallet,
+    fetchImpl,
+    ...(anonClient ? { anonClient } : {})
+  });
+  stages.siwe = { ok: true, roleless: true, workerSource, ...siwe.summary };
+
+  const worker =
+    authedWorker ?? new AgentPlatformClient({ baseUrl: apiBaseUrl, token: siwe.token, fetchImpl });
+
+  // Stage 2 — authed read (reused: identical #626 guard).
+  const account = await runAccountStage({ authedWorker: worker, workerAddress: wallet.address });
+  stages.account = { ok: true, wallet: account.wallet };
+
+  // Stage 3 — preflight (read-only).
+  const preflight = await runPreflightStage({
+    authedWorker: worker,
+    explicitJobId: pick(env.API_SMOKE_JOB_ID),
+    log
+  });
+  stages.preflight = preflight;
+
+  // Stage 4 — optional operator-tier funding/settlement readiness.
+  const opAuth = operatorAuth ?? (await resolveOperatorAuth({ env, readSecretImpl, log }));
+  if (opAuth || operatorClient) {
+    const opClient =
+      operatorClient ??
+      new AgentPlatformClient({ baseUrl: apiBaseUrl, token: opAuth.token, fetchImpl });
+    stages.funding = await runFundingStage({ operatorClient: opClient });
+  } else {
+    stages.funding = { ok: true, skipped: true, detail: "no admin credential — worker-tier probe only" };
+  }
+
+  const ok = Object.values(stages).every((stage) => stage.ok !== false);
+  return {
+    ok,
+    apiBaseUrl,
+    worker: wallet.address,
+    elapsedMs: Date.now() - startedAt,
+    stages
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runApiReadinessSmoke()
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2));
+      if (!result.ok) {
+        process.exitCode = 1;
+      }
+    })
+    .catch((error) => {
+      console.error(error?.message ?? String(error));
+      process.exitCode = 1;
+    });
+}

--- a/scripts/ops/api-readiness-smoke.test.mjs
+++ b/scripts/ops/api-readiness-smoke.test.mjs
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  runApiReadinessSmoke,
+  runPreflightStage,
+  runFundingStage
+} from "./api-readiness-smoke.mjs";
+
+const WORKER = "0x30BC468dA4E95a8FA4b3f2043c86687a57CdeE05";
+
+class FakeApiError extends Error {
+  constructor(status, payload) {
+    super(payload?.message ?? `api error ${status}`);
+    this.status = status;
+    this.payload = payload;
+  }
+}
+
+// A fresh roleless wallet stand-in: address + EIP-191 signMessage.
+function fakeWallet(address = WORKER) {
+  return {
+    address,
+    async signMessage(message) {
+      return `0xsig:${Buffer.from(String(message)).toString("hex").slice(0, 8)}`;
+    }
+  };
+}
+
+function fakeAnonClient({ verifyImpl } = {}) {
+  return {
+    async issueNonce(wallet) {
+      return { message: `siwe-message-for-${wallet}` };
+    },
+    async verifySignature(message, signature) {
+      if (verifyImpl) return verifyImpl(message, signature);
+      return { token: "h.e.s", roles: [], expiresAt: "2027-01-01T00:00:00Z" };
+    }
+  };
+}
+
+function fakeWorker({ account = { wallet: WORKER }, claimable, preflight } = {}) {
+  return {
+    calls: [],
+    async getAccountSummary() {
+      return account;
+    },
+    async listClaimableJobs() {
+      return claimable ?? { jobs: [{ id: "job-ready-1" }] };
+    },
+    async preflightJob(jobId) {
+      // The real endpoint always echoes the requested jobId; force it so a
+      // custom fixture only overrides the readiness fields, never the id.
+      const base = {
+        jobId,
+        eligible: true,
+        claimable: true,
+        currentWalletCanClaim: true,
+        fundingState: "funded",
+        claimEconomicsWaived: true,
+        totalClaimLock: "0.05"
+      };
+      return preflight ? { ...base, ...preflight, jobId } : base;
+    }
+  };
+}
+
+function silent() {}
+
+test("worker-tier happy path: SIWE → account → preflight, funding skipped (no admin creds)", async () => {
+  const result = await runApiReadinessSmoke({
+    env: {},
+    workerWallet: fakeWallet(),
+    anonClient: fakeAnonClient(),
+    authedWorker: fakeWorker(),
+    log: silent
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.stages.siwe.ok, true);
+  assert.equal(result.stages.siwe.roleless, true);
+  assert.equal(result.stages.account.ok, true);
+  assert.equal(result.stages.preflight.ok, true);
+  assert.equal(result.stages.preflight.jobId, "job-ready-1");
+  assert.equal(result.stages.funding.skipped, true, "funding tier is skipped without an admin credential");
+});
+
+test("operator tier: /admin/status settlement-ready makes funding pass", async () => {
+  const result = await runApiReadinessSmoke({
+    env: {},
+    workerWallet: fakeWallet(),
+    anonClient: fakeAnonClient(),
+    authedWorker: fakeWorker(),
+    operatorAuth: { token: "admin.jwt.sig" },
+    operatorClient: {
+      async getAdminStatus() {
+        return {
+          maintenance: {
+            policy: {
+              enabled: true,
+              settlementReady: true,
+              roles: { escrowIsServiceOperator: true },
+              signerFunding: { usdcRaw: "3300000" }
+            }
+          }
+        };
+      }
+    },
+    log: silent
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.stages.funding.ok, true);
+  assert.equal(result.stages.funding.escrowIsServiceOperator, true);
+});
+
+test("preflight surfaces a funding-pending job as not-ready (the claim-409 class)", async () => {
+  const result = await runApiReadinessSmoke({
+    env: {},
+    workerWallet: fakeWallet(),
+    anonClient: fakeAnonClient(),
+    authedWorker: fakeWorker({
+      claimable: { jobs: [{ id: "job-pending-1" }] },
+      preflight: {
+        eligible: true,
+        claimable: false,
+        currentWalletCanClaim: null,
+        fundingState: "pending",
+        reason: "reward_funding_pending"
+      }
+    }),
+    log: silent
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.stages.preflight.ok, false);
+  assert.equal(result.stages.preflight.reason, "reward_funding_pending");
+});
+
+test("operator tier flags settlementReady=false (today's signer-liquidity failure mode)", async () => {
+  const funding = await runFundingStage({
+    operatorClient: {
+      async getAdminStatus() {
+        return { maintenance: { policy: { enabled: true, settlementReady: false, signerFunding: { usdcRaw: "0" } } } };
+      }
+    }
+  });
+  assert.equal(funding.ok, false);
+  assert.equal(funding.reason, "settlement_not_ready");
+});
+
+test("SIWE 500 surfaces the #625 roleless-mint regression and fails the probe", async () => {
+  await assert.rejects(
+    () =>
+      runApiReadinessSmoke({
+        env: {},
+        workerWallet: fakeWallet(),
+        anonClient: fakeAnonClient({
+          verifyImpl: () => {
+            throw new FakeApiError(500, { message: "boom" });
+          }
+        }),
+        authedWorker: fakeWorker(),
+        log: silent
+      }),
+    /625/
+  );
+});
+
+test("an empty board reports no_claimable_job rather than passing blind", async () => {
+  const preflight = await runPreflightStage({
+    authedWorker: { async listClaimableJobs() { return { jobs: [] }; } },
+    explicitJobId: undefined,
+    log: silent
+  });
+  assert.equal(preflight.ok, false);
+  assert.equal(preflight.reason, "no_claimable_job");
+});


### PR DESCRIPTION
## Go-live punch-list P2 — "Standalone API-only smoke ladder"

> *`claim-readiness-smoke.sh` needs the full Docker/Hermes stack; an API-only probe (nonce→verify→authed read→preflight→funding) would catch the blockers in seconds.*

`run-worker-canary.mjs` is the full external-worker proof, but its **settle** + **token-freshness** stages need a live RPC and functional on-chain settlement, so it can't run as a quick liveness probe and is gated behind the Docker/Hermes stack. The 2026-06-13 first-settled-job round-trip surfaced the front-door blockers (SIWE roleless-mint 500 #625, JWT sub-casing 401 #626, claim-409 `reward_funding_pending`) one full user round-trip at a time.

## What this adds
`scripts/ops/api-readiness-smoke.mjs` — a fast, **read-only** HTTP probe of the worker front door:
1. **SIWE** — nonce → sign → verify → usable roleless token (reuses `runSiweStage`, so the #625 guard is identical)
2. **Account** — authed `GET /account`, not 401 (reuses `runAccountStage`, identical #626 guard)
3. **Preflight** — `GET /jobs/preflight` for a claimable job: `eligible` + `claimable` + `currentWalletCanClaim`, surfacing `fundingState`/`reason` (catches the claim-409 / `reward_funding_pending` class **without claiming**)
4. **Funding** *(optional operator tier)* — if an admin token is configured, assert `/admin/status` `maintenance.policy.enabled` + `settlementReady` and report `escrowIsServiceOperator` + `signerFunding`

### Deliberately read-only
No claim / submit / settle, **no on-chain write**, no funds spent, no disposable job, no chain RPC. Worker stages run as a **fresh roleless wallet** (ephemeral by default — read-only needs no provisioned key; a provisioned key is honored for parity with the canary). So it's safe on every deploy and in a tight loop, and finishes in seconds.

This complements (does not replace) the Hosted Worker Canary, which remains the full settle-path proof.

## Tests
`api-readiness-smoke.test.mjs` — 6 cases: worker-tier happy path (funding skipped, no admin creds); operator-tier settlement-ready; funding-pending preflight → not-ready; `settlementReady=false` (today's signer-liquidity mode); SIWE-500 surfaces the #625 message; empty board → `no_claimable_job` (no blind pass).

Full ops suite: **420 pass / 0 fail** (the new 6 included). Reuses the canary's exported stages — no duplication of the auth-guard logic.

### Scope
Two new files under `scripts/ops/`. No changes to existing scripts or backend. Part of the go-live P2 polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)