### PR TITLE
fix(claims): converge a chain-claimed job stranded by a lost local write (MAIN-002)

### DIFF
--- a/mcp-server/src/core/job-execution-service.js
+++ b/mcp-server/src/core/job-execution-service.js
@@ -36,6 +36,7 @@ import { claimExpiresAt, countClaimAttempts, isExpiredClaim, isTerminalSession }
 
 // EscrowCore JobState enum: None=0, Open=1, Claimed=2, Submitted=3, Rejected=4,
 // Disputed=5, Closed=6. Used to reconcile a mined-but-receipt-lost submit.
+const ESCROW_JOB_STATE_CLAIMED = 2;
 const ESCROW_JOB_STATE_SUBMITTED = 3;
 
 export class JobExecutionService {
@@ -187,6 +188,17 @@ export class JobExecutionService {
       if (this.blockchainGateway?.isEnabled()) {
         const live = await this.blockchainGateway.getJob(jobId);
         if (live.state !== 0 && live.state !== 1) {
+          // The job is no longer Open on-chain. If a prior claim already mined
+          // for THIS wallet but the local session write was lost, converge and
+          // return the rebuilt session instead of stranding the worker behind
+          // job_not_claimable (MAIN-002). Any other non-open state is genuinely
+          // not claimable.
+          const converged = await this.convergeStrandedClaim({
+            sessionId, wallet, jobId, chainJobId, claimEconomics, job, protocol, idempotencyKey, live
+          });
+          if (converged) {
+            return converged;
+          }
           throw new ConflictError(`Job ${jobId} is not claimable in its current on-chain state.`, "job_not_claimable");
         }
         if (this.blockchainGateway.ensureJob) {
@@ -204,35 +216,75 @@ export class JobExecutionService {
         await this.accountMutationService?.lockJobStake?.(wallet, job.rewardAsset, claimEconomics.totalClaimLock, undefined);
       }
 
-      const baseSession = {
-        sessionId,
-        wallet,
-        jobId,
-        chainJobId,
-        claimStake: claimEconomics.claimStake,
-        claimStakeBps: claimEconomics.claimStakeBps,
-        claimFee: claimEconomics.claimFee,
-        claimFeeBps: claimEconomics.claimFeeBps,
-        claimEconomicsWaived: claimEconomics.claimEconomicsWaived,
-        claimNumber: claimEconomics.claimNumber,
-        totalClaimLock: claimEconomics.totalClaimLock,
-        ...chainClaimTiming,
-        idempotencyKey,
-        protocolHistory: [protocol]
-      };
-      const session = transitionSession(baseSession, "claimed", {
-        reason: "job_claimed",
-        metadata: { protocol, idempotencyKey }
+      return await this.finalizeClaim({
+        sessionId, wallet, jobId, chainJobId, claimEconomics, chainClaimTiming, job, protocol, idempotencyKey
       });
-
-      const persisted = await this.stateStore.upsertSession(session);
-      await this.stateStore.upsertFundedJob?.(buildFundedJobFromClaim({ job, session: persisted }));
-      this.publishSessionEvent("session.claimed", persisted);
-      this.publishClaimFundingEvent(persisted, job, claimEconomics);
-      return persisted;
     } finally {
       await this.stateStore.releaseClaimLock?.(sessionLockId, lockOwner);
     }
+  }
+
+  // Build + persist the local 'claimed' session, the funded-job record, and the
+  // claim events from an on-chain claim. Shared by the normal claim path and the
+  // MAIN-002 convergence path so both produce an identical session.
+  async finalizeClaim({ sessionId, wallet, jobId, chainJobId, claimEconomics, chainClaimTiming = {}, job, protocol, idempotencyKey }) {
+    const baseSession = {
+      sessionId,
+      wallet,
+      jobId,
+      chainJobId,
+      claimStake: claimEconomics.claimStake,
+      claimStakeBps: claimEconomics.claimStakeBps,
+      claimFee: claimEconomics.claimFee,
+      claimFeeBps: claimEconomics.claimFeeBps,
+      claimEconomicsWaived: claimEconomics.claimEconomicsWaived,
+      claimNumber: claimEconomics.claimNumber,
+      totalClaimLock: claimEconomics.totalClaimLock,
+      ...chainClaimTiming,
+      idempotencyKey,
+      protocolHistory: [protocol]
+    };
+    const session = transitionSession(baseSession, "claimed", {
+      reason: "job_claimed",
+      metadata: { protocol, idempotencyKey }
+    });
+
+    const persisted = await this.stateStore.upsertSession(session);
+    await this.stateStore.upsertFundedJob?.(buildFundedJobFromClaim({ job, session: persisted }));
+    this.publishSessionEvent("session.claimed", persisted);
+    this.publishClaimFundingEvent(persisted, job, claimEconomics);
+    return persisted;
+  }
+
+  // MAIN-002 self-heal. When claimJob mines on-chain but the subsequent local
+  // session/funded-job write fails, the chain job is left CLAIMED while Averray
+  // has no durable session — and a retry would 'job_not_claimable' because the
+  // job is no longer Open. If the on-chain claim is CLAIMED by THIS wallet and
+  // no local session exists, rebuild + persist the expected session (idempotent
+  // recovery, no second claimJob). Returns null for any other non-open state
+  // (claimed by another worker, submitted, closed) so the caller fails closed.
+  async convergeStrandedClaim({ sessionId, wallet, jobId, chainJobId, claimEconomics, job, protocol, idempotencyKey, live }) {
+    if (Number(live?.state) !== ESCROW_JOB_STATE_CLAIMED) {
+      return null;
+    }
+    if (typeof live?.worker !== "string" || live.worker.toLowerCase() !== String(wallet).toLowerCase()) {
+      return null;
+    }
+    const existing = await this.stateStore.getSession?.(sessionId);
+    if (existing) {
+      return existing;
+    }
+    return this.finalizeClaim({
+      sessionId,
+      wallet,
+      jobId,
+      chainJobId,
+      claimEconomics,
+      chainClaimTiming: this.buildChainClaimTiming(live),
+      job,
+      protocol,
+      idempotencyKey
+    });
   }
 
   async submitWork(sessionId, protocol, submissionInput = "submitted-via-service") {

--- a/mcp-server/src/core/job-execution-service.test.js
+++ b/mcp-server/src/core/job-execution-service.test.js
@@ -367,6 +367,76 @@ test("claimJob stores on-chain claim expiry when blockchain is enabled", async (
   assert.equal(claimExpiresAt(claimed, job), "2026-05-01T10:01:00.000Z");
 });
 
+test("claimJob converges a stranded claim: chain claim mined but local session write failed (MAIN-002)", async () => {
+  const stateStore = new MemoryStateStore();
+  const job = makeJob({ claimTtlSeconds: 60 });
+  let claimJobCalls = 0;
+  let onChainClaimed = false;
+  const blockchainGateway = {
+    isEnabled: () => true,
+    toJobId: (jobId) => `chain:${jobId}`,
+    async getWorkerClaimCount() { return 0; },
+    async getJob() {
+      // Open until the on-chain claim lands, then CLAIMED (state 2) by WALLET.
+      return onChainClaimed
+        ? { state: 2, worker: WALLET, claimExpiry: Date.parse("2026-05-01T10:01:00.000Z") / 1000 }
+        : { state: 0 };
+    },
+    async ensureJob() {},
+    async ensureClaimStakeLiquidity() {},
+    async claimJob() {
+      claimJobCalls += 1;
+      onChainClaimed = true; // the tx mines
+    }
+  };
+  const service = new JobExecutionService(stateStore, blockchainGateway, () => job);
+
+  // First attempt: the on-chain claim mines, but the local session write fails once.
+  const realUpsert = stateStore.upsertSession.bind(stateStore);
+  let upsertFailed = false;
+  stateStore.upsertSession = async (session) => {
+    if (!upsertFailed) {
+      upsertFailed = true;
+      throw new Error("redis blip");
+    }
+    return realUpsert(session);
+  };
+
+  await assert.rejects(() => service.claimJob(WALLET, job.id, "http", "idemp-strand"), /redis blip/);
+  assert.equal(claimJobCalls, 1, "the on-chain claim mined exactly once");
+
+  // Retry: the chain job is now CLAIMED by this wallet, but there is no local
+  // session. claimJob must CONVERGE (rebuild the session) without re-claiming.
+  const recovered = await service.claimJob(WALLET, job.id, "http", "idemp-strand");
+  assert.equal(claimJobCalls, 1, "retry must NOT call claimJob again");
+  assert.equal(recovered.status, "claimed");
+  assert.equal(recovered.wallet, WALLET);
+  assert.equal(recovered.jobId, job.id);
+});
+
+test("claimJob does NOT converge when the chain job is claimed by a different worker (MAIN-002 guard)", async () => {
+  const stateStore = new MemoryStateStore();
+  const job = makeJob({ claimTtlSeconds: 60 });
+  const blockchainGateway = {
+    isEnabled: () => true,
+    toJobId: (jobId) => `chain:${jobId}`,
+    async getWorkerClaimCount() { return 0; },
+    async getJob() {
+      // Already claimed on-chain by someone else.
+      return { state: 2, worker: WALLET_2 };
+    },
+    async ensureJob() {},
+    async ensureClaimStakeLiquidity() {},
+    async claimJob() { throw new Error("should not claim"); }
+  };
+  const service = new JobExecutionService(stateStore, blockchainGateway, () => job);
+
+  await assert.rejects(
+    () => service.claimJob(WALLET, job.id, "http", "idemp-other"),
+    (error) => error.code === "job_not_claimable"
+  );
+});
+
 test("claimJob uses chain worker claim count before ensuring a chain job", async () => {
   const stateStore = new MemoryStateStore();
   const job = makeJob({ rewardAmount: 5 });


### PR DESCRIPTION
## Main-audit MAIN-002 (HIGH) — on-chain claim stranded if local persistence fails

`claimJob` does the on-chain claim, then persists the local session (`upsertSession` + funded-job). If the chain claim **mines** but that local write **fails** (Redis blip), the chain job is left `Claimed` while Averray has **no durable session** — and a retry hits the state check, sees the job is no longer `Open`, and throws `job_not_claimable`. The worker has no session id to submit against; the job is locked until claim timeout.

`submitWork` already self-heals the mirror case (`onChainSubmitLanded`, #649); claim had no analogue.

## Fix
- Extract the session build / persist / publish into **`finalizeClaim()`** — shared by the normal path and the convergence path, so both produce an identical session.
- At the on-chain state check, if the job is **`Claimed` by THIS wallet** and **no local session exists**, **`convergeStrandedClaim()`** rebuilds + persists the expected session (idempotent, **no second `claimJob`**) and returns it.
- Any other non-open state — claimed by a **different** worker, submitted, closed — still fails closed with `job_not_claimable`.

## Tests
- chain claim mines + `upsertSession` fails once → **retry converges without a second `claimJob`** (`claimJobCalls === 1`);
- chain job claimed by a **different** worker → still throws `job_not_claimable`.

Full backend suite **980/980**.

### Scope
Backend claim path only (`job-execution-service.js` + test). No contract change; reuses the existing `gateway.getJob` read (which already returns `worker`/`state`). Second of three HIGH main-audit remediations (MAIN-001 = #667; MAIN-003 dispute convergence next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)