### PR TITLE
fix(auth): strict KMS-only JWT auth without an HMAC secret (MAIN-001)

### DIFF
--- a/mcp-server/src/auth/config.js
+++ b/mcp-server/src/auth/config.js
@@ -71,9 +71,19 @@ export function loadAuthConfig(env = process.env) {
     .map((value) => value.trim())
     .filter(Boolean);
 
-  if (rawMode === "strict" && secrets.length === 0) {
+  // Which JWT algorithm(s) the dispatcher signs/verifies. HMAC (HS256) secrets
+  // are only needed when an HMAC path is active — JWT_BACKEND=hmac, or the dual
+  // "both" migration mode. Under JWT_BACKEND=kms the verifier signs AND verifies
+  // ES256 via the KMS JWT signer, so strict mode must NOT demand an HMAC secret:
+  // the mainnet posture renders none, and requiring one would leave a symmetric
+  // admin-token-minting secret in the environment (MAIN-001). parseKmsJwtConfig
+  // (below) enforces the KMS signer config for the kms/both backends.
+  const jwtBackend = parseJwtBackend(env.JWT_BACKEND);
+  const jwtBackendUsesHmac = jwtBackend === "hmac" || jwtBackend === "both";
+
+  if (rawMode === "strict" && jwtBackendUsesHmac && secrets.length === 0) {
     throw new ConfigError(
-      "AUTH_MODE=strict requires AUTH_JWT_SECRETS (or AUTH_JWT_SECRET). Set at least one secret with >=32 chars."
+      `AUTH_MODE=strict with JWT_BACKEND=${jwtBackend} requires AUTH_JWT_SECRETS (or AUTH_JWT_SECRET); set at least one secret with >=32 chars. (JWT_BACKEND=kms needs no HMAC secret — it signs/verifies ES256 via KMS.)`
     );
   }
 
@@ -103,7 +113,7 @@ export function loadAuthConfig(env = process.env) {
   const verifierWallets = parseWalletSet(env.AUTH_VERIFIER_WALLETS, "AUTH_VERIFIER_WALLETS");
 
   // ── Phase 4b — JWT dispatcher mode ────────────────────────────────────
-  const jwtBackend = parseJwtBackend(env.JWT_BACKEND);
+  // jwtBackend is parsed above (it gates the HMAC-secret requirement).
   const jwtPrimaryAlg = parseJwtPrimaryAlg(env.JWT_PRIMARY_ALG, jwtBackend);
   const kmsJwt = parseKmsJwtConfig(env, jwtBackend);
 

--- a/mcp-server/src/auth/config.test.js
+++ b/mcp-server/src/auth/config.test.js
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { resolvePublicKeyPem } from "./config.js";
+import { loadAuthConfig, resolvePublicKeyPem } from "./config.js";
 import { ConfigError } from "../core/errors.js";
 
 // A minimal PEM-shaped string for tests. We don't need a real P-256
@@ -16,6 +16,47 @@ const SAMPLE_PEM = [
 ].join("\n");
 
 const SAMPLE_PEM_BASE64 = Buffer.from(SAMPLE_PEM, "utf8").toString("base64");
+
+const KMS_ENV = {
+  AUTH_MODE: "strict",
+  AUTH_DOMAIN: "api.averray.com",
+  AUTH_CHAIN_ID: "420420419",
+  JWT_BACKEND: "kms",
+  AWS_JWT_REGION: "eu-central-2",
+  AWS_JWT_KEY_ID: "arn:aws:kms:eu-central-2:079209845430:key/mrk-test",
+  JWT_PUBLIC_KEY_PEM: SAMPLE_PEM,
+  JWT_PUBLIC_KEY_FINGERPRINT: `sha256:${"a".repeat(64)}`
+};
+
+test("loadAuthConfig: strict + JWT_BACKEND=kms boots with NO AUTH_JWT_SECRETS (MAIN-001)", () => {
+  const config = loadAuthConfig({ ...KMS_ENV });
+  assert.equal(config.strict, true);
+  assert.equal(config.jwtBackend, "kms");
+  assert.equal(config.jwtPrimaryAlg, "kms");
+  assert.ok(config.kmsJwt, "KMS JWT signer config is present");
+  assert.equal(config.signingSecret, undefined, "no HMAC signing secret is rendered");
+});
+
+test("loadAuthConfig: strict + JWT_BACKEND=hmac still requires AUTH_JWT_SECRETS", () => {
+  assert.throws(
+    () => loadAuthConfig({ AUTH_MODE: "strict", AUTH_DOMAIN: "api.averray.com", JWT_BACKEND: "hmac" }),
+    (error) => error instanceof ConfigError && /JWT_BACKEND=hmac requires AUTH_JWT_SECRETS/u.test(error.message)
+  );
+});
+
+test("loadAuthConfig: strict + JWT_BACKEND=both still requires AUTH_JWT_SECRETS", () => {
+  assert.throws(
+    () => loadAuthConfig({ AUTH_MODE: "strict", AUTH_DOMAIN: "api.averray.com", JWT_BACKEND: "both" }),
+    (error) => error instanceof ConfigError && /JWT_BACKEND=both requires AUTH_JWT_SECRETS/u.test(error.message)
+  );
+});
+
+test("loadAuthConfig: strict with default (hmac) backend + no secrets still throws", () => {
+  assert.throws(
+    () => loadAuthConfig({ AUTH_MODE: "strict", AUTH_DOMAIN: "api.averray.com" }),
+    ConfigError
+  );
+});
 
 test("resolvePublicKeyPem: returns null when neither env var is set", () => {
   assert.equal(resolvePublicKeyPem({}), null);

--- a/mcp-server/src/protocols/http/auth-routes.js
+++ b/mcp-server/src/protocols/http/auth-routes.js
@@ -34,6 +34,17 @@ function walletsMatch(a, b) {
   return String(a).toLowerCase() === String(b).toLowerCase();
 }
 
+// True when the configured primary JWT signer can actually mint a token.
+// Under JWT_BACKEND=kms there is no HMAC `signingSecret` (the KMS-only mainnet
+// posture renders none — MAIN-001), yet signTokenFromConfig can still issue
+// ES256 via the KMS JWT signer. Gating on `signingSecret` alone wrongly locked
+// out SIWE verify/refresh in that posture, so check the primary signer instead.
+function canIssueTokens(authConfig) {
+  return authConfig?.jwtPrimaryAlg === "kms"
+    ? Boolean(authConfig?.kmsJwt)
+    : Boolean(authConfig?.signingSecret);
+}
+
 function supportsRefreshStore(stateStore) {
   return Boolean(
     stateStore
@@ -134,9 +145,9 @@ export function createAuthRoutes({
       if (!SIGNATURE_RE.test(signature)) {
         throw new ValidationError("signature must be a 65-byte hex string.");
       }
-      if (!authConfig.signingSecret) {
+      if (!canIssueTokens(authConfig)) {
         throw new AuthenticationError(
-          "Auth not configured — set AUTH_JWT_SECRETS to issue tokens.",
+          "Auth not configured — configure the JWT signer (AUTH_JWT_SECRETS for HMAC, or the KMS JWT signer for ES256).",
           "auth_not_configured"
         );
       }
@@ -257,9 +268,9 @@ export function createAuthRoutes({
 
       if (refreshCookie && supportsRefreshStore(stateStore)) {
         await enforceLimit("auth_refresh", clientIp(request), rateLimitConfig.authRefresh);
-        if (!authConfig.signingSecret) {
+        if (!canIssueTokens(authConfig)) {
           throw new AuthenticationError(
-            "Auth not configured — set AUTH_JWT_SECRETS to issue tokens.",
+            "Auth not configured — configure the JWT signer (AUTH_JWT_SECRETS for HMAC, or the KMS JWT signer for ES256).",
             "auth_not_configured"
           );
         }
@@ -345,9 +356,9 @@ export function createAuthRoutes({
         );
       }
       await enforceLimit("auth_refresh", auth.wallet, rateLimitConfig.authRefresh);
-      if (!authConfig.signingSecret) {
+      if (!canIssueTokens(authConfig)) {
         throw new AuthenticationError(
-          "Auth not configured — set AUTH_JWT_SECRETS to issue tokens.",
+          "Auth not configured — configure the JWT signer (AUTH_JWT_SECRETS for HMAC, or the KMS JWT signer for ES256).",
           "auth_not_configured"
         );
       }

--- a/mcp-server/src/protocols/http/auth-routes.test.js
+++ b/mcp-server/src/protocols/http/auth-routes.test.js
@@ -208,6 +208,23 @@ test("POST /auth/nonce rejects malformed wallet before storing", async () => {
   assert.ok(!calls.some(([name]) => name === "storeNonce"));
 });
 
+test("POST /auth/verify issues a token under KMS-only auth with no HMAC signingSecret (MAIN-001)", async () => {
+  const { response, route } = makeHarness({
+    payload: { message: "siwe", signature: VALID_SIGNATURE },
+    authConfig: {
+      signingSecret: undefined,
+      jwtPrimaryAlg: "kms",
+      kmsJwt: { keyId: "arn:aws:kms:eu-central-2:079209845430:key/mrk-test" }
+    }
+  });
+
+  // Must NOT 401 auth_not_configured just because there is no HMAC secret —
+  // signTokenFromConfig signs ES256 via the KMS JWT signer.
+  assert.equal(await callRoute(route, response, "POST", "/auth/verify"), true);
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.token, "signed-token");
+});
+
 test("POST /auth/verify consumes nonce, signs token, and issues refresh cookie when supported", async () => {
   const { calls, response, route } = makeHarness({
     payload: { message: "siwe", signature: VALID_SIGNATURE },


### PR DESCRIPTION
## Main-audit MAIN-001 (HIGH) — KMS-only mainnet auth couldn't boot/login

The mainnet-env-secrets proof demands `auth.jwtBackend=kms`, `hmacVerifyAccepted=false`, and **no rendered HMAC secret** — but the code couldn't satisfy that and still operate:

- `loadAuthConfig` threw `AUTH_MODE=strict requires AUTH_JWT_SECRETS` **before** `JWT_BACKEND` was considered (`config.js`).
- `/auth/verify` + `/auth/refresh` rejected with `auth_not_configured` whenever `authConfig.signingSecret` was absent — even though `signTokenFromConfig` can issue **ES256 via the KMS JWT signer** (`auth-routes.js:137/260/348`).

Keeping an HMAC secret rendered just to appease config contradicts the proof gate and leaves a symmetric admin-token-minting secret in the environment.

## Fix
- **`config.js`**: parse `JWT_BACKEND` first; require `AUTH_JWT_SECRETS` only when an HMAC path is active (`hmac` or `both`). `kms` needs no HMAC secret — `parseKmsJwtConfig` already enforces the KMS signer config.
- **`auth-routes.js`**: replace the three `!signingSecret` prechecks with `canIssueTokens(authConfig)`, which checks the **primary** signer is ready (KMS when `jwtPrimaryAlg=kms`, else the HMAC secret).

## Tests
- `config.test.js`: strict + `JWT_BACKEND=kms` **boots with no `AUTH_JWT_SECRETS`**; strict + `hmac` and strict + `both` **still require** it; default(hmac)+no-secret still throws.
- `auth-routes.test.js`: `/auth/verify` issues a token under KMS-only config with **no `signingSecret`** (no `auth_not_configured`).

Full backend suite **982/982**.

## Scope / note
Backend auth only. This makes the code *tolerate* a missing HMAC secret under `kms`; the shared `deploy/backend.env.template` still renders `AUTH_JWT_SECRETS` (testnet keeps it — its removal is the separate Stage 2C-3 HMAC retirement). The mainnet env profile can now omit it, satisfying the proof. First of the three HIGH main-audit remediations (MAIN-002 claim convergence + MAIN-003 dispute convergence to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)