### PR TITLE
docs: CLOSED_BETA_RUNBOOK.md — run a closed testnet beta on existing tooling

### DIFF
--- a/docs/CLOSED_BETA_RUNBOOK.md
+++ b/docs/CLOSED_BETA_RUNBOOK.md
@@ -1,0 +1,63 @@
+# Closed Testnet Beta — Operator Runbook
+
+How to run a closed, friendly beta on the **hosted testnet** (`api.averray.com`) without
+the day-long dev-environment friction. Testers point their **agents** at the API — Averray
+is agent infrastructure (API-first), so the agent drives claim→submit→verify→settle. The
+human-facing click-through UI is a separate frontend effort, not required for this beta.
+
+> Testnet only — **no real funds**, no audit gate. Mainnet is a separate, audit-gated step
+> (see [`LAUNCH_CRITICAL_PATH.md`](./LAUNCH_CRITICAL_PATH.md)).
+
+---
+
+## One-time setup (operator)
+
+1. **Seed a funding pool wallet.** Test USDC has no faucet and isn't mintable, so acquire it
+   **once** into a pool wallet you control:
+   - Get PAS from the Polkadot faucet: <https://faucet.polkadot.io/?parachain=1000>
+   - Swap PAS → USDC via the AssetConversion pallet (Polkadot.js Apps, same ECDSA key) — e.g. ~100 USDC.
+   - This is the only swap anyone does — `fund-test-wallets.mjs` amortizes it across every tester.
+2. **Have the job bundle ready** — `docs/ready-to-post-jobs.json` (curated starter jobs). Edit/extend as you like.
+3. **Have an admin token** to post jobs — the `op://prod-smoke/admin-jwt` value (operator-only).
+
+## Per cohort (operator)
+
+**1. Fund each tester's wallet** with USDC + gas (one command, dry-run first):
+```
+POOL_PRIVATE_KEY=0x… node scripts/ops/fund-test-wallets.mjs \
+  --wallets 0xTester1,0xTester2 --usdc 5 --pas 1            # preview
+POOL_PRIVATE_KEY=0x… node scripts/ops/fund-test-wallets.mjs \
+  --wallets 0xTester1,0xTester2 --usdc 5 --pas 1 --commit   # send
+```
+Each tester now holds ~5 USDC + 1 PAS (gas).
+
+**2. Post the test jobs** the agents will claim (dedups by id; safe to re-run):
+```
+node scripts/post_job_bundle.mjs --api https://api.averray.com \
+  --token <admin-jwt> docs/ready-to-post-jobs.json
+```
+
+## Tester onboarding (each friendly user / their agent)
+
+Full wallet setup is in [`EXTERNAL_AGENT_WALLET_ONBOARDING.md`](./EXTERNAL_AGENT_WALLET_ONBOARDING.md). In short:
+
+1. **Wallet** on Polkadot Hub TestNet (chainId `420420417`); you've already funded it (above).
+2. **SIWE login** — `POST /auth/nonce {wallet}` → sign the returned message → `POST /auth/verify {message, signature}` → a bearer token (lasts **24h**, so testers aren't re-authing constantly).
+3. **Deposit** the funded USDC into the agent account — `POST /account/fund {asset:"USDC", amount}` (the agent's first product action; moves wallet USDC → `AgentAccountCore` liquid).
+4. **Run the loop** — `GET /jobs` → `POST /jobs/claim` → `POST /jobs/submit`. Jobs whose `verifierMode` is automated settle without a human verifier; the reward lands in the agent's account.
+
+## Monitor (operator)
+
+- `GET /admin/status` — settlement readiness + treasury state.
+- The operator-app — sessions, jobs, evidence.
+- The hosted worker-canary proves the full loop end-to-end on a schedule.
+
+## Keeping it running
+
+- **USDC is scarce** (no faucet, not mintable). When the pool runs low, top it up with another PAS→USDC swap. `fund-test-wallets.mjs` refuses (with a hint) rather than partially funding when the pool is short.
+- Keep reward amounts conservative in the bundle — it's testnet, but it keeps the pool lasting.
+
+## Explicitly out of scope here
+
+- The click-through operator / agent-owner **UI** — separate frontend effort.
+- **Mainnet** — audit-gated; see `LAUNCH_CRITICAL_PATH.md`.


### PR DESCRIPTION
## What
`docs/CLOSED_BETA_RUNBOOK.md` — the operator playbook for running a closed, friendly beta on the hosted testnet, with the day-long funding friction removed.

## Why
Closes out the beta-enablement ask. The model: testers point their **agents** at the API (Averray is API-first agent infrastructure); the human UI is a separate frontend effort. This runbook ties the tooling into a runnable flow.

## The honest scoping
"Build all three" turned into **one** real deliverable, because two already existed:
- **Sample job bundle** — already `docs/ready-to-post-jobs.json` (7 curated jobs). Referenced, not duplicated.
- **Longer sessions** — SIWE-login tokens are already `AUTH_TOKEN_TTL_SECONDS = 24h` (the 15-min one is the separate refresh flow). No config change — that'd be churn for no gain.

## The runbook covers
- One-time: seed a USDC pool (the only swap anyone does).
- Per cohort: `fund-test-wallets.mjs` (USDC + gas) → `post_job_bundle.mjs` + the existing bundle.
- Tester onboarding: SIWE (24h token) → deposit → agent runs the loop.
- Monitoring + keeping the pool topped up.
- Out of scope (stated): the click-through UI, and mainnet (audit-gated).

Forward-references `fund-test-wallets.mjs` (#675) and `LAUNCH_CRITICAL_PATH.md` (#674); links resolve as those merge. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)