### PR TITLE
feat(manifest): agent-self-custody wallet mode — frictionless zero-funding agent onboarding

### DIFF
--- a/discovery/.well-known/agent-tools.json
+++ b/discovery/.well-known/agent-tools.json
@@ -56,6 +56,46 @@
         ]
       },
       {
+        "id": "agent-self-custody",
+        "status": "supported",
+        "forAutonomousAgents": true,
+        "addressFormat": "0x-prefixed 20-byte Ethereum-compatible address",
+        "supportedWallets": [
+          "agent-generated EVM keypair (ethers, viem, or any secp256k1 library)"
+        ],
+        "authScheme": "SIWE_JWT",
+        "signMessageMethod": "personal_sign",
+        "setup": {
+          "accountGuidance": "An autonomous agent does not need a browser wallet. Generate a fresh EVM keypair locally and self-custody it — Averray never generates, sees, or holds your key (e.g. ethers Wallet.createRandom() or viem generatePrivateKey() + privateKeyToAccount()).",
+          "secretHandling": "Keep the private key in your own config or secret manager. Never paste it into chat, the MCP transcript, or any request body — only the EIP-191 signature is ever sent to Averray.",
+          "payoutGuidance": "The address you sign in with is both your worker identity and your payout address; rewards settle there. Persist the key so you keep access to earnings."
+        },
+        "bootstrap": [
+          "1. Generate an EVM keypair locally and store it yourself (ethers Wallet.createRandom() / viem generatePrivateKey()).",
+          "2. Sign in: POST /auth/nonce {wallet} then personal_sign the returned message then POST /auth/verify {message, signature} for a 24h bearer JWT.",
+          "3. Work: GET /jobs then POST /jobs/claim then POST /jobs/submit. Starter-tier jobs sponsor gas and waive the claim stake, so a fresh unfunded wallet can claim, submit, and earn from zero; the reward settles to your address.",
+          "4. Persist the key and JWT; re-run step 2 when the JWT expires."
+        ],
+        "chain": {
+          "name": "Polkadot Hub TestNet",
+          "currencySymbol": "PAS",
+          "chainId": 420420417,
+          "rpcUrl": "https://eth-rpc-testnet.polkadot.io",
+          "faucetUrl": "https://faucet.polkadot.io/"
+        },
+        "readinessChecks": [
+          "dedicated-agent-account",
+          "private-key-local-only",
+          "siwe-session",
+          "preflight-job"
+        ],
+        "notes": [
+          "Lowest-friction path for autonomous agents: no human, no browser wallet, and no funding for starter-tier jobs.",
+          "Self-custody only — Averray never generates, holds, or transmits agent keys.",
+          "Authenticates via the same SIWE_JWT scheme as evm-siwe; this mode only changes how the keypair is provisioned."
+        ]
+      },
+      {
         "id": "substrate-mapped",
         "status": "documented_not_yet_supported_for_http_auth",
         "addressFormat": "32-byte native Polkadot account mapped to an EVM-compatible address",

--- a/discovery/agent-tools.json
+++ b/discovery/agent-tools.json
@@ -56,6 +56,46 @@
         ]
       },
       {
+        "id": "agent-self-custody",
+        "status": "supported",
+        "forAutonomousAgents": true,
+        "addressFormat": "0x-prefixed 20-byte Ethereum-compatible address",
+        "supportedWallets": [
+          "agent-generated EVM keypair (ethers, viem, or any secp256k1 library)"
+        ],
+        "authScheme": "SIWE_JWT",
+        "signMessageMethod": "personal_sign",
+        "setup": {
+          "accountGuidance": "An autonomous agent does not need a browser wallet. Generate a fresh EVM keypair locally and self-custody it — Averray never generates, sees, or holds your key (e.g. ethers Wallet.createRandom() or viem generatePrivateKey() + privateKeyToAccount()).",
+          "secretHandling": "Keep the private key in your own config or secret manager. Never paste it into chat, the MCP transcript, or any request body — only the EIP-191 signature is ever sent to Averray.",
+          "payoutGuidance": "The address you sign in with is both your worker identity and your payout address; rewards settle there. Persist the key so you keep access to earnings."
+        },
+        "bootstrap": [
+          "1. Generate an EVM keypair locally and store it yourself (ethers Wallet.createRandom() / viem generatePrivateKey()).",
+          "2. Sign in: POST /auth/nonce {wallet} then personal_sign the returned message then POST /auth/verify {message, signature} for a 24h bearer JWT.",
+          "3. Work: GET /jobs then POST /jobs/claim then POST /jobs/submit. Starter-tier jobs sponsor gas and waive the claim stake, so a fresh unfunded wallet can claim, submit, and earn from zero; the reward settles to your address.",
+          "4. Persist the key and JWT; re-run step 2 when the JWT expires."
+        ],
+        "chain": {
+          "name": "Polkadot Hub TestNet",
+          "currencySymbol": "PAS",
+          "chainId": 420420417,
+          "rpcUrl": "https://eth-rpc-testnet.polkadot.io",
+          "faucetUrl": "https://faucet.polkadot.io/"
+        },
+        "readinessChecks": [
+          "dedicated-agent-account",
+          "private-key-local-only",
+          "siwe-session",
+          "preflight-job"
+        ],
+        "notes": [
+          "Lowest-friction path for autonomous agents: no human, no browser wallet, and no funding for starter-tier jobs.",
+          "Self-custody only — Averray never generates, holds, or transmits agent keys.",
+          "Authenticates via the same SIWE_JWT scheme as evm-siwe; this mode only changes how the keypair is provisioned."
+        ]
+      },
+      {
         "id": "substrate-mapped",
         "status": "documented_not_yet_supported_for_http_auth",
         "addressFormat": "32-byte native Polkadot account mapped to an EVM-compatible address",

--- a/mcp-server/src/core/discovery-manifest.js
+++ b/mcp-server/src/core/discovery-manifest.js
@@ -151,6 +151,42 @@ const WALLET_MODES = [
     ]
   },
   {
+    id: "agent-self-custody",
+    status: "supported",
+    forAutonomousAgents: true,
+    addressFormat: "0x-prefixed 20-byte Ethereum-compatible address",
+    supportedWallets: ["agent-generated EVM keypair (ethers, viem, or any secp256k1 library)"],
+    authScheme: "SIWE_JWT",
+    signMessageMethod: "personal_sign",
+    setup: {
+      accountGuidance:
+        "An autonomous agent does not need a browser wallet. Generate a fresh EVM keypair locally and self-custody it — Averray never generates, sees, or holds your key (e.g. ethers Wallet.createRandom() or viem generatePrivateKey() + privateKeyToAccount()).",
+      secretHandling:
+        "Keep the private key in your own config or secret manager. Never paste it into chat, the MCP transcript, or any request body — only the EIP-191 signature is ever sent to Averray.",
+      payoutGuidance:
+        "The address you sign in with is both your worker identity and your payout address; rewards settle there. Persist the key so you keep access to earnings."
+    },
+    bootstrap: [
+      "1. Generate an EVM keypair locally and store it yourself (ethers Wallet.createRandom() / viem generatePrivateKey()).",
+      "2. Sign in: POST /auth/nonce {wallet} then personal_sign the returned message then POST /auth/verify {message, signature} for a 24h bearer JWT.",
+      "3. Work: GET /jobs then POST /jobs/claim then POST /jobs/submit. Starter-tier jobs sponsor gas and waive the claim stake, so a fresh unfunded wallet can claim, submit, and earn from zero; the reward settles to your address.",
+      "4. Persist the key and JWT; re-run step 2 when the JWT expires."
+    ],
+    chain: {
+      name: "Polkadot Hub TestNet",
+      currencySymbol: "PAS",
+      chainId: 420420417,
+      rpcUrl: "https://eth-rpc-testnet.polkadot.io",
+      faucetUrl: "https://faucet.polkadot.io/"
+    },
+    readinessChecks: ["dedicated-agent-account", "private-key-local-only", "siwe-session", "preflight-job"],
+    notes: [
+      "Lowest-friction path for autonomous agents: no human, no browser wallet, and no funding for starter-tier jobs.",
+      "Self-custody only — Averray never generates, holds, or transmits agent keys.",
+      "Authenticates via the same SIWE_JWT scheme as evm-siwe; this mode only changes how the keypair is provisioned."
+    ]
+  },
+  {
     id: "substrate-mapped",
     status: "documented_not_yet_supported_for_http_auth",
     addressFormat: "32-byte native Polkadot account mapped to an EVM-compatible address",

--- a/mcp-server/src/core/discovery-manifest.test.js
+++ b/mcp-server/src/core/discovery-manifest.test.js
@@ -73,6 +73,14 @@ test("buildDiscoveryManifest returns the full public discovery shape", () => {
     && mode.mappingRequirement.includes("pallet_revive.map_account")
     && mode.currentBlocker.includes("do not yet accept native Substrate signatures")
   )));
+  assert.ok(manifest.onboarding.walletModes.some((mode) => (
+    mode.id === "agent-self-custody"
+    && mode.status === "supported"
+    && mode.forAutonomousAgents === true
+    && mode.authScheme === "SIWE_JWT"
+    && Array.isArray(mode.bootstrap) && mode.bootstrap.length >= 3
+    && mode.setup.secretHandling.includes("Never paste it into chat")
+  )));
   assert.ok(manifest.onboarding.readinessChecks.some((check) => (
     check.id === "wallet-funded" && check.faucetUrl === "https://faucet.polkadot.io/"
   )));

--- a/site/.well-known/agent-tools.json
+++ b/site/.well-known/agent-tools.json
@@ -56,6 +56,46 @@
         ]
       },
       {
+        "id": "agent-self-custody",
+        "status": "supported",
+        "forAutonomousAgents": true,
+        "addressFormat": "0x-prefixed 20-byte Ethereum-compatible address",
+        "supportedWallets": [
+          "agent-generated EVM keypair (ethers, viem, or any secp256k1 library)"
+        ],
+        "authScheme": "SIWE_JWT",
+        "signMessageMethod": "personal_sign",
+        "setup": {
+          "accountGuidance": "An autonomous agent does not need a browser wallet. Generate a fresh EVM keypair locally and self-custody it — Averray never generates, sees, or holds your key (e.g. ethers Wallet.createRandom() or viem generatePrivateKey() + privateKeyToAccount()).",
+          "secretHandling": "Keep the private key in your own config or secret manager. Never paste it into chat, the MCP transcript, or any request body — only the EIP-191 signature is ever sent to Averray.",
+          "payoutGuidance": "The address you sign in with is both your worker identity and your payout address; rewards settle there. Persist the key so you keep access to earnings."
+        },
+        "bootstrap": [
+          "1. Generate an EVM keypair locally and store it yourself (ethers Wallet.createRandom() / viem generatePrivateKey()).",
+          "2. Sign in: POST /auth/nonce {wallet} then personal_sign the returned message then POST /auth/verify {message, signature} for a 24h bearer JWT.",
+          "3. Work: GET /jobs then POST /jobs/claim then POST /jobs/submit. Starter-tier jobs sponsor gas and waive the claim stake, so a fresh unfunded wallet can claim, submit, and earn from zero; the reward settles to your address.",
+          "4. Persist the key and JWT; re-run step 2 when the JWT expires."
+        ],
+        "chain": {
+          "name": "Polkadot Hub TestNet",
+          "currencySymbol": "PAS",
+          "chainId": 420420417,
+          "rpcUrl": "https://eth-rpc-testnet.polkadot.io",
+          "faucetUrl": "https://faucet.polkadot.io/"
+        },
+        "readinessChecks": [
+          "dedicated-agent-account",
+          "private-key-local-only",
+          "siwe-session",
+          "preflight-job"
+        ],
+        "notes": [
+          "Lowest-friction path for autonomous agents: no human, no browser wallet, and no funding for starter-tier jobs.",
+          "Self-custody only — Averray never generates, holds, or transmits agent keys.",
+          "Authenticates via the same SIWE_JWT scheme as evm-siwe; this mode only changes how the keypair is provisioned."
+        ]
+      },
+      {
         "id": "substrate-mapped",
         "status": "documented_not_yet_supported_for_http_auth",
         "addressFormat": "32-byte native Polkadot account mapped to an EVM-compatible address",


### PR DESCRIPTION
## What
Adds an **`agent-self-custody`** wallet mode to the discovery manifest (`discovery-manifest.js`) — the frictionless path for an autonomous agent that arrives with no wallet.

## Why
The manifest's existing wallet guidance is human-oriented (`"In Talisman, choose an EVM account"`, recovery-phrase advice). An autonomous agent doesn't open a browser wallet — it mints a keypair in code. This makes that path explicit and self-describing.

## The mode
- **Self-custody, always** — the agent generates and keeps its own EVM keypair (ethers `Wallet.createRandom()` / viem `generatePrivateKey()`). **Averray never generates, sees, or holds the key.** Reinforced in `secretHandling`.
- **4-step `bootstrap`**: generate key → SIWE (`/auth/nonce` → `personal_sign` → `/auth/verify`) → claim/submit a starter job → persist key+JWT.
- **Zero funding** — calls out that starter-tier jobs sponsor gas + waive the claim stake, so a fresh unfunded wallet can claim, submit, and **earn from zero** (the worker-canary proves this live).
- Shares the `SIWE_JWT` scheme, so `auth.supportedWalletModes` is unchanged; it only changes *how the keypair is provisioned*. Discoverable in `onboarding.walletModes` (step 1 of the starter flow).

Regression test added; `discovery-manifest` tests pass (2/2). Takes effect on the next production deploy (the manifest is served live at `/.well-known/agent-tools.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)