### PR TITLE
fix(worker-canary): fail loud on settlement setup drift

### DIFF
--- a/mcp-server/src/blockchain/abis.js
+++ b/mcp-server/src/blockchain/abis.js
@@ -38,6 +38,7 @@ export const AGENT_ACCOUNT_ABI = [
 ];
 
 export const ESCROW_CORE_ABI = [
+  "function accounts() view returns (address)",
   "function createSinglePayoutJob(bytes32 jobId, address asset, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 claimTtl, bytes32 verifierMode, bytes32 category, bytes32 specHash)",
   "function createSinglePayoutJob(bytes32 jobId, address asset, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 claimTtl, bytes32 verifierMode, bytes32 category, bytes32 specHash, (bytes32 schemaHash, string schemaUrl, address schemaIssuer, bytes schemaSignature) externalSchema)",
   "function createSinglePayoutJobFromRecurringReserve((bytes32 jobId, bytes32 templateId, address poster, address asset, uint256 reward, uint256 opsReserve, uint256 contingencyReserve, uint256 claimTtl, bytes32 verifierMode, bytes32 category, bytes32 specHash, bytes32 schemaHash, string schemaUrl, address schemaIssuer, bytes schemaSignature) params)",

--- a/mcp-server/src/blockchain/gateway.js
+++ b/mcp-server/src/blockchain/gateway.js
@@ -448,6 +448,7 @@ export class BlockchainGateway {
             arbitratorSignerIsArbitrator: false,
             escrowIsServiceOperator: false,
             escrowIsAgentAccountEscrowOperator: false,
+            escrowAgentAccountMatchesConfig: false,
             agentAccountIsServiceOperator: false
           },
           readErrors: [],
@@ -483,6 +484,7 @@ export class BlockchainGateway {
         escrowIsServiceOperator,
         escrowIsAgentAccountEscrowOperator,
         agentAccountIsServiceOperator,
+        escrowCoreAgentAccountAddress,
         dailyOutflowCap,
         perAccountBorrowCap,
         minimumCollateralRatioBps,
@@ -514,6 +516,9 @@ export class BlockchainGateway {
         this.config.agentAccountAddress
           ? optionalBool("serviceOperators(agentAccount)", this.policyContract.serviceOperators(this.config.agentAccountAddress))
           : false,
+        this.config.escrowCoreAddress && typeof this.escrowContract?.accounts === "function"
+          ? optionalRead("EscrowCore.accounts()", this.escrowContract.accounts(), undefined)
+          : undefined,
         optionalRead("dailyOutflowCap", this.policyContract.dailyOutflowCap(), 0),
         optionalRead("perAccountBorrowCap", this.policyContract.perAccountBorrowCap(), 0),
         optionalRead("minimumCollateralRatioBps", this.policyContract.minimumCollateralRatioBps(), 0),
@@ -535,6 +540,11 @@ export class BlockchainGateway {
           : "missing";
       const agentAccountEscrowAuthorized = escrowIsAgentAccountEscrowOperator || (
         agentAccountEscrowAuthorizationMode === "legacyServiceOperator"
+      );
+      const escrowAgentAccountMatchesConfig = Boolean(
+        escrowCoreAgentAccountAddress
+          && this.config.agentAccountAddress
+          && String(escrowCoreAgentAccountAddress).toLowerCase() === String(this.config.agentAccountAddress).toLowerCase()
       );
       const supportedAssets = await Promise.all((this.config.supportedAssets ?? []).map(async (asset) => ({
         ...summarizeSupportedAsset(asset),
@@ -583,6 +593,7 @@ export class BlockchainGateway {
           signerIsVerifier
             && escrowIsServiceOperator
             && agentAccountEscrowAuthorized
+            && escrowAgentAccountMatchesConfig
             && agentAccountIsServiceOperator
             && supportedAssetsReady
             && paused === false
@@ -590,6 +601,7 @@ export class BlockchainGateway {
         contracts: {
           escrowCoreAddress: this.config.escrowCoreAddress,
           agentAccountAddress: this.config.agentAccountAddress,
+          escrowCoreAgentAccountAddress,
           reputationSbtAddress: this.config.reputationSbtAddress,
           supportedAssets
         },
@@ -602,6 +614,7 @@ export class BlockchainGateway {
           escrowIsAgentAccountEscrowOperator: agentAccountEscrowAuthorized,
           agentAccountEscrowAuthorizationMode,
           agentAccountEscrowOperatorsGetterReady: escrowIsAgentAccountEscrowOperator,
+          escrowAgentAccountMatchesConfig,
           agentAccountIsServiceOperator
         },
         signerFunding,

--- a/mcp-server/src/blockchain/gateway.test.js
+++ b/mcp-server/src/blockchain/gateway.test.js
@@ -614,6 +614,11 @@ test("getTreasuryPolicyStatus surfaces settlement readiness roles", async () => 
       });
     }
   };
+  gateway.escrowContract = {
+    async accounts() {
+      return "0x3333333333333333333333333333333333333333";
+    }
+  };
 
   const status = await gateway.getTreasuryPolicyStatus();
 
@@ -622,8 +627,10 @@ test("getTreasuryPolicyStatus surfaces settlement readiness roles", async () => 
   assert.equal(status.roles.signerIsVerifier, true);
   assert.equal(status.roles.escrowIsServiceOperator, true);
   assert.equal(status.roles.escrowIsAgentAccountEscrowOperator, true);
+  assert.equal(status.roles.escrowAgentAccountMatchesConfig, true);
   assert.equal(status.roles.agentAccountIsServiceOperator, true);
   assert.deepEqual(status.readErrors, []);
+  assert.equal(status.contracts.escrowCoreAgentAccountAddress, "0x3333333333333333333333333333333333333333");
   assert.deepEqual(status.contracts.supportedAssets, [{
     symbol: "DOT",
     address: DOT_ASSET.address,
@@ -658,6 +665,91 @@ test("getTreasuryPolicyStatus surfaces settlement readiness roles", async () => 
       debtOutstandingRaw: "0"
     }]
   });
+});
+
+test("getTreasuryPolicyStatus marks settlement not ready when EscrowCore points at a different AgentAccountCore", async () => {
+  const gateway = new BlockchainGateway({
+    enabled: true,
+    rpcUrl: "http://127.0.0.1:8545",
+    signerPrivateKey: `0x${"11".repeat(32)}`,
+    treasuryPolicyAddress: "0x1111111111111111111111111111111111111111",
+    agentAccountAddress: "0x3333333333333333333333333333333333333333",
+    escrowCoreAddress: "0x2222222222222222222222222222222222222222",
+    reputationSbtAddress: "0x4444444444444444444444444444444444444444",
+    supportedAssets: [DOT_ASSET]
+  });
+  gateway.policyContract = {
+    async owner() {
+      return "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    },
+    async pauser() {
+      return "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    },
+    async paused() {
+      return false;
+    },
+    async verifiers() {
+      return true;
+    },
+    async serviceOperators() {
+      return true;
+    },
+    async approvedAssets() {
+      return true;
+    },
+    async dailyOutflowCap() {
+      return 100n;
+    },
+    async perAccountBorrowCap() {
+      return 200n;
+    },
+    async minimumCollateralRatioBps() {
+      return 300n;
+    },
+    async defaultClaimStakeBps() {
+      return 400n;
+    },
+    async claimFeeBps() {
+      return 5n;
+    },
+    async claimFeeVerifierBps() {
+      return 6000n;
+    },
+    async onboardingWaiverClaimCount() {
+      return 7n;
+    },
+    async rejectionSkillPenalty() {
+      return 8n;
+    },
+    async rejectionReliabilityPenalty() {
+      return 9n;
+    },
+    async disputeLossSkillPenalty() {
+      return 10n;
+    },
+    async disputeLossReliabilityPenalty() {
+      return 11n;
+    }
+  };
+  gateway.accountContract = {
+    async escrowOperators() {
+      return true;
+    },
+    async positions() {
+      return emptyPosition();
+    }
+  };
+  gateway.escrowContract = {
+    async accounts() {
+      return "0x9999999999999999999999999999999999999999";
+    }
+  };
+
+  const status = await gateway.getTreasuryPolicyStatus();
+
+  assert.equal(status.roles.escrowAgentAccountMatchesConfig, false);
+  assert.equal(status.contracts.escrowCoreAgentAccountAddress, "0x9999999999999999999999999999999999999999");
+  assert.equal(status.settlementReady, false);
 });
 
 test("getTreasuryPolicyStatus accepts legacy AgentAccountCore operator authorization when escrowOperators getter is absent", async () => {
@@ -743,6 +835,11 @@ test("getTreasuryPolicyStatus accepts legacy AgentAccountCore operator authoriza
       return emptyPosition();
     }
   };
+  gateway.escrowContract = {
+    async accounts() {
+      return "0x3333333333333333333333333333333333333333";
+    }
+  };
 
   const status = await gateway.getTreasuryPolicyStatus();
 
@@ -752,6 +849,7 @@ test("getTreasuryPolicyStatus accepts legacy AgentAccountCore operator authoriza
   assert.equal(status.roles.agentAccountIsServiceOperator, true);
   assert.equal(status.roles.agentAccountEscrowAuthorizationMode, "legacyServiceOperator");
   assert.equal(status.roles.agentAccountEscrowOperatorsGetterReady, false);
+  assert.equal(status.roles.escrowAgentAccountMatchesConfig, true);
   assert.deepEqual(status.readErrors, [{
     field: "AgentAccountCore.escrowOperators(escrowCore)",
     message: "execution reverted"
@@ -830,6 +928,11 @@ test("getTreasuryPolicyStatus preserves raw policy risk values when numbers are 
     },
     async positions() {
       return emptyPosition();
+    }
+  };
+  gateway.escrowContract = {
+    async accounts() {
+      return "0x3333333333333333333333333333333333333333";
     }
   };
 
@@ -923,6 +1026,11 @@ test("getTreasuryPolicyStatus records individual read errors without hiding role
     },
     async positions() {
       return emptyPosition();
+    }
+  };
+  gateway.escrowContract = {
+    async accounts() {
+      return "0x3333333333333333333333333333333333333333";
     }
   };
 

--- a/scripts/ops/run-worker-canary.mjs
+++ b/scripts/ops/run-worker-canary.mjs
@@ -124,7 +124,10 @@ export async function runWorkerCanary({
     assertTestnet({ chainId, profile: config.profile });
 
     // ── operator readiness: capabilities + settlement, BEFORE creating a job
-    await stage("operatorReadiness", () => assertOperatorReady(operatorPlatform));
+    await stage("operatorReadiness", () => assertOperatorReady(operatorPlatform, {
+      rewardRaw: config.rewardRaw,
+      rewardAssetSymbol: DEFAULT_ESCROW_ASSET.symbol
+    }));
 
     // ── worker identity: a fresh, roleless wallet — NOT the admin JWT ─────
     const wallet = injectedWallet ?? (await resolveWorkerWallet({ env, config, readSecretImpl, log }));
@@ -386,6 +389,15 @@ export async function runClaimStage({ authedWorker, jobId, workerAddress, idempo
     claim = await authedWorker.claimJob(jobId, idempotencyKey);
   } catch (error) {
     if (error?.status === 409) {
+      if (isEnsureJobRevert(error)) {
+        throw new Error(
+          `Claim stage FAILED during canary job funding/setup: /jobs/claim returned HTTP 409 (${describeApiError(error)}). ` +
+            "The disposable canary job is created in the API first and funded on-chain by ensureJob during claim; " +
+            "ensureJob reverted before claimJobFor could run. Check /admin/status for signerFunding, " +
+            "EscrowCore.accounts() -> AgentAccountCore binding, service-operator grants, and asset approval. " +
+            `mechanism=${mechanism}; totalClaimLock=${lockRaw}.`
+        );
+      }
       throw new Error(
         `Claim stage FAILED: /jobs/claim returned HTTP 409 (${describeApiError(error)}). ` +
           "This is the claim-funding 409 class: the brokered on-chain claimJobFor could not lock the claim " +
@@ -595,7 +607,7 @@ export function assertOperatorTokenFreshness({ operatorAuth, minDays, now }) {
 }
 
 // ── operator readiness ───────────────────────────────────────────────────────
-async function assertOperatorReady(operatorPlatform) {
+export async function assertOperatorReady(operatorPlatform, { rewardRaw = undefined, rewardAssetSymbol = DEFAULT_ESCROW_ASSET.symbol } = {}) {
   const authSession = await operatorPlatform.getAuthSession();
   const capabilities = Array.isArray(authSession?.capabilities) ? authSession.capabilities : [];
   const missing = REQUIRED_OPERATOR_CAPABILITIES.filter((cap) => !capabilities.includes(cap));
@@ -609,7 +621,7 @@ async function assertOperatorReady(operatorPlatform) {
 
   const status = await operatorPlatform.getAdminStatus();
   const policy = status?.maintenance?.policy;
-  if (!policy?.enabled || policy.settlementReady !== true) {
+  if (!policy?.enabled) {
     throw new Error(
       "Operator readiness FAILED: on-chain settlement is not ready (/admin/status). " +
         `enabled=${String(policy?.enabled)}; settlementReady=${String(policy?.settlementReady)}. ` +
@@ -628,11 +640,51 @@ async function assertOperatorReady(operatorPlatform) {
         "ledger mutations are disabled. Run the EscrowCore multisig wiring recipe before the canary."
     );
   }
+  if (policy.roles?.escrowAgentAccountMatchesConfig === false) {
+    throw new Error(
+      "Operator readiness FAILED: EscrowCore.accounts() does not match the configured AgentAccountCore. " +
+        `escrowCore=${policy.contracts?.escrowCoreAddress ?? "unknown"}; ` +
+        `EscrowCore.accounts=${policy.contracts?.escrowCoreAgentAccountAddress ?? "unknown"}; ` +
+        `configured AgentAccountCore=${policy.contracts?.agentAccountAddress ?? "unknown"}. ` +
+        "The backend may read signer liquidity from one AgentAccountCore while EscrowCore reserves from another, " +
+        "which makes ensureJob revert during canary claim setup."
+    );
+  }
+  const fundingAsset = Array.isArray(policy.signerFunding?.assets)
+    ? policy.signerFunding.assets.find((asset) => asset?.symbol === rewardAssetSymbol)
+    : undefined;
+  if (fundingAsset) {
+    if (fundingAsset.readable !== true) {
+      throw new Error(
+        `Operator readiness FAILED: signer reward-bank position for ${rewardAssetSymbol} is not readable from ` +
+          `AgentAccountCore ${policy.signerFunding?.agentAccountAddress ?? policy.contracts?.agentAccountAddress ?? "unknown"}. ` +
+          "The canary cannot prove the disposable job can be funded."
+      );
+    }
+    const liquidRaw = BigInt(fundingAsset.liquidRaw ?? 0);
+    if (rewardRaw !== undefined && liquidRaw < BigInt(rewardRaw)) {
+      throw new Error(
+        `Operator readiness FAILED: signer reward bank is underfunded for ${rewardAssetSymbol}. ` +
+          `liquid=${liquidRaw} raw (${fundingAsset.liquid ?? "unknown"} ${rewardAssetSymbol}); ` +
+          `required=${rewardRaw} raw (${formatBaseUnits(rewardRaw)} ${rewardAssetSymbol}). ` +
+          "Deposit reward liquidity into AgentAccountCore before running the worker canary."
+      );
+    }
+  }
+  if (policy.settlementReady !== true) {
+    throw new Error(
+      "Operator readiness FAILED: on-chain settlement is not ready (/admin/status). " +
+        `enabled=${String(policy?.enabled)}; settlementReady=${String(policy?.settlementReady)}. ` +
+        "Brokered claim/submit/settle cannot complete."
+    );
+  }
   return {
     capabilities: REQUIRED_OPERATOR_CAPABILITIES,
     settlementReady: true,
     escrowIsServiceOperator: true,
-    escrowIsAgentAccountEscrowOperator: true
+    escrowIsAgentAccountEscrowOperator: true,
+    escrowAgentAccountMatchesConfig: policy.roles?.escrowAgentAccountMatchesConfig,
+    signerFundingChecked: Boolean(fundingAsset)
   };
 }
 
@@ -892,6 +944,12 @@ function describeApiError(error) {
   const message = error?.payload?.message ?? error?.message ?? "";
   const requestId = error?.payload?.requestId ? `; requestId=${error.payload.requestId}` : "";
   return `status=${error?.status ?? "?"}; code=${code || "?"}; message=${message}${requestId}`;
+}
+
+function isEnsureJobRevert(error) {
+  const code = String(error?.payload?.error ?? error?.payload?.code ?? "");
+  const message = String(error?.payload?.message ?? error?.message ?? "");
+  return code === "blockchain_revert" || /ensureJob failed|require\(false\)/iu.test(message);
 }
 
 function round1(value) {

--- a/scripts/ops/run-worker-canary.test.mjs
+++ b/scripts/ops/run-worker-canary.test.mjs
@@ -12,7 +12,8 @@ import {
   runSubmitStage,
   runVerifyStage,
   runSettleStage,
-  assertOperatorTokenFreshness
+  assertOperatorTokenFreshness,
+  assertOperatorReady
 } from "./run-worker-canary.mjs";
 
 // ── fixtures ──────────────────────────────────────────────────────────────
@@ -56,7 +57,22 @@ function okOperatorClient(overrides = {}) {
             settlementReady: true,
             roles: {
               escrowIsServiceOperator: true,
-              escrowIsAgentAccountEscrowOperator: true
+              escrowIsAgentAccountEscrowOperator: true,
+              escrowAgentAccountMatchesConfig: true
+            },
+            contracts: {
+              escrowCoreAddress: "0x2222222222222222222222222222222222222222",
+              agentAccountAddress: "0x3333333333333333333333333333333333333333",
+              escrowCoreAgentAccountAddress: "0x3333333333333333333333333333333333333333"
+            },
+            signerFunding: {
+              agentAccountAddress: "0x3333333333333333333333333333333333333333",
+              assets: [{
+                symbol: "USDC",
+                readable: true,
+                liquid: 1,
+                liquidRaw: "1000000"
+              }]
             }
           }
         }
@@ -248,6 +264,63 @@ test("operator readiness fails loud if the escrow service-operator broker is dis
   await assert.rejects(() => runFull({ operatorClient }), /service operator/u);
 });
 
+test("operator readiness fails before job creation when EscrowCore points at a different AgentAccountCore", async () => {
+  const operatorClient = okOperatorClient({
+    async getAdminStatus() {
+      return {
+        maintenance: {
+          policy: {
+            enabled: true,
+            settlementReady: false,
+            roles: {
+              escrowIsServiceOperator: true,
+              escrowIsAgentAccountEscrowOperator: true,
+              escrowAgentAccountMatchesConfig: false
+            },
+            contracts: {
+              escrowCoreAddress: "0x2222222222222222222222222222222222222222",
+              agentAccountAddress: "0x3333333333333333333333333333333333333333",
+              escrowCoreAgentAccountAddress: "0x9999999999999999999999999999999999999999"
+            }
+          }
+        }
+      };
+    }
+  });
+  await assert.rejects(() => runFull({ operatorClient }), /EscrowCore\.accounts\(\) does not match/u);
+});
+
+test("operator readiness fails before job creation when signer reward bank is short", async () => {
+  const operatorPlatform = {
+    async getAuthSession() {
+      return { roles: ["admin", "verifier"], capabilities: ["jobs:create", "jobs:lifecycle", "verifier:run", "admin:status"] };
+    },
+    async getAdminStatus() {
+      return {
+        maintenance: {
+          policy: {
+            enabled: true,
+            settlementReady: true,
+            roles: {
+              escrowIsServiceOperator: true,
+              escrowIsAgentAccountEscrowOperator: true,
+              escrowAgentAccountMatchesConfig: true
+            },
+            signerFunding: {
+              agentAccountAddress: "0x3333333333333333333333333333333333333333",
+              assets: [{ symbol: "USDC", readable: true, liquid: 0, liquidRaw: "0" }]
+            }
+          }
+        }
+      };
+    }
+  };
+  await assert.rejects(
+    () => assertOperatorReady(operatorPlatform, { rewardRaw: REWARD_RAW, rewardAssetSymbol: "USDC" }),
+    /reward bank is underfunded/u
+  );
+});
+
 // ── STAGE 1: SIWE (guards #625) ──────────────────────────────────────────────
 test("stage 1 SIWE: HTTP 500 on /auth/verify names the #625 roleless-mint regression", async () => {
   const anonClient = {
@@ -319,6 +392,21 @@ test("stage 3 claim: a 409 from /jobs/claim names the claim-funding class", asyn
   await assert.rejects(
     () => runClaimStage({ authedWorker, jobId: JOB_ID, workerAddress: WORKER, idempotencyKey: "k", before: { aacLiquidRaw: 0n } }),
     /409 class|claim-funding/u
+  );
+});
+
+test("stage 3 claim: ensureJob blockchain_revert names canary job funding/setup diagnostics", async () => {
+  const authedWorker = {
+    async preflightJob(jobId) {
+      return { jobId, eligible: true, claimable: true, currentWalletCanClaim: true, claimEconomicsWaived: true, totalClaimLock: 0 };
+    },
+    async claimJob() {
+      throw new FakeApiError(409, { error: "blockchain_revert", message: "ensureJob failed: require(false)" });
+    }
+  };
+  await assert.rejects(
+    () => runClaimStage({ authedWorker, jobId: JOB_ID, workerAddress: WORKER, idempotencyKey: "k", before: { aacLiquidRaw: 0n } }),
+    /funding\/setup|EscrowCore\.accounts\(\)|ensureJob/u
   );
 });
 


### PR DESCRIPTION
## What changed
- Add the `EscrowCore.accounts()` ABI getter and surface its live AgentAccountCore binding in `/admin/status` policy telemetry.
- Include the EscrowCore -> AgentAccountCore binding in `settlementReady` so a redeploy/config drift fails before the Hosted Worker Canary creates a disposable job.
- Harden the worker canary readiness gate to fail before mutation when signer USDC reward-bank liquidity is short or EscrowCore points at a different AgentAccountCore.
- Reclassify `/jobs/claim` 409 `blockchain_revert` / `ensureJob failed` as canary job funding/setup drift, with concrete remediation hints instead of the generic claim-funding message.

## Why
The current Hosted Worker Canary deployment job is failing after deploy with:

`/jobs/claim returned HTTP 409 code=blockchain_revert message="ensureJob failed: require(false)"`

That means auth and deploy are fine; the canary reached on-chain setup and the lazy `ensureJob` funding/create call reverted. This PR makes the pipeline identify the likely settlement prerequisite directly: signer reward-bank funding, EscrowCore -> AgentAccountCore wiring, service-operator grants, or asset approval.

## Checks run
- `node --test mcp-server/src/blockchain/gateway.test.js scripts/ops/run-worker-canary.test.mjs`
- `npm --workspace mcp-server test`
- `npm run test:ops`
- `git diff --check`

## Affected surfaces
- Backend status telemetry: yes (`/admin/status` policy readiness fields)
- Ops/CI worker canary: yes
- Contracts: no deployment/change
- Frontend/indexer/public site/Caddy: no

## Environment / VPS secrets
None.
