### PR TITLE
fix(auth): fail closed when JWT_KMS_CREDENTIAL_CHECK_SKIP ships to production (H1)

### DIFF
--- a/mcp-server/src/auth/credential-check.js
+++ b/mcp-server/src/auth/credential-check.js
@@ -70,11 +70,34 @@ export async function validateJwtKmsCredentialAccess(kmsJwtConfig, opts = {}) {
     // HMAC-only mode; nothing to validate.
     return { ok: true, skipped: "hmac-only" };
   }
-  if (opts.skip === true || process.env.JWT_KMS_CREDENTIAL_CHECK_SKIP === "1") {
-    // Explicit escape hatch for test environments where AWS is not
-    // available. Logged at warn level so a stray prod skip is loud.
+  if (opts.skip === true) {
+    // Programmatic test-only hatch. bootstrap never sets opts.skip, so it
+    // cannot reach production — honor it directly.
+    opts.logger?.warn?.({ reason: "opts.skip=true" }, "jwt-kms-credential-check.skipped");
+    return { ok: true, skipped: "explicit" };
+  }
+  if (process.env.JWT_KMS_CREDENTIAL_CHECK_SKIP === "1") {
+    // Operator/emergency env hatch for disconnected dev + CI where AWS is
+    // unreachable. In production it must NOT silently bypass the check: a
+    // stray skip masks exactly the credential misconfiguration this check
+    // exists to catch (the backend boots green, then every SIWE sign-in
+    // returns 500). Fail closed unless a deliberate second ack flag is also
+    // set, so an accidental production skip is caught at boot, not shipped.
+    const isProduction = process.env.NODE_ENV === "production";
+    const acknowledged = process.env.JWT_KMS_CREDENTIAL_CHECK_SKIP_ACK_PRODUCTION === "1";
+    if (isProduction && !acknowledged) {
+      throw new ConfigError(
+        "JWT_KMS_CREDENTIAL_CHECK_SKIP=1 is set under NODE_ENV=production. This emergency " +
+          "boot hatch bypasses the JWT KMS credential check and must not ship to production " +
+          "unintentionally — a stray skip masks exactly the misconfiguration the check exists " +
+          "to catch (the backend boots green, then every SIWE sign-in returns 500). Remove " +
+          "JWT_KMS_CREDENTIAL_CHECK_SKIP from the production environment. If this is a " +
+          "deliberate, supervised emergency boot, also set " +
+          "JWT_KMS_CREDENTIAL_CHECK_SKIP_ACK_PRODUCTION=1 to acknowledge the risk explicitly.",
+      );
+    }
     opts.logger?.warn?.(
-      { reason: "JWT_KMS_CREDENTIAL_CHECK_SKIP=1 or opts.skip=true" },
+      { reason: "JWT_KMS_CREDENTIAL_CHECK_SKIP=1", production: isProduction, acknowledged },
       "jwt-kms-credential-check.skipped",
     );
     return { ok: true, skipped: "explicit" };

--- a/mcp-server/src/auth/credential-check.test.js
+++ b/mcp-server/src/auth/credential-check.test.js
@@ -78,23 +78,67 @@ test("validateJwtKmsCredentialAccess: respects opts.skip escape hatch", async ()
   assert.equal(result.skipped, "explicit");
 });
 
-test("validateJwtKmsCredentialAccess: respects JWT_KMS_CREDENTIAL_CHECK_SKIP=1 env hatch", async () => {
-  const prior = process.env.JWT_KMS_CREDENTIAL_CHECK_SKIP;
+function restoreEnv(name, prior) {
+  if (prior === undefined) delete process.env[name];
+  else process.env[name] = prior;
+}
+
+const SKIP_HATCH_CFG = () => ({
+  ...VALID_CFG,
+  kmsClient: new FakeKMSClient({
+    getPublicKey: () => {
+      throw new Error("should not be called");
+    },
+  }),
+});
+
+test("validateJwtKmsCredentialAccess: respects JWT_KMS_CREDENTIAL_CHECK_SKIP=1 env hatch (non-production)", async () => {
+  const priorSkip = process.env.JWT_KMS_CREDENTIAL_CHECK_SKIP;
+  const priorNodeEnv = process.env.NODE_ENV;
   process.env.JWT_KMS_CREDENTIAL_CHECK_SKIP = "1";
+  process.env.NODE_ENV = "test";
   try {
-    const cfg = {
-      ...VALID_CFG,
-      kmsClient: new FakeKMSClient({
-        getPublicKey: () => {
-          throw new Error("should not be called");
-        },
-      }),
-    };
-    const result = await validateJwtKmsCredentialAccess(cfg, { logger: silentLogger() });
+    const result = await validateJwtKmsCredentialAccess(SKIP_HATCH_CFG(), { logger: silentLogger() });
     assert.equal(result.skipped, "explicit");
   } finally {
-    if (prior === undefined) delete process.env.JWT_KMS_CREDENTIAL_CHECK_SKIP;
-    else process.env.JWT_KMS_CREDENTIAL_CHECK_SKIP = prior;
+    restoreEnv("JWT_KMS_CREDENTIAL_CHECK_SKIP", priorSkip);
+    restoreEnv("NODE_ENV", priorNodeEnv);
+  }
+});
+
+test("validateJwtKmsCredentialAccess: env hatch fails closed under NODE_ENV=production without ack", async () => {
+  const priorSkip = process.env.JWT_KMS_CREDENTIAL_CHECK_SKIP;
+  const priorNodeEnv = process.env.NODE_ENV;
+  const priorAck = process.env.JWT_KMS_CREDENTIAL_CHECK_SKIP_ACK_PRODUCTION;
+  process.env.JWT_KMS_CREDENTIAL_CHECK_SKIP = "1";
+  process.env.NODE_ENV = "production";
+  delete process.env.JWT_KMS_CREDENTIAL_CHECK_SKIP_ACK_PRODUCTION;
+  try {
+    await assert.rejects(
+      () => validateJwtKmsCredentialAccess(SKIP_HATCH_CFG(), { logger: silentLogger() }),
+      (err) => err instanceof ConfigError && /NODE_ENV=production/.test(err.message),
+    );
+  } finally {
+    restoreEnv("JWT_KMS_CREDENTIAL_CHECK_SKIP", priorSkip);
+    restoreEnv("NODE_ENV", priorNodeEnv);
+    restoreEnv("JWT_KMS_CREDENTIAL_CHECK_SKIP_ACK_PRODUCTION", priorAck);
+  }
+});
+
+test("validateJwtKmsCredentialAccess: env hatch honored under production with explicit ack", async () => {
+  const priorSkip = process.env.JWT_KMS_CREDENTIAL_CHECK_SKIP;
+  const priorNodeEnv = process.env.NODE_ENV;
+  const priorAck = process.env.JWT_KMS_CREDENTIAL_CHECK_SKIP_ACK_PRODUCTION;
+  process.env.JWT_KMS_CREDENTIAL_CHECK_SKIP = "1";
+  process.env.NODE_ENV = "production";
+  process.env.JWT_KMS_CREDENTIAL_CHECK_SKIP_ACK_PRODUCTION = "1";
+  try {
+    const result = await validateJwtKmsCredentialAccess(SKIP_HATCH_CFG(), { logger: silentLogger() });
+    assert.equal(result.skipped, "explicit");
+  } finally {
+    restoreEnv("JWT_KMS_CREDENTIAL_CHECK_SKIP", priorSkip);
+    restoreEnv("NODE_ENV", priorNodeEnv);
+    restoreEnv("JWT_KMS_CREDENTIAL_CHECK_SKIP_ACK_PRODUCTION", priorAck);
   }
 });
 


### PR DESCRIPTION
Implements **H1** from the external-agent security-review tracking (LAUNCH_CRITICAL_PATH, #684).

## Problem
`JWT_KMS_CREDENTIAL_CHECK_SKIP=1` defers the boot-time JWT KMS credential check. It's an emergency hatch for disconnected dev / CI, but today it only `warn`s and proceeds — so a **stray production skip silently masks exactly the misconfiguration the check exists to catch**: the backend boots green, `/health` is fine, then every SIWE sign-in returns 500. There was no guard against shipping it accidentally.

## Fix (fail closed, emergency hatch preserved)
In `credential-check.js`, split the two hatches:
- `opts.skip === true` — programmatic **test-only** hatch (bootstrap never sets it) → honored directly.
- `JWT_KMS_CREDENTIAL_CHECK_SKIP=1` env hatch → under `NODE_ENV=production`, **throws `ConfigError` (boot fails closed)** unless `JWT_KMS_CREDENTIAL_CHECK_SKIP_ACK_PRODUCTION=1` is *also* set. Non-production is unchanged.

So an accidental prod skip is caught at boot; a deliberate, supervised emergency boot is a two-flag, self-documenting action (the error message states the exact procedure). `bootstrap.js` already rethrows on `ConfigError` → the boot aborts.

## Safety
- The flag is **not set in any prod env template** (`deploy/`) or CI workflow — verified — so no current boot or pipeline breaks.
- `NODE_ENV=production` is the codebase's existing prod signal (drives the `AUTH_MODE=strict` default; live `/health` shows `auth.mode: strict`).

## Tests
Added 3 deterministic cases (pin `NODE_ENV`): env hatch honored (non-prod), **fails closed (prod, no ack)**, honored (prod + ack). All pass. (The 9 unrelated reds in this worktree are the known missing `@aws-sdk/client-kms` dep — those tests reach the KMS import and pass in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)