### PR TITLE
fix(disputes): idempotent dispute verdict across post-chain persist failure (MAIN-003)

### DIFF
--- a/mcp-server/src/protocols/http/dispute-routes.js
+++ b/mcp-server/src/protocols/http/dispute-routes.js
@@ -17,6 +17,27 @@ function compactObject(value) {
   );
 }
 
+// EscrowCore JobState: …Rejected=4, Disputed=5, Closed=6. The dispute path is
+// Rejected → openDispute → Disputed → resolveDispute → CLOSED, so a dispute is
+// "already resolved on-chain" ONLY at Closed(6) — resolveDispute reverts
+// InvalidState once the job has left Disputed. (Unlike verifier settlement,
+// Rejected(4) is the dispute's STARTING state, not a resolved one.) Used to make
+// the dispute verdict idempotent across a post-chain-write failure (MAIN-003): a
+// read failure returns false so the caller falls back to attempting the settle.
+const ESCROW_JOB_STATE_CLOSED = 6;
+
+async function disputeAlreadyResolvedOnChain(gateway, jobId) {
+  try {
+    if (!gateway?.isEnabled?.() || typeof gateway.getJob !== "function") {
+      return false;
+    }
+    const job = await gateway.getJob(jobId);
+    return Number(job?.state) === ESCROW_JOB_STATE_CLOSED;
+  } catch {
+    return false;
+  }
+}
+
 export function createDisputeRoutes({
   authMiddleware,
   buildScopedIdempotentMutationContext,
@@ -246,7 +267,17 @@ export function createDisputeRoutes({
       });
       await persistContentRecord(reasoning.contentRecord);
       const chainDisputeReceipt = await ensureChainDisputeOpen(session);
-      const chainReceipt = gateway?.isEnabled?.() && typeof gateway.resolveDispute === "function"
+      // Idempotent settle (MAIN-003). resolveDispute mutates chain state BEFORE
+      // the receipt/session writes below; if a prior attempt resolved on-chain
+      // but failed to persist, a naive retry re-calls resolveDispute and reverts
+      // InvalidState (it only runs from Disputed) — wedging the arbitration. So
+      // skip the settle when the dispute is already resolved on-chain and let the
+      // receipt + session writes below converge local state.
+      const chainEnabled = gateway?.isEnabled?.() && typeof gateway.resolveDispute === "function";
+      const alreadyResolvedOnChain = chainEnabled
+        ? await disputeAlreadyResolvedOnChain(gateway, session.chainJobId ?? session.jobId)
+        : false;
+      const chainReceipt = chainEnabled && !alreadyResolvedOnChain
         ? await gateway.resolveDispute(
             session.chainJobId ?? session.jobId,
             resolution.workerPayout,
@@ -278,7 +309,7 @@ export function createDisputeRoutes({
         txHash: chainReceipt.txHash,
         blockNumber: chainReceipt.blockNumber,
         chainStatus: gateway?.isEnabled?.()
-          ? (chainReceipt.status === 1 ? "confirmed" : "submitted")
+          ? (alreadyResolvedOnChain || chainReceipt.status === 1 ? "confirmed" : "submitted")
           : "local_only",
         decidedBy: auth.wallet,
         decidedAt

--- a/mcp-server/src/protocols/http/dispute-routes.test.js
+++ b/mcp-server/src/protocols/http/dispute-routes.test.js
@@ -313,7 +313,10 @@ test("POST /disputes/:id/verdict opens the chain dispute before arbitrator resol
   assert.equal(response.body.chainDisputeBlockNumber, 41);
   assert.equal(response.body.txHash, "0xresolve");
   assert.equal(response.body.blockNumber, 42);
-  assert.deepEqual(gatewayCalls.map(([name]) => name), ["getJob", "getJob", "openDispute", "resolveDispute"]);
+  // The extra getJob before resolveDispute is the MAIN-003 idempotency guard
+  // (disputeAlreadyResolvedOnChain) — here the job is not yet Closed, so the
+  // settle proceeds normally.
+  assert.deepEqual(gatewayCalls.map(([name]) => name), ["getJob", "getJob", "openDispute", "getJob", "resolveDispute"]);
   // The chain dispute is brokered on behalf of the worker (the claimant) so the
   // operator signer can open it even when it is not a participant on chain.
   assert.ok(gatewayCalls.some(([name, , participant]) => name === "openDispute" && participant === WORKER));
@@ -322,6 +325,49 @@ test("POST /disputes/:id/verdict opens the chain dispute before arbitrator resol
     && detail.receipt.chainDisputeBlockNumber === 41
     && detail.receipt.blockNumber === 42
     && detail.receipt.txHash === "0xresolve"));
+});
+
+test("POST /disputes/:id/verdict converges when the dispute is already resolved on-chain (MAIN-003)", async () => {
+  const id = disputeIdForSession(SESSION.sessionId);
+  const gatewayCalls = [];
+  const { calls, response, route } = makeHarness({
+    auth: { wallet: ADMIN, claims: { roles: ["admin"] } },
+    payload: { verdict: "upheld", rationale: "Replay after a lost receipt write.", idempotencyKey: "idem-converge-1" },
+    gateway: {
+      isEnabled: () => true,
+      // A prior resolveDispute already mined → the job is Closed (state 6).
+      async getJob(jobId) {
+        gatewayCalls.push(["getJob", jobId]);
+        return { reward: JOB.rewardAmount, released: JOB.rewardAmount, state: 6 };
+      },
+      async openDispute(jobId, participant) {
+        gatewayCalls.push(["openDispute", jobId, participant]);
+        return { txHash: "0xopen", blockNumber: 41, status: 1 };
+      },
+      async resolveDispute(jobId, workerPayout, reasonCode, metadataURI) {
+        gatewayCalls.push(["resolveDispute", { jobId, workerPayout, reasonCode, metadataURI }]);
+        return { txHash: "0xresolve", blockNumber: 42, status: 1 };
+      }
+    }
+  });
+
+  const handled = await route({
+    request: { method: "POST" },
+    response,
+    url: new URL(`http://localhost/disputes/${id}/verdict`),
+    pathname: `/disputes/${id}/verdict`,
+  });
+
+  assert.equal(handled, true);
+  assert.equal(response.statusCode, 200);
+  // resolveDispute must NOT be called again (would revert InvalidState); the
+  // already-Closed job converges to a confirmed verdict, and the session still
+  // transitions out of `disputed`.
+  assert.ok(!gatewayCalls.some(([name]) => name === "resolveDispute"), "resolveDispute must not re-run");
+  assert.ok(!gatewayCalls.some(([name]) => name === "openDispute"), "openDispute must not run on a Closed job");
+  assert.equal(response.body.chainStatus, "confirmed");
+  assert.ok(calls.some(([name]) => name === "upsertMutationReceipt"), "verdict receipt is persisted");
+  assert.ok(calls.some(([name]) => name === "upsertSession"), "session transition is converged");
 });
 
 test("POST /disputes/:id/release requires a verdict before recording release", async () => {


### PR DESCRIPTION
## Main-audit MAIN-003 (HIGH) — dispute verdict not idempotent after chain success

The dispute verdict route calls `gateway.resolveDispute` (`dispute-routes.js:249`) → writes the receipt (`:286`) → transitions the session (`:299`). If `resolveDispute` **mines** but the receipt write **fails**, a retry **re-calls `resolveDispute`** — the contract has already `Closed` the job, so it **reverts `InvalidState`** and wedges the arbitration even though settlement already happened. (And if the receipt write succeeds but the session write fails, the session can stay `disputed`.)

Verifier settlement already had this fix (`onChainAlreadySettled`, #652) — disputes didn't.

## Fix
- Add `disputeAlreadyResolvedOnChain(gateway, jobId)` — mirrors the verifier guard.
- Before `resolveDispute`, if the dispute is already resolved on-chain, **skip the settle** and let the (idempotent) receipt upsert + the `status === "disputed"`-guarded session transition **converge** local state. A retry that previously failed mid-write now completes without a second chain call.

**State nuance:** for the dispute path "already resolved" is **`Closed(6)` only** — `Rejected(4)` is the dispute's *starting* state (`Rejected → openDispute → Disputed → resolveDispute → Closed`), unlike verifier settlement which treats both 4 and 6 as terminal. (The existing chain-resolution test, whose `getJob` returns `state: 4`, still drives a full settle — confirming the distinction.)

## Tests
- already-`Closed` job → verdict **converges to `confirmed` with NO second `resolveDispute`** (and no `openDispute`, since `ensureChainDisputeOpen` only opens from `Rejected`); receipt persisted + session transition converged.
- existing chain-resolution test updated for the added guard `getJob`.

Full backend suite **978/978**.

### Scope
Backend dispute route only; reuses the existing `gateway.getJob` read (no contract change). This convergence-guard layer (mirrors #652) **composes with** — does not replace — the separate mainnet backend-`resolveDispute` *disablement* from the hardware-arbitrator decision (Codex/chain-settlement). Third of the three HIGH main-audit remediations (MAIN-001 #667, MAIN-002 #668).

🤖 Generated with [Claude Code](https://claude.com/claude-code)