### PR TITLE
fix(contracts): sync touched strategy accounting only

### DIFF
--- a/contracts/AgentAccountCore.sol
+++ b/contracts/AgentAccountCore.sol
@@ -69,6 +69,7 @@ contract AgentAccountCore is ReentrancyGuard {
 
     mapping(address => mapping(address => AssetPosition)) public positions;
     mapping(address => mapping(bytes32 => uint256)) public strategyShares;
+    mapping(address => mapping(bytes32 => uint256)) public strategyAllocationValues;
     mapping(bytes32 => StrategyRequest) public strategyRequests;
     mapping(address => mapping(address => uint256)) public pendingStrategyAssets;
     mapping(address => mapping(bytes32 => uint256)) public pendingStrategyWithdrawalShares;
@@ -345,7 +346,7 @@ contract AgentAccountCore is ReentrancyGuard {
         SafeTransfer.safeApprove(strategy.asset, strategy.adapter, amount);
         uint256 sharesMinted = adapter.deposit(amount);
         strategyShares[account][strategyId] += sharesMinted;
-        _refreshStrategyAllocated(account, strategy.asset);
+        _syncStrategyAllocation(account, strategy.asset, strategyId, strategy.adapter);
         emit StrategyAllocated(account, strategyId, strategy.asset, amount);
     }
 
@@ -373,7 +374,7 @@ contract AgentAccountCore is ReentrancyGuard {
         uint256 assetsReturned = adapter.withdraw(sharesToBurn, address(this));
         strategyShares[account][strategyId] = accountShares - sharesToBurn;
         position.liquid += assetsReturned;
-        _refreshStrategyAllocated(account, strategy.asset);
+        _syncStrategyAllocation(account, strategy.asset, strategyId, strategy.adapter);
         emit StrategyDeallocated(account, strategyId, strategy.asset, assetsReturned);
     }
 
@@ -502,7 +503,7 @@ contract AgentAccountCore is ReentrancyGuard {
         request.failureCode = failureCode;
         request.settled = true;
 
-        _refreshStrategyAllocated(request.account, request.asset);
+        _syncStrategyAllocation(request.account, request.asset, request.strategyId, request.adapter);
         emit StrategyRequestSettled(
             request.account, request.strategyId, requestId, status, settledAssets, settledShares, request.recipient
         );
@@ -789,22 +790,26 @@ contract AgentAccountCore is ReentrancyGuard {
         return ((assets * totalShares_) + totalAssets_ - 1) / totalAssets_;
     }
 
-    function _refreshStrategyAllocated(address account, address asset) internal {
-        bytes32[] memory ids = registry.listStrategyIds();
-        uint256 totalAllocated;
-        for (uint256 i = 0; i < ids.length; i++) {
-            StrategyAdapterRegistry.StrategyMetadata memory strategy = registry.getStrategy(ids[i]);
-            if (strategy.adapter == address(0) || strategy.asset != asset) {
-                continue;
-            }
-            uint256 shares = strategyShares[account][ids[i]];
-            if (shares == 0) {
-                continue;
-            }
-            IStrategyAdapter adapter = IStrategyAdapter(strategy.adapter);
-            totalAllocated += _assetValueForShares(shares, adapter.totalAssets(), adapter.totalShares());
+    function _syncStrategyAllocation(address account, address asset, bytes32 strategyId, address adapterAddress)
+        internal
+    {
+        uint256 previousValue = strategyAllocationValues[account][strategyId];
+        IStrategyAdapter adapter = IStrategyAdapter(adapterAddress);
+        uint256 currentValue =
+            _assetValueForShares(strategyShares[account][strategyId], adapter.totalAssets(), adapter.totalShares());
+        if (currentValue == previousValue) {
+            return;
         }
-        positions[account][asset].strategyAllocated = totalAllocated;
+
+        AssetPosition storage position = positions[account][asset];
+        if (currentValue > previousValue) {
+            position.strategyAllocated += currentValue - previousValue;
+        } else {
+            uint256 decrease = previousValue - currentValue;
+            if (position.strategyAllocated < decrease) revert InvalidSettlement();
+            position.strategyAllocated -= decrease;
+        }
+        strategyAllocationValues[account][strategyId] = currentValue;
     }
 
     function _createPendingDepositRequest(

--- a/docs/LAUNCH_CRITICAL_PATH.md
+++ b/docs/LAUNCH_CRITICAL_PATH.md
@@ -100,7 +100,7 @@ and must land in the audited artifact.
 | **Med** | Onboarding claim-waiver enables sybil claim-griefing (free claim → no submit → timeout → repeat with fresh wallets) | Bounded for the *closed* beta (trusted testers + curated starter jobs). For open/mainnet: restrict waivers to curated jobs / verified workers, or a minimal refundable fee. |
 | **Med** | `reserveForRecurringTemplate` has no cancellation/refund path → misconfigured/retired templates strand funds | Covered by `cancelRecurringTemplateReserve`: refunds unused template reserve to liquid, emits cancellation event, and keeps template + aggregate reserved accounting synchronized. Not used in the beta. |
 | **Med** | Open prod dep advisories | `drizzle`/`kysely` = **H3** (partially fixed, #686). **New:** `ws` (via `ethers`/`viem` — fix bumps `viem` out-of-range, chain-lib care needed) + `vite` (in `app/`, Windows-only advisories → frontend owner). |
-| **Low** | `_refreshStrategyAllocated` loops all registered strategies → owner-controlled OOG / config DoS | Cap strategy count / per-asset lists / touch-only accounting. |
+| **Low** | `_refreshStrategyAllocated` loops all registered strategies → owner-controlled OOG / config DoS | Covered by touched-strategy accounting: cache each strategy's contribution and resync only the strategy whose shares changed. Requires contract deployment with the frozen artifact. |
 | **Low** | External-schema sig lacks low-s + chainId/address domain separation | Move to EIP-712 typed data (chainId + `address(this)`) + enforce low-s. |
 
 ## Explicitly NOT blocking v1

--- a/test/AgentAccountStrategyAccounting.t.sol
+++ b/test/AgentAccountStrategyAccounting.t.sol
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import {AgentAccountCore} from "../contracts/AgentAccountCore.sol";
+import {IStrategyAdapter} from "../contracts/interfaces/IStrategyAdapter.sol";
+import {MockERC20} from "../contracts/mocks/MockERC20.sol";
+import {StrategyAdapterRegistry} from "../contracts/StrategyAdapterRegistry.sol";
+import {TreasuryPolicy} from "../contracts/TreasuryPolicy.sol";
+
+contract RevertingValuationStrategyAdapter is IStrategyAdapter {
+    MockERC20 internal immutable token;
+    bytes32 public immutable override strategyId;
+    address public immutable override asset;
+    uint256 internal totalShares_;
+    uint256 internal totalAssets_;
+    bool public valuationReverts;
+
+    error ValuationUnavailable();
+
+    constructor(MockERC20 token_, bytes32 strategyId_) {
+        token = token_;
+        asset = address(token_);
+        strategyId = strategyId_;
+    }
+
+    function setValuationReverts(bool enabled) external {
+        valuationReverts = enabled;
+    }
+
+    function deposit(uint256 amount) external override returns (uint256 sharesMinted) {
+        sharesMinted = amount;
+        totalShares_ += sharesMinted;
+        totalAssets_ += amount;
+        require(token.transferFrom(msg.sender, address(this), amount), "TRANSFER_FROM_FAILED");
+    }
+
+    function withdraw(uint256 shares, address recipient) external override returns (uint256 assetsReturned) {
+        require(totalShares_ >= shares, "INSUFFICIENT_SHARES");
+        assetsReturned = shares;
+        totalShares_ -= shares;
+        totalAssets_ -= assetsReturned;
+        require(token.transfer(recipient, assetsReturned), "TRANSFER_FAILED");
+    }
+
+    function totalShares() external view override returns (uint256) {
+        return totalShares_;
+    }
+
+    function totalAssets() external view override returns (uint256) {
+        if (valuationReverts) revert ValuationUnavailable();
+        return totalAssets_;
+    }
+
+    function maxWithdraw(address) external view override returns (uint256) {
+        return totalAssets_;
+    }
+
+    function riskLabel() external pure override returns (string memory) {
+        return "test strategy";
+    }
+}
+
+contract AgentAccountStrategyAccountingTest is Test {
+    TreasuryPolicy internal policy;
+    StrategyAdapterRegistry internal registry;
+    AgentAccountCore internal accounts;
+    MockERC20 internal token;
+
+    address internal worker = address(0xB0B);
+
+    uint256 internal constant WORKER_DEPOSIT = 200 ether;
+
+    function setUp() public {
+        policy = new TreasuryPolicy();
+        registry = new StrategyAdapterRegistry(policy);
+        accounts = new AgentAccountCore(policy, registry);
+        token = new MockERC20("Mock DOT", "mDOT");
+
+        policy.setApprovedAsset(address(token), true);
+        policy.setServiceOperator(address(accounts), true);
+
+        token.mint(worker, WORKER_DEPOSIT);
+        vm.startPrank(worker);
+        token.approve(address(accounts), type(uint256).max);
+        accounts.deposit(address(token), WORKER_DEPOSIT);
+        vm.stopPrank();
+    }
+
+    function testStrategyAccountingOnlySyncsTouchedStrategy() public {
+        bytes32 primaryStrategyId = bytes32("PRIMARY_STRATEGY");
+        bytes32 unrelatedStrategyId = bytes32("UNRELATED_STRATEGY");
+        _registerStrategy(primaryStrategyId);
+        RevertingValuationStrategyAdapter unrelated = _registerStrategy(unrelatedStrategyId);
+
+        vm.prank(worker);
+        accounts.allocateIdleFunds(worker, unrelatedStrategyId, 10 ether);
+
+        unrelated.setValuationReverts(true);
+
+        vm.prank(worker);
+        accounts.allocateIdleFunds(worker, primaryStrategyId, 5 ether);
+
+        (uint256 liquidAfterAllocate,, uint256 allocatedAfterAllocate,,,) =
+            accounts.positions(worker, address(token));
+        assertEq(liquidAfterAllocate, WORKER_DEPOSIT - 15 ether);
+        assertEq(allocatedAfterAllocate, 15 ether);
+        assertEq(accounts.strategyAllocationValues(worker, unrelatedStrategyId), 10 ether);
+        assertEq(accounts.strategyAllocationValues(worker, primaryStrategyId), 5 ether);
+
+        vm.prank(worker);
+        accounts.deallocateIdleFunds(worker, primaryStrategyId, 5 ether);
+
+        (uint256 liquidAfterDeallocate,, uint256 allocatedAfterDeallocate,,,) =
+            accounts.positions(worker, address(token));
+        assertEq(liquidAfterDeallocate, WORKER_DEPOSIT - 10 ether);
+        assertEq(allocatedAfterDeallocate, 10 ether);
+        assertEq(accounts.strategyAllocationValues(worker, unrelatedStrategyId), 10 ether);
+        assertEq(accounts.strategyAllocationValues(worker, primaryStrategyId), 0);
+    }
+
+    function _registerStrategy(bytes32 strategyId) internal returns (RevertingValuationStrategyAdapter adapter) {
+        adapter = new RevertingValuationStrategyAdapter(token, strategyId);
+        policy.setApprovedStrategy(address(adapter), true);
+        registry.registerStrategy(address(adapter));
+    }
+}


### PR DESCRIPTION
## Summary
- replace registry-wide strategy allocation refresh with a per-account/per-strategy cached contribution
- resync only the strategy whose shares changed after allocate, deallocate, or async settlement
- add a regression test where an unrelated allocated strategy reverts on valuation but touched-strategy operations still succeed
- update the launch-critical audit row for the low OOG/config-DoS finding

## Checks
- forge test --match-path test/AgentAccountStrategyAccounting.t.sol -vvv
- forge test
- git diff --check
- attempted: npm --workspace mcp-server test (blocked by local missing deps: @aws-sdk/client-kms, @aws-sdk/credential-provider-ini, jose, @paraspell/sdk-core, plus @noble/curves ./nist.js export under local Node 25)

## Surfaces
- contracts: AgentAccountCore strategy accounting
- tests: new focused Forge regression
- docs: launch critical path audit row
- backend/frontend/indexer/public site: not touched

## Deployment / secrets
- No environment or secret changes.
- Contract artifact changes require the explicit contract deployment/frozen-artifact path before live use.

## Notes
- This intentionally refreshes only the touched strategy's contribution. Passive yield on other strategies is not recomputed as a side effect of unrelated strategy operations.
