### PR TITLE
fix(indexer): remove direct Drizzle dependency

### DIFF
--- a/docs/LAUNCH_CRITICAL_PATH.md
+++ b/docs/LAUNCH_CRITICAL_PATH.md
@@ -75,7 +75,31 @@ testnet beta** (testnet financial risk ≈ 0); all are mainnet-prep.
 |---|------|-------|-------|
 | H1 | **Deploy-time guard for `JWT_KMS_CREDENTIAL_CHECK_SKIP`** | Claude | The emergency boot-cred-check bypass has no guard against accidental ship. Add a CI/deploy assertion that it's unset in the rendered production env (fail closed). |
 | H2 | **Move `DISCOVERY_PUBLISHER_PRIVATE_KEY` off GitHub Secrets → KMS** | Pascal / infra | The last raw signer key not on KMS; signs discovery-manifest hashes (not funds), and the on-chain `DiscoveryRegistry` hash-check bounds the blast radius today. Migrate before mainnet. |
-| H3 | **Known-vuln deps: `drizzle-orm` + `kysely` SQLi** | Codex | `drizzle-orm <0.45.2` (GHSA-gpj5-g38j-94v9) + `kysely <=0.28.16` (3× SQLi). **Not a clean bump:** (a) direct `drizzle-orm ^0.41→^0.45.2` is breaking and touches settlement code (`indexer/src/api/xcm-outcome*.ts` import `sql`/`eq`/`and`) → Codex must verify against a live chain+DB; (b) `kysely` + ponder-nested `drizzle` are **transitive via `ponder@0.16.6`, already the latest** — unclearable by upgrade until ponder patches, or via a risky `overrides` force that may break ponder's runtime. Bounded today by the indexer SQL validator + testnet-only. Track upstream ponder; revisit before real funds. |
+| H3 | **Known-vuln deps: `drizzle-orm` + `kysely` SQLi** | Codex | Partially remediated 2026-06-25: the direct indexer `drizzle-orm <0.45.2` dependency was removed and XCM outcome code now consumes Ponder's Drizzle re-export, avoiding a broken mixed-Drizzle runtime. Residual risk remains inside `ponder@0.16.6`, which is still latest and still vendors vulnerable Drizzle/Kysely. Track upstream Ponder or ship only a separately rehearsed override. |
+
+### H3 detail — indexer ORM SQLi advisories
+
+**Status as of 2026-06-25:** partially remediated. The indexer's direct
+`drizzle-orm` dependency is removed and Averray-owned XCM outcome queries now
+use Ponder's Drizzle re-export, avoiding a broken mixed-Drizzle runtime while
+closing the direct dependency exposure in `indexer/package.json`. The XCM
+outcome publisher has a regression test proving external outcome values remain
+parameterized through the SQL template.
+
+Residual risk remains in `ponder@0.16.6`, which is still the latest Ponder
+release and still vendors `drizzle-orm@0.41.0` plus `kysely@0.26.3`. Do not
+force an override into Ponder without a dedicated live-ingest rehearsal; that
+could break Ponder's runtime query layer while giving a false sense of security.
+
+Close criteria:
+
+- [x] Direct indexer `drizzle-orm <0.45.2` dependency is removed.
+- [x] `npm --workspace indexer run typecheck` and
+  `npm --workspace indexer run test:api` pass with XCM queries using Ponder's
+  Drizzle re-export.
+- [ ] Ponder releases a compatible version that removes its vulnerable
+  transitive `drizzle-orm` / `kysely` copies, or Averray validates and ships a
+  deliberately tested override with live ingest evidence.
 
 ## Honest timeline
 

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -12,7 +12,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "drizzle-orm": "^0.41.0",
     "hono": "^4.12.25",
     "ponder": "^0.16.6",
     "viem": "^2.21.3"

--- a/indexer/src/api/xcm-outcome-publisher-sql.test.ts
+++ b/indexer/src/api/xcm-outcome-publisher-sql.test.ts
@@ -32,6 +32,34 @@ test("external outcome upsert ignores stale observedAt replays", () => {
   ]);
 });
 
+test("external outcome upsert keeps dynamic values parameterized", () => {
+  const injectedOutcome = {
+    ...outcome,
+    requestId: `0x${"33".repeat(32)}`,
+    status: "succeeded'); DROP TABLE xcm_external_outcomes; --",
+    settledAssets: "0); DROP TABLE xcm_external_observer_state; --",
+    settledShares: "1",
+    remoteRef: "remote'); SELECT current_user; --",
+    failureCode: "failure'); DELETE FROM xcm_external_outcomes; --",
+    source: "feed'); DROP SCHEMA public; --"
+  };
+  const query = buildUpsertExternalOutcomeSql(injectedOutcome);
+  const text = sqlText(query);
+
+  assert.doesNotMatch(text, /DROP TABLE|DELETE FROM|DROP SCHEMA|current_user/u);
+  assert.match(text, /VALUES \(\s*\?,\s*\?,\s*\?,\s*\?,\s*\?,\s*\?,\s*\?,\s*\?\s*\)/u);
+  assert.deepEqual(sqlParams(query), [
+    injectedOutcome.requestId,
+    injectedOutcome.status,
+    injectedOutcome.settledAssets,
+    injectedOutcome.settledShares,
+    injectedOutcome.remoteRef,
+    injectedOutcome.failureCode,
+    injectedOutcome.observedAt,
+    injectedOutcome.source
+  ]);
+});
+
 function sqlText(query: { queryChunks: unknown[] }) {
   return query.queryChunks
     .map((chunk) => isStringChunk(chunk) ? chunk.value.join("") : "?")

--- a/indexer/src/api/xcm-outcome-publisher-sql.ts
+++ b/indexer/src/api/xcm-outcome-publisher-sql.ts
@@ -1,4 +1,4 @@
-import { sql } from "drizzle-orm";
+import { sql } from "ponder";
 
 import type { PublishedOutcome } from "./xcm-upstream-source";
 

--- a/indexer/src/api/xcm-outcome-publisher.ts
+++ b/indexer/src/api/xcm-outcome-publisher.ts
@@ -1,4 +1,4 @@
-import { sql } from "drizzle-orm";
+import { sql } from "ponder";
 
 import { db } from "ponder:api";
 

--- a/indexer/src/api/xcm-outcomes.ts
+++ b/indexer/src/api/xcm-outcomes.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gt, inArray, or } from "drizzle-orm";
+import { and, asc, eq, gt, inArray, or } from "ponder";
 
 import { db } from "ponder:api";
 import schema from "ponder:schema";

--- a/package-lock.json
+++ b/package-lock.json
@@ -260,7 +260,6 @@
       "name": "@polkadot/agent-platform-indexer",
       "version": "0.1.0",
       "dependencies": {
-        "drizzle-orm": "^0.41.0",
         "hono": "^4.12.25",
         "ponder": "^0.16.6",
         "viem": "^2.21.3"
@@ -279,125 +278,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "indexer/node_modules/drizzle-orm": {
-      "version": "0.41.0",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@aws-sdk/client-rds-data": ">=3",
-        "@cloudflare/workers-types": ">=4",
-        "@electric-sql/pglite": ">=0.2.0",
-        "@libsql/client": ">=0.10.0",
-        "@libsql/client-wasm": ">=0.10.0",
-        "@neondatabase/serverless": ">=0.10.0",
-        "@op-engineering/op-sqlite": ">=2",
-        "@opentelemetry/api": "^1.4.1",
-        "@planetscale/database": ">=1",
-        "@prisma/client": "*",
-        "@tidbcloud/serverless": "*",
-        "@types/better-sqlite3": "*",
-        "@types/pg": "*",
-        "@types/sql.js": "*",
-        "@vercel/postgres": ">=0.8.0",
-        "@xata.io/client": "*",
-        "better-sqlite3": ">=7",
-        "bun-types": "*",
-        "expo-sqlite": ">=14.0.0",
-        "gel": ">=2",
-        "knex": "*",
-        "kysely": "*",
-        "mysql2": ">=2",
-        "pg": ">=8",
-        "postgres": ">=3",
-        "sql.js": ">=1",
-        "sqlite3": ">=5"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/client-rds-data": {
-          "optional": true
-        },
-        "@cloudflare/workers-types": {
-          "optional": true
-        },
-        "@electric-sql/pglite": {
-          "optional": true
-        },
-        "@libsql/client": {
-          "optional": true
-        },
-        "@libsql/client-wasm": {
-          "optional": true
-        },
-        "@neondatabase/serverless": {
-          "optional": true
-        },
-        "@op-engineering/op-sqlite": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@planetscale/database": {
-          "optional": true
-        },
-        "@prisma/client": {
-          "optional": true
-        },
-        "@tidbcloud/serverless": {
-          "optional": true
-        },
-        "@types/better-sqlite3": {
-          "optional": true
-        },
-        "@types/pg": {
-          "optional": true
-        },
-        "@types/sql.js": {
-          "optional": true
-        },
-        "@vercel/postgres": {
-          "optional": true
-        },
-        "@xata.io/client": {
-          "optional": true
-        },
-        "better-sqlite3": {
-          "optional": true
-        },
-        "bun-types": {
-          "optional": true
-        },
-        "expo-sqlite": {
-          "optional": true
-        },
-        "gel": {
-          "optional": true
-        },
-        "knex": {
-          "optional": true
-        },
-        "kysely": {
-          "optional": true
-        },
-        "mysql2": {
-          "optional": true
-        },
-        "pg": {
-          "optional": true
-        },
-        "postgres": {
-          "optional": true
-        },
-        "prisma": {
-          "optional": true
-        },
-        "sql.js": {
-          "optional": true
-        },
-        "sqlite3": {
-          "optional": true
-        }
       }
     },
     "indexer/node_modules/typescript": {


### PR DESCRIPTION
## Summary
- remove the indexer's direct vulnerable drizzle-orm dependency and consume Ponder's Drizzle helper re-exports instead
- keep XCM outcome SQL objects on Ponder's single Drizzle runtime to avoid the broken mixed-version type/runtime boundary
- add a regression test proving external XCM outcome values stay parameterized
- document H3 status and the remaining Ponder-owned drizzle/kysely advisories in docs/LAUNCH_CRITICAL_PATH.md

## Verification
- npm --workspace indexer run typecheck
- npm --workspace indexer run test:api
- npm audit --workspace indexer --omit=dev --json (still reports Ponder transitive drizzle-orm@0.41.0 and kysely@0.26.3; direct indexer drizzle dependency is gone)

## Impact
- Indexer/backend docs only; no contract, frontend, Caddy, or public site changes
- No environment or VPS secret changes
- Residual risk remains bounded to Ponder 0.16.6 until upstream patches or a dedicated override/live-ingest rehearsal lands