### PR TITLE
docs(manifest): clarify starter-tier gas is operator-brokered, not the Pimlico paymaster

### DIFF
--- a/discovery/.well-known/agent-tools.json
+++ b/discovery/.well-known/agent-tools.json
@@ -73,7 +73,7 @@
         "bootstrap": [
           "1. Generate an EVM keypair locally and store it yourself (ethers Wallet.createRandom() / viem generatePrivateKey()).",
           "2. Sign in: POST /auth/nonce {wallet} then personal_sign the returned message then POST /auth/verify {message, signature} for a 24h bearer JWT.",
-          "3. Work: GET /jobs then POST /jobs/claim then POST /jobs/submit. Starter-tier jobs sponsor gas and waive the claim stake, so a fresh unfunded wallet can claim, submit, and earn from zero; the reward settles to your address.",
+          "3. Work: GET /jobs then POST /jobs/claim then POST /jobs/submit. Starter-tier jobs are operator-brokered — Averray's backend signer submits the on-chain claim and settlement on your behalf and covers the gas, and the claim stake is waived — so a fresh unfunded wallet can claim, submit, and earn from zero; the reward settles to your address. This brokered sponsorship is independent of the /health gasSponsor (Pimlico ERC-4337 paymaster) capability, which may read 'disabled' without affecting starter-tier earning.",
           "4. Persist the key and JWT; re-run step 2 when the JWT expires."
         ],
         "chain": {
@@ -486,7 +486,7 @@
     },
     {
       "path": "/gas/health",
-      "description": "Pimlico gas-sponsor health."
+      "description": "Pimlico ERC-4337 gas-sponsor (paymaster) health. Distinct from starter-tier gas: starter jobs are claimed and settled on-chain by the backend signer, so they earn from zero even when this paymaster reads 'disabled'."
     },
     {
       "path": "/gas/capabilities",

--- a/discovery/agent-tools.json
+++ b/discovery/agent-tools.json
@@ -73,7 +73,7 @@
         "bootstrap": [
           "1. Generate an EVM keypair locally and store it yourself (ethers Wallet.createRandom() / viem generatePrivateKey()).",
           "2. Sign in: POST /auth/nonce {wallet} then personal_sign the returned message then POST /auth/verify {message, signature} for a 24h bearer JWT.",
-          "3. Work: GET /jobs then POST /jobs/claim then POST /jobs/submit. Starter-tier jobs sponsor gas and waive the claim stake, so a fresh unfunded wallet can claim, submit, and earn from zero; the reward settles to your address.",
+          "3. Work: GET /jobs then POST /jobs/claim then POST /jobs/submit. Starter-tier jobs are operator-brokered — Averray's backend signer submits the on-chain claim and settlement on your behalf and covers the gas, and the claim stake is waived — so a fresh unfunded wallet can claim, submit, and earn from zero; the reward settles to your address. This brokered sponsorship is independent of the /health gasSponsor (Pimlico ERC-4337 paymaster) capability, which may read 'disabled' without affecting starter-tier earning.",
           "4. Persist the key and JWT; re-run step 2 when the JWT expires."
         ],
         "chain": {
@@ -486,7 +486,7 @@
     },
     {
       "path": "/gas/health",
-      "description": "Pimlico gas-sponsor health."
+      "description": "Pimlico ERC-4337 gas-sponsor (paymaster) health. Distinct from starter-tier gas: starter jobs are claimed and settled on-chain by the backend signer, so they earn from zero even when this paymaster reads 'disabled'."
     },
     {
       "path": "/gas/capabilities",

--- a/mcp-server/src/core/discovery-manifest.js
+++ b/mcp-server/src/core/discovery-manifest.js
@@ -23,7 +23,7 @@ const DISCOVERY_PUBLIC_ENDPOINTS = [
   { path: "/agents/:wallet", description: "Averray Agent Profile v1 - aggregate reputation, stats, earned badges." },
   { path: "/shares/:token", description: "Public signed read-only snapshot resolver for share URLs." },
   { path: "/verifier/handlers", description: "List of supported verifier modes." },
-  { path: "/gas/health", description: "Pimlico gas-sponsor health." },
+  { path: "/gas/health", description: "Pimlico ERC-4337 gas-sponsor (paymaster) health. Distinct from starter-tier gas: starter jobs are claimed and settled on-chain by the backend signer, so they earn from zero even when this paymaster reads 'disabled'." },
   { path: "/gas/capabilities", description: "Available ERC-4337 sponsorship features." }
 ];
 
@@ -169,7 +169,7 @@ const WALLET_MODES = [
     bootstrap: [
       "1. Generate an EVM keypair locally and store it yourself (ethers Wallet.createRandom() / viem generatePrivateKey()).",
       "2. Sign in: POST /auth/nonce {wallet} then personal_sign the returned message then POST /auth/verify {message, signature} for a 24h bearer JWT.",
-      "3. Work: GET /jobs then POST /jobs/claim then POST /jobs/submit. Starter-tier jobs sponsor gas and waive the claim stake, so a fresh unfunded wallet can claim, submit, and earn from zero; the reward settles to your address.",
+      "3. Work: GET /jobs then POST /jobs/claim then POST /jobs/submit. Starter-tier jobs are operator-brokered — Averray's backend signer submits the on-chain claim and settlement on your behalf and covers the gas, and the claim stake is waived — so a fresh unfunded wallet can claim, submit, and earn from zero; the reward settles to your address. This brokered sponsorship is independent of the /health gasSponsor (Pimlico ERC-4337 paymaster) capability, which may read 'disabled' without affecting starter-tier earning.",
       "4. Persist the key and JWT; re-run step 2 when the JWT expires."
     ],
     chain: {

--- a/site/.well-known/agent-tools.json
+++ b/site/.well-known/agent-tools.json
@@ -73,7 +73,7 @@
         "bootstrap": [
           "1. Generate an EVM keypair locally and store it yourself (ethers Wallet.createRandom() / viem generatePrivateKey()).",
           "2. Sign in: POST /auth/nonce {wallet} then personal_sign the returned message then POST /auth/verify {message, signature} for a 24h bearer JWT.",
-          "3. Work: GET /jobs then POST /jobs/claim then POST /jobs/submit. Starter-tier jobs sponsor gas and waive the claim stake, so a fresh unfunded wallet can claim, submit, and earn from zero; the reward settles to your address.",
+          "3. Work: GET /jobs then POST /jobs/claim then POST /jobs/submit. Starter-tier jobs are operator-brokered — Averray's backend signer submits the on-chain claim and settlement on your behalf and covers the gas, and the claim stake is waived — so a fresh unfunded wallet can claim, submit, and earn from zero; the reward settles to your address. This brokered sponsorship is independent of the /health gasSponsor (Pimlico ERC-4337 paymaster) capability, which may read 'disabled' without affecting starter-tier earning.",
           "4. Persist the key and JWT; re-run step 2 when the JWT expires."
         ],
         "chain": {
@@ -486,7 +486,7 @@
     },
     {
       "path": "/gas/health",
-      "description": "Pimlico gas-sponsor health."
+      "description": "Pimlico ERC-4337 gas-sponsor (paymaster) health. Distinct from starter-tier gas: starter jobs are claimed and settled on-chain by the backend signer, so they earn from zero even when this paymaster reads 'disabled'."
     },
     {
       "path": "/gas/capabilities",


### PR DESCRIPTION
## Why
An external reviewer agent (onboarding to the closed beta) saw `/health` report `gasSponsor: "disabled"` and read it as contradicting the manifest's repeated "starter jobs sponsor gas" promise — a truth-boundary flag worth resolving.

## The reality (verified live)
- `gateway.js:885` — starter jobs are claimed via `escrowContract.claimJobFor(chainJobId, wallet)`: the **backend signer** submits the on-chain claim + settlement and pays the gas. The worker never sends a tx, so it needs no PAS.
- The `/health` `gasSponsor` capability is the **separate Pimlico ERC-4337 paymaster** (manifest `/gas/health` = "Pimlico gas-sponsor", `/gas/capabilities` = "ERC-4337 sponsorship"). It can read `disabled` without affecting starter-tier earn-from-zero — proven live by the worker canary (a roleless, unfunded wallet completes claim→submit→settle).

So the promise holds; the manifest just didn't explain the mechanism, which let `disabled` look like a broken guarantee.

## Change
Clarify two strings so the brokered path isn't mistaken for the paymaster:
- agent-self-custody **bootstrap step 3** — says gas is operator-brokered + independent of the `gasSponsor` flag.
- **`/gas/health` description** — names it the Pimlico 4337 paymaster, distinct from brokered starter-tier gas.

Docs/strings only — no behavior change. Regenerated `discovery/` + `site/` copies; manifest test 2/2. `[allow-generated]` marks the `site/` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)