### PR TITLE
ops: fix hosted signer funding runtime mounts

### DIFF
--- a/.github/workflows/hosted-signer-liquidity-funding.yml
+++ b/.github/workflows/hosted-signer-liquidity-funding.yml
@@ -116,8 +116,11 @@ jobs:
             --project-directory /srv/agent-stack \
             -f /srv/agent-stack/docker-compose.yml \
             run --rm --no-deps -T \
+            -e AWS_PROFILE=averray-signer \
+            -e AWS_SDK_LOAD_CONFIG=1 \
             -v /srv/agent-stack/app/scripts:/app/scripts:ro \
             -v /srv/agent-stack/app/deployments:/app/deployments:ro \
+            -v /srv/agent-stack/app/mcp-server:/app/mcp-server:ro \
             backend \
             sh -lc 'cd /app && node scripts/ops/fund-signer-usdc-deposit.mjs "$@"' \
             sh "${mode_args[@]}"


### PR DESCRIPTION
## What changed
- Updates the Hosted Signer Liquidity Funding workflow to match the successful VPS command path.
- Sets AWS_PROFILE=averray-signer and AWS_SDK_LOAD_CONFIG=1 so the direct KmsSigner path can use the Roles Anywhere shared config.
- Mounts mcp-server read-only into /app because fund-signer-usdc-deposit.mjs imports KmsSigner from source.

## Why
The first workflow dry-run failed before any signing because /app/mcp-server was missing. The live direct command succeeded with these exact additions.

## Checks
- ruby YAML parse check: passed

## Affected surface
- GitHub Actions ops workflow only.
