### PR TITLE
ops: gate mainnet AUTH_CHAIN_ID + SHARE_URL_SECRET in the env-secrets proof

### DIFF
--- a/deployments/mainnet.env.example
+++ b/deployments/mainnet.env.example
@@ -10,6 +10,11 @@ MUTATION_BACKEND=required
 
 # RPC + deployer
 RPC_URL=https://eth-rpc.polkadot.io/
+# Polkadot Hub mainnet EVM chain id (TestNet is 420420417, Kusama Hub 420420418).
+# A wrong AUTH_CHAIN_ID silently breaks every SIWE sign-in. Verified via the
+# Polkadot docs (smart-contracts/connect.md); enforced by
+# scripts/ops/check-mainnet-env-secrets-proof.mjs (environment.chainId).
+AUTH_CHAIN_ID=420420419
 PRIVATE_KEY=0x<deployer-private-key>
 
 # v1 escrow asset: USDC, Trust-Backed Asset ID 1337, 6 decimals.
@@ -36,6 +41,13 @@ REJECTION_SKILL_PENALTY=10
 REJECTION_RELIABILITY_PENALTY=25
 DISPUTE_LOSS_SKILL_PENALTY=35
 DISPUTE_LOSS_RELIABILITY_PENALTY=60
+
+# Backend auth secret (mainnet runtime — provision in 1Password, never commit).
+# SHARE_URL_SECRET MUST be set explicitly on mainnet: on testnet it silently
+# falls back to AUTH_JWT_SECRETS[0], but once HMAC is retired that fallback is
+# gone and share-link signing fails closed. Enforced by
+# scripts/ops/check-mainnet-env-secrets-proof.mjs (auth.shareUrlSecret*).
+SHARE_URL_SECRET=<dedicated-mainnet-share-url-secret>
 
 # Must remain disabled on mainnet until a real audited strategy path exists.
 # WITH_VDOT_MOCK=0

--- a/scripts/ops/check-mainnet-env-secrets-proof.mjs
+++ b/scripts/ops/check-mainnet-env-secrets-proof.mjs
@@ -8,6 +8,10 @@ const SCRIPT_NAME = basename(fileURLToPath(import.meta.url));
 
 export const SCHEMA_VERSION = "mainnet-env-secrets-proof-v1";
 export const EXPECTED_MAINNET_RPC_URL = "https://eth-rpc.polkadot.io/";
+// Polkadot Hub mainnet EVM chain id (verified via polkadot-docs MCP
+// smart-contracts/connect.md). TestNet is 420420417, Kusama Hub is 420420418 —
+// a wrong AUTH_CHAIN_ID silently breaks every SIWE sign-in, so the proof pins it.
+export const EXPECTED_MAINNET_CHAIN_ID = 420420419;
 export const MAX_MAINNET_JWT_TTL_SECONDS = 30 * 24 * 60 * 60;
 
 const FUTURE_SKEW_MS = 5 * 60 * 1000;
@@ -248,6 +252,10 @@ function validateEnvironment(rawEnvironment, errors) {
   if (rpcUrl && rpcUrl !== EXPECTED_MAINNET_RPC_URL) {
     errors.push(`environment.rpcUrl must be ${EXPECTED_MAINNET_RPC_URL}`);
   }
+  const chainId = requireNumber(environment.chainId, "environment.chainId", errors, { integer: true });
+  if (chainId !== undefined && chainId !== EXPECTED_MAINNET_CHAIN_ID) {
+    errors.push(`environment.chainId must be ${EXPECTED_MAINNET_CHAIN_ID} (Polkadot Hub mainnet; testnet 420420417 is not allowed)`);
+  }
   for (const [index, rawUrl] of requireArray(environment.additionalRpcUrls ?? [], "environment.additionalRpcUrls", errors).entries()) {
     const url = requireString(rawUrl, `environment.additionalRpcUrls[${index}]`, errors);
     if (url && looksLikeNonMainnetUrl(url)) {
@@ -263,6 +271,7 @@ function validateEnvironment(rawEnvironment, errors) {
   }
   return {
     rpcUrl,
+    chainId,
     privateEnvSource: environment.privateEnvSource,
     renderedEnvChecksum: environment.renderedEnvChecksum
   };
@@ -380,6 +389,15 @@ function validateAuth(rawAuth, errors) {
     min: 1,
     max: MAX_MAINNET_JWT_TTL_SECONDS
   });
+  // SHARE_URL_SECRET silently falls back to AUTH_JWT_SECRETS[0] today. Once HMAC
+  // is retired for mainnet that fallback disappears, so share-link signing must
+  // have its own explicitly-provisioned secret or it fails closed at runtime.
+  if (requireBoolean(auth.shareUrlSecretConfigured, "auth.shareUrlSecretConfigured", errors) !== true) {
+    errors.push("auth.shareUrlSecretConfigured must be true (SHARE_URL_SECRET must be explicitly provisioned for mainnet)");
+  }
+  if (requireBoolean(auth.shareUrlSecretInheritedFromJwt, "auth.shareUrlSecretInheritedFromJwt", errors) !== false) {
+    errors.push("auth.shareUrlSecretInheritedFromJwt must be false (do not let SHARE_URL_SECRET fall back to AUTH_JWT_SECRETS once HMAC is retired)");
+  }
 }
 
 function validateRawFallbacks(rawFallbacks, errors) {
@@ -496,6 +514,7 @@ export function validateEvidence(evidence, options = {}) {
       schemaVersion: doc.schemaVersion,
       completedAt: doc.completedAt,
       rpcUrl: doc.environment?.rpcUrl,
+      chainId: doc.environment?.chainId,
       contractCount: REQUIRED_CONTRACTS.length,
       serviceTokenCount: REQUIRED_SERVICE_TOKENS.length,
       jwtBackend: doc.auth?.jwtBackend,

--- a/scripts/ops/check-mainnet-env-secrets-proof.test.mjs
+++ b/scripts/ops/check-mainnet-env-secrets-proof.test.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
 import {
+  EXPECTED_MAINNET_CHAIN_ID,
   EXPECTED_MAINNET_RPC_URL,
   SCHEMA_VERSION,
   validateEvidence
@@ -31,6 +32,7 @@ function validEvidence(overrides = {}) {
       chainEnv: "mainnet",
       profile: "mainnet",
       rpcUrl: EXPECTED_MAINNET_RPC_URL,
+      chainId: EXPECTED_MAINNET_CHAIN_ID,
       additionalRpcUrls: [EXPECTED_MAINNET_RPC_URL],
       deployEnvExample: "deployments/mainnet.env.example",
       privateEnvSource: "op://prod-mainnet-backend/backend-env/notes",
@@ -76,7 +78,9 @@ function validEvidence(overrides = {}) {
       jwtBackend: "kms",
       jwtPrimaryAlg: "kms",
       hmacVerifyAccepted: false,
-      maxTtlSeconds: 2_592_000
+      maxTtlSeconds: 2_592_000,
+      shareUrlSecretConfigured: true,
+      shareUrlSecretInheritedFromJwt: false
     },
     rawFallbacks: {
       signerPrivateKeyRendered: false,
@@ -177,6 +181,32 @@ test("validateEvidence rejects testnet RPCs and missing Polkadot docs evidence",
   assert.ok(result.errors.includes("polkadotDocs must include smart-contracts/precompiles/erc20.md"));
   assert.ok(result.errors.includes(`environment.rpcUrl must be ${EXPECTED_MAINNET_RPC_URL}`));
   assert.ok(result.errors.includes("environment.additionalRpcUrls[0] must not point at testnet, Paseo, localhost, or a private endpoint"));
+});
+
+test("validateEvidence rejects a non-mainnet chain id (the silent SIWE break)", () => {
+  const result = validateEvidence(validEvidence({
+    environment: {
+      ...validEvidence().environment,
+      chainId: 420420417
+    }
+  }));
+
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((error) => error.startsWith(`environment.chainId must be ${EXPECTED_MAINNET_CHAIN_ID}`)));
+});
+
+test("validateEvidence rejects an unprovisioned or JWT-inherited SHARE_URL_SECRET", () => {
+  const result = validateEvidence(validEvidence({
+    auth: {
+      ...validEvidence().auth,
+      shareUrlSecretConfigured: false,
+      shareUrlSecretInheritedFromJwt: true
+    }
+  }));
+
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.includes("auth.shareUrlSecretConfigured must be true (SHARE_URL_SECRET must be explicitly provisioned for mainnet)"));
+  assert.ok(result.errors.includes("auth.shareUrlSecretInheritedFromJwt must be false (do not let SHARE_URL_SECRET fall back to AUTH_JWT_SECRETS once HMAC is retired)"));
 });
 
 test("validateEvidence rejects placeholder, zero, or duplicate contract addresses", () => {


### PR DESCRIPTION
## Two silent-break traps the mainnet-secrets proof didn't catch

The mainnet-credential investigation surfaced two cutover failure modes the machine gate (`check-mainnet-env-secrets-proof.mjs`) didn't enforce:

1. **`AUTH_CHAIN_ID` was unpinned anywhere in the repo.** Polkadot Hub mainnet is EVM chain id **`420420419`** (TestNet `420420417`, Kusama Hub `420420418` — verified via the Polkadot docs `smart-contracts/connect.md`). A wrong value silently breaks **every SIWE sign-in**.
2. **`SHARE_URL_SECRET` silently inherits `AUTH_JWT_SECRETS[0]`** today. Once HMAC is retired for mainnet that fallback is gone and share-link signing **fails closed** unless the secret is explicitly provisioned.

## Change
`check-mainnet-env-secrets-proof.mjs` now asserts (new `EXPECTED_MAINNET_CHAIN_ID = 420420419`):
- `environment.chainId === 420420419` — rejects the testnet id;
- `auth.shareUrlSecretConfigured === true` and `auth.shareUrlSecretInheritedFromJwt === false`.

`chainId` is added to the proof summary. `deployments/mainnet.env.example` now records `AUTH_CHAIN_ID=420420419` and a `SHARE_URL_SECRET` line with the fail-closed rationale (the canonical launch profile carries the resolved value).

## Tests
Valid fixture updated; **two new negative cases** — wrong chain id (the silent SIWE break), and an unprovisioned / JWT-inherited `SHARE_URL_SECRET`. Env-secrets proof test **12/12**; full ops suite **425 pass / 0 fail**; `check-mainnet-usdc-config.mjs` still passes on the edited example.

### Scope
Backend ops guard + its test + the mainnet env example. No runtime/contract code. This is the machine-enforcement half of the mainnet credential plan (the full plan doc is a companion PR). The full `deploy/backend.env.template` mainnet repointing is deferred to launch time (it depends on mainnet vaults/contracts that don't exist yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)