### PR TITLE
fix(manifest): advertised JWT alg HS256 → ES256 (it actually signs ES256)

### DIFF
--- a/discovery/.well-known/agent-tools.json
+++ b/discovery/.well-known/agent-tools.json
@@ -388,7 +388,7 @@
     "entrypoint": "https://api.averray.com/onboarding"
   },
   "auth": {
-    "scheme": "SIWE + JWT (HS256)",
+    "scheme": "SIWE + JWT (ES256)",
     "schemeId": "SIWE_JWT",
     "flow": [
       "POST /auth/nonce { wallet } -> { nonce, message }",

--- a/discovery/agent-tools.json
+++ b/discovery/agent-tools.json
@@ -388,7 +388,7 @@
     "entrypoint": "https://api.averray.com/onboarding"
   },
   "auth": {
-    "scheme": "SIWE + JWT (HS256)",
+    "scheme": "SIWE + JWT (ES256)",
     "schemeId": "SIWE_JWT",
     "flow": [
       "POST /auth/nonce { wallet } -> { nonce, message }",

--- a/mcp-server/src/core/discovery-manifest.js
+++ b/mcp-server/src/core/discovery-manifest.js
@@ -420,7 +420,7 @@ const BASE_MANIFEST = {
     ]
   },
   auth: {
-    scheme: "SIWE + JWT (HS256)",
+    scheme: "SIWE + JWT (ES256)",
     schemeId: "SIWE_JWT",
     flow: [
       "POST /auth/nonce { wallet } -> { nonce, message }",

--- a/site/.well-known/agent-tools.json
+++ b/site/.well-known/agent-tools.json
@@ -388,7 +388,7 @@
     "entrypoint": "https://api.averray.com/onboarding"
   },
   "auth": {
-    "scheme": "SIWE + JWT (HS256)",
+    "scheme": "SIWE + JWT (ES256)",
     "schemeId": "SIWE_JWT",
     "flow": [
       "POST /auth/nonce { wallet } -> { nonce, message }",


### PR DESCRIPTION
An external agent onboarding to the closed beta read the discovery manifest and flagged that it advertises `SIWE + JWT (HS256)`. Verified live against prod — the backend actually signs **ES256** (KMS JWT signer; header `{"alg":"ES256","typ":"averray-auth+jwt","kid":"jwt-1"}`). Corrected the manifest `auth.scheme` to ES256 and regenerated the committed `discovery/` + `site/` copies. Cosmetic for token consumers (agents just present the bearer), but it's a truth-boundary accuracy fix. `[allow-generated]` marks the regenerated `site/` output. Manifest test 2/2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)