### PR TITLE
ops(iam): pin mainnet KMS regions — eu-central-2 primary + eu-west-1 replica

### DIFF
--- a/deploy/iam-policies/README.md
+++ b/deploy/iam-policies/README.md
@@ -12,14 +12,21 @@ account/region/key creation order.
 
 ## Substituting placeholders
 
+Mainnet topology (decided 2026-06-16): single AWS account **079209845430**
+(same as testnet — fresh keys + distinct prod roles/profiles within it),
+**primary region `eu-central-2`** (Zurich, matches the live signer), **replica
+region `eu-west-1`** (Ireland). Both the blockchain signer and JWT signer keys
+are multi-region KMS keys (`mrk-*`, same key id in both regions). Testnet stays
+single-region (`eu-central-2` only). See `docs/MAINNET_CREDENTIALS_PLAN.md`.
+
 ```bash
 # Single-region testnet: drop the replica ARN line.
 # Multi-region mainnet: fill both ARNs.
 sed \
-  -e 's|<primary-region>|eu-central-1|g' \
-  -e 's|<account>|123456789012|g' \
+  -e 's|<primary-region>|eu-central-2|g' \
+  -e 's|<account>|079209845430|g' \
   -e 's|<key-id>|abcd1234-aaaa-aaaa-aaaa-aaaaaaaaaaaa|g' \
-  -e 's|<replica-region>|us-east-1|g' \
+  -e 's|<replica-region>|eu-west-1|g' \
   averray-signer-prod-role.json > /tmp/averray-signer-prod-role.rendered.json
 
 aws iam create-policy \
@@ -28,11 +35,14 @@ aws iam create-policy \
   --description "Phase 3a — KMS sign-only permissions for the backend signer role"
 ```
 
-For the **JWT** signer policy (`averray-jwt-signer-prod-role.json`), the
-placeholder is a single token `<JWT_KEY_ID_PLACEHOLDER>` (the AWS account and
-region are hard-coded — same account/region as the blockchain signer, distinct
-key). See `docs/SECRETS_MIGRATION.md` §"PR 4b.3 operator runbook" for the full
-provisioning sequence (key creation, IAM user, 1Password item, verification).
+For the **JWT** signer policy (`averray-jwt-signer-prod-role.json`), the only
+placeholder is `<JWT_KEY_ID_PLACEHOLDER>` — the AWS account (079209845430) and
+regions are hard-coded: mainnet lists both the primary `eu-central-2` and replica
+`eu-west-1` ARNs (the multi-region key shares one key id); testnet uses the
+primary ARN only (drop the `eu-west-1` line). Same account as the blockchain
+signer, distinct key. See `docs/SECRETS_MIGRATION.md` §"PR 4b.3 operator runbook"
+for the full provisioning sequence (key creation, IAM user, 1Password item,
+verification).
 
 ## Why the deny statement is constrained to this role
 

--- a/deploy/iam-policies/averray-jwt-signer-prod-role.json
+++ b/deploy/iam-policies/averray-jwt-signer-prod-role.json
@@ -1,7 +1,7 @@
 {
   "_comment": "IAM permissions policy for averray-jwt-signer-prod-role. Phase 4b per docs/PHASE_4B_KMS_JWT_PLAN.md §3.",
   "_comment_2": "Replace <JWT_KEY_ID_PLACEHOLDER> with the KeyId returned by `aws kms create-key` for the new ECC_NIST_P256 JWT signing key. The full provisioning runbook (`sed` substitution + `aws iam put-user-policy`) lives in docs/SECRETS_MIGRATION.md §'PR 4b.3 operator runbook'.",
-  "_comment_3": "Single-region testnet by design — the JWT key is single-region; multi-region is deferred to mainnet per design doc §3. Account ID and region are hard-coded to match the Phase 3 blockchain signer key (same AWS account 079209845430, same eu-central-2 region) so ops sees a single set of credentials and a single CloudTrail surface; the keys themselves are SEPARATE so a compromise of one signer cannot sign on the other.",
+  "_comment_3": "Mainnet is MULTI-REGION (decided 2026-06-16): the JWT key is a multi-region KMS key (mrk-*) with primary eu-central-2 + replica eu-west-1 — the SAME key id in both regions — so both ARNs are listed in the Allow statements below. SINGLE-REGION testnet: omit the eu-west-1 replica ARN line. Account 079209845430 and the primary region match the blockchain signer (same AWS account per the single-account decision, so ops sees one set of credentials and one CloudTrail surface); the keys themselves are SEPARATE so a compromise of one signer cannot sign on the other.",
   "_comment_4": "Sign + GetPublicKey are intentionally separate statements. kms:SigningAlgorithm and kms:MessageType condition keys apply to Sign/Verify only, NOT GetPublicKey — combining them would implicitly deny GetPublicKey.",
   "_comment_5": "The DenyKeyMaterialEscape statement defends against signer-principal compromise only. Admin-path protection (root, IAM admins) requires KMS key policy + SCPs + permission boundaries + CloudTrail alarms, NOT this user's permissions policy. The Resource is intentionally `*` for the deny — we want to refuse these actions on every key, not just this one, in case the credential is ever used against a different key.",
   "Version": "2012-10-17",
@@ -10,13 +10,19 @@
       "Sid": "AllowGetPublicKey",
       "Effect": "Allow",
       "Action": "kms:GetPublicKey",
-      "Resource": "arn:aws:kms:eu-central-2:079209845430:key/<JWT_KEY_ID_PLACEHOLDER>"
+      "Resource": [
+        "arn:aws:kms:eu-central-2:079209845430:key/<JWT_KEY_ID_PLACEHOLDER>",
+        "arn:aws:kms:eu-west-1:079209845430:key/<JWT_KEY_ID_PLACEHOLDER>"
+      ]
     },
     {
       "Sid": "AllowSignWithEcdsaSha256",
       "Effect": "Allow",
       "Action": "kms:Sign",
-      "Resource": "arn:aws:kms:eu-central-2:079209845430:key/<JWT_KEY_ID_PLACEHOLDER>",
+      "Resource": [
+        "arn:aws:kms:eu-central-2:079209845430:key/<JWT_KEY_ID_PLACEHOLDER>",
+        "arn:aws:kms:eu-west-1:079209845430:key/<JWT_KEY_ID_PLACEHOLDER>"
+      ],
       "Condition": {
         "StringEquals": {
           "kms:SigningAlgorithm": "ECDSA_SHA_256",

--- a/scripts/ops/derive-kms-signer-address.mjs
+++ b/scripts/ops/derive-kms-signer-address.mjs
@@ -10,7 +10,7 @@
  * SubjectPublicKeyInfo (SPKI).
  *
  * Usage:
- *   AWS_REGION=eu-central-1 \
+ *   AWS_REGION=eu-central-2 \
  *     node scripts/ops/derive-kms-signer-address.mjs <key-arn-or-id>
  *
  * Or, for offline testing against a captured fixture (no AWS creds
@@ -40,7 +40,7 @@ import {
 } from "../../mcp-server/src/blockchain/spki.js";
 
 const HELP = `Usage:
-  AWS_REGION=eu-central-1 node scripts/ops/derive-kms-signer-address.mjs <key-arn-or-id>
+  AWS_REGION=eu-central-2 node scripts/ops/derive-kms-signer-address.mjs <key-arn-or-id>
   node scripts/ops/derive-kms-signer-address.mjs --spki-file <path-to-der>
 
 Flags:


### PR DESCRIPTION
## What
Records the launch decisions and removes the region drift I flagged in the credential plan:
- **Single AWS account `079209845430`** (same as testnet — fresh keys + distinct prod roles within it).
- **Primary `eu-central-2`** (Zurich, matches the live signer), **replica `eu-west-1`** (Ireland).

Previously the committed `averray-jwt-signer-prod-role.json` hard-coded `eu-central-2` while the IAM README's example said `eu-central-1` / `us-east-1` — they disagreed.

## Changes
- **`averray-jwt-signer-prod-role.json`** — the JWT key becomes a **multi-region** KMS key for mainnet: both the `eu-central-2` primary and `eu-west-1` replica ARNs are now listed in the `Allow` statements (a multi-region key shares one key id across regions). Comment documents that **testnet stays single-region** (omit the replica ARN). The `Deny` stays `Resource:"*"`, unchanged.
- **`iam-policies/README.md`** — the `sed` example now fills `eu-central-2` / `eu-west-1` / `079209845430`; added a **"Mainnet topology (decided 2026-06-16)"** note; refreshed the JWT-signer paragraph.
- **`derive-kms-signer-address.mjs`** — usage examples use `eu-central-2` (where the keys actually live), not the generic `eu-central-1`.
- **`averray-signer-prod-role.json`** — no change; it's already a correct placeholder template with both ARN lines (filled per-env via the README `sed`).
- **`aws-credentials.js`** — no change; it pins profile *names* only, the KMS region is env-supplied (`AWS_REGION` / `AWS_JWT_REGION`).

JSON validated; `derive-kms-signer-address` test 8/8. Key ids stay `<placeholder>` (mainnet keys don't exist yet). Companion to the credential plan ([#663](https://github.com/averray-agent/agent/pull/663)) and the proof guards ([#662](https://github.com/averray-agent/agent/pull/662)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)