### PR TITLE
revert(ci): restore schema-proof to static admin-jwt; park JWT-TTL → mainnet

### DIFF
--- a/.github/workflows/hosted-external-schema-proof.yml
+++ b/.github/workflows/hosted-external-schema-proof.yml
@@ -32,55 +32,40 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      # JWT-TTL hardening (F13): mint a SHORT-LIVED admin access token via the
-      # refresh flow instead of loading the long-lived static admin JWT
-      # (op://prod-smoke/admin-jwt). This is what lets JWT_MAX_TTL_SECONDS drop
-      # from 30d to 1h on mainnet — see docs/MAINNET_CREDENTIALS_PLAN.md. A
-      # DEDICATED per-consumer refresh item is used so this workflow never
-      # rotate-collides with another consumer (refresh tokens rotate on every
-      # use; replaying a stale one revokes the chain).
-      - name: Install 1Password CLI (refresh-token rotation write-back)
-        uses: 1password/install-cli-action@a5215d3a7f75c1629216c465ea9ab3ab399c4b71 # v4.0.0
-
-      - name: Mint short-lived admin access token (refresh flow)
+      - name: Load ADMIN_JWT from 1Password (fail-closed)
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE }}
-          ADMIN_REFRESH_TOKEN_OP: op://prod-smoke/admin-refresh-token-schema-proof/password
-          API_BASE_URL: https://api.averray.com
+          ADMIN_JWT_OP: op://prod-smoke/admin-jwt/password
+
+      - name: Verify ADMIN_JWT_OP loaded and shape-valid
         run: |
           set -euo pipefail
           set +x
 
-          # get-admin-refresh-token.mjs POSTs the refresh cookie to
-          # /auth/refresh, prints a fresh access token to stdout, and writes
-          # the rotated refresh cookie back to $ADMIN_REFRESH_TOKEN_OP (needs
-          # the prod-smoke service account to have READ+WRITE on that item).
-          token="$(node scripts/ops/get-admin-refresh-token.mjs)"
-
-          if [ -z "${token:-}" ]; then
-            echo "::error::refresh exchange returned an empty access token — check $ADMIN_REFRESH_TOKEN_OP is seeded and the prod-smoke service account has READ+WRITE on it."
+          if [ -z "${ADMIN_JWT_OP:-}" ]; then
+            echo "::error::ADMIN_JWT_OP is empty after load step — check op://prod-smoke/admin-jwt/password and OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE."
             exit 1
           fi
 
-          case "$token" in
+          case "$ADMIN_JWT_OP" in
             ey*.*.*)
-              echo "minted admin access token: JWT shape valid"
+              echo "ADMIN_JWT_OP: JWT shape valid"
               ;;
             *)
-              echo "::error::minted value does not look like a JWT (expected ey<...>.<...>.<...>)"
+              echo "::error::ADMIN_JWT_OP does not look like a JWT (expected ey<...>.<...>.<...>)"
               exit 1
               ;;
           esac
-
-          echo "::add-mask::$token"
-          printf 'ADMIN_ACCESS_TOKEN=%s\n' "$token" >> "$GITHUB_ENV"
 
       - name: Run hosted proof
         run: |
           set -euo pipefail
           set +x
 
-          ADMIN_JWT="$ADMIN_ACCESS_TOKEN" ./scripts/ops/check-hosted-stack.sh
+          ADMIN_JWT="$ADMIN_JWT_OP" ./scripts/ops/check-hosted-stack.sh
 
       - name: Summarize proof evidence
         if: always()

--- a/docs/MAINNET_CREDENTIALS_PLAN.md
+++ b/docs/MAINNET_CREDENTIALS_PLAN.md
@@ -100,7 +100,26 @@ enforced by `check-mainnet-env-secrets-proof.mjs` and recorded in
 | `AUTH_DOMAIN=api.averray.com` | **CONFIG (likely unchanged)** | Must match the mainnet SIWE message domain the frontend sends. |
 | `RPC_URL` / `AUTH_CHAIN_ID` | **CONFIG (new values, not secret)** | `https://eth-rpc.polkadot.io/` + `420420419`. Proof exact-matches and rejects testnet/paseo/localhost. |
 | Conservative launch economic params (12 values) | **CONFIG (new values)** | Exact-matched by `check-mainnet-usdc-config.mjs`; must also match on-chain TreasuryPolicy params. |
-| `JWT_MAX_TTL_SECONDS` | **CONFIG (new value)** | Proof ceiling is 30d, but PHASE_4B intent is ≤1h — pick the tighter value. |
+| `JWT_MAX_TTL_SECONDS` | **CONFIG (new value)** | Proof ceiling is 30d, but PHASE_4B intent is ≤1h. **≤1h is a workflow migration, not a standalone flip** (callout below): the static `admin-jwt` is rejected the moment the ceiling drops under its lifetime. |
+
+> **JWT TTL ≤1h is automation, not a config flip — deferred testnet → mainnet (2026-06).**
+> Today every hosted workflow authenticates with the long-lived static `admin-jwt`
+> (hand-minted ~monthly via `mint-admin-jwt.mjs`; **not** auto-rotated — confirmed: no
+> workflow/cron re-mints it). Dropping `JWT_MAX_TTL_SECONDS` below 30d rejects that token
+> → all 5 hosted workflows 401. So ≤1h first requires migrating them to the **refresh flow**
+> (short-lived tokens minted on demand, refresh cookie rotated server-side). Mainnet sequence:
+> 1. **One read+write 1Password service account** for the rotation write-back. NB: 1P
+>    service-account permissions are **immutable** — you cannot add write to the existing
+>    read-only `prod-smoke-tests`/`prod-smoke-deploy`; create a *new* R+W SA. One R+W SA
+>    serves all workflows; per-consumer isolation lives at the **item** level, not the SA.
+> 2. **Seed** a per-consumer refresh item per workflow (`op://…/admin-refresh-token-<name>`)
+>    with `seed-admin-refresh-token.mjs` (#672, on `main`) using the **mainnet hardware admin
+>    wallet** — testnet seeds are throwaway.
+> 3. **Re-apply** the per-workflow change (install `op` CLI → `get-admin-refresh-token.mjs`
+>    mints a masked short-lived Bearer → rotation write-back) to all 5 hosted workflows.
+>    Reference pattern: **PR #670** (reverted from `main`, preserved in git history).
+> 4. **Then** drop `JWT_MAX_TTL_SECONDS` 2592000 → 3600. Bonus: this also retires the manual
+>    monthly `admin-jwt` re-mint toil.
 
 **Retired (rendered nowhere on mainnet):** `AUTH_JWT_SECRETS` (HMAC),
 `SIGNER_PRIVATE_KEY`, raw `ARBITRATOR_SIGNER_PRIVATE_KEY`, all static
@@ -122,7 +141,7 @@ ceremony.
 |---|---|---|---|
 | 0 | Pass external audit; freeze audited artifacts | no-multiparty | `prepare-mainnet-audit-freeze.mjs` |
 | 1 | Enroll 2× YubiKey across the 6 accounts; flip GitHub org 2FA; registrar FIDO2 | **no-human-hardware** | validate: `check-hardware-mfa-evidence.mjs` |
-| 2 | Create mainnet 1Password vault tier + mint 4 SA tokens | partial | 1P admin UI + `op service-account create`; **GAP: vault/token bootstrap script** |
+| 2 | Create mainnet 1Password vault tier + mint SA tokens (incl. **one read+write SA** for refresh-token rotation — 1P SA perms are immutable, so set R+W at creation) | partial | 1P admin UI + `op service-account create`; **GAP: vault/token bootstrap script** |
 | 3 | Create multi-region KMS blockchain key (secp256k1); derive + verify EVM address | partial | `aws kms create-key`/`replicate-key` → `derive-kms-signer-address.mjs` + `verify-kms-signer.mjs` |
 | 4 | Create multi-region KMS JWT key (P-256); capture PEM-base64 + fingerprint | partial | `aws kms create-key` → `verify-jwt-kms-signer.mjs` |
 | 5 | Roles Anywhere mainnet CA + 2 trust anchors + 2 profiles + 2 prod roles; client certs on VPS | partial → **no-human-hardware** (CA custody) | `deploy/iam-policies/*-prod-role.json`; **GAP: multi-region role JSON + unscripted IAM apply** |
@@ -137,7 +156,7 @@ ceremony.
 | 14 | Verify all on-chain roles green | yes | `audit-launch-readiness.mjs` |
 | 15 | Rehearse pause/unpause from the dedicated pauser | partial | `run-pauser-rehearsal.mjs --live --require-dedicated-pauser` → `check-pauser-rehearsal-evidence.mjs` |
 | 16 | Author mainnet backend env profile (repoint `op://` to mainnet items; remove HMAC; set `SHARE_URL_SECRET`, `AUTH_CHAIN_ID`, launch caps); drop 4 SA tokens to the VPS; render | partial / no-multiparty | `install-op-vps.sh` + `render-vps-env.sh`; **GAP: no committed mainnet backend env profile** |
-| 17 | Capture `ADMIN_REFRESH_TOKEN` via human SIWE with the mainnet admin wallet | **no-multiparty** | `get-admin-refresh-token.mjs` (first capture manual) |
+| 17 | Seed per-consumer `ADMIN_REFRESH_TOKEN` items via human SIWE with the mainnet admin wallet (enables the ≤1h JWT-TTL migration — see §2 callout) | **no-multiparty** | `seed-admin-refresh-token.mjs` (SIWE login → writes the op item; #672) |
 | 18 | Capture USDC runtime evidence; validate | partial | `check-mainnet-usdc-config.mjs --runtime-evidence … --require-runtime` |
 | 19 | Fund mainnet signer with real low-value USDC; run ≥3 claim→submit→verify→settle loops | partial | `run-hosted-worker-loop.mjs`; liquidity is manual (not auto-mintable) |
 | 20 | Validate the 3 closing proofs (<24h fresh, secret-scanned) | yes | `check-mainnet-env-secrets-proof.mjs`, `-usdc-config`, `-smoke --max-completed-age-hours 24` |

--- a/scripts/ops/hermes-workflow-artifacts.test.mjs
+++ b/scripts/ops/hermes-workflow-artifacts.test.mjs
@@ -84,17 +84,11 @@ test("hosted external-schema proof uploads sanitized evidence as a workflow arti
   assert.match(workflow, /workflow_dispatch:/u);
   assert.match(workflow, /environment: production/u);
   assert.match(workflow, /OP_SERVICE_ACCOUNT_TOKEN_PROD_SMOKE/u);
-  // JWT-TTL phase 1: this workflow mints a short-lived admin access token via
-  // the refresh flow (dedicated per-consumer item) instead of loading the
-  // long-lived static admin JWT — see PR #670 / docs/MAINNET_CREDENTIALS_PLAN.md (F13).
-  assert.match(workflow, /uses: 1password\/install-cli-action@[a-f0-9]{40} # v4\.0\.0/u);
-  assert.match(workflow, /ADMIN_REFRESH_TOKEN_OP: op:\/\/prod-smoke\/admin-refresh-token-schema-proof\/password/u);
-  assert.match(workflow, /node scripts\/ops\/get-admin-refresh-token\.mjs/u);
-  assert.doesNotMatch(workflow, /ADMIN_JWT_OP: op:\/\/prod-smoke\/admin-jwt\/password/u);
+  assert.match(workflow, /ADMIN_JWT_OP: op:\/\/prod-smoke\/admin-jwt\/password/u);
   assert.match(workflow, /CHECK_EXTERNAL_SCHEMA_PROOF: "1"/u);
   assert.match(workflow, /EXTERNAL_SCHEMA_PROOF_EVIDENCE_FILE: artifacts\/external-schema-proof-hosted-\$\{\{ github\.run_id \}\}\.json/u);
   assert.match(workflow, /EXTERNAL_SCHEMA_PROOF_IDEMPOTENCY_KEY: github-hosted-external-schema-proof-\$\{\{ github\.run_id \}\}/u);
-  assert.match(workflow, /ADMIN_JWT="\$ADMIN_ACCESS_TOKEN" \.\/scripts\/ops\/check-hosted-stack\.sh/u);
+  assert.match(workflow, /ADMIN_JWT="\$ADMIN_JWT_OP" \.\/scripts\/ops\/check-hosted-stack\.sh/u);
   assert.match(workflow, /uses: actions\/upload-artifact@(?:v7\b|[a-f0-9]{40} # v7\b)/u);
   assert.match(workflow, /name: hosted-external-schema-proof-\$\{\{ github\.run_id \}\}/u);
   assert.match(workflow, /path: \$\{\{ env\.EXTERNAL_SCHEMA_PROOF_EVIDENCE_FILE \}\}/u);


### PR DESCRIPTION
## What

Reverts [#670](https://github.com/averray-agent/agent/pull/670) and parks the JWT-TTL ≤1h automation for mainnet prep.

## Why

Dropping `JWT_MAX_TTL_SECONDS` to ≤1h isn't a config flip — it requires migrating all 5 hosted workflows off the long-lived static `admin-jwt` to the refresh flow, because the verifier rejects any token whose lifetime exceeds the ceiling. The refresh flow needs a **read+write** 1Password service account for the rotation write-back, and 1P SA permissions are **immutable** — so it's a new-SA setup, not a checkbox. On top of that the testnet refresh-token seeds are throwaway (mainnet re-seeds with the hardware admin wallet), and it's mainnet hardening gated behind the external audit anyway.

Confirmed along the way: `admin-jwt` is **not** auto-rotated today — it's hand-minted ~monthly via `mint-admin-jwt.mjs`. So this is building automation, not tweaking a duration. Sensible to do it once, properly, at mainnet.

## This PR
- Reverts #670 → `hosted-external-schema-proof` is back on the static `admin-jwt`, consistent with the other four (nothing half-wired on `main`).
- Keeps **#672** (`seed-admin-refresh-token.mjs`) — it's the groundwork mainnet needs.
- `docs/MAINNET_CREDENTIALS_PLAN.md`: adds a turnkey runbook callout (the 4-step migration + the immutability gotcha + per-item isolation) and updates steps 2 & 17 to reference the seeding helper.

Reverted test stays green (9/9). The reference refresh-flow pattern lives on in #670's git history for mainnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)