### PR TITLE
docs(runbook): document the reward-bank (signer liquidity) dependency

### DIFF
--- a/docs/CLOSED_BETA_RUNBOOK.md
+++ b/docs/CLOSED_BETA_RUNBOOK.md
@@ -54,6 +54,10 @@ Full wallet setup is in [`EXTERNAL_AGENT_WALLET_ONBOARDING.md`](./EXTERNAL_AGENT
 
 ## Keeping it running
 
+- **⚠️ Keep the reward bank funded — this is the one that bites.** Job rewards are paid from the **backend signer's** on-chain liquidity (`AgentAccountCore.positions(signer, USDC).liquid`), **not** from tester wallets. It drains as agents earn — roughly **~20 starter-job completions per 100 USDC** (rewards are 4–7 USDC each). When it hits 0, every `/jobs/claim` returns HTTP 409 `insufficient_liquidity` and the worker canary goes red.
+  - **Fuel gauge:** the Hosted Worker Canary. Green = bank funded; a `409 insufficient_liquidity` at the claim stage = empty.
+  - **Top up:** the hosted signer-liquidity funding workflow (#679, manual dispatch), or by hand — `cast send <USDC-precompile> "transfer(address,uint256)" <signer-wallet> <baseUnits>`, then `node scripts/ops/fund-signer-usdc-deposit.mjs --amount <baseUnits> --use-kms --commit` (KMS-signed; runs where the signer's KMS creds live — VPS/ops).
+  - **Don't confuse it with the faucet pool:** the **pool** (`fund-test-wallets`) funds *testers'* gas/USDC (rarely needed — starter jobs sponsor gas + waive the stake); the **signer** funds the *rewards testers earn*. Put your USDC in the signer.
 - **USDC is scarce** (no faucet, not mintable). When the pool runs low, top it up with another PAS→USDC swap. `fund-test-wallets.mjs` refuses (with a hint) rather than partially funding when the pool is short.
 - Keep reward amounts conservative in the bundle — it's testnet, but it keeps the pool lasting.
 


### PR DESCRIPTION
Adds a 'Keeping it running' note to CLOSED_BETA_RUNBOOK.md: job rewards pay from the **backend signer's** `AAC.liquid` (not tester wallets), it drains as agents earn (~20 starter completions per 100 USDC), and a `409 insufficient_liquidity` / red worker canary = empty. Documents both top-up paths (#679 manual workflow; or `cast` transfer + `fund-signer-usdc-deposit.mjs --use-kms`) and the pool-vs-signer distinction. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)