### PR TITLE
ci(auth): refresh-flow admin token in hosted-external-schema-proof (JWT-TTL phase 1)

### DIFF
--- a/.github/workflows/hosted-external-schema-proof.yml
+++ b/.github/workflows/hosted-external-schema-proof.yml
@@ -32,40 +32,55 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - name: Load ADMIN_JWT from 1Password (fail-closed)
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
-        with:
-          export-env: true
+      # JWT-TTL hardening (F13): mint a SHORT-LIVED admin access token via the
+      # refresh flow instead of loading the long-lived static admin JWT
+      # (op://prod-smoke/admin-jwt). This is what lets JWT_MAX_TTL_SECONDS drop
+      # from 30d to 1h on mainnet — see docs/MAINNET_CREDENTIALS_PLAN.md. A
+      # DEDICATED per-consumer refresh item is used so this workflow never
+      # rotate-collides with another consumer (refresh tokens rotate on every
+      # use; replaying a stale one revokes the chain).
+      - name: Install 1Password CLI (refresh-token rotation write-back)
+        uses: 1password/install-cli-action@a5215d3a7f75c1629216c465ea9ab3ab399c4b71 # v4.0.0
+
+      - name: Mint short-lived admin access token (refresh flow)
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE }}
-          ADMIN_JWT_OP: op://prod-smoke/admin-jwt/password
-
-      - name: Verify ADMIN_JWT_OP loaded and shape-valid
+          ADMIN_REFRESH_TOKEN_OP: op://prod-smoke/admin-refresh-token-schema-proof/password
+          API_BASE_URL: https://api.averray.com
         run: |
           set -euo pipefail
           set +x
 
-          if [ -z "${ADMIN_JWT_OP:-}" ]; then
-            echo "::error::ADMIN_JWT_OP is empty after load step — check op://prod-smoke/admin-jwt/password and OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE."
+          # get-admin-refresh-token.mjs POSTs the refresh cookie to
+          # /auth/refresh, prints a fresh access token to stdout, and writes
+          # the rotated refresh cookie back to $ADMIN_REFRESH_TOKEN_OP (needs
+          # the prod-smoke service account to have READ+WRITE on that item).
+          token="$(node scripts/ops/get-admin-refresh-token.mjs)"
+
+          if [ -z "${token:-}" ]; then
+            echo "::error::refresh exchange returned an empty access token — check $ADMIN_REFRESH_TOKEN_OP is seeded and the prod-smoke service account has READ+WRITE on it."
             exit 1
           fi
 
-          case "$ADMIN_JWT_OP" in
+          case "$token" in
             ey*.*.*)
-              echo "ADMIN_JWT_OP: JWT shape valid"
+              echo "minted admin access token: JWT shape valid"
               ;;
             *)
-              echo "::error::ADMIN_JWT_OP does not look like a JWT (expected ey<...>.<...>.<...>)"
+              echo "::error::minted value does not look like a JWT (expected ey<...>.<...>.<...>)"
               exit 1
               ;;
           esac
+
+          echo "::add-mask::$token"
+          printf 'ADMIN_ACCESS_TOKEN=%s\n' "$token" >> "$GITHUB_ENV"
 
       - name: Run hosted proof
         run: |
           set -euo pipefail
           set +x
 
-          ADMIN_JWT="$ADMIN_JWT_OP" ./scripts/ops/check-hosted-stack.sh
+          ADMIN_JWT="$ADMIN_ACCESS_TOKEN" ./scripts/ops/check-hosted-stack.sh
 
       - name: Summarize proof evidence
         if: always()

--- a/scripts/ops/hermes-workflow-artifacts.test.mjs
+++ b/scripts/ops/hermes-workflow-artifacts.test.mjs
@@ -84,11 +84,17 @@ test("hosted external-schema proof uploads sanitized evidence as a workflow arti
   assert.match(workflow, /workflow_dispatch:/u);
   assert.match(workflow, /environment: production/u);
   assert.match(workflow, /OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE/u);
-  assert.match(workflow, /ADMIN_JWT_OP: op:\/\/prod-smoke\/admin-jwt\/password/u);
+  // JWT-TTL phase 1: this workflow mints a short-lived admin access token via
+  // the refresh flow (dedicated per-consumer item) instead of loading the
+  // long-lived static admin JWT — see PR #670 / docs/MAINNET_CREDENTIALS_PLAN.md (F13).
+  assert.match(workflow, /uses: 1password\/install-cli-action@[a-f0-9]{40} # v4\.0\.0/u);
+  assert.match(workflow, /ADMIN_REFRESH_TOKEN_OP: op:\/\/prod-smoke\/admin-refresh-token-schema-proof\/password/u);
+  assert.match(workflow, /node scripts\/ops\/get-admin-refresh-token\.mjs/u);
+  assert.doesNotMatch(workflow, /ADMIN_JWT_OP: op:\/\/prod-smoke\/admin-jwt\/password/u);
   assert.match(workflow, /CHECK_EXTERNAL_SCHEMA_PROOF: "1"/u);
   assert.match(workflow, /EXTERNAL_SCHEMA_PROOF_EVIDENCE_FILE: artifacts\/external-schema-proof-hosted-\$\{\{ github\.run_id \}\}\.json/u);
   assert.match(workflow, /EXTERNAL_SCHEMA_PROOF_IDEMPOTENCY_KEY: github-hosted-external-schema-proof-\$\{\{ github\.run_id \}\}/u);
-  assert.match(workflow, /ADMIN_JWT="\$ADMIN_JWT_OP" \.\/scripts\/ops\/check-hosted-stack\.sh/u);
+  assert.match(workflow, /ADMIN_JWT="\$ADMIN_ACCESS_TOKEN" \.\/scripts\/ops\/check-hosted-stack\.sh/u);
   assert.match(workflow, /uses: actions\/upload-artifact@(?:v7\b|[a-f0-9]{40} # v7\b)/u);
   assert.match(workflow, /name: hosted-external-schema-proof-\$\{\{ github\.run_id \}\}/u);
   assert.match(workflow, /path: \$\{\{ env\.EXTERNAL_SCHEMA_PROOF_EVIDENCE_FILE \}\}/u);


### PR DESCRIPTION
## What

Phase 1 of migrating the **5 workflows** that consume the long-lived static admin JWT (`op://prod-smoke/admin-jwt`) onto the **refresh flow**, so `JWT_MAX_TTL_SECONDS` can be dropped from 30d → 1h on mainnet (closes the 30-day skeleton-key window for any leaked admin *access* token). See `docs/MAINNET_CREDENTIALS_PLAN.md` (F13).

This PR migrates **`hosted-external-schema-proof`** only — the lowest-risk consumer (`workflow_dispatch`-only, self-contained) — to prove the pattern end-to-end before replicating to the other four.

Instead of loading a long-lived static admin JWT, the workflow now:
1. installs the 1Password CLI (needed for the rotation write-back),
2. runs `get-admin-refresh-token.mjs`, which exchanges a stored refresh cookie at `POST /auth/refresh` for a fresh ≤15-min access token (printed to stdout) and writes the rotated refresh cookie back to 1Password,
3. masks the minted token (`::add-mask::`) and passes it to `check-hosted-stack.sh` as the `ADMIN_JWT` Bearer.

## Why a *dedicated* refresh item

Refresh tokens rotate on every use, and replaying a stale one **revokes the whole chain**. If multiple workflows shared one refresh item, a concurrent exchange would strand them all (recovery = manual SIWE re-seed). So this workflow gets its own item — `op://prod-smoke/admin-refresh-token-schema-proof` — and each of the other four will get its own in phase 2.

## ⚠️ Operator prerequisites before this can be dispatched/merged (cannot be automated)

1. **Seed the item** — capture a refresh token for the admin wallet via the F13 manual human SIWE (plan-doc step 17) and store the `refresh_token` cookie value in `op://prod-smoke/admin-refresh-token-schema-proof` (field `password`). Testnet identity: admin EOA `0x6778F050…3ac8`.
2. **Grant write scope** — the `prod-smoke` service account needs **READ + WRITE** on that item. Write is mandatory: the rotation write-back uses `op item edit`. This must be in place *before* the first dispatch.
3. **Dispatch to verify** — run the workflow from this branch and confirm it goes green on the refresh flow.

### Sharp edge
The server rotates the refresh token on every *successful* exchange. If a run succeeds at the exchange but fails before the write-back persists (e.g., missing write scope), the stored token is stranded and must be **re-seeded via SIWE**. Get the write scope right before the first run.

## Scope / sequencing
- **Phase 1 of 3.** Do **not** drop `JWT_MAX_TTL_SECONDS` yet — the other 4 workflows still use the static JWT and would break at a 1h ceiling.
- **Phase 2:** replicate to `hosted-worker-canary` (script-internal exchange via `run-hosted-worker-loop.mjs`), `hosted-service-token-proof`, `hosted-dispute-verdict-proof`, and `deploy-production` (token handed to the VPS as `ADMIN_JWT`; deploy last — highest blast radius). Each gets its own dedicated refresh item.
- **Phase 3:** drop the ceiling 2592000 → 3600 in `deploy/backend.env.template` + update the plan-doc decision.

Internal hardening — **not** a substitute for the external audit, which remains the mainnet gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
