### PR TITLE
fix(contracts): harden external schema signatures

### DIFF
--- a/contracts/EscrowCore.sol
+++ b/contracts/EscrowCore.sol
@@ -7,6 +7,13 @@ import {ReputationSBT} from "./ReputationSBT.sol";
 import {ReentrancyGuard} from "./lib/ReentrancyGuard.sol";
 
 contract EscrowCore is ReentrancyGuard {
+    bytes32 public constant EXTERNAL_SCHEMA_REGISTRATION_TYPEHASH =
+        keccak256("ExternalSchemaRegistration(bytes32 schemaHash,string schemaUrl,bytes32 jobId)");
+    bytes32 internal constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 internal constant EIP712_NAME_HASH = keccak256("Averray EscrowCore");
+    bytes32 internal constant EIP712_VERSION_HASH = keccak256("1");
+    uint256 internal constant SECP256K1N_HALF = 0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0;
     uint256 public constant DISPUTE_WINDOW = 7 days;
     uint256 public constant ARBITRATOR_SLA = 14 days;
     // Caps the per-job milestone count so the settlement loop in
@@ -745,7 +752,7 @@ contract EscrowCore is ReentrancyGuard {
         }
 
         address recovered = _recoverExternalSchemaSigner(
-            _externalSchemaSigningHash(externalSchema.schemaHash, externalSchema.schemaUrl, jobId),
+            hashExternalSchemaRegistration(externalSchema.schemaHash, externalSchema.schemaUrl, jobId),
             externalSchema.schemaSignature
         );
         if (recovered != externalSchema.schemaIssuer) revert InvalidSchemaSignature();
@@ -759,13 +766,21 @@ contract EscrowCore is ReentrancyGuard {
         );
     }
 
-    function _externalSchemaSigningHash(bytes32 schemaHash, string memory schemaUrl, bytes32 jobId)
-        internal
-        pure
+    function externalSchemaDomainSeparator() public view returns (bytes32) {
+        return keccak256(
+            abi.encode(EIP712_DOMAIN_TYPEHASH, EIP712_NAME_HASH, EIP712_VERSION_HASH, block.chainid, address(this))
+        );
+    }
+
+    function hashExternalSchemaRegistration(bytes32 schemaHash, string memory schemaUrl, bytes32 jobId)
+        public
+        view
         returns (bytes32)
     {
-        bytes32 digest = keccak256(abi.encode(schemaHash, schemaUrl, jobId));
-        return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", digest));
+        bytes32 structHash = keccak256(
+            abi.encode(EXTERNAL_SCHEMA_REGISTRATION_TYPEHASH, schemaHash, keccak256(bytes(schemaUrl)), jobId)
+        );
+        return keccak256(abi.encodePacked("\x19\x01", externalSchemaDomainSeparator(), structHash));
     }
 
     function _recoverExternalSchemaSigner(bytes32 ethSignedHash, bytes memory signature)
@@ -787,6 +802,7 @@ contract EscrowCore is ReentrancyGuard {
             v += 27;
         }
         if (v != 27 && v != 28) revert InvalidSchemaSignature();
+        if (uint256(s) > SECP256K1N_HALF) revert InvalidSchemaSignature();
 
         address signer = ecrecover(ethSignedHash, v, r, s);
         if (signer == address(0)) revert InvalidSchemaSignature();

--- a/docs/AVERRAY_WORKING_SPEC.md
+++ b/docs/AVERRAY_WORKING_SPEC.md
@@ -572,8 +572,10 @@ External schemas add four fields to the job contract metadata:
 - `schemaHash`: `keccak256` of the canonical JSON Schema document.
 - `schemaUrl`: HTTPS fetch hint for the schema document.
 - `schemaIssuer`: EVM address that endorsed the schema.
-- `schemaSignature`: EIP-191 signature by `schemaIssuer` over
-  `keccak256(abi.encode(schemaHash, schemaUrl, jobId))`.
+- `schemaSignature`: EIP-712 signature by `schemaIssuer` over
+  `ExternalSchemaRegistration(bytes32 schemaHash,string schemaUrl,bytes32 jobId)`,
+  using the `Averray EscrowCore` domain bound to the live `chainId` and
+  `EscrowCore` address.
 
 `TreasuryPolicy.trustedSchemaIssuers(address)` is the trust boundary. The
 owner multisig approves issuers through `setTrustedSchemaIssuer(issuer, true)`;
@@ -582,9 +584,10 @@ signature does not recover to `schemaIssuer`, or the issuer is not trusted.
 Built-in schemas omit all four fields and keep the existing path.
 
 The backend mirrors the same validation before broadcasting a job transaction:
-`POST /admin/jobs` accepts optional `externalSchema`, verifies the EIP-191
-signature, checks the trusted-issuer policy, fetches the schema URL, verifies
-the content hash, and stores the registration on the job definition. Runtime
+`POST /admin/jobs` accepts optional `externalSchema`, verifies the EIP-712
+signature against the live EscrowCore domain, checks the trusted-issuer policy,
+fetches the schema URL, verifies the content hash, and stores the registration
+on the job definition. Runtime
 submission validation selects the registered external schema for that job and
 falls back to built-in validation only when no external schema registration is
 present. This keeps the public receipt trail honest: the schema used to judge a

--- a/docs/LAUNCH_CRITICAL_PATH.md
+++ b/docs/LAUNCH_CRITICAL_PATH.md
@@ -101,7 +101,7 @@ and must land in the audited artifact.
 | **Med** | `reserveForRecurringTemplate` has no cancellation/refund path → misconfigured/retired templates strand funds | Covered by `cancelRecurringTemplateReserve`: refunds unused template reserve to liquid, emits cancellation event, and keeps template + aggregate reserved accounting synchronized. Not used in the beta. |
 | **Med** | Open prod dep advisories | `drizzle`/`kysely` = **H3** (partially fixed, #686). **New:** `ws` (via `ethers`/`viem` — fix bumps `viem` out-of-range, chain-lib care needed) + `vite` (in `app/`, Windows-only advisories → frontend owner). |
 | **Low** | `_refreshStrategyAllocated` loops all registered strategies → owner-controlled OOG / config DoS | Covered by touched-strategy accounting: cache each strategy's contribution and resync only the strategy whose shares changed. Requires contract deployment with the frozen artifact. |
-| **Low** | External-schema sig lacks low-s + chainId/address domain separation | Move to EIP-712 typed data (chainId + `address(this)`) + enforce low-s. |
+| **Low** | External-schema sig lacks low-s + chainId/address domain separation | Addressed in `codex/external-schema-eip712`: EIP-712 typed data is bound to `chainId` + `address(this)`, and low-s signatures are rejected. Requires the hardened EscrowCore artifact to be deployed before mainnet. |
 
 ## Explicitly NOT blocking v1
 

--- a/docs/OPERATOR_ONBOARDING.md
+++ b/docs/OPERATOR_ONBOARDING.md
@@ -500,7 +500,8 @@ admin shortcut.
 Before proposing the multisig call:
 
 1. Confirm the issuer address is an EVM address controlled by the schema
-   publisher and that the issuer can sign an EIP-191 message.
+   publisher and that the issuer can sign EIP-712 typed data for the live
+   `Averray EscrowCore` domain.
 2. Confirm the schema document is canonical JSON Schema served at the expected
    HTTPS URL and that its `keccak256` hash matches the registration request.
 3. Dry-run one representative registration through the backend or local

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -30,7 +30,10 @@ import {
 } from "../services/aws-credentials.js";
 import { buildXcmRequestPayload } from "./xcm-message-builder.js";
 import { hashCanonicalContent } from "../core/canonical-content.js";
-import { getRegisteredJobSchemaRegistration } from "../core/job-schema-registry.js";
+import {
+  EXTERNAL_SCHEMA_EIP712_VERSION,
+  getRegisteredJobSchemaRegistration
+} from "../core/job-schema-registry.js";
 import { redactProviderError } from "../core/redact-provider-error.js";
 import {
   BlockchainRevertError,
@@ -164,6 +167,17 @@ export class BlockchainGateway {
 
   isEnabled() {
     return this.config.enabled;
+  }
+
+  async getExternalSchemaSigningDomain() {
+    if (!this.isEnabled()) {
+      return undefined;
+    }
+    const network = await this.provider.getNetwork();
+    return {
+      chainId: network.chainId.toString(),
+      verifyingContract: this.config.escrowCoreAddress
+    };
   }
 
   async healthCheck() {
@@ -1304,7 +1318,7 @@ export class BlockchainGateway {
 
   externalSchemaMetadataForJob(job) {
     const registration = getRegisteredJobSchemaRegistration(job?.outputSchemaRef, job?.schemaRegistrations);
-    if (registration?.registrationVersion !== "external-job-schema-eip191-v1") {
+    if (registration?.registrationVersion !== EXTERNAL_SCHEMA_EIP712_VERSION) {
       return EMPTY_EXTERNAL_SCHEMA;
     }
     return {

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -4,6 +4,7 @@ import { encodeBytes32String, Interface } from "ethers";
 
 import { BlockchainGateway } from "./gateway.js";
 import { InsufficientLiquidityError, ValidationError } from "../core/errors.js";
+import { EXTERNAL_SCHEMA_EIP712_VERSION } from "../core/job-schema-registry.js";
 
 const DOT_ASSET = {
   symbol: "DOT",
@@ -1817,7 +1818,7 @@ test("createSinglePayoutJobForJob forwards registered external schema metadata",
       outputSchemaRef: "schema://jobs/external-output",
       schemaRegistrations: [{
         schemaRef: "schema://jobs/external-output",
-        registrationVersion: "external-job-schema-eip191-v1",
+        registrationVersion: EXTERNAL_SCHEMA_EIP712_VERSION,
         schemaHash,
         schemaUrl: "https://schemas.example.com/external-output.json",
         schemaIssuer,

--- a/mcp-server/src/core/job-execution-service.js
+++ b/mcp-server/src/core/job-execution-service.js
@@ -13,6 +13,7 @@ import {
 } from "./session-state-machine.js";
 import { hashSubmission, isStructuredSubmission, normalizeSubmission } from "./submission.js";
 import {
+  EXTERNAL_SCHEMA_EIP712_VERSION,
   getBuiltinJobSchema,
   getJobSchema,
   getRegisteredJobSchemaRegistration,
@@ -733,7 +734,7 @@ export function validateSubmissionContract(schemaRef, submission, { path = "subm
 
 async function validateJobSubmissionAgainstSchema(job, submission) {
   const registration = getRegisteredJobSchemaRegistration(job?.outputSchemaRef, job?.schemaRegistrations);
-  if (registration?.registrationVersion === "external-job-schema-eip191-v1") {
+  if (registration?.registrationVersion === EXTERNAL_SCHEMA_EIP712_VERSION) {
     await validateSubmissionAgainstRegisteredSchema(submission, job.id, {
       schemaRef: job.outputSchemaRef,
       registrations: job.schemaRegistrations

--- a/mcp-server/src/core/job-schema-registration.js
+++ b/mcp-server/src/core/job-schema-registration.js
@@ -1,13 +1,32 @@
-import { AbiCoder, getAddress, getBytes, id, isAddress, keccak256, toUtf8Bytes, verifyMessage } from "ethers";
+import {
+  Signature,
+  TypedDataEncoder,
+  getAddress,
+  id,
+  isAddress,
+  keccak256,
+  toUtf8Bytes,
+  verifyMessage,
+  verifyTypedData
+} from "ethers";
 
 import { canonicalizeContent, hashCanonicalContent } from "./canonical-content.js";
 import { ValidationError } from "./errors.js";
 import { isPlainObject } from "./job-schema-validation.js";
 
 export const EXTERNAL_SCHEMA_TRUST_BOUNDARY = "external_signed_schema";
-export const EXTERNAL_SCHEMA_EIP191_VERSION = "external-job-schema-eip191-v1";
+export const EXTERNAL_SCHEMA_EIP712_VERSION = "external-job-schema-eip712-v1";
+export const EXTERNAL_SCHEMA_EIP712_DOMAIN_NAME = "Averray EscrowCore";
+export const EXTERNAL_SCHEMA_EIP712_DOMAIN_VERSION = "1";
 
-const abiCoder = AbiCoder.defaultAbiCoder();
+const EXTERNAL_SCHEMA_TYPES = {
+  ExternalSchemaRegistration: [
+    { name: "schemaHash", type: "bytes32" },
+    { name: "schemaUrl", type: "string" },
+    { name: "jobId", type: "bytes32" }
+  ]
+};
+const SECP256K1N_HALF = BigInt("0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0");
 
 export function normalizeExternalSchemaRegistrations(raw, {
   allowedSchemaRefs = [],
@@ -126,10 +145,14 @@ function normalizeExternalSchemaRegistrationV1(raw, { index, schema }) {
   const jobId = requireNonEmptyString(raw.jobId, `${prefix}.jobId`);
   const chainJobId = normalizeBytes32(raw.chainJobId ?? id(jobId), `${prefix}.chainJobId`);
   const signature = requireNonEmptyString(raw.schemaSignature ?? raw.signature, `${prefix}.signature`);
+  const chainId = normalizeChainId(raw.chainId, `${prefix}.chainId`);
+  const verifyingContract = normalizeIssuerAddress(raw.verifyingContract, `${prefix}.verifyingContract`);
   const recovered = recoverExternalSchemaRegistrationSignerV1({
     schemaHash,
     schemaUrl,
     jobId: chainJobId,
+    chainId,
+    verifyingContract,
     signature
   });
   if (recovered !== issuer) {
@@ -145,11 +168,19 @@ function normalizeExternalSchemaRegistrationV1(raw, { index, schema }) {
     schemaIssuer: issuer,
     jobId,
     chainJobId,
+    chainId: chainId.toString(),
+    verifyingContract,
     signature,
-    registrationVersion: EXTERNAL_SCHEMA_EIP191_VERSION,
+    registrationVersion: EXTERNAL_SCHEMA_EIP712_VERSION,
     trustBoundary: EXTERNAL_SCHEMA_TRUST_BOUNDARY,
     signatureVerified: true,
-    registrationMessageHash: buildExternalSchemaRegistrationDigest({ schemaHash, schemaUrl, jobId: chainJobId })
+    registrationMessageHash: buildExternalSchemaRegistrationDigest({
+      schemaHash,
+      schemaUrl,
+      jobId: chainJobId,
+      chainId,
+      verifyingContract
+    })
   };
 }
 
@@ -157,21 +188,57 @@ export function hashExternalSchemaContent(schema) {
   return keccak256(toUtf8Bytes(canonicalizeContent(requirePlainObject(schema, "schema"))));
 }
 
-export function buildExternalSchemaRegistrationDigest({ schemaHash, schemaUrl, jobId }) {
-  return keccak256(abiCoder.encode(
-    ["bytes32", "string", "bytes32"],
-    [
-      normalizeBytes32(schemaHash, "schemaHash"),
-      requireNonEmptyString(schemaUrl, "schemaUrl"),
-      normalizeBytes32(jobId, "jobId")
-    ]
-  ));
+export function buildExternalSchemaRegistrationTypedData({
+  schemaHash,
+  schemaUrl,
+  jobId,
+  chainId,
+  verifyingContract
+}) {
+  return {
+    domain: {
+      name: EXTERNAL_SCHEMA_EIP712_DOMAIN_NAME,
+      version: EXTERNAL_SCHEMA_EIP712_DOMAIN_VERSION,
+      chainId: normalizeChainId(chainId, "chainId"),
+      verifyingContract: normalizeIssuerAddress(verifyingContract, "verifyingContract")
+    },
+    types: EXTERNAL_SCHEMA_TYPES,
+    value: {
+      schemaHash: normalizeBytes32(schemaHash, "schemaHash"),
+      schemaUrl: requireNonEmptyString(schemaUrl, "schemaUrl"),
+      jobId: normalizeBytes32(jobId, "jobId")
+    }
+  };
 }
 
-export function recoverExternalSchemaRegistrationSignerV1({ schemaHash, schemaUrl, jobId, signature }) {
-  const digest = buildExternalSchemaRegistrationDigest({ schemaHash, schemaUrl, jobId });
+export function buildExternalSchemaRegistrationDigest(params) {
+  const typedData = buildExternalSchemaRegistrationTypedData(params);
+  return TypedDataEncoder.hash(typedData.domain, typedData.types, typedData.value);
+}
+
+export function recoverExternalSchemaRegistrationSignerV1({
+  schemaHash,
+  schemaUrl,
+  jobId,
+  chainId,
+  verifyingContract,
+  signature
+}) {
+  const typedData = buildExternalSchemaRegistrationTypedData({
+    schemaHash,
+    schemaUrl,
+    jobId,
+    chainId,
+    verifyingContract
+  });
   try {
-    return getAddress(verifyMessage(getBytes(digest), requireNonEmptyString(signature, "signature")));
+    assertLowSSignature(signature);
+    return getAddress(verifyTypedData(
+      typedData.domain,
+      typedData.types,
+      typedData.value,
+      requireNonEmptyString(signature, "signature")
+    ));
   } catch (error) {
     throw new ValidationError(`External schema signature verification failed: ${error?.message ?? "invalid signature"}`);
   }
@@ -251,12 +318,27 @@ function normalizeIssuerAddress(value, field) {
   return getAddress(text);
 }
 
+function normalizeChainId(value, field) {
+  const text = typeof value === "bigint" ? value.toString() : String(value ?? "").trim();
+  if (!/^[1-9][0-9]*$/u.test(text)) {
+    throw new ValidationError(`${field} must be a positive chain id.`);
+  }
+  return BigInt(text);
+}
+
 function normalizeBytes32(value, field) {
   const text = requireNonEmptyString(value, field);
   if (!/^0x[a-fA-F0-9]{64}$/u.test(text)) {
     throw new ValidationError(`${field} must be a bytes32 hex string.`);
   }
   return text;
+}
+
+function assertLowSSignature(signature) {
+  const parsed = Signature.from(requireNonEmptyString(signature, "signature"));
+  if (BigInt(parsed.s) > SECP256K1N_HALF) {
+    throw new ValidationError("signature must use a low-s secp256k1 value.");
+  }
 }
 
 function assertSupportedExternalSchema(schema, path) {

--- a/mcp-server/src/core/job-schema-registry.js
+++ b/mcp-server/src/core/job-schema-registry.js
@@ -13,10 +13,13 @@ import { normalizeJobSchemaRef } from "./job-schema-registration.js";
 export { validateAgainstSchema } from "./job-schema-validation.js";
 
 export {
-  EXTERNAL_SCHEMA_EIP191_VERSION,
+  EXTERNAL_SCHEMA_EIP712_DOMAIN_NAME,
+  EXTERNAL_SCHEMA_EIP712_DOMAIN_VERSION,
+  EXTERNAL_SCHEMA_EIP712_VERSION,
   EXTERNAL_SCHEMA_TRUST_BOUNDARY,
   buildExternalSchemaRegistrationDigest,
   buildExternalSchemaRegistrationMessage,
+  buildExternalSchemaRegistrationTypedData,
   hashExternalSchemaContent,
   normalizeExternalSchemaRegistration,
   normalizeExternalSchemaRegistrations,

--- a/mcp-server/src/core/platform-service.js
+++ b/mcp-server/src/core/platform-service.js
@@ -10,7 +10,11 @@ import { VerificationIngestionService } from "../services/verification-ingestion
 import { ConflictError, InsufficientLiquidityError, ValidationError } from "./errors.js";
 import { normalizeSubmission } from "./submission.js";
 import { buildPlatformCapabilities } from "./discovery-manifest.js";
-import { getBuiltinJobSchema, getRegisteredJobSchemaRegistration } from "./job-schema-registry.js";
+import {
+  EXTERNAL_SCHEMA_EIP712_VERSION,
+  getBuiltinJobSchema,
+  getRegisteredJobSchemaRegistration
+} from "./job-schema-registry.js";
 import {
   buildSessionLifecycle,
   getSessionStateMachineDefinition
@@ -262,12 +266,17 @@ export class PlatformService {
       ? existingTrustPolicy.trustedIssuers
       : [];
     const external = input.externalSchema;
+    const signingDomain = this.blockchainGateway?.isEnabled?.() && this.blockchainGateway?.getExternalSchemaSigningDomain
+      ? await this.blockchainGateway.getExternalSchemaSigningDomain()
+      : undefined;
     const registration = await registerExternalSchema({
       schemaHash: external.schemaHash,
       schemaUrl: external.schemaUrl,
       schemaIssuer: external.schemaIssuer,
       signature: external.signature ?? external.schemaSignature,
       jobId: input.id,
+      chainId: signingDomain?.chainId ?? external.chainId,
+      verifyingContract: signingDomain?.verifyingContract ?? external.verifyingContract,
       schemaRef: outputSchemaRef,
       trustedIssuers,
       isTrustedIssuer: this.blockchainGateway?.isEnabled?.() && this.blockchainGateway?.isTrustedSchemaIssuer
@@ -677,7 +686,7 @@ export class PlatformService {
         registrations: job.schemaRegistrations
       }));
       const registration = getRegisteredJobSchemaRegistration(job.outputSchemaRef, job.schemaRegistrations);
-      if (registration?.registrationVersion === "external-job-schema-eip191-v1") {
+      if (registration?.registrationVersion === EXTERNAL_SCHEMA_EIP712_VERSION) {
         await validateSubmissionAgainstRegisteredSchema(normalized, job.id, {
           schemaRef: job.outputSchemaRef,
           registrations: job.schemaRegistrations

--- a/mcp-server/src/core/platform-service.test.js
+++ b/mcp-server/src/core/platform-service.test.js
@@ -1,13 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { Wallet, getBytes, id } from "ethers";
+import { Wallet, id } from "ethers";
 
 import { PlatformService } from "./platform-service.js";
 import { EventBus } from "./event-bus.js";
 import { InsufficientLiquidityError } from "./errors.js";
 import { MemoryStateStore } from "./state-store.js";
 import {
-  buildExternalSchemaRegistrationDigest,
+  buildExternalSchemaRegistrationTypedData,
   hashExternalSchemaContent
 } from "./job-schema-registry.js";
 
@@ -23,6 +23,8 @@ const CANONICAL_USDC_ASSET = {
 const EXTERNAL_SCHEMA_SIGNER = new Wallet("0x8b3a350cf5c34c9194ca3a545d0ec67d61f328d6e5d11dd95b9af16e70ec4c63");
 const EXTERNAL_SCHEMA_REF = "schema://jobs/off-platform-output";
 const EXTERNAL_SCHEMA_URL = "https://schemas.example.com/jobs/off-platform-output.json";
+const EXTERNAL_SCHEMA_CHAIN_ID = 420420421n;
+const EXTERNAL_SCHEMA_VERIFYING_CONTRACT = "0x2222222222222222222222222222222222222222";
 const EXTERNAL_SCHEMA = {
   $id: EXTERNAL_SCHEMA_REF,
   type: "object",
@@ -153,11 +155,14 @@ test("createAdminJob reserves finite recurring template funding from the poster 
 test("external-schema admin job posts, claims, and validates against off-platform schema", async () => {
   const schemaHash = hashExternalSchemaContent(EXTERNAL_SCHEMA);
   const jobId = "off-platform-schema-job-001";
-  const signature = await EXTERNAL_SCHEMA_SIGNER.signMessage(getBytes(buildExternalSchemaRegistrationDigest({
+  const typedData = buildExternalSchemaRegistrationTypedData({
     schemaHash,
     schemaUrl: EXTERNAL_SCHEMA_URL,
-    jobId: id(jobId)
-  })));
+    jobId: id(jobId),
+    chainId: EXTERNAL_SCHEMA_CHAIN_ID,
+    verifyingContract: EXTERNAL_SCHEMA_VERIFYING_CONTRACT
+  });
+  const signature = await EXTERNAL_SCHEMA_SIGNER.signTypedData(typedData.domain, typedData.types, typedData.value);
   const calls = [];
   let liveState = 0;
   const gateway = {
@@ -166,6 +171,10 @@ test("external-schema admin job posts, claims, and validates against off-platfor
     getDefaultClaimStakeBps: async () => 500,
     getClaimEconomicsConfig: async () => ({}),
     isTrustedSchemaIssuer: async (issuer) => issuer === EXTERNAL_SCHEMA_SIGNER.address,
+    getExternalSchemaSigningDomain: async () => ({
+      chainId: EXTERNAL_SCHEMA_CHAIN_ID,
+      verifyingContract: EXTERNAL_SCHEMA_VERIFYING_CONTRACT
+    }),
     getJob: async () => ({ state: liveState }),
     ensureJob: async (job, instanceJobId) => {
       calls.push(["ensureJob", { job, instanceJobId }]);

--- a/mcp-server/src/services/schema-registry.js
+++ b/mcp-server/src/services/schema-registry.js
@@ -1,5 +1,5 @@
 import {
-  EXTERNAL_SCHEMA_EIP191_VERSION,
+  EXTERNAL_SCHEMA_EIP712_VERSION,
   getRegisteredJobSchemaRegistration,
   hashExternalSchemaContent,
   normalizeExternalSchemaRegistrations,
@@ -16,6 +16,8 @@ export async function registerExternalSchema({
   schemaIssuer,
   signature,
   jobId,
+  chainId,
+  verifyingContract,
   schemaRef = undefined,
   trustedIssuers = [],
   isTrustedIssuer = undefined,
@@ -36,6 +38,8 @@ export async function registerExternalSchema({
     schemaHash: computedHash,
     schemaUrl,
     jobId: chainJobId,
+    chainId,
+    verifyingContract,
     signature
   });
   if (recovered.toLowerCase() !== String(schemaIssuer ?? "").toLowerCase()) {
@@ -64,7 +68,9 @@ export async function registerExternalSchema({
       signature,
       jobId,
       chainJobId,
-      registrationVersion: EXTERNAL_SCHEMA_EIP191_VERSION
+      chainId,
+      verifyingContract,
+      registrationVersion: EXTERNAL_SCHEMA_EIP712_VERSION
     }
   ], {
     allowedSchemaRefs: [schemaRef ?? schema.$id].filter(Boolean),
@@ -139,7 +145,7 @@ function selectRegistrationForJob({ jobId, schemaRef, registrations }) {
   }
   const normalizedChainJobId = jobId ? id(String(jobId)) : undefined;
   return registrations.find((entry) =>
-    entry?.registrationVersion === EXTERNAL_SCHEMA_EIP191_VERSION
+    entry?.registrationVersion === EXTERNAL_SCHEMA_EIP712_VERSION
       && (!normalizedChainJobId || entry.chainJobId === normalizedChainJobId || entry.jobId === jobId)
   );
 }

--- a/mcp-server/src/services/schema-registry.test.js
+++ b/mcp-server/src/services/schema-registry.test.js
@@ -1,9 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { Wallet, getBytes, id } from "ethers";
+import { Wallet, id } from "ethers";
 
 import {
-  buildExternalSchemaRegistrationDigest,
+  buildExternalSchemaRegistrationTypedData,
   hashExternalSchemaContent
 } from "../core/job-schema-registry.js";
 import {
@@ -14,6 +14,8 @@ import {
 const ISSUER = new Wallet("0x59c6995e998f97a5a004497e5da795437b4466ad5c2af1c6a6d1dcb1b1ce36b9");
 const OTHER = new Wallet("0x8b3a350cf5c34c9194ca3a545d0ec67d61f328d6e5d11dd95b9af16e70ec4c63");
 const JOB_ID = "external-schema-job-001";
+const CHAIN_ID = 420420421n;
+const VERIFYING_CONTRACT = "0x2222222222222222222222222222222222222222";
 const SCHEMA_URL = "https://schemas.example.com/jobs/external-audit-output.json";
 const SCHEMA_REF = "schema://jobs/external-audit-output";
 const SCHEMA = {
@@ -29,14 +31,16 @@ const SCHEMA = {
 
 async function signSchema({ signer = ISSUER, schema = SCHEMA, schemaUrl = SCHEMA_URL, jobId = JOB_ID } = {}) {
   const schemaHash = hashExternalSchemaContent(schema);
-  const digest = buildExternalSchemaRegistrationDigest({
+  const typedData = buildExternalSchemaRegistrationTypedData({
     schemaHash,
     schemaUrl,
-    jobId: id(jobId)
+    jobId: id(jobId),
+    chainId: CHAIN_ID,
+    verifyingContract: VERIFYING_CONTRACT
   });
   return {
     schemaHash,
-    signature: await signer.signMessage(getBytes(digest))
+    signature: await signer.signTypedData(typedData.domain, typedData.types, typedData.value)
   };
 }
 
@@ -59,12 +63,14 @@ test("registerExternalSchema verifies signer, trust, URL fetch, and content hash
     schemaIssuer: ISSUER.address,
     signature: signed.signature,
     jobId: JOB_ID,
+    chainId: CHAIN_ID,
+    verifyingContract: VERIFYING_CONTRACT,
     schemaRef: SCHEMA_REF,
     isTrustedIssuer: async (issuer) => issuer === ISSUER.address,
     fetchImpl: fetchSchema()
   });
 
-  assert.equal(registration.registrationVersion, "external-job-schema-eip191-v1");
+  assert.equal(registration.registrationVersion, "external-job-schema-eip712-v1");
   assert.equal(registration.schemaHash, signed.schemaHash);
   assert.equal(registration.schemaIssuer, ISSUER.address);
   assert.equal(registration.chainJobId, id(JOB_ID));
@@ -82,6 +88,8 @@ test("registerExternalSchema rejects invalid signatures and untrusted issuers", 
       schemaIssuer: ISSUER.address,
       signature: signedByOther.signature,
       jobId: JOB_ID,
+      chainId: CHAIN_ID,
+      verifyingContract: VERIFYING_CONTRACT,
       schemaRef: SCHEMA_REF,
       isTrustedIssuer: async () => true,
       fetchImpl: fetchSchema()
@@ -97,6 +105,8 @@ test("registerExternalSchema rejects invalid signatures and untrusted issuers", 
       schemaIssuer: ISSUER.address,
       signature: signed.signature,
       jobId: JOB_ID,
+      chainId: CHAIN_ID,
+      verifyingContract: VERIFYING_CONTRACT,
       schemaRef: SCHEMA_REF,
       isTrustedIssuer: async () => false,
       fetchImpl: fetchSchema()
@@ -113,6 +123,8 @@ test("validateSubmissionAgainstRegisteredSchema fetches schema and catches hash 
     schemaIssuer: ISSUER.address,
     signature: signed.signature,
     jobId: JOB_ID,
+    chainId: CHAIN_ID,
+    verifyingContract: VERIFYING_CONTRACT,
     schemaRef: SCHEMA_REF,
     trustedIssuers: [ISSUER.address],
     fetchImpl: fetchSchema()

--- a/test/ExternalSchemaRegistration.t.sol
+++ b/test/ExternalSchemaRegistration.t.sol
@@ -14,8 +14,13 @@ interface VmEvent {
     function expectEmit(bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData, address emitter) external;
 }
 
+interface VmSign {
+    function sign(uint256 privateKey, bytes32 digest) external returns (uint8 v, bytes32 r, bytes32 s);
+}
+
 contract ExternalSchemaRegistrationTest is Test {
     VmEvent internal constant vmEvent = VmEvent(address(uint160(uint256(keccak256("hevm cheat code")))));
+    VmSign internal constant vmSign = VmSign(address(uint160(uint256(keccak256("hevm cheat code")))));
 
     TreasuryPolicy internal policy;
     StrategyAdapterRegistry internal registry;
@@ -25,20 +30,19 @@ contract ExternalSchemaRegistrationTest is Test {
     MockERC20 internal dot;
 
     address internal poster = address(0xA11CE);
+    uint256 internal constant ISSUER_KEY = 0xA11CE123;
+    uint256 internal constant OTHER_ISSUER_KEY = 0xB0B;
     address internal issuer = 0xCc8940b1c72567cf04c9Ccc96242Ee7A4444534C;
-    address internal otherIssuer = 0xFf1914A904ed524aec571244c5aEb2140C234304;
+    address internal otherIssuer = 0x0376AAc07Ad725E01357B1725B5ceC61aE10473c;
 
     bytes32 internal constant SPEC_HASH = bytes32("SPEC_HASH");
     bytes32 internal constant SCHEMA_HASH = keccak256("external schema");
     string internal constant SCHEMA_URL = "https://schemas.example.com/jobs/external-output.json";
-    bytes internal constant VALID_SIGNATURE =
-        hex"876a9ed85c63b0773c3d2d5a7eac09204aa00c7da465bfe2648f063336d5efba33eda920e896a1f5d977e15bc55c29813382e9d0fcac3679a96bc1d760c576e01b";
-    bytes internal constant BAD_SIGNATURE =
-        hex"a1d1c6d2e40953c768d6b12351c9029ab3d0a7d0b238444fca2163ff8934b79e56eceb48f9440700cdf90bbf372e4d7e0d06cf2162df0d5961aaa72400104aed1c";
-    bytes internal constant UNTRUSTED_SIGNATURE =
-        hex"1aa6b1387ef692d01bccd36f02a8e05f202500db457f28f1c558e0b3bf43c9fc1c5525a8c931d1928b10aa1083e19e649ef91691d24dc94f003f5ba338689b811b";
-    bytes internal constant RECURRING_SIGNATURE =
-        hex"64e2697330e5627eb177c3c9f7e5849f8a9ee101f0b04263a5bb3c824fd6cea15b243561da102b39c329e036650435b9562f5ca11e68e06f0ad36ba03c849f031b";
+    bytes32 internal constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 internal constant EIP712_NAME_HASH = keccak256("Averray EscrowCore");
+    bytes32 internal constant EIP712_VERSION_HASH = keccak256("1");
+    uint256 internal constant SECP256K1N = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141;
 
     event TrustedSchemaIssuerSet(address indexed issuer, bool approved);
     event ExternalSchemaRegistered(
@@ -79,7 +83,7 @@ contract ExternalSchemaRegistrationTest is Test {
     function testValidExternalSchemaAccepted() public {
         policy.setTrustedSchemaIssuer(issuer, true);
         bytes32 jobId = keccak256("job/external-schema/valid");
-        bytes memory signature = VALID_SIGNATURE;
+        bytes memory signature = signExternalSchema(escrow, jobId, ISSUER_KEY);
 
         vmEvent.expectEmit(true, true, true, true, address(escrow));
         emit ExternalSchemaRegistered(jobId, SCHEMA_HASH, issuer, SCHEMA_URL);
@@ -111,7 +115,7 @@ contract ExternalSchemaRegistrationTest is Test {
     function testInvalidSignatureRejected() public {
         policy.setTrustedSchemaIssuer(issuer, true);
         bytes32 jobId = keccak256("job/external-schema/bad-signature");
-        bytes memory signature = BAD_SIGNATURE;
+        bytes memory signature = signExternalSchema(escrow, jobId, OTHER_ISSUER_KEY);
 
         vm.prank(poster);
         (bool ok,) = address(escrow).call(createExternalSchemaJobCalldata(jobId, issuer, signature));
@@ -120,18 +124,51 @@ contract ExternalSchemaRegistrationTest is Test {
 
     function testUntrustedIssuerRejected() public {
         bytes32 jobId = keccak256("job/external-schema/untrusted");
-        bytes memory signature = UNTRUSTED_SIGNATURE;
+        bytes memory signature = signExternalSchema(escrow, jobId, ISSUER_KEY);
 
         vm.prank(poster);
         (bool ok,) = address(escrow).call(createExternalSchemaJobCalldata(jobId, issuer, signature));
         require(!ok, "EXPECTED_UNTRUSTED_ISSUER_REVERT");
     }
 
+    function testExternalSchemaSignatureCannotReplayAcrossEscrowContracts() public {
+        policy.setTrustedSchemaIssuer(issuer, true);
+        bytes32 jobId = keccak256("job/external-schema/replay-contract");
+        bytes memory signature = signExternalSchema(escrow, jobId, ISSUER_KEY);
+        EscrowCore otherEscrow = new EscrowCore(policy, accounts, reputation);
+        policy.setServiceOperator(address(otherEscrow), true);
+        accounts.setEscrowOperator(address(otherEscrow), true);
+
+        vm.prank(poster);
+        (bool ok,) = address(otherEscrow).call(createExternalSchemaJobCalldata(jobId, issuer, signature));
+        require(!ok, "EXPECTED_CROSS_CONTRACT_REPLAY_REVERT");
+    }
+
+    function testExternalSchemaSignatureCannotReplayAcrossChainIds() public {
+        policy.setTrustedSchemaIssuer(issuer, true);
+        bytes32 jobId = keccak256("job/external-schema/replay-chain");
+        bytes memory signature = signExternalSchemaForDomain(escrow, jobId, ISSUER_KEY, block.chainid + 1);
+
+        vm.prank(poster);
+        (bool ok,) = address(escrow).call(createExternalSchemaJobCalldata(jobId, issuer, signature));
+        require(!ok, "EXPECTED_CROSS_CHAIN_REPLAY_REVERT");
+    }
+
+    function testHighSSignatureRejected() public {
+        policy.setTrustedSchemaIssuer(issuer, true);
+        bytes32 jobId = keccak256("job/external-schema/high-s");
+        bytes memory signature = highSSignature(escrow, jobId, ISSUER_KEY);
+
+        vm.prank(poster);
+        (bool ok,) = address(escrow).call(createExternalSchemaJobCalldata(jobId, issuer, signature));
+        require(!ok, "EXPECTED_HIGH_S_REVERT");
+    }
+
     function testRecurringReserveAcceptsExternalSchemaMetadata() public {
         policy.setTrustedSchemaIssuer(issuer, true);
         bytes32 templateId = keccak256("template/external-schema");
         bytes32 jobId = keccak256("template/external-schema/run/1");
-        bytes memory signature = RECURRING_SIGNATURE;
+        bytes memory signature = signExternalSchema(escrow, jobId, ISSUER_KEY);
 
         vm.prank(poster);
         accounts.reserveForRecurringTemplate(poster, address(dot), templateId, 10 ether);
@@ -185,5 +222,36 @@ contract ExternalSchemaRegistrationTest is Test {
                 schemaHash: SCHEMA_HASH, schemaUrl: SCHEMA_URL, schemaIssuer: schemaIssuer, schemaSignature: signature
             })
         );
+    }
+
+    function signExternalSchema(EscrowCore target, bytes32 jobId, uint256 signerKey) internal returns (bytes memory) {
+        bytes32 digest = target.hashExternalSchemaRegistration(SCHEMA_HASH, SCHEMA_URL, jobId);
+        (uint8 v, bytes32 r, bytes32 s) = vmSign.sign(signerKey, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function signExternalSchemaForDomain(EscrowCore target, bytes32 jobId, uint256 signerKey, uint256 chainId)
+        internal
+        returns (bytes memory)
+    {
+        bytes32 domainSeparator = keccak256(
+            abi.encode(EIP712_DOMAIN_TYPEHASH, EIP712_NAME_HASH, EIP712_VERSION_HASH, chainId, address(target))
+        );
+        bytes32 structHash = keccak256(
+            abi.encode(
+                target.EXTERNAL_SCHEMA_REGISTRATION_TYPEHASH(), SCHEMA_HASH, keccak256(bytes(SCHEMA_URL)), jobId
+            )
+        );
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vmSign.sign(signerKey, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function highSSignature(EscrowCore target, bytes32 jobId, uint256 signerKey) internal returns (bytes memory) {
+        bytes32 digest = target.hashExternalSchemaRegistration(SCHEMA_HASH, SCHEMA_URL, jobId);
+        (uint8 v, bytes32 r, bytes32 s) = vmSign.sign(signerKey, digest);
+        bytes32 highS = bytes32(SECP256K1N - uint256(s));
+        uint8 highV = v == 27 ? 28 : 27;
+        return abi.encodePacked(r, highS, highV);
     }
 }


### PR DESCRIPTION
## Summary
- move on-chain external schema registration signatures to EIP-712 typed data bound to the live chainId and EscrowCore address
- reject high-s schema signatures on-chain and in backend registration verification
- teach backend registration, gateway domain discovery, and docs/tests the new external-job-schema-eip712-v1 format

## Checks
- forge test
- forge test --match-path test/ExternalSchemaRegistration.t.sol -vvv
- node --test mcp-server/src/core/job-schema-registration.test.js mcp-server/src/core/job-schema-registry.test.js mcp-server/src/services/schema-registry.test.js mcp-server/src/core/platform-service.test.js
- git diff --check

Note: npm --workspace mcp-server test was attempted locally during this work but the local environment is missing several optional/runtime deps and has a Node 25 package export mismatch (examples: @aws-sdk/client-kms, @aws-sdk/credential-provider-ini, jose, @paraspell/sdk-core, @noble/curves/nist.js). Focused touched-area tests and full Forge pass.

## Impact
- Affects contracts, backend schema registration/gateway validation, and docs.
- External schema issuers must sign the new EIP-712 typed data for the live Averray EscrowCore domain.
- Requires deploying the hardened EscrowCore artifact before this audit item is fully closed for mainnet.

## Environment / VPS
- No env var changes.
- Contract deployment plan required before live chain use of the hardened artifact.