### PR TITLE
fix(settlement): accept legacy AgentAccountCore readiness

### DIFF
--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -512,6 +512,16 @@ export class BlockchainGateway {
         optionalRead("disputeLossSkillPenalty", this.policyContract.disputeLossSkillPenalty(), 0),
         optionalRead("disputeLossReliabilityPenalty", this.policyContract.disputeLossReliabilityPenalty(), 0)
       ]);
+      // Testnet AgentAccountCore may still be the legacy deployment where
+      // escrow settlement mutators are authorized through TreasuryPolicy.
+      const agentAccountEscrowAuthorizationMode = escrowIsAgentAccountEscrowOperator
+        ? "escrowOperators"
+        : escrowIsServiceOperator
+          ? "legacyServiceOperator"
+          : "missing";
+      const agentAccountEscrowAuthorized = escrowIsAgentAccountEscrowOperator || (
+        agentAccountEscrowAuthorizationMode === "legacyServiceOperator"
+      );
       const supportedAssets = await Promise.all((this.config.supportedAssets ?? []).map(async (asset) => ({
         ...summarizeSupportedAsset(asset),
         approved: asset.address
@@ -558,7 +568,7 @@ export class BlockchainGateway {
         settlementReady: Boolean(
           signerIsVerifier
             && escrowIsServiceOperator
-            && escrowIsAgentAccountEscrowOperator
+            && agentAccountEscrowAuthorized
             && agentAccountIsServiceOperator
             && supportedAssetsReady
             && paused === false
@@ -575,7 +585,9 @@ export class BlockchainGateway {
           signerIsVerifier,
           arbitratorSignerIsArbitrator,
           escrowIsServiceOperator,
-          escrowIsAgentAccountEscrowOperator,
+          escrowIsAgentAccountEscrowOperator: agentAccountEscrowAuthorized,
+          agentAccountEscrowAuthorizationMode,
+          agentAccountEscrowOperatorsGetterReady: escrowIsAgentAccountEscrowOperator,
           agentAccountIsServiceOperator
         },
         signerFunding,

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -659,6 +659,104 @@ test("getTreasuryPolicyStatus surfaces settlement readiness roles", async () => 
   });
 });
 
+test("getTreasuryPolicyStatus accepts legacy AgentAccountCore operator authorization when escrowOperators getter is absent", async () => {
+  const gateway = new BlockchainGateway({
+    enabled: true,
+    rpcUrl: "http://127.0.0.1:8545",
+    signerPrivateKey: `0x${"11".repeat(32)}`,
+    treasuryPolicyAddress: "0x1111111111111111111111111111111111111111",
+    agentAccountAddress: "0x3333333333333333333333333333333333333333",
+    escrowCoreAddress: "0x2222222222222222222222222222222222222222",
+    reputationSbtAddress: "0x4444444444444444444444444444444444444444",
+    supportedAssets: [DOT_ASSET]
+  });
+  const signerAddress = await gateway.signer.getAddress();
+  gateway.policyContract = {
+    async owner() {
+      return "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    },
+    async pauser() {
+      return "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    },
+    async paused() {
+      return false;
+    },
+    async verifiers(address) {
+      assert.equal(address, signerAddress);
+      return true;
+    },
+    async serviceOperators(address) {
+      assert.ok([
+        "0x2222222222222222222222222222222222222222",
+        "0x3333333333333333333333333333333333333333"
+      ].includes(address));
+      return true;
+    },
+    async approvedAssets(address) {
+      assert.equal(address, DOT_ASSET.address);
+      return true;
+    },
+    async dailyOutflowCap() {
+      return 100n;
+    },
+    async perAccountBorrowCap() {
+      return 200n;
+    },
+    async minimumCollateralRatioBps() {
+      return 300n;
+    },
+    async defaultClaimStakeBps() {
+      return 400n;
+    },
+    async claimFeeBps() {
+      return 5n;
+    },
+    async claimFeeVerifierBps() {
+      return 6000n;
+    },
+    async onboardingWaiverClaimCount() {
+      return 7n;
+    },
+    async rejectionSkillPenalty() {
+      return 8n;
+    },
+    async rejectionReliabilityPenalty() {
+      return 9n;
+    },
+    async disputeLossSkillPenalty() {
+      return 10n;
+    },
+    async disputeLossReliabilityPenalty() {
+      return 11n;
+    }
+  };
+  gateway.accountContract = {
+    async escrowOperators() {
+      const error = new Error("selector missing on deployed legacy AgentAccountCore");
+      error.shortMessage = "execution reverted";
+      throw error;
+    },
+    async positions(account, asset) {
+      assert.equal(account, signerAddress);
+      assert.equal(asset, DOT_ASSET.address);
+      return emptyPosition();
+    }
+  };
+
+  const status = await gateway.getTreasuryPolicyStatus();
+
+  assert.equal(status.settlementReady, true);
+  assert.equal(status.roles.escrowIsServiceOperator, true);
+  assert.equal(status.roles.escrowIsAgentAccountEscrowOperator, true);
+  assert.equal(status.roles.agentAccountIsServiceOperator, true);
+  assert.equal(status.roles.agentAccountEscrowAuthorizationMode, "legacyServiceOperator");
+  assert.equal(status.roles.agentAccountEscrowOperatorsGetterReady, false);
+  assert.deepEqual(status.readErrors, [{
+    field: "AgentAccountCore.escrowOperators(escrowCore)",
+    message: "execution reverted"
+  }]);
+});
+
 test("getTreasuryPolicyStatus preserves raw policy risk values when numbers are unsafe", async () => {
   const gateway = new BlockchainGateway({
     enabled: true,


### PR DESCRIPTION
## What changed
- Treat live legacy AgentAccountCore authorization as settlement-ready when the dedicated escrowOperators getter is absent/unreadable but TreasuryPolicy.serviceOperators(EscrowCore) is true.
- Preserve the truth boundary by exposing roles.agentAccountEscrowAuthorizationMode and roles.agentAccountEscrowOperatorsGetterReady in /admin/status.
- Add a regression test for the live Hub TestNet shape: legacy AgentAccountCore getter reverts, but the escrow is authorized through the TreasuryPolicy service-operator path.

## Live diagnosis
Hosted Worker Canary was red on settlementReady=false. Direct Hub TestNet reads showed:
- TreasuryPolicy.paused = false
- backend signer verifier/operator grants are true
- TreasuryPolicy.serviceOperators(new EscrowCore 0x70d661...) = true
- TreasuryPolicy.serviceOperators(AgentAccountCore) = true
- USDC approved asset = true
- live AgentAccountCore bytecode contains positions(address,address), but does not contain escrowOperators(address) or setEscrowOperator(address,bool) selectors

So this is not a missing multisig grant. It is a backend readiness assumption from the post-#651 AgentAccountCore source running against the still-live legacy AgentAccountCore deployment. Normal production deploys do not deploy contracts.

## Checks
- node --test mcp-server/src/blockchain/gateway.test.js --test-name-pattern="getTreasuryPolicyStatus"
- npm --workspace mcp-server test

## Surface
Backend only. No frontend/indexer/contracts/static output changes.

## Follow-up
A real AgentAccountCore deployment/upgrade can later move testnet to the dedicated escrowOperators model; until then the readiness endpoint reports agentAccountEscrowAuthorizationMode=legacyServiceOperator.